### PR TITLE
Guarantee correctness for the search permissions fast path

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -999,6 +999,7 @@
            legacy-mbql
            lib
            models
+           permissions
            query-processor
            search
            sync
@@ -3194,7 +3195,7 @@
            task
            tracing
            util}
-   :model-imports #{:model/Card :model/Collection :model/Dashboard}}
+   :model-imports #{:model/Collection}}
 
   enterprise/serialization
   {:team "Graphy"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1034,6 +1034,7 @@
            legacy-mbql
            lib
            models
+           permissions
            query-processor
            search
            sync
@@ -3372,7 +3373,7 @@
            task
            tracing
            util}
-   :model-imports #{:model/Card :model/Collection :model/Dashboard}}
+   :model-imports #{:model/Collection}}
 
   enterprise/serialization
   {:team "Graphy"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -718,11 +718,15 @@
 ;; Computed lazily so the registry has time to populate at app init before first search.
 (def ^:private collection-id-only-search-models
   (delay
-    (let [registered-t2-models (perms/collection-id-only-read-models)]
+    ;; Force `(search/specifications)` first: its `t2/resolve-model` calls load the namespaces
+    ;; whose `perms/define-collection-id-only-read-perms!` invocations populate the registry.
+    ;; Reading the registry before this would risk caching an empty set for the JVM lifetime.
+    (let [specs                (search/specifications)
+          registered-t2-models (perms/collection-id-only-read-models)]
       (into #{"indexed-entity"}
             (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
                   (map key))
-            (search/specifications)))))
+            specs))))
 
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -711,50 +711,38 @@
   (update row :legacy_input decode-pgobject))
 
 (defn- compute-collection-id-only-search-models
-  "Body of the `collection-id-only-search-models` delay, extracted so the cold-start ordering
-  (specs-before-registry) is exercised by a regression test.
-
-  Must call `(search/specifications)` BEFORE reading the registry: the `t2/resolve-model`
-  calls inside `specifications` load the model namespaces whose
-  `perms/define-collection-id-only-read-perms!` invocations populate the registry. Reading
-  the registry first risks snapshotting an empty set on cold start and caching it for the
-  JVM lifetime."
+  "Compute search-models whose read perms are determined fully by their collection id."
   []
-  (let [specs                (search/specifications)
-        registered-t2-models (perms/collection-id-only-read-models)]
-    (into #{"indexed-entity"}
+  ;; `search/specifications` must run before reading the registry: its `t2/resolve-model` calls load the
+  ;; model namespaces that populate it. Otherwise cold start caches an empty set for the JVM lifetime.
+  (let [specs                    (search/specifications)
+        registered-t2-models     (perms/collection-id-only-read-models)
+        registered-search-models (perms/collection-based-visibility-search-models)]
+    (into registered-search-models
           (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
                 (map key))
           specs)))
 
-;; Search-model strings whose read permission is determined by `:collection_id` alone. Derived
-;; from `perms/collection-id-only-read-models` (models registered via
-;; `perms/define-collection-id-only-read-perms!`) plus `"indexed-entity"`, whose index-row
-;; `:collection_id` is denormalized from the parent Card via the search spec's Collection join
-;; and whose read policy is therefore transitively the registered Card's.
-;; Computed lazily so the registry has time to populate at app init before first search.
 (def ^:private collection-id-only-search-models
+  "Search-models whose read perms are determined fully by their collection id.
+  Wrapped in `delay` so the registry can populate before first read."
   (delay (compute-collection-id-only-search-models)))
 
 (defn- filter-read-permitted
-  "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
+  "Returns the subset of `docs` whose t2 instances pass `mi/can-read?` for the current user."
   [docs]
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         fast-set      @collection-id-only-search-models
         {fast-docs true slow-docs false} (group-by #(contains? fast-set (:model %)) docs)
-        ;; Fast path: for models registered via `perms/define-collection-id-only-read-perms!`,
-        ;; `mi/can-read?` is definitionally `(perms/can-read-via-parent-collection?
-        ;; (:collection_id instance))`, so we can skip the t2/select and check permissions
-        ;; straight from the denormalized `:collection_id` on the index row. Calling the shared
-        ;; helper directly means the fast path runs literally the same code as the slow path
-        ;; for these models — no drift possible on the permission logic. Memoizing dedupes the
-        ;; perm check across docs that share a collection.
+        ;; Fast path: for models registered via `perms/define-collection-based-visibility!`, `mi/can-read?` is
+        ;; definitionally `(perms/can-read-via-parent-collection? (:collection_id instance))`, so we skip the
+        ;; t2/select and check perms straight from the denormalized `:collection_id` on the index row.
+        ;; Calling the shared helper means fast and slow paths run the same code for these models.
+        ;; Memoizing dedupes the perm check across docs that share a collection.
         ;;
-        ;; Trade-off: the indexed `:collection_id` is eventually-consistent. Between a move or
-        ;; delete and the next reindex, a user may see a search hit whose live `collection_id`
-        ;; they no longer have access to. The per-row entity fetch on click-through still
-        ;; enforces live permissions, bounding exposure to search-result metadata.
+        ;; Trade-off: the indexed `:collection_id` is eventually-consistent, so a moved/deleted row may appear
+        ;; in results until the next reindex. Click-through still enforces live perms.
         coll-readable? (memoize perms/can-read-via-parent-collection?)
         fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         slow-t2-instances (vec

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -717,7 +717,7 @@
   ;; model namespaces that populate it. Otherwise cold start caches an empty set for the JVM lifetime.
   (let [specs                    (search/specifications)
         registered-t2-models     (perms/collection-id-only-read-models)
-        registered-search-models (perms/collection-based-visibility-search-models)]
+        registered-search-models (set (keys (perms/collection-based-visibility-search-models)))]
     (into registered-search-models
           (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
                 (map key))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -710,6 +710,23 @@
   [row]
   (update row :legacy_input decode-pgobject))
 
+(defn- compute-collection-id-only-search-models
+  "Body of the `collection-id-only-search-models` delay, extracted so the cold-start ordering
+  (specs-before-registry) is exercised by a regression test.
+
+  Must call `(search/specifications)` BEFORE reading the registry: the `t2/resolve-model`
+  calls inside `specifications` load the model namespaces whose
+  `perms/define-collection-id-only-read-perms!` invocations populate the registry. Reading
+  the registry first risks snapshotting an empty set on cold start and caching it for the
+  JVM lifetime."
+  []
+  (let [specs                (search/specifications)
+        registered-t2-models (perms/collection-id-only-read-models)]
+    (into #{"indexed-entity"}
+          (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
+                (map key))
+          specs)))
+
 ;; Search-model strings whose read permission is determined by `:collection_id` alone. Derived
 ;; from `perms/collection-id-only-read-models` (models registered via
 ;; `perms/define-collection-id-only-read-perms!`) plus `"indexed-entity"`, whose index-row
@@ -717,16 +734,7 @@
 ;; and whose read policy is therefore transitively the registered Card's.
 ;; Computed lazily so the registry has time to populate at app init before first search.
 (def ^:private collection-id-only-search-models
-  (delay
-    ;; Force `(search/specifications)` first: its `t2/resolve-model` calls load the namespaces
-    ;; whose `perms/define-collection-id-only-read-perms!` invocations populate the registry.
-    ;; Reading the registry before this would risk caching an empty set for the JVM lifetime.
-    (let [specs                (search/specifications)
-          registered-t2-models (perms/collection-id-only-read-models)]
-      (into #{"indexed-entity"}
-            (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
-                  (map key))
-            specs))))
+  (delay (compute-collection-id-only-search-models)))
 
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -735,8 +735,16 @@
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
-        ;; Fast path: the permission check depends only on `:collection_id`, which is already on the
-        ;; index row. Dedupe by `[stub-model, collection_id]` so `can-read?` runs at most once per
+        ;; Fast path: for `collection-id-only-search-models` the read permission is a pure function
+        ;; of `:collection_id`, which is denormalized onto the index row at ingest time. We deliberately
+        ;; trust the indexed value rather than re-fetching the app DB row — that avoids an N-row
+        ;; `t2/select` on every semantic search and is the main win of this path. The trade-off is
+        ;; that between a move (or delete) and the next reindex, a user can see a search hit whose
+        ;; live `collection_id` they no longer have access to. The index is eventually consistent by
+        ;; design; and the per-row API fetch (loading the entity after clicking through) still
+        ;; enforces live permissions, so the exposure is bounded to search-result metadata.
+        ;;
+        ;; Dedupe by `[stub-model, collection_id]` so `can-read?` runs at most once per
         ;; (model, collection) pair instead of once per document.
         readable? (memoize
                    (fn [stub-model coll-id]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -733,7 +733,7 @@
   [docs]
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
-        fast-set      @collection-id-only-search-models
+        fast-set @collection-id-only-search-models
         {fast-docs true slow-docs false} (group-by #(contains? fast-set (:model %)) docs)
         ;; Fast path: for models registered via `perms/define-collection-based-visibility!`, `mi/can-read?` is
         ;; definitionally `(perms/can-read-via-parent-collection? (:collection_id instance))`, so we skip the

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -718,6 +718,12 @@
   (let [specs                    (search/specifications)
         registered-t2-models     (perms/collection-id-only-read-models)
         registered-search-models (set (keys (perms/collection-based-visibility-search-models)))]
+    ;; Two sources:
+    ;; (1) string-form registrations, whose spec's `:model` is a different t2-model (e.g. ModelIndex)
+    ;;     and wouldn't be picked up by the filter below;
+    ;; (2) every spec whose `:model` was registered via the keyword form — `mi/can-read?` dispatches on
+    ;;     the t2-model, so sibling specs like "dataset"/"metric" that share `:model/Card` are covered
+    ;;     by one registration.
     (into registered-search-models
           (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
                 (map key))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics.core :as analytics]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.tracing.core :as tracing]
@@ -709,50 +710,41 @@
   [row]
   (update row :legacy_input decode-pgobject))
 
-;; Search-models whose `mi/can-read?` is a pure function of `:collection_id`, which is
-;; already denormalized on the index row. Values are the Toucan model whose `can-read?`
-;; defmethod is invoked on a stub instance carrying only `:collection_id`.
-;;
-;;  - "card" / "metric" / "dataset" → :model/Card
-;;  - "dashboard"                   → :model/Dashboard (as of 20260420 this _could_ be
-;;                                    :model/Card for additional albeit modest perf gains
-;;                                    but choosing to not silently ride Card's semantics)
-;;  - "indexed-entity"              → :model/Card by design: the index row's
-;;                                    `collection_id` is the parent Card's (denormalized
-;;                                    via the spec's Collection join), so routing through
-;;                                    Card short-circuits the original ModelIndex → Card
-;;                                    resolution in `filter-can-read-indexed-entity`.
+;; Search-model strings whose read permission is determined by `:collection_id` alone. Derived
+;; from `perms/collection-id-only-read-models` (models registered via
+;; `perms/define-collection-id-only-read-perms!`) plus `"indexed-entity"`, whose index-row
+;; `:collection_id` is denormalized from the parent Card via the search spec's Collection join
+;; and whose read policy is therefore transitively the registered Card's.
+;; Computed lazily so the registry has time to populate at app init before first search.
 (def ^:private collection-id-only-search-models
-  {"card"           :model/Card
-   "metric"         :model/Card
-   "dataset"        :model/Card
-   "dashboard"      :model/Dashboard
-   "indexed-entity" :model/Card})
+  (delay
+    (let [registered-t2-models (perms/collection-id-only-read-models)]
+      (into #{"indexed-entity"}
+            (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
+                  (map key))
+            (search/specifications)))))
 
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
   [docs]
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
-        {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
-        ;; Fast path: for `collection-id-only-search-models` the read permission is a pure function
-        ;; of `:collection_id`, which is denormalized onto the index row at ingest time. We deliberately
-        ;; trust the indexed value rather than re-fetching the app DB row — that avoids an N-row
-        ;; `t2/select` on every semantic search and is the main win of this path. The trade-off is
-        ;; that between a move (or delete) and the next reindex, a user can see a search hit whose
-        ;; live `collection_id` they no longer have access to. The index is eventually consistent by
-        ;; design; and the per-row API fetch (loading the entity after clicking through) still
-        ;; enforces live permissions, so the exposure is bounded to search-result metadata.
+        fast-set      @collection-id-only-search-models
+        {fast-docs true slow-docs false} (group-by #(contains? fast-set (:model %)) docs)
+        ;; Fast path: for models registered via `perms/define-collection-id-only-read-perms!`,
+        ;; `mi/can-read?` is definitionally `(perms/can-read-via-parent-collection?
+        ;; (:collection_id instance))`, so we can skip the t2/select and check permissions
+        ;; straight from the denormalized `:collection_id` on the index row. Calling the shared
+        ;; helper directly means the fast path runs literally the same code as the slow path
+        ;; for these models — no drift possible on the permission logic. Memoizing dedupes the
+        ;; perm check across docs that share a collection.
         ;;
-        ;; Dedupe by `[stub-model, collection_id]` so `can-read?` runs at most once per
-        ;; (model, collection) pair instead of once per document.
-        readable? (memoize
-                   (fn [stub-model coll-id]
-                     (mi/can-read? (t2/instance stub-model {:collection_id coll-id}))))
-        fast-filtered (filterv (fn [doc]
-                                 (readable? (get collection-id-only-search-models (:model doc))
-                                            (:collection_id doc)))
-                               fast-docs)
+        ;; Trade-off: the indexed `:collection_id` is eventually-consistent. Between a move or
+        ;; delete and the next reindex, a user may see a search hit whose live `collection_id`
+        ;; they no longer have access to. The per-row entity fetch on click-through still
+        ;; enforces live permissions, bounding exposure to search-result metadata.
+        coll-readable? (memoize perms/can-read-via-parent-collection?)
+        fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         slow-t2-instances (vec
                            (for [[t2-model docs] (group-by doc->t2-model slow-docs)
                                  t2-instance (t2/select t2-model :id [:in (map :id docs)])]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics-interface.core :as analytics]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.tracing.core :as tracing]
@@ -767,42 +768,47 @@
             (let [decoded (decode-pgobject pgo)]
               (cond-> decoded (string? decoded) json/decode+kw)))))
 
-;; Search-models whose `mi/can-read?` is a pure function of `:collection_id`, which is
-;; already denormalized on the index row. Values are the Toucan model whose `can-read?`
-;; defmethod is invoked on a stub instance carrying only `:collection_id`.
-;;
-;;  - "card" / "metric" / "dataset" → :model/Card
-;;  - "dashboard"                   → :model/Dashboard (as of 20260420 this _could_ be
-;;                                    :model/Card for additional albeit modest perf gains
-;;                                    but choosing to not silently ride Card's semantics)
-;;  - "indexed-entity"              → :model/Card by design: the index row's
-;;                                    `collection_id` is the parent Card's (denormalized
-;;                                    via the spec's Collection join), so routing through
-;;                                    Card short-circuits the original ModelIndex → Card
-;;                                    resolution in `filter-can-read-indexed-entity`.
+(defn- compute-collection-id-only-search-models
+  "Compute search-models whose read perms are determined fully by their collection id."
+  []
+  ;; `search/specifications` must run before reading the registry: its `t2/resolve-model` calls load the
+  ;; model namespaces that populate it. Otherwise cold start caches an empty set for the JVM lifetime.
+  (let [specs                    (search/specifications)
+        registered-t2-models     (perms/collection-id-only-read-models)
+        registered-search-models (set (keys (perms/collection-based-visibility-search-models)))]
+    ;; Two sources:
+    ;; (1) string-form registrations, whose spec's `:model` is a different t2-model (e.g. ModelIndex)
+    ;;     and wouldn't be picked up by the filter below;
+    ;; (2) every spec whose `:model` was registered via the keyword form — `mi/can-read?` dispatches on
+    ;;     the t2-model, so sibling specs like "dataset"/"metric" that share `:model/Card` are covered
+    ;;     by one registration.
+    (into registered-search-models
+          (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
+                (map key))
+          specs)))
+
 (def ^:private collection-id-only-search-models
-  {"card"           :model/Card
-   "metric"         :model/Card
-   "dataset"        :model/Card
-   "dashboard"      :model/Dashboard
-   "indexed-entity" :model/Card})
+  "Search-models whose read perms are determined fully by their collection id.
+  Wrapped in `delay` so the registry can populate before first read."
+  (delay (compute-collection-id-only-search-models)))
 
 (defn- filter-read-permitted
-  "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
+  "Returns the subset of `docs` whose t2 instances pass `mi/can-read?` for the current user."
   [docs]
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
-        {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
-        ;; Fast path: the permission check depends only on `:collection_id`, which is already on the
-        ;; index row. Dedupe by `[stub-model, collection_id]` so `can-read?` runs at most once per
-        ;; (model, collection) pair instead of once per document.
-        readable? (memoize
-                   (fn [stub-model coll-id]
-                     (mi/can-read? (t2/instance stub-model {:collection_id coll-id}))))
-        fast-filtered (filterv (fn [doc]
-                                 (readable? (get collection-id-only-search-models (:model doc))
-                                            (:collection_id doc)))
-                               fast-docs)
+        fast-set @collection-id-only-search-models
+        {fast-docs true slow-docs false} (group-by #(contains? fast-set (:model %)) docs)
+        ;; Fast path: for models registered via `perms/define-collection-based-visibility!`, `mi/can-read?` is
+        ;; definitionally `(perms/can-read-via-parent-collection? (:collection_id instance))`, so we skip the
+        ;; t2/select and check perms straight from the denormalized `:collection_id` on the index row.
+        ;; Calling the shared helper means fast and slow paths run the same code for these models.
+        ;; Memoizing dedupes the perm check across docs that share a collection.
+        ;;
+        ;; Trade-off: the indexed `:collection_id` is eventually-consistent, so a moved/deleted row may appear
+        ;; in results until the next reindex. Click-through still enforces live perms.
+        coll-readable? (memoize perms/can-read-via-parent-collection?)
+        fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         slow-t2-instances (vec
                            (for [[t2-model docs] (group-by doc->t2-model slow-docs)
                                  t2-instance (t2/select t2-model :id [:in (map :id docs)])]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -466,50 +466,53 @@
                  (#'semantic.index/batch-resolve-personal-owner-ids
                   [user1-personal-coll-id user2-sub-coll-id shared-coll-id nil]))))))))
 
-(deftest filter-read-permitted-indexed-entity-test
+(deftest filter-read-permitted-fast-path-test
   (mt/with-premium-features #{:semantic-search}
-    (testing "filter-read-permitted routes indexed-entity docs through the collection_id-only fast path"
+    (testing "filter-read-permitted routes collection-id-only models through the fast path"
       (mt/with-temp [:model/Collection {readable-coll-id :id} {}
                      :model/Collection {unreadable-coll-id :id} {}]
-        (let [indexed-entity-docs [{:id "1:123"
-                                    :model "indexed-entity"
-                                    :collection_id readable-coll-id}
-                                   {:id "2:456"
-                                    :model "indexed-entity"
-                                    :collection_id unreadable-coll-id}
-                                   {:id "3:789"
-                                    :model "indexed-entity"
-                                    :collection_id nil}]]
+        (testing "indexed-entity docs are filtered by denormalized :collection_id"
+          (let [docs [{:id "1:123" :model "indexed-entity" :collection_id readable-coll-id}
+                      {:id "2:456" :model "indexed-entity" :collection_id unreadable-coll-id}
+                      {:id "3:789" :model "indexed-entity" :collection_id nil}]]
+            (testing "keeps all entities when user has root permissions"
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (is (= 3 (count (#'semantic.index/filter-read-permitted docs))))))
 
-          (testing "keeps all entities when user has root permissions"
-            (binding [api/*current-user-permissions-set* (atom #{"/"})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 3 (count result))))))
+            (testing "drops all entities when user has no permissions"
+              (binding [api/*current-user-permissions-set* (atom #{})]
+                (is (= 0 (count (#'semantic.index/filter-read-permitted docs))))))
 
-          (testing "drops all entities when user has no permissions"
-            (binding [api/*current-user-permissions-set* (atom #{})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 0 (count result))))))
+            (testing "keeps only entities in readable collections"
+              (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                (let [result (#'semantic.index/filter-read-permitted docs)]
+                  (is (= 1 (count result)))
+                  (is (= "1:123" (:id (first result)))))))))
 
-          (testing "keeps only entities in readable collections"
-            (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 1 (count result)))
-                (is (= "1:123" (:id (first result)))))))
+        (testing "card/metric/dataset/dashboard docs use the same fast path"
+          (doseq [model ["card" "metric" "dataset" "dashboard"]]
+            (testing (str "model=" model)
+              (let [docs [{:id 1 :model model :collection_id readable-coll-id}
+                          {:id 2 :model model :collection_id unreadable-coll-id}
+                          {:id 3 :model model :collection_id nil}]]
+                (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                  (let [result (#'semantic.index/filter-read-permitted docs)]
+                    (is (= [1] (map :id result))
+                        "only the doc whose denormalized collection_id is readable survives")))))))
 
-          (testing "memoizes permission check per collection_id across docs"
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                  (#'semantic.index/filter-read-permitted
-                   (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
-                  (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
+        (testing "memoizes permission check per collection_id across docs"
+          (let [calls (atom 0)
+                real-can-read? mi/can-read?]
+            (with-redefs [mi/can-read? (fn [& args]
+                                         (swap! calls inc)
+                                         (apply real-can-read? args))]
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (#'semantic.index/filter-read-permitted
+                 (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
+                (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
 
-          (testing "handles empty input"
-            (is (= [] (#'semantic.index/filter-read-permitted [])))))))))
+        (testing "handles empty input"
+          (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
 (deftest filter-read-permitted-dispatch-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -11,7 +11,8 @@
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -550,6 +551,63 @@
                   {:id "1:99" :model "indexed-entity" :collection_id coll-id}])
                 (is (= 1 @calls)
                     "card and indexed-entity both dispatch through :model/Card and memoize together")))))))))
+
+;; The fast path in `filter-read-permitted` assumes every model listed in
+;; `collection-id-only-search-models` has a `mi/can-read?` whose result is fully determined by
+;; `:collection_id` + the current user's permissions set. This contract test catches drift in
+;; two directions:
+;;   1. A model is added to the set that doesn't actually satisfy the contract.
+;;   2. An existing model's `can-read?` grows a check on a field other than `:collection_id`
+;;      (e.g., `:archived`, `:type`, `:database_id`), silently making the fast path incorrect.
+;; If the set gains a new entry, add a spec here — the `keys` check below will fail otherwise.
+;; We vary the "should-be-irrelevant" fields across permutations so any new check in `can-read?`
+;; against such a field will flip at least one permutation away from the helper and fail the test.
+(def ^:private collection-id-only-model-test-specs
+  "Maps each entry in `collection-id-only-search-models` to the t2 model used for dispatch.
+  `indexed-entity` resolves to the parent Card at ingest time, so Card covers its contract."
+  {"card"           :model/Card
+   "metric"         :model/Card
+   "dataset"        :model/Card
+   "dashboard"      :model/Dashboard
+   "indexed-entity" :model/Card})
+
+(deftest collection-id-only-search-models-contract-test
+  (testing "every entry in `collection-id-only-search-models` has a matching test spec"
+    (is (= @#'semantic.index/collection-id-only-search-models
+           collection-id-only-model-test-specs)
+        "If you added/changed a model in `collection-id-only-search-models`, update `collection-id-only-model-test-specs` to match."))
+
+  (testing "mi/can-read? is a pure function of :collection_id for each listed model"
+    ;; Synthetic coll-ids chosen to align with the perm-set strings below. No DB involvement —
+    ;; the permission check only reads the instance map and the bound perm set.
+    (let [perm-scenarios [["root perms"                42  #{"/"}]
+                          ["no perms"                  42  #{}]
+                          ["read on matching coll"     42  #{"/collection/42/read/"}]
+                          ["read on other coll only"   42  #{"/collection/99/read/"}]
+                          ["nil collection with root"  nil #{"/"}]
+                          ["nil collection no perms"   nil #{}]]
+          ;; Extra fields on the synthetic instance. If `can-read?` stays collection_id-only,
+          ;; none of these should affect the result. A future `can-read?` that gates on any of
+          ;; them will diverge from the stub for at least one permutation.
+          extra-fields   [{}
+                          {:archived true}
+                          {:archived false}
+                          {:type :question}
+                          {:type :model}
+                          {:type :metric}
+                          {:database_id 1}
+                          {:dataset_query {}}]]
+      (doseq [[search-model t2-model] collection-id-only-model-test-specs
+              [label coll-id perms]   perm-scenarios
+              extras                  extra-fields]
+        (let [full-instance (t2/instance t2-model (assoc extras :collection_id coll-id))
+              stub-instance (t2/instance t2-model {:collection_id coll-id})]
+          (binding [api/*current-user-permissions-set* (atom perms)]
+            (let [slow-path (boolean (mi/can-read? full-instance))
+                  fast-path (boolean (mi/can-read? stub-instance))]
+              (is (= slow-path fast-path)
+                  (format "%s %s extras=%s: fast path=%s mi/can-read?=%s. If these disagree, `can-read?` likely depends on a field other than `:collection_id`, so removing this model from `collection-id-only-search-models` is required."
+                          search-model label extras fast-path slow-path)))))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -656,14 +656,15 @@
              :attrs {:collection-id [:coalesce :collection.id :other.foo]}
              :joins {:collection [:model/Collection [:= :collection.id :this.c]]
                      :other      [:model/Other [:= :other.foo :this.o]]}}))))
-  (testing "recurses into nested vector expressions and skips control keywords"
-    ;; Mirrors `find-fields-expr`: a `:case` form contains a nested `[:= ...]` predicate plus
-    ;; branch keywords. The recursive walk must pull column refs out of the nested predicate and
-    ;; must not treat `:else` as a column.
+  (testing "recurses into nested vector expressions"
+    ;; Mirrors `find-fields-expr`: a `:case` form contains a nested `[:= ...]` predicate plus a
+    ;; direct branch keyword. The recursive walk must pull column refs out of the nested predicate —
+    ;; if it didn't descend, `:other.flag` would never seed the walk and `:model/Other` would be
+    ;; missing from the reachable set.
     (is (= #{:model/Base :model/Collection :model/Other}
            (trace-collection-id-source-models
             {:model :model/Base
-             :attrs {:collection-id [:case [:= :other.flag true] :collection.id :else :this.collection_id]}
+             :attrs {:collection-id [:case [:= :other.flag true] :collection.id :this.collection_id]}
              :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
                      :other      [:model/Other [:= :other.flag :this.other_flag]]}}))))
   (testing "descends into `{:fn ... :fields [...]}` attr maps"
@@ -674,6 +675,22 @@
             {:model :model/Base
              :attrs {:collection-id {:fn identity :fields [:collection.id]}}
              :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}})))))
+
+(deftest attr-expr-columns-skips-control-keywords-test
+  (testing "control and SQL-function keywords are dropped instead of being qualified to `:this.<kw>`"
+    ;; `qualify-this` would otherwise turn `:else` into `:this.else` and let branch/type keywords
+    ;; masquerade as column references. Integration coverage can't distinguish filtered from
+    ;; unfiltered behavior because `:this` usually resolves to a model already in the expected set,
+    ;; so assert directly against the extractor.
+    (doseq [kw [:else :integer :float :%now :%foo]]
+      (testing kw
+        (is (= #{} (#'attr-expr-columns kw))
+            (str kw " should be filtered, not returned as a column reference"))))
+    (testing "filtering happens inside nested vector expressions too"
+      (is (= #{:other.flag :collection.id}
+             (#'attr-expr-columns [:case [:= :other.flag true] :collection.id :else :integer]))))
+    (testing "non-control keywords are still qualified to `:this`"
+      (is (= #{:this.foo} (#'attr-expr-columns :foo))))))
 
 (deftest collection-based-visibility-search-model-claims-verified-test
   (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -543,12 +543,33 @@
       (when idx
         (keyword (subs (name col) 0 idx))))))
 
+(defn- qualify-this
+  "Ensure `kw` is a dotted column-reference keyword. Bare column keywords are treated as belonging to
+  `:this`, mirroring `find-fields-kw` in `metabase.search.spec`."
+  [kw]
+  (if (column-alias kw)
+    kw
+    (keyword (str "this." (name kw)))))
+
+(defn- attr-seed-columns
+  "Return the set of dotted column-reference keywords to seed a trace from, given an `:attrs` attr
+  value. Handles the three shorthand forms accepted by the search spec:
+  - `true`: column with the attr's name in snake_case, qualified to `:this`
+  - keyword (bare or dotted): the referenced column
+  - vector expression: every column keyword referenced in its arguments"
+  [attr-key attr-val]
+  (cond
+    (true? attr-val)    #{(keyword (str "this." (u/->snake_case_en (name attr-key))))}
+    (keyword? attr-val) #{(qualify-this attr-val)}
+    (vector? attr-val)  (into #{} (comp (filter keyword?) (map qualify-this)) (rest attr-val))
+    :else               #{}))
+
 (defn- trace-collection-id-source-models
   "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
   `:this` resolves to the spec's own base model; other aliases resolve via `:joins`. A claim of
   `:denormalized-from X` is structurally sound iff `X` is in the returned set."
   [spec]
-  (let [attr-col     (get-in spec [:attrs :collection-id])
+  (let [seed-cols    (attr-seed-columns :collection-id (get-in spec [:attrs :collection-id]))
         joins        (:joins spec)
         alias->model (-> (into {} (map (fn [[alias [model _]]] [alias model])) joins)
                          (assoc :this (:model spec)))
@@ -560,7 +581,7 @@
                              {}
                              edges)
         reachable    (loop [visited #{}
-                            queue   [attr-col]]
+                            queue   (vec seed-cols)]
                        (if-let [col (first queue)]
                          (if (visited col)
                            (recur visited (rest queue))
@@ -596,7 +617,23 @@
              :attrs {:collection-id :collection.id}
              :joins {:collection [:model/Collection
                                   [:and [:= :this.is_published true]
-                                   [:= :collection.id :this.collection_id]]]}})))))
+                                   [:= :collection.id :this.collection_id]]]}}))))
+  (testing "normalizes shorthand `true` to `:this.<attr-name-in-snake-case>`"
+    ;; Mirrors the card/dashboard spec shape where `:collection-id true` means the direct column on
+    ;; the base model. Without this normalization the walk would start from `true` and reach nothing.
+    (is (= #{:model/Base :model/Collection}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id true}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}}))))
+  (testing "extracts referenced columns from a vector attr expression"
+    ;; A computed `:collection-id` — e.g. `[:coalesce :collection.id :this.collection_id]` — seeds
+    ;; the walk from every column keyword in the expression.
+    (is (= #{:model/Base :model/Collection}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id [:coalesce :collection.id :this.collection_id]}
+             :joins {:collection [:model/Collection [:= :collection.id :this.some_other_field]]}})))))
 
 (deftest collection-based-visibility-search-model-claims-verified-test
   (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -9,10 +9,9 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
-   [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -503,111 +502,28 @@
 
         (testing "memoizes permission check per collection_id across docs"
           (let [calls (atom 0)
-                real-can-read? mi/can-read?]
-            (with-redefs [mi/can-read? (fn [& args]
-                                         (swap! calls inc)
-                                         (apply real-can-read? args))]
+                real-helper perms/can-read-via-parent-collection?]
+            (with-redefs [perms/can-read-via-parent-collection? (fn [& args]
+                                                                  (swap! calls inc)
+                                                                  (apply real-helper args))]
               (binding [api/*current-user-permissions-set* (atom #{"/"})]
                 (#'semantic.index/filter-read-permitted
                  (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
-                (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
+                (is (= 1 @calls) "expected one can-read-via-parent-collection? call for the single distinct collection_id")))))
 
         (testing "handles empty input"
           (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
-(deftest filter-read-permitted-dispatch-test
-  (mt/with-premium-features #{:semantic-search}
-    (testing "fast path dispatches through the per-search-model t2 model"
-      (mt/with-temp [:model/Collection {coll-id :id} {}]
-        (binding [api/*current-user-permissions-set* (atom #{"/"})]
-
-          (testing "card and dashboard in the same collection do NOT share a memo bucket"
-            ;; Card dispatches through :model/Card, Dashboard through :model/Dashboard. Their
-            ;; `can-read?` answers happen to agree today (both route through
-            ;; `can-read-audit-helper` which ignores the model keyword for non-Collection models),
-            ;; but the dispatch MUST still hit each model's own defmethod so future divergence
-            ;; cannot silently ride on Card's semantics.
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (#'semantic.index/filter-read-permitted
-                 [{:id 1 :model "card" :collection_id coll-id}
-                  {:id 2 :model "dashboard" :collection_id coll-id}])
-                (is (= 2 @calls)
-                    "card and dashboard must dispatch separately even for the same collection_id"))))
-
-          (testing "card and indexed-entity share the :model/Card memo bucket"
-            ;; indexed-entity is deliberately routed through :model/Card — its index row's
-            ;; `collection_id` is the parent Card's, denormalized at ingest time.
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (#'semantic.index/filter-read-permitted
-                 [{:id 1   :model "card"            :collection_id coll-id}
-                  {:id "1:99" :model "indexed-entity" :collection_id coll-id}])
-                (is (= 1 @calls)
-                    "card and indexed-entity both dispatch through :model/Card and memoize together")))))))))
-
-;; The fast path in `filter-read-permitted` assumes every model listed in
-;; `collection-id-only-search-models` has a `mi/can-read?` whose result is fully determined by
-;; `:collection_id` + the current user's permissions set. This contract test catches drift in
-;; two directions:
-;;   1. A model is added to the set that doesn't actually satisfy the contract.
-;;   2. An existing model's `can-read?` grows a check on a field other than `:collection_id`
-;;      (e.g., `:archived`, `:type`, `:database_id`), silently making the fast path incorrect.
-;; If the set gains a new entry, add a spec here — the `keys` check below will fail otherwise.
-;; We vary the "should-be-irrelevant" fields across permutations so any new check in `can-read?`
-;; against such a field will flip at least one permutation away from the helper and fail the test.
-(def ^:private collection-id-only-model-test-specs
-  "Maps each entry in `collection-id-only-search-models` to the t2 model used for dispatch.
-  `indexed-entity` resolves to the parent Card at ingest time, so Card covers its contract."
-  {"card"           :model/Card
-   "metric"         :model/Card
-   "dataset"        :model/Card
-   "dashboard"      :model/Dashboard
-   "indexed-entity" :model/Card})
-
-(deftest collection-id-only-search-models-contract-test
-  (testing "every entry in `collection-id-only-search-models` has a matching test spec"
-    (is (= @#'semantic.index/collection-id-only-search-models
-           collection-id-only-model-test-specs)
-        "If you added/changed a model in `collection-id-only-search-models`, update `collection-id-only-model-test-specs` to match."))
-
-  (testing "mi/can-read? is a pure function of :collection_id for each listed model"
-    ;; Synthetic coll-ids chosen to align with the perm-set strings below. No DB involvement —
-    ;; the permission check only reads the instance map and the bound perm set.
-    (let [perm-scenarios [["root perms"                42  #{"/"}]
-                          ["no perms"                  42  #{}]
-                          ["read on matching coll"     42  #{"/collection/42/read/"}]
-                          ["read on other coll only"   42  #{"/collection/99/read/"}]
-                          ["nil collection with root"  nil #{"/"}]
-                          ["nil collection no perms"   nil #{}]]
-          ;; Extra fields on the synthetic instance. If `can-read?` stays collection_id-only,
-          ;; none of these should affect the result. A future `can-read?` that gates on any of
-          ;; them will diverge from the stub for at least one permutation.
-          extra-fields   [{}
-                          {:archived true}
-                          {:archived false}
-                          {:type :question}
-                          {:type :model}
-                          {:type :metric}
-                          {:database_id 1}
-                          {:dataset_query {}}]]
-      (doseq [[search-model t2-model] collection-id-only-model-test-specs
-              [label coll-id perms]   perm-scenarios
-              extras                  extra-fields]
-        (let [full-instance (t2/instance t2-model (assoc extras :collection_id coll-id))
-              stub-instance (t2/instance t2-model {:collection_id coll-id})]
-          (binding [api/*current-user-permissions-set* (atom perms)]
-            (let [slow-path (boolean (mi/can-read? full-instance))
-                  fast-path (boolean (mi/can-read? stub-instance))]
-              (is (= slow-path fast-path)
-                  (format "%s %s extras=%s: fast path=%s mi/can-read?=%s. If these disagree, `can-read?` likely depends on a field other than `:collection_id`, so removing this model from `collection-id-only-search-models` is required."
-                          search-model label extras fast-path slow-path)))))))))
+(deftest collection-id-only-search-models-derived-correctly-test
+  (testing "derived set includes every search-model whose t2 model is registered as collection-id-only, plus indexed-entity"
+    ;; Sanity smoke test: derivation machinery is working. If this fails, the registry
+    ;; probably isn't populating (namespace load order) or the search spec for one of these
+    ;; models lost its t2 model keyword.
+    (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
+           @@#'semantic.index/collection-id-only-search-models)
+        "The fast-path set is derived from `perms/collection-id-only-read-models` plus
+         indexed-entity. If you added `perms/define-collection-id-only-read-perms!` to a new
+         model (or removed it from an existing one), update this expected set.")))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -502,7 +502,7 @@
                         "only the doc whose denormalized collection_id is readable survives")))))))
 
         (testing "memoizes permission check per collection_id across docs"
-          (let [calls (atom 0)
+          (let [calls       (atom 0)
                 real-helper perms/can-read-via-parent-collection?]
             (with-redefs [perms/can-read-via-parent-collection? (fn [& args]
                                                                   (swap! calls inc)
@@ -516,25 +516,16 @@
           (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
 (deftest collection-id-only-search-models-derived-correctly-test
-  (testing "derived set includes every search-model whose t2 model is registered as collection-id-only, plus indexed-entity"
-    ;; Sanity smoke test: derivation machinery is working. If this fails, the registry
-    ;; probably isn't populating (namespace load order) or the search spec for one of these
-    ;; models lost its t2 model keyword.
+  (testing "derived set includes every collection-id-only search-model plus indexed-entity"
+    ;; Update the expected set when `define-collection-based-visibility!` is added to or removed from a model.
     (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
-           @@#'semantic.index/collection-id-only-search-models)
-        "The fast-path set is derived from `perms/collection-id-only-read-models` plus
-         indexed-entity. If you added `perms/define-collection-id-only-read-perms!` to a new
-         model (or removed it from an existing one), update this expected set.")))
+           @@#'semantic.index/collection-id-only-search-models))))
 
 (deftest collection-id-only-search-models-cold-start-regression-test
   (testing "derivation populates correctly even if registry is empty at first access"
-    ;; Regression guard: on cold start, the namespaces whose
-    ;; `perms/define-collection-id-only-read-perms!` calls populate the registry haven't
-    ;; loaded yet. The derivation relies on `search/specifications` (via its internal
-    ;; `t2/resolve-model`) to trigger those loads BEFORE reading the registry. If the order
-    ;; ever flips, the derivation would snapshot an empty registry and cache an incomplete
-    ;; set for the JVM lifetime. The existing smoke test above can't catch this because
-    ;; other tests have already loaded the model namespaces by the time it runs.
+    ;; The derivation must call `search/specifications` before reading the registry — `t2/resolve-model`
+    ;; inside `specifications` loads the model namespaces that populate the registry.
+    ;; If the order flips, cold start caches an empty set for the JVM lifetime.
     (let [real-specs    (var-get #'search/specifications)
           real-registry perms/collection-id-only-read-models
           specs-loaded? (atom false)]
@@ -546,13 +537,9 @@
                                                              (real-registry)
                                                              #{}))]
         (let [result (#'semantic.index/compute-collection-id-only-search-models)]
-          (is (contains? result "card")
-              "card must appear even when the registry is empty at first call — proves
-               `search/specifications` was called before the registry was read.")
-          (is (contains? result "dashboard")
-              "dashboard must appear even when the registry is empty at first call.")
-          (is (contains? result "indexed-entity")
-              "indexed-entity is always included."))))))
+          (is (contains? result "card"))
+          (is (contains? result "dashboard"))
+          (is (contains? result "indexed-entity")))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -521,21 +521,100 @@
     (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
            @@#'semantic.index/collection-id-only-search-models))))
 
+(defn- join-equality-pairs
+  "Return `[col-a col-b]` for every `[:= col-a col-b]` subform of `condition` where both sides are
+  column-reference keywords. Walks through compound conditions like `[:and ...]`."
+  [condition]
+  (->> (tree-seq sequential? seq condition)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (= := (first node))
+                      (= 3 (count node))
+                      (keyword? (nth node 1))
+                      (keyword? (nth node 2)))))
+       (map (fn [[_ a b]] [a b]))))
+
+(defn- column-alias
+  "Extract the `:alias` from a dotted column-reference keyword like `:alias.col`. Returns nil if the
+  keyword is not in `alias.col` form."
+  [col]
+  (when (keyword? col)
+    (let [idx (str/index-of (name col) \.)]
+      (when idx
+        (keyword (subs (name col) 0 idx))))))
+
+(defn- trace-collection-id-source-models
+  "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
+  `:this` resolves to the spec's own base model; other aliases resolve via `:joins`. A claim of
+  `:denormalized-from X` is structurally sound iff `X` is in the returned set."
+  [spec]
+  (let [attr-col     (get-in spec [:attrs :collection-id])
+        joins        (:joins spec)
+        alias->model (-> (into {} (map (fn [[alias [model _]]] [alias model])) joins)
+                         (assoc :this (:model spec)))
+        edges        (mapcat (fn [[_ [_ jcond]]] (join-equality-pairs jcond)) joins)
+        eq-map       (reduce (fn [m [a b]]
+                               (-> m
+                                   (update a (fnil conj #{}) b)
+                                   (update b (fnil conj #{}) a)))
+                             {}
+                             edges)
+        reachable    (loop [visited #{}
+                            queue   [attr-col]]
+                       (if-let [col (first queue)]
+                         (if (visited col)
+                           (recur visited (rest queue))
+                           (recur (conj visited col)
+                                  (into (vec (rest queue)) (eq-map col))))
+                         visited))]
+    (into #{} (keep (comp alias->model column-alias)) reachable)))
+
+(deftest trace-collection-id-source-models-test
+  (testing "traces `:collection-id` through `[:= a b]` equalities to every equivalent model"
+    ;; Mirrors the `indexed-entity` spec shape: `:collection-id` → `:collection.id`, which joins to
+    ;; `:model.collection_id`, so both :model/Collection and :model/Card are valid claims.
+    (is (= #{:model/Collection :model/Card}
+           (trace-collection-id-source-models
+            {:model :model/ModelIndexValue
+             :attrs {:collection-id :collection.id}
+             :joins {:model_index [:model/ModelIndex [:= :model_index.id :this.model_index_id]]
+                     :model       [:model/Card [:= :model.id :model_index.model_id]]
+                     :collection  [:model/Collection [:= :collection.id :model.collection_id]]}}))))
+  (testing "unrelated joins do not pollute the source set"
+    ;; A join for some other field must not count: `:table` is joined for display but `:collection.id`
+    ;; only resolves through `:this.collection_id`.
+    (is (= #{:model/Collection :model/Base}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id :collection.id}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
+                     :table      [:model/Table [:= :table.id :this.table_id]]}}))))
+  (testing "handles compound `:and` conditions"
+    (is (= #{:model/Collection :model/Base}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id :collection.id}
+             :joins {:collection [:model/Collection
+                                  [:and [:= :this.is_published true]
+                                   [:= :collection.id :this.collection_id]]]}})))))
+
 (deftest collection-based-visibility-search-model-claims-verified-test
-  (testing "every search-model registered with :denormalized-from actually joins to that model in its spec"
-    ;; Guards the `:denormalized-from` claim made at `define-collection-based-visibility!` call sites
-    ;; against drift: if someone removes the Card join from the `indexed-entity` spec (or typoes the
-    ;; claim), this test fails. Without this, the claim is documentation-only.
+  (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"
+    ;; Guards the `:denormalized-from` claim at `define-collection-based-visibility!` call sites against
+    ;; drift. We walk the join equality graph from `:collection-id` and require the claim to be a
+    ;; structural source — not merely any model mentioned in `:joins`. Without this, a stale claim can
+    ;; still pass if the model stays joined for an unrelated field.
     (let [specs (search/specifications)]
       (doseq [[search-model denormalized-from] (perms/collection-based-visibility-search-models)]
-        (testing (str search-model " denormalizes from " denormalized-from)
-          (let [spec          (get specs search-model)
-                joined-models (set (map first (vals (:joins spec))))]
+        (testing (str search-model " traces :collection-id to " denormalized-from)
+          (let [spec    (get specs search-model)
+                reached (trace-collection-id-source-models spec)]
             (is (some? spec)
                 (str "no search spec registered for " (pr-str search-model)))
-            (is (contains? joined-models denormalized-from)
+            (is (contains? reached denormalized-from)
                 (str (pr-str search-model) " claims :denormalized-from " (pr-str denormalized-from)
-                     " but its spec joins are " joined-models))))))))
+                     " but tracing :collection-id through its join equalities only reaches "
+                     reached))))))))
 
 (deftest collection-id-only-search-models-cold-start-regression-test
   (testing "derivation populates correctly even if registry is empty at first access"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -539,19 +539,25 @@
 
 (deftest collection-id-only-search-models-cold-start-regression-test
   (testing "derivation populates correctly even if registry is empty at first access"
-    ;; The derivation must call `search/specifications` before reading the registry — `t2/resolve-model`
-    ;; inside `specifications` loads the model namespaces that populate the registry.
-    ;; If the order flips, cold start caches an empty set for the JVM lifetime.
-    (let [real-specs    (var-get #'search/specifications)
-          real-registry perms/collection-id-only-read-models
-          specs-loaded? (atom false)]
+    ;; The derivation must call `search/specifications` before reading either registry — `t2/resolve-model`
+    ;; inside `specifications` loads the model namespaces that populate them.
+    ;; If the order flips, cold start caches an empty set for the JVM lifetime. Both the t2-model registry
+    ;; (card/metric/dataset/dashboard) and the search-model registry (indexed-entity) must be covered.
+    (let [real-specs          (var-get #'search/specifications)
+          real-t2-registry    perms/collection-id-only-read-models
+          real-search-registry perms/collection-based-visibility-search-models
+          specs-loaded?       (atom false)]
       (with-redefs [search/specifications (fn []
                                             (reset! specs-loaded? true)
                                             (real-specs))
                     perms/collection-id-only-read-models (fn []
                                                            (if @specs-loaded?
-                                                             (real-registry)
-                                                             #{}))]
+                                                             (real-t2-registry)
+                                                             #{}))
+                    perms/collection-based-visibility-search-models (fn []
+                                                                      (if @specs-loaded?
+                                                                        (real-search-registry)
+                                                                        {}))]
         (let [result (#'semantic.index/compute-collection-id-only-search-models)]
           (is (contains? result "card"))
           (is (contains? result "dashboard"))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -521,6 +521,22 @@
     (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
            @@#'semantic.index/collection-id-only-search-models))))
 
+(deftest collection-based-visibility-search-model-claims-verified-test
+  (testing "every search-model registered with :denormalized-from actually joins to that model in its spec"
+    ;; Guards the `:denormalized-from` claim made at `define-collection-based-visibility!` call sites
+    ;; against drift: if someone removes the Card join from the `indexed-entity` spec (or typoes the
+    ;; claim), this test fails. Without this, the claim is documentation-only.
+    (let [specs (search/specifications)]
+      (doseq [[search-model denormalized-from] (perms/collection-based-visibility-search-models)]
+        (testing (str search-model " denormalizes from " denormalized-from)
+          (let [spec          (get specs search-model)
+                joined-models (set (map first (vals (:joins spec))))]
+            (is (some? spec)
+                (str "no search spec registered for " (pr-str search-model)))
+            (is (contains? joined-models denormalized-from)
+                (str (pr-str search-model) " claims :denormalized-from " (pr-str denormalized-from)
+                     " but its spec joins are " joined-models))))))))
+
 (deftest collection-id-only-search-models-cold-start-regression-test
   (testing "derivation populates correctly even if registry is empty at first access"
     ;; The derivation must call `search/specifications` before reading the registry — `t2/resolve-model`

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.spec-trace-test-util :as spec-trace]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
@@ -521,177 +522,6 @@
     (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
            @@#'semantic.index/collection-id-only-search-models))))
 
-(defn- join-equality-pairs
-  "Return `[col-a col-b]` for every `[:= col-a col-b]` subform of `condition` where both sides are
-  column-reference keywords. Walks through compound conditions like `[:and ...]`."
-  [condition]
-  (->> (tree-seq sequential? seq condition)
-       (filter (fn [node]
-                 (and (vector? node)
-                      (= := (first node))
-                      (= 3 (count node))
-                      (keyword? (nth node 1))
-                      (keyword? (nth node 2)))))
-       (map (fn [[_ a b]] [a b]))))
-
-(defn- column-alias
-  "Extract the `:alias` from a dotted column-reference keyword like `:alias.col`. Returns nil if the
-  keyword is not in `alias.col` form."
-  [col]
-  (when (keyword? col)
-    (let [idx (str/index-of (name col) \.)]
-      (when idx
-        (keyword (subs (name col) 0 idx))))))
-
-(defn- qualify-this
-  "Ensure `kw` is a dotted column-reference keyword. Bare column keywords are treated as belonging to
-  `:this`, mirroring `find-fields-kw` in `metabase.search.spec`."
-  [kw]
-  (if (column-alias kw)
-    kw
-    (keyword (str "this." (name kw)))))
-
-(defn- attr-expr-columns
-  "Recursively extract the set of dotted column-reference keywords referenced in an `:attrs`
-  expression, mirroring `find-fields-expr`/`find-fields-kw` in `metabase.search.spec`. Descends
-  into nested vectors and `{:fields ...}` maps, and filters out SQL-function/control keywords
-  (`:else`, `:integer`, `:float`, `%...`)."
-  [expr]
-  (cond
-    (keyword? expr)
-    (if (or (str/starts-with? (name expr) "%")
-            (#{:else :integer :float} expr))
-      #{}
-      #{(qualify-this expr)})
-
-    (and (vector? expr) (> (count expr) 1))
-    (into #{} (mapcat attr-expr-columns) (subvec expr 1))
-
-    (and (map? expr) (:fields expr))
-    (into #{} (mapcat attr-expr-columns) (:fields expr))
-
-    :else #{}))
-
-(defn- attr-seed-columns
-  "Return the set of dotted column-reference keywords to seed a trace from, given an `:attrs` attr
-  value. Mirrors the shorthand expansion in `metabase.search.spec`:
-  - `true`: column with the attr's name in snake_case, qualified to `:this`
-  - keyword, vector expression, or `{:fields ...}` map: recursively collected via
-    `attr-expr-columns`, matching `find-fields-expr` semantics"
-  [attr-key attr-val]
-  (if (true? attr-val)
-    #{(keyword (str "this." (u/->snake_case_en (name attr-key))))}
-    (attr-expr-columns attr-val)))
-
-(defn- trace-collection-id-source-models
-  "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
-  `:this` resolves to the spec's own base model; other aliases resolve via `:joins`. A claim of
-  `:denormalized-from X` is structurally sound iff `X` is in the returned set."
-  [spec]
-  (let [seed-cols    (attr-seed-columns :collection-id (get-in spec [:attrs :collection-id]))
-        joins        (:joins spec)
-        alias->model (-> (into {} (map (fn [[alias [model _]]] [alias model])) joins)
-                         (assoc :this (:model spec)))
-        edges        (mapcat (fn [[_ [_ jcond]]] (join-equality-pairs jcond)) joins)
-        eq-map       (reduce (fn [m [a b]]
-                               (-> m
-                                   (update a (fnil conj #{}) b)
-                                   (update b (fnil conj #{}) a)))
-                             {}
-                             edges)
-        reachable    (loop [visited #{}
-                            queue   (vec seed-cols)]
-                       (if-let [col (first queue)]
-                         (if (visited col)
-                           (recur visited (rest queue))
-                           (recur (conj visited col)
-                                  (into (vec (rest queue)) (eq-map col))))
-                         visited))]
-    (into #{} (keep (comp alias->model column-alias)) reachable)))
-
-(deftest trace-collection-id-source-models-test
-  (testing "traces `:collection-id` through `[:= a b]` equalities to every equivalent model"
-    ;; Mirrors the `indexed-entity` spec shape: `:collection-id` → `:collection.id`, which joins to
-    ;; `:model.collection_id`, so both :model/Collection and :model/Card are valid claims.
-    (is (= #{:model/Collection :model/Card}
-           (trace-collection-id-source-models
-            {:model :model/ModelIndexValue
-             :attrs {:collection-id :collection.id}
-             :joins {:model_index [:model/ModelIndex [:= :model_index.id :this.model_index_id]]
-                     :model       [:model/Card [:= :model.id :model_index.model_id]]
-                     :collection  [:model/Collection [:= :collection.id :model.collection_id]]}}))))
-  (testing "unrelated joins do not pollute the source set"
-    ;; A join for some other field must not count: `:table` is joined for display but `:collection.id`
-    ;; only resolves through `:this.collection_id`.
-    (is (= #{:model/Collection :model/Base}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id :collection.id}
-             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
-                     :table      [:model/Table [:= :table.id :this.table_id]]}}))))
-  (testing "handles compound `:and` conditions"
-    (is (= #{:model/Collection :model/Base}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id :collection.id}
-             :joins {:collection [:model/Collection
-                                  [:and [:= :this.is_published true]
-                                   [:= :collection.id :this.collection_id]]]}}))))
-  (testing "normalizes shorthand `true` to `:this.<attr-name-in-snake-case>`"
-    ;; Mirrors the card/dashboard spec shape where `:collection-id true` means the direct column on
-    ;; the base model. Without this normalization the walk would start from `true` and reach nothing.
-    (is (= #{:model/Base :model/Collection}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id true}
-             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}}))))
-  (testing "extracts referenced columns from a vector attr expression"
-    ;; A computed `:collection-id` seeds the walk from every column keyword in the expression.
-    ;; The fixture is shaped so each referenced column reaches a distinct model: without extracting
-    ;; `:collection.id` the walk misses `:model/Collection`, and without extracting `:other.foo` it
-    ;; misses `:model/Other`. A regression that only seeded from the first column would fail.
-    (is (= #{:model/Base :model/Collection :model/Other}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id [:coalesce :collection.id :other.foo]}
-             :joins {:collection [:model/Collection [:= :collection.id :this.c]]
-                     :other      [:model/Other [:= :other.foo :this.o]]}}))))
-  (testing "recurses into nested vector expressions"
-    ;; Mirrors `find-fields-expr`: a `:case` form contains a nested `[:= ...]` predicate plus a
-    ;; direct branch keyword. The recursive walk must pull column refs out of the nested predicate —
-    ;; if it didn't descend, `:other.flag` would never seed the walk and `:model/Other` would be
-    ;; missing from the reachable set.
-    (is (= #{:model/Base :model/Collection :model/Other}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id [:case [:= :other.flag true] :collection.id :this.collection_id]}
-             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
-                     :other      [:model/Other [:= :other.flag :this.other_flag]]}}))))
-  (testing "descends into `{:fn ... :fields [...]}` attr maps"
-    ;; The search spec allows `{:fn f :fields [:a :b]}` attr values; `find-fields-expr` descends
-    ;; into `:fields`. The test helper must do the same.
-    (is (= #{:model/Base :model/Collection}
-           (trace-collection-id-source-models
-            {:model :model/Base
-             :attrs {:collection-id {:fn identity :fields [:collection.id]}}
-             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}})))))
-
-(deftest attr-expr-columns-skips-control-keywords-test
-  (testing "control and SQL-function keywords are dropped instead of being qualified to `:this.<kw>`"
-    ;; `qualify-this` would otherwise turn `:else` into `:this.else` and let branch/type keywords
-    ;; masquerade as column references. Integration coverage can't distinguish filtered from
-    ;; unfiltered behavior because `:this` usually resolves to a model already in the expected set,
-    ;; so assert directly against the extractor.
-    (doseq [kw [:else :integer :float :%now :%foo]]
-      (testing kw
-        (is (= #{} (#'attr-expr-columns kw))
-            (str kw " should be filtered, not returned as a column reference"))))
-    (testing "filtering happens inside nested vector expressions too"
-      (is (= #{:other.flag :collection.id}
-             (#'attr-expr-columns [:case [:= :other.flag true] :collection.id :else :integer]))))
-    (testing "non-control keywords are still qualified to `:this`"
-      (is (= #{:this.foo} (#'attr-expr-columns :foo))))))
-
 (deftest collection-based-visibility-search-model-claims-verified-test
   (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"
     ;; Guards the `:denormalized-from` claim at `define-collection-based-visibility!` call sites against
@@ -702,7 +532,7 @@
       (doseq [[search-model denormalized-from] (perms/collection-based-visibility-search-models)]
         (testing (str search-model " traces :collection-id to " denormalized-from)
           (let [spec    (get specs search-model)
-                reached (trace-collection-id-source-models spec)]
+                reached (spec-trace/trace-collection-id-source-models spec)]
             (is (some? spec)
                 (str "no search spec registered for " (pr-str search-model)))
             (is (contains? reached denormalized-from)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -551,18 +551,37 @@
     kw
     (keyword (str "this." (name kw)))))
 
+(defn- attr-expr-columns
+  "Recursively extract the set of dotted column-reference keywords referenced in an `:attrs`
+  expression, mirroring `find-fields-expr`/`find-fields-kw` in `metabase.search.spec`. Descends
+  into nested vectors and `{:fields ...}` maps, and filters out SQL-function/control keywords
+  (`:else`, `:integer`, `:float`, `%...`)."
+  [expr]
+  (cond
+    (keyword? expr)
+    (if (or (str/starts-with? (name expr) "%")
+            (#{:else :integer :float} expr))
+      #{}
+      #{(qualify-this expr)})
+
+    (and (vector? expr) (> (count expr) 1))
+    (into #{} (mapcat attr-expr-columns) (subvec expr 1))
+
+    (and (map? expr) (:fields expr))
+    (into #{} (mapcat attr-expr-columns) (:fields expr))
+
+    :else #{}))
+
 (defn- attr-seed-columns
   "Return the set of dotted column-reference keywords to seed a trace from, given an `:attrs` attr
-  value. Handles the three shorthand forms accepted by the search spec:
+  value. Mirrors the shorthand expansion in `metabase.search.spec`:
   - `true`: column with the attr's name in snake_case, qualified to `:this`
-  - keyword (bare or dotted): the referenced column
-  - vector expression: every column keyword referenced in its arguments"
+  - keyword, vector expression, or `{:fields ...}` map: recursively collected via
+    `attr-expr-columns`, matching `find-fields-expr` semantics"
   [attr-key attr-val]
-  (cond
-    (true? attr-val)    #{(keyword (str "this." (u/->snake_case_en (name attr-key))))}
-    (keyword? attr-val) #{(qualify-this attr-val)}
-    (vector? attr-val)  (into #{} (comp (filter keyword?) (map qualify-this)) (rest attr-val))
-    :else               #{}))
+  (if (true? attr-val)
+    #{(keyword (str "this." (u/->snake_case_en (name attr-key))))}
+    (attr-expr-columns attr-val)))
 
 (defn- trace-collection-id-source-models
   "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
@@ -627,13 +646,34 @@
              :attrs {:collection-id true}
              :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}}))))
   (testing "extracts referenced columns from a vector attr expression"
-    ;; A computed `:collection-id` — e.g. `[:coalesce :collection.id :this.collection_id]` — seeds
-    ;; the walk from every column keyword in the expression.
+    ;; A computed `:collection-id` seeds the walk from every column keyword in the expression.
+    ;; The fixture is shaped so each referenced column reaches a distinct model: without extracting
+    ;; `:collection.id` the walk misses `:model/Collection`, and without extracting `:other.foo` it
+    ;; misses `:model/Other`. A regression that only seeded from the first column would fail.
+    (is (= #{:model/Base :model/Collection :model/Other}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id [:coalesce :collection.id :other.foo]}
+             :joins {:collection [:model/Collection [:= :collection.id :this.c]]
+                     :other      [:model/Other [:= :other.foo :this.o]]}}))))
+  (testing "recurses into nested vector expressions and skips control keywords"
+    ;; Mirrors `find-fields-expr`: a `:case` form contains a nested `[:= ...]` predicate plus
+    ;; branch keywords. The recursive walk must pull column refs out of the nested predicate and
+    ;; must not treat `:else` as a column.
+    (is (= #{:model/Base :model/Collection :model/Other}
+           (trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id [:case [:= :other.flag true] :collection.id :else :this.collection_id]}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
+                     :other      [:model/Other [:= :other.flag :this.other_flag]]}}))))
+  (testing "descends into `{:fn ... :fields [...]}` attr maps"
+    ;; The search spec allows `{:fn f :fields [:a :b]}` attr values; `find-fields-expr` descends
+    ;; into `:fields`. The test helper must do the same.
     (is (= #{:model/Base :model/Collection}
            (trace-collection-id-source-models
             {:model :model/Base
-             :attrs {:collection-id [:coalesce :collection.id :this.collection_id]}
-             :joins {:collection [:model/Collection [:= :collection.id :this.some_other_field]]}})))))
+             :attrs {:collection-id {:fn identity :fields [:collection.id]}}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}})))))
 
 (deftest collection-based-visibility-search-model-claims-verified-test
   (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -10,6 +10,7 @@
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
+   [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -524,6 +525,34 @@
         "The fast-path set is derived from `perms/collection-id-only-read-models` plus
          indexed-entity. If you added `perms/define-collection-id-only-read-perms!` to a new
          model (or removed it from an existing one), update this expected set.")))
+
+(deftest collection-id-only-search-models-cold-start-regression-test
+  (testing "derivation populates correctly even if registry is empty at first access"
+    ;; Regression guard: on cold start, the namespaces whose
+    ;; `perms/define-collection-id-only-read-perms!` calls populate the registry haven't
+    ;; loaded yet. The derivation relies on `search/specifications` (via its internal
+    ;; `t2/resolve-model`) to trigger those loads BEFORE reading the registry. If the order
+    ;; ever flips, the derivation would snapshot an empty registry and cache an incomplete
+    ;; set for the JVM lifetime. The existing smoke test above can't catch this because
+    ;; other tests have already loaded the model namespaces by the time it runs.
+    (let [real-specs    (var-get #'search/specifications)
+          real-registry perms/collection-id-only-read-models
+          specs-loaded? (atom false)]
+      (with-redefs [search/specifications (fn []
+                                            (reset! specs-loaded? true)
+                                            (real-specs))
+                    perms/collection-id-only-read-models (fn []
+                                                           (if @specs-loaded?
+                                                             (real-registry)
+                                                             #{}))]
+        (let [result (#'semantic.index/compute-collection-id-only-search-models)]
+          (is (contains? result "card")
+              "card must appear even when the registry is empty at first call — proves
+               `search/specifications` was called before the registry was read.")
+          (is (contains? result "dashboard")
+              "dashboard must appear even when the registry is empty at first call.")
+          (is (contains? result "indexed-entity")
+              "indexed-entity is always included."))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -589,6 +589,11 @@
     ;; silently gaining incorrect read semantics.
     (let [specs                (search/specifications)
           registered-t2-models (perms/collection-id-only-read-models)]
+      ;; Guard against a vacuous pass: if the registry is empty the `:when` filter below matches nothing
+      ;; and the only assertion never runs. A future refactor that breaks registry population should fail
+      ;; here rather than silently no-op.
+      (is (seq registered-t2-models)
+          "registry must be populated by search/specifications")
       (doseq [[search-model spec] specs
               :let [t2-model (:model spec)]
               :when (contains? registered-t2-models t2-model)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -577,6 +577,28 @@
                      " but tracing :collection-id through its join equalities only reaches "
                      reached))))))))
 
+(deftest keyword-form-derived-search-models-trace-to-own-model-test
+  (testing "every keyword-form-derived search-model denormalizes :collection_id from its own t2-model"
+    ;; The string form of `define-collection-based-visibility!` carries an explicit `:denormalized-from`
+    ;; claim verified above. The keyword form has no such claim: sibling specs like "dataset"/"metric"
+    ;; are swept into the fast path purely because their `:model` is a registered t2-model. The fast path
+    ;; checks `can-read-via-parent-collection?` against the index row's `:collection_id`, so this is only
+    ;; correct if the spec's `:collection-id` is its own collection. Assert that structurally — tracing
+    ;; `:collection-id` through join equalities must reach the spec's own registered t2-model — so a future
+    ;; sibling sourcing `:collection-id` from a join (a different collection) fails here instead of
+    ;; silently gaining incorrect read semantics.
+    (let [specs                (search/specifications)
+          registered-t2-models (perms/collection-id-only-read-models)]
+      (doseq [[search-model spec] specs
+              :let [t2-model (:model spec)]
+              :when (contains? registered-t2-models t2-model)]
+        (testing (str search-model " traces :collection-id to its own model " t2-model)
+          (let [reached (spec-trace/trace-collection-id-source-models spec)]
+            (is (contains? reached t2-model)
+                (str (pr-str search-model) " is derived into the fast path via its registered t2-model "
+                     (pr-str t2-model) " but tracing :collection-id through its join equalities only reaches "
+                     reached " — its denormalized :collection_id is not its own collection"))))))))
+
 (deftest collection-id-only-search-models-cold-start-regression-test
   (testing "derivation populates correctly even if registry is empty at first access"
     ;; The derivation must call `search/specifications` before reading either registry — `t2/resolve-model`

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -8,11 +8,13 @@
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
+   [metabase-enterprise.semantic-search.spec-trace-test-util :as spec-trace]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
-   [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
+   [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.util :as u])
   (:import
@@ -508,80 +510,98 @@
                  (#'semantic.index/batch-resolve-personal-owner-ids
                   [user1-personal-coll-id user2-sub-coll-id shared-coll-id nil]))))))))
 
-(deftest filter-read-permitted-indexed-entity-test
+(deftest filter-read-permitted-fast-path-test
   (mt/with-premium-features #{:semantic-search}
-    (testing "filter-read-permitted routes indexed-entity docs through the collection_id-only fast path"
+    (testing "filter-read-permitted routes collection-id-only models through the fast path"
       (mt/with-temp [:model/Collection {readable-coll-id :id} {}
                      :model/Collection {unreadable-coll-id :id} {}]
-        (let [indexed-entity-docs [{:id "1:123"
-                                    :model "indexed-entity"
-                                    :collection_id readable-coll-id}
-                                   {:id "2:456"
-                                    :model "indexed-entity"
-                                    :collection_id unreadable-coll-id}
-                                   {:id "3:789"
-                                    :model "indexed-entity"
-                                    :collection_id nil}]]
-          (testing "keeps all entities when user has root permissions"
-            (binding [api/*current-user-permissions-set* (atom #{"/"})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 3 (count result))))))
-          (testing "drops all entities when user has no permissions"
-            (binding [api/*current-user-permissions-set* (atom #{})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 0 (count result))))))
-          (testing "keeps only entities in readable collections"
-            (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 1 (count result)))
-                (is (= "1:123" (:id (first result)))))))
-          (testing "memoizes permission check per collection_id across docs"
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                  (#'semantic.index/filter-read-permitted
-                   (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
-                  (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
-          (testing "handles empty input"
-            (is (= [] (#'semantic.index/filter-read-permitted [])))))))))
+        (testing "indexed-entity docs are filtered by denormalized :collection_id"
+          (let [docs [{:id "1:123" :model "indexed-entity" :collection_id readable-coll-id}
+                      {:id "2:456" :model "indexed-entity" :collection_id unreadable-coll-id}
+                      {:id "3:789" :model "indexed-entity" :collection_id nil}]]
+            (testing "keeps all entities when user has root permissions"
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (is (= 3 (count (#'semantic.index/filter-read-permitted docs))))))
+            (testing "drops all entities when user has no permissions"
+              (binding [api/*current-user-permissions-set* (atom #{})]
+                (is (= 0 (count (#'semantic.index/filter-read-permitted docs))))))
+            (testing "keeps only entities in readable collections"
+              (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                (let [result (#'semantic.index/filter-read-permitted docs)]
+                  (is (= 1 (count result)))
+                  (is (= "1:123" (:id (first result)))))))))
+        (testing "card/metric/dataset/dashboard docs use the same fast path"
+          (doseq [model ["card" "metric" "dataset" "dashboard"]]
+            (testing (str "model=" model)
+              (let [docs [{:id 1 :model model :collection_id readable-coll-id}
+                          {:id 2 :model model :collection_id unreadable-coll-id}
+                          {:id 3 :model model :collection_id nil}]]
+                (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                  (let [result (#'semantic.index/filter-read-permitted docs)]
+                    (is (= [1] (map :id result))
+                        "only the doc whose denormalized collection_id is readable survives")))))))
+        (testing "memoizes permission check per collection_id across docs"
+          (let [calls       (atom 0)
+                real-helper perms/can-read-via-parent-collection?]
+            (with-redefs [perms/can-read-via-parent-collection? (fn [& args]
+                                                                  (swap! calls inc)
+                                                                  (apply real-helper args))]
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (#'semantic.index/filter-read-permitted
+                 (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
+                (is (= 1 @calls) "expected one can-read-via-parent-collection? call for the single distinct collection_id")))))
+        (testing "handles empty input"
+          (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
-(deftest filter-read-permitted-dispatch-test
-  (mt/with-premium-features #{:semantic-search}
-    (testing "fast path dispatches through the per-search-model t2 model"
-      (mt/with-temp [:model/Collection {coll-id :id} {}]
-        (binding [api/*current-user-permissions-set* (atom #{"/"})]
-          (testing "card and dashboard in the same collection do NOT share a memo bucket"
-            ;; Card dispatches through :model/Card, Dashboard through :model/Dashboard. Their
-            ;; `can-read?` answers happen to agree today (both route through
-            ;; `can-read-audit-helper` which ignores the model keyword for non-Collection models),
-            ;; but the dispatch MUST still hit each model's own defmethod so future divergence
-            ;; cannot silently ride on Card's semantics.
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (#'semantic.index/filter-read-permitted
-                 [{:id 1 :model "card" :collection_id coll-id}
-                  {:id 2 :model "dashboard" :collection_id coll-id}])
-                (is (= 2 @calls)
-                    "card and dashboard must dispatch separately even for the same collection_id"))))
-          (testing "card and indexed-entity share the :model/Card memo bucket"
-            ;; indexed-entity is deliberately routed through :model/Card — its index row's
-            ;; `collection_id` is the parent Card's, denormalized at ingest time.
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (#'semantic.index/filter-read-permitted
-                 [{:id 1   :model "card"            :collection_id coll-id}
-                  {:id "1:99" :model "indexed-entity" :collection_id coll-id}])
-                (is (= 1 @calls)
-                    "card and indexed-entity both dispatch through :model/Card and memoize together")))))))))
+(deftest collection-id-only-search-models-derived-correctly-test
+  (testing "derived set includes every collection-id-only search-model plus indexed-entity"
+    ;; Update the expected set when `define-collection-based-visibility!` is added to or removed from a model.
+    (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
+           @@#'semantic.index/collection-id-only-search-models))))
+
+(deftest collection-based-visibility-search-model-claims-verified-test
+  (testing "every search-model registered with :denormalized-from traces to that model from :collection-id"
+    ;; Guards the `:denormalized-from` claim at `define-collection-based-visibility!` call sites against
+    ;; drift. We walk the join equality graph from `:collection-id` and require the claim to be a
+    ;; structural source — not merely any model mentioned in `:joins`. Without this, a stale claim can
+    ;; still pass if the model stays joined for an unrelated field.
+    (let [specs (search/specifications)]
+      (doseq [[search-model denormalized-from] (perms/collection-based-visibility-search-models)]
+        (testing (str search-model " traces :collection-id to " denormalized-from)
+          (let [spec    (get specs search-model)
+                reached (spec-trace/trace-collection-id-source-models spec)]
+            (is (some? spec)
+                (str "no search spec registered for " (pr-str search-model)))
+            (is (contains? reached denormalized-from)
+                (str (pr-str search-model) " claims :denormalized-from " (pr-str denormalized-from)
+                     " but tracing :collection-id through its join equalities only reaches "
+                     reached))))))))
+
+(deftest collection-id-only-search-models-cold-start-regression-test
+  (testing "derivation populates correctly even if registry is empty at first access"
+    ;; The derivation must call `search/specifications` before reading either registry — `t2/resolve-model`
+    ;; inside `specifications` loads the model namespaces that populate them.
+    ;; If the order flips, cold start caches an empty set for the JVM lifetime. Both the t2-model registry
+    ;; (card/metric/dataset/dashboard) and the search-model registry (indexed-entity) must be covered.
+    (let [real-specs          (var-get #'search/specifications)
+          real-t2-registry    perms/collection-id-only-read-models
+          real-search-registry perms/collection-based-visibility-search-models
+          specs-loaded?       (atom false)]
+      (with-redefs [search/specifications (fn []
+                                            (reset! specs-loaded? true)
+                                            (real-specs))
+                    perms/collection-id-only-read-models (fn []
+                                                           (if @specs-loaded?
+                                                             (real-t2-registry)
+                                                             #{}))
+                    perms/collection-based-visibility-search-models (fn []
+                                                                      (if @specs-loaded?
+                                                                        (real-search-registry)
+                                                                        {}))]
+        (let [result (#'semantic.index/compute-collection-id-only-search-models)]
+          (is (contains? result "card"))
+          (is (contains? result "dashboard"))
+          (is (contains? result "indexed-entity")))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util.clj
@@ -1,0 +1,94 @@
+(ns metabase-enterprise.semantic-search.spec-trace-test-util
+  "Helpers for walking `metabase.search.spec` shapes in tests — used to verify structural claims
+  like `:denormalized-from` against the actual join-equality graph of a spec."
+  (:require
+   [clojure.string :as str]
+   [metabase.util :as u]))
+
+(defn- join-equality-pairs
+  "Return `[col-a col-b]` for every `[:= col-a col-b]` subform of `condition` where both sides are
+  column-reference keywords. Walks through compound conditions like `[:and ...]`."
+  [condition]
+  (->> (tree-seq sequential? seq condition)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (= := (first node))
+                      (= 3 (count node))
+                      (keyword? (nth node 1))
+                      (keyword? (nth node 2)))))
+       (map (fn [[_ a b]] [a b]))))
+
+(defn- column-alias
+  "Extract the `:alias` from a dotted column-reference keyword like `:alias.col`. Returns nil if the
+  keyword is not in `alias.col` form."
+  [col]
+  (when (keyword? col)
+    (let [idx (str/index-of (name col) \.)]
+      (when idx
+        (keyword (subs (name col) 0 idx))))))
+
+(defn- qualify-this
+  "Ensure `kw` is a dotted column-reference keyword. Bare column keywords are treated as belonging to
+  `:this`, mirroring `find-fields-kw` in `metabase.search.spec`."
+  [kw]
+  (if (column-alias kw)
+    kw
+    (keyword (str "this." (name kw)))))
+
+(defn attr-expr-columns
+  "Recursively extract the set of dotted column-reference keywords referenced in an `:attrs`
+  expression, mirroring `find-fields-expr`/`find-fields-kw` in `metabase.search.spec`. Descends
+  into nested vectors and `{:fields ...}` maps, and filters out SQL-function/control keywords
+  (`:else`, `:integer`, `:float`, `%...`)."
+  [expr]
+  (cond
+    (keyword? expr)
+    (if (or (str/starts-with? (name expr) "%")
+            (#{:else :integer :float} expr))
+      #{}
+      #{(qualify-this expr)})
+
+    (and (vector? expr) (> (count expr) 1))
+    (into #{} (mapcat attr-expr-columns) (subvec expr 1))
+
+    (and (map? expr) (:fields expr))
+    (into #{} (mapcat attr-expr-columns) (:fields expr))
+
+    :else #{}))
+
+(defn- attr-seed-columns
+  "Return the set of dotted column-reference keywords to seed a trace from, given an `:attrs` attr
+  value. Mirrors the shorthand expansion in `metabase.search.spec`:
+  - `true`: column with the attr's name in snake_case, qualified to `:this`
+  - keyword, vector expression, or `{:fields ...}` map: recursively collected via
+    `attr-expr-columns`, matching `find-fields-expr` semantics"
+  [attr-key attr-val]
+  (if (true? attr-val)
+    #{(keyword (str "this." (u/->snake_case_en (name attr-key))))}
+    (attr-expr-columns attr-val)))
+
+(defn trace-collection-id-source-models
+  "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
+  `:this` resolves to the spec's own base model; other aliases resolve via `:joins`. A claim of
+  `:denormalized-from X` is structurally sound iff `X` is in the returned set."
+  [spec]
+  (let [seed-cols    (attr-seed-columns :collection-id (get-in spec [:attrs :collection-id]))
+        joins        (:joins spec)
+        alias->model (-> (into {} (map (fn [[alias [model _]]] [alias model])) joins)
+                         (assoc :this (:model spec)))
+        edges        (mapcat (fn [[_ [_ jcond]]] (join-equality-pairs jcond)) joins)
+        eq-map       (reduce (fn [m [a b]]
+                               (-> m
+                                   (update a (fnil conj #{}) b)
+                                   (update b (fnil conj #{}) a)))
+                             {}
+                             edges)
+        reachable    (loop [visited #{}
+                            queue   (vec seed-cols)]
+                       (if-let [col (first queue)]
+                         (if (visited col)
+                           (recur visited (rest queue))
+                           (recur (conj visited col)
+                                  (into (vec (rest queue)) (eq-map col))))
+                         visited))]
+    (into #{} (keep (comp alias->model column-alias)) reachable)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util.clj
@@ -1,0 +1,65 @@
+(ns metabase-enterprise.semantic-search.spec-trace-test-util
+  "Helpers for walking `metabase.search.spec` shapes in tests — used to verify structural claims
+  like `:denormalized-from` against the actual join-equality graph of a spec."
+  (:require
+   [clojure.string :as str]
+   [metabase.search.spec :as search.spec]))
+
+(defn- join-equality-pairs
+  "Return `[col-a col-b]` for every `[:= col-a col-b]` subform of `condition` where both sides are
+  column-reference keywords. Walks through compound conditions like `[:and ...]`."
+  [condition]
+  (->> (tree-seq sequential? seq condition)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (= := (first node))
+                      (= 3 (count node))
+                      (keyword? (nth node 1))
+                      (keyword? (nth node 2)))))
+       (map (fn [[_ a b]] [a b]))))
+
+(defn- column-alias
+  "Extract the `:alias` from a dotted column-reference keyword like `:alias.col`. Returns nil if the
+  keyword is not in `alias.col` form."
+  [col]
+  (when (keyword? col)
+    (let [idx (str/index-of (name col) \.)]
+      (when idx
+        (keyword (subs (name col) 0 idx))))))
+
+(defn- attr-seed-columns
+  "Qualified `:alias.col` columns that `:attrs` entry `attr-key`/`attr-val` references, to seed a trace."
+  [attr-key attr-val]
+  ;; Delegate to the indexer's own extractor so the seed grammar (`true` shorthand, nested
+  ;; vector/`{:fields ...}` exprs, SQL-function/control-keyword filtering) can't drift from what the index
+  ;; reads. `find-fields-attr` yields `[alias col]` pairs (`:this` = base model); re-qualify to the
+  ;; `:alias.col` keywords used in `:joins`.
+  (into #{}
+        (map (fn [[alias col]] (keyword (str (name alias) "." (name col)))))
+        (persistent! (#'search.spec/find-fields-attr (transient []) attr-key attr-val))))
+
+(defn trace-collection-id-source-models
+  "Return t2-model keywords reachable from the spec's `:collection-id` attribute via join equalities.
+  `:this` resolves to the spec's own base model; other aliases resolve via `:joins`. A claim of
+  `:denormalized-from X` is structurally sound iff `X` is in the returned set."
+  [spec]
+  (let [seed-cols    (attr-seed-columns :collection-id (get-in spec [:attrs :collection-id]))
+        joins        (:joins spec)
+        alias->model (-> (into {} (map (fn [[alias [model _]]] [alias model])) joins)
+                         (assoc :this (:model spec)))
+        edges        (mapcat (fn [[_ [_ jcond]]] (join-equality-pairs jcond)) joins)
+        eq-map       (reduce (fn [m [a b]]
+                               (-> m
+                                   (update a (fnil conj #{}) b)
+                                   (update b (fnil conj #{}) a)))
+                             {}
+                             edges)
+        reachable    (loop [visited #{}
+                            queue   (vec seed-cols)]
+                       (if-let [col (first queue)]
+                         (if (visited col)
+                           (recur visited (rest queue))
+                           (recur (conj visited col)
+                                  (into (vec (rest queue)) (eq-map col))))
+                         visited))]
+    (into #{} (keep (comp alias->model column-alias)) reachable)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util_test.clj
@@ -1,0 +1,87 @@
+(ns metabase-enterprise.semantic-search.spec-trace-test-util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.spec-trace-test-util :as spec-trace]))
+
+(deftest trace-collection-id-source-models-test
+  (testing "traces `:collection-id` through `[:= a b]` equalities to every equivalent model"
+    ;; Mirrors the `indexed-entity` spec shape: `:collection-id` → `:collection.id`, which joins to
+    ;; `:model.collection_id`, so both :model/Collection and :model/Card are valid claims.
+    (is (= #{:model/Collection :model/Card}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/ModelIndexValue
+             :attrs {:collection-id :collection.id}
+             :joins {:model_index [:model/ModelIndex [:= :model_index.id :this.model_index_id]]
+                     :model       [:model/Card [:= :model.id :model_index.model_id]]
+                     :collection  [:model/Collection [:= :collection.id :model.collection_id]]}}))))
+  (testing "unrelated joins do not pollute the source set"
+    ;; A join for some other field must not count: `:table` is joined for display but `:collection.id`
+    ;; only resolves through `:this.collection_id`.
+    (is (= #{:model/Collection :model/Base}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id :collection.id}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
+                     :table      [:model/Table [:= :table.id :this.table_id]]}}))))
+  (testing "handles compound `:and` conditions"
+    (is (= #{:model/Collection :model/Base}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id :collection.id}
+             :joins {:collection [:model/Collection
+                                  [:and [:= :this.is_published true]
+                                   [:= :collection.id :this.collection_id]]]}}))))
+  (testing "normalizes shorthand `true` to `:this.<attr-name-in-snake-case>`"
+    ;; Mirrors the card/dashboard spec shape where `:collection-id true` means the direct column on
+    ;; the base model. Without this normalization the walk would start from `true` and reach nothing.
+    (is (= #{:model/Base :model/Collection}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id true}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}}))))
+  (testing "extracts referenced columns from a vector attr expression"
+    ;; A computed `:collection-id` seeds the walk from every column keyword in the expression.
+    ;; The fixture is shaped so each referenced column reaches a distinct model: without extracting
+    ;; `:collection.id` the walk misses `:model/Collection`, and without extracting `:other.foo` it
+    ;; misses `:model/Other`. A regression that only seeded from the first column would fail.
+    (is (= #{:model/Base :model/Collection :model/Other}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id [:coalesce :collection.id :other.foo]}
+             :joins {:collection [:model/Collection [:= :collection.id :this.c]]
+                     :other      [:model/Other [:= :other.foo :this.o]]}}))))
+  (testing "recurses into nested vector expressions"
+    ;; Mirrors `find-fields-expr`: a `:case` form contains a nested `[:= ...]` predicate plus a
+    ;; direct branch keyword. The recursive walk must pull column refs out of the nested predicate —
+    ;; if it didn't descend, `:other.flag` would never seed the walk and `:model/Other` would be
+    ;; missing from the reachable set.
+    (is (= #{:model/Base :model/Collection :model/Other}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id [:case [:= :other.flag true] :collection.id :this.collection_id]}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
+                     :other      [:model/Other [:= :other.flag :this.other_flag]]}}))))
+  (testing "descends into `{:fn ... :fields [...]}` attr maps"
+    ;; The search spec allows `{:fn f :fields [:a :b]}` attr values; `find-fields-expr` descends
+    ;; into `:fields`. The test helper must do the same.
+    (is (= #{:model/Base :model/Collection}
+           (spec-trace/trace-collection-id-source-models
+            {:model :model/Base
+             :attrs {:collection-id {:fn identity :fields [:collection.id]}}
+             :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}})))))
+
+(deftest attr-expr-columns-skips-control-keywords-test
+  (testing "control and SQL-function keywords are dropped instead of being qualified to `:this.<kw>`"
+    ;; `qualify-this` would otherwise turn `:else` into `:this.else` and let branch/type keywords
+    ;; masquerade as column references. Integration coverage can't distinguish filtered from
+    ;; unfiltered behavior because `:this` usually resolves to a model already in the expected set,
+    ;; so assert directly against the extractor.
+    (doseq [kw [:else :integer :float :%now :%foo]]
+      (testing kw
+        (is (= #{} (spec-trace/attr-expr-columns kw))
+            (str kw " should be filtered, not returned as a column reference"))))
+    (testing "filtering happens inside nested vector expressions too"
+      (is (= #{:other.flag :collection.id}
+             (spec-trace/attr-expr-columns [:case [:= :other.flag true] :collection.id :else :integer]))))
+    (testing "non-control keywords are still qualified to `:this`"
+      (is (= #{:this.foo} (spec-trace/attr-expr-columns :foo))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/spec_trace_test_util_test.clj
@@ -1,0 +1,48 @@
+(ns metabase-enterprise.semantic-search.spec-trace-test-util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.spec-trace-test-util :as spec-trace]))
+
+;; Seed extraction (shorthand `true`, vector/`:case`/`:fields` expressions, control-keyword filtering) is
+;; `search.spec/find-fields-attr`'s behavior and is tested there. These tests cover this util's own logic:
+;; the join-equality graph walk, and that the two attr forms real specs use (`true` and a `:alias.col`
+;; keyword) seed it correctly.
+
+(deftest trace-reaches-every-model-on-the-collection-id-path-test
+  ;; indexed-entity shape: `:collection-id` → `:collection.id` joins to `:model.collection_id`, so both
+  ;; Collection and Card are structurally valid `:denormalized-from` claims.
+  (is (= #{:model/Collection :model/Card}
+         (spec-trace/trace-collection-id-source-models
+          {:model :model/ModelIndexValue
+           :attrs {:collection-id :collection.id}
+           :joins {:model_index [:model/ModelIndex [:= :model_index.id :this.model_index_id]]
+                   :model       [:model/Card [:= :model.id :model_index.model_id]]
+                   :collection  [:model/Collection [:= :collection.id :model.collection_id]]}}))))
+
+(deftest trace-excludes-joins-not-on-the-collection-id-path-test
+  ;; `:table` is joined for display only; models reached through joins that don't connect to the
+  ;; `:collection-id` seed must not appear.
+  (is (= #{:model/Collection :model/Base}
+         (spec-trace/trace-collection-id-source-models
+          {:model :model/Base
+           :attrs {:collection-id :collection.id}
+           :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]
+                   :table      [:model/Table [:= :table.id :this.table_id]]}}))))
+
+(deftest trace-walks-equalities-inside-compound-and-conditions-test
+  (is (= #{:model/Collection :model/Base}
+         (spec-trace/trace-collection-id-source-models
+          {:model :model/Base
+           :attrs {:collection-id :collection.id}
+           :joins {:collection [:model/Collection
+                                [:and [:= :this.is_published true]
+                                 [:= :collection.id :this.collection_id]]]}}))))
+
+(deftest trace-seeds-from-true-shorthand-test
+  ;; card/dashboard shape: `:collection-id true` means `:this.collection_id`. The seed must expand the
+  ;; shorthand or the walk starts from `true` and reaches nothing.
+  (is (= #{:model/Base :model/Collection}
+         (spec-trace/trace-collection-id-source-models
+          {:model :model/Base
+           :attrs {:collection-id true}
+           :joins {:collection [:model/Collection [:= :collection.id :this.collection_id]]}}))))

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -59,11 +59,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 
-(defmethod mi/can-read? :model/Dashboard
-  ([instance]
-   (perms/can-read-audit-helper :model/Dashboard instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Dashboard :id pk))))
+(perms/define-collection-id-only-read-perms! :model/Dashboard)
 
 (defmethod mi/non-timestamped-fields :model/Dashboard [_]
   #{:last_viewed_at})

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -59,7 +59,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 
-(perms/define-collection-id-only-read-perms! :model/Dashboard)
+(perms/define-collection-based-visibility! :model/Dashboard)
 
 (defmethod mi/non-timestamped-fields :model/Dashboard [_]
   #{:last_viewed_at})

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -58,11 +58,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 
-(defmethod mi/can-read? :model/Dashboard
-  ([instance]
-   (perms/can-read-audit-helper :model/Dashboard instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Dashboard :id pk))))
+(perms/define-collection-based-visibility! :model/Dashboard)
 
 (defmethod mi/non-timestamped-fields :model/Dashboard [_]
   #{:last_viewed_at})

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -8,6 +8,7 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.query-processor.core :as qp]
    [metabase.search.core :as search]
    [metabase.sync.schedules :as sync.schedules]
@@ -205,6 +206,8 @@
    :joins        {:model_index [:model/ModelIndex [:= :model_index.id :this.model_index_id]]
                   :model       [:model/Card [:= :model.id :model_index.model_id]]
                   :collection  [:model/Collection [:= :collection.id :model.collection_id]]}})
+
+(perms/define-collection-based-visibility! "indexed-entity" :denormalized-from :model/Card)
 
 ;; TODO resolve the toucan2 issue preventing us from using this hook
 (underive :model/ModelIndexValue :hook/search-index)

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -80,16 +80,15 @@
   namespace-clause
   can-read-audit-helper
   can-read-via-parent-collection?
-  collection-id-only-read-method
+  collection-based-visibility-search-models
   collection-id-only-read-models
   current-user-has-application-permissions?
-  define-collection-id-only-read-perms!
+  define-collection-based-visibility!
   grant-application-permissions!
   grant-collection-read-permissions!
   grant-collection-readwrite-permissions!
   grant-permissions!
   perms-objects-set-for-parent-collection
-  register-collection-id-only-read-method!
   revoke-application-permissions!
   revoke-collection-permissions!
   set-has-application-permission-of-type?

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -79,12 +79,17 @@
  [metabase.permissions.models.permissions
   namespace-clause
   can-read-audit-helper
+  can-read-via-parent-collection?
+  collection-id-only-read-method
+  collection-id-only-read-models
   current-user-has-application-permissions?
+  define-collection-id-only-read-perms!
   grant-application-permissions!
   grant-collection-read-permissions!
   grant-collection-readwrite-permissions!
   grant-permissions!
   perms-objects-set-for-parent-collection
+  register-collection-id-only-read-method!
   revoke-application-permissions!
   revoke-collection-permissions!
   set-has-application-permission-of-type?

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -85,7 +85,12 @@
  [metabase.permissions.models.permissions
   namespace-clause
   can-read-audit-helper
+  can-read-via-parent-collection?
+  collection-based-visibility-search-models
+  collection-id-only-read-method
+  collection-id-only-read-models
   current-user-has-application-permissions?
+  define-collection-based-visibility!
   grant-application-permissions!
   grant-collection-read-permissions!
   grant-collection-readwrite-permissions!

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -421,12 +421,10 @@
      [:= namespace-keyword "tenant-specific"])])
 
 (defn can-read-via-parent-collection?
-  "Read permission for any row whose read policy is a pure function of `:collection_id` plus
-  the current user's permissions set. Both [[can-read-audit-helper]] (the standard
-  Card/Dashboard/etc. path) and semantic search's `filter-read-permitted` fast path go through
-  this function, so they cannot drift: the signature is deliberately `[coll-id]` (not an
-  instance), making it structurally impossible for the logic to grow a dependency on other
-  instance fields."
+  "Read permission for rows whose read policy is a pure function of `:collection_id` and current user perms.
+  Used by models that opt into the collection-id-only contract via [[define-collection-based-visibility!]],
+  and by semantic search's fast path; sharing this helper keeps the two paths structurally in sync.
+  Takes `coll-id` (not an instance) so the logic cannot grow a dependency on other instance fields."
   [coll-id]
   (and (or (premium-features/enable-audit-app?)
            (not (and (some? coll-id) (audit/is-collection-id-audit? coll-id))))
@@ -441,56 +439,80 @@
   "Audit instances should only be readable if audit app is enabled."
   [model    :- :keyword
    instance :- :map]
-  (case model
-    :model/Collection
-    (if (and (not (premium-features/enable-audit-app?))
-             (audit/is-collection-id-audit? (:id instance)))
-      false
-      (mi/current-user-has-full-permissions? :read instance))
-    ;; default: models whose read perms depend only on `:collection_id`.
-    (can-read-via-parent-collection? (:collection_id instance))))
+  (if (and (not (premium-features/enable-audit-app?))
+           (case model
+             :model/Collection (audit/is-collection-id-audit? (:id instance))
+             (audit/is-parent-collection-audit? instance)))
+    false
+    (case model
+      :model/Collection (mi/current-user-has-full-permissions? :read instance)
+      (mi/current-user-has-full-permissions? (perms-objects-set-for-parent-collection instance :read)))))
 
-;;; ---- Collection-id-only read registration ----
+;;; ---- Collection-based visibility registration ----
 
-(defonce ^:private collection-id-only-read-method-registry
-  ;; t2-model-kw → the fn installed as `mi/can-read?` by
-  ;; `define-collection-id-only-read-perms!`. The identity-check test uses this to detect any
-  ;; later `defmethod mi/can-read?` that would silently override the registered semantics.
-  (atom {}))
+(defonce ^:private collection-based-visibility-registry
+  ;; Registrations from `define-collection-based-visibility!`.
+  ;; `:t2-methods` maps t2-model-kw → the installed `mi/can-read?` fn (identity-check test uses the value).
+  ;; `:search-models` holds search-model strings whose `:collection_id` is denormalized at index time
+  ;; (e.g. `indexed-entity`) and therefore have no direct t2 model to install `mi/can-read?` on.
+  (atom {:t2-methods {} :search-models #{}}))
 
 (defn collection-id-only-read-models
-  "Set of t2 model keywords whose `mi/can-read?` was installed via
-  [[define-collection-id-only-read-perms!]]. Downstream consumers (e.g., semantic search's
-  fast-path filter) derive their own sets from this so the two can't drift."
+  "Set of t2 model keywords whose `mi/can-read?` was installed via [[define-collection-based-visibility!]]."
   []
-  (set (keys @collection-id-only-read-method-registry)))
+  (set (keys (:t2-methods @collection-based-visibility-registry))))
 
 (defn collection-id-only-read-method
-  "The exact `mi/can-read?` fn installed by [[define-collection-id-only-read-perms!]] for
-  `t2-model`. Exposed so identity-check tests can detect later overrides. Returns nil for
-  unregistered models."
+  "The `mi/can-read?` fn [[define-collection-based-visibility!]] installed for `t2-model`, or nil.
+  Exposed so identity-check tests can detect later overrides."
   [t2-model]
-  (get @collection-id-only-read-method-registry t2-model))
+  (get-in @collection-based-visibility-registry [:t2-methods t2-model]))
+
+(defn collection-based-visibility-search-models
+  "Search-model strings registered via the string form of [[define-collection-based-visibility!]]."
+  []
+  (:search-models @collection-based-visibility-registry))
 
 (defn register-collection-id-only-read-method!
-  "Implementation detail of [[define-collection-id-only-read-perms!]]. Do not call directly."
+  "Implementation detail of [[define-collection-based-visibility!]]. Do not call directly."
   [t2-model method]
-  (swap! collection-id-only-read-method-registry assoc t2-model method))
+  (swap! collection-based-visibility-registry assoc-in [:t2-methods t2-model] method))
 
-(defmacro define-collection-id-only-read-perms!
-  "Install `mi/can-read?` for `t2-model` as a pure delegate to
-  [[can-read-via-parent-collection?]], and register the model so downstream code (notably
-  semantic search's permission-filter fast path) can discover it. Use this in a model
-  namespace in place of a handwritten `(defmethod mi/can-read? t2-model ...)` whose body is
-  `(can-read-audit-helper t2-model instance)`. If the model ever needs richer read perms,
-  remove the macro invocation and write a plain `defmethod` — the identity-check test in
-  `metabase.permissions.models.permissions-test` will otherwise flag a silent override."
-  [t2-model]
-  `(do
-     (defmethod mi/can-read? ~t2-model
-       ([instance#] (can-read-via-parent-collection? (:collection_id instance#)))
-       ([_# pk#]    (mi/can-read? (t2/select-one ~t2-model :id pk#))))
-     (register-collection-id-only-read-method! ~t2-model (get-method mi/can-read? ~t2-model))))
+(defn register-collection-based-visibility-search-model!
+  "Implementation detail of [[define-collection-based-visibility!]]. Do not call directly."
+  [search-model]
+  (swap! collection-based-visibility-registry update :search-models conj search-model))
+
+(defmacro define-collection-based-visibility!
+  "Register read perms as determined fully by `:collection_id`.
+
+  Normal form — `target` is a t2-model keyword: installs `mi/can-read?` as a delegate to
+  [[can-read-via-parent-collection?]] and registers the model.
+  If a model later needs richer read perms, remove the macro call and write a plain `defmethod`.
+  The identity-check test in `metabase.permissions.models.permissions-test` will flag silent overrides.
+
+  Alternate form — `target` is a search-model string whose index-row `:collection_id` is denormalized
+  from a parent model at index time (e.g. `\"indexed-entity\"` from its parent Card).
+  No `mi/can-read?` is installed; the registration only flags the search-model for the semantic-search
+  fast path. `:denormalized-from` is required and names the parent t2-model for documentation."
+  [target & {:keys [denormalized-from]}]
+  (cond
+    (keyword? target)
+    `(do
+       (defmethod mi/can-read? ~target
+         ([instance#] (can-read-via-parent-collection? (:collection_id instance#)))
+         ([_# pk#]    (mi/can-read? (t2/select-one ~target :id pk#))))
+       (register-collection-id-only-read-method! ~target (get-method mi/can-read? ~target)))
+
+    (string? target)
+    (do
+      (assert denormalized-from
+              "string form of define-collection-based-visibility! requires :denormalized-from")
+      `(register-collection-based-visibility-search-model! ~target))
+
+    :else
+    (throw (IllegalArgumentException.
+            "define-collection-based-visibility! target must be a t2-model keyword or search-model string"))))
 
 ; Audit permissions helper fns end
 

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -453,9 +453,10 @@
 (defonce ^:private collection-based-visibility-registry
   ;; Registrations from `define-collection-based-visibility!`.
   ;; `:t2-methods` maps t2-model-kw → the installed `mi/can-read?` fn (identity-check test uses the value).
-  ;; `:search-models` holds search-model strings whose `:collection_id` is denormalized at index time
-  ;; (e.g. `indexed-entity`) and therefore have no direct t2 model to install `mi/can-read?` on.
-  (atom {:t2-methods {} :search-models #{}}))
+  ;; `:search-models` maps search-model-string → claimed parent t2-model the `:collection_id` is denormalized
+  ;; from at index time. The claim is verified against the spec's joins by a contract test; see
+  ;; `metabase-enterprise.semantic-search.index-test`.
+  (atom {:t2-methods {} :search-models {}}))
 
 (defn collection-id-only-read-models
   "Set of t2 model keywords whose `mi/can-read?` was installed via [[define-collection-based-visibility!]]."
@@ -469,7 +470,8 @@
   (get-in @collection-based-visibility-registry [:t2-methods t2-model]))
 
 (defn collection-based-visibility-search-models
-  "Search-model strings registered via the string form of [[define-collection-based-visibility!]]."
+  "Map of search-model-string → the claimed parent t2-model the `:collection_id` is denormalized from.
+  Registrations come from the string form of [[define-collection-based-visibility!]]."
   []
   (:search-models @collection-based-visibility-registry))
 
@@ -480,8 +482,8 @@
 
 (defn register-collection-based-visibility-search-model!
   "Implementation detail of [[define-collection-based-visibility!]]. Do not call directly."
-  [search-model]
-  (swap! collection-based-visibility-registry update :search-models conj search-model))
+  [search-model denormalized-from]
+  (swap! collection-based-visibility-registry assoc-in [:search-models search-model] denormalized-from))
 
 (defmacro define-collection-based-visibility!
   "Register read perms as determined fully by `:collection_id`.
@@ -508,7 +510,7 @@
     (do
       (assert denormalized-from
               "string form of define-collection-based-visibility! requires :denormalized-from")
-      `(register-collection-based-visibility-search-model! ~target))
+      `(register-collection-based-visibility-search-model! ~target ~denormalized-from))
 
     :else
     (throw (IllegalArgumentException.

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -420,19 +420,77 @@
    (when (and include-tenant-namespaces? (nil? namespace-val) (setting/get :use-tenants))
      [:= namespace-keyword "tenant-specific"])])
 
+(defn can-read-via-parent-collection?
+  "Read permission for any row whose read policy is a pure function of `:collection_id` plus
+  the current user's permissions set. Both [[can-read-audit-helper]] (the standard
+  Card/Dashboard/etc. path) and semantic search's `filter-read-permitted` fast path go through
+  this function, so they cannot drift: the signature is deliberately `[coll-id]` (not an
+  instance), making it structurally impossible for the logic to grow a dependency on other
+  instance fields."
+  [coll-id]
+  (and (or (premium-features/enable-audit-app?)
+           (not (and (some? coll-id) (audit/is-collection-id-audit? coll-id))))
+       (mi/current-user-has-full-permissions?
+        #{(permissions.path/collection-read-path
+           (or coll-id
+               {:metabase.collections.models.collection.root/is-root? true
+                :namespace                                            nil}))})))
+
 ;;; TODO -- this is a predicate function that returns truthy or falsey, it should end in a `?` -- Cam
 (mu/defn can-read-audit-helper
   "Audit instances should only be readable if audit app is enabled."
   [model    :- :keyword
    instance :- :map]
-  (if (and (not (premium-features/enable-audit-app?))
-           (case model
-             :model/Collection (audit/is-collection-id-audit? (:id instance))
-             (audit/is-parent-collection-audit? instance)))
-    false
-    (case model
-      :model/Collection (mi/current-user-has-full-permissions? :read instance)
-      (mi/current-user-has-full-permissions? (perms-objects-set-for-parent-collection instance :read)))))
+  (case model
+    :model/Collection
+    (if (and (not (premium-features/enable-audit-app?))
+             (audit/is-collection-id-audit? (:id instance)))
+      false
+      (mi/current-user-has-full-permissions? :read instance))
+    ;; default: models whose read perms depend only on `:collection_id`.
+    (can-read-via-parent-collection? (:collection_id instance))))
+
+;;; ---- Collection-id-only read registration ----
+
+(defonce ^:private collection-id-only-read-method-registry
+  ;; t2-model-kw → the fn installed as `mi/can-read?` by
+  ;; `define-collection-id-only-read-perms!`. The identity-check test uses this to detect any
+  ;; later `defmethod mi/can-read?` that would silently override the registered semantics.
+  (atom {}))
+
+(defn collection-id-only-read-models
+  "Set of t2 model keywords whose `mi/can-read?` was installed via
+  [[define-collection-id-only-read-perms!]]. Downstream consumers (e.g., semantic search's
+  fast-path filter) derive their own sets from this so the two can't drift."
+  []
+  (set (keys @collection-id-only-read-method-registry)))
+
+(defn collection-id-only-read-method
+  "The exact `mi/can-read?` fn installed by [[define-collection-id-only-read-perms!]] for
+  `t2-model`. Exposed so identity-check tests can detect later overrides. Returns nil for
+  unregistered models."
+  [t2-model]
+  (get @collection-id-only-read-method-registry t2-model))
+
+(defn register-collection-id-only-read-method!
+  "Implementation detail of [[define-collection-id-only-read-perms!]]. Do not call directly."
+  [t2-model method]
+  (swap! collection-id-only-read-method-registry assoc t2-model method))
+
+(defmacro define-collection-id-only-read-perms!
+  "Install `mi/can-read?` for `t2-model` as a pure delegate to
+  [[can-read-via-parent-collection?]], and register the model so downstream code (notably
+  semantic search's permission-filter fast path) can discover it. Use this in a model
+  namespace in place of a handwritten `(defmethod mi/can-read? t2-model ...)` whose body is
+  `(can-read-audit-helper t2-model instance)`. If the model ever needs richer read perms,
+  remove the macro invocation and write a plain `defmethod` — the identity-check test in
+  `metabase.permissions.models.permissions-test` will otherwise flag a silent override."
+  [t2-model]
+  `(do
+     (defmethod mi/can-read? ~t2-model
+       ([instance#] (can-read-via-parent-collection? (:collection_id instance#)))
+       ([_# pk#]    (mi/can-read? (t2/select-one ~t2-model :id pk#))))
+     (register-collection-id-only-read-method! ~t2-model (get-method mi/can-read? ~t2-model))))
 
 ; Audit permissions helper fns end
 

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -420,6 +420,20 @@
    (when (and include-tenant-namespaces? (nil? namespace-val) (setting/get :use-tenants))
      [:= namespace-keyword "tenant-specific"])])
 
+(defn can-read-via-parent-collection?
+  "Read permission for rows whose read policy is a pure function of `:collection_id` and current user perms.
+  Used by models that opt into the collection-id-only contract via [[define-collection-based-visibility!]],
+  and by semantic search's fast path; sharing this helper keeps the two paths structurally in sync.
+  Takes `coll-id` (not an instance) so the logic cannot grow a dependency on other instance fields."
+  [coll-id]
+  (and (or (premium-features/enable-audit-app?)
+           (not (and (some? coll-id) (audit/is-collection-id-audit? coll-id))))
+       (mi/current-user-has-full-permissions?
+        #{(permissions.path/collection-read-path
+           (or coll-id
+               {:metabase.collections.models.collection.root/is-root? true
+                :namespace                                            nil}))})))
+
 ;;; TODO -- this is a predicate function that returns truthy or falsey, it should end in a `?` -- Cam
 (mu/defn can-read-audit-helper
   "Audit instances should only be readable if audit app is enabled."
@@ -433,6 +447,76 @@
     (case model
       :model/Collection (mi/current-user-has-full-permissions? :read instance)
       (mi/current-user-has-full-permissions? (perms-objects-set-for-parent-collection instance :read)))))
+
+;;; ---- Collection-based visibility registration ----
+
+(defonce ^:private collection-based-visibility-registry
+  ;; Registrations from `define-collection-based-visibility!`.
+  ;; `:t2-methods` maps t2-model-kw → the installed `mi/can-read?` fn (identity-check test uses the value).
+  ;; `:search-models` maps search-model-string → claimed parent t2-model the `:collection_id` is denormalized
+  ;; from at index time. The claim is verified against the spec's joins by a contract test; see
+  ;; `metabase-enterprise.semantic-search.index-test`.
+  (atom {:t2-methods {} :search-models {}}))
+
+(defn collection-id-only-read-models
+  "Set of t2 model keywords whose `mi/can-read?` was installed via [[define-collection-based-visibility!]]."
+  []
+  (set (keys (:t2-methods @collection-based-visibility-registry))))
+
+(defn collection-id-only-read-method
+  "The `mi/can-read?` fn [[define-collection-based-visibility!]] installed for `t2-model`, or nil.
+  Exposed so identity-check tests can detect later overrides."
+  [t2-model]
+  (get-in @collection-based-visibility-registry [:t2-methods t2-model]))
+
+(defn collection-based-visibility-search-models
+  "Map of search-model-string → the claimed parent t2-model the `:collection_id` is denormalized from.
+  Registrations come from the string form of [[define-collection-based-visibility!]]."
+  []
+  (:search-models @collection-based-visibility-registry))
+
+(defn register-collection-id-only-read-method!
+  "Implementation detail of [[define-collection-based-visibility!]]. Do not call directly."
+  [t2-model method]
+  (swap! collection-based-visibility-registry assoc-in [:t2-methods t2-model] method))
+
+(defn register-collection-based-visibility-search-model!
+  "Implementation detail of [[define-collection-based-visibility!]]. Do not call directly."
+  [search-model denormalized-from]
+  (swap! collection-based-visibility-registry assoc-in [:search-models search-model] denormalized-from))
+
+(defmacro define-collection-based-visibility!
+  "Register read perms as determined fully by `:collection_id`.
+
+  Normal form — `target` is a t2-model keyword: installs `mi/can-read?` as a delegate to
+  [[can-read-via-parent-collection?]] and registers the model.
+  If a model later needs richer read perms, remove the macro call and write a plain `defmethod`.
+  The identity-check test in `metabase.permissions.models.permissions-test` will flag silent overrides.
+
+  Alternate form — `target` is a search-model string whose index-row `:collection_id` is denormalized
+  from a parent model at index time (e.g. `\"indexed-entity\"` from its parent Card).
+  No `mi/can-read?` is installed; the registration only flags the search-model for the semantic-search
+  fast path. `:denormalized-from` is required and names the parent t2-model for documentation."
+  [target & {:keys [denormalized-from]}]
+  (cond
+    (keyword? target)
+    `(do
+       (defmethod mi/can-read? ~target
+         ([instance#] (can-read-via-parent-collection? (:collection_id instance#)))
+         ([_# pk#]    (mi/can-read? (t2/select-one ~target :id pk#))))
+       (register-collection-id-only-read-method! ~target (get-method mi/can-read? ~target)))
+
+    (string? target)
+    ;; Throw unconditionally rather than `assert` — assertions are elided when `*assert*` is false (AOT
+    ;; release builds), and a nil `:denormalized-from` would silently break fast-path derivation.
+    (if denormalized-from
+      `(register-collection-based-visibility-search-model! ~target ~denormalized-from)
+      (throw (IllegalArgumentException.
+              "string form of define-collection-based-visibility! requires :denormalized-from")))
+
+    :else
+    (throw (IllegalArgumentException.
+            "define-collection-based-visibility! target must be a t2-model keyword or search-model string"))))
 
 ; Audit permissions helper fns end
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -144,7 +144,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Card :id pk))))
 
-(perms/define-collection-id-only-read-perms! :model/Card)
+(perms/define-collection-based-visibility! :model/Card)
 
 (defn model?
   "Returns true if `card` is a model."

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -144,11 +144,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Card :id pk))))
 
-(defmethod mi/can-read? :model/Card
-  ([instance]
-   (perms/can-read-audit-helper :model/Card instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Card :id pk))))
+(perms/define-collection-id-only-read-perms! :model/Card)
 
 (defn model?
   "Returns true if `card` is a model."

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -144,11 +144,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Card :id pk))))
 
-(defmethod mi/can-read? :model/Card
-  ([instance]
-   (perms/can-read-audit-helper :model/Card instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Card :id pk))))
+(perms/define-collection-based-visibility! :model/Card)
 
 (defn model?
   "Returns true if `card` is a model."

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -41,6 +41,7 @@
 
  [search.spec
   spec
+  specifications
   define-spec]
 
  [search.util

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -37,6 +37,7 @@
   searchable-value-trim-sql]
  [search.spec
   spec
+  specifications
   define-spec]
  [search.util
   collapse-id

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -431,7 +431,11 @@
                             (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
                             true (add-collection-effective-location)
                             true (map (partial add-can-write search-ctx))
-                            true (map serialize))]
+                            true (map serialize)
+                            ;; Realize within the enclosing tracing span so hydration and
+                            ;; serialization time is attributed here rather than deferred to
+                            ;; JSON encoding after the span closes.
+                            true vec)]
     (cond-> {:data        paginated-results
              :limit       (:limit-int search-ctx)
              :models      (:models search-ctx)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -434,7 +434,11 @@
                             (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
                             true (add-collection-effective-location)
                             true (map (partial add-can-write search-ctx))
-                            true (map serialize))]
+                            true (map serialize)
+                            ;; Realize within the enclosing tracing span so hydration and
+                            ;; serialization time is attributed here rather than deferred to
+                            ;; JSON encoding after the span closes.
+                            true vec)]
     (cond-> {:data        paginated-results
              :limit       (:limit-int search-ctx)
              :models      (:models search-ctx)

--- a/test/metabase/permissions/models/permissions_test.clj
+++ b/test/metabase/permissions/models/permissions_test.clj
@@ -306,19 +306,15 @@
 
 (deftest collection-id-only-read-methods-not-overridden-test
   (testing "no one has redefmethod'd mi/can-read? for a model registered as collection-id-only"
-    ;; Require the model namespaces to ensure their `define-collection-id-only-read-perms!`
-    ;; invocations have run and populated the registry.
+    ;; Load the model namespaces so their `define-collection-based-visibility!` calls populate the registry.
     (require 'metabase.queries.models.card
              'metabase.dashboards.models.dashboard)
     (let [registered (perms/collection-id-only-read-models)]
-      (is (seq registered)
-          "registry should be populated after loading Card/Dashboard namespaces")
+      (is (seq registered))
       (doseq [t2-model registered]
         (is (identical? (perms/collection-id-only-read-method t2-model)
                         (get-method mi/can-read? t2-model))
             (str t2-model ": `mi/can-read?` was overridden after "
-                 "`perms/define-collection-id-only-read-perms!` installed it. "
-                 "If this model's read policy now needs more than `:collection_id`, "
-                 "remove the macro invocation in its model namespace so downstream consumers "
-                 "(e.g., semantic search's fast-path filter) don't continue to assume the "
-                 "collection-id-only contract."))))))
+                 "`define-collection-based-visibility!` installed it. "
+                 "If this model needs richer read perms, remove the macro call so downstream consumers "
+                 "(e.g., semantic search's fast path) don't assume the collection-id-only contract."))))))

--- a/test/metabase/permissions/models/permissions_test.clj
+++ b/test/metabase/permissions/models/permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.permissions.models.permissions-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.audit-app.impl :as audit.impl]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
@@ -290,3 +291,34 @@
 
         (testing "admin can create dashboard in root collection"
           (is (true? (mi/can-create? :model/Dashboard {}))))))))
+
+(deftest ^:parallel can-read-via-parent-collection?-test
+  (testing "read perm is true iff the current user has read on the parent collection"
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (true?  (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{})]
+      (is (false? (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{"/collection/42/read/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? 99)))))))
+
+(deftest collection-id-only-read-methods-not-overridden-test
+  (testing "no one has redefmethod'd mi/can-read? for a model registered as collection-id-only"
+    ;; Require the model namespaces to ensure their `define-collection-id-only-read-perms!`
+    ;; invocations have run and populated the registry.
+    (require 'metabase.queries.models.card
+             'metabase.dashboards.models.dashboard)
+    (let [registered (perms/collection-id-only-read-models)]
+      (is (seq registered)
+          "registry should be populated after loading Card/Dashboard namespaces")
+      (doseq [t2-model registered]
+        (is (identical? (perms/collection-id-only-read-method t2-model)
+                        (get-method mi/can-read? t2-model))
+            (str t2-model ": `mi/can-read?` was overridden after "
+                 "`perms/define-collection-id-only-read-perms!` installed it. "
+                 "If this model's read policy now needs more than `:collection_id`, "
+                 "remove the macro invocation in its model namespace so downstream consumers "
+                 "(e.g., semantic search's fast-path filter) don't continue to assume the "
+                 "collection-id-only contract."))))))

--- a/test/metabase/permissions/models/permissions_test.clj
+++ b/test/metabase/permissions/models/permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.permissions.models.permissions-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.audit-app.impl :as audit.impl]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
@@ -286,3 +287,30 @@
           (is (true? (mi/can-create? :model/Dashboard {:collection_id (:id coll)}))))
         (testing "admin can create dashboard in root collection"
           (is (true? (mi/can-create? :model/Dashboard {}))))))))
+
+(deftest ^:parallel can-read-via-parent-collection?-test
+  (testing "read perm is true iff the current user has read on the parent collection"
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (true?  (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{})]
+      (is (false? (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{"/collection/42/read/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? 99)))))))
+
+(deftest collection-id-only-read-methods-not-overridden-test
+  (testing "no one has redefmethod'd mi/can-read? for a model registered as collection-id-only"
+    ;; Load the model namespaces so their `define-collection-based-visibility!` calls populate the registry.
+    (require 'metabase.queries.models.card
+             'metabase.dashboards.models.dashboard)
+    (let [registered (perms/collection-id-only-read-models)]
+      (is (seq registered))
+      (doseq [t2-model registered]
+        (is (identical? (perms/collection-id-only-read-method t2-model)
+                        (get-method mi/can-read? t2-model))
+            (str t2-model ": `mi/can-read?` was overridden after "
+                 "`define-collection-based-visibility!` installed it. "
+                 "If this model needs richer read perms, remove the macro call so downstream consumers "
+                 "(e.g., semantic search's fast path) don't assume the collection-id-only contract."))))))


### PR DESCRIPTION
## Summary

It made me quite uneasy to rely on a standalone map for routing permission checks to the fast path: the map and each model's real `can-read?` could silently drift, so editing a model's read perms could leave it routed through the fast path with the wrong semantics.

This flips things around so membership comes from an authoritative "this has standard collection-based permissions" declaration, `define-collection-based-visibility!`:

- **t2-model form** installs `mi/can-read?` (delegating to the shared `perms/can-read-via-parent-collection?`) *and* registers the model in one call — a model can't be in the fast-path set unless its `can-read?` is actually collection-id-only.
- **search-model form** registers a search-model whose index-row `:collection_id` is denormalized from a parent model (e.g. `"indexed-entity"` ← Card), with a required `:denormalized-from`.

Semantic search derives its fast-path set from these registries instead of the hardcoded map, and the fast path calls the same helper the slow path installs.

Correctness is guarded three ways:

- an identity check fails if anyone overrides `mi/can-read?` on a registered model;
- a contract test structurally traces each `:denormalized-from` claim through the spec's join graph;
- a cold-start regression pins the specs-before-registry load order.

## Test plan

- [x] `metabase.permissions.models.permissions-test/collection-id-only-read-methods-not-overridden-test`
- [x] `metabase.permissions.models.permissions-test/can-read-via-parent-collection?-test`
- [x] `metabase-enterprise.semantic-search.index-test/collection-id-only-search-models-derived-correctly-test`
- [x] `metabase-enterprise.semantic-search.index-test/collection-based-visibility-search-model-claims-verified-test`
- [x] `metabase-enterprise.semantic-search.index-test/collection-id-only-search-models-cold-start-regression-test`
- [x] CI green on full test suite
