### PR TITLE
Fix stale viz-settings in cached dashboard subscriptions

### DIFF
--- a/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
+++ b/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
@@ -1,4 +1,7 @@
-(ns metabase.notification.payload.execute-test
+(ns metabase.notification.payload.execute-ee-test
+  "EE-only tests for `metabase.notification.payload.execute`. Kept in its own ns to avoid
+  colliding with the OSS `metabase.notification.payload.execute-test` ns, which lives under
+  `test/` and would otherwise shadow this file on the classpath."
   (:require
    [clojure.test :refer :all]
    [metabase.notification.payload.execute :as notification.payload.execute]
@@ -44,31 +47,30 @@
                                                   :strategy :duration
                                                   :config   {:unit    :hours
                                                              :duration 1}}]
+          ;; `:cached` is not asserted here — `format-qp-result` strips it from the
+          ;; notification result. The regression this test guards against is viz-settings
+          ;; bleeding across two cards that share a query, independent of cache state.
           (testing "Card 1 has count hidden and sum visible"
-            (is (=? {:cached nil?
-                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+            (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled false
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
                     (result-for-dashcard dashboard-id dashcard-1 card-1)))
-            (is (=? {:cached some?
-                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+            (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled false
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
                     (result-for-dashcard dashboard-id dashcard-2 card-2))))
           (testing "Card 2 has count visible and sum hidden"
-            (is (=? {:cached some?
-                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+            (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled false
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
                     (result-for-card card-1)))
-            (is (=? {:cached some?
-                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+            (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled false
@@ -80,6 +82,9 @@
                 "produce current viz-settings on subsequent subscription runs, not the stale "
                 "cached ones (#72922 / GDGT-2327)")
     (let [query            (mt/mbql-query orders {:aggregation [[:count] [:sum $total]]})
+          ;; `extra-1`/`extra-2` aren't real result columns — they only exist in viz-settings,
+          ;; so their survival after the card edit is a proxy for the cache returning stale
+          ;; viz-settings.
           initial-setting  {:table.cell_column "count"
                             :table.columns     [{:name "count"   :enabled true}
                                                 {:name "sum"     :enabled true}
@@ -102,19 +107,25 @@
                                                :model_id (mt/id)
                                                :strategy :duration
                                                :config   {:unit :hours :duration 1}}]
-          (let [dashcard {:dashboard_id dash-id :card_id card-id :id dc-id}
-                run-sub! (fn [] (:result (mt/as-admin
-                                           (notification.payload.execute/execute-dashboard-subscription-card
-                                            dashcard []))))]
+          (let [dashcard         {:dashboard_id dash-id :card_id card-id :id dc-id}
+                run-sub!         (fn [] (:result (mt/as-admin
+                                                   (notification.payload.execute/execute-dashboard-subscription-card
+                                                    dashcard []))))
+                cache-updated-at #(t2/select-one-fn :updated_at :model/QueryCache)]
             (testing "initial run populates cache with four columns"
               (let [result (run-sub!)]
                 (is (= 4 (count (table-columns-of result))))
-                (is (pos? (t2/count :model/QueryCache))
-                    "The query should have been cached")))
-            (t2/update! :model/Card card-id {:visualization_settings edited-setting})
-            (testing "after card edit, cache-hit run reflects the two-column setting"
-              (let [result (run-sub!)]
-                (is (= 2 (count (table-columns-of result))))
-                (is (= ["count" "sum"]
-                       (map :metabase.models.visualization-settings/table-column-name
-                            (table-columns-of result))))))))))))
+                (is (= 1 (t2/count :model/QueryCache))
+                    "The query should have been cached exactly once")))
+            (let [first-updated-at (cache-updated-at)]
+              (t2/update! :model/Card card-id {:visualization_settings edited-setting})
+              (testing "after card edit, cache-hit run reflects the two-column setting"
+                (let [result (run-sub!)]
+                  (is (= 1 (t2/count :model/QueryCache))
+                      "Second run should reuse the cache entry, not create a new one")
+                  (is (= first-updated-at (cache-updated-at))
+                      "Cache entry should not have been overwritten — confirms cache hit")
+                  (is (= 2 (count (table-columns-of result))))
+                  (is (= ["count" "sum"]
+                         (map :metabase.models.visualization-settings/table-column-name
+                              (table-columns-of result)))))))))))))

--- a/enterprise/backend/test/metabase/notification/payload/execute_test.clj
+++ b/enterprise/backend/test/metabase/notification/payload/execute_test.clj
@@ -74,3 +74,47 @@
                                             {:metabase.models.visualization-settings/table-column-enabled false
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
                     (result-for-card card-2)))))))))
+
+(deftest viz-settings-reflect-card-edit-after-cache-hit-test
+  (testing (str "Editing a card's visualization_settings after its query has been cached should "
+                "produce current viz-settings on subsequent subscription runs, not the stale "
+                "cached ones (#72922 / GDGT-2327)")
+    (let [query            (mt/mbql-query orders {:aggregation [[:count] [:sum $total]]})
+          initial-setting  {:table.cell_column "count"
+                            :table.columns     [{:name "count"   :enabled true}
+                                                {:name "sum"     :enabled true}
+                                                {:name "extra-1" :enabled true}
+                                                {:name "extra-2" :enabled true}]}
+          edited-setting   {:table.cell_column "count"
+                            :table.columns     [{:name "count" :enabled true}
+                                                {:name "sum"   :enabled true}]}
+          table-columns-of (fn [result]
+                             (get-in result [:data :viz-settings
+                                             :metabase.models.visualization-settings/table-columns]))]
+      (t2/delete! :model/QueryCache)
+      (mt/with-premium-features #{:cache-granular-controls}
+        (mt/with-temp
+          [:model/Card          {card-id :id} {:dataset_query          query
+                                               :visualization_settings initial-setting}
+           :model/Dashboard     {dash-id :id} {}
+           :model/DashboardCard {dc-id :id}   {:dashboard_id dash-id :card_id card-id}
+           :model/CacheConfig   _             {:model    "database"
+                                               :model_id (mt/id)
+                                               :strategy :duration
+                                               :config   {:unit :hours :duration 1}}]
+          (let [dashcard {:dashboard_id dash-id :card_id card-id :id dc-id}
+                run-sub! (fn [] (:result (mt/as-admin
+                                           (notification.payload.execute/execute-dashboard-subscription-card
+                                            dashcard []))))]
+            (testing "initial run populates cache with four columns"
+              (let [result (run-sub!)]
+                (is (= 4 (count (table-columns-of result))))
+                (is (pos? (t2/count :model/QueryCache))
+                    "The query should have been cached")))
+            (t2/update! :model/Card card-id {:visualization_settings edited-setting})
+            (testing "after card edit, cache-hit run reflects the two-column setting"
+              (let [result (run-sub!)]
+                (is (= 2 (count (table-columns-of result))))
+                (is (= ["count" "sum"]
+                       (map :metabase.models.visualization-settings/table-column-name
+                            (table-columns-of result))))))))))))

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -137,7 +137,8 @@
 (defn- fixup-viz-settings
   "The viz-settings from :data :viz-settings might be incorrect if there is a cached of the same query.
   See #58469 and #64687.
-  TODO: remove this hack when it's fixed in QP."
+  TODO (Ngoc 2026-04-23) -- now that the QP cache preserves fresh viz-settings on cache hit
+  (#72922), this hack is likely redundant. Confirm with coverage and remove."
   [qp-result]
   (update-in qp-result [:data :viz-settings] merge (-> (get-in qp-result [:json_query :viz-settings])
                                                        viz-settings/db->norm)))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -152,11 +152,16 @@
 
         ([acc row]
          (if (map? row)
-           ;; Keep the fresh acc; returning `row` would replace it with the stale cached map,
-           ;; clobbering anything post-processing just wrote (e.g. viz-settings). `unreduced`
-           ;; handles a reduced acc from transducers like `(take N)` so completion runs.
+           ;; The map-row is the cached final-metadata; stash it and preserve the fresh
+           ;; acc (returning `row` would clobber anything middlewares wrote at init,
+           ;; e.g. :viz-settings). `unreduced` strips any reduced marker so it doesn't
+           ;; leak out through the stashed handoff.
            (do (vreset! final-metadata row) (unreduced acc))
-           (rf acc row)))))))
+           ;; `reducible-rows` keeps reading past a reduced acc (see cache/impl.clj);
+           ;; propagate it here instead of calling `rf` past the short-circuit.
+           (if (reduced? acc)
+             acc
+             (rf acc row))))))))
 
 (mu/defn- maybe-reduce-cached-results :- [:tuple
                                           #_status

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -152,7 +152,10 @@
 
         ([acc row]
          (if (map? row)
-           (vreset! final-metadata row)
+           ;; Keep the fresh acc; returning `row` would replace it with the stale cached map,
+           ;; clobbering anything post-processing just wrote (e.g. viz-settings). `unreduced`
+           ;; handles a reduced acc from transducers like `(take N)` so completion runs.
+           (do (vreset! final-metadata row) (unreduced acc))
            (rf acc row)))))))
 
 (mu/defn- maybe-reduce-cached-results :- [:tuple

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -746,3 +746,30 @@
                      clojure.lang.ExceptionInfo
                      #"You do not have permissions to run this query"
                      (run-forbidden-query)))))))))))
+
+(deftest cached-results-rff-preserves-fresh-accumulator-test
+  (testing "On cache hit, the rff chain's accumulator (with any modifications from middlewares
+            like update-viz-settings) must not be clobbered by the replayed cached final-metadata
+            map. Before the fix, `([acc row] (vreset! final-metadata row))` returned the row,
+            replacing `acc`. Regression for #72922."
+    (let [cached-results-rff @#'cache/cached-results-rff
+          ;; An rff that injects a sentinel `:fresh` into metadata, the same shape
+          ;; `update-viz-settings` uses to inject fresh viz-settings on cache hit.
+          fresh-injecting-rff (fn [metadata]
+                                (let [inner (qp.reducible/default-rff
+                                             (assoc metadata :fresh "fresh-value"))]
+                                  inner))
+          rf ((cached-results-rff fresh-injecting-rff (byte-array 1))
+              {:last-ran (t/zoned-date-time) :cache-version "v1" :cols [{:name "x"}]})
+          ;; Simulate a cached replay: two actual row vectors, then the final cached
+          ;; result map (which used to stomp acc).
+          acc (reduce rf (rf)
+                      [[1] [2]
+                       {:data {:cols [{:name "x"}] :stale "stale-value"}}])
+          result (rf acc)]
+      (is (= "fresh-value" (get-in result [:data :fresh]))
+          "Fresh value injected by the rff chain must survive the cached-final-metadata replay")
+      (is (= "stale-value" (get-in result [:data :stale]))
+          "Stale-only keys from @final-metadata are still deep-merged in")
+      (is (= [[1] [2]] (get-in result [:data :rows]))
+          "Replayed cached rows are preserved"))))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -747,7 +747,7 @@
                      #"You do not have permissions to run this query"
                      (run-forbidden-query)))))))))))
 
-(deftest cached-results-rff-preserves-fresh-accumulator-test
+(deftest ^:parallel cached-results-rff-preserves-fresh-accumulator-test
   (testing "On cache hit, the rff chain's accumulator (with any modifications from middlewares
             like update-viz-settings) must not be clobbered by the replayed cached final-metadata
             map. Before the fix, `([acc row] (vreset! final-metadata row))` returned the row,
@@ -756,9 +756,7 @@
           ;; An rff that injects a sentinel `:fresh` into metadata, the same shape
           ;; `update-viz-settings` uses to inject fresh viz-settings on cache hit.
           fresh-injecting-rff (fn [metadata]
-                                (let [inner (qp.reducible/default-rff
-                                             (assoc metadata :fresh "fresh-value"))]
-                                  inner))
+                                (qp.reducible/default-rff (assoc metadata :fresh "fresh-value")))
           rf ((cached-results-rff fresh-injecting-rff (byte-array 1))
               {:last-ran (t/zoned-date-time) :cache-version "v1" :cols [{:name "x"}]})
           ;; Simulate a cached replay: two actual row vectors, then the final cached


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72922
On a cache hit, `cached-results-rff`'s `[acc row]` returned the cached final-result map as the new accumulator for map rows, discarding anything post-processing middleware had just written to the fresh acc at init (notably `:viz-settings` from `update-viz-settings`). At completion, `deep-merge @final-metadata (unreduced result)` then had both args pointing at the same stale cached map — a no-op merge, so stale viz-settings won.

Symptom: dashboard subscriptions sometimes rendered/exported with stale `::table-columns` — e.g. a column removed from the card still appeared in the email — on cache hits only.

The `fixup-viz-settings` hack in `notification/payload/execute.clj` was the original workaround for a narrower version of this (two cards sharing a query with different viz-settings, #57793/#58469). Leaving it in place as belt-and-braces; removing it can be a follow-up.

https://linear.app/metabase/issue/GDGT-2327/columns-sometimes-missing-from-dashboard-subscription