### PR TITLE
Fix the mlv2 module boundary

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -37,7 +37,7 @@ const elements = [
   createElement({
     type: "basic",
     name: "mlv2",
-    pattern: "frontend/src/metabase-lib/*/**",
+    pattern: "frontend/src/metabase-lib/**",
   }),
   createElement({ type: "basic", name: "ui", enforceOutgoing: true }),
   createElement({ type: "shared", name: "api" }),


### PR DESCRIPTION
Removes 17 violations that were caused by `metabase-lib` inadvertently being marked as `shared/querying` instead of `basic/mlv2`