### PR TITLE
Show usage limit error in inline SQL prompt

### DIFF
--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -114,6 +114,16 @@ const handleResponseError = (
       },
       shouldRetry: true,
     }))
+    .with(
+      { "error-code": "ai_usage_limit_reached", message: P.string },
+      ({ message }) => ({
+        errorMessage: {
+          type: "message" as const,
+          message,
+        },
+        shouldRetry: true,
+      }),
+    )
     .with(P.string, (err) => ({
       errorMessage: {
         type: "message" as const,

--- a/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
@@ -4,6 +4,7 @@ import fetchMock from "fetch-mock";
 import { METABOT_ERR_MSG } from "metabase/metabot/constants";
 
 import {
+  adminQuotaLimitErroredResponse,
   assertConversation,
   enterChatMessage,
   erroredResponse,
@@ -76,6 +77,19 @@ describe("metabot > errors", () => {
     await assertConversation([
       ["user", "Who is your favorite?"],
       ["agent", /A different billing problem happened/],
+    ]);
+    expect(await input()).toHaveTextContent("Who is your favorite?");
+  });
+
+  it("should show the backend message for admin quota limit errors", async () => {
+    setup();
+    mockAgentEndpoint({ textChunks: adminQuotaLimitErroredResponse });
+
+    await enterChatMessage("Who is your favorite?");
+
+    await assertConversation([
+      ["user", "Who is your favorite?"],
+      ["agent", /You have reached your AI usage limit for the current period/],
     ]);
     expect(await input()).toHaveTextContent("Who is your favorite?");
   });

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -144,6 +144,12 @@ export const erroredResponse = [
   `d:{"finishReason":"error","usage":{}}`,
 ];
 
+// Admin-configured quota exceeded — carries ai_usage_limit_reached error-code
+export const adminQuotaLimitErroredResponse = [
+  `3:{"message":"You have reached your AI usage limit for the current period. Please contact your administrator.","error-code":"ai_usage_limit_reached"}`,
+  `d:{"finishReason":"error","usage":{}}`,
+];
+
 // Setup function for metabot tests
 export function setup(
   options: {

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -273,7 +273,7 @@
    (if-let [limit-msg (usage/check-usage-limits!)]
      (reify clojure.lang.IReduceInit
        (reduce [_ rf init]
-         (rf init {:type :text :text limit-msg})))
+         (rf init {:type :error :error {:message limit-msg :error-code "ai_usage_limit_reached"}})))
      (let [{:keys [provider stream-fn model ai-proxy?]} (parse-provider-model provider-and-model)]
        (log/info "Calling LLM" {:provider    provider :model model :parts (count parts) :tools (count tools)
                                 :tool-choice tool-choice :ai-proxy? ai-proxy?})

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -240,9 +240,18 @@
                             :value   value}))))
 
 (defn format-error-line
-  "Format error part as AI SDK line: 3:\"error message\""
+  "Format error part as AI SDK line.
+  Emits a JSON object when the error carries an :error-code, so clients can
+  distinguish typed errors from generic ones:
+    3:{\"message\":\"...\",\"error-code\":\"...\"}
+  Otherwise emits a plain string for backwards compatibility:
+    3:\"error message\""
   [{:keys [error]}]
-  (str "3:" (json/encode (or (:message error) (str error)))))
+  (let [msg        (or (:message error) (str error))
+        error-code (some-> (:error-code error) name)]
+    (str "3:" (json/encode (if error-code
+                             {"message" msg "error-code" error-code}
+                             msg)))))
 
 (defn format-tool-call-line
   "Format tool-input part as AI SDK line: 9:{\"toolCallId\":...,\"toolName\":...,\"args\":...}"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -405,9 +405,28 @@
            (self.core/format-data-line {:data-type "navigate_to" :data {:url "/question/123"}})))))
 
 (deftest format-error-line-test
-  (testing "formats error message as JSON string with 3: prefix"
+  (testing "formats plain error message as a JSON string with 3: prefix"
     (is (= "3:\"Something went wrong\"" (self.core/format-error-line {:error {:message "Something went wrong"}})))
-    (is (= "3:\"Unknown error\"" (self.core/format-error-line {:error "Unknown error"})))))
+    (is (= "3:\"Unknown error\"" (self.core/format-error-line {:error "Unknown error"}))))
+  (testing "formats structured error with error-code as a JSON object"
+    (let [line   (self.core/format-error-line {:error {:message    "You've used all of your included AI service tokens."
+                                                       :error-code "metabase_ai_managed_locked"}})
+          parsed (json/decode+kw (subs line 2))]
+      (is (str/starts-with? line "3:"))
+      (is (= "You've used all of your included AI service tokens." (:message parsed)))
+      (is (= "metabase_ai_managed_locked" (:error-code parsed)))))
+  (testing "formats ai_usage_limit_reached error-code as a JSON object"
+    (let [line   (self.core/format-error-line {:error {:message    "You have reached your AI usage limit."
+                                                       :error-code "ai_usage_limit_reached"}})
+          parsed (json/decode+kw (subs line 2))]
+      (is (str/starts-with? line "3:"))
+      (is (= "You have reached your AI usage limit." (:message parsed)))
+      (is (= "ai_usage_limit_reached" (:error-code parsed)))))
+  (testing "coerces keyword error-code to string"
+    (let [line   (self.core/format-error-line {:error {:message    "Usage limit reached"
+                                                       :error-code :metabase_ai_managed_locked}})
+          parsed (json/decode+kw (subs line 2))]
+      (is (= "metabase_ai_managed_locked" (:error-code parsed))))))
 
 (deftest format-tool-call-line-test
   (testing "formats tool call with toolCallId, toolName, and args"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3723/show-usage-limit-error-in-inline-sql-prompt

### Description

Fixing Metabot error handling on the SQL editor not showing usage limit error message properly.

### How to verify

1. Go to Admin > AI
2. Have Metabot set up with an Anthropic key and model
3. Go to AI Usage Control > AI usage limit
  3.1 Set the inntance limit to 0, or a very low value that will cause the chat to show the usage quota message on the next message
4. Go back to the main app, start creating a SQL question
5. Type Ctrl+shift+I or Cmd+shift+I to open the inline Metabot prompt
6. Type something, and if you reached the limit, the correct error message (e.g. the default one is "You have reached your AI usage limit for the current period. Please contact your administrator.", instead of a generic message)
7. Try using also the sidebar chat to confirm that the same error is displayed (no regressions)

### Demo
https://www.loom.com/share/edee580710354a9888aa919cf913a1c6

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
