### PR TITLE
[BOT-1384] Fix slackbot tool persistence format

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/queries_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/queries_test.clj
@@ -213,7 +213,8 @@
         (is (= "create_sql_query" (-> rows first :tool)))))))
 
 (deftest slackbot-shape-blocks-are-filtered-test
-  (testing "slackbot persists :_type 'TOOL_CALL' blocks; the :type filter excludes them"
+  (testing "legacy slackbot rows wrote :_type 'TOOL_CALL' blocks with no recoverable structured-output;
+            the :type filter excludes them and the extractor yields nothing for those historical rows"
     (with-stubbed-tables! []
       (fn []
         (let [rows (analytics.queries/messages->generated-queries
@@ -228,6 +229,44 @@
                               :tool_call_id "slack-call-1"
                               :content      "<result>...</result>"}]}])]
           (is (= [] rows)))))))
+
+(deftest slackbot-native-shape-blocks-are-extracted-test
+  (testing "going-forward slackbot rows are persisted via store-native-parts!, so they carry
+            the same :type 'tool-input'/'tool-output' block shape as in-app rows and the
+            analytics extractor handles them identically"
+    (with-stubbed-tables! ["orders"]
+      (fn []
+        (let [data [{:type "tool-input"
+                     :id "call-search"
+                     :function "search"
+                     :arguments {:query "orders"}}
+                    {:type "tool-output"
+                     :id "call-search"
+                     :result {:output "<result>orders</result>"}}
+                    {:type "tool-input"
+                     :id "call-sql"
+                     :function "create_sql_query"
+                     :arguments {:database_id 1 :sql_query "SELECT 1 FROM orders"}}
+                    {:type "tool-output"
+                     :id "call-sql"
+                     :result {:output            "<result>sql</result>"
+                              :structured-output {:query-id      "qid-slack"
+                                                  :query-content "SELECT 1 FROM orders"
+                                                  :query         {:database 1
+                                                                  :type     :native
+                                                                  :native   {:query "SELECT 1 FROM orders"}}
+                                                  :database      1}}}]
+              message {:id 200 :data data}]
+          (testing "count-tool-invocations reaches tool names directly by :function"
+            (is (= 1 (analytics.queries/count-tool-invocations [message] "search")))
+            (is (= 1 (analytics.queries/count-tool-invocations
+                      [message] analytics.queries/new-query-tool-names))))
+          (testing "messages->generated-queries surfaces the SQL tool call"
+            (let [rows (analytics.queries/messages->generated-queries [message])]
+              (is (= 1 (count rows)))
+              (is (= "create_sql_query" (-> rows first :tool)))
+              (is (= "qid-slack" (-> rows first :query_id)))
+              (is (= "SELECT 1 FROM orders" (-> rows first :sql))))))))))
 
 ;;; ------------------------- aggregation -------------------------
 

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -4,7 +4,6 @@
    [clojure.core.async :as a]
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -22,6 +21,7 @@
    [metabase.metabot.context :as metabot.context]
    [metabase.metabot.envelope :as metabot.envelope]
    [metabase.metabot.feedback :as metabot.feedback]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.provider-util :as provider-util]
    [metabase.metabot.schema :as metabot.schema]
    [metabase.metabot.self :as metabot.self]
@@ -35,7 +35,6 @@
    [metabase.settings.core :as setting]
    [metabase.slackbot.api]
    [metabase.util :as u]
-   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -87,94 +86,6 @@
                                        (apply +))
                  :ai_proxied      (boolean ai-proxy?)})))
 
-(defn- extract-usage
-  "Extract usage from parts, taking the last `:usage` per model.
-
-  The agent loop emits cumulative usage — each `:usage` part subsumes all prior
-  usage for that model — so we simply take the last one per model rather than
-  summing. Returns a map keyed by model name:
-  {\"model-name\" {:prompt X :completion Y}}"
-  [parts]
-  (transduce
-   (filter #(= :usage (:type %)))
-   (completing
-    (fn [acc {:keys [usage model]}]
-      (let [model (or model "unknown")]
-        (assoc acc model {:prompt     (:promptTokens usage 0)
-                          :completion (:completionTokens usage 0)}))))
-   {}
-   parts))
-
-(def ^:private persisted-structured-output-keys
-  "Subset of `:structured-output` that must survive persistence so
-  `metabase-enterprise.metabot-analytics.queries` can surface generated
-  queries on the admin detail page."
-  [:query-id :query-content :query :database])
-
-(defn- trim-structured-output [structured]
-  (when (map? structured)
-    (not-empty (select-keys structured persisted-structured-output-keys))))
-
-(defn- strip-tool-output-bloat
-  "For :tool-output parts, keep `:output` and a trimmed `:structured-output` in
-  the result map. Both LLM adapters only read `(get-in part [:result :output])`
-  when replaying history, so `:output` is all they need. The analytics extractor,
-  however, reads a small subset of `:structured-output` off persisted messages
-  (see `persisted-structured-output-keys`), so we keep those four keys and drop
-  everything else (`:resources`, `:data-parts`, `:reactions`, …) — that's where
-  the bulk of the bloat lives."
-  [{:keys [type] :as part}]
-  (if (= :tool-output type)
-    (update part :result
-            (fn [r]
-              (cond-> (select-keys r [:output])
-                (trim-structured-output (:structured-output r))
-                (assoc :structured-output (trim-structured-output (:structured-output r)))
-                (trim-structured-output (:structured_output r))
-                (assoc :structured_output (trim-structured-output (:structured_output r))))))
-    part))
-
-(defn- store-native-parts!
-  "Store assistant response parts directly to the database.
-
-  Takes AI SDK parts (after aisdk-xf combining) and stores them in the native format,
-  avoiding the intermediate 'aisdk messages' format.
-
-  Parts format: [{:type :text :text \"...\"} {:type :tool-input ...} ...]"
-  [conversation-id profile-id ip-address embed-url external-id parts]
-  (let [state-part (u/seek #(and (= :data (:type %))
-                                 (= "state" (:data-type %)))
-                           parts)
-        usage      (extract-usage parts)
-        ai-proxy?  (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
-        ;; Filter out :start, :usage, :finish, :data - these are metadata, not message content
-        ;; :data is like `:navigate_to`
-        content    (->> parts
-                        (remove #(#{:start :usage :finish :data} (:type %)))
-                        (mapv strip-tool-output-bloat))]
-    (prometheus/observe! :metabase-metabot/message-persist-bytes
-                         {:profile-id (or profile-id "unknown")}
-                         (u/string-byte-count (json/encode content)))
-    (t2/with-transaction [_conn]
-      (when state-part
-        (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
-                                  (fn [existing]
-                                    (cond-> {:user_id api/*current-user-id*
-                                             :state   (:data state-part)}
-                                      (nil? (:ip_address existing)) (assoc :ip_address ip-address)
-                                      (nil? (:embed_url existing))  (assoc :embed_url embed-url)))))
-      (t2/insert! :model/MetabotMessage
-                  {:conversation_id conversation-id
-                   :data            content
-                   :usage           usage
-                   :role            :assistant
-                   :profile_id      profile-id
-                   :external_id     external-id
-                   :total_tokens    (->> (vals usage)
-                                         (map #(+ (:prompt %) (:completion %)))
-                                         (reduce + 0))
-                   :ai_proxied      (boolean ai-proxy?)}))))
-
 (defn- streaming-writer-rf
   "Creates a reducing function that writes AI SDK lines to an OutputStream.
 
@@ -195,22 +106,6 @@
          (.flush os)
          (catch org.eclipse.jetty.io.EofException _
            (reduced acc)))))))
-
-(defn- combine-text-parts-xf []
-  (fn [rf]
-    (let [pending (volatile! nil)]
-      (fn
-        ([] (rf))
-        ([result]
-         (let [p @pending]
-           (rf (if p (rf result p) result))))
-        ([result part]
-         (let [prev @pending]
-           (if (and prev (= :text (:type prev) (:type part)))
-             (do (vswap! pending update :text str (:text part))
-                 result)
-             (do (vreset! pending part)
-                 (if prev (rf result prev) result)))))))))
 
 (defn- native-agent-streaming-request
   "Handle streaming request using native Clojure agent.
@@ -249,8 +144,12 @@
             (log/debug "Client disconnected during native agent streaming"))
           (finally
             (try
-              (store-native-parts! conversation-id profile-id ip-address embed-url external-id
-                                   (into [] (combine-text-parts-xf) @parts-atom))
+              (metabot.persistence/store-native-parts!
+               conversation-id profile-id
+               (into [] (metabot.persistence/combine-text-parts-xf) @parts-atom)
+               :ip-address  ip-address
+               :embed-url   embed-url
+               :external-id external-id)
               (catch Exception e
                 (log/error e "Failed to persist native agent parts"
                            {:conversation-id conversation-id

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -1,11 +1,158 @@
 (ns metabase.metabot.persistence
   "Persistence for Metabot conversations and messages."
   (:require
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.app-db.core :as app-db]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
+
+(def persisted-structured-output-keys
+  "Subset of `:structured-output` that must survive persistence so
+  `metabase-enterprise.metabot-analytics.queries` can surface generated
+  queries on the admin detail page."
+  [:query-id :query-content :query :database])
+
+(defn- trim-structured-output [structured]
+  (when (map? structured)
+    (not-empty (select-keys structured persisted-structured-output-keys))))
+
+(defn strip-tool-output-bloat
+  "For :tool-output parts, keep `:output` and a trimmed `:structured-output` in
+  the result map. Both LLM adapters only read `(get-in part [:result :output])`
+  when replaying history, so `:output` is all they need. The analytics extractor,
+  however, reads a small subset of `:structured-output` off persisted messages
+  (see `persisted-structured-output-keys`), so we keep those four keys and drop
+  everything else (`:resources`, `:data-parts`, `:reactions`, …) — that's where
+  the bulk of the bloat lives."
+  [{:keys [type] :as part}]
+  (if (= :tool-output type)
+    (update part :result
+            (fn [r]
+              (cond-> (select-keys r [:output])
+                (trim-structured-output (:structured-output r))
+                (assoc :structured-output (trim-structured-output (:structured-output r)))
+                (trim-structured-output (:structured_output r))
+                (assoc :structured_output (trim-structured-output (:structured_output r))))))
+    part))
+
+(defn extract-usage
+  "Extract usage from parts, taking the last `:usage` per model.
+
+  The agent loop emits cumulative usage — each `:usage` part subsumes all prior
+  usage for that model — so we simply take the last one per model rather than
+  summing. Returns a map keyed by model name:
+  {\"model-name\" {:prompt X :completion Y}}"
+  [parts]
+  (transduce
+   (filter #(= :usage (:type %)))
+   (completing
+    (fn [acc {:keys [usage model]}]
+      (let [model (or model "unknown")]
+        (assoc acc model {:prompt     (:promptTokens usage 0)
+                          :completion (:completionTokens usage 0)}))))
+   {}
+   parts))
+
+(defn combine-text-parts-xf
+  "Transducer that merges consecutive `:text` parts into a single `:text` part.
+  Non-text parts pass through unchanged. Used before persistence so streaming
+  text deltas consolidate into one stored block."
+  []
+  (fn [rf]
+    (let [pending (volatile! nil)]
+      (fn
+        ([] (rf))
+        ([result]
+         (let [p @pending]
+           (rf (if p (rf result p) result))))
+        ([result part]
+         (let [prev @pending]
+           (if (and prev (= :text (:type prev) (:type part)))
+             (do (vswap! pending update :text str (:text part))
+                 result)
+             (do (vreset! pending part)
+                 (if prev (rf result prev) result)))))))))
+
+(defn store-native-parts!
+  "Persist assistant response parts directly in the native agent-loop format.
+
+  Takes raw AISDK parts (ideally after `combine-text-parts-xf` merging) and stores
+  them without the lossy AI-SDK-line round-trip that would strip `:structured-output`
+  from tool-output results. Preserves the `persisted-structured-output-keys` subset
+  that the analytics reader needs.
+
+  Positional args: `conversation-id`, `profile-id`, `parts`.
+
+  Keyword args:
+  - `:ip-address`, `:embed-url` — recorded on the conversation row on first insert only.
+  - `:slack-msg-id`, `:channel-id`, `:slack-team-id`, `:slack-thread-ts` — slack
+     metadata. `:slack-team-id`/`:channel-id`/`:slack-thread-ts` land on the
+     conversation row on first insert only; `:slack-msg-id`/`:channel-id` land on
+     the message row.
+  - `:user-id` — when set, recorded on the message row (slackbot uses this to
+     record the invoking Metabase user).
+  - `:external-id` — message external id used by feedback; generated if omitted.
+  - `:ai-proxy?` — override; otherwise derived from `llm-metabot-provider`.
+
+  Returns the inserted `MetabotMessage` primary key."
+  [conversation-id profile-id parts
+   & {:keys [ip-address embed-url external-id
+             slack-msg-id channel-id slack-team-id slack-thread-ts
+             user-id ai-proxy?]}]
+  (let [state-part  (u/seek #(and (= :data (:type %))
+                                  (= "state" (:data-type %)))
+                            parts)
+        usage       (extract-usage parts)
+        ai-proxy?   (if (some? ai-proxy?)
+                      ai-proxy?
+                      (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider)))
+        external-id (or external-id (str (random-uuid)))
+        ;; Filter out :start, :usage, :finish, :data - these are metadata, not message content
+        ;; :data is like `:navigate_to`
+        content     (->> parts
+                         (remove #(#{:start :usage :finish :data} (:type %)))
+                         (mapv strip-tool-output-bloat))]
+    (prometheus/observe! :metabase-metabot/message-persist-bytes
+                         {:profile-id (or profile-id "unknown")}
+                         (u/string-byte-count (json/encode content)))
+    (t2/with-transaction [_conn]
+      ;; Always upsert the conversation row — the assistant message insert FKs
+      ;; to it, and the caller may not have written a user-message row (e.g.
+      ;; slackbot replies to follow-ups inside an existing thread). `:state` is
+      ;; only updated when we actually have a fresh state part to record.
+      (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
+                                (fn [existing]
+                                  (cond-> {:user_id api/*current-user-id*}
+                                    state-part
+                                    (assoc :state (:data state-part))
+                                    (and ip-address (nil? (:ip_address existing)))
+                                    (assoc :ip_address ip-address)
+                                    (and embed-url (nil? (:embed_url existing)))
+                                    (assoc :embed_url embed-url)
+                                    (and slack-team-id (nil? (:slack_team_id existing)))
+                                    (assoc :slack_team_id slack-team-id)
+                                    (and channel-id (nil? (:slack_channel_id existing)))
+                                    (assoc :slack_channel_id channel-id)
+                                    (and slack-thread-ts (nil? (:slack_thread_ts existing)))
+                                    (assoc :slack_thread_ts slack-thread-ts))))
+      (t2/insert-returning-pk! :model/MetabotMessage
+                               (cond-> {:conversation_id conversation-id
+                                        :data            content
+                                        :usage           usage
+                                        :role            :assistant
+                                        :profile_id      profile-id
+                                        :external_id     external-id
+                                        :total_tokens    (->> (vals usage)
+                                                              (map #(+ (:prompt %) (:completion %)))
+                                                              (reduce + 0))
+                                        :ai_proxied      (boolean ai-proxy?)}
+                                 channel-id   (assoc :channel_id channel-id)
+                                 slack-msg-id (assoc :slack_msg_id slack-msg-id)
+                                 user-id      (assoc :user_id user-id))))))
 
 (defn store-message!
   "Persist messages to MetabotConversation and MetabotMessage tables."

--- a/src/metabase/slackbot/persistence.clj
+++ b/src/metabase/slackbot/persistence.clj
@@ -5,22 +5,50 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private history-message-types
-  "Message types to include in history sent to ai-service."
+(def ^:private legacy-history-block-types
+  "Legacy AI-SDK-message `:_type` values that carry tool history."
   #{"TOOL_CALL" "TOOL_RESULT"})
 
-(defn- normalize-history-message
-  "Keep only ai-service schema fields, keywordize role."
-  [msg]
-  (-> (select-keys msg [:role :content :tool_calls :tool_call_id])
+(defn- legacy-block->history-message
+  "Legacy AI-SDK-message block: keep history-relevant fields, keywordize role."
+  [block]
+  (-> (select-keys block [:role :content :tool_calls :tool_call_id])
       (update :role keyword)))
 
+(defn- native-tool-input->history-message
+  "Native `tool-input` block → AI-SDK-message with a single `:tool_calls` entry."
+  [block]
+  {:role       :assistant
+   :tool_calls [{:id        (:id block)
+                 :name      (:function block)
+                 :arguments (:arguments block)}]})
+
+(defn- native-tool-output->history-message
+  "Native `tool-output` block → AI-SDK `tool` message. Only the `:output`
+  string is needed for history replay."
+  [block]
+  {:role         :tool
+   :tool_call_id (:id block)
+   :content      (get-in block [:result :output])})
+
+(defn- block->history-message
+  "Dispatch a single stored `:data` block to an AI-SDK-message map, or nil to
+  skip. Handles both legacy slackbot blocks (`:_type \"TOOL_CALL\"` /
+  `\"TOOL_RESULT\"`) and native agent-loop blocks (`:type \"tool-input\"` /
+  `\"tool-output\"`). Text blocks are skipped — assistant text still comes
+  from Slack's copy of the thread."
+  [block]
+  (cond
+    (legacy-history-block-types (:_type block)) (legacy-block->history-message block)
+    (= "tool-input" (:type block))              (native-tool-input->history-message block)
+    (= "tool-output" (:type block))             (native-tool-output->history-message block)
+    :else                                       nil))
+
 (defn- extract-history-messages
-  "Filter and normalize stored message data for history."
+  "Walk `(:data message)` in insertion order and emit AI-SDK-message maps for
+  history replay. Preserves adjacency of tool calls and their tool results."
   [message]
-  (->> (:data message)
-       (filter #(history-message-types (:_type %)))
-       (mapv normalize-history-message)))
+  (into [] (keep block->history-message) (:data message)))
 
 (defn message-history
   "Tool call history for Slack messages. Returns {slack-msg-id -> [messages...]}."

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -11,10 +11,8 @@
    [metabase.metabot.core :as metabot]
    [metabase.metabot.envelope :as metabot.envelope]
    [metabase.metabot.persistence :as metabot.persistence]
-   [metabase.metabot.self.core :as self.core]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.usage :as metabot.usage]
-   [metabase.metabot.util :as metabot.u]
    [metabase.permissions.core :as perms]
    [metabase.slackbot.channel :as slackbot.channel]
    [metabase.slackbot.client :as slackbot.client]
@@ -232,18 +230,19 @@
                    :tracking-opts {:source "slackbot"}}))
       (finally
         ;; Persist whatever parts we collected, even if the pipeline threw.
+        ;; Stores raw native parts (not the lossy AI-SDK-message round-trip) so
+        ;; tool-output :structured-output survives for analytics extraction.
         (let [parts @parts-atom]
           (when (seq parts)
-            (let [lines (into [] (self.core/aisdk-line-xf) parts)
-                  pk    (metabot.persistence/store-message!
-                         conversation-id "slackbot"
-                         (metabot.u/aisdk->messages :assistant lines)
-                         :channel-id      channel-id
-                         :slack-team-id   team-id
-                         :slack-thread-ts thread-ts
-                         :slack-msg-id    (when get-res-slack-msg-id (get-res-slack-msg-id))
-                         :user-id         api/*current-user-id*
-                         :ai-proxy?       ai-proxy?)]
+            (let [pk (metabot.persistence/store-native-parts!
+                      conversation-id "slackbot"
+                      (into [] (metabot.persistence/combine-text-parts-xf) parts)
+                      :channel-id      channel-id
+                      :slack-team-id   team-id
+                      :slack-thread-ts thread-ts
+                      :slack-msg-id    (when get-res-slack-msg-id (get-res-slack-msg-id))
+                      :user-id         api/*current-user-id*
+                      :ai-proxy?       ai-proxy?)]
               (when stored-msg-id
                 (reset! stored-msg-id pk)))))))))
 

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -7,7 +7,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.agent.memory :as memory]
-   [metabase.metabot.api :as api]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self :as self]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.test-util :as mut]
@@ -333,7 +333,7 @@
                           :data      {:queries map?
                                       :charts  map?}}]
                         (mt/with-log-level [metabase.metabot.agent.core :warn]
-                          (into [] (#'api/combine-text-parts-xf)
+                          (into [] (metabot.persistence/combine-text-parts-xf)
                                 (agent/run-agent-loop
                                  {:messages   [{:role    :user
                                                 :content "Show me the first 10 orders"}]
@@ -434,7 +434,7 @@
             (is (=? [{:type :text :text "Hello after retry"}
                      {:type :data :data-type "state"}]
                     (mt/with-log-level [metabase.metabot.self :fatal]
-                      (into [] (#'api/combine-text-parts-xf)
+                      (into [] (metabot.persistence/combine-text-parts-xf)
                             (agent/run-agent-loop
                              {:messages   [{:role :user :content "Hi"}]
                               :state      {}

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -15,6 +15,7 @@
    [metabase.metabot.api :as api]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.self :as metabot.self]
    [metabase.metabot.self.openrouter :as openrouter]
@@ -160,7 +161,7 @@
                             http/post                                (fn [url opts]
                                                                        (real-http-post url (assoc opts :decompress-body false)))
                             metabot.context/create-context           identity
-                            api/store-native-parts!                  (fn [_conv-id _prof-id _ip _embed-url _external-id parts]
+                            metabot.persistence/store-native-parts!  (fn [_conv-id _prof-id parts & _kwargs]
                                                                        (reset! stored-parts parts))
                             sr/async-cancellation-poll-interval-ms   5]
                 (testing "Closing stream body will drop connection to LLM"
@@ -619,7 +620,7 @@
 (deftest extract-usage-test
   (testing "takes last cumulative usage per model"
     (is (= {"gpt-4" {:prompt 250 :completion 50}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :text :text "hi"}
              {:type :usage :usage {:promptTokens 100 :completionTokens 20} :model "gpt-4"}
              {:type :tool-input :id "t1"}
@@ -629,27 +630,27 @@
   (testing "handles multiple models independently"
     (is (= {"model-a" {:prompt 100 :completion 20}
             "model-b" {:prompt 200 :completion 40}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :usage :usage {:promptTokens 100 :completionTokens 20} :model "model-a"}
              {:type :usage :usage {:promptTokens 200 :completionTokens 40} :model "model-b"}]))))
 
   (testing "returns empty map when no usage parts"
-    (is (= {} (#'api/extract-usage [{:type :text :text "hi"}]))))
+    (is (= {} (metabot.persistence/extract-usage [{:type :text :text "hi"}]))))
 
   (testing "missing model defaults to unknown"
     (is (= {"unknown" {:prompt 50 :completion 10}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :usage :usage {:promptTokens 50 :completionTokens 10}}])))))
 
 (deftest combine-text-parts-xf-test
   (testing "passes through non-text parts"
     (is (= [{:type :tool, :id 1} {:type :tool, :id 2}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :tool, :id 1} {:type :tool, :id 2}]))))
 
   (testing "combines consecutive text parts"
     (is (= [{:type :text, :text "hello world"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "hello "}
                   {:type :text, :text "world"}]))))
 
@@ -657,7 +658,7 @@
     (is (= [{:type :text, :text "ab"}
             {:type :tool, :id 1}
             {:type :text, :text "cd"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "a"}
                   {:type :text, :text "b"}
                   {:type :tool, :id 1}
@@ -665,11 +666,11 @@
                   {:type :text, :text "d"}]))))
 
   (testing "handles empty input"
-    (is (= [] (into [] (#'api/combine-text-parts-xf) []))))
+    (is (= [] (into [] (metabot.persistence/combine-text-parts-xf) []))))
 
   (testing "handles single text part"
     (is (= [{:type :text, :text "solo"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "solo"}])))))
 
 (defn- store-and-check!
@@ -679,14 +680,15 @@
     (let [conv-id (str (random-uuid))]
       (try
         (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider provider]
-          (#'api/store-native-parts!
-           conv-id "internal" nil nil (str (random-uuid))
+          (metabot.persistence/store-native-parts!
+           conv-id "internal"
            [{:type :start :id "msg-1"}
             {:type :text :text "Hello"}
             ;; SSE usage parts carry bare model names (from provider API response)
             {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 100 :completionTokens 50}}
             {:type :data :data-type "state" :data {:step 1}}
-            {:type :finish}])
+            {:type :finish}]
+           :external-id (str (random-uuid)))
           (t2/select-one :model/MetabotMessage :conversation_id conv-id))
         (finally
           (t2/delete! :model/MetabotMessage :conversation_id conv-id)
@@ -709,7 +711,7 @@
 (deftest strip-tool-output-bloat-test
   (testing "drops transient keys and structured-output fields outside the persisted subset"
     (is (= {:type :tool-output :id "call-1" :result {:output "<result>XML</result>"}}
-           (#'api/strip-tool-output-bloat
+           (metabot.persistence/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-1"
              :result {:output            "<result>XML</result>"
@@ -725,7 +727,7 @@
                                            :query-content "SELECT 1"
                                            :query         query-map
                                            :database      1}}}
-             (#'api/strip-tool-output-bloat
+             (metabot.persistence/strip-tool-output-bloat
               {:type   :tool-output
                :id     "call-sql"
                :result {:output            "<result>...</result>"
@@ -741,7 +743,7 @@
             :id     "call-snake"
             :result {:output            "<result>...</result>"
                      :structured_output {:query-id "qid-2" :query-content "SELECT 2"}}}
-           (#'api/strip-tool-output-bloat
+           (metabot.persistence/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-snake"
              :result {:output            "<result>...</result>"
@@ -750,10 +752,10 @@
                                           :extra-bloat   [1 2 3]}}}))))
   (testing "leaves non-tool-output parts untouched"
     (let [text-part {:type :text :text "hello"}]
-      (is (= text-part (#'api/strip-tool-output-bloat text-part)))))
+      (is (= text-part (metabot.persistence/strip-tool-output-bloat text-part)))))
   (testing "handles result with no :output key and no query-related structured-output"
     (is (= {:type :tool-output :id "call-2" :result {}}
-           (#'api/strip-tool-output-bloat
+           (metabot.persistence/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-2"
              :result {:structured-output {:some "data"}}})))))

--- a/test/metabase/slackbot/persistence_test.clj
+++ b/test/metabase/slackbot/persistence_test.clj
@@ -61,6 +61,99 @@
           (is (= #{deleted-ts}
                  (slackbot.persistence/deleted-message-ids conv-id #{deleted-ts}))))))))
 
+(deftest message-history-native-shape-test
+  (testing "assistant messages persisted in native-parts shape are translated to AI-SDK messages"
+    (let [conv-id    (str (random-uuid))
+          slack-ts   "1712000000.000001"
+          search-id  "call-search"
+          query-id   "call-query"]
+      (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (t2/insert! :model/MetabotConversation {:id conv-id :user_id (mt/user->id :rasta)})
+        (t2/insert! :model/MetabotMessage
+                    {:conversation_id conv-id
+                     :slack_msg_id    slack-ts
+                     :role            "assistant"
+                     :profile_id      "slackbot"
+                     :total_tokens    10
+                     :data            [{:type :text :text "Let me check."}
+                                       {:type      :tool-input
+                                        :id        search-id
+                                        :function  "search"
+                                        :arguments {:query "orders"}}
+                                       {:type   :tool-output
+                                        :id     search-id
+                                        :result {:output            "<result>orders</result>"
+                                                 :structured-output {:query-id "qid-1"}}}
+                                       {:type      :tool-input
+                                        :id        query-id
+                                        :function  "construct_notebook_query"
+                                        :arguments {:data_source_ids ["table-1"]}}
+                                       {:type   :tool-output
+                                        :id     query-id
+                                        :result {:output "<result>query</result>"}}]})
+        (let [result (slackbot.persistence/message-history conv-id #{slack-ts})
+              msgs   (get result slack-ts)]
+          (testing "text blocks are skipped — only tool blocks surface"
+            (is (= 4 (count msgs))))
+          (testing "tool-input → assistant message with :tool_calls"
+            (is (= {:role       :assistant
+                    :tool_calls [{:id        search-id
+                                  :name      "search"
+                                  :arguments {:query "orders"}}]}
+                   (first msgs))))
+          (testing "tool-output → tool message with :content and :tool_call_id"
+            (is (= {:role         :tool
+                    :tool_call_id search-id
+                    :content      "<result>orders</result>"}
+                   (second msgs))))
+          (testing "order is preserved — matching tool-call/tool-result pairs stay adjacent"
+            (is (= [search-id search-id query-id query-id]
+                   (mapv #(or (:tool_call_id %)
+                              (-> % :tool_calls first :id))
+                         msgs)))
+            (is (= ["search" "construct_notebook_query"]
+                   (->> msgs
+                        (filter #(= :assistant (:role %)))
+                        (map #(-> % :tool_calls first :name)))))))))))
+
+(deftest message-history-mixed-shape-test
+  (testing "a single message row with both legacy and native blocks round-trips both shapes in order"
+    (let [conv-id  (str (random-uuid))
+          slack-ts "1712000000.000002"]
+      (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (t2/insert! :model/MetabotConversation {:id conv-id :user_id (mt/user->id :rasta)})
+        (t2/insert! :model/MetabotMessage
+                    {:conversation_id conv-id
+                     :slack_msg_id    slack-ts
+                     :role            "assistant"
+                     :profile_id      "slackbot"
+                     :total_tokens    5
+                     :data            [{:_type      "TOOL_CALL"
+                                        :role       "assistant"
+                                        :tool_calls [{:id "legacy-1" :name "search" :arguments "{}"}]}
+                                       {:_type        "TOOL_RESULT"
+                                        :role         "tool"
+                                        :tool_call_id "legacy-1"
+                                        :content      "legacy output"}
+                                       {:type      :tool-input
+                                        :id        "native-1"
+                                        :function  "construct_notebook_query"
+                                        :arguments {:data_source_ids ["t1"]}}
+                                       {:type   :tool-output
+                                        :id     "native-1"
+                                        :result {:output "native output"}}]})
+        (let [msgs (get (slackbot.persistence/message-history conv-id #{slack-ts}) slack-ts)]
+          (is (= 4 (count msgs)))
+          (testing "legacy blocks still normalize correctly"
+            (is (= :assistant (:role (nth msgs 0))))
+            (is (= "legacy-1" (-> (nth msgs 0) :tool_calls first :id)))
+            (is (= {:role :tool :tool_call_id "legacy-1" :content "legacy output"}
+                   (nth msgs 1))))
+          (testing "native blocks translate alongside legacy blocks"
+            (is (= "native-1" (-> (nth msgs 2) :tool_calls first :id)))
+            (is (= {:role :tool :tool_call_id "native-1" :content "native output"}
+                   (nth msgs 3)))))))))
+
 (deftest soft-delete-response-test
   (testing "soft-delete-response! marks the assistant response as deleted"
     (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -174,7 +174,7 @@
                @posted-message))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
-  (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
+  (testing "user + assistant persists receive ai-proxy? = true for metabase/ prefixed provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
             store-opts (atom [])]
@@ -187,6 +187,10 @@
                             metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)
+                              nil)
+                            metabot.persistence/store-native-parts!
+                            (fn [_conv-id _profile-id _parts & {:as opts}]
+                              (swap! store-opts conj opts)
                               nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
@@ -194,7 +198,7 @@
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user + assistant store-message! calls both received ai-proxy? = true"
+            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = true"
               (is (=? [{:ai-proxy? true}
                        {:ai-proxy? true}]
                       @store-opts)))))))))
@@ -223,7 +227,7 @@
                   (is (some? (:slack-msg-id opts))))))))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
-  (testing "store-message! receives ai-proxy? = false for direct BYOK provider"
+  (testing "user + assistant persists receive ai-proxy? = false for direct BYOK provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
             store-opts (atom [])]
@@ -234,6 +238,10 @@
               (with-redefs [metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)
+                              nil)
+                            metabot.persistence/store-native-parts!
+                            (fn [_conv-id _profile-id _parts & {:as opts}]
+                              (swap! store-opts conj opts)
                               nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
@@ -241,7 +249,7 @@
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user + assistant store-message! calls both received ai-proxy? = false"
+            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = false"
               (is (=? [{:ai-proxy? false}
                        {:ai-proxy? false}]
                       @store-opts)))))))))


### PR DESCRIPTION
Closes [BOT-1384: Slackbot profile not recording searches or queries](https://linear.app/metabase/issue/BOT-1384/slackbot-profile-not-recording-searches-or-queries)

  - Two write paths persisted `metabot_message.data` in incompatible shapes, and the analytics extractor only understood one:
    - In-app (`store-native-parts!`): raw AISDK parts — `{:type "tool-input", :function ..., :arguments ...} / {:type "tool-output", :result {:output ..., :structured-output ...}}`
    - Slackbot: parts ran through `aisdk-line-xf` → `aisdk->messages` → `store-message!`, landing as legacy AI-SDK messages with `:_type "TOOL_CALL" / :_type "TOOL_RESULT"` and no `:function/:type` keys.
  - `queries.clj` keyed on `(= "tool-input" (:type block))` and `(:function block)`, so every slackbot block was filtered out
  - The slackbot round-trip also called `format-tool-result-line`, which dropped `:structured-output` before encoding — so even counts aside, legacy slackbot rows have permanently lost the `:query-id`/`:query`/`:database` data needed for the generated-queries list.

Fix

  - Shared persistence helper: moved `store-native-parts!`, `combine-text-parts-xf`, `strip-tool-output-bloat`, `extract-usage`, and `persisted-structured-output-keys` from `metabot/api.clj` into `metabot/persistence.clj` and widened its signature to accept slack metadata
  - Slackbot now persists raw native parts: slackbot/streaming.clj drops the `aisdk-line-xf` → `aisdk->messages` → `store-message!` chain and calls `store-native-parts!` directly (after `combine-text-parts-xf`). Slackbot rows now carry the same `{:type "tool-input"/"tool-output"}` shape as in-app, with `:structured-output ([:query-id :query-content :query :database])`
  preserved by `strip-tool-output-bloat`
  - updated `message-history` to handle both shapes: `slackbot/persistence.clj` replaces the flat filter with a per-block dispatcher — legacy `:_type "TOOL_CALL"/"TOOL_RESULT"` blocks keep their existing normalization (old rows keep working), new `:type "tool-input"/"tool-output"` blocks translate to the equivalent AI-SDK-message shape. Insertion order preserved so tool-call/result pairs stay adjacent for replay
  - Always upsert the conversation row in `store-native-parts!` (not just when a state part is present), so assistant inserts can never FK-fail if the agent throws before emitting state