### PR TITLE
Improve the e2e group naming in the build matrix

### DIFF
--- a/.github/scripts/build-e2e-matrix.js
+++ b/.github/scripts/build-e2e-matrix.js
@@ -52,17 +52,21 @@ function buildMatrix(options, inputSpecs, inputChunks) {
     );
   }
 
-  const regularTests = new Array(regularChunks).fill(1).map((files, index) => ({
-    name: `e2e-group-${index + 1}`,
-    // works when specs less than 5, otherwise seems all chunks will contain
-    // same specs
-    ...(!isDefaultSpecPattern && {
-      specs: inputSpecs
-        .split(",")
-        .slice(SPECS_PER_CHUNK * index, SPECS_PER_CHUNK * (index + 1))
-        .join(","),
-    }),
-  }));
+  const regularTests = Array.from({ length: regularChunks }, (_, index) => {
+    const paddedIndex = String(index + 1).padStart(2, "0");
+
+    return {
+      name: `e2e-group-${paddedIndex}`,
+      // works when specs less than 5, otherwise seems all chunks will contain
+      // same specs
+      ...(!isDefaultSpecPattern && {
+        specs: inputSpecs
+          .split(",")
+          .slice(SPECS_PER_CHUNK * index, SPECS_PER_CHUNK * (index + 1))
+          .join(","),
+      }),
+    };
+  });
 
   const testSets = isDefaultSpecPattern
     ? regularTests.concat(specialTestConfigs)

--- a/.github/scripts/build-e2e-matrix.unit.spec.js
+++ b/.github/scripts/build-e2e-matrix.unit.spec.js
@@ -34,7 +34,9 @@ describe("buildMatrix", () => {
     );
 
     regularTests.forEach((test, index) => {
-      expect(test.name).toBe(`e2e-group-${index + 1}`);
+      expect(test.name).toBe(
+        `e2e-group-${String(index + 1).padStart(2, "0")}`,
+      );
     });
   });
 
@@ -92,6 +94,6 @@ describe("buildMatrix", () => {
     const result = testBuildMatrix("test1.cy.spec.js,test2.cy.spec.js", 50);
 
     expect(result.config.length).toBe(1);
-    expect(result.config[0].name).toBe("e2e-group-1");
+    expect(result.config[0].name).toBe("e2e-group-01");
   });
 });


### PR DESCRIPTION
Resolves DEV-1859

## Summary

GitHub's Actions UI orders workflow artifacts alphabetically (lexicographically), not numerically. As a result, Cypress recording artifacts produced per e2e chunk are interleaved in a confusing order, making it difficult to locate the artifact for a specific failing group.

### Example

Current ordering (alphabetical):

```
cypress-recording-10-ee
cypress-recording-2-ee
cypress-recording-34-ee
cypress-recording-5-ee
```

Intuitively we want 2 before 5 before 10 before 34.