### PR TITLE
Gdgt 2338 revise custom visualizations activation flow

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -59,18 +59,14 @@ describe("admin > custom visualizations", () => {
         H.getAddVisualizationLink().should("not.exist");
       });
 
-      it("should show manage page with valid token", () => {
+      it("should enable and disable custom visualizations", () => {
         H.activateToken("bleeding-edge");
 
         H.visitCustomVizSettings();
 
         H.main()
-          .findByText(
-            "Should custom visualizations be enabled for this instance? Enabling this will reload the page.",
-          )
-          .should("be.visible");
-        H.main()
-          .findByRole("switch", { name: /Enable Custom Visualizations/ })
+          .findByRole("button", { name: /Enable Custom Visualizations/ })
+          .should("be.visible")
           .click();
 
         H.main()
@@ -79,13 +75,9 @@ describe("admin > custom visualizations", () => {
         H.getAddVisualizationLink().should("be.visible");
 
         H.main()
-          .findByText(
-            "Should custom visualizations be enabled for this instance? Disabling this will reload the page.",
-          )
-          .should("be.visible");
-        H.main()
-          .findByRole("switch", { name: /Enable Custom Visualizations/ })
+          .findByRole("button", { name: /More options/ })
           .click();
+        H.popover().findByText("Deactivate custom visualizations").click();
 
         H.main()
           .findByRole("heading", { name: "Custom visualizations" })
@@ -148,21 +140,8 @@ describe("admin > custom visualizations", () => {
         "be.enabled",
       );
 
-      cy.log("Clicking submit opens the confirmation modal");
-      cy.findByRole("button", { name: "Add visualization" }).click();
-
       H.interceptPluginCreate();
-      H.modal().within(() => {
-        cy.findByRole("heading", { name: "Add this visualization?" }).should(
-          "be.visible",
-        );
-        // Body text has a <strong> inside so findByText's default leaf
-        // matcher misses it — cy.contains matches across children.
-        cy.contains(
-          /Be aware that custom visualizations.*can execute arbitrary code.*should only be added from trusted sources/,
-        ).should("be.visible");
-        cy.findByRole("button", { name: "Add this visualization" }).click();
-      });
+      cy.findByRole("button", { name: "Add visualization" }).click();
       cy.wait("@pluginCreate");
 
       // Should redirect to list and show the plugin
@@ -207,22 +186,15 @@ describe("admin > custom visualizations", () => {
         "pluginCreateInvalid",
       );
       cy.findByRole("button", { name: "Add visualization" }).click();
-      H.modal()
-        .findByRole("button", { name: "Add this visualization" })
-        .click();
 
       cy.wait("@pluginCreateInvalid")
         .its("response.statusCode")
         .should("eq", 400);
 
-      cy.log("Error is surfaced inside the confirmation modal");
-      H.modal()
-        .findByText(/Failed to clone git repository/)
-        .should("be.visible");
-
-      H.modal()
-        .findByRole("button", { name: /Cancel/ })
-        .click();
+      cy.log("Error is surfaced inline in the form");
+      cy.findByTestId("custom-viz-settings-form").within(() => {
+        cy.findByText(/Failed to clone git repository/).should("be.visible");
+      });
 
       cy.location("pathname").should(
         "eq",
@@ -290,9 +262,6 @@ describe("admin > custom visualizations", () => {
       }).as("pluginCreateWithToken");
 
       cy.findByRole("button", { name: "Add visualization" }).click();
-      H.modal()
-        .findByRole("button", { name: "Add this visualization" })
-        .click();
       cy.wait("@pluginCreateWithToken");
     });
 
@@ -340,74 +309,6 @@ describe("admin > custom visualizations", () => {
       cy.findByTestId("custom-viz-settings-form").within(() => {
         cy.findAllByText(/required/i).should("have.length.at.least", 2);
       });
-    });
-
-    it("should show a confirmation modal before adding a plugin and skip it after 'Don't warn me about this again' is selected", () => {
-      H.setupCustomVizRepo();
-      H.setupCustomVizRepo2();
-
-      H.visitCustomVizNewForm();
-      cy.findByLabelText(/Repository URL/).type(H.CUSTOM_VIZ_REPO_URL);
-      cy.findByRole("button", { name: "Add visualization" }).click();
-
-      cy.log("Modal shows the warning, ack checkbox, and both buttons");
-      H.modal().within(() => {
-        cy.findByRole("heading", { name: "Add this visualization?" }).should(
-          "be.visible",
-        );
-        cy.contains(
-          /Be aware that custom visualizations.*can execute arbitrary code.*should only be added from trusted sources/,
-        ).should("be.visible");
-        cy.findByLabelText(/Don't warn me about this again/).should(
-          "be.visible",
-        );
-        cy.findByRole("button", { name: /Cancel/ }).should("be.visible");
-        cy.findByRole("button", {
-          name: "Add this visualization",
-        }).should("be.visible");
-      });
-
-      cy.log(
-        "Cancel closes the modal without submitting and keeps the URL in the form",
-      );
-      H.modal()
-        .findByRole("button", { name: /Cancel/ })
-        .click();
-      cy.findByRole("dialog").should("not.exist");
-      cy.findByLabelText(/Repository URL/).should(
-        "have.value",
-        H.CUSTOM_VIZ_REPO_URL,
-      );
-
-      cy.log("Re-open the modal, check 'Don't warn me again', and confirm");
-      cy.findByRole("button", { name: "Add visualization" }).click();
-
-      cy.intercept(
-        "PUT",
-        "/api/user-key-value/namespace/user_acknowledgement/key/*",
-      ).as("ackWarning");
-      H.interceptPluginCreate();
-
-      H.modal().within(() => {
-        cy.findByLabelText(/Don't warn me about this again/).click();
-        cy.findByRole("button", { name: "Add this visualization" }).click();
-      });
-      cy.wait("@ackWarning");
-      cy.wait("@pluginCreate");
-
-      H.main().findByText("demo-viz").should("be.visible");
-
-      cy.log("Next add: modal should be skipped and the POST fires directly");
-      H.getAddVisualizationLink().click();
-      cy.findByLabelText(/Repository URL/).type(H.CUSTOM_VIZ_REPO_URL_2);
-      cy.findByRole("button", { name: "Add visualization" }).click();
-
-      // If the modal had opened, no POST would fire until the user clicks
-      // "Add this visualization" inside it — waiting on the intercept without
-      // any further interaction asserts the modal was skipped.
-      cy.wait("@pluginCreate");
-      cy.findByRole("dialog").should("not.exist");
-      H.main().findByText("demo-viz-2").should("be.visible");
     });
 
     describe("updating a plugin", () => {

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -69,9 +69,6 @@ describe("admin > custom visualizations", () => {
           .should("be.visible")
           .click();
 
-        H.main()
-          .findByRole("heading", { name: "Custom visualizations" })
-          .should("be.visible");
         H.getAddVisualizationLink().should("be.visible");
 
         H.main()
@@ -80,8 +77,11 @@ describe("admin > custom visualizations", () => {
         H.popover().findByText("Deactivate custom visualizations").click();
 
         H.main()
-          .findByRole("heading", { name: "Custom visualizations" })
+          .findByRole("heading", { name: "Add a new visualization" })
           .should("not.exist");
+        H.main()
+          .findByRole("heading", { name: "Build custom visualizations" })
+          .should("be.visible");
       });
 
       it('should not show custom visualizations page to non-admins with "Settings access" permission', () => {

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
@@ -200,25 +200,27 @@ export function CustomVizPage({ params }: Props) {
           >
             {({ dirty, values }) => (
               <Form>
-                <Stack gap={0}>
-                  <Title order={2} mb="2.5rem">
+                <Stack gap="40px">
+                  <Title order={2}>
                     {isEdit
                       ? t`Edit visualization`
                       : t`Add a new visualization`}
                   </Title>
-                  <FormTextInput
-                    name="repoUrl"
-                    label={t`Repository URL`}
-                    description={t`The location of the git repository where your visualization bundle is.`}
-                    placeholder="https://github.com/user/custom-viz-plugin"
-                    disabled={isEdit}
-                    autoFocus={!isEdit}
-                    styles={{
-                      description: { color: "var(--mb-color-text-tertiary)" },
-                      root: { marginBottom: "1rem" },
-                    }}
-                  />
                   <Stack gap="md">
+                    <FormTextInput
+                      name="repoUrl"
+                      label={t`Repository URL`}
+                      description={t`The location of the git repository where your visualization bundle is.`}
+                      placeholder="https://github.com/user/custom-viz-plugin"
+                      disabled={isEdit}
+                      autoFocus={!isEdit}
+                      styles={{
+                        description: {
+                          color: "var(--mb-color-text-tertiary)",
+                        },
+                      }}
+                    />
+
                     <FormCheckbox
                       name="isPrivateRepo"
                       label={t`This is a private repository`}
@@ -233,7 +235,7 @@ export function CustomVizPage({ params }: Props) {
                       />
                     )}
                   </Stack>
-                  <Stack gap="md" mt="2rem">
+                  <Stack gap="md">
                     <Flex gap="sm" align="center">
                       <FormSwitch
                         size="sm"

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
@@ -1,14 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { push } from "react-router-redux";
-import { jt, t } from "ttag";
+import { t } from "ttag";
 import * as Yup from "yup";
 
 import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { getErrorMessage } from "metabase/api/utils";
-import { useUserAcknowledgement } from "metabase/common/hooks/use-user-acknowledgement";
 import {
   Form,
   FormCheckbox,
@@ -18,17 +16,7 @@ import {
   FormSwitch,
   FormTextInput,
 } from "metabase/forms";
-import {
-  Box,
-  Button,
-  Checkbox,
-  Flex,
-  Group,
-  Modal,
-  Stack,
-  Text,
-  Title,
-} from "metabase/ui";
+import { Box, Button, Flex, Group, Stack, Text, Title } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
 import { getUrlProtocol } from "metabase/utils/formatting/url";
 import { useDispatch } from "metabase/utils/redux";
@@ -57,8 +45,6 @@ type FormState = {
   pinVersion: boolean;
   pinnedVersion: string;
 };
-
-const WARNING_ACK_KEY = "custom_viz_add_warning";
 
 const ALLOWED_REPO_URL_PROTOCOLS = new Set([
   "http:",
@@ -106,14 +92,6 @@ export function CustomVizPage({ params }: Props) {
 
   const [createPlugin] = useCreateCustomVizPluginMutation();
   const [updatePlugin] = useUpdateCustomVizPluginMutation();
-
-  const [warningAcknowledged, { ack }] =
-    useUserAcknowledgement(WARNING_ACK_KEY);
-
-  const [pendingValues, setPendingValues] = useState<FormState | null>(null);
-  const [dontWarnAgain, setDontWarnAgain] = useState(false);
-  const [confirmError, setConfirmError] = useState<string | null>(null);
-  const [confirming, setConfirming] = useState(false);
 
   const initialValues = useMemo<FormState>(
     () => ({
@@ -164,46 +142,6 @@ export function CustomVizPage({ params }: Props) {
     },
     [createPlugin, updatePlugin, plugin, isEdit, dispatch],
   );
-
-  const handleSubmit = useCallback(
-    async (values: FormState) => {
-      if (!isEdit && !warningAcknowledged) {
-        setPendingValues(values);
-        setDontWarnAgain(false);
-        setConfirmError(null);
-        return;
-      }
-      await submitValues(values);
-    },
-    [isEdit, warningAcknowledged, submitValues],
-  );
-
-  const handleConfirm = useCallback(async () => {
-    if (!pendingValues) {
-      return;
-    }
-    setConfirming(true);
-    setConfirmError(null);
-    try {
-      await submitValues(pendingValues);
-      if (dontWarnAgain) {
-        ack();
-      }
-      setPendingValues(null);
-    } catch (error) {
-      setConfirmError(getErrorMessage(error));
-    } finally {
-      setConfirming(false);
-    }
-  }, [pendingValues, dontWarnAgain, ack, submitValues]);
-
-  const handleCancelConfirm = useCallback(() => {
-    if (confirming) {
-      return;
-    }
-    setPendingValues(null);
-    setConfirmError(null);
-  }, [confirming]);
 
   const handleCancel = useCallback(() => {
     dispatch(push(Urls.customViz()));
@@ -257,7 +195,7 @@ export function CustomVizPage({ params }: Props) {
           <FormProvider
             initialValues={initialValues}
             validationSchema={validationSchema}
-            onSubmit={handleSubmit}
+            onSubmit={submitValues}
             enableReinitialize
           >
             {({ dirty, values }) => (
@@ -328,14 +266,6 @@ export function CustomVizPage({ params }: Props) {
                     </Button>
                     <FormSubmitButton
                       label={isEdit ? t`Save` : t`Add visualization`}
-                      // In create mode the real submit happens inside the
-                      // confirmation modal — keep the form button's label
-                      // stable so Formik's transient "fulfilled" state doesn't
-                      // flash "Success" before the user has actually added
-                      // anything.
-                      activeLabel={isEdit ? undefined : t`Add visualization`}
-                      successLabel={isEdit ? undefined : t`Add visualization`}
-                      failedLabel={isEdit ? undefined : t`Add visualization`}
                       disabled={!dirty}
                       variant="filled"
                     />
@@ -346,42 +276,6 @@ export function CustomVizPage({ params }: Props) {
           </FormProvider>
         </Box>
       </SettingsSection>
-
-      <Modal
-        opened={pendingValues !== null}
-        onClose={handleCancelConfirm}
-        title={t`Add this visualization?`}
-        size="lg"
-      >
-        <Stack gap="lg" mt="md">
-          <Text>
-            {jt`Be aware that custom visualizations ${<strong key="arbitrary-code">{t`can execute arbitrary code`}</strong>} and should only be added from trusted sources.`}
-          </Text>
-          <Checkbox
-            checked={dontWarnAgain}
-            onChange={(event) => setDontWarnAgain(event.currentTarget.checked)}
-            label={t`Don't warn me about this again`}
-            disabled={confirming}
-          />
-          {confirmError && <Text c="danger">{confirmError}</Text>}
-          <Flex justify="flex-end" gap="md">
-            <Button
-              variant="subtle"
-              onClick={handleCancelConfirm}
-              disabled={confirming}
-            >
-              {t`Cancel`}
-            </Button>
-            <Button
-              variant="filled"
-              onClick={handleConfirm}
-              loading={confirming}
-            >
-              {t`Add this visualization`}
-            </Button>
-          </Flex>
-        </Stack>
-      </Modal>
     </SettingsPageWrapper>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
@@ -1,21 +1,19 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
-import { CustomVizEnableSwitch } from "metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useAdminSetting } from "metabase/api/utils";
 import { Link } from "metabase/common/components/Link";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import {
+  ActionIcon,
   Box,
   Button,
   Flex,
   Group,
   Icon,
   Loader,
+  Menu,
   Stack,
   Text,
   Title,
@@ -35,7 +33,7 @@ import S from "./ManageCustomVizPage.module.css";
 const CUSTOM_VIZ_ENABLED_SETTING = "custom-viz-enabled";
 
 export function ManageCustomVizPage() {
-  const { value: isCustomVizEnabled } = useAdminSetting(
+  const { value: isCustomVizEnabled, updateSetting } = useAdminSetting(
     CUSTOM_VIZ_ENABLED_SETTING,
   );
   const hasCustomVizFeature = useHasTokenFeature("custom-viz");
@@ -47,6 +45,15 @@ export function ManageCustomVizPage() {
     () => plugins?.filter((p) => !p.dev_only),
     [plugins],
   );
+
+  const handleDeactivate = useCallback(async () => {
+    await updateSetting({
+      key: CUSTOM_VIZ_ENABLED_SETTING,
+      value: false,
+      toast: false,
+    });
+    setTimeout(() => window.location.reload(), 1000);
+  }, [updateSetting]);
 
   const handleDelete = useCallback(
     async (id: CustomVizPluginId) => {
@@ -67,24 +74,41 @@ export function ManageCustomVizPage() {
           <Title order={1} style={{ height: "2.5rem" }}>
             {t`Custom visualizations`}
           </Title>
-          <Button
-            component={Link}
-            to={Urls.customVizAdd()}
-            leftSection={<Icon name="add" />}
-            variant="filled"
-          >
-            {t`Add`}
-          </Button>
+          <Group gap="xs">
+            <Button
+              component={Link}
+              to={Urls.customVizAdd()}
+              leftSection={<Icon name="add" />}
+              variant="filled"
+            >
+              {t`Add`}
+            </Button>
+            <Menu position="bottom-end">
+              <Menu.Target>
+                <ActionIcon
+                  variant="subtle"
+                  size="lg"
+                  aria-label={t`More options`}
+                >
+                  <Icon name="ellipsis" />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Item
+                  onClick={handleDeactivate}
+                  leftSection={<Icon name="pause" />}
+                >
+                  {t`Deactivate custom visualizations`}
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
         </Flex>
 
         <Text c="text-secondary" maw="40rem">
           {t`Add custom visualizations to your instance here by adding links to git repositories containing custom visualization bundles.`}
         </Text>
       </Stack>
-
-      <SettingsSection>
-        <CustomVizEnableSwitch />
-      </SettingsSection>
 
       {isLoading && (
         <Flex justify="center" p="xl">

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
@@ -52,7 +52,7 @@ export function ManageCustomVizPage() {
       value: false,
       toast: false,
     });
-    setTimeout(() => window.location.reload(), 1000);
+    window.location.reload();
   }, [updateSetting]);
 
   const handleDelete = useCallback(

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -1,9 +1,6 @@
-import { useEffect } from "react";
-import { usePrevious } from "react-use";
 import { jt, t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
-import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { UpsellCustomViz } from "metabase/admin/upsells";
 import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
@@ -25,8 +22,6 @@ import {
 export function CustomVisualizationsManagePage() {
   const customVizLoaded = useHasTokenFeature("custom-viz");
   const customVizAvailable = useHasTokenFeature("custom-viz-available");
-
-  useCustomVizEnabledSetting();
 
   if (!customVizAvailable) {
     return (
@@ -50,7 +45,6 @@ export function CustomVisualizationsFormPage({
 }) {
   const customVizFeatureLoaded = useHasTokenFeature("custom-viz");
   const hasCustomVizAvailable = useHasTokenFeature("custom-viz-available");
-  useCustomVizEnabledSetting();
 
   if (!hasCustomVizAvailable) {
     return (
@@ -70,7 +64,6 @@ export function CustomVisualizationsFormPage({
 export function CustomVisualizationsDevelopmentPage() {
   const hasCustomVizAvailable = useHasTokenFeature("custom-viz-available");
   const customVizFeatureLoaded = useHasTokenFeature("custom-viz");
-  useCustomVizEnabledSetting();
 
   if (!hasCustomVizAvailable) {
     return (
@@ -94,12 +87,13 @@ function CustomVizEmptyState() {
     CUSTOM_VIZ_ENABLED_SETTING,
   );
 
-  const handleEnable = () => {
-    updateSetting({
+  const handleEnable = async () => {
+    await updateSetting({
       key: CUSTOM_VIZ_ENABLED_SETTING,
       value: true,
       toast: false,
     });
+    window.location.reload();
   };
 
   return (
@@ -113,11 +107,10 @@ function CustomVizEmptyState() {
                 {t`Extend Metabase with chart types tailored to your data. Build visualization plugins using the Custom Viz SDK and link them from a Git repository.`}
               </Text>
 
-              <Text c="text-secondary" maw="40rem"></Text>
               <Alert
                 color="warning"
                 icon={<Icon name="warning" />}
-                title="Risks"
+                title={t`Risks`}
               >{jt`Be aware that custom visualizations ${<strong key="arbitrary-code">{t`can execute arbitrary code`}</strong>} and should only be added from trusted sources.`}</Alert>
             </Stack>
             <Group gap="sm">
@@ -180,46 +173,4 @@ function FeatureCard({ icon, title, description }: FeatureCardProps) {
       </Group>
     </Paper>
   );
-}
-
-export function CustomVizEnableSwitch() {
-  const { value: customVizEnabledSetting } = useAdminSetting(
-    CUSTOM_VIZ_ENABLED_SETTING,
-  );
-
-  const description = customVizEnabledSetting
-    ? t`Should custom visualizations be enabled for this instance? Disabling this will reload the page.`
-    : t`Should custom visualizations be enabled for this instance? Enabling this will reload the page.`;
-
-  return (
-    <AdminSettingInput
-      name={CUSTOM_VIZ_ENABLED_SETTING}
-      title={t`Enable Custom Visualizations`}
-      inputType="boolean"
-      description={description}
-    />
-  );
-}
-
-function useCustomVizEnabledSetting() {
-  const { value: customVizEnabledSetting } = useAdminSetting(
-    CUSTOM_VIZ_ENABLED_SETTING,
-  );
-  const customVizEnabledSettingPrev = usePrevious(customVizEnabledSetting);
-
-  useEffect(() => {
-    if (
-      customVizEnabledSettingPrev === undefined ||
-      customVizEnabledSetting === undefined
-    ) {
-      return;
-    }
-
-    if (customVizEnabledSetting !== customVizEnabledSettingPrev) {
-      setTimeout(() => {
-        window.location.reload();
-        // timeout helps to render the UI consistently when toggling feature
-      }, 1000);
-    }
-  }, [customVizEnabledSetting, customVizEnabledSettingPrev]);
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -159,7 +159,7 @@ type FeatureCardProps = {
 
 function FeatureCard({ icon, title, description }: FeatureCardProps) {
   return (
-    <Paper bg="background-secondary" p="md" radius="8px" shadow="none">
+    <Paper bg="background-secondary" p="md" radius="md" shadow="none">
       <Group gap="sm" align="flex-start" wrap="nowrap">
         <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
         <Stack gap="xs">

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { usePrevious } from "react-use";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
@@ -118,7 +118,7 @@ function CustomVizEmptyState() {
                 color="warning"
                 icon={<Icon name="warning" />}
                 title="Risks"
-              >{t`Be aware that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}</Alert>
+              >{jt`Be aware that custom visualizations ${<strong key="arbitrary-code">{t`can execute arbitrary code`}</strong>} and should only be added from trusted sources.`}</Alert>
             </Stack>
             <Group gap="sm">
               <Button

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -2,15 +2,25 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { UpsellCustomViz } from "metabase/admin/upsells";
 import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
+import {
+  Alert,
+  Button,
+  Card,
+  Group,
+  Icon,
+  type IconName,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
 
 export function CustomVisualizationsManagePage() {
   const customVizLoaded = useHasTokenFeature("custom-viz");
@@ -27,7 +37,7 @@ export function CustomVisualizationsManagePage() {
   }
 
   if (!customVizLoaded) {
-    return <CustomVizNotLoaded />;
+    return <CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.ManageCustomVizPage />;
@@ -51,7 +61,7 @@ export function CustomVisualizationsFormPage({
   }
 
   if (!customVizFeatureLoaded) {
-    return <CustomVizNotLoaded />;
+    return <CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizPage params={params} />;
@@ -71,7 +81,7 @@ export function CustomVisualizationsDevelopmentPage() {
   }
 
   if (!customVizFeatureLoaded) {
-    return <CustomVizNotLoaded />;
+    return <CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizDevPage />;
@@ -79,13 +89,96 @@ export function CustomVisualizationsDevelopmentPage() {
 
 const CUSTOM_VIZ_ENABLED_SETTING = "custom-viz-enabled";
 
-function CustomVizNotLoaded() {
+function CustomVizEmptyState() {
+  const { updateSetting, updateSettingResult } = useAdminSetting(
+    CUSTOM_VIZ_ENABLED_SETTING,
+  );
+
+  const handleEnable = () => {
+    updateSetting({
+      key: CUSTOM_VIZ_ENABLED_SETTING,
+      value: true,
+      toast: false,
+    });
+  };
+
   return (
     <SettingsPageWrapper title={t`Custom visualizations`}>
-      <SettingsSection>
-        <CustomVizEnableSwitch />
-      </SettingsSection>
+      <Card bg="background-primary" p={48} maw={640} withBorder>
+        <Stack gap="3rem">
+          <Stack gap="md">
+            <Stack gap="sm">
+              <Title order={3}>{t`Build custom visualizations`}</Title>
+              <Text c="text-secondary" lh="1.25rem">
+                {t`Extend Metabase with chart types tailored to your data. Build visualization plugins using the Custom Viz SDK and link them from a Git repository.`}
+              </Text>
+
+              <Text c="text-secondary" maw="40rem"></Text>
+              <Alert
+                color="warning"
+                icon={<Icon name="warning" />}
+                title="Risks"
+              >{t`Be aware that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}</Alert>
+            </Stack>
+            <Group gap="sm">
+              <Button
+                variant="filled"
+                onClick={handleEnable}
+                loading={updateSettingResult.isLoading}
+              >
+                {t`Enable Custom Visualizations`}
+              </Button>
+            </Group>
+          </Stack>
+          <SimpleGrid cols={2} spacing="sm">
+            <FeatureCard
+              icon="lineandbar"
+              title={t`Custom chart types`}
+              description={t`Create visualization types designed for your specific data and use cases`}
+            />
+            <FeatureCard
+              icon="code_block"
+              title={t`SDK-based development`}
+              description={t`Build plugins with the Custom Visualizations SDK`}
+            />
+            <FeatureCard
+              icon="git_branch"
+              title={t`Git-based distribution`}
+              description={t`Publish custom visualizations by linking to a Git repository`}
+            />
+            <FeatureCard
+              icon="gear"
+              title={t`Full control`}
+              description={t`Enable, disable, and manage custom visualization plugins`}
+            />
+          </SimpleGrid>
+        </Stack>
+      </Card>
     </SettingsPageWrapper>
+  );
+}
+
+type FeatureCardProps = {
+  icon: IconName;
+  title: string;
+  description: string;
+};
+
+function FeatureCard({ icon, title, description }: FeatureCardProps) {
+  return (
+    <Paper bg="background-secondary" p="md" radius="8px" shadow="none">
+      <Group gap="sm" align="flex-start" wrap="nowrap">
+        <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
+        <Stack gap="xs">
+          <Text fw="bold" lh="1rem">
+            {title}
+          </Text>
+          <Text c="text-secondary" lh="1rem">
+            {description}
+          </Text>
+        </Stack>
+      </Group>
+    </Paper>
   );
 }
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2338/revise-custom-visualizations-activation-flow

### Description

UX and UI adjustment to the enable/disable flow.

### How to verify

### Demo

[Custom Visualizations Enable Disable Flow](https://www.loom.com/share/faf244b4fb60491d98ab36ecf5b59075)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
