### PR TITLE
Strip client-supplied :card before hydrating in update-dashcards!

### DIFF
--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -280,7 +280,12 @@
                                    (update :series #(map :id %)))
             dashboard-card     (update dashcard :series #(map :id %))]
         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
-    (let [new-param-field-ids (params/dashcards->param-field-ids (t2/hydrate new-dashcards :card))]
+    ;; `t2/hydrate` is a no-op when `:card` is already present, so strip any
+    ;; client-supplied value first: a JSON round-trip strings-ifies keyword
+    ;; metadata (`type/Category`, `source/table-defaults`, ...) that
+    ;; `param-target->field-id` later validates against `:metabase.queries.schema/card`.
+    (let [dashcards-for-hydration (map #(dissoc % :card) new-dashcards)
+          new-param-field-ids    (params/dashcards->param-field-ids (t2/hydrate dashcards-for-hydration :card))]
       (update-field-values-for-on-demand-dbs! (params/dashcards->param-field-ids old-dashcards) new-param-field-ids))))
 
 (defn- legacy-result-metadata-for-query

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -300,7 +300,12 @@
                                    (update :series #(map :id %)))
             dashboard-card     (update dashcard :series #(map :id %))]
         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
-    (let [new-param-field-ids (params/dashcards->param-field-ids (t2/hydrate new-dashcards :card))]
+    ;; `t2/hydrate` is a no-op when `:card` is already present, so strip any
+    ;; client-supplied value first: a JSON round-trip strings-ifies keyword
+    ;; metadata (`type/Category`, `source/table-defaults`, ...) that
+    ;; `param-target->field-id` later validates against `:metabase.queries.schema/card`.
+    (let [dashcards-for-hydration (map #(dissoc % :card) new-dashcards)
+          new-param-field-ids    (params/dashcards->param-field-ids (t2/hydrate dashcards-for-hydration :card))]
       (update-field-values-for-on-demand-dbs! (params/dashcards->param-field-ids old-dashcards) new-param-field-ids))))
 
 (defn- legacy-result-metadata-for-query


### PR DESCRIPTION
## Summary

`dashboard/update-dashcards!` runs

```clj
(params/dashcards->param-field-ids (t2/hydrate new-dashcards :card))
```

to compute the field IDs referenced by parameter mappings (for the
`update-field-values-for-on-demand-dbs!` side effect). Because `t2/hydrate`
is a no-op when `:card` is already present, a client that `PUT`s
`/api/dashboard/:id` with a dashcard that still carries the nested `:card`
it received from `GET /api/dashboard/:id` forwards that object straight into
`params/param-target->field-id`.

That function validates its `card` arg against
`:metabase.queries.schema/card`. Since Oct 2025 (`1a73c0ac20` "MBQL 5 over
the wire") the schema requires keywordized metadata — `:type/Category`,
`:source/table-defaults`, etc. After a JSON round-trip through `cy.request`
/ `fetch`, those values are strings, and the request 500s with:

```
Invalid input: {:result_metadata [{:semantic_type ["should be a keyword, got: \"type/Category\"" ...]
                                   :lib/source ["should be ... got: \"source/table-defaults\""]
                                   :source ["should be ... got: \"breakout\""]
                                   :field_ref [["should be :field, got: \"field\""]]
                                   ...}]}
```

For example, the `title-drill.cy.spec.js` "as a user without access to
underlying data" beforeEach calls `H.editDashboardCard` which does exactly
this `PUT`.

The fix is to `dissoc :card` from each dashcard before calling
`t2/hydrate`, forcing a fresh select that doesn't trust the data from the client.