### PR TITLE
Notify Slack when the auto-patch workflow skips a release (DEV-1854)

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -35,12 +35,16 @@ jobs:
         run: bun install --cwd release --frozen-lockfile && bun run --cwd release build
       - name: Trigger auto-patch
         uses: actions/github-script@v7
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
             const {
               getLatestGreenCommit,
               getNextPatchVersion,
               hasCommitBeenReleased,
+              sendAutoPatchFailureMessage,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const currentRelease = Number('${{ vars.CURRENT_VERSION }}');
@@ -86,9 +90,25 @@ jobs:
                     auto: true,
                   }
                 }).catch(console.error);
-              } else {
-                console.error(`No new patch version or no green commit found for v${majorVersion}`);
+                return;
               }
+
+              const reason = !nextPatch
+                ? 'no-next-patch'
+                : !releaseCommit
+                  ? 'no-green-commit'
+                  : 'already-released';
+
+              console.error(`Auto-patch skipped for v${majorVersion}: ${reason}`);
+
+              await sendAutoPatchFailureMessage({
+                channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
+                majorVersion,
+                reason,
+                runId: '${{ github.run_id }}',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }).catch(console.error);
             }
 
             if (context.eventName === 'workflow_dispatch') {

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -279,6 +279,46 @@ export function githubRunLink(
   );
 }
 
+export type AutoPatchSkipReason =
+  | "no-next-patch"
+  | "no-green-commit"
+  | "already-released";
+
+type AutoPatchSkipArgs = {
+  majorVersion: number;
+  reason: AutoPatchSkipReason;
+  runId: string;
+  owner: string;
+  repo: string;
+};
+
+export function buildAutoPatchSkipMessage({
+  majorVersion,
+  reason,
+  runId,
+  owner,
+  repo,
+}: AutoPatchSkipArgs): string {
+  const runLink = githubRunLink("workflow run", runId, owner, repo);
+
+  const messageByReason: Record<AutoPatchSkipReason, string> = {
+    "no-green-commit": `:x: Auto-patch for *v${majorVersion}* skipped: no commit found suitable for the release. ${runLink}`,
+    "no-next-patch": `:x: Auto-patch for *v${majorVersion}* skipped: could not determine next patch version. ${runLink}`,
+    "already-released": `:information_source: Auto-patch for *v${majorVersion}* skipped: latest green commit has already been released — nothing new to patch. ${runLink}`,
+  };
+
+  return messageByReason[reason];
+}
+
+export async function sendAutoPatchFailureMessage(
+  args: AutoPatchSkipArgs & { channelName: string },
+) {
+  return sendSlackMessage({
+    channelName: args.channelName,
+    message: buildAutoPatchSkipMessage(args),
+  });
+}
+
 export async function sendPreReleaseMessage({
   github,
   owner,

--- a/release/src/slack.unit.spec.ts
+++ b/release/src/slack.unit.spec.ts
@@ -1,0 +1,51 @@
+import { buildAutoPatchSkipMessage } from "./slack";
+
+describe("buildAutoPatchSkipMessage", () => {
+  const baseArgs = {
+    majorVersion: 54,
+    runId: "12345",
+    owner: "metabase",
+    repo: "metabase",
+  };
+
+  const runLink = "<https://github.com/metabase/metabase/actions/runs/12345|workflow run>";
+
+  it("uses a failure emoji for no-green-commit", () => {
+    const message = buildAutoPatchSkipMessage({ ...baseArgs, reason: "no-green-commit" });
+
+    expect(message).toContain(":x:");
+    expect(message).toContain("v54");
+    expect(message).toContain("no commit found suitable for the release");
+    expect(message).toContain(runLink);
+  });
+
+  it("uses a failure emoji for no-next-patch", () => {
+    const message = buildAutoPatchSkipMessage({ ...baseArgs, reason: "no-next-patch" });
+
+    expect(message).toContain(":x:");
+    expect(message).toContain("v54");
+    expect(message).toContain("next patch version");
+    expect(message).toContain(runLink);
+  });
+
+  it("uses an info emoji (not a failure emoji) for already-released", () => {
+    const message = buildAutoPatchSkipMessage({ ...baseArgs, reason: "already-released" });
+
+    expect(message).toContain(":information_source:");
+    expect(message).not.toContain(":x:");
+    expect(message).toContain("v54");
+    expect(message).toContain("nothing new to patch");
+    expect(message).toContain(runLink);
+  });
+
+  it("uses the provided major version in the message", () => {
+    const message = buildAutoPatchSkipMessage({
+      ...baseArgs,
+      majorVersion: 53,
+      reason: "no-green-commit",
+    });
+
+    expect(message).toContain("v53");
+    expect(message).not.toContain("v54");
+  });
+});


### PR DESCRIPTION
Resolves DEV-1854

## Summary

Replace the silent console.error in .github/workflows/release-patch.yml with a Slack post that names the specific reason (broken CI, no next patch version, or already-released). Failures use :x:; the benign already-released case uses :information_source: so daily no-op runs don't read as alerts.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
