### PR TITLE
feat: surface complexity score in admin UI

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2853,6 +2853,7 @@
            collections
            config
            metabot
+           models
            premium-features
            settings
            startup

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
    [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
+   [metabase-enterprise.data-complexity-score.settings :as settings]
    [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -89,6 +90,12 @@
     (let [fingerprint (task.complexity-score/current-fingerprint)
           result      (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))]
       (data-complexity-score/record-score! fingerprint result)
+      ;; Advance the last-published fingerprint iff Snowplow actually accepted the event — mirrors
+      ;; the scheduled path's gate in `task.complexity-score/run-scoring!`. Without this, a
+      ;; superuser-triggered refresh leaves the setting stale and the next boot would redundantly
+      ;; re-score even though a valid snapshot was just persisted.
+      (when (::complexity/snowplow-published? (meta result))
+        (settings/data-complexity-scoring-last-fingerprint! fingerprint))
       (m.util/deep-snake-keys result))
     (finally
       (.set api-scoring-running? false))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -3,9 +3,12 @@
   (:require
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
+   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.api.routes.common :refer [+auth]]))
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.util :as m.util]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,11 +30,11 @@
    [:total [:maybe nat-int?]]
    [:components
     [:map
-     [:entity-count      SubScore]
-     [:name-collisions   SubScore]
-     [:synonym-pairs     SubScore]
-     [:field-count       SubScore]
-     [:repeated-measures SubScore]]]])
+     [:entity_count      SubScore]
+     [:name_collisions   SubScore]
+     [:synonym_pairs     SubScore]
+     [:field_count       SubScore]
+     [:repeated_measures SubScore]]]])
 
 (def ^:private EmbeddingModelMeta
   "Identifies the embedding model backing the synonym calculations, so benchmark consumers can pin to it.
@@ -39,7 +42,7 @@
   [:maybe
    [:map
     [:provider   string?]
-    [:model-name string?]]])
+    [:model_name string?]]])
 
 (def ^:private ComplexityScoresResponse
   "Full response body for `GET /api/ee/data-complexity-score/complexity`."
@@ -49,9 +52,9 @@
    [:metabot  Catalog]
    [:meta
     [:map
-     [:formula-version   pos-int?]
-     [:synonym-threshold number?]
-     [:embedding-model {:optional true} EmbeddingModelMeta]]]])
+     [:formula_version   pos-int?]
+     [:synonym_threshold number?]
+     [:embedding_model {:optional true} EmbeddingModelMeta]]]])
 
 ;; Per-JVM single-flight guard for the /complexity endpoint. Each scoring run walks the entire
 ;; app-db catalog and emits Snowplow events, so concurrent superuser requests on the same node
@@ -65,7 +68,15 @@
   (java.util.concurrent.atomic.AtomicBoolean. false))
 
 (api.macros/defendpoint :get "/complexity" :- ComplexityScoresResponse
-  "Return the current Data Complexity Score for this instance.
+  "Return the most recently stored Data Complexity Score for this instance.
+  Superuser-only."
+  [_route _query _body]
+  (api/check-superuser)
+  (api/check-404 (some-> (data-complexity-score/latest-score)
+                         m.util/deep-snake-keys)))
+
+(api.macros/defendpoint :post "/complexity/refresh" :- ComplexityScoresResponse
+  "Run the Data Complexity Score job now, persist the fresh snapshot, and return it.
   Superuser-only, expensive, and emits Snowplow events for benchmark consumers. Concurrent
   requests on the same JVM fast-fail with HTTP 409 — a scoring pass walks the full app-db
   catalog and one in-flight run per node is enough. The guard is per-JVM, so in a clustered
@@ -75,7 +86,10 @@
   (when-not (.compareAndSet api-scoring-running? false true)
     (throw (ex-info "Data Complexity Score calculation already in progress" {:status-code 409})))
   (try
-    (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))
+    (let [fingerprint (task.complexity-score/current-fingerprint)
+          result      (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))]
+      (data-complexity-score/record-score! fingerprint result)
+      (m.util/deep-snake-keys result))
     (finally
       (.set api-scoring-running? false))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -9,7 +9,8 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
-   [metabase.util :as m.util]))
+   [metabase.util :as m.util]
+   [metabase.util.i18n :refer [tru]]))
 
 (set! *warn-on-reflection* true)
 
@@ -55,6 +56,7 @@
     [:map
      [:formula_version   pos-int?]
      [:synonym_threshold number?]
+     [:calculated_at {:optional true} some?]
      [:embedding_model {:optional true} EmbeddingModelMeta]]]])
 
 ;; Per-JVM single-flight guard for the /complexity endpoint. Each scoring run walks the entire
@@ -73,8 +75,9 @@
   Superuser-only."
   [_route _query _body]
   (api/check-superuser)
-  (api/check-404 (some-> (data-complexity-score/latest-score)
-                         m.util/deep-snake-keys)))
+  (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
+                         m.util/deep-snake-keys)
+                 (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot.")))
 
 (api.macros/defendpoint :post "/complexity/refresh" :- ComplexityScoresResponse
   "Run the Data Complexity Score job now, persist the fresh snapshot, and return it.
@@ -88,15 +91,15 @@
     (throw (ex-info "Data Complexity Score calculation already in progress" {:status-code 409})))
   (try
     (let [fingerprint (task.complexity-score/current-fingerprint)
-          result      (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))]
-      (data-complexity-score/record-score! fingerprint result)
+          result      (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))
+          stored      (data-complexity-score/record-score! fingerprint result)]
       ;; Advance the last-published fingerprint iff Snowplow actually accepted the event — mirrors
       ;; the scheduled path's gate in `task.complexity-score/run-scoring!`. Without this, a
       ;; superuser-triggered refresh leaves the setting stale and the next boot would redundantly
       ;; re-score even though a valid snapshot was just persisted.
       (when (::complexity/snowplow-published? (meta result))
         (settings/data-complexity-scoring-last-fingerprint! fingerprint))
-      (m.util/deep-snake-keys result))
+      (m.util/deep-snake-keys (or stored result)))
     (finally
       (.set api-scoring-running? false))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -10,7 +10,8 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.util :as m.util]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
@@ -70,23 +71,13 @@
 (defonce ^:private ^java.util.concurrent.atomic.AtomicBoolean api-scoring-running?
   (java.util.concurrent.atomic.AtomicBoolean. false))
 
-(api.macros/defendpoint :get "/complexity" :- ComplexityScoresResponse
-  "Return the most recently stored Data Complexity Score for this instance.
-  Superuser-only."
-  [_route _query _body]
-  (api/check-superuser)
-  (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
-                         m.util/deep-snake-keys)
-                 (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot.")))
-
-(api.macros/defendpoint :post "/complexity/refresh" :- ComplexityScoresResponse
+(defn- force-recalculate-score!
   "Run the Data Complexity Score job now, persist the fresh snapshot, and return it.
-  Superuser-only, expensive, and emits Snowplow events for benchmark consumers. Concurrent
-  requests on the same JVM fast-fail with HTTP 409 — a scoring pass walks the full app-db
-  catalog and one in-flight run per node is enough. The guard is per-JVM, so in a clustered
+  This is expensive and emits Snowplow events for benchmark consumers. Concurrent requests
+  on the same JVM fast-fail with HTTP 409 — a scoring pass walks the full app-db catalog
+  and one in-flight run per node is enough. The guard is per-JVM, so in a clustered
   deployment each node can still run one pass concurrently."
-  [_route _query _body]
-  (api/check-superuser)
+  []
   (when-not (.compareAndSet api-scoring-running? false true)
     (throw (ex-info "Data Complexity Score calculation already in progress" {:status-code 409})))
   (try
@@ -95,13 +86,28 @@
           stored      (data-complexity-score/record-score! fingerprint result)]
       ;; Advance the last-published fingerprint iff Snowplow actually accepted the event — mirrors
       ;; the scheduled path's gate in `task.complexity-score/run-scoring!`. Without this, a
-      ;; superuser-triggered refresh leaves the setting stale and the next boot would redundantly
-      ;; re-score even though a valid snapshot was just persisted.
+      ;; superuser-triggered recalculation leaves the setting stale and the next boot would
+      ;; redundantly re-score even though a valid snapshot was just persisted.
       (when (::complexity/snowplow-published? (meta result))
         (settings/data-complexity-scoring-last-fingerprint! fingerprint))
       (m.util/deep-snake-keys (or stored result)))
     (finally
       (.set api-scoring-running? false))))
+
+(api.macros/defendpoint :get "/complexity" :- ComplexityScoresResponse
+  "Return the most recently stored Data Complexity Score for this instance.
+  Pass `force-recalculation=true` to recompute, persist, and return a fresh score.
+  Superuser-only."
+  [_route
+   {force-recalculation? :force-recalculation} :- [:map
+                                                   [:force-recalculation {:default false} ms/BooleanValue]]
+   _body]
+  (api/check-superuser)
+  (if force-recalculation?
+    (force-recalculate-score!)
+    (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
+                           m.util/deep-snake-keys)
+                   (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-complexity-score` routes."

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/init.clj
@@ -4,6 +4,7 @@
   (:require
    [metabase-enterprise.data-complexity-score.settings]
    [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
+   [metabase-enterprise.data-complexity-score.task.complexity-score-trimmer]
    [metabase.startup.core :as startup]
    [metabase.util.quick-task :as quick-task]))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -1,0 +1,31 @@
+(ns metabase-enterprise.data-complexity-score.models.data-complexity-score
+  "Persistence for cached Data Complexity Score snapshots."
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/DataComplexityScore [_model] :data_complexity_score)
+
+(doto :model/DataComplexityScore
+  (derive :metabase/model))
+
+(t2/deftransforms :model/DataComplexityScore
+  {:score_data mi/transform-json})
+
+(defn latest-entry
+  "Return the most recently persisted Data Complexity Score row, or nil if none exist."
+  []
+  (t2/select-one :model/DataComplexityScore {:order-by [[:id :desc]]}))
+
+(defn latest-score
+  "Return the latest persisted Data Complexity Score payload, or nil if none exist."
+  []
+  (:score_data (latest-entry)))
+
+(defn record-score!
+  "Persist one append-only Data Complexity Score snapshot."
+  [fingerprint score]
+  (t2/insert! :model/DataComplexityScore
+              {:fingerprint fingerprint
+               :score_data  score}))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -13,19 +13,28 @@
 (t2/deftransforms :model/DataComplexityScore
   {:score_data mi/transform-json})
 
+(defn- score-with-calculated-at
+  [{:keys [score_data created_at]}]
+  (when score_data
+    (assoc-in score_data [:meta :calculated-at] created_at)))
+
 (defn latest-entry
-  "Return the most recently persisted Data Complexity Score row, or nil if none exist."
-  []
-  (t2/select-one :model/DataComplexityScore {:order-by [[:id :desc]]}))
+  "Return the most recently persisted Data Complexity Score row for `fingerprint`, or nil if none exist."
+  [fingerprint]
+  (t2/select-one :model/DataComplexityScore :fingerprint fingerprint {:order-by [[:id :desc]]}))
 
 (defn latest-score
-  "Return the latest persisted Data Complexity Score payload, or nil if none exist."
-  []
-  (:score_data (latest-entry)))
+  "Return the latest persisted Data Complexity Score payload for `fingerprint`, or nil if none exist."
+  [fingerprint]
+  (some-> (latest-entry fingerprint)
+          score-with-calculated-at))
 
 (defn record-score!
   "Persist one append-only Data Complexity Score snapshot."
   [fingerprint score]
-  (t2/insert! :model/DataComplexityScore
-              {:fingerprint fingerprint
-               :score_data  score}))
+  (let [id (t2/insert-returning-pk! :model/DataComplexityScore
+                                    {:fingerprint fingerprint
+                                     :score_data  score})]
+    (if id
+      (score-with-calculated-at (t2/select-one :model/DataComplexityScore :id id))
+      (latest-score fingerprint))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -7,6 +7,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
    [metabase-enterprise.data-complexity-score.settings :as settings]
    [metabase-enterprise.semantic-search.core :as semantic-search]
    [metabase.app-db.cluster-lock :as cluster-lock]
@@ -21,7 +22,7 @@
 (def ^:private job-key     (jobs/key "metabase.task.data-complexity-score.job"))
 (def ^:private trigger-key (triggers/key "metabase.task.data-complexity-score.trigger"))
 
-(defn- current-fingerprint
+(defn current-fingerprint
   "String capturing everything that changes the meaning of an emitted score — mirror of the Snowplow
   `formula_version` + `parameters` fields. Includes `weights` so re-tuning forces a re-score
   without bumping `formula-version`; only structural changes to the scoring algorithm need that."
@@ -49,12 +50,17 @@
   (if (settings/data-complexity-scoring-enabled)
     (try
       (let [result (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))]
-        (if (::complexity/snowplow-published? (meta result))
-          (settings/data-complexity-scoring-last-fingerprint! claim-fingerprint)
-          (log/warn "Data Complexity Score: Snowplow publish failed; leaving fingerprint unchanged so the next boot or cron retries"))
+        (try
+          (data-complexity-score/record-score! claim-fingerprint result)
+          (if (::complexity/snowplow-published? (meta result))
+            (settings/data-complexity-scoring-last-fingerprint! claim-fingerprint)
+            (log/warn "Data Complexity Score: Snowplow publish failed; leaving fingerprint unchanged so the next boot or cron retries"))
+          (catch Throwable t
+            (log/warn t "Data Complexity Score: failed to persist score snapshot; leaving fingerprint unchanged so the next boot or cron retries")))
         result)
       (catch Throwable t
-        (log/warn t "Data Complexity Score run failed")))
+        (log/warn t "Data Complexity Score run failed")
+        nil))
     (log/debug "Data Complexity Score run skipped — data-complexity-scoring-enabled is off")))
 
 ;; Long enough that any realistic scoring run finishes well inside it, short enough that a crashed

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer.clj
@@ -1,0 +1,57 @@
+(ns metabase-enterprise.data-complexity-score.task.complexity-score-trimmer
+  "Scheduled task to delete old Data Complexity Score snapshots."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [java-time.api :as t]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private job-key
+  (jobs/key "metabase-enterprise.data-complexity-score.task.complexity-score-trimmer.job"))
+
+(def ^:private trigger-key
+  (triggers/key "metabase-enterprise.data-complexity-score.task.complexity-score-trimmer.trigger"))
+
+(def ^:private retention-months 3)
+
+(defn- retention-cutoff-timestamp
+  [months]
+  (Timestamp/valueOf ^java.time.LocalDateTime
+   (t/minus (t/local-date-time) (t/months months))))
+
+(defn- trim-old-complexity-score-data!
+  []
+  (log/info "Trimming old Data Complexity Score snapshots.")
+  (let [cutoff  (retention-cutoff-timestamp retention-months)
+        deleted (t2/delete! :model/DataComplexityScore {:where [:< :created_at cutoff]})]
+    (log/infof "Data Complexity Score cleanup complete. Deleted %d rows." (or deleted 0))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Delete old Data Complexity Score snapshots"}
+  DataComplexityScoreTrimmer [_ctx]
+  (trim-old-complexity-score-data!))
+
+(defmethod task/init! ::DataComplexityScoreTrimmer [_]
+  (let [job     (jobs/build
+                 (jobs/of-type DataComplexityScoreTrimmer)
+                 (jobs/store-durably)
+                 (jobs/with-identity job-key)
+                 (jobs/with-description "Data Complexity Score cleanup"))
+        ;; 03:43 UTC — separate from the scoring run, still off-hour.
+        trigger (triggers/build
+                 (triggers/with-identity trigger-key)
+                 (triggers/for-job job-key)
+                 (triggers/with-schedule
+                  (cron/schedule
+                   (cron/cron-schedule "0 43 3 * * ? *")
+                   (cron/in-time-zone (java.util.TimeZone/getTimeZone "UTC"))
+                   (cron/with-misfire-handling-instruction-fire-and-proceed))))]
+    (task/schedule-task! job trigger)))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer.clj
@@ -15,10 +15,10 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private job-key
-  (jobs/key "metabase-enterprise.data-complexity-score.task.complexity-score-trimmer.job"))
+  (jobs/key "metabase.task.data-complexity-score-trimmer.trim.job"))
 
 (def ^:private trigger-key
-  (triggers/key "metabase-enterprise.data-complexity-score.task.complexity-score-trimmer.trigger"))
+  (triggers/key "metabase.task.data-complexity-score-trimmer.trim.trigger"))
 
 (def ^:private retention-months 3)
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -77,6 +77,7 @@
    "ConnectionImpersonation"
    "ContentTranslation"
    "DashboardBookmark"
+   "DataComplexityScore"
    "DataPermissions"
    "DatabaseRouter"
    "Dependency"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -4,8 +4,12 @@
    [metabase-enterprise.data-complexity-score.api :as api]
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
+   [metabase-enterprise.data-complexity-score.settings :as data-complexity-score.settings]
+   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase.metabot.config :as metabot.config]
    [metabase.test :as mt]
+   [metabase.util :as m.util]
    [toucan2.core :as t2])
   (:import
    (java.util.concurrent CountDownLatch TimeUnit)))
@@ -15,6 +19,7 @@
 (comment api/keep-me)
 
 (def ^:private endpoint "ee/data-complexity-score/complexity")
+(def ^:private refresh-endpoint "ee/data-complexity-score/complexity/refresh")
 
 (defn- internal-metabot-id
   "Primary key of the internal Metabot row — used by the tests that temporarily tweak its
@@ -32,44 +37,110 @@
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 endpoint)))))
 
-(deftest complexity-endpoint-superuser-gets-consistent-totals-test
-  (testing "check invariants not covered by schema"
-    (let [resp (mt/user-http-request :crowberto :get 200 endpoint)
-          measurement      (fn [cat k] (get-in resp [cat :components k :measurement]))
-          component-score  (fn [cat k] (get-in resp [cat :components k :score]))
-          ;; NOTE: `:synonym-pairs` is intentionally included here even though it's *theoretically*
-          ;; non-monotonic — `score-synonym-pairs` dedupes by normalized name and keeps whichever
-          ;; embedding `search-index-embedder` happens to pick for that name, so adding
-          ;; universe-only entities that collide on normalized name with a library entity could in
-          ;; principle flip which vector wins and drop the pair count below library's. Reviewers
-          ;; (human or AI) sometimes want to carve it out on that basis — don't. In every realistic
-          ;; configuration (prod, dev, the fixture that backs this endpoint's hermetic path in
-          ;; complexity_test.clj) the invariant holds, and asserting it keeps us honest about
-          ;; regressions in the common case. If the edge case ever actually trips this, *that* is
-          ;; the surprising thing we want to see and we'll deal with it then.
-          component-keys   [:entity-count :name-collisions :synonym-pairs
-                            :field-count :repeated-measures]]
-      (testing ":total equals the sum of its component :score values"
-        (doseq [catalog [:library :universe :metabot]
-                :let [{:keys [total components]} (get resp catalog)]]
-          (is (= total (reduce + (map :score (vals components))))
-              (format "%s :total should equal sum of component :score values" catalog))))
-      (testing "universe is a superset of library: every measurement and score ≥ library's"
-        (doseq [k      component-keys
-                getter [measurement component-score]
-                :let   [lib (getter :library k)
-                        uni (getter :universe k)]]
-          (is (>= uni lib)
-              (format "universe %s (%s) should be ≥ library's (%s)" k uni lib))))
-      (testing ":synonym-pairs can't exceed the number of distinct-name pairs possible"
-        (doseq [catalog [:library :universe :metabot]
-                :let [n-entities (measurement catalog :entity-count)
-                      syn-pairs  (measurement catalog :synonym-pairs)
-                      max-pairs  (/ (* n-entities (dec n-entities)) 2)]]
-          (is (<= syn-pairs max-pairs)
-              (format "%s :synonym-pairs (%s) can't exceed n*(n-1)/2 for n=%s" catalog syn-pairs n-entities)))))))
+(deftest complexity-refresh-endpoint-requires-superuser-test
+  (testing "non-superusers cannot trigger a forced recomputation"
+    (is (= "You don't have permissions to do that."
+           (mt/user-http-request :rasta :post 403 refresh-endpoint)))))
 
-(deftest complexity-endpoint-metabot-catalog-test
+(def ^:private sample-score
+  {:library  {:total 18
+              :components {:entity-count      {:measurement 1.0 :score 10}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 8.0 :score 8}
+                           :repeated-measures {:measurement 0.0 :score 0}}}
+   :universe {:total 54
+              :components {:entity-count      {:measurement 2.0 :score 20}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 24.0 :score 24}
+                           :repeated-measures {:measurement 5.0 :score 10}}}
+   :metabot  {:total 30
+              :components {:entity-count      {:measurement 1.0 :score 10}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 20.0 :score 20}
+                           :repeated-measures {:measurement 0.0 :score 0}}}
+   :meta     {:formula-version 3
+              :synonym-threshold 0.9}})
+
+(deftest complexity-endpoint-returns-latest-stored-score-test
+  (testing "superusers read the latest persisted score snapshot instead of recomputing it on demand"
+    (mt/with-dynamic-fn-redefs [data-complexity-score/latest-score (constantly sample-score)]
+      (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+        (is (= (m.util/deep-snake-keys sample-score) resp))
+        (is (contains? (:meta resp) :formula_version))
+        (is (not (contains? (:meta resp) :formula-version)))
+        (is (contains? (get-in resp [:library :components]) :entity_count))
+        (is (not (contains? (get-in resp [:library :components]) :entity-count)))))))
+
+(deftest complexity-endpoint-404s-when-no-score-has-been-persisted-yet-test
+  (testing "the endpoint 404s until the background scorer has produced its first snapshot"
+    (mt/with-dynamic-fn-redefs [data-complexity-score/latest-score (constantly nil)]
+      (is (= "Not found."
+             (mt/user-http-request :crowberto :get 404 endpoint))))))
+
+(deftest complexity-refresh-endpoint-returns-fresh-score-test
+  (testing "superusers can trigger the expensive recompute path on demand"
+    (let [persisted? (atom nil)]
+      (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                    task.complexity-score/current-fingerprint (constantly "api-test-fp")
+                    complexity/complexity-scores              (fn [& _] sample-score)
+                    data-complexity-score/record-score!       (fn [fingerprint stored-score]
+                                                                (reset! persisted? [fingerprint stored-score]))]
+        (is (= (m.util/deep-snake-keys sample-score)
+               (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
+        (is (= ["api-test-fp" sample-score] @persisted?))))))
+
+(deftest complexity-refresh-endpoint-runs-when-scheduled-scoring-disabled-test
+  (testing "manual refresh does not reuse the scheduled scorer's enabled gate"
+    (mt/with-temporary-setting-values [data-complexity-scoring-enabled false]
+      (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                    task.complexity-score/current-fingerprint (constantly "api-test-fp")
+                    complexity/complexity-scores              (fn [& _] sample-score)
+                    data-complexity-score/record-score!       (fn [& _] nil)]
+        (is (= (m.util/deep-snake-keys sample-score)
+               (mt/user-http-request :crowberto :post 200 refresh-endpoint)))))))
+
+(deftest ^:sequential complexity-refresh-endpoint-superuser-gets-consistent-totals-test
+  (testing "check invariants not covered by schema"
+    (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
+      (let [resp             (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+            measurement      (fn [cat k] (get-in resp [cat :components k :measurement]))
+            component-score  (fn [cat k] (get-in resp [cat :components k :score]))
+            ;; NOTE: `:synonym_pairs` is intentionally included here even though it's *theoretically*
+            ;; non-monotonic — `score-synonym-pairs` dedupes by normalized name and keeps whichever
+            ;; embedding `search-index-embedder` happens to pick for that name, so adding
+            ;; universe-only entities that collide on normalized name with a library entity could in
+            ;; principle flip which vector wins and drop the pair count below library's. Reviewers
+            ;; (human or AI) sometimes want to carve it out on that basis — don't. In every realistic
+            ;; configuration (prod, dev, the fixture that backs this endpoint's hermetic path in
+            ;; complexity_test.clj) the invariant holds, and asserting it keeps us honest about
+            ;; regressions in the common case. If the edge case ever actually trips this, *that* is
+            ;; the surprising thing we want to see and we'll deal with it then.
+            component-keys   [:entity_count :name_collisions :synonym_pairs
+                              :field_count :repeated_measures]]
+        (testing ":total equals the sum of its component :score values"
+          (doseq [catalog [:library :universe :metabot]
+                  :let [{:keys [total components]} (get resp catalog)]]
+            (is (= total (reduce + (map :score (vals components))))
+                (format "%s :total should equal sum of component :score values" catalog))))
+        (testing "universe is a superset of library: every measurement and score >= library's"
+          (doseq [k      component-keys
+                  getter [measurement component-score]
+                  :let   [lib (getter :library k)
+                          uni (getter :universe k)]]
+            (is (>= uni lib)
+                (format "universe %s (%s) should be >= library's (%s)" k uni lib))))
+        (testing ":synonym_pairs can't exceed the number of distinct-name pairs possible"
+          (doseq [catalog [:library :universe :metabot]
+                  :let [n-entities (measurement catalog :entity_count)
+                        syn-pairs  (measurement catalog :synonym_pairs)
+                        max-pairs  (/ (* n-entities (dec n-entities)) 2)]]
+            (is (<= syn-pairs max-pairs)
+                (format "%s :synonym_pairs (%s) can't exceed n*(n-1)/2 for n=%s" catalog syn-pairs n-entities))))))))
+
+(deftest ^:sequential complexity-refresh-endpoint-metabot-catalog-test
   (testing ":metabot mirrors :universe when neither content-verification nor use_verified_content is active"
     ;; Pin both gates explicitly instead of relying on test-env defaults — the reused-verbatim path
     ;; is only exercised when the scope is empty, and we want this assertion to keep passing even
@@ -77,8 +148,9 @@
     (mt/with-premium-features #{}
       (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                {:use_verified_content false :collection_id nil}
-        (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-          (is (= (:universe resp) (:metabot resp)))))))
+        (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
+          (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+            (is (= (:universe resp) (:metabot resp))))))))
   (testing ":metabot is scored separately when :content-verification + use_verified_content are both active"
     ;; Positive path: verified-only filtering restricts Cards to those with an active verified
     ;; moderation review. We inject a fresh unverified Card so the assertion doesn't depend on
@@ -91,12 +163,13 @@
                                                  :archived    false}]
         (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                  {:use_verified_content true :collection_id nil}
-          (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-            (is (< (get-in resp [:metabot  :components :entity-count :measurement])
-                   (get-in resp [:universe :components :entity-count :measurement]))
-                ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card")))))))
+          (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
+            (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+              (is (< (get-in resp [:metabot  :components :entity_count :measurement])
+                     (get-in resp [:universe :components :entity_count :measurement]))
+                  ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card"))))))))
 
-(deftest complexity-endpoint-metabot-collection-scope-test
+(deftest ^:sequential complexity-refresh-endpoint-metabot-collection-scope-test
   (testing ":metabot is scoped to the internal Metabot's collection_id subtree (root + descendants)"
     ;; Fixture shape — exercises both halves of `metabot-collection-scope-ids`:
     ;;   parent     ← Metabot's collection_id; holds a Card directly (catches root-omitted regressions)
@@ -137,9 +210,10 @@
                                   (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                                            {:use_verified_content false
                                                             :collection_id cid}
-                                    (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-                                      {:metabot  (get-in resp [:metabot  :components :entity-count :measurement])
-                                       :universe (get-in resp [:universe :components :entity-count :measurement])})))
+                                    (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
+                                      (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+                                        {:metabot  (get-in resp [:metabot  :components :entity_count :measurement])
+                                         :universe (get-in resp [:universe :components :entity_count :measurement])}))))
               empty-counts   (counts-with-scope empty-id)
               parent-counts  (counts-with-scope parent-id)
               sibling-counts (counts-with-scope sibling-id)
@@ -178,7 +252,27 @@
   {:library empty-catalog :universe empty-catalog :metabot empty-catalog
    :meta {:formula-version 1 :synonym-threshold 0.0}})
 
-(deftest ^:sequential complexity-endpoint-rejects-concurrent-requests-test
+(deftest ^:sequential complexity-refresh-endpoint-allows-active-scheduled-claim-test
+  (testing "manual API refresh does not share the cron/boot scoring claim"
+    (let [active-claim (pr-str {:fingerprint "older-fingerprint"
+                                :claimed-at  (System/currentTimeMillis)
+                                :owner       "scheduled-owner"})
+          scoring-ran? (atom false)]
+      (mt/with-temporary-setting-values [data-complexity-scoring-claim active-claim]
+        (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                      task.complexity-score/current-fingerprint (constantly "api-test-fp")
+                      data-complexity-score/record-score!       (fn [& _] nil)
+                      complexity/complexity-scores
+                      (fn [& _]
+                        (reset! scoring-ran? true)
+                        stub-scores)]
+          (is (= (m.util/deep-snake-keys stub-scores)
+                 (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
+          (is (true? @scoring-ran?)
+              "refresh endpoint should compute independently of scheduled claims")
+          (is (= active-claim (data-complexity-score.settings/data-complexity-scoring-claim))))))))
+
+(deftest ^:sequential complexity-refresh-endpoint-rejects-concurrent-requests-test
   (testing "a second concurrent request fast-fails with 409 instead of running a duplicate scoring pass"
     ;; Block the stubbed scoring call on a latch so the second request is guaranteed to land
     ;; while the guard is held. Plain `with-redefs` (not `with-dynamic-fn-redefs`) because
@@ -186,19 +280,22 @@
     (let [release-scoring (CountDownLatch. 1)
           scoring-started (CountDownLatch. 1)
           call-count      (atom 0)]
-      (with-redefs [complexity/complexity-scores
+      (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                    task.complexity-score/current-fingerprint (constantly "api-test-fp")
+                    data-complexity-score/record-score!       (fn [& _] nil)
+                    complexity/complexity-scores
                     (fn [& _]
                       (swap! call-count inc)
                       (.countDown scoring-started)
                       (.await release-scoring 10 TimeUnit/SECONDS)
                       stub-scores)]
-        (let [first-request (future (mt/user-http-request :crowberto :get 200 endpoint))]
+        (let [first-request (future (mt/user-http-request :crowberto :post 200 refresh-endpoint))]
           (try
             (is (.await scoring-started 10 TimeUnit/SECONDS)
                 "first request must reach the guarded section before we fire the second")
             (testing "concurrent superuser request is rejected with 409"
               (is (= "Data Complexity Score calculation already in progress"
-                     (mt/user-http-request :crowberto :get 409 endpoint))))
+                     (mt/user-http-request :crowberto :post 409 refresh-endpoint))))
             (finally
               (.countDown release-scoring)
               ;; Drain the in-flight request so the guard is released before the next test
@@ -207,7 +304,7 @@
         (testing "only the first request actually ran scoring; the second short-circuited"
           (is (= 1 @call-count)))
         (testing "guard is released after the in-flight request finishes — a follow-up request succeeds"
-          (mt/user-http-request :crowberto :get 200 endpoint)
+          (mt/user-http-request :crowberto :post 200 refresh-endpoint)
           (is (= 2 @call-count)))))))
 
 (deftest internal-metabot-scope-test

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -92,6 +92,34 @@
                (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
         (is (= ["api-test-fp" sample-score] @persisted?))))))
 
+(deftest ^:sequential complexity-refresh-endpoint-advances-last-fingerprint-on-snowplow-publish-test
+  (testing "refresh mirrors the scheduled path's fingerprint gate — advance only when Snowplow accepted the event"
+    (mt/with-temporary-setting-values [data-complexity-scoring-last-fingerprint "stale"]
+      (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                    task.complexity-score/current-fingerprint (constantly "refresh-fp")
+                    data-complexity-score/record-score!       (fn [& _] nil)
+                    complexity/complexity-scores
+                    (fn [& _]
+                      (with-meta sample-score
+                                 {::complexity/snowplow-published? true}))]
+        (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+        (is (= "refresh-fp" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
+            "successful Snowplow publish must advance the last-fingerprint so the next boot doesn't redundantly re-score")))))
+
+(deftest ^:sequential complexity-refresh-endpoint-keeps-fingerprint-stale-when-snowplow-publish-fails-test
+  (testing "refresh leaves the fingerprint stale when Snowplow didn't accept the event, so the next scheduled run retries"
+    (mt/with-temporary-setting-values [data-complexity-scoring-last-fingerprint "stale"]
+      (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
+                    task.complexity-score/current-fingerprint (constantly "refresh-fp")
+                    data-complexity-score/record-score!       (fn [& _] nil)
+                    complexity/complexity-scores
+                    (fn [& _]
+                      (with-meta sample-score
+                                 {::complexity/snowplow-published? false}))]
+        (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+        (is (= "stale" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
+            "failed publish must preserve the stale fingerprint — same semantics as the scheduled path")))))
+
 (deftest complexity-refresh-endpoint-runs-when-scheduled-scoring-disabled-test
   (testing "manual refresh does not reuse the scheduled scorer's enabled gate"
     (mt/with-temporary-setting-values [data-complexity-scoring-enabled false]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -64,20 +64,33 @@
    :meta     {:formula-version 3
               :synonym-threshold 0.9}})
 
+(def ^:private sample-calculated-at "2026-04-23T12:00:00Z")
+
+(defn- with-sample-calculated-at
+  [score]
+  (assoc-in score [:meta :calculated-at] sample-calculated-at))
+
 (deftest complexity-endpoint-returns-latest-stored-score-test
   (testing "superusers read the latest persisted score snapshot instead of recomputing it on demand"
-    (mt/with-dynamic-fn-redefs [data-complexity-score/latest-score (constantly sample-score)]
-      (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-        (is (= (m.util/deep-snake-keys sample-score) resp))
-        (is (contains? (:meta resp) :formula_version))
-        (is (not (contains? (:meta resp) :formula-version)))
-        (is (contains? (get-in resp [:library :components]) :entity_count))
-        (is (not (contains? (get-in resp [:library :components]) :entity-count)))))))
+    (let [captured-fingerprint (atom nil)]
+      (mt/with-dynamic-fn-redefs [task.complexity-score/current-fingerprint (constantly "api-test-fp")
+                                  data-complexity-score/latest-score
+                                  (fn [fingerprint]
+                                    (reset! captured-fingerprint fingerprint)
+                                    (with-sample-calculated-at sample-score))]
+        (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+          (is (= "api-test-fp" @captured-fingerprint))
+          (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score)) resp))
+          (is (contains? (:meta resp) :formula_version))
+          (is (= sample-calculated-at (get-in resp [:meta :calculated_at])))
+          (is (not (contains? (:meta resp) :formula-version)))
+          (is (contains? (get-in resp [:library :components]) :entity_count))
+          (is (not (contains? (get-in resp [:library :components]) :entity-count))))))))
 
 (deftest complexity-endpoint-404s-when-no-score-has-been-persisted-yet-test
   (testing "the endpoint 404s until the background scorer has produced its first snapshot"
     (mt/with-dynamic-fn-redefs [data-complexity-score/latest-score (constantly nil)]
-      (is (= "Not found."
+      (is (= "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."
              (mt/user-http-request :crowberto :get 404 endpoint))))))
 
 (deftest complexity-refresh-endpoint-returns-fresh-score-test
@@ -87,8 +100,9 @@
                     task.complexity-score/current-fingerprint (constantly "api-test-fp")
                     complexity/complexity-scores              (fn [& _] sample-score)
                     data-complexity-score/record-score!       (fn [fingerprint stored-score]
-                                                                (reset! persisted? [fingerprint stored-score]))]
-        (is (= (m.util/deep-snake-keys sample-score)
+                                                                (reset! persisted? [fingerprint stored-score])
+                                                                (with-sample-calculated-at stored-score))]
+        (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score))
                (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
         (is (= ["api-test-fp" sample-score] @persisted?))))))
 

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -19,7 +19,6 @@
 (comment api/keep-me)
 
 (def ^:private endpoint "ee/data-complexity-score/complexity")
-(def ^:private refresh-endpoint "ee/data-complexity-score/complexity/refresh")
 
 (defn- internal-metabot-id
   "Primary key of the internal Metabot row — used by the tests that temporarily tweak its
@@ -37,10 +36,10 @@
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 endpoint)))))
 
-(deftest complexity-refresh-endpoint-requires-superuser-test
+(deftest complexity-endpoint-force-recalculation-requires-superuser-test
   (testing "non-superusers cannot trigger a forced recomputation"
     (is (= "You don't have permissions to do that."
-           (mt/user-http-request :rasta :post 403 refresh-endpoint)))))
+           (mt/user-http-request :rasta :get 403 endpoint :force-recalculation true)))))
 
 (def ^:private sample-score
   {:library  {:total 18
@@ -93,7 +92,7 @@
       (is (= "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."
              (mt/user-http-request :crowberto :get 404 endpoint))))))
 
-(deftest complexity-refresh-endpoint-returns-fresh-score-test
+(deftest complexity-endpoint-force-recalculation-returns-fresh-score-test
   (testing "superusers can trigger the expensive recompute path on demand"
     (let [persisted? (atom nil)]
       (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
@@ -103,11 +102,11 @@
                                                                 (reset! persisted? [fingerprint stored-score])
                                                                 (with-sample-calculated-at stored-score))]
         (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score))
-               (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
+               (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))
         (is (= ["api-test-fp" sample-score] @persisted?))))))
 
-(deftest ^:sequential complexity-refresh-endpoint-advances-last-fingerprint-on-snowplow-publish-test
-  (testing "refresh mirrors the scheduled path's fingerprint gate — advance only when Snowplow accepted the event"
+(deftest ^:sequential complexity-endpoint-force-recalculation-advances-last-fingerprint-on-snowplow-publish-test
+  (testing "force recalculation mirrors the scheduled path's fingerprint gate — advance only when Snowplow accepted the event"
     (mt/with-temporary-setting-values [data-complexity-scoring-last-fingerprint "stale"]
       (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
                     task.complexity-score/current-fingerprint (constantly "refresh-fp")
@@ -116,12 +115,12 @@
                     (fn [& _]
                       (with-meta sample-score
                                  {::complexity/snowplow-published? true}))]
-        (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+        (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)
         (is (= "refresh-fp" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
             "successful Snowplow publish must advance the last-fingerprint so the next boot doesn't redundantly re-score")))))
 
-(deftest ^:sequential complexity-refresh-endpoint-keeps-fingerprint-stale-when-snowplow-publish-fails-test
-  (testing "refresh leaves the fingerprint stale when Snowplow didn't accept the event, so the next scheduled run retries"
+(deftest ^:sequential complexity-endpoint-force-recalculation-keeps-fingerprint-stale-when-snowplow-publish-fails-test
+  (testing "force recalculation leaves the fingerprint stale when Snowplow didn't accept the event, so the next scheduled run retries"
     (mt/with-temporary-setting-values [data-complexity-scoring-last-fingerprint "stale"]
       (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
                     task.complexity-score/current-fingerprint (constantly "refresh-fp")
@@ -130,24 +129,24 @@
                     (fn [& _]
                       (with-meta sample-score
                                  {::complexity/snowplow-published? false}))]
-        (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+        (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)
         (is (= "stale" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
             "failed publish must preserve the stale fingerprint — same semantics as the scheduled path")))))
 
-(deftest complexity-refresh-endpoint-runs-when-scheduled-scoring-disabled-test
-  (testing "manual refresh does not reuse the scheduled scorer's enabled gate"
+(deftest complexity-endpoint-force-recalculation-runs-when-scheduled-scoring-disabled-test
+  (testing "manual force recalculation does not reuse the scheduled scorer's enabled gate"
     (mt/with-temporary-setting-values [data-complexity-scoring-enabled false]
       (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
                     task.complexity-score/current-fingerprint (constantly "api-test-fp")
                     complexity/complexity-scores              (fn [& _] sample-score)
                     data-complexity-score/record-score!       (fn [& _] nil)]
         (is (= (m.util/deep-snake-keys sample-score)
-               (mt/user-http-request :crowberto :post 200 refresh-endpoint)))))))
+               (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))))))
 
-(deftest ^:sequential complexity-refresh-endpoint-superuser-gets-consistent-totals-test
+(deftest ^:sequential complexity-endpoint-force-recalculation-superuser-gets-consistent-totals-test
   (testing "check invariants not covered by schema"
     (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
-      (let [resp             (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+      (let [resp             (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)
             measurement      (fn [cat k] (get-in resp [cat :components k :measurement]))
             component-score  (fn [cat k] (get-in resp [cat :components k :score]))
             ;; NOTE: `:synonym_pairs` is intentionally included here even though it's *theoretically*
@@ -182,7 +181,7 @@
             (is (<= syn-pairs max-pairs)
                 (format "%s :synonym_pairs (%s) can't exceed n*(n-1)/2 for n=%s" catalog syn-pairs n-entities))))))))
 
-(deftest ^:sequential complexity-refresh-endpoint-metabot-catalog-test
+(deftest ^:sequential complexity-endpoint-force-recalculation-metabot-catalog-test
   (testing ":metabot mirrors :universe when neither content-verification nor use_verified_content is active"
     ;; Pin both gates explicitly instead of relying on test-env defaults — the reused-verbatim path
     ;; is only exercised when the scope is empty, and we want this assertion to keep passing even
@@ -191,7 +190,7 @@
       (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                {:use_verified_content false :collection_id nil}
         (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
-          (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+          (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
             (is (= (:universe resp) (:metabot resp))))))))
   (testing ":metabot is scored separately when :content-verification + use_verified_content are both active"
     ;; Positive path: verified-only filtering restricts Cards to those with an active verified
@@ -206,12 +205,12 @@
         (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                  {:use_verified_content true :collection_id nil}
           (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
-            (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+            (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
               (is (< (get-in resp [:metabot  :components :entity_count :measurement])
                      (get-in resp [:universe :components :entity_count :measurement]))
                   ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card"))))))))
 
-(deftest ^:sequential complexity-refresh-endpoint-metabot-collection-scope-test
+(deftest ^:sequential complexity-endpoint-force-recalculation-metabot-collection-scope-test
   (testing ":metabot is scoped to the internal Metabot's collection_id subtree (root + descendants)"
     ;; Fixture shape — exercises both halves of `metabot-collection-scope-ids`:
     ;;   parent     ← Metabot's collection_id; holds a Card directly (catches root-omitted regressions)
@@ -253,7 +252,7 @@
                                                            {:use_verified_content false
                                                             :collection_id cid}
                                     (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
-                                      (let [resp (mt/user-http-request :crowberto :post 200 refresh-endpoint)]
+                                      (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
                                         {:metabot  (get-in resp [:metabot  :components :entity_count :measurement])
                                          :universe (get-in resp [:universe :components :entity_count :measurement])}))))
               empty-counts   (counts-with-scope empty-id)
@@ -294,8 +293,8 @@
   {:library empty-catalog :universe empty-catalog :metabot empty-catalog
    :meta {:formula-version 1 :synonym-threshold 0.0}})
 
-(deftest ^:sequential complexity-refresh-endpoint-allows-active-scheduled-claim-test
-  (testing "manual API refresh does not share the cron/boot scoring claim"
+(deftest ^:sequential complexity-endpoint-force-recalculation-allows-active-scheduled-claim-test
+  (testing "manual API recalculation does not share the cron/boot scoring claim"
     (let [active-claim (pr-str {:fingerprint "older-fingerprint"
                                 :claimed-at  (System/currentTimeMillis)
                                 :owner       "scheduled-owner"})
@@ -309,12 +308,12 @@
                         (reset! scoring-ran? true)
                         stub-scores)]
           (is (= (m.util/deep-snake-keys stub-scores)
-                 (mt/user-http-request :crowberto :post 200 refresh-endpoint)))
+                 (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))
           (is (true? @scoring-ran?)
-              "refresh endpoint should compute independently of scheduled claims")
+              "force recalculation should compute independently of scheduled claims")
           (is (= active-claim (data-complexity-score.settings/data-complexity-scoring-claim))))))))
 
-(deftest ^:sequential complexity-refresh-endpoint-rejects-concurrent-requests-test
+(deftest ^:sequential complexity-endpoint-force-recalculation-rejects-concurrent-requests-test
   (testing "a second concurrent request fast-fails with 409 instead of running a duplicate scoring pass"
     ;; Block the stubbed scoring call on a latch so the second request is guaranteed to land
     ;; while the guard is held. Plain `with-redefs` (not `with-dynamic-fn-redefs`) because
@@ -331,13 +330,13 @@
                       (.countDown scoring-started)
                       (.await release-scoring 10 TimeUnit/SECONDS)
                       stub-scores)]
-        (let [first-request (future (mt/user-http-request :crowberto :post 200 refresh-endpoint))]
+        (let [first-request (future (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true))]
           (try
             (is (.await scoring-started 10 TimeUnit/SECONDS)
                 "first request must reach the guarded section before we fire the second")
             (testing "concurrent superuser request is rejected with 409"
               (is (= "Data Complexity Score calculation already in progress"
-                     (mt/user-http-request :crowberto :post 409 refresh-endpoint))))
+                     (mt/user-http-request :crowberto :get 409 endpoint :force-recalculation true))))
             (finally
               (.countDown release-scoring)
               ;; Drain the in-flight request so the guard is released before the next test
@@ -346,7 +345,7 @@
         (testing "only the first request actually ran scoring; the second short-circuited"
           (is (= 1 @call-count)))
         (testing "guard is released after the in-flight request finishes — a follow-up request succeeds"
-          (mt/user-http-request :crowberto :post 200 refresh-endpoint)
+          (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)
           (is (= 2 @call-count)))))))
 
 (deftest internal-metabot-scope-test

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -8,6 +8,7 @@
    ;; `scoring-task-registered-test` verifies init.clj's actual wiring path.
    [metabase-enterprise.data-complexity-score.init]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
    [metabase-enterprise.data-complexity-score.settings :as data-complexity-score.settings]
    [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase-enterprise.semantic-search.core :as semantic-search]
@@ -874,6 +875,22 @@
     :metabot {:total 0 :components {}} :meta {}}
    {:metabase-enterprise.data-complexity-score.complexity/snowplow-published? published?}))
 
+(deftest ^:sequential run-scoring-persists-latest-score-snapshot-test
+  (testing "every successful computation persists a fresh snapshot for the overview endpoint"
+    (mt/initialize-if-needed! :db)
+    (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
+      (let [before-id (some-> (data-complexity-score/latest-entry) :id)
+            result    (stub-result false)]
+        (mt/with-temporary-setting-values [data-complexity-scoring-enabled true]
+          (mt/with-dynamic-fn-redefs [complexity/complexity-scores (fn [& _] result)]
+            (#'task.complexity-score/run-scoring! "persist-test-fp")
+            (let [{:keys [id fingerprint score_data]} (data-complexity-score/latest-entry)]
+              (is (= result score_data))
+              (is (= "persist-test-fp" fingerprint))
+              (when before-id
+                (is (> id before-id)
+                    "a new append-only snapshot should be written for each run")))))))))
+
 (deftest ^:sequential run-scoring-persists-fingerprint-only-on-successful-publish-test
   (testing "fingerprint advances only when Snowplow accepted the event — failed publish must leave
            the stale fingerprint in place so the next boot / cron retries"
@@ -892,6 +909,18 @@
             (#'task.complexity-score/run-scoring! "fresh-fp")
             (is (= "stale" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
                 "fingerprint preserved — next boot / cron will retry the emission")))))))
+
+(deftest ^:sequential run-scoring-keeps-fingerprint-stale-when-persistence-fails-test
+  (testing "persistence is part of a successful run now — if the cache write fails we must retry"
+    (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
+      (mt/with-temporary-setting-values [data-complexity-scoring-enabled          true
+                                         data-complexity-scoring-last-fingerprint "stale"]
+        (mt/with-dynamic-fn-redefs [complexity/complexity-scores      (fn [& _] (stub-result true))
+                                    data-complexity-score/record-score! (fn [& _]
+                                                                          (throw (RuntimeException. "db boom")))]
+          (#'task.complexity-score/run-scoring! "fresh-fp")
+          (is (= "stale" (data-complexity-score.settings/data-complexity-scoring-last-fingerprint))
+              "fingerprint preserved so the next boot / cron retries the failed cache write"))))))
 
 (deftest ^:sequential maybe-emit-boot-score-only-advances-fingerprint-on-successful-publish-test
   (testing "boot-time emission never advances the last-successful fingerprint on failure — the

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -875,16 +875,32 @@
     :metabot {:total 0 :components {}} :meta {}}
    {:metabase-enterprise.data-complexity-score.complexity/snowplow-published? published?}))
 
+(deftest ^:sequential latest-score-filters-by-fingerprint-test
+  (testing "the overview cache only returns scores matching the current scoring fingerprint"
+    (mt/initialize-if-needed! :db)
+    (let [other-fingerprint "latest-score-test/other"
+          fingerprint       "latest-score-test/current"]
+      (try
+        (t2/delete! :model/DataComplexityScore :fingerprint [:in [other-fingerprint fingerprint]])
+        (data-complexity-score/record-score! other-fingerprint {:meta {:label "other"}})
+        (data-complexity-score/record-score! fingerprint {:meta {:label "older"}})
+        (data-complexity-score/record-score! fingerprint {:meta {:label "newer"}})
+        (let [score (data-complexity-score/latest-score fingerprint)]
+          (is (= "newer" (get-in score [:meta :label])))
+          (is (some? (get-in score [:meta :calculated-at]))))
+        (finally
+          (t2/delete! :model/DataComplexityScore :fingerprint [:in [other-fingerprint fingerprint]]))))))
+
 (deftest ^:sequential run-scoring-persists-latest-score-snapshot-test
   (testing "every successful computation persists a fresh snapshot for the overview endpoint"
     (mt/initialize-if-needed! :db)
     (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
-      (let [before-id (some-> (data-complexity-score/latest-entry) :id)
+      (let [before-id (some-> (data-complexity-score/latest-entry "persist-test-fp") :id)
             result    (stub-result false)]
         (mt/with-temporary-setting-values [data-complexity-scoring-enabled true]
           (mt/with-dynamic-fn-redefs [complexity/complexity-scores (fn [& _] result)]
             (#'task.complexity-score/run-scoring! "persist-test-fp")
-            (let [{:keys [id fingerprint score_data]} (data-complexity-score/latest-entry)]
+            (let [{:keys [id fingerprint score_data]} (data-complexity-score/latest-entry "persist-test-fp")]
               (is (= result score_data))
               (is (= "persist-test-fp" fingerprint))
               (when before-id

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
@@ -1,0 +1,59 @@
+(ns metabase-enterprise.data-complexity-score.task.complexity-score-trimmer-test
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.data-complexity-score.task.complexity-score-trimmer :as complexity-score-trimmer]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(def ^:private fingerprint-prefix "complexity-score-trimmer-test/")
+
+(defn- cleanup-test-rows!
+  []
+  (t2/delete! :model/DataComplexityScore
+              {:where [:like :fingerprint (str fingerprint-prefix "%")]}))
+
+(defn- cleanup-tables
+  [f]
+  (cleanup-test-rows!)
+  (f)
+  (cleanup-test-rows!))
+
+(use-fixtures :each cleanup-tables)
+
+(defn- insert-score!
+  [label created-at]
+  (t2/insert! :model/DataComplexityScore
+              {:fingerprint (str fingerprint-prefix label)
+               :score_data  {:label label}
+               :created_at  created-at}))
+
+(deftest trim-old-complexity-score-data-deletes-expired-snapshots-test
+  (mt/with-clock #t "2026-04-23T12:00:00Z[UTC]"
+    (let [now                  (t/local-date-time)
+          recent-score-label   "score-recent"
+          boundary-score-label "score-boundary"
+          old-score-label      "score-old"]
+      (insert-score! recent-score-label (t/minus now (t/months 2)))
+      (insert-score! boundary-score-label (t/minus now (t/months 3)))
+      (insert-score! old-score-label (t/minus now (t/months 4)))
+
+      (is (= 3 (t2/count :model/DataComplexityScore
+                         {:where [:like :fingerprint (str fingerprint-prefix "%")]})))
+
+      (#'complexity-score-trimmer/trim-old-complexity-score-data!)
+
+      (is (some? (t2/select-one :model/DataComplexityScore
+                                :fingerprint (str fingerprint-prefix recent-score-label))))
+      (is (some? (t2/select-one :model/DataComplexityScore
+                                :fingerprint (str fingerprint-prefix boundary-score-label))))
+      (is (nil? (t2/select-one :model/DataComplexityScore
+                               :fingerprint (str fingerprint-prefix old-score-label))))
+
+      (is (= 2 (t2/count :model/DataComplexityScore
+                         {:where [:like :fingerprint (str fingerprint-prefix "%")]}))))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
@@ -13,16 +13,13 @@
 
 (def ^:private fingerprint-prefix "complexity-score-trimmer-test/")
 
-(defn- cleanup-test-rows!
-  []
-  (t2/delete! :model/DataComplexityScore
-              {:where [:like :fingerprint (str fingerprint-prefix "%")]}))
-
 (defn- cleanup-tables
   [f]
-  (cleanup-test-rows!)
+  (t2/delete! :model/DataComplexityScore
+              {:where [:like :fingerprint (str fingerprint-prefix "%")]})
   (f)
-  (cleanup-test-rows!))
+  (t2/delete! :model/DataComplexityScore
+              {:where [:like :fingerprint (str fingerprint-prefix "%")]}))
 
 (use-fixtures :each cleanup-tables)
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -49,6 +49,7 @@
     :model/CollectionBookmark
     :model/ContentTranslation
     :model/DashboardBookmark
+    :model/DataComplexityScore
     :model/DataPermissions
     :model/DatabaseRouter
     :model/Dependency

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -48,6 +48,7 @@ export const ENTERPRISE_TAG_TYPES = [
   "ai-controls-usage-instance-limit",
   "ai-controls-usage-group-limits",
   "ai-controls-usage-tenant-limits",
+  "data-complexity-scores",
 ] as const;
 
 export type EnterpriseTagType = TagType | (typeof ENTERPRISE_TAG_TYPES)[number];

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/api.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/api.ts
@@ -1,9 +1,11 @@
 import { EnterpriseApi } from "metabase-enterprise/api/api";
+import { invalidateTags, tag } from "metabase-enterprise/api/tags";
 
 import type {
   ConversationDetail,
   ConversationsRequest,
   ConversationsResponse,
+  DataComplexityScoresResponse,
 } from "./types";
 
 export const metabotAnalyticsApi = EnterpriseApi.injectEndpoints({
@@ -24,10 +26,30 @@ export const metabotAnalyticsApi = EnterpriseApi.injectEndpoints({
         url: `/api/ee/metabot-analytics/conversations/${id}`,
       }),
     }),
+    getDataComplexityScores: builder.query<DataComplexityScoresResponse, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/ee/data-complexity-score/complexity",
+      }),
+      providesTags: () => [tag("data-complexity-scores")],
+    }),
+    refreshDataComplexityScores: builder.mutation<
+      DataComplexityScoresResponse,
+      void
+    >({
+      query: () => ({
+        method: "POST",
+        url: "/api/ee/data-complexity-score/complexity/refresh",
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [tag("data-complexity-scores")]),
+    }),
   }),
 });
 
 export const {
   useListMetabotConversationsQuery,
   useGetMetabotConversationQuery,
+  useGetDataComplexityScoresQuery,
+  useRefreshDataComplexityScoresMutation,
 } = metabotAnalyticsApi;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/api.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/api.ts
@@ -38,8 +38,9 @@ export const metabotAnalyticsApi = EnterpriseApi.injectEndpoints({
       void
     >({
       query: () => ({
-        method: "POST",
-        url: "/api/ee/data-complexity-score/complexity/refresh",
+        method: "GET",
+        url: "/api/ee/data-complexity-score/complexity",
+        params: { "force-recalculation": true },
       }),
       invalidatesTags: (_, error) =>
         invalidateTags(error, [tag("data-complexity-scores")]),

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -9,8 +9,8 @@ import { getErrorMessage } from "metabase/api/utils";
 import { useToast } from "metabase/common/hooks";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { MetabotAdminLayout } from "metabase/metabot/components/MetabotAdmin/MetabotAdminLayout";
+import { useDispatch } from "metabase/redux";
 import { Button, Flex, SimpleGrid, Tabs, Title } from "metabase/ui";
-import { useDispatch } from "metabase/utils/redux";
 
 import { useRefreshDataComplexityScoresMutation } from "../../api";
 import {
@@ -28,6 +28,7 @@ import {
 import { BreakoutChart } from "./BreakoutChart";
 import S from "./ConversationStatsPage.module.css";
 import { ConversationsByDayChart } from "./ConversationsByDayChart";
+import { DataComplexityCards } from "./DataComplexityCards";
 import {
   type StatsFilters,
   type UsageStatsMetric,
@@ -35,7 +36,6 @@ import {
   buildSourceBreakoutQuery,
   buildTenantBreakoutQuery,
 } from "./query-utils";
-import { DataComplexityCards } from "./DataComplexityCards";
 import type { ChartDataSources, ChartProps } from "./types";
 import { statsUrlStateConfig } from "./utils";
 

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -5,6 +5,8 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { MetabotAdminLayout } from "metabase/metabot/components/MetabotAdmin/MetabotAdminLayout";
 import { Button, Flex, SimpleGrid, Tabs, Title } from "metabase/ui";
@@ -326,6 +328,22 @@ export function DataComplexityHeader() {
     refreshDataComplexityScores,
     { isLoading: refreshDataComplexityScoresLoading },
   ] = useRefreshDataComplexityScoresMutation();
+  const [sendToast] = useToast();
+
+  const handleRecompute = useCallback(async () => {
+    try {
+      await refreshDataComplexityScores().unwrap();
+    } catch (error) {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: getErrorMessage(
+          error,
+          t`Could not recompute data complexity.`,
+        ),
+      });
+    }
+  }, [refreshDataComplexityScores, sendToast]);
 
   return (
     <Flex align="center" justify="space-between">
@@ -336,10 +354,11 @@ export function DataComplexityHeader() {
       <Flex gap="sm" wrap="wrap" align="center">
         <Button
           variant="default"
-          onClick={() => refreshDataComplexityScores()}
+          onClick={handleRecompute}
           loading={refreshDataComplexityScoresLoading}
+          disabled={refreshDataComplexityScoresLoading}
         >
-          {t`Refresh`}
+          {t`Recompute`}
         </Button>
       </Flex>
     </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -7,9 +7,10 @@ import { t } from "ttag";
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { MetabotAdminLayout } from "metabase/metabot/components/MetabotAdmin/MetabotAdminLayout";
-import { useDispatch } from "metabase/redux";
-import { Flex, SimpleGrid, Tabs, Title } from "metabase/ui";
+import { Button, Flex, SimpleGrid, Tabs, Title } from "metabase/ui";
+import { useDispatch } from "metabase/utils/redux";
 
+import { useRefreshDataComplexityScoresMutation } from "../../api";
 import {
   VIEW_CONVERSATIONS,
   VIEW_GROUP_MEMBERS,
@@ -32,6 +33,7 @@ import {
   buildSourceBreakoutQuery,
   buildTenantBreakoutQuery,
 } from "./query-utils";
+import { DataComplexityCards } from "./DataComplexityCards";
 import type { ChartDataSources, ChartProps } from "./types";
 import { statsUrlStateConfig } from "./utils";
 
@@ -211,10 +213,12 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
 
   return (
     <MetabotAdminLayout fullWidth>
-      <SettingsPageWrapper mt="sm">
+      <SettingsPageWrapper mt="sm" title={t`Usage stats`}>
+        <DataComplexityHeader />
+        <DataComplexityCards />
         <Flex align="center" justify="space-between">
-          <Title order={2} display="flex" style={{ alignItems: "center" }}>
-            {t`Usage stats`}
+          <Title order={3} display="flex" style={{ alignItems: "center" }}>
+            {t`Usage metrics`}
           </Title>
 
           <ConversationFilters
@@ -314,5 +318,30 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
         </SimpleGrid>
       </SettingsPageWrapper>
     </MetabotAdminLayout>
+  );
+}
+
+export function DataComplexityHeader() {
+  const [
+    refreshDataComplexityScores,
+    { isLoading: refreshDataComplexityScoresLoading },
+  ] = useRefreshDataComplexityScoresMutation();
+
+  return (
+    <Flex align="center" justify="space-between">
+      <Title order={3} display="flex" style={{ alignItems: "center" }}>
+        {t`Data complexity`}
+      </Title>
+
+      <Flex gap="sm" wrap="wrap" align="center">
+        <Button
+          variant="default"
+          onClick={() => refreshDataComplexityScores()}
+          loading={refreshDataComplexityScoresLoading}
+        >
+          {t`Refresh`}
+        </Button>
+      </Flex>
+    </Flex>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
@@ -1,0 +1,342 @@
+import { useDisclosure } from "@mantine/hooks";
+import { P, match } from "ts-pattern";
+import { msgid, ngettext, t } from "ttag";
+
+import { getErrorMessage } from "metabase/api/utils";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Group,
+  Icon,
+  Modal,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import { formatNumber } from "metabase/utils/formatting";
+
+import { useGetDataComplexityScoresQuery } from "../../api";
+import type {
+  DataComplexityCatalog,
+  DataComplexityCatalogId,
+  DataComplexityComponentId,
+} from "../../types";
+
+const CATALOG_IDS: DataComplexityCatalogId[] = [
+  "library",
+  "universe",
+  "metabot",
+];
+
+type DataComplexityComponentGroupId = "size" | "ambiguity";
+
+const COMPONENT_GROUPS: {
+  groupId: DataComplexityComponentGroupId;
+  componentIds: DataComplexityComponentId[];
+}[] = [
+  {
+    groupId: "size",
+    componentIds: ["entity_count", "field_count"],
+  },
+  {
+    groupId: "ambiguity",
+    componentIds: ["name_collisions", "synonym_pairs", "repeated_measures"],
+  },
+];
+
+function DataComplexityCardSkeleton() {
+  return (
+    <Card withBorder shadow="none" p="md">
+      <Box my={5} w="70%">
+        <Skeleton h={14} />
+      </Box>
+      <Box my={5} w="40%">
+        <Skeleton h={14} />
+      </Box>
+      <Stack align="center" gap={0} my="sm">
+        <Skeleton h="4rem" w="30%" />
+      </Stack>
+    </Card>
+  );
+}
+
+function DataComplexityCard({
+  catalogId,
+  catalog,
+}: {
+  catalogId: DataComplexityCatalogId;
+  catalog: DataComplexityCatalog;
+}) {
+  const [isModalOpen, { close, open }] = useDisclosure();
+  const { title, subtitle } = match(catalogId)
+    .with("library", () => ({
+      title: t`Curated semantic layer`,
+      subtitle: t`Models and metrics from the curated Library subset.`,
+    }))
+    .with("universe", () => ({
+      title: t`Full semantic layer`,
+      subtitle: t`Library entities plus every active physical table.`,
+    }))
+    .with("metabot", () => ({
+      title: t`Metabot-visible layer`,
+      subtitle: t`The subset the internal Metabot can surface with its current scope.`,
+    }))
+    .exhaustive();
+
+  return (
+    <Card withBorder shadow="none" p="md">
+      <UnstyledButton onClick={open}>
+        <Flex align="center" justify="space-between" gap="sm">
+          <Text fw={700}>{title}</Text>
+          <Icon name="chevronright" size={12} c="text-tertiary" />
+        </Flex>
+        <Text c="text-secondary">{subtitle}</Text>
+        {match(catalog.total)
+          .with(P.number, (total) => (
+            <Stack align="center" gap="sm" my="sm">
+              <Text size="4rem" fw={700}>
+                {formatNumber(total, { maximumFractionDigits: 0 })}
+              </Text>
+              <Text c="text-secondary">{t`Lower is better`}</Text>
+            </Stack>
+          ))
+          .otherwise(() => (
+            <Stack gap={4} my="sm">
+              <Text c="error" fw={700}>{t`Score unavailable`}</Text>
+              <Text c="text-secondary">{t`Open for component details.`}</Text>
+            </Stack>
+          ))}
+      </UnstyledButton>
+
+      <Modal opened={isModalOpen} onClose={close} title={title} size="lg">
+        <Stack gap="lg">
+          <Text size="sm" c="text-secondary">
+            {subtitle}
+          </Text>
+          <DataComplexityBreakdown catalog={catalog} />
+          <Group justify="flex-end">
+            <Button variant="default" onClick={close}>{t`Close`}</Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Card>
+  );
+}
+
+function DataComplexityBreakdown({
+  catalog,
+}: {
+  catalog: DataComplexityCatalog;
+}) {
+  const hasError = catalog.total == null;
+
+  return (
+    <Stack gap="lg">
+      {hasError && (
+        <Alert color="warning" icon={<Icon name="warning" />}>
+          {t`Some component scores could not be computed.`}
+        </Alert>
+      )}
+
+      {COMPONENT_GROUPS.map(({ groupId, componentIds }) => {
+        const { title, description } = match(groupId)
+          .with("size", () => ({
+            title: t`Size`,
+            description: t`How much surface area this layer exposes.`,
+          }))
+          .with("ambiguity", () => ({
+            title: t`Ambiguity`,
+            description: t`Signals that similar or repeated names could make answers harder to trust.`,
+          }))
+          .exhaustive();
+
+        return (
+          <Box key={groupId}>
+            <Text fw={700}>{title}</Text>
+            <Text size="sm" c="text-secondary">
+              {description}
+            </Text>
+
+            <Stack gap="sm" mt="md">
+              {componentIds.map((componentId) => (
+                <DataComplexityComponentItem
+                  key={componentId}
+                  componentId={componentId}
+                  catalog={catalog}
+                />
+              ))}
+            </Stack>
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}
+
+function DataComplexityComponentItem({
+  componentId,
+  catalog,
+}: {
+  componentId: DataComplexityComponentId;
+  catalog: DataComplexityCatalog;
+}) {
+  const component = catalog.components[componentId];
+  const measurement = component.measurement;
+
+  const { title, description, count } = match(componentId)
+    .with("entity_count", () => ({
+      title: t`Entity count`,
+      description: t`How many tables, models, and metrics are included in this layer.`,
+      count:
+        measurement !== null &&
+        ngettext(
+          msgid`${measurement} entity`,
+          `${measurement} entities`,
+          measurement,
+        ),
+    }))
+    .with("name_collisions", () => ({
+      title: t`Name collisions`,
+      description: t`Exact duplicate names after normalization, which can make entities harder to distinguish.`,
+      count:
+        measurement !== null &&
+        ngettext(
+          msgid`${measurement} collision`,
+          `${measurement} collisions`,
+          measurement,
+        ),
+    }))
+    .with("synonym_pairs", () => ({
+      title: t`Synonym pairs`,
+      description: t`Pairs of entity names that are semantically similar enough to be treated as possible synonyms.`,
+      count:
+        measurement !== null &&
+        ngettext(
+          msgid`${measurement} similar pair`,
+          `${measurement} similar pairs`,
+          measurement,
+        ),
+    }))
+    .with("field_count", () => ({
+      title: t`Field count`,
+      description: t`Active physical-table fields exposed through this layer.`,
+      count:
+        measurement !== null &&
+        ngettext(
+          msgid`${measurement} field`,
+          `${measurement} fields`,
+          measurement,
+        ),
+    }))
+    .with("repeated_measures", () => ({
+      title: t`Repeated measures`,
+      description: t`Duplicate measure names across included tables.`,
+      count:
+        measurement !== null &&
+        ngettext(
+          msgid`${measurement} repeated name`,
+          `${measurement} repeated names`,
+          measurement,
+        ),
+    }))
+    .exhaustive();
+
+  return (
+    <Box
+      p="md"
+      bdrs="md"
+      bg="background-secondary"
+      style={{
+        border: "1px solid var(--mb-color-border)",
+      }}
+    >
+      <Flex gap="md" justify="space-between" align="flex-start">
+        <Group gap="sm" align="flex-start" wrap="nowrap" flex={1}>
+          <Box>
+            <Text fw={700}>{title}</Text>
+            <Text size="sm" c="text-secondary">
+              {description}
+            </Text>
+            {component.score === null && (
+              <Text mt="sm" size="sm" c="error" role="alert">
+                {component.error}
+              </Text>
+            )}
+          </Box>
+        </Group>
+
+        {count !== false && (
+          <Box
+            px="sm"
+            py={4}
+            bdrs="sm"
+            bg="background-primary"
+            style={{
+              border: "1px solid var(--mb-color-border)",
+              flexShrink: 0,
+            }}
+          >
+            <Text
+              size="sm"
+              fw={700}
+              c="text-secondary"
+              style={{ whiteSpace: "nowrap" }}
+            >
+              {count}
+            </Text>
+          </Box>
+        )}
+      </Flex>
+    </Box>
+  );
+}
+
+export function DataComplexityCards() {
+  const {
+    data,
+    isLoading,
+    error: queryError,
+  } = useGetDataComplexityScoresQuery();
+
+  return (
+    <SimpleGrid cols={{ base: 1, md: 3 }} spacing="lg">
+      {match({ isLoading, queryError, data })
+        .with({ isLoading: true }, () =>
+          CATALOG_IDS.map((catalogId) => (
+            <DataComplexityCardSkeleton key={catalogId} />
+          )),
+        )
+        .with(
+          { queryError: P.nonNullable },
+          { data: P.nullish },
+          ({ queryError }) => (
+            <Card
+              withBorder
+              shadow="none"
+              p="md"
+              style={{ gridColumn: "1 / -1" }}
+            >
+              <Text fw={700}>{t`Data complexity scores`}</Text>
+              <Text mt="xs" size="sm" c="text-secondary">
+                {getErrorMessage(
+                  queryError,
+                  t`Data complexity scores are unavailable right now.`,
+                )}
+              </Text>
+            </Card>
+          ),
+        )
+        .with({ data: P.nonNullable }, ({ data }) =>
+          CATALOG_IDS.map((key) => (
+            <DataComplexityCard key={key} catalogId={key} catalog={data[key]} />
+          )),
+        )
+        .exhaustive()}
+    </SimpleGrid>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
@@ -1,0 +1,175 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, within } from "__support__/ui";
+
+import type { DataComplexityScoresResponse } from "../../types";
+
+import { DataComplexityCards } from "./DataComplexityCards";
+
+const mockScores: DataComplexityScoresResponse = {
+  library: {
+    total: 18,
+    components: {
+      entity_count: { measurement: 1, score: 10 },
+      name_collisions: { measurement: 0, score: 0 },
+      synonym_pairs: { measurement: 0, score: 0 },
+      field_count: { measurement: 8, score: 8 },
+      repeated_measures: { measurement: 0, score: 0 },
+    },
+  },
+  universe: {
+    total: 54,
+    components: {
+      entity_count: { measurement: 2, score: 20 },
+      name_collisions: { measurement: 0, score: 0 },
+      synonym_pairs: { measurement: 0, score: 0 },
+      field_count: { measurement: 24, score: 24 },
+      repeated_measures: { measurement: 5, score: 10 },
+    },
+  },
+  metabot: {
+    total: 30,
+    components: {
+      entity_count: { measurement: 1, score: 10 },
+      name_collisions: { measurement: 0, score: 0 },
+      synonym_pairs: { measurement: 0, score: 0 },
+      field_count: { measurement: 20, score: 20 },
+      repeated_measures: { measurement: 0, score: 0 },
+    },
+  },
+  meta: {
+    formula_version: 3,
+    synonym_threshold: 0.9,
+  },
+};
+
+const mockScoresWithError: DataComplexityScoresResponse = {
+  ...mockScores,
+  metabot: {
+    total: null,
+    components: {
+      ...mockScores.metabot.components,
+      synonym_pairs: {
+        measurement: null,
+        score: null,
+        error: "Embedding service timed out",
+      },
+    },
+  },
+};
+
+describe("DataComplexityCards", () => {
+  afterEach(() => {
+    fetchMock.removeRoutes();
+    fetchMock.callHistory.clear();
+  });
+
+  it("renders the data complexity cards", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.get("path:/api/ee/data-complexity-score/complexity", mockScores);
+
+    renderWithProviders(<DataComplexityCards />);
+
+    expect(
+      await screen.findByText("Curated semantic layer"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Models and metrics from the curated Library subset."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Full semantic layer")).toBeInTheDocument();
+    expect(
+      screen.getByText("Library entities plus every active physical table."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Metabot-visible layer")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The subset the internal Metabot can surface with its current scope.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("18")).toBeInTheDocument();
+    expect(screen.getByText("54")).toBeInTheDocument();
+    expect(screen.getByText("30")).toBeInTheDocument();
+    expect(screen.getAllByText("Lower is better")).toHaveLength(3);
+
+    await user.click(screen.getByText("Curated semantic layer"));
+    const modal = within(await screen.findByRole("dialog"));
+
+    expect(await modal.findByText("Size")).toBeInTheDocument();
+    expect(
+      modal.getByText("How much surface area this layer exposes."),
+    ).toBeInTheDocument();
+    expect(modal.getByText("Ambiguity")).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "Signals that similar or repeated names could make answers harder to trust.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "How many tables, models, and metrics are included in this layer.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "Exact duplicate names after normalization, which can make entities harder to distinguish.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "Pairs of entity names that are semantically similar enough to be treated as possible synonyms.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "Active physical-table fields exposed through this layer.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      modal.getByText("Duplicate measure names across included tables."),
+    ).toBeInTheDocument();
+    expect(modal.getByText("1 entity")).toBeInTheDocument();
+    expect(modal.getByText("8 fields")).toBeInTheDocument();
+    expect(modal.getByText("0 collisions")).toBeInTheDocument();
+    expect(modal.getByText("0 repeated names")).toBeInTheDocument();
+    expect(modal.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("shows a fallback message when the complexity endpoint fails", async () => {
+    fetchMock.get("path:/api/ee/data-complexity-score/complexity", 500);
+
+    renderWithProviders(<DataComplexityCards />);
+
+    expect(
+      await screen.findByText("Data complexity scores"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Data complexity scores are unavailable right now."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows component errors inside the modal", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.get(
+      "path:/api/ee/data-complexity-score/complexity",
+      mockScoresWithError,
+    );
+
+    renderWithProviders(<DataComplexityCards />);
+
+    expect(
+      await screen.findByText("Metabot-visible layer"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Score unavailable")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Metabot-visible layer"));
+    const modal = within(await screen.findByRole("dialog"));
+
+    expect(
+      await modal.findByText("Some component scores could not be computed."),
+    ).toBeInTheDocument();
+    expect(modal.getByText("Embedding service timed out")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
@@ -7,6 +7,22 @@ import type { DataComplexityScoresResponse } from "../../types";
 
 import { DataComplexityCards } from "./DataComplexityCards";
 
+/* eslint-disable testing-library/no-node-access -- Snapshot cleanup is applied to a cloned DOM tree. */
+const cleanForSnapshot = (element: Element) => {
+  const clone = element.cloneNode(true) as Element;
+  clone.querySelectorAll("style").forEach((style) => style.remove());
+  [clone, ...Array.from(clone.querySelectorAll("*"))].forEach((node) => {
+    node.removeAttribute("class");
+    node.removeAttribute("style");
+    node.removeAttribute("id");
+    node.removeAttribute("aria-describedby");
+    node.removeAttribute("aria-labelledby");
+  });
+
+  return clone;
+};
+/* eslint-enable testing-library/no-node-access */
+
 const mockScores: DataComplexityScoresResponse = {
   library: {
     total: 18,
@@ -60,80 +76,20 @@ const mockScoresWithError: DataComplexityScoresResponse = {
 };
 
 describe("DataComplexityCards", () => {
-  afterEach(() => {
-    fetchMock.removeRoutes();
-    fetchMock.callHistory.clear();
-  });
-
   it("renders the data complexity cards", async () => {
-    const user = userEvent.setup();
-
     fetchMock.get("path:/api/ee/data-complexity-score/complexity", mockScores);
 
-    renderWithProviders(<DataComplexityCards />);
+    const { container } = renderWithProviders(<DataComplexityCards />);
 
     expect(
       await screen.findByText("Curated semantic layer"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Models and metrics from the curated Library subset."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Full semantic layer")).toBeInTheDocument();
-    expect(
-      screen.getByText("Library entities plus every active physical table."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Metabot-visible layer")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "The subset the internal Metabot can surface with its current scope.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("18")).toBeInTheDocument();
-    expect(screen.getByText("54")).toBeInTheDocument();
-    expect(screen.getByText("30")).toBeInTheDocument();
-    expect(screen.getAllByText("Lower is better")).toHaveLength(3);
+    expect(cleanForSnapshot(container)).toMatchSnapshot();
 
-    await user.click(screen.getByText("Curated semantic layer"));
-    const modal = within(await screen.findByRole("dialog"));
+    await userEvent.click(screen.getByText("Curated semantic layer"));
+    const modal = await screen.findByRole("dialog");
 
-    expect(await modal.findByText("Size")).toBeInTheDocument();
-    expect(
-      modal.getByText("How much surface area this layer exposes."),
-    ).toBeInTheDocument();
-    expect(modal.getByText("Ambiguity")).toBeInTheDocument();
-    expect(
-      modal.getByText(
-        "Signals that similar or repeated names could make answers harder to trust.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      modal.getByText(
-        "How many tables, models, and metrics are included in this layer.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      modal.getByText(
-        "Exact duplicate names after normalization, which can make entities harder to distinguish.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      modal.getByText(
-        "Pairs of entity names that are semantically similar enough to be treated as possible synonyms.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      modal.getByText(
-        "Active physical-table fields exposed through this layer.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      modal.getByText("Duplicate measure names across included tables."),
-    ).toBeInTheDocument();
-    expect(modal.getByText("1 entity")).toBeInTheDocument();
-    expect(modal.getByText("8 fields")).toBeInTheDocument();
-    expect(modal.getByText("0 collisions")).toBeInTheDocument();
-    expect(modal.getByText("0 repeated names")).toBeInTheDocument();
-    expect(modal.getByText("Close")).toBeInTheDocument();
+    expect(cleanForSnapshot(modal)).toMatchSnapshot();
   });
 
   it("shows a fallback message when the complexity endpoint fails", async () => {
@@ -150,8 +106,6 @@ describe("DataComplexityCards", () => {
   });
 
   it("shows component errors inside the modal", async () => {
-    const user = userEvent.setup();
-
     fetchMock.get(
       "path:/api/ee/data-complexity-score/complexity",
       mockScoresWithError,
@@ -164,7 +118,7 @@ describe("DataComplexityCards", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Score unavailable")).toBeInTheDocument();
 
-    await user.click(screen.getByText("Metabot-visible layer"));
+    await userEvent.click(screen.getByText("Metabot-visible layer"));
     const modal = within(await screen.findByRole("dialog"));
 
     expect(

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
@@ -1,0 +1,32 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import { DataComplexityHeader } from "./ConversationStatsPage";
+
+describe("DataComplexityHeader", () => {
+  afterEach(() => {
+    fetchMock.removeRoutes();
+    fetchMock.callHistory.clear();
+  });
+
+  it("refreshes data complexity scores when the refresh button is clicked", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.post("path:/api/ee/data-complexity-score/complexity/refresh", {});
+
+    renderWithProviders(<DataComplexityHeader />);
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.called(
+          "path:/api/ee/data-complexity-score/complexity/refresh",
+          { method: "POST" },
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
@@ -1,24 +1,18 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { UndoListing } from "metabase/common/components/UndoListing";
 
 import { DataComplexityHeader } from "./ConversationStatsPage";
 
 describe("DataComplexityHeader", () => {
-  afterEach(() => {
-    fetchMock.removeRoutes();
-    fetchMock.callHistory.clear();
-  });
-
-  it("refreshes data complexity scores when the refresh button is clicked", async () => {
-    const user = userEvent.setup();
-
+  it("recomputes data complexity scores when the recompute button is clicked", async () => {
     fetchMock.post("path:/api/ee/data-complexity-score/complexity/refresh", {});
 
     renderWithProviders(<DataComplexityHeader />);
 
-    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    await userEvent.click(screen.getByRole("button", { name: "Recompute" }));
 
     await waitFor(() => {
       expect(
@@ -27,6 +21,57 @@ describe("DataComplexityHeader", () => {
           { method: "POST" },
         ),
       ).toBe(true);
+    });
+  });
+
+  it("disables the recompute button while recomputation is running", async () => {
+    let resolveRequest!: (value: unknown) => void;
+    const pendingResponse = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    fetchMock.post(
+      "path:/api/ee/data-complexity-score/complexity/refresh",
+      pendingResponse,
+    );
+
+    renderWithProviders(<DataComplexityHeader />);
+
+    const button = screen.getByRole("button", { name: "Recompute" });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveRequest({});
+    });
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+  });
+
+  it("shows a toast when recomputation fails", async () => {
+    fetchMock.post(
+      "path:/api/ee/data-complexity-score/complexity/refresh",
+      500,
+    );
+
+    renderWithProviders(
+      <>
+        <DataComplexityHeader />
+        <UndoListing />
+      </>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Recompute" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Could not recompute data complexity."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx
@@ -8,7 +8,7 @@ import { DataComplexityHeader } from "./ConversationStatsPage";
 
 describe("DataComplexityHeader", () => {
   it("recomputes data complexity scores when the recompute button is clicked", async () => {
-    fetchMock.post("path:/api/ee/data-complexity-score/complexity/refresh", {});
+    fetchMock.get("path:/api/ee/data-complexity-score/complexity", {});
 
     renderWithProviders(<DataComplexityHeader />);
 
@@ -17,8 +17,11 @@ describe("DataComplexityHeader", () => {
     await waitFor(() => {
       expect(
         fetchMock.callHistory.called(
-          "path:/api/ee/data-complexity-score/complexity/refresh",
-          { method: "POST" },
+          "path:/api/ee/data-complexity-score/complexity",
+          {
+            method: "GET",
+            query: { "force-recalculation": "true" },
+          },
         ),
       ).toBe(true);
     });
@@ -30,8 +33,8 @@ describe("DataComplexityHeader", () => {
       resolveRequest = resolve;
     });
 
-    fetchMock.post(
-      "path:/api/ee/data-complexity-score/complexity/refresh",
+    fetchMock.get(
+      "path:/api/ee/data-complexity-score/complexity",
       pendingResponse,
     );
 
@@ -54,10 +57,7 @@ describe("DataComplexityHeader", () => {
   });
 
   it("shows a toast when recomputation fails", async () => {
-    fetchMock.post(
-      "path:/api/ee/data-complexity-score/complexity/refresh",
-      500,
-    );
+    fetchMock.get("path:/api/ee/data-complexity-score/complexity", 500);
 
     renderWithProviders(
       <>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/__snapshots__/DataComplexityCards.unit.spec.tsx.snap
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/__snapshots__/DataComplexityCards.unit.spec.tsx.snap
@@ -1,0 +1,361 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`DataComplexityCards renders the data complexity cards 1`] = `
+<div>
+  <div>
+    <div
+      data-with-border="true"
+    >
+      <button
+        type="button"
+      >
+        <div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Curated semantic layer
+          </div>
+          <svg
+            aria-label="chevronright icon"
+            height="12"
+            role="img"
+            width="12"
+          />
+        </div>
+        <div
+          color="text-primary"
+          data-size="md"
+        >
+          Models and metrics from the curated Library subset.
+        </div>
+        <div>
+          <div
+            color="text-primary"
+          >
+            18
+          </div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Lower is better
+          </div>
+        </div>
+      </button>
+    </div>
+    <div
+      data-with-border="true"
+    >
+      <button
+        type="button"
+      >
+        <div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Full semantic layer
+          </div>
+          <svg
+            aria-label="chevronright icon"
+            height="12"
+            role="img"
+            width="12"
+          />
+        </div>
+        <div
+          color="text-primary"
+          data-size="md"
+        >
+          Library entities plus every active physical table.
+        </div>
+        <div>
+          <div
+            color="text-primary"
+          >
+            54
+          </div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Lower is better
+          </div>
+        </div>
+      </button>
+    </div>
+    <div
+      data-with-border="true"
+    >
+      <button
+        type="button"
+      >
+        <div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Metabot-visible layer
+          </div>
+          <svg
+            aria-label="chevronright icon"
+            height="12"
+            role="img"
+            width="12"
+          />
+        </div>
+        <div
+          color="text-primary"
+          data-size="md"
+        >
+          The subset the internal Metabot can surface with its current scope.
+        </div>
+        <div>
+          <div
+            color="text-primary"
+          >
+            30
+          </div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Lower is better
+          </div>
+        </div>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataComplexityCards renders the data complexity cards 2`] = `
+<section
+  aria-modal="true"
+  data-modal-content="true"
+  role="dialog"
+  tabindex="-1"
+>
+  <header>
+    <h2>
+      Curated semantic layer
+    </h2>
+    <button
+      aria-label="Close"
+      data-variant="subtle"
+      type="button"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 15 15"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+  </header>
+  <div>
+    <div>
+      <div
+        color="text-primary"
+        data-size="sm"
+      >
+        Models and metrics from the curated Library subset.
+      </div>
+      <div>
+        <div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Size
+          </div>
+          <div
+            color="text-primary"
+            data-size="sm"
+          >
+            How much surface area this layer exposes.
+          </div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      color="text-primary"
+                      data-size="md"
+                    >
+                      Entity count
+                    </div>
+                    <div
+                      color="text-primary"
+                      data-size="sm"
+                    >
+                      How many tables, models, and metrics are included in this layer.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    color="text-primary"
+                    data-size="sm"
+                  >
+                    1 entity
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      color="text-primary"
+                      data-size="md"
+                    >
+                      Field count
+                    </div>
+                    <div
+                      color="text-primary"
+                      data-size="sm"
+                    >
+                      Active physical-table fields exposed through this layer.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    color="text-primary"
+                    data-size="sm"
+                  >
+                    8 fields
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            color="text-primary"
+            data-size="md"
+          >
+            Ambiguity
+          </div>
+          <div
+            color="text-primary"
+            data-size="sm"
+          >
+            Signals that similar or repeated names could make answers harder to trust.
+          </div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      color="text-primary"
+                      data-size="md"
+                    >
+                      Name collisions
+                    </div>
+                    <div
+                      color="text-primary"
+                      data-size="sm"
+                    >
+                      Exact duplicate names after normalization, which can make entities harder to distinguish.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    color="text-primary"
+                    data-size="sm"
+                  >
+                    0 collisions
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      color="text-primary"
+                      data-size="md"
+                    >
+                      Synonym pairs
+                    </div>
+                    <div
+                      color="text-primary"
+                      data-size="sm"
+                    >
+                      Pairs of entity names that are semantically similar enough to be treated as possible synonyms.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    color="text-primary"
+                    data-size="sm"
+                  >
+                    0 similar pairs
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      color="text-primary"
+                      data-size="md"
+                    >
+                      Repeated measures
+                    </div>
+                    <div
+                      color="text-primary"
+                      data-size="sm"
+                    >
+                      Duplicate measure names across included tables.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    color="text-primary"
+                    data-size="sm"
+                  >
+                    0 repeated names
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <button
+          data-size="md"
+          data-variant="default"
+          type="button"
+        >
+          <span>
+            <span>
+              Close
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -90,3 +90,42 @@ export type ConversationDetail = {
   ip_address: string | null;
   feedback: ConversationFeedback[];
 };
+
+export type DataComplexityCatalogId = "library" | "universe" | "metabot";
+export type DataComplexityComponentId =
+  | "entity_count"
+  | "name_collisions"
+  | "synonym_pairs"
+  | "field_count"
+  | "repeated_measures";
+
+export type DataComplexitySubScore =
+  | {
+      measurement: null;
+      score: null;
+      error: string;
+    }
+  | {
+      measurement: number;
+      score: number;
+    };
+
+export type DataComplexityCatalog = {
+  total: number | null;
+  components: {
+    [K in DataComplexityComponentId]: DataComplexitySubScore;
+  };
+};
+
+export type DataComplexityScoresResponse = {
+  meta: {
+    formula_version: number;
+    synonym_threshold: number;
+    embedding_model?: {
+      provider: string;
+      model_name: string;
+    } | null;
+  };
+} & {
+  [K in DataComplexityCatalogId]: DataComplexityCatalog;
+};

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -121,6 +121,7 @@ export type DataComplexityScoresResponse = {
   meta: {
     formula_version: number;
     synonym_threshold: number;
+    calculated_at?: string;
     embedding_model?: {
       provider: string;
       model_name: string;

--- a/resources/migrations/061/20260423_data_complexity_score.yaml
+++ b/resources/migrations/061/20260423_data_complexity_score.yaml
@@ -1,0 +1,40 @@
+## Persist computed Data Complexity Score snapshots for the overview UI.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/061_update_migrations.yaml
+
+  - changeSet:
+      id: v61.2026-04-23T10:00:00
+      author: undrfined
+      comment: Create data_complexity_score table
+      changes:
+        - createTable:
+            tableName: data_complexity_score
+            remarks: Append-only snapshots of the computed Data Complexity Score shown in the Metabot overview UI
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: fingerprint
+                  type: varchar(512)
+                  constraints:
+                    nullable: false
+                  remarks: Fingerprint of the scoring inputs (formula version, synonym threshold, embedding model)
+              - column:
+                  name: score_data
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+                  remarks: JSON-serialized complexity score response returned by the data-complexity-score endpoint
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+                  remarks: When this score snapshot was computed and stored

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -266,8 +266,10 @@
 
 (defn check-404
   "Throw a `404` if `arg` is `false` or `nil`, otherwise return as-is."
-  [arg]
-  (check arg generic-404))
+  ([arg]
+   (check arg generic-404))
+  ([arg msg]
+   (check arg [404 msg])))
 
 (defmacro let-404
   "Bind a form as with `let`; throw a 404 if it is `nil` or `false`."

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -61,6 +61,7 @@
     :model/MetabotFeedback                   metabase.metabot.models.metabot-feedback
     :model/MetabotMessage                    metabase.metabot.models.metabot-message
     :model/AiUsageLog                        metabase.metabot.models.ai-usage-log
+    :model/DataComplexityScore               metabase-enterprise.data-complexity-score.models.data-complexity-score
     :model/MetabotGroupLimit                 metabase-enterprise.metabot.models.metabot-group-limit
     :model/MetabotInstanceLimit              metabase-enterprise.metabot.models.metabot-instance-limit
     :model/MetabotPermissions                metabase-enterprise.metabot.models.metabot-permissions

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -9,6 +9,7 @@
    [metabase.server.middleware.misc :as mw.misc]
    [metabase.server.middleware.security :as mw.security]
    [metabase.test :as mt]
+   [metabase.util.i18n :refer [tru]]
    [methodical.core :as methodical])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -59,6 +60,13 @@
   (testing "check that 404 is returned otherwise"
     (is (= (four-oh-four)
            (-> (my-mock-api-fn)
+               (update-in [:headers "Last-Modified"] string?)))))
+
+  (testing "check-404 can return a custom message"
+    (is (= (assoc (four-oh-four) :body "Custom not found.")
+           (-> (mock-api-fn
+                (fn [_]
+                  (api/check-404 nil (tru "Custom not found."))))
                (update-in [:headers "Last-Modified"] string?)))))
 
   (testing "let-404 should return nil if test fails"

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -34,6 +34,7 @@
     :model/CloudMigration
     :model/ContentTranslation
     :model/DashboardFavorite
+    :model/DataComplexityScore
     :model/DatabaseRouter
     :model/Dependency
     :model/DependencyStatus


### PR DESCRIPTION
Closes [BOT-1327: Surface data complexity score in overview UI](https://linear.app/metabase/issue/BOT-1327/surface-data-complexity-score-in-overview-ui)

Closes [BOT-1403: Persist Data Complexity Score calculations](https://linear.app/metabase/issue/BOT-1403/persist-data-complexity-score-calculations)

### Description

Surface complexity score in admin UI. Adds a new table `data_complexity_score` that stores the results of the scoring with `created_at`, `fingerprint`, and `score_data` fields. Data older than 3 months is trimmed (do we actually need historical data? I'd say yes, but maybe we can just store the current in a setting or something.)

### How to verify

1. Go to AI usage
2. Click on the Data Complexity Score

### Demo

https://www.loom.com/share/e1db92bda50946b18b4c7b1bc7d2053c

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
