### PR TITLE
fix: render tables in AI markdown

### DIFF
--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -1,7 +1,45 @@
 .aiMarkdown {
   line-height: 1.5;
+  min-width: 0;
   max-width: 100%;
+}
+
+.tableWrapper {
+  border: 1px solid var(--mb-color-border);
+  border-radius: 8px;
   overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.tableContainer {
+  width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.aiMarkdown table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.aiMarkdown th,
+.aiMarkdown td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+  border-top: 1px solid var(--mb-color-border);
+}
+
+.aiMarkdown tr:first-child th {
+  border-top: none;
+}
+
+.aiMarkdown th {
+  font-weight: 700;
+  background: var(--mb-color-background-secondary);
 }
 
 .aiMarkdown pre {

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -1,7 +1,7 @@
 // TODO: consolidate this component w/ AIAnalysisContent
 
 import cx from "classnames";
-import { memo, useMemo } from "react";
+import { type ComponentPropsWithoutRef, memo, useMemo } from "react";
 
 import {
   Markdown,
@@ -15,6 +15,7 @@ import { MarkdownSmartLink } from "./components/MarkdownSmartLink";
 
 type AIMarkdownProps = MarkdownProps & {
   onInternalLinkClick?: (link: string) => void;
+  singleNewlinesAreParagraphs?: boolean;
 };
 
 const splitMessageLinesAsParagraphs = (message: string) =>
@@ -60,18 +61,34 @@ const getComponents = ({
       </a>
     );
   },
+  table: ({ children, ...props }: ComponentPropsWithoutRef<"table">) => (
+    <div className={S.tableWrapper}>
+      <div className={S.tableContainer}>
+        <table {...props}>{children}</table>
+      </div>
+    </div>
+  ),
 });
 
 export const AIMarkdown = memo(
-  ({ className, onInternalLinkClick, children, ...props }: AIMarkdownProps) => {
+  ({
+    className,
+    onInternalLinkClick,
+    children,
+    singleNewlinesAreParagraphs = false,
+    ...props
+  }: AIMarkdownProps) => {
     const components = useMemo(
       () => getComponents({ onInternalLinkClick }),
       [onInternalLinkClick],
     );
 
     const normalizedChildren = useMemo(
-      () => splitMessageLinesAsParagraphs(children),
-      [children],
+      () =>
+        singleNewlinesAreParagraphs
+          ? splitMessageLinesAsParagraphs(children)
+          : children,
+      [children, singleNewlinesAreParagraphs],
     );
 
     return (

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
@@ -34,4 +34,25 @@ describe("AIMarkdown", () => {
     // Verify it's rendered as a smart link by checking for the icon
     expect(screen.getByRole("img", { name: /icon/ })).toBeInTheDocument();
   });
+
+  it("should render GFM tables", async () => {
+    setup({
+      children: `
+| Name | Value |
+| --- | --- |
+| Revenue | $42 |
+| Profit | $12 |
+      `.trim(),
+    });
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Value" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Revenue" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "$42" })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.module.css
@@ -52,6 +52,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  min-width: 0;
 }
 
 .messageContainerUser {
@@ -71,6 +72,7 @@
 .message {
   font-size: 0.875rem;
   line-height: 1.4 !important;
+  min-width: 0;
 }
 
 .messageUser {

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -73,7 +73,10 @@ export const UserMessage = ({
 }: UserMessageProps) => (
   <MessageContainer chatRole={message.role} {...props}>
     {message.type === "text" && (
-      <AIMarkdown className={cx(Styles.message, Styles.messageUser)}>
+      <AIMarkdown
+        className={cx(Styles.message, Styles.messageUser)}
+        singleNewlinesAreParagraphs
+      >
         {message.message}
       </AIMarkdown>
     )}


### PR DESCRIPTION
Closes [BOT-1323: Fix Metabot's AIMarkdown table rendering](https://linear.app/metabase/issue/BOT-1323/fix-metabots-aimarkdown-table-rendering)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open Metabot pane
2. Type `generate a markdown table of 10 columns and 20 rows with random data, don't reply with anything else but the table.`

### Demo

Before:
<img width="501" height="960" alt="image" src="https://github.com/user-attachments/assets/2e8220f5-ac0f-40bc-a532-cfbfdd88f9a8" />

After:
<img width="496" height="942" alt="image" src="https://github.com/user-attachments/assets/fa0ac49b-da18-409f-af79-e39238d75338" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
