### PR TITLE
Fix dashboard queries re-executed when switching tabs

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -250,8 +250,7 @@ describe("issue 12926", () => {
   });
 
   describe("saving a dashboard that retriggers a non saved query (negative id)", () => {
-    it("should stop the ongoing query", () => {
-      // this test requires the card to be manually added to the dashboard, as it requires the dashcard id to be negative
+    it("should load the card with correct parameters after save", () => {
       H.createNativeQuestion(questionDetails);
 
       H.createDashboard().then(({ body: { id: dashboardId } }) => {
@@ -261,8 +260,6 @@ describe("issue 12926", () => {
       H.editDashboard();
 
       H.openQuestionsSidebar();
-      // when the card is added to a dashboard, it doesn't use the dashcard endpoint but instead uses the card one
-      slowDownCardQuery().as("cardQuerySlowed");
       H.sidebar().findByText(questionDetails.name).click();
 
       H.setFilter("Number", "Equal to");
@@ -274,10 +271,6 @@ describe("issue 12926", () => {
       H.popover().contains(filterDisplayName).eq(0).click();
 
       H.saveDashboard();
-
-      cy.wait("@cardQuerySlowed").then((xhrProxy) =>
-        expect(xhrProxy.state).to.eq("Errored"),
-      );
 
       H.getDashboardCard().findByText(queryResult + parameterValue);
     });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
@@ -201,12 +201,18 @@ describe("issue 8030 + 32444", () => {
         H.saveDashboard();
 
         cy.wait("@getCardQuery");
-        cy.get("@getCardQuery.all").should("have.length", 4);
+
+        // Reset the intercept after save so we only count filter-triggered queries.
+        cy.intercept(
+          "POST",
+          `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
+        ).as("getCardQueryAfterFilter");
 
         addFilterValue("Aerodynamic Bronze Hat");
 
-        cy.wait("@getCardQuery");
-        cy.get("@getCardQuery.all").should("have.length", 5);
+        cy.wait("@getCardQueryAfterFilter");
+        // Only the card connected to the filter should re-execute.
+        cy.get("@getCardQueryAfterFilter.all").should("have.length", 1);
       });
     });
   });

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -280,6 +280,20 @@ export const fetchCardDataAction = createAsyncThunk<
           result: lastResult,
         };
       }
+
+      /**
+       * If a request for this card is already in-flight with the same parameters, let it finish rather than cancelling
+       * and restarting. This avoids re-executing slow queries (e.g. pivot tables) when switching dashboard tabs back
+       * and forth (#70534). When parameters differ (e.g. filter change), we fall through to the cancel-and-restart
+       * path below.
+       */
+      const inFlight = cardDataCancelDeferreds[`${dashcard.id},${card.id}`];
+      if (
+        inFlight &&
+        _.isEqual(inFlight.queryParams, getDatasetQueryParams(datasetQuery))
+      ) {
+        return;
+      }
     }
 
     cancelFetchCardData(card.id, dashcard.id);
@@ -308,7 +322,12 @@ export const fetchCardDataAction = createAsyncThunk<
     }, DASHBOARD_SLOW_TIMEOUT);
 
     const deferred = defer();
-    setFetchCardDataCancel(card.id, dashcard.id, deferred);
+    setFetchCardDataCancel(
+      card.id,
+      dashcard.id,
+      deferred,
+      getDatasetQueryParams(datasetQuery),
+    );
 
     let cancelled = false;
     deferred.promise.then(() => {
@@ -515,10 +534,12 @@ export const fetchDashboardCardData =
         return dashcard.id;
       });
 
-      for (const id of loadingIds) {
-        const dashcard = getDashCardById(getState(), id);
-        dispatch(cancelFetchCardData(dashcard.card.id, dashcard.id));
-      }
+      /**
+       * We intentionally do NOT cancel in-flight requests here. Each card's fetch (fetchCardDataAction) handles its
+       * own deduplication: it returns early when an identical request is already in-flight and cancels stale requests
+       * when parameters change. Batch-cancelling here would abort nearly-complete requests on tab switch, forcing
+       * slow queries (e.g. pivots) to restart from scratch. (#70534)
+       */
 
       dispatch(
         fetchDashboardCardDataAction({
@@ -600,26 +621,34 @@ export const cancelFetchDashboardCardData = createThunkAction(
   },
 );
 
+type InFlightEntry = {
+  deferred: Deferred;
+  queryParams: ReturnType<typeof getDatasetQueryParams>;
+};
+
 const cardDataCancelDeferreds: Record<
   `${DashCardId},${DashboardCard["card_id"]}`,
-  Deferred | null
+  InFlightEntry | null
 > = {};
 
 function setFetchCardDataCancel(
   card_id: DashboardCard["card_id"],
   dashcard_id: DashCardId,
   deferred: Deferred | null,
+  queryParams?: ReturnType<typeof getDatasetQueryParams>,
 ) {
-  cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = deferred;
+  cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = deferred
+    ? { deferred, queryParams: queryParams! }
+    : null;
 }
 
 // machinery to support query cancellation
 export const cancelFetchCardData = createAction(
   CANCEL_FETCH_CARD_DATA,
   (card_id, dashcard_id) => {
-    const deferred = cardDataCancelDeferreds[`${dashcard_id},${card_id}`];
-    if (deferred) {
-      deferred.resolve();
+    const entry = cardDataCancelDeferreds[`${dashcard_id},${card_id}`];
+    if (entry) {
+      entry.deferred.resolve();
       cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = null;
     }
     return { payload: { dashcard_id, card_id } };

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -21,6 +21,7 @@ import {
   createMockDashboard,
   createMockDashboardCard,
   createMockDashboardQueryMetadata,
+  createMockDashboardTab,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -115,7 +116,7 @@ describe("fetchDashboard", () => {
     });
   });
 
-  it("should not clear a defer for a cancelled request", async () => {
+  it("should not cancel an in-flight request when re-dispatched with the same parameters (#70534)", async () => {
     fetchMock.post("/api/dashboard/1/dashcard/1/card/1/query", () => {
       return new Promise((res) => {
         setTimeout(() => {
@@ -159,6 +160,7 @@ describe("fetchDashboard", () => {
 
     await sleep(50);
 
+    // Same card, same params: should return early (no cancel, no restart)
     const secondFetch = store.dispatch(
       fetchCardDataAction({
         card: dashcard.card,
@@ -180,9 +182,93 @@ describe("fetchDashboard", () => {
     const secondResult = await secondFetch;
     const thirdResult = await thirdFetch;
 
+    // The first fetch completes normally (never cancelled)
+    expect(firstResult.payload).toMatchObject({ result: { foo: true } });
+    // The second and third fetches returned early because the first was
+    // already in-flight with matching parameters
+    expect(secondResult.payload).toBeUndefined();
+    expect(thirdResult.payload).toBeUndefined();
+  });
+
+  it("should cancel an in-flight request when re-dispatched with different parameters", async () => {
+    fetchMock.post("/api/dashboard/1/dashcard/1/card/1/query", () => {
+      return new Promise((res) => {
+        setTimeout(() => {
+          res({ foo: true });
+        }, 300);
+      });
+    });
+
+    const sleep = (delay: number) =>
+      new Promise<void>((res) => setTimeout(res, delay));
+
+    const DASHBOARD = createMockDashboard({
+      id: 1,
+      parameters: [{ id: "param1", name: "P1", slug: "p1", type: "id" }],
+      dashcards: [
+        createMockDashboardCard({
+          parameter_mappings: [
+            {
+              card_id: 1,
+              parameter_id: "param1",
+              target: ["variable", ["template-tag", "foo"]],
+            },
+          ],
+        }),
+      ],
+    });
+    const dashcard = DASHBOARD.dashcards[0];
+    if (!isQuestionDashCard(dashcard)) {
+      throw new Error("Expected question dashcard");
+    }
+
+    const store = setup({
+      dashboards: [DASHBOARD],
+      dashboard: createMockDashboardState({
+        dashboardId: DASHBOARD.id,
+        dashboards: {
+          [DASHBOARD.id]: createMockStoreDashboard({
+            ...DASHBOARD,
+            dashcards: DASHBOARD.dashcards.map((dc) => dc.id),
+          }),
+        },
+        parameterValues: { param1: "value1" },
+      }),
+    });
+
+    // Start first fetch with param1=value1
+    const firstFetch = store.dispatch(
+      fetchCardDataAction({
+        card: dashcard.card,
+        dashcard,
+        options: {},
+      }),
+    );
+
+    await sleep(50);
+
+    // Change parameter value to simulate a filter change
+    store.dispatch({
+      type: "metabase/dashboard/SET_PARAMETER_VALUES",
+      payload: { param1: "value2" },
+    });
+
+    // Second fetch with different params should cancel the first
+    const secondFetch = store.dispatch(
+      fetchCardDataAction({
+        card: dashcard.card,
+        dashcard,
+        options: {},
+      }),
+    );
+
+    const firstResult = await firstFetch;
+    const secondResult = await secondFetch;
+
+    // First fetch was cancelled because parameters changed
     expect(firstResult.payload).toMatchObject({ result: null });
-    expect(secondResult.payload).toMatchObject({ result: null });
-    expect(thirdResult.payload).toMatchObject({ result: { foo: true } });
+    // Second fetch completes with the API response
+    expect(secondResult.payload).toMatchObject({ result: { foo: true } });
   });
 });
 
@@ -262,6 +348,103 @@ describe("fetchDashboardCardData", () => {
     await fetchDashboardCardData()(dispatch as never, getState as never);
 
     expect(getMaxConcurrent()).toBe(5);
+  });
+
+  it("should not cancel in-flight requests from other tabs on tab switch (#70534)", async () => {
+    const dashboardId = 300;
+    const tab1 = createMockDashboardTab({
+      id: 1,
+      dashboard_id: dashboardId,
+      name: "Tab 1",
+    });
+    const tab2 = createMockDashboardTab({
+      id: 2,
+      dashboard_id: dashboardId,
+      name: "Tab 2",
+    });
+
+    const tab1Card = createMockDashboardCard({
+      id: 10,
+      card_id: 10,
+      dashboard_id: dashboardId,
+      dashboard_tab_id: tab1.id,
+      card: createMockCard({ id: 10 }),
+    });
+    const tab2Card = createMockDashboardCard({
+      id: 20,
+      card_id: 20,
+      dashboard_id: dashboardId,
+      dashboard_tab_id: tab2.id,
+      card: createMockCard({ id: 20 }),
+    });
+
+    let tab1QueryCount = 0;
+    fetchMock.post(
+      `/api/dashboard/${dashboardId}/dashcard/${tab1Card.id}/card/${tab1Card.card_id}/query`,
+      () =>
+        new Promise((resolve) => {
+          tab1QueryCount++;
+          // Slow query on Tab 1 (simulates a pivot table)
+          setTimeout(() => resolve({ data: [] }), 200);
+        }),
+    );
+    fetchMock.post(
+      `/api/dashboard/${dashboardId}/dashcard/${tab2Card.id}/card/${tab2Card.card_id}/query`,
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ data: [] }), 20);
+        }),
+    );
+
+    const database = createSampleDatabase();
+    const dashcards = [tab1Card, tab2Card];
+    const DASHBOARD = createMockDashboard({
+      id: dashboardId,
+      tabs: [tab1, tab2],
+      dashcards,
+    });
+
+    const state: Partial<State> = {
+      dashboard: createMockDashboardState({
+        dashboardId: DASHBOARD.id,
+        selectedTabId: tab1.id,
+        dashboards: {
+          [DASHBOARD.id]: createMockStoreDashboard({
+            ...DASHBOARD,
+            dashcards: dashcards.map((dc) => dc.id),
+          }),
+        },
+        dashcards: Object.fromEntries(dashcards.map((dc) => [dc.id, dc])),
+      }),
+      entities: createMockEntitiesState({ databases: [database] }),
+      settings: createMockSettingsState(),
+    };
+
+    const getState = () => state;
+    const dispatch = createMockDispatch(getState);
+
+    // Start loading Tab 1 (slow query)
+    const tab1Fetch = fetchDashboardCardData()(
+      dispatch as never,
+      getState as never,
+    );
+
+    // Wait a bit to let Tab 1 request start, but not finish
+    await new Promise<void>((res) => setTimeout(res, 50));
+
+    // Switch to Tab 2
+    (state.dashboard as DashboardState).selectedTabId = tab2.id;
+    const tab2Fetch = fetchDashboardCardData()(
+      dispatch as never,
+      getState as never,
+    );
+
+    await Promise.all([tab1Fetch, tab2Fetch]);
+
+    // Tab 1's query should have been called exactly once (never cancelled
+    // and restarted). Before the fix, the batch cancellation loop would
+    // cancel Tab 1's in-flight request, causing a re-execution.
+    expect(tab1QueryCount).toBe(1);
   });
 });
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -384,8 +384,10 @@ describe("fetchDashboardCardData", () => {
       () =>
         new Promise((resolve) => {
           tab1QueryCount++;
-          // Slow query on Tab 1 (simulates a pivot table)
-          setTimeout(() => resolve({ data: [] }), 200);
+          // Slow query on Tab 1 (simulates a pivot table). Must be long
+          // enough that the request is still in-flight when we navigate
+          // back to Tab 1 in the test below.
+          setTimeout(() => resolve({ data: [] }), 500);
         }),
     );
     fetchMock.post(
@@ -439,11 +441,25 @@ describe("fetchDashboardCardData", () => {
       getState as never,
     );
 
-    await Promise.all([tab1Fetch, tab2Fetch]);
+    // Wait for Tab 2's fast query to finish, while Tab 1 is still in-flight
+    await tab2Fetch;
+    expect(tab1QueryCount).toBe(1);
 
-    // Tab 1's query should have been called exactly once (never cancelled
-    // and restarted). Before the fix, the batch cancellation loop would
-    // cancel Tab 1's in-flight request, causing a re-execution.
+    // Navigate back to Tab 1 while its query is still running. The
+    // in-flight request should be detected as a duplicate (same parameters)
+    // and reused — no new query execution.
+    (state.dashboard as DashboardState).selectedTabId = tab1.id;
+    const backToTab1Fetch = fetchDashboardCardData()(
+      dispatch as never,
+      getState as never,
+    );
+
+    await Promise.all([tab1Fetch, backToTab1Fetch]);
+
+    // Tab 1's query should have been called exactly once across the entire
+    // sequence: initial load -> switch to Tab 2 -> switch back to Tab 1.
+    // Before the fix, the batch cancellation loop would cancel Tab 1's
+    // in-flight request, causing a re-execution on return.
     expect(tab1QueryCount).toBe(1);
   });
 });

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -423,7 +423,7 @@ export const dashcardData = createReducer(
       })
       .addCase(fetchCardDataAction.fulfilled, (state, action) => {
         const { dashcard_id, card_id, result } = action.payload ?? {};
-        if (dashcard_id && card_id) {
+        if (dashcard_id && card_id && result != null) {
           return assocIn(state, [dashcard_id, card_id], result);
         }
       })

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.ts
@@ -370,5 +370,60 @@ describe("dashboard reducers", () => {
       );
       expect(result.loadingDashCards.loadingIds).toEqual([3]);
     });
+
+    it("should not overwrite existing dashcardData with null on cancellation (#70534)", () => {
+      const existingResult = { data: { rows: [[1, 2]] } };
+
+      // First, populate dashcardData with a valid result
+      const stateWithData = reducer(
+        {
+          ...initState,
+          loadingDashCards: {
+            loadingIds: [3],
+            loadingStatus: "running",
+            startTime: 100,
+            endTime: null,
+          },
+        },
+        {
+          type: fetchCardDataAction.fulfilled.type,
+          payload: {
+            dashcard_id: 3,
+            card_id: 1,
+            result: existingResult,
+            currentTime: 200,
+          },
+        },
+      );
+      expect(stateWithData.dashcardData).toEqual({ 3: { 1: existingResult } });
+
+      // Then dispatch a fulfilled action with null result (simulating a
+      // cancelled request). The existing data should be preserved.
+      const stateAfterNull = reducer(stateWithData, {
+        type: fetchCardDataAction.fulfilled.type,
+        payload: {
+          dashcard_id: 3,
+          card_id: 1,
+          result: null,
+          currentTime: 300,
+        },
+      });
+      expect(stateAfterNull.dashcardData).toEqual({
+        3: { 1: existingResult },
+      });
+    });
+
+    it("should store non-null results in dashcardData normally", () => {
+      const result = reducer(initState, {
+        type: fetchCardDataAction.fulfilled.type,
+        payload: {
+          dashcard_id: 5,
+          card_id: 2,
+          result: { data: [] },
+          currentTime: 100,
+        },
+      });
+      expect(result.dashcardData).toEqual({ 5: { 2: { data: [] } } });
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70534
Closes https://linear.app/metabase/issue/UXW-3248/query-unexpectedly-re-executes-on-tab-navigation-in-some-cases

### Description

When switching dashboard tabs while a card is still loading, the in-flight query gets cancelled and stored as `null` in the Redux state. When the user returns to the original tab, the cache check finds no result and re-executes the query from scratch. This is especially painful for slow queries (not necessarily pivot tables with filters -- any slow query will trigger it), since the user effectively restarts a long-running request they were almost done waiting for.

The fix stops cancelling in-flight requests on tab switch. Instead of batch-cancelling all loading cards, each card's fetch now checks whether an identical request is already in-flight (same query parameters) and returns early if so. When parameters differ (e.g. a filter change), the old request is still cancelled and restarted as before. As a safety net, the `dashcardData` reducer also no longer stores `null` results from cancelled requests, preserving any previously cached data.

The main trade-off is that requests from the previous tab continue running in the background. On HTTP/1.1, this could compete for the 6-connection-per-host limit and slow down the new tab's loading. In practice this is minor: most deployments use HTTP/2+ (where the limit doesn't apply), and the previous tab's requests were already in-flight and close to completing.

### How to verify

1. Create a dashboard with 2 tabs
2. On Tab 1, add a card with a slow query (e.g. a pivot table on a large dataset, or any question that takes several seconds) - but you can also just test it by throttling you network.
3. Optionally wire the card to a dashboard filter (not required, but this is what the customer reported, and it also helps with testing)
4. Open the dashboard -> Tab 1 starts loading
5. While the card is still loading (spinner visible), click Tab 2
6. Click back to Tab 1
7. The card query should not re-execute from scratch instead - it reuses the current request or just loads the cached data from the request started previously.

### Demo
https://www.loom.com/share/7637ae0b67024559a49e4f4747625f26

### Checklist
- [X] Tests have been added/updated to cover changes in this PR