### PR TITLE
Update Apache POI dependencies to version 5.5.1

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -128,11 +128,11 @@
   {:mvn/version "2.25.4"}             ; allows the custom json logging format
   org.apache.logging.log4j/log4j-slf4j2-impl
   {:mvn/version "2.25.4"}             ; allows the slf4j2 API to work with log4j 2
-  org.apache.poi/poi                        {:mvn/version "5.4.1"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
-  org.apache.poi/poi-ooxml                  {:mvn/version "5.4.1"
+  org.apache.poi/poi                        {:mvn/version "5.5.1"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.poi/poi-ooxml                  {:mvn/version "5.5.1"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  org.apache.poi/poi-ooxml-full             {:mvn/version "5.4.1"}
+  org.apache.poi/poi-ooxml-full             {:mvn/version "5.5.1"}
   org.apache.sshd/sshd-core                 {:mvn/version "3.0.0-M2"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}


### PR DESCRIPTION
5.5.1
Upgrade bouncycastle dependency to 1.83
Upgrade commons-io dependency to 2.21.0
Upgrade commons-codec dependency to 1.20.0
Upgrade pdfbox dependency to 3.0.6

5.5.0
Upgrade batik dependency to 1.19
Upgrade bouncycastle dependency to 1.82
Upgrade commons-codec dependency to 1.19.0
Upgrade commons-collections4 dependency to 4.5.0
Upgrade commons-compress dependency to 1.28.0
Upgrade commons-io dependency to 2.20.0
Upgrade pdfbox dependency to 3.0.5
Upgrade graphics2d dependency to 3.0.5
Upgrade xmlsec dependency to 3.0.6
Upgrade JaCoCo code-coverage tooling to 0.8.13