### PR TITLE
BOT-1389 Use v_ai_usage_log view for all AI usage stats dashboards

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.ts
@@ -9,16 +9,14 @@ import type { ColumnMetadata, Query } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type { VisualizationSettings } from "metabase-types/api";
 
-import { VIEW_CONVERSATIONS, VIEW_USAGE_LOG } from "../../constants";
+import { VIEW_USAGE_LOG } from "../../constants";
 
 export type UsageStatsMetric = "conversations" | "messages" | "tokens";
 
-// The Tokens tab reads from v_ai_usage_log (per-LLM-call ledger) for complete
-// token accounting across all call sites. The Conversations and Messages tabs
-// stay on v_metabot_conversations because aggregate-by-count and sum(message_count)
-// would be semantically wrong over a per-LLM-call table.
-export function getViewForMetric(metric: UsageStatsMetric): string {
-  return metric === "tokens" ? VIEW_USAGE_LOG : VIEW_CONVERSATIONS;
+// All three tabs read from v_ai_usage_log. Messages = COUNT DISTINCT request_id
+// (one per run-agent-loop call), Conversations = COUNT DISTINCT conversation_id.
+export function getViewForMetric(_metric: UsageStatsMetric): string {
+  return VIEW_USAGE_LOG;
 }
 
 const METRIC_ACCENT: Record<UsageStatsMetric, string> = {
@@ -30,7 +28,7 @@ const METRIC_ACCENT: Record<UsageStatsMetric, string> = {
 const METRIC_COLUMN_NAME: Record<UsageStatsMetric, string> = {
   conversations: "count",
   tokens: "sum",
-  messages: "sum",
+  messages: "count",
 };
 
 export type TokenSeriesSettings = Pick<
@@ -107,19 +105,50 @@ export function applyDateFilter(
 }
 
 /**
+ * Apply a "column IS NOT NULL" filter.
+ */
+export function applyNotNullFilter(query: Query, columnName: string): Query {
+  const col = findColumn(query, columnName, Lib.filterableColumns);
+  if (!col) {
+    return query;
+  }
+  const clause = Lib.defaultFilterClause({ operator: "not-null", column: col });
+  return Lib.filter(query, 0, clause);
+}
+
+/**
  * Add a sum aggregation for the given column name.
  */
 export function addSumAggregation(query: Query, columnName: string): Query {
+  return addAggregationByShortName(query, columnName, "sum");
+}
+
+/**
+ * Add a count-distinct aggregation for the given column name. The result column
+ * is named "count" (see src/metabase/lib/aggregation.cljc — :distinct → "count").
+ */
+export function addCountDistinctAggregation(
+  query: Query,
+  columnName: string,
+): Query {
+  return addAggregationByShortName(query, columnName, "distinct");
+}
+
+function addAggregationByShortName(
+  query: Query,
+  columnName: string,
+  shortName: string,
+): Query {
   const operators = Lib.availableAggregationOperators(query, 0);
-  const sumOp = operators.find((op) => {
-    const info = Lib.displayInfo(query, 0, op);
-    return info.shortName === "sum";
+  const op = operators.find((o) => {
+    const info = Lib.displayInfo(query, 0, o);
+    return info.shortName === shortName;
   });
-  if (!sumOp) {
+  if (!op) {
     return query;
   }
 
-  const columns = Lib.aggregationOperatorColumns(sumOp);
+  const columns = Lib.aggregationOperatorColumns(op);
   const lowerName = columnName.toLowerCase();
   const col = columns.find((c) => {
     const info = Lib.displayInfo(query, 0, c);
@@ -129,7 +158,7 @@ export function addSumAggregation(query: Query, columnName: string): Query {
     return query;
   }
 
-  const clause = Lib.aggregationClause(sumOp, col);
+  const clause = Lib.aggregationClause(op, col);
   return Lib.aggregate(query, 0, clause);
 }
 
@@ -138,16 +167,20 @@ export function applyUsageStatsAggregation(
   metric: UsageStatsMetric,
 ): { query: Query; orderColumnName: string | null } {
   switch (metric) {
-    case "conversations":
+    case "conversations": {
+      const filtered = applyNotNullFilter(query, "conversation_id");
       return {
-        query: Lib.aggregateByCount(query, 0),
+        query: addCountDistinctAggregation(filtered, "conversation_id"),
         orderColumnName: "count",
       };
-    case "messages":
+    }
+    case "messages": {
+      const filtered = applyNotNullFilter(query, "conversation_id");
       return {
-        query: addSumAggregation(query, "message_count"),
-        orderColumnName: "sum",
+        query: addCountDistinctAggregation(filtered, "request_id"),
+        orderColumnName: "count",
       };
+    }
     case "tokens": {
       const withInput = addSumAggregation(query, "prompt_tokens");
       const withBoth = addSumAggregation(withInput, "completion_tokens");

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.unit.spec.ts
@@ -1,21 +1,74 @@
 import type { DateFilterValue } from "metabase/querying/common/types";
+import * as Lib from "metabase-lib";
+import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 
-import { VIEW_CONVERSATIONS, VIEW_USAGE_LOG } from "../../constants";
+import { VIEW_USAGE_LOG } from "../../constants";
 
 import {
+  addCountDistinctAggregation,
+  applyNotNullFilter,
+  applyUsageStatsAggregation,
   getMetricSeriesSettings,
   getViewForMetric,
   isSingleDayFilter,
 } from "./query-utils";
 
 describe("getViewForMetric", () => {
-  it("routes the tokens metric to v_ai_usage_log", () => {
+  it("routes all metrics to v_ai_usage_log", () => {
     expect(getViewForMetric("tokens")).toBe(VIEW_USAGE_LOG);
+    expect(getViewForMetric("conversations")).toBe(VIEW_USAGE_LOG);
+    expect(getViewForMetric("messages")).toBe(VIEW_USAGE_LOG);
+  });
+});
+
+describe("addCountDistinctAggregation", () => {
+  it("adds a distinct-count aggregation on the named column", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    const result = addCountDistinctAggregation(query, "USER_ID");
+
+    expect(Lib.aggregations(result, 0)).toHaveLength(1);
+    const [clause] = Lib.aggregations(result, 0);
+    const info = Lib.displayInfo(result, 0, clause);
+    expect(info.displayName?.toLowerCase()).toContain("distinct");
   });
 
-  it("routes conversations and messages to v_metabot_conversations", () => {
-    expect(getViewForMetric("conversations")).toBe(VIEW_CONVERSATIONS);
-    expect(getViewForMetric("messages")).toBe(VIEW_CONVERSATIONS);
+  it("returns the query unchanged when the column is not found", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    const result = addCountDistinctAggregation(query, "nonexistent_column");
+    expect(Lib.aggregations(result, 0)).toHaveLength(0);
+  });
+});
+
+describe("applyNotNullFilter", () => {
+  it("adds a not-null filter on the named column", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    const result = applyNotNullFilter(query, "USER_ID");
+    expect(Lib.filters(result, 0)).toHaveLength(1);
+  });
+
+  it("returns the query unchanged when the column is not found", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    const result = applyNotNullFilter(query, "nonexistent_column");
+    expect(Lib.filters(result, 0)).toHaveLength(0);
+  });
+});
+
+describe("applyUsageStatsAggregation", () => {
+  it("returns orderColumnName 'count' for the conversations and messages metrics", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    expect(
+      applyUsageStatsAggregation(query, "conversations").orderColumnName,
+    ).toBe("count");
+    expect(applyUsageStatsAggregation(query, "messages").orderColumnName).toBe(
+      "count",
+    );
+  });
+
+  it("returns orderColumnName null for the tokens metric (dual aggregation)", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+    expect(
+      applyUsageStatsAggregation(query, "tokens").orderColumnName,
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes [BOT-1389: Use v_ai_usage_log view for all stats dashboards](https://linear.app/metabase/issue/BOT-1389/use-v-ai-usage-log-view-for-all-stats-dashboards)

### Description

We recently switched the Tokens tab to pull data from the new `v_ai_usage_log` view. This PR switches over the Conversations and Messages tabs as well.

- `getViewForMetric` now returns `VIEW_USAGE_LOG` for all three metrics
- Added `applyNotNullFilter` and `addCountDistinctAggregation`
- `applyUsageStatsAggregation`
  - conversations now filters `conversation_id IS NOT NULL` and counts distinct `conversation_id`
  - messages filters `conversation_id IS NOT NULL` and counts distinct `request_id`
  - tokens unchanged

Caveats
* this switches the meaning of the Messages tab so that it's no longer counting `metabot_message`s, which counts both the user and assistant message for a single turn as separate messages, and instead counts unique `request_id`s, which corresponds to a single chat request / response "turn". As such, if we decide to merge this, we might want to rename the Messages tab to something more descriptive like Chat Requests.
* does not include data for conversations prior to the introduction of `ai_usage_log` in v60.2
* does not include conversations where an error happens before the response is returned

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
