### PR TITLE
Add pivot table transpose toggle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install wget apt-transport-h
     && apt install temurin-21-jdk -y \
     && curl -O https://download.clojure.org/install/linux-install-1.12.0.1488.sh \
     && chmod +x linux-install-1.12.0.1488.sh \
-    && ./linux-install-1.12.0.1488.sh
+    && ./linux-install-1.12.0.1488.sh \
     && curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ENV PATH="/root/.local/bin:$PATH"

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -31,6 +31,8 @@ import {
   isPivotGroupColumn,
   multiLevelPivot,
 } from "metabase/visualizations/lib/data_grid";
+
+import { transposePivot } from "./transpose";
 import {
   getDefaultSize,
   getMinSize,
@@ -188,7 +190,13 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       }
 
       try {
-        return multiLevelPivot(data, settings);
+        const result = multiLevelPivot(data, settings);
+        if (!result) {
+          return null;
+        }
+        return settings["pivot.transpose"]
+          ? transposePivot(result)
+          : result;
       } catch (e) {
         console.warn(e);
       }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -296,6 +296,85 @@ describe("Visualizations > PivotTable > PivotTable", () => {
   });
 });
 
+describe("Visualizations > PivotTable > Transpose", () => {
+  const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  ) as number;
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetWidth",
+  ) as number;
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 500,
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      value: 500,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      originalOffsetHeight,
+    );
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetWidth",
+      originalOffsetWidth,
+    );
+  });
+
+  it("should render measure names as row headers when transposed", () => {
+    const transposedSettings = createMockVisualizationSettings({
+      ...settings,
+      "pivot.transpose": true,
+    });
+
+    setupPivotTable({ initialSettings: transposedSettings });
+
+    const pivotTable = screen.getByTestId("pivot-table");
+    expect(pivotTable).toHaveTextContent("aggregation-1");
+    expect(pivotTable).toHaveTextContent("aggregation-2");
+  });
+
+  it("should render breakout values as column headers when transposed", () => {
+    const transposedSettings = createMockVisualizationSettings({
+      ...settings,
+      "pivot.transpose": true,
+    });
+
+    setupPivotTable({ initialSettings: transposedSettings });
+
+    const pivotTable = screen.getByTestId("pivot-table");
+    // original left header values should now appear as top headers
+    expect(pivotTable).toHaveTextContent("foo1");
+    expect(pivotTable).toHaveTextContent("foo2");
+    expect(pivotTable).toHaveTextContent("foo3");
+  });
+
+  it("should render cell values correctly when transposed", () => {
+    const transposedSettings = createMockVisualizationSettings({
+      ...settings,
+      "pivot.transpose": true,
+    });
+
+    setupPivotTable({ initialSettings: transposedSettings });
+
+    const pivotTable = screen.getByTestId("pivot-table");
+    // values from the original rows should still be present
+    expect(pivotTable).toHaveTextContent("111");
+    expect(pivotTable).toHaveTextContent("222");
+    expect(pivotTable).toHaveTextContent("555");
+    expect(pivotTable).toHaveTextContent("666");
+  });
+});
+
 describe("Visualizations > PivotTable > Chart Settings", () => {
   it("should allow you to update a column name", async () => {
     setupPivotSettings();

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -194,6 +194,20 @@ export const settings = {
     },
     readDependencies: ["pivot.show_row_totals", "pivot.show_column_totals"],
   },
+  "pivot.transpose": {
+    get section() {
+      return t`Columns`;
+    },
+    get title() {
+      return t`Transpose`;
+    },
+    get hint() {
+      return t`Swap rows and columns`;
+    },
+    widget: "toggle",
+    getDefault: () => false,
+    inline: true,
+  },
   "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {
     get section() {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/transpose.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/transpose.ts
@@ -1,0 +1,71 @@
+import type { DatasetColumn } from "metabase-types/api";
+
+import type { BodyItem, HeaderItem } from "./types";
+
+export interface PivotData {
+  leftHeaderItems: HeaderItem[];
+  topHeaderItems: HeaderItem[];
+  rowCount: number;
+  columnCount: number;
+  rowIndex: string[];
+  getRowSection: (columnIndex: number, rowIndex: number) => BodyItem[];
+  rowIndexes: number[];
+  columnIndexes: number[];
+  valueIndexes: number[];
+  columnsWithoutPivotGroup: DatasetColumn[];
+}
+
+export function transposePivot(result: PivotData): PivotData {
+  const cols = result.columnsWithoutPivotGroup;
+  const numMeasures = result.valueIndexes.length;
+
+  const leftHeaderItems: HeaderItem[] = result.valueIndexes.map(
+    (valIdx: number, i: number) => ({
+      value: cols[valIdx].display_name || cols[valIdx].name,
+      rawValue: cols[valIdx].name,
+      depth: 0,
+      offset: i,
+      span: 1,
+      maxDepthBelow: 1,
+      hasChildren: false,
+      hasSubtotal: false,
+      isSubtotal: false,
+      isGrandTotal: false,
+      path: [cols[valIdx].name],
+      clicked: { value: cols[valIdx].display_name, column: cols[valIdx] },
+    }),
+  );
+
+  const topHeaderItems: HeaderItem[] = result.leftHeaderItems.map(
+    (item: HeaderItem) => ({
+      ...item,
+      depth: 0,
+      maxDepthBelow: 0,
+    }),
+  );
+
+  const origFn = result.getRowSection;
+  const getRowSection = (colIdx: number, rowIdx: number): BodyItem[] => {
+    if (colIdx >= result.rowCount || rowIdx >= numMeasures) {
+      return [];
+    }
+    const row = origFn(0, colIdx);
+    if (!row) {
+      return [];
+    }
+    return [row[rowIdx]];
+  };
+
+  return {
+    leftHeaderItems,
+    topHeaderItems,
+    rowCount: numMeasures,
+    columnCount: result.rowCount,
+    rowIndex: Array.from({ length: numMeasures }, (_, i) => String(i)),
+    getRowSection,
+    rowIndexes: [0],
+    columnIndexes: result.rowIndexes,
+    valueIndexes: [0],
+    columnsWithoutPivotGroup: cols,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a **Transpose** toggle to pivot table visualization settings (under Columns section)
- When enabled, measures become row headers and dimensions become column headers
- Handles the common case where users want to view metrics as rows with time periods as columns
- Also fixes a missing `\` line continuation in the Dockerfile

Closes #60354
Closes #3769

## How it works
- New `pivot.transpose` boolean setting in `settings.ts`
- In `PivotTable.tsx`, after `multiLevelPivot()`, restructures the pivot data:
  - Creates synthetic left header items from measure/value names
  - Remaps original left header items (dimensions) to top header
  - Wraps `getRowSection` to extract individual measure values
  - Sets `rowIndexes: [0]` and `valueIndexes: [0]` so cell size computation works correctly

## Test plan
- [ ] Enable transpose on a pivot table with 1+ row dimensions and multiple measures
- [ ] Verify measure names appear as row headers
- [ ] Verify dimension values appear as column headers
- [ ] Verify cell values are correct and match non-transposed view
- [ ] Verify no NaN/crash in react-virtualized cell positioning
- [ ] Verify toggle persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)