### PR TITLE
Custom viz: bundle upload instead of git sync  

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2831,8 +2831,7 @@
            premium-features
            server
            settings
-           util
-           enterprise/remote-sync}
+           util}
    :model-exports #{:model/CustomVizPlugin}}
 
   enterprise/dashboard-subscription-filters
@@ -3078,8 +3077,7 @@
   {:team "UX West"
    :api  #{metabase-enterprise.remote-sync.api
            metabase-enterprise.remote-sync.core
-           metabase-enterprise.remote-sync.init
-           metabase-enterprise.remote-sync.source.git}
+           metabase-enterprise.remote-sync.init}
    :uses #{analytics
            api
            app-db

--- a/docs/installation-and-operation/commands.md
+++ b/docs/installation-and-operation/commands.md
@@ -61,7 +61,6 @@ Options:
 - `-D, --no-data-model` - Do not export any data model entities; useful for subsequent exports.
 - `-f, --include-field-values` - Include field values along with field metadata.
 - `-s, --include-database-secrets` - Include database connection details (in plain text; use caution).
-- `--include-custom-viz-token` - Include custom visualization plugin access tokens (in plain text; use caution).
 - `-e, --continue-on-error` - Do not break execution on errors.
 - `--full-stacktrace` - Output full stacktraces on errors.
 
@@ -119,4 +118,3 @@ Open an SQL shell for the Metabase H2 DB:
 ```sh
 java -cp metabase.jar org.h2.tools.Shell -url jdbc:h2:/path/to/metabase.db
 ```
-

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -3,7 +3,6 @@
   (:require
    [clj-http.client :as http]
    [clojure.core.async :as a]
-   [clojure.string :as str]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
    [metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin]
@@ -17,7 +16,8 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
-   (java.io BufferedReader InputStream InputStreamReader OutputStream)))
+   (java.io BufferedReader File InputStream InputStreamReader OutputStream)
+   (java.nio.file Files)))
 
 (set! *warn-on-reflection* true)
 
@@ -29,20 +29,33 @@
   (api/check (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
              [403 "Custom visualization plugin dev mode is not enabled."]))
 
+;;; ------------------------------------------------ Upload guard ------------------------------------------------
+
+(defn- check-upload!
+  "Validate an incoming multipart `file` part before we spend any IO reading it.
+   Rejects oversized uploads with 413 using the `:size` hint and rejects missing
+   files with 400. Returns the `java.io.File` tempfile."
+  ^File [file]
+  (when (> (or (:size file) 0) cache/max-bundle-bytes)
+    (throw (ex-info (format "Bundle must be less than %dMB." cache/max-bundle-mib)
+                    {:status-code 413})))
+  (let [tempfile (:tempfile file)]
+    (when-not (instance? File tempfile)
+      (throw (ex-info "No file provided" {:status-code 400})))
+    tempfile))
+
 ;;; ------------------------------------------------ Schemas ------------------------------------------------
 
 (def ^:private CustomVizPluginResponse
   [:map
    [:id              ms/PositiveInt]
-   [:repo_url        ms/NonBlankString]
    [:display_name    ms/NonBlankString]
    [:identifier      ms/NonBlankString]
    [:status          [:enum :active :error]]
    [:enabled         :boolean]
    [:icon            {:optional true} [:maybe :string]]
    [:error_message   {:optional true} [:maybe :string]]
-   [:pinned_version  {:optional true} [:maybe :string]]
-   [:resolved_commit {:optional true} [:maybe :string]]
+   [:bundle_hash     {:optional true} [:maybe :string]]
    [:dev_bundle_url  {:optional true} [:maybe :string]]
    [:dev_only        :boolean]
    [:manifest        {:optional true} [:maybe :any]]
@@ -57,78 +70,96 @@
    [:display_name    ms/NonBlankString]
    [:icon            {:optional true} [:maybe :string]]
    [:bundle_url      ms/NonBlankString]
-   [:resolved_commit {:optional true} [:maybe :string]]
+   [:bundle_hash     {:optional true} [:maybe :string]]
    [:dev_bundle_url  {:optional true} [:maybe :string]]
    [:manifest        {:optional true} [:maybe :any]]])
 
 ;;; ------------------------------------------------ Helpers ------------------------------------------------
 
 (defn- dev-only-plugin?
-  "Returns true if the plugin was created via the dev-only flow (no git repo)."
+  "Returns true if the plugin has no uploaded bundle and is served from a dev URL."
   [plugin]
-  (str/starts-with? (:repo_url plugin) "dev://local/"))
-
-(defn- parse-repo-name
-  "Extract the repository name from a git URL.
-     'https://github.com/user/custom-heatmap'     -> 'custom-heatmap'
-     'https://github.com/user/custom-heatmap.git' -> 'custom-heatmap'"
-  [^String url]
-  (-> url
-      (str/replace #"\.git$" "")
-      (str/split #"[/:]")
-      last))
+  (nil? (:bundle_hash plugin)))
 
 (defn- plugin->response
   "Convert a plugin record to API response format."
   [plugin]
   (-> plugin
       (assoc :dev_only (dev-only-plugin? plugin))
-      ;; already stripped by to-json, but dissocing for extra safety
-      (dissoc :access_token)))
+      ;; never expose the raw bundle bytes
+      (dissoc :bundle)))
 
 (defn- plugin->runtime-response
   "Convert a plugin record to the safe runtime response shape."
-  [{:keys [id identifier display_name icon resolved_commit manifest dev_bundle_url]}]
-  (cond-> {:id              id
-           :identifier      identifier
-           :display_name    display_name
-           :icon            icon
-           :bundle_url      (format "/api/ee/custom-viz-plugin/%d/bundle" id)
-           :resolved_commit resolved_commit
-           :manifest        manifest}
+  [{:keys [id identifier display_name icon bundle_hash manifest dev_bundle_url]}]
+  (cond-> {:id           id
+           :identifier   identifier
+           :display_name display_name
+           :icon         icon
+           :bundle_url   (format "/api/ee/custom-viz-plugin/%d/bundle" id)
+           :bundle_hash  bundle_hash
+           :manifest     manifest}
     dev_bundle_url (assoc :dev_bundle_url dev_bundle_url)))
+
+;; Every selector except the raw `/bundle` serve path wants the full plugin row
+;; *without* the bundle blob — loading a multi-MB archive on every list / update
+;; would be wasteful. These helpers drive that: they target the same column set
+;; as a normal `t2/select` but omit `:bundle`.
+
+(def ^:private non-blob-columns
+  [:id :identifier :display_name :icon :status :error_message :enabled
+   :manifest :metabase_version :bundle_hash :dev_bundle_url
+   :created_at :updated_at])
+
+(defn- select-one-plugin
+  "Like `t2/select-one` on `:model/CustomVizPlugin`, but excludes the bundle blob."
+  [& conditions]
+  (apply t2/select-one (into [:model/CustomVizPlugin] non-blob-columns) conditions))
+
+(defn- select-plugins
+  "Like `t2/select` on `:model/CustomVizPlugin`, but excludes the bundle blob."
+  [& conditions]
+  (apply t2/select (into [:model/CustomVizPlugin] non-blob-columns) conditions))
 
 ;;; ------------------------------------------------ Endpoints ------------------------------------------------
 
 (api.macros/defendpoint :post "/" :- CustomVizPluginResponse
-  "Register a new custom visualization plugin from a git repository.
-   Validates by fetching index.js from the repo."
+  "Register a new custom visualization plugin from an uploaded tar.gz bundle.
+
+  The archive must contain `metabase-plugin.json` at the root and
+  `dist/index.js` for the JS bundle, plus any whitelisted assets under
+  `dist/assets/`. The plugin's `identifier` is taken from the manifest's `name`
+  field."
+  {:multipart true}
   [_route-params
    _query-params
-   {:keys [repo_url access_token pinned_version]} :- [:map
-                                                      [:repo_url       ms/NonBlankString]
-                                                      [:access_token   {:optional true} [:maybe :string]]
-                                                      [:pinned_version {:optional true} [:maybe :string]]]]
+   _body
+   {{file "file"} :multipart-params, :as _request}
+   :- [:map
+       [:multipart-params
+        [:map
+         ["file" [:map
+                  [:filename :string]
+                  [:tempfile (ms/InstanceOfClass File)]]]]]]]
   (api/check-superuser)
-  (cache/validate-repo-url! repo_url)
-  (let [identifier (parse-repo-name repo_url)
-        _          (api/check-400
-                    (not (t2/exists? :model/CustomVizPlugin :repo_url repo_url))
-                    (format "A custom visualization with repo URL \"%s\" already exists." repo_url))
-        _          (api/check-400
-                    (not (t2/exists? :model/CustomVizPlugin :identifier identifier))
-                    (format "A custom visualization with identifier \"%s\" already exists." identifier))
-        plugin (cache/fetch-and-save! {:repo_url       repo_url
-                                       :access_token   access_token
-                                       :identifier     identifier
-                                       :pinned_version pinned_version})]
-    (events/publish-event! :event/custom-viz-plugin-create {:object  plugin
-                                                            :user-id api/*current-user-id*})
-    (plugin->response plugin)))
+  (let [tempfile (check-upload! file)]
+    (try
+      (let [bundle-bytes (Files/readAllBytes (.toPath tempfile))
+            validated    (cache/validate-bundle! bundle-bytes)
+            identifier   (get-in validated [:manifest :name])
+            _            (api/check-400
+                          (not (t2/exists? :model/CustomVizPlugin :identifier identifier))
+                          (format "A custom visualization with identifier \"%s\" already exists." identifier))
+            plugin       (cache/insert-bundle! identifier validated)]
+        (events/publish-event! :event/custom-viz-plugin-create {:object  plugin
+                                                                :user-id api/*current-user-id*})
+        (plugin->response (dissoc plugin :bundle)))
+      (finally
+        (try (.delete tempfile) (catch Exception _))))))
 
 (api.macros/defendpoint :post "/dev" :- CustomVizPluginResponse
   "Register a dev-only custom visualization plugin from a local dev server.
-   No git repository is required — the bundle is served from the dev server URL.
+   No bundle upload is required — files are served from the dev server URL.
    Requires custom viz plugin dev mode to be enabled."
   [_route-params
    _query-params
@@ -144,10 +175,6 @@
                                            "metabase-plugin.json is missing a \"name\" field."
                                            "Could not fetch metabase-plugin.json from the dev server.")
                                          {:status-code 400})))
-        sentinel-url (str "dev://local/" identifier)
-        _            (api/check-400
-                      (not (t2/exists? :model/CustomVizPlugin :repo_url sentinel-url))
-                      (format "A custom visualization with repo URL \"%s\" already exists." sentinel-url))
         _            (api/check-400
                       (not (t2/exists? :model/CustomVizPlugin :identifier identifier))
                       (format "A custom visualization with identifier \"%s\" already exists." identifier))
@@ -155,7 +182,6 @@
         icon         (:icon manifest)
         version-str  (get-in manifest [:metabase :version])
         plugin       (first (t2/insert-returning-instances! :model/CustomVizPlugin
-                                                            :repo_url        sentinel-url
                                                             :display_name    display-name
                                                             :identifier      identifier
                                                             :status          :active
@@ -173,7 +199,8 @@
   "List all registered custom visualization plugins."
   []
   (api/check-superuser)
-  (mapv (comp plugin->response api/read-check) (t2/select :model/CustomVizPlugin {:order-by [[:display_name :asc]]})))
+  (->> (select-plugins {:order-by [[:display_name :asc]]})
+       (mapv (comp plugin->response api/read-check))))
 
 (api.macros/defendpoint :get "/list" :- [:sequential CustomVizPluginRuntimeResponse]
   "List active and enabled custom visualization plugins. Available to any authenticated user.
@@ -181,23 +208,22 @@
    Dev-only plugins are excluded when dev mode is disabled."
   []
   (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
-        plugins   (mapv api/read-check
-                        (t2/select [:model/CustomVizPlugin
-                                    :id :identifier :display_name :icon :resolved_commit
-                                    :manifest :metabase_version :dev_bundle_url :repo_url]
-                                   :status :active
-                                   :enabled true
-                                   {:order-by [[:display_name :asc]]}))]
+        plugins   (t2/select [:model/CustomVizPlugin
+                              :id :identifier :display_name :icon :bundle_hash
+                              :manifest :metabase_version :dev_bundle_url]
+                             :status :active
+                             :enabled true
+                             {:order-by [[:display_name :asc]]})]
     (->> plugins
          (filter manifest/compatible?)
          (remove #(and (not dev-mode?) (dev-only-plugin? %)))
-         (map plugin->runtime-response))))
+         (mapv (comp plugin->runtime-response api/read-check)))))
 
 (api.macros/defendpoint :delete "/:id" :- :nil
-  "Remove a custom visualization plugin and evict its cached bundle."
+  "Remove a custom visualization plugin and evict its on-disk cache."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/check-superuser)
-  (let [plugin (api/write-check (t2/select-one :model/CustomVizPlugin :id id))]
+  (let [plugin (api/write-check (select-one-plugin :id id))]
     (t2/delete! :model/CustomVizPlugin :id id)
     (cache/purge-plugin-cache! plugin)
     (events/publish-event! :event/custom-viz-plugin-delete {:object  plugin
@@ -205,32 +231,60 @@
     nil))
 
 (api.macros/defendpoint :put "/:id" :- CustomVizPluginResponse
-  "Update a custom visualization plugin."
+  "Update a custom visualization plugin. Currently only `enabled` may be toggled."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    body :- [:map
-            [:enabled        {:optional true} [:maybe :boolean]]
-            [:access_token   {:optional true} [:maybe :string]]
-            [:pinned_version {:optional true} [:maybe :string]]]]
+            [:enabled {:optional true} [:maybe :boolean]]]]
   (api/check-superuser)
-  (let [existing        (api/read-check (t2/select-one :model/CustomVizPlugin :id id))
-        updates         (select-keys body [:enabled :access_token :pinned_version])
-        pinned-changed? (and (contains? updates :pinned_version)
-                             (not= (:pinned_version updates) (:pinned_version existing)))
-        result          (if pinned-changed?
-                          (cache/fetch-and-save! (merge existing updates) updates)
-                          (do (when (seq updates)
-                                (t2/update! :model/CustomVizPlugin id updates))
-                              (t2/select-one :model/CustomVizPlugin :id id)))]
-    (events/publish-event! :event/custom-viz-plugin-update {:object          result
-                                                            :previous-object existing
-                                                            :user-id         api/*current-user-id*})
-    (plugin->response result)))
+  (let [existing (api/write-check (select-one-plugin :id id))
+        updates  (select-keys body [:enabled])]
+    (when (seq updates)
+      (t2/update! :model/CustomVizPlugin id updates))
+    (let [result (select-one-plugin :id id)]
+      (events/publish-event! :event/custom-viz-plugin-update {:object          result
+                                                              :previous-object existing
+                                                              :user-id         api/*current-user-id*})
+      (plugin->response result))))
+
+(api.macros/defendpoint :post "/:id/bundle" :- CustomVizPluginResponse
+  "Replace the bundle for an existing plugin. Accepts a multipart tar.gz upload in
+   the same format as the `POST /` endpoint. The manifest's `name` field must
+   match the plugin's existing `identifier`."
+  {:multipart true}
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   _body
+   {{file "file"} :multipart-params, :as _request}
+   :- [:map
+       [:multipart-params
+        [:map
+         ["file" [:map
+                  [:filename :string]
+                  [:tempfile (ms/InstanceOfClass File)]]]]]]]
+  (api/check-superuser)
+  (let [existing (api/write-check (select-one-plugin :id id))
+        tempfile (check-upload! file)]
+    (try
+      (let [bundle-bytes (Files/readAllBytes (.toPath tempfile))
+            validated    (cache/validate-bundle! bundle-bytes)
+            new-name     (get-in validated [:manifest :name])]
+        (api/check-400 (= new-name (:identifier existing))
+                       (format "Bundle manifest \"name\" (%s) does not match the plugin's identifier (%s)."
+                               new-name (:identifier existing)))
+        (let [result (cache/save-bundle! existing validated)]
+          (events/publish-event! :event/custom-viz-plugin-update
+                                 {:object          result
+                                  :previous-object existing
+                                  :user-id         api/*current-user-id*})
+          (plugin->response (dissoc result :bundle))))
+      (finally
+        (try (.delete tempfile) (catch Exception _))))))
 
 (api.macros/defendpoint :get "/:id/bundle" :- :any
-  "Serve the cached JS bundle for a plugin.
+  "Serve the JS bundle for a plugin from the on-disk cache.
    Returns application/javascript with ETag and Cache-Control headers.
-   In dev mode, proxies from dev_bundle_url if set."
+   In dev mode, proxies from `dev_bundle_url` if set."
   [{:keys [id], :as _route-params} :- [:map [:id ms/PositiveInt]]
    _query-params
    _body
@@ -238,7 +292,7 @@
    respond
    raise]
   (try
-    (let [plugin  (api/read-check (t2/select-one :model/CustomVizPlugin :id id))
+    (let [plugin  (api/read-check (select-one-plugin :id id))
           dev-url (cache/resolve-dev-bundle id)
           entry   (cache/resolve-bundle plugin)]
       (if entry
@@ -258,7 +312,7 @@
       (raise e))))
 
 (api.macros/defendpoint :get "/:id/asset" :- :any
-  "Serve a static image asset from the plugin's cached assets.
+  "Serve a static image asset from the plugin's bundle.
    The asset path is passed as a `path` query parameter (e.g. `?path=icon.svg`)
    and must match an entry in the manifest's `assets` whitelist.
    Only image files are served.
@@ -270,7 +324,7 @@
    respond
    raise]
   (try
-    (let [plugin       (api/read-check (t2/select-one :model/CustomVizPlugin :id id))
+    (let [plugin       (api/read-check (select-one-plugin :id id))
           content-type (or (manifest/asset-content-type path)
                            (throw (ex-info "Unsupported asset type" {:status-code 404})))
           dev?         (cache/resolve-dev-bundle id)
@@ -300,7 +354,7 @@
    {:keys [dev_bundle_url]} :- [:map [:dev_bundle_url [:maybe :string]]]]
   (api/check-superuser)
   (check-dev-mode-enabled!)
-  (api/read-check (t2/select-one :model/CustomVizPlugin :id id))
+  (api/write-check (select-one-plugin :id id))
   (cache/set-or-clear-dev-bundle! id dev_bundle_url)
   {:dev_bundle_url (cache/resolve-dev-bundle id)})
 
@@ -338,29 +392,29 @@
             (log/debugf "SSE proxy for plugin %d ended: %s" id (ex-message e))))))))
 
 (api.macros/defendpoint :post "/:id/refresh" :- CustomVizPluginResponse
-  "Re-fetch the bundle from the git repository.
-   For dev-only plugins, re-fetches the manifest from the dev server instead."
+  "Re-fetch the manifest from the dev server for a dev-only plugin. For uploaded
+   plugins this is a no-op — to update an upload-backed plugin, POST a new bundle
+   to `/:id/bundle`."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/check-superuser)
-  (let [plugin (api/write-check (t2/select-one :model/CustomVizPlugin :id id))]
-    (if (dev-only-plugin? plugin)
-      ;; dev-only: re-fetch manifest from dev server
-      (let [dev-url  (or (cache/resolve-dev-bundle id)
-                         (throw (ex-info "No dev server URL configured" {:status-code 404})))
-            manifest (or (cache/fetch-dev-manifest dev-url)
-                         (throw (ex-info "Failed to fetch manifest from dev server" {:status-code 502})))
-            version-str  (get-in manifest [:metabase :version])]
-        (t2/update! :model/CustomVizPlugin id
-                    {:display_name     (or (:name manifest) (:identifier plugin))
-                     :icon             (:icon manifest)
-                     :manifest         manifest
-                     :metabase_version version-str}))
-      (cache/fetch-and-save! plugin))
-    (let [result (t2/select-one :model/CustomVizPlugin :id id)]
-      (events/publish-event! :event/custom-viz-plugin-update {:object          result
-                                                              :previous-object plugin
-                                                              :user-id         api/*current-user-id*})
-      (plugin->response result))))
+  (let [plugin (api/write-check (select-one-plugin :id id))]
+    (api/check-400 (dev-only-plugin? plugin)
+                   "Refresh is only supported for dev-only plugins; upload a new bundle to /:id/bundle.")
+    (let [dev-url      (or (cache/resolve-dev-bundle id)
+                           (throw (ex-info "No dev server URL configured" {:status-code 404})))
+          manifest     (or (cache/fetch-dev-manifest dev-url)
+                           (throw (ex-info "Failed to fetch manifest from dev server" {:status-code 502})))
+          version-str  (get-in manifest [:metabase :version])]
+      (t2/update! :model/CustomVizPlugin id
+                  {:display_name     (or (:name manifest) (:identifier plugin))
+                   :icon             (:icon manifest)
+                   :manifest         manifest
+                   :metabase_version version-str})
+      (let [result (select-one-plugin :id id)]
+        (events/publish-event! :event/custom-viz-plugin-update {:object          result
+                                                                :previous-object plugin
+                                                                :user-id         api/*current-user-id*})
+        (plugin->response result)))))
 
 (def routes
   "`/api/ee/custom-viz-plugin` routes."

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
    [metabase.events.core :as events]
    [metabase.server.streaming-response :as sr]
    [metabase.util.log :as log]
@@ -179,7 +180,6 @@
    Plugins with incompatible Metabase version requirements are excluded.
    Dev-only plugins are excluded when dev mode is disabled."
   []
-  (api/check api/*current-user-id* [401 "Unauthenticated"])
   (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
         plugins   (mapv api/read-check
                         (t2/select [:model/CustomVizPlugin
@@ -364,4 +364,4 @@
 
 (def routes
   "`/api/ee/custom-viz-plugin` routes."
-  (api.macros/ns-handler *ns*))
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -208,12 +208,9 @@
    Dev-only plugins are excluded when dev mode is disabled."
   []
   (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
-        plugins   (t2/select [:model/CustomVizPlugin
-                              :id :identifier :display_name :icon :bundle_hash
-                              :manifest :metabase_version :dev_bundle_url]
-                             :status :active
-                             :enabled true
-                             {:order-by [[:display_name :asc]]})]
+        plugins   (select-plugins :status :active
+                                  :enabled true
+                                  {:order-by [[:display_name :asc]]})]
     (->> plugins
          (filter manifest/compatible?)
          (remove #(and (not dev-mode?) (dev-only-plugin? %)))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -245,7 +245,7 @@
                                                               :user-id         api/*current-user-id*})
       (plugin->response result))))
 
-(api.macros/defendpoint :post "/:id/bundle" :- CustomVizPluginResponse
+(api.macros/defendpoint :put "/:id/bundle" :- CustomVizPluginResponse
   "Replace the bundle for an existing plugin. Accepts a multipart tar.gz upload in
    the same format as the `POST /` endpoint. The manifest's `name` field must
    match the plugin's existing `identifier`."
@@ -391,13 +391,13 @@
 
 (api.macros/defendpoint :post "/:id/refresh" :- CustomVizPluginResponse
   "Re-fetch the manifest from the dev server for a dev-only plugin. For uploaded
-   plugins this is a no-op — to update an upload-backed plugin, POST a new bundle
+   plugins this is a no-op — to update an upload-backed plugin, PUT a new bundle
    to `/:id/bundle`."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/check-superuser)
   (let [plugin (api/write-check (select-one-plugin :id id))]
     (api/check-400 (dev-only-plugin? plugin)
-                   "Refresh is only supported for dev-only plugins; upload a new bundle to /:id/bundle.")
+                   "Refresh is only supported for dev-only plugins")
     (let [dev-url      (or (cache/resolve-dev-bundle id)
                            (throw (ex-info "No dev server URL configured" {:status-code 404})))
           manifest     (or (cache/fetch-dev-manifest dev-url)

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -33,10 +33,11 @@
 
 (defn- check-upload!
   "Validate an incoming multipart `file` part before we spend any IO reading it.
-   Rejects oversized uploads with 413 using the `:size` hint and rejects missing
-   files with 400. Returns the `java.io.File` tempfile."
+   Rejects oversized uploads with 413 using `:size` (populated by Ring from the
+   bytes it actually buffered, not a client header) and rejects missing files with
+   400. Returns the `java.io.File` tempfile."
   ^File [file]
-  (when (> (or (:size file) 0) cache/max-bundle-bytes)
+  (when (> (:size file) cache/max-bundle-bytes)
     (throw (ex-info (format "Bundle must be less than %dMB." cache/max-bundle-mib)
                     {:status-code 413})))
   (let [tempfile (:tempfile file)]

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -37,12 +37,12 @@
    bytes it actually buffered, not a client header) and rejects missing files with
    400. Returns the `java.io.File` tempfile."
   ^File [file]
-  (when (> (:size file) cache/max-bundle-bytes)
-    (throw (ex-info (format "Bundle must be less than %dMB." cache/max-bundle-mib)
-                    {:status-code 413})))
   (let [tempfile (:tempfile file)]
     (when-not (instance? File tempfile)
       (throw (ex-info "No file provided" {:status-code 400})))
+    (when (> (:size file) cache/max-bundle-bytes)
+      (throw (ex-info (format "Bundle must be less than %dMB." cache/max-bundle-mib)
+                      {:status-code 413})))
     tempfile))
 
 ;;; ------------------------------------------------ Schemas ------------------------------------------------

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -394,7 +394,7 @@
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (let [plugin (api/write-check (select-one-plugin :id id))]
     (api/check-400 (dev-only-plugin? plugin)
-                   "Refresh is only supported for dev-only plugins")
+                   "Refresh is only supported for dev-only plugins; upload a new bundle to update an upload-backed plugin.")
     (let [dev-url      (or (cache/resolve-dev-bundle id)
                            (throw (ex-info "No dev server URL configured" {:status-code 404})))
           manifest     (or (cache/fetch-dev-manifest dev-url)

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -131,7 +131,8 @@
   `dist/index.js` for the JS bundle, plus any whitelisted assets under
   `dist/assets/`. The plugin's `identifier` is taken from the manifest's `name`
   field."
-  {:multipart true}
+  {:multipart {:max-file-size  cache/max-bundle-bytes
+               :max-file-count 1}}
   [_route-params
    _query-params
    _body
@@ -247,7 +248,8 @@
   "Replace the bundle for an existing plugin. Accepts a multipart tar.gz upload in
    the same format as the `POST /` endpoint. The manifest's `name` field must
    match the plugin's existing `identifier`."
-  {:multipart true}
+  {:multipart {:max-file-size  cache/max-bundle-bytes
+               :max-file-count 1}}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    _body

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -91,13 +91,16 @@
       (dissoc :bundle)))
 
 (defn- plugin->runtime-response
-  "Convert a plugin record to the safe runtime response shape."
+  "Convert a plugin record to the safe runtime response shape.
+   `bundle_url` is suffixed with `?v=<bundle_hash>` so that a re-uploaded bundle is fetched
+   instead of served from the browser's `immutable` cache."
   [{:keys [id identifier display_name icon bundle_hash manifest dev_bundle_url]}]
   (cond-> {:id           id
            :identifier   identifier
            :display_name display_name
            :icon         icon
-           :bundle_url   (format "/api/ee/custom-viz-plugin/%d/bundle" id)
+           :bundle_url   (cond-> (format "/api/ee/custom-viz-plugin/%d/bundle" id)
+                           bundle_hash (str "?v=" bundle_hash))
            :bundle_hash  bundle_hash
            :manifest     manifest}
     dev_bundle_url (assoc :dev_bundle_url dev_bundle_url)))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -347,7 +347,7 @@
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    {:keys [dev_bundle_url]} :- [:map [:dev_bundle_url [:maybe :string]]]]
-  (api/write-check (t2/select-one :model/CustomVizPlugin :id id))
+  (api/write-check (select-one-plugin :id id))
   (check-dev-mode-enabled!)
   (cache/set-or-clear-dev-bundle! id dev_bundle_url)
   {:dev_bundle_url (cache/resolve-dev-bundle id)})

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -1,37 +1,288 @@
 (ns metabase-enterprise.custom-viz-plugin.cache
-  "Cache layer for custom visualization plugin bundles and static assets.
-   Fetches and reads files from git repos via remote-sync's git infrastructure.
-   GitSnapshots are cached per-plugin and only re-fetched when the resolved commit changes."
+  "Storage layer for custom visualization plugin bundles.
+
+   Plugins are uploaded as tar+gzip archives. The raw archive bytes (and their
+   SHA-256 hash) are stored in `custom_viz_plugin.bundle` / `bundle_hash`. On the
+   first read of a bundle file or static asset, the archive is lazily extracted to
+   a per-instance scratch directory under the OS temp dir and files are then
+   served straight from the local filesystem. When a plugin's bundle is replaced
+   or the plugin is deleted, the on-disk directory is evicted.
+
+   Dev-only plugins (no uploaded bundle) live entirely off `dev_bundle_url` and
+   bypass this storage; only the dev http fetch helpers below are used for them."
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
    [clj-http.client :as http]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
-   [metabase-enterprise.remote-sync.source.git :as rs.git]
    [metabase.config.core :as config]
    [metabase.util :as u]
+   [metabase.util.compress :as u.compress]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.nio.file Files Path)))
 
 (set! *warn-on-reflection* true)
 
 ;;; ------------------------------------------------ Hash ------------------------------------------------
 
-(defn- content-hash [^String content]
-  (-> content .getBytes buddy-hash/sha256 codecs/bytes->hex))
+(defn- bytes-hash [^bytes b]
+  (-> b buddy-hash/sha256 codecs/bytes->hex))
 
-;;; ------------------------------------------------ Git Helpers ------------------------------------------------
+(defn- string-hash [^String s]
+  (bytes-hash (.getBytes s "UTF-8")))
 
-;; Per-plugin snapshot cache. Only fetches from remote on first access or when resolved_commit changes.
-;; {plugin-id -> GitSnapshot}
-(defonce ^:private local-snapshots (atom {}))
+;;; ------------------------------------------------ Layout ------------------------------------------------
 
-;;; ------------------------------------------------ URL Validation ------------------------------------------------
+;; The uploaded archive has the same layout as the previous git-sourced plugins:
+;;   metabase-plugin.json  (manifest, at the archive root)
+;;   dist/index.js         (the JS bundle)
+;;   dist/assets/*         (static assets)
+
+(def ^:private ^:const bundle-rel-path "index.js")
+
+(defn- asset-rel-path ^String [^String asset-name] (str "assets/" asset-name))
+
+(defn- dist-path
+  "Prefix a relative path with `dist/` to match the bundle layout."
+  ^String [^String rel-path]
+  (str "dist/" rel-path))
+
+;;; ------------------------------------------------ Size Limits ------------------------------------------------
+
+(def ^:const max-bundle-mib
+  "Maximum size of an uploaded plugin bundle, in MiB. The API layer enforces
+   this on the archive bytes up front using the multipart `:size` hint; every
+   other size (per-entry, total uncompressed) is bounded by it transitively."
+  5)
+
+(def ^:const max-bundle-bytes
+  "Maximum size of an uploaded plugin bundle, in bytes. See [[max-bundle-mib]]."
+  (* max-bundle-mib 1024 1024))
+
+;;; ------------------------------------------------ Validate Bundle ------------------------------------------------
+
+(defn- delete-recursive! [^Path path]
+  (when (Files/exists path (into-array java.nio.file.LinkOption []))
+    (with-open [stream (Files/walk path (into-array java.nio.file.FileVisitOption []))]
+      (doseq [^Path p (reverse (vec (.iterator stream)))]
+        (try (Files/delete p)
+             (catch Exception e
+               (log/warnf "Failed to delete %s: %s" p (ex-message e))))))))
+
+(defn- regular-file? [^Path path]
+  (Files/isRegularFile path (into-array java.nio.file.LinkOption [])))
+
+(defn validate-bundle!
+  "Extract an uploaded tar+gzip `bundle-bytes` into a scratch directory and
+   validate its contents against the expected layout. Returns
+   `{:bytes bundle-bytes :hash sha :manifest m :version-str v}` on success.
+   Throws ex-info with `:status-code 400` for any user-facing failure.
+
+   The caller is responsible for enforcing the upload size cap — by the time we
+   get here the bytes are known to be under [[max-bundle-bytes]]."
+  [^bytes bundle-bytes]
+  (when (or (nil? bundle-bytes) (zero? (alength bundle-bytes)))
+    (throw (ex-info "Bundle is empty" {:status-code 400})))
+  (let [scratch (Files/createTempDirectory "custom-viz-validate-"
+                                           (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (try
+        (u.compress/untgz bundle-bytes (.toFile scratch))
+        (catch Exception e
+          (throw (ex-info (str "Bundle is not a valid tar.gz archive: " (ex-message e))
+                          {:status-code 400}
+                          e))))
+      (let [manifest-file (.resolve scratch (manifest/manifest-path))
+            bundle-file   (.resolve scratch (dist-path bundle-rel-path))
+            _             (when-not (regular-file? manifest-file)
+                            (throw (ex-info (str (manifest/manifest-path) " not found in bundle")
+                                            {:status-code 400})))
+            parsed        (or (manifest/parse-manifest (String. (Files/readAllBytes manifest-file) "UTF-8"))
+                              (throw (ex-info (str (manifest/manifest-path) " is not valid JSON")
+                                              {:status-code 400})))
+            _             (when-not (regular-file? bundle-file)
+                            (throw (ex-info (str (dist-path bundle-rel-path) " not found in bundle")
+                                            {:status-code 400})))
+            version-str   (get-in parsed [:metabase :version])]
+        (when (str/blank? (:name parsed))
+          (throw (ex-info (str (manifest/manifest-path) " is missing a \"name\" field")
+                          {:status-code 400})))
+        (when (and version-str
+                   (not (manifest/compatible? {:metabase_version version-str})))
+          (throw (ex-info
+                  (format "Plugin requires Metabase version %s but current version is %s"
+                          version-str (:tag config/mb-version-info))
+                  {:status-code 400 :metabase_version version-str})))
+        {:bytes       bundle-bytes
+         :hash        (bytes-hash bundle-bytes)
+         :manifest    parsed
+         :version-str version-str})
+      (finally
+        (delete-recursive! scratch)))))
+
+;;; ------------------------------------------------ FS Cache ------------------------------------------------
+
+(defn- custom-viz-cache-root
+  "The on-disk cache root for extracted plugin bundles. Placed under the OS
+   temp dir so it's per-instance and naturally reclaimed when the host is
+   rebooted; [[ensure-unpacked!]] will lazily re-extract from the DB on the
+   next serve after a wipe."
+  ^Path []
+  (let [root (.resolve (.toPath (io/file (System/getProperty "java.io.tmpdir"))) "metabase-custom-viz")]
+    (Files/createDirectories root (into-array java.nio.file.attribute.FileAttribute []))
+    root))
+
+(defn- plugin-cache-dir ^Path [id ^String bundle-hash]
+  (.resolve (custom-viz-cache-root) (str id "-" bundle-hash)))
+
+(defn- safe-resolve
+  "Resolve `rel-path` under `base`, refusing to escape it. Used on the serve
+   side to guard against caller-supplied asset paths that attempt traversal —
+   the archive extraction itself is already zip-slip-safe via
+   [[u.compress/untgz]]."
+  ^Path [^Path base ^String rel-path]
+  (let [resolved (.normalize (.resolve base rel-path))]
+    (when (.startsWith resolved base)
+      resolved)))
+
+(defn- evict-other-cache-dirs!
+  "Delete cache dirs for `id` that don't match `keep-hash`."
+  [id ^String keep-hash]
+  (let [root  (custom-viz-cache-root)
+        keep  (str id "-" keep-hash)
+        prefix (str id "-")]
+    (with-open [stream (Files/list root)]
+      (doseq [^Path child (vec (.iterator stream))]
+        (let [name (str (.getFileName child))]
+          (when (and (str/starts-with? name prefix)
+                     (not= name keep))
+            (delete-recursive! child)))))))
+
+(defn- unpack-bundle!
+  "Extract `bundle-bytes` into `dir`, creating it. Atomic-ish: unpacks into a
+   sibling temp directory and renames into place so other threads never observe
+   a half-written cache dir. Zip-slip is handled by `u.compress/untgz`, which
+   resolves each entry under the temp dir via `TarArchiveEntry.resolveIn`."
+  [^Path dir ^bytes bundle-bytes]
+  (let [parent (.getParent dir)
+        _      (Files/createDirectories parent (into-array java.nio.file.attribute.FileAttribute []))
+        tmp    (Files/createTempDirectory parent (str (.getFileName dir) ".tmp.")
+                                          (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (u.compress/untgz bundle-bytes (.toFile tmp))
+      (try
+        (Files/move tmp dir
+                    (into-array java.nio.file.CopyOption
+                                [java.nio.file.StandardCopyOption/ATOMIC_MOVE]))
+        (catch java.nio.file.AtomicMoveNotSupportedException _
+          (Files/move tmp dir (into-array java.nio.file.CopyOption []))))
+      (catch java.nio.file.FileAlreadyExistsException _
+        ;; Another thread won the race; keep their copy and discard ours.
+        (delete-recursive! tmp))
+      (catch Throwable t
+        (delete-recursive! tmp)
+        (throw t)))))
+
+(defn- ensure-unpacked!
+  "Guarantee that the cache dir for `plugin` is on disk. If `bundle` is null in the
+   row (dev-only plugin) this returns nil. Returns the directory `Path` on success."
+  ^Path [{:keys [id bundle_hash]}]
+  (when bundle_hash
+    (let [dir (plugin-cache-dir id bundle_hash)]
+      (when-not (Files/isDirectory dir (into-array java.nio.file.LinkOption []))
+        (let [bundle-bytes (t2/select-one-fn :bundle :model/CustomVizPlugin :id id)]
+          (when (and bundle-bytes (not (Files/isDirectory dir (into-array java.nio.file.LinkOption []))))
+            (unpack-bundle! dir bundle-bytes)
+            (evict-other-cache-dirs! id bundle_hash))))
+      dir)))
+
+(defn purge-plugin-cache!
+  "Remove on-disk cache dirs for `plugin` (typically because it's being deleted or
+   updated). Safe to call even if no dir exists."
+  [{:keys [id]}]
+  (let [root   (custom-viz-cache-root)
+        prefix (str id "-")]
+    (with-open [stream (Files/list root)]
+      (doseq [^Path child (vec (.iterator stream))]
+        (when (str/starts-with? (str (.getFileName child)) prefix)
+          (delete-recursive! child))))))
+
+;;; ------------------------------------------------ Save Bundle ------------------------------------------------
+
+(defn- derived-columns
+  "DB columns derived from a validated bundle."
+  [{:keys [bytes hash manifest version-str]}]
+  {:status           :active
+   :error_message    nil
+   :bundle           bytes
+   :bundle_hash      hash
+   :manifest         manifest
+   :display_name     (or (:name manifest) (:identifier manifest))
+   :icon             (:icon manifest)
+   :metabase_version version-str})
+
+(defn save-bundle!
+  "Persist a validated bundle for an existing plugin row, evict stale on-disk
+   caches, and return the refreshed row."
+  [{:keys [id]} validated]
+  (t2/update! :model/CustomVizPlugin id (derived-columns validated))
+  (purge-plugin-cache! {:id id})
+  (t2/select-one :model/CustomVizPlugin :id id))
+
+(defn insert-bundle!
+  "Insert a new plugin row from a validated bundle and an `:identifier`. Returns
+   the inserted row."
+  [identifier validated]
+  (t2/insert-returning-instance!
+   :model/CustomVizPlugin
+   (merge {:identifier identifier
+           :enabled    true}
+          (derived-columns validated))))
+
+;;; ------------------------------------------------ Read From Cache ------------------------------------------------
+
+(defn- read-cached-bytes
+  "Read the bytes of `dist-rel-path` from the on-disk cache for `plugin`. Returns
+   nil if the plugin has no bundle or the file is missing."
+  ^bytes [plugin ^String dist-rel-path]
+  (when-let [dir (try (ensure-unpacked! plugin)
+                      (catch Exception e
+                        (log/warnf "Failed to unpack plugin %d bundle: %s"
+                                   (:id plugin) (ex-message e))
+                        nil))]
+    (when-let [^Path file (safe-resolve dir dist-rel-path)]
+      (when (Files/isRegularFile file (into-array java.nio.file.LinkOption []))
+        (Files/readAllBytes file)))))
+
+(defn get-bundle
+  "Get the JS bundle for an upload-backed plugin. Returns
+   `{:content str :hash str}` or nil."
+  [plugin]
+  (when-let [bytes (read-cached-bytes plugin (dist-path bundle-rel-path))]
+    {:content (String. bytes "UTF-8")
+     :hash    (or (:bundle_hash plugin) (bytes-hash bytes))}))
+
+(defn- asset-whitelisted?
+  "Check whether an asset path is explicitly listed in the plugin's manifest."
+  [{:keys [manifest]} ^String asset-path]
+  (when manifest
+    (let [allowed (set (manifest/asset-paths manifest))]
+      (contains? allowed asset-path))))
+
+(defn get-asset
+  "Get a static asset for an upload-backed plugin. Returns a byte array or nil."
+  ^bytes [plugin ^String asset-name]
+  (read-cached-bytes plugin (dist-path (asset-rel-path asset-name))))
+
+;;; ------------------------------------------------ Dev Bundle ------------------------------------------------
 
 (defn- allowed-schemes
-  "Set of URL schemes allowed for repo and dev bundle URLs.
+  "Set of URL schemes allowed for dev bundle URLs.
    In dev/test/e2e mode, `file://` and `git://` are also permitted."
   []
   (cond-> #{"http" "https"}
@@ -44,191 +295,6 @@
     (when-not (contains? (allowed-schemes) scheme)
       (throw (ex-info (str label " must use http or https, got: " scheme)
                       {:status-code 400 :url url})))))
-
-(defn validate-repo-url!
-  "Validate that a repo URL uses an allowed scheme (http/https, plus file:// in dev/test/e2e).
-   Throws on invalid input."
-  [^String url]
-  (validate-url! url "Repo URL"))
-
-(defn- plugin-snapshot
-  "Return a GitSnapshot for a plugin at its resolved commit.
-   Caches the snapshot per plugin; only fetches from remote on first access
-   or when the resolved commit has changed.
-   Always fetches at the exact `resolved_commit` SHA so that multi-server
-   deployments serve the same bundle regardless of what HEAD points to."
-  [{:keys [id repo_url pinned_version access_token resolved_commit]}]
-  (validate-repo-url! repo_url)
-  (let [cached (get @local-snapshots id)]
-    (if (and cached (= (:version cached) resolved_commit))
-      cached
-      (let [source   (rs.git/git-source repo_url pinned_version access_token nil)
-            snapshot (rs.git/snapshot-at-ref source resolved_commit)]
-        (swap! local-snapshots assoc id snapshot)
-        snapshot))))
-
-(defn purge-plugin-cache!
-  "Evict all cached state for a deleted plugin: the in-memory snapshot and the
-   on-disk bare git repository (which may contain auth credentials in its config)."
-  [{:keys [id repo_url access_token]}]
-  (swap! local-snapshots dissoc id)
-  (when-not (str/starts-with? (str repo_url) "dev://")
-    (rs.git/purge-cached-repo! repo_url access_token)))
-
-;;; ------------------------------------------------ Paths ------------------------------------------------
-
-(def ^:private ^:const bundle-rel-path "index.js")
-
-(defn- asset-rel-path ^String [^String asset-name] (str "assets/" asset-name))
-
-(defn- git-path
-  "Prefix a relative path with dist/ for git repo layout."
-  ^String [^String rel-path]
-  (str "dist/" rel-path))
-
-;;; ------------------------------------------------ Git Reads ------------------------------------------------
-
-(defn- read-from-git
-  "Read a file from the plugin's git snapshot. Obtains the snapshot internally.
-   Returns the raw result of `read-fn` (string or byte array) or nil on error."
-  [plugin ^String rel-path read-fn]
-  (try
-    (let [snapshot (plugin-snapshot plugin)]
-      (read-fn snapshot (git-path rel-path)))
-    (catch Exception e
-      (log/warnf "Failed to read %s from git at %s: %s" rel-path (:resolved_commit plugin) (ex-message e))
-      nil)))
-
-;;; ------------------------------------------------ Size Limits ------------------------------------------------
-
-(def ^:private ^:const max-file-bytes
-  "Maximum size in bytes for any single bundled file (bundle or asset)."
-  (* 2 1024 1024))
-
-(def ^:private ^:const max-plugin-bytes
-  "Maximum combined size in bytes of all files served for a single plugin."
-  (* 8 1024 1024))
-
-(defn- validate-size!
-  "Ensure no file in `git-paths` exceeds `max-file-bytes` and their combined
-   size stays below `max-plugin-bytes`."
-  [snapshot commit-sha git-paths]
-  (reduce
-   (fn [total path]
-     (if-let [size (rs.git/file-size snapshot path)]
-       (do
-         (when (> size max-file-bytes)
-           (throw (ex-info (format "%s is %d bytes, exceeds the %d byte per-file limit"
-                                   path size max-file-bytes)
-                           {:status-code 400 :commit commit-sha})))
-         (let [total' (+ total size)]
-           (when (> total' max-plugin-bytes)
-             (throw (ex-info (format "Plugin exceeds the %d byte total size limit"
-                                     max-plugin-bytes)
-                             {:status-code 400 :commit commit-sha})))
-           total'))
-       total))
-   0
-   git-paths))
-
-;;; ------------------------------------------------ Fetch & Update ------------------------------------------------
-
-(defn- fetch-plugin-data!
-  "Fetch and validate index.js and manifest from a plugin's git repo.
-   Returns `{:commit-sha :parsed :version-str :snapshot}` on success.
-   Throws ex-info with `:status-code 400` on any failure."
-  [{:keys [repo_url access_token pinned_version]}]
-  (validate-repo-url! repo_url)
-  (try
-    (let [branch      (or pinned_version "HEAD")
-          source      (rs.git/git-source repo_url branch access_token nil)
-          snapshot    (rs.git/snapshot-at-ref source branch)
-          commit-sha  (:version snapshot)
-          _content    (or (rs.git/read-file snapshot (git-path bundle-rel-path))
-                          (throw (ex-info (str (git-path bundle-rel-path) " not found in repository")
-                                          {:status-code 400 :commit commit-sha})))
-          parsed      (or (some-> (rs.git/read-file snapshot (manifest/manifest-path))
-                                  manifest/parse-manifest)
-                          (throw (ex-info (str (manifest/manifest-path) " not found or invalid in repository")
-                                          {:status-code 400 :commit commit-sha})))
-          version-str (get-in parsed [:metabase :version])
-          asset-paths (map #(git-path (asset-rel-path %)) (manifest/asset-paths parsed))]
-      (validate-size! snapshot commit-sha (cons (git-path bundle-rel-path) asset-paths))
-      (when (and version-str
-                 (not (manifest/compatible? {:metabase_version version-str})))
-        (throw (ex-info
-                (format "Plugin requires Metabase version %s but current version is %s"
-                        version-str (:tag config/mb-version-info))
-                {:status-code 400 :metabase_version version-str})))
-      {:commit-sha  commit-sha
-       :parsed      parsed
-       :version-str version-str
-       :snapshot    snapshot})
-    (catch Exception e
-      (if (:status-code (ex-data e))
-        (throw e)
-        (throw (ex-info (str "Failed to fetch plugin from repository: " (ex-message e))
-                        {:status-code 400}
-                        e))))))
-
-(defn fetch-and-save!
-  "Fetch plugin data from git, validate, and save to DB.
-   For new plugins (no `:id` in the plugin map), inserts a new row using fields
-   from the plugin map plus the derived manifest fields.
-   For existing plugins, updates the existing row.
-   `extra-columns` are merged into the DB write (e.g. `:enabled` changes from a
-   PUT that coincide with a pinned_version change).
-   Seeds the snapshot cache so the first bundle serve avoids a redundant git fetch.
-   Returns the saved plugin row.
-   Throws on fetch/validation failure."
-  ([plugin]
-   (fetch-and-save! plugin nil))
-  ([{:keys [id identifier] :as plugin} extra-columns]
-   (let [{:keys [commit-sha parsed version-str snapshot]} (fetch-plugin-data! plugin)
-         derived {:status           :active
-                  :error_message    nil
-                  :resolved_commit  commit-sha
-                  :manifest         parsed
-                  :display_name     (or (:name parsed) identifier)
-                  :icon             (:icon parsed)
-                  :metabase_version version-str}
-         columns (merge derived extra-columns)]
-     (if id
-       (do (t2/update! :model/CustomVizPlugin id columns)
-           (swap! local-snapshots assoc id snapshot)
-           (t2/select-one :model/CustomVizPlugin :id id))
-       (let [row (t2/insert-returning-instance!
-                  :model/CustomVizPlugin
-                  (merge (select-keys plugin [:repo_url :access_token :identifier :pinned_version])
-                         columns))]
-         (swap! local-snapshots assoc (:id row) snapshot)
-         row)))))
-
-;;; ------------------------------------------------ Get ------------------------------------------------
-
-(defn get-bundle
-  "Get the JS bundle for a plugin. Reads from the local bare git repo at the resolved commit.
-   Returns {:content str :hash str} or nil."
-  [{:keys [resolved_commit] :as plugin}]
-  (when resolved_commit
-    (when-let [content (read-from-git plugin bundle-rel-path rs.git/read-file)]
-      {:content content :hash (content-hash content)})))
-
-(defn- asset-whitelisted?
-  "Check whether an asset path is explicitly listed in the plugin's manifest."
-  [{:keys [manifest]} ^String asset-path]
-  (when manifest
-    (let [allowed (set (manifest/asset-paths manifest))]
-      (contains? allowed asset-path))))
-
-(defn get-asset
-  "Get a static asset for a plugin. Reads from the local bare git repo at the resolved commit.
-   Returns a byte array or nil."
-  ^bytes [{:keys [resolved_commit] :as plugin} ^String asset-name]
-  (when resolved_commit
-    (read-from-git plugin (asset-rel-path asset-name) rs.git/read-file-bytes)))
-
-;;; ------------------------------------------------ Dev Bundle ------------------------------------------------
 
 (defn dev-base-url
   "Validate and normalize the dev base URL. Ensures http/https scheme and trailing slash."
@@ -251,7 +317,7 @@
   (let [content (:body (http/get (dev-url base-url bundle-rel-path)
                                  (assoc http-opts :as :string)))]
     {:content content
-     :hash    (content-hash content)}))
+     :hash    (string-hash content)}))
 
 (defn fetch-dev-manifest
   "Fetch and parse the manifest from a dev base URL.

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -68,7 +68,7 @@
 (defn- delete-recursive! [^Path path]
   (when (Files/exists path (into-array LinkOption []))
     (with-open [stream (Files/walk path (into-array FileVisitOption []))]
-      (doseq [^Path p (reverse (vec (.iterator stream)))]
+      (doseq [^Path p (rseq (vec (iterator-seq (.iterator stream))))]
         (try (Files/delete p)
              (catch Exception e
                (log/warnf "Failed to delete %s: %s" p (ex-message e))))))))
@@ -153,7 +153,7 @@
         keep  (str id "-" keep-hash)
         prefix (str id "-")]
     (with-open [stream (Files/list root)]
-      (doseq [^Path child (vec (.iterator stream))]
+      (doseq [^Path child (iterator-seq (.iterator stream))]
         (let [name (str (.getFileName child))]
           (when (and (str/starts-with? name prefix)
                      (not= name keep))
@@ -199,7 +199,7 @@
   (let [root   (custom-viz-cache-root)
         prefix (str id "-")]
     (with-open [stream (Files/list root)]
-      (doseq [^Path child (vec (.iterator stream))]
+      (doseq [^Path child (iterator-seq (.iterator stream))]
         (when (str/starts-with? (str (.getFileName child)) prefix)
           (delete-recursive! child))))))
 
@@ -273,7 +273,7 @@
 ;;; ------------------------------------------------ Dev Bundle ------------------------------------------------
 
 (defn- allowed-schemes
-  "Set of URL schemes allowed for dev bundle URLs. "
+  "Set of URL schemes allowed for dev bundle URLs."
   []
   #{"http" "https"})
 

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -24,7 +24,8 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.nio.file Files Path)))
+   (java.nio.file Files Path LinkOption FileVisitOption CopyOption FileAlreadyExistsException)
+   (java.nio.file.attribute FileAttribute)))
 
 (set! *warn-on-reflection* true)
 
@@ -55,9 +56,7 @@
 ;;; ------------------------------------------------ Size Limits ------------------------------------------------
 
 (def ^:const max-bundle-mib
-  "Maximum size of an uploaded plugin bundle, in MiB. The API layer enforces
-   this on the archive bytes up front using the multipart `:size` hint; every
-   other size (per-entry, total uncompressed) is bounded by it transitively."
+  "Maximum size of an uploaded plugin bundle, in MiB."
   5)
 
 (def ^:const max-bundle-bytes
@@ -67,29 +66,26 @@
 ;;; ------------------------------------------------ Validate Bundle ------------------------------------------------
 
 (defn- delete-recursive! [^Path path]
-  (when (Files/exists path (into-array java.nio.file.LinkOption []))
-    (with-open [stream (Files/walk path (into-array java.nio.file.FileVisitOption []))]
+  (when (Files/exists path (into-array LinkOption []))
+    (with-open [stream (Files/walk path (into-array FileVisitOption []))]
       (doseq [^Path p (reverse (vec (.iterator stream)))]
         (try (Files/delete p)
              (catch Exception e
                (log/warnf "Failed to delete %s: %s" p (ex-message e))))))))
 
 (defn- regular-file? [^Path path]
-  (Files/isRegularFile path (into-array java.nio.file.LinkOption [])))
+  (Files/isRegularFile path (into-array LinkOption [])))
 
 (defn validate-bundle!
   "Extract an uploaded tar+gzip `bundle-bytes` into a scratch directory and
    validate its contents against the expected layout. Returns
    `{:bytes bundle-bytes :hash sha :manifest m :version-str v}` on success.
-   Throws ex-info with `:status-code 400` for any user-facing failure.
-
-   The caller is responsible for enforcing the upload size cap — by the time we
-   get here the bytes are known to be under [[max-bundle-bytes]]."
+   Throws ex-info with `:status-code 400` for any user-facing failure."
   [^bytes bundle-bytes]
   (when (or (nil? bundle-bytes) (zero? (alength bundle-bytes)))
     (throw (ex-info "Bundle is empty" {:status-code 400})))
   (let [scratch (Files/createTempDirectory "custom-viz-validate-"
-                                           (into-array java.nio.file.attribute.FileAttribute []))]
+                                           (into-array FileAttribute []))]
     (try
       (try
         (u.compress/untgz bundle-bytes (.toFile scratch))
@@ -134,7 +130,7 @@
    next serve after a wipe."
   ^Path []
   (let [root (.resolve (.toPath (io/file (System/getProperty "java.io.tmpdir"))) "metabase-custom-viz")]
-    (Files/createDirectories root (into-array java.nio.file.attribute.FileAttribute []))
+    (Files/createDirectories root (into-array FileAttribute []))
     root))
 
 (defn- plugin-cache-dir ^Path [id ^String bundle-hash]
@@ -170,18 +166,13 @@
    resolves each entry under the temp dir via `TarArchiveEntry.resolveIn`."
   [^Path dir ^bytes bundle-bytes]
   (let [parent (.getParent dir)
-        _      (Files/createDirectories parent (into-array java.nio.file.attribute.FileAttribute []))
+        _      (Files/createDirectories parent (into-array FileAttribute []))
         tmp    (Files/createTempDirectory parent (str (.getFileName dir) ".tmp.")
-                                          (into-array java.nio.file.attribute.FileAttribute []))]
+                                          (into-array FileAttribute []))]
     (try
       (u.compress/untgz bundle-bytes (.toFile tmp))
-      (try
-        (Files/move tmp dir
-                    (into-array java.nio.file.CopyOption
-                                [java.nio.file.StandardCopyOption/ATOMIC_MOVE]))
-        (catch java.nio.file.AtomicMoveNotSupportedException _
-          (Files/move tmp dir (into-array java.nio.file.CopyOption []))))
-      (catch java.nio.file.FileAlreadyExistsException _
+      (Files/move tmp dir (into-array CopyOption []))
+      (catch FileAlreadyExistsException _
         ;; Another thread won the race; keep their copy and discard ours.
         (delete-recursive! tmp))
       (catch Throwable t
@@ -282,11 +273,9 @@
 ;;; ------------------------------------------------ Dev Bundle ------------------------------------------------
 
 (defn- allowed-schemes
-  "Set of URL schemes allowed for dev bundle URLs.
-   In dev/test/e2e mode, `file://` and `git://` are also permitted."
+  "Set of URL schemes allowed for dev bundle URLs. "
   []
-  (cond-> #{"http" "https"}
-    (or config/is-dev? config/is-test? config/is-e2e?) (conj "file" "git")))
+  #{"http" "https"})
 
 (defn- validate-url!
   "Validate that a URL uses an allowed scheme. Throws on invalid input."

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -14,17 +14,17 @@
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
    [clj-http.client :as http]
-   [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase.config.core :as config]
    [metabase.util :as u]
    [metabase.util.compress :as u.compress]
+   [metabase.util.files :as u.files]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.nio.file Files Path LinkOption FileVisitOption CopyOption FileAlreadyExistsException)
+   (java.nio.file CopyOption FileAlreadyExistsException Files FileVisitOption Path)
    (java.nio.file.attribute FileAttribute)))
 
 (set! *warn-on-reflection* true)
@@ -66,15 +66,12 @@
 ;;; ------------------------------------------------ Validate Bundle ------------------------------------------------
 
 (defn- delete-recursive! [^Path path]
-  (when (Files/exists path (into-array LinkOption []))
+  (when (u.files/exists? path)
     (with-open [stream (Files/walk path (into-array FileVisitOption []))]
       (doseq [^Path p (rseq (vec (iterator-seq (.iterator stream))))]
         (try (Files/delete p)
              (catch Exception e
                (log/warnf "Failed to delete %s: %s" p (ex-message e))))))))
-
-(defn- regular-file? [^Path path]
-  (Files/isRegularFile path (into-array LinkOption [])))
 
 (defn validate-bundle!
   "Extract an uploaded tar+gzip `bundle-bytes` into a scratch directory and
@@ -95,13 +92,13 @@
                           e))))
       (let [manifest-file (.resolve scratch ^String (manifest/manifest-path))
             bundle-file   (.resolve scratch ^String (dist-path bundle-rel-path))
-            _             (when-not (regular-file? manifest-file)
+            _             (when-not (u.files/regular-file? manifest-file)
                             (throw (ex-info (str (manifest/manifest-path) " not found in bundle")
                                             {:status-code 400})))
             parsed        (or (manifest/parse-manifest (String. (Files/readAllBytes manifest-file) "UTF-8"))
                               (throw (ex-info (str (manifest/manifest-path) " is not valid JSON")
                                               {:status-code 400})))
-            _             (when-not (regular-file? bundle-file)
+            _             (when-not (u.files/regular-file? bundle-file)
                             (throw (ex-info (str (dist-path bundle-rel-path) " not found in bundle")
                                             {:status-code 400})))
             version-str   (get-in parsed [:metabase :version])]
@@ -129,12 +126,11 @@
    rebooted; [[ensure-unpacked!]] will lazily re-extract from the DB on the
    next serve after a wipe."
   ^Path []
-  (let [root (.resolve (.toPath (io/file (System/getProperty "java.io.tmpdir"))) "metabase-custom-viz")]
-    (Files/createDirectories root (into-array FileAttribute []))
-    root))
+  (doto (u.files/get-path (System/getProperty "java.io.tmpdir") "metabase-custom-viz")
+    u.files/create-dir-if-not-exists!))
 
 (defn- plugin-cache-dir ^Path [id ^String bundle-hash]
-  (.resolve (custom-viz-cache-root) (str id "-" bundle-hash)))
+  (u.files/append-to-path (custom-viz-cache-root) (str id "-" bundle-hash)))
 
 (defn- safe-resolve
   "Resolve `rel-path` under `base`, refusing to escape it. Used on the serve
@@ -149,15 +145,12 @@
 (defn- evict-other-cache-dirs!
   "Delete cache dirs for `id` that don't match `keep-hash`."
   [id ^String keep-hash]
-  (let [root  (custom-viz-cache-root)
-        keep  (str id "-" keep-hash)
+  (let [keep   (str id "-" keep-hash)
         prefix (str id "-")]
-    (with-open [stream (Files/list root)]
-      (doseq [^Path child (iterator-seq (.iterator stream))]
-        (let [name (str (.getFileName child))]
-          (when (and (str/starts-with? name prefix)
-                     (not= name keep))
-            (delete-recursive! child)))))))
+    (doseq [^Path child (u.files/files-seq (custom-viz-cache-root))
+            :let [name (str (.getFileName child))]
+            :when (and (str/starts-with? name prefix) (not= name keep))]
+      (delete-recursive! child))))
 
 (defn- unpack-bundle!
   "Extract `bundle-bytes` into `dir`, creating it. Atomic-ish: unpacks into a
@@ -166,7 +159,7 @@
    resolves each entry under the temp dir via `TarArchiveEntry.resolveIn`."
   [^Path dir ^bytes bundle-bytes]
   (let [parent (.getParent dir)
-        _      (Files/createDirectories parent (into-array FileAttribute []))
+        _      (u.files/create-dir-if-not-exists! parent)
         tmp    (Files/createTempDirectory parent (str (.getFileName dir) ".tmp.")
                                           (into-array FileAttribute []))]
     (try
@@ -185,23 +178,20 @@
   ^Path [{:keys [id bundle_hash]}]
   (when bundle_hash
     (let [dir (plugin-cache-dir id bundle_hash)]
-      (when-not (Files/isDirectory dir (into-array LinkOption []))
-        (let [bundle-bytes (t2/select-one-fn :bundle :model/CustomVizPlugin :id id)]
-          (when (and bundle-bytes (not (Files/isDirectory dir (into-array LinkOption []))))
-            (unpack-bundle! dir bundle-bytes)
-            (evict-other-cache-dirs! id bundle_hash))))
+      (when-not (u.files/exists? dir)
+        (when-let [bundle-bytes (t2/select-one-fn :bundle :model/CustomVizPlugin :id id)]
+          (unpack-bundle! dir bundle-bytes)
+          (evict-other-cache-dirs! id bundle_hash)))
       dir)))
 
 (defn purge-plugin-cache!
   "Remove on-disk cache dirs for `plugin` (typically because it's being deleted or
    updated). Safe to call even if no dir exists."
   [{:keys [id]}]
-  (let [root   (custom-viz-cache-root)
-        prefix (str id "-")]
-    (with-open [stream (Files/list root)]
-      (doseq [^Path child (iterator-seq (.iterator stream))]
-        (when (str/starts-with? (str (.getFileName child)) prefix)
-          (delete-recursive! child))))))
+  (let [prefix (str id "-")]
+    (doseq [^Path child (u.files/files-seq (custom-viz-cache-root))
+            :when (str/starts-with? (str (.getFileName child)) prefix)]
+      (delete-recursive! child))))
 
 ;;; ------------------------------------------------ Save Bundle ------------------------------------------------
 
@@ -247,7 +237,7 @@
                                    (:id plugin) (ex-message e))
                         nil))]
     (when-let [^Path file (safe-resolve dir dist-rel-path)]
-      (when (Files/isRegularFile file (into-array java.nio.file.LinkOption []))
+      (when (u.files/regular-file? file)
         (Files/readAllBytes file)))))
 
 (defn get-bundle

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -185,9 +185,9 @@
   ^Path [{:keys [id bundle_hash]}]
   (when bundle_hash
     (let [dir (plugin-cache-dir id bundle_hash)]
-      (when-not (Files/isDirectory dir (into-array java.nio.file.LinkOption []))
+      (when-not (Files/isDirectory dir (into-array LinkOption []))
         (let [bundle-bytes (t2/select-one-fn :bundle :model/CustomVizPlugin :id id)]
-          (when (and bundle-bytes (not (Files/isDirectory dir (into-array java.nio.file.LinkOption []))))
+          (when (and bundle-bytes (not (Files/isDirectory dir (into-array LinkOption []))))
             (unpack-bundle! dir bundle-bytes)
             (evict-other-cache-dirs! id bundle_hash))))
       dir)))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -93,8 +93,8 @@
           (throw (ex-info (str "Bundle is not a valid tar.gz archive: " (ex-message e))
                           {:status-code 400}
                           e))))
-      (let [manifest-file (.resolve scratch (manifest/manifest-path))
-            bundle-file   (.resolve scratch (dist-path bundle-rel-path))
+      (let [manifest-file (.resolve scratch ^String (manifest/manifest-path))
+            bundle-file   (.resolve scratch ^String (dist-path bundle-rel-path))
             _             (when-not (regular-file? manifest-file)
                             (throw (ex-info (str (manifest/manifest-path) " not found in bundle")
                                             {:status-code 400})))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -63,6 +63,22 @@
   "Maximum size of an uploaded plugin bundle, in bytes. See [[max-bundle-mib]]."
   (* max-bundle-mib 1024 1024))
 
+(def ^:const ^:private max-uncompressed-bytes
+  "Cap on total uncompressed bytes from a bundle archive. Set to 5x the
+   compressed cap, which comfortably fits a real JS bundle + image assets but
+   refuses tar bombs (which need 1000x+ ratios to be interesting)."
+  (* 5 max-bundle-bytes))
+
+(def ^:const ^:private max-entries
+  "Cap on entry count in a bundle archive. A real plugin has a manifest, the JS
+   bundle, and a handful of image assets; 256 leaves plenty of slack without
+   inviting denial-of-service via metadata-only entries."
+  256)
+
+(def ^:private untgz-opts
+  {:max-uncompressed-bytes max-uncompressed-bytes
+   :max-entries            max-entries})
+
 ;;; ------------------------------------------------ Validate Bundle ------------------------------------------------
 
 (defn- delete-recursive! [^Path path]
@@ -85,11 +101,14 @@
                                            (into-array FileAttribute []))]
     (try
       (try
-        (u.compress/untgz bundle-bytes (.toFile scratch))
+        (u.compress/untgz bundle-bytes (.toFile scratch) untgz-opts)
         (catch Exception e
-          (throw (ex-info (str "Bundle is not a valid tar.gz archive: " (ex-message e))
-                          {:status-code 400}
-                          e))))
+          (if (:status-code (ex-data e))
+            ;; tar-bomb / oversize / entry-count failures carry their own clear message — re-raise.
+            (throw e)
+            (throw (ex-info (str "Bundle is not a valid tar.gz archive: " (ex-message e))
+                            {:status-code 400}
+                            e)))))
       (let [manifest-file (.resolve scratch ^String (manifest/manifest-path))
             bundle-file   (.resolve scratch ^String (dist-path bundle-rel-path))
             _             (when-not (u.files/regular-file? manifest-file)
@@ -163,7 +182,7 @@
         tmp    (Files/createTempDirectory parent (str (.getFileName dir) ".tmp.")
                                           (into-array FileAttribute []))]
     (try
-      (u.compress/untgz bundle-bytes (.toFile tmp))
+      (u.compress/untgz bundle-bytes (.toFile tmp) untgz-opts)
       (Files/move tmp dir (into-array CopyOption []))
       (catch FileAlreadyExistsException _
         ;; Another thread won the race; keep their copy and discard ours.

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -174,12 +174,20 @@
 
 (defn- ensure-unpacked!
   "Guarantee that the cache dir for `plugin` is on disk. If `bundle` is null in the
-   row (dev-only plugin) this returns nil. Returns the directory `Path` on success."
+   row (dev-only plugin) this returns nil. Returns the directory `Path` on success.
+
+   Recomputes the SHA-256 of the stored bytes against `bundle_hash` before unpacking
+   so a mismatch (DB corruption or tampering with one column but not the other) is
+   refused rather than served."
   ^Path [{:keys [id bundle_hash]}]
   (when bundle_hash
     (let [dir (plugin-cache-dir id bundle_hash)]
       (when-not (u.files/exists? dir)
         (when-let [bundle-bytes (t2/select-one-fn :bundle :model/CustomVizPlugin :id id)]
+          (let [actual-hash (bytes-hash bundle-bytes)]
+            (when-not (= actual-hash bundle_hash)
+              (throw (ex-info "Bundle integrity check failed: stored bytes do not match bundle_hash"
+                              {:plugin-id id :expected bundle_hash :actual actual-hash}))))
           (unpack-bundle! dir bundle-bytes)
           (evict-other-cache-dirs! id bundle_hash)))
       dir)))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
@@ -5,15 +5,29 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [methodical.core :as methodical]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Blob)))
 
 (set! *warn-on-reflection* true)
 
 (methodical/defmethod t2/table-name :model/CustomVizPlugin [_model] :custom_viz_plugin)
 
+(defn- blob->bytes ^bytes [v]
+  (cond
+    (nil? v)           nil
+    (instance? Blob v) (let [^Blob b v] (.getBytes b 1 (int (.length b))))
+    :else              v))
+
+(def ^:private transform-bundle
+  "Coerce JDBC `Blob` values into plain byte arrays on read."
+  {:in  identity
+   :out blob->bytes})
+
 (t2/deftransforms :model/CustomVizPlugin
   {:status   mi/transform-keyword
-   :manifest mi/transform-json})
+   :manifest mi/transform-json
+   :bundle   transform-bundle})
 
 (doto :model/CustomVizPlugin
   (derive :metabase/model)

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
@@ -1,10 +1,13 @@
 (ns metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin
   (:require
+   [buddy.core.codecs :as codecs]
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
 
 (methodical/defmethod t2/table-name :model/CustomVizPlugin [_model] :custom_viz_plugin)
 
@@ -35,18 +38,22 @@
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
+(defn- bundle->b64 ^String [^bytes b]
+  (some-> b codecs/bytes->b64-str))
+
+(defn- b64->bundle ^bytes [^String s]
+  (some-> s codecs/b64->bytes))
+
 (defmethod serdes/make-spec "CustomVizPlugin"
   [_model-name _opts]
-  ;; The uploaded zip bundle and its hash are intentionally skipped: they're
-  ;; binary, multi-MB blobs and YAML serdes is the wrong transport for them.
-  ;; Callers that need to ship a plugin between instances should re-upload the
-  ;; zip via the API on the destination side.
-  {:copy      [:display_name :identifier :enabled :icon :manifest :metabase_version]
-   :skip      [:bundle :bundle_hash :dev_bundle_url :error_message]
+  {:copy      [:display_name :identifier :enabled :icon :manifest :metabase_version :bundle_hash]
+   :skip      [:dev_bundle_url :error_message]
    :defaults  {:enabled true}
    :transform {:created_at (serdes/date)
                :status     {:export (constantly ::serdes/skip)
-                            :import (constantly "pending")}}})
+                            :import (constantly "pending")}
+               :bundle     {:export bundle->b64
+                            :import b64->bundle}}})
 
 (defmethod serdes/entity-id "CustomVizPlugin" [_ {:keys [identifier]}]
   identifier)

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
@@ -9,9 +9,8 @@
 (methodical/defmethod t2/table-name :model/CustomVizPlugin [_model] :custom_viz_plugin)
 
 (t2/deftransforms :model/CustomVizPlugin
-  {:access_token mi/transform-encrypted-json
-   :status       mi/transform-keyword
-   :manifest     mi/transform-json})
+  {:status   mi/transform-keyword
+   :manifest mi/transform-json})
 
 (doto :model/CustomVizPlugin
   (derive :metabase/model)
@@ -30,26 +29,24 @@
   api/*is-superuser?*)
 
 (methodical/defmethod mi/to-json :model/CustomVizPlugin
-  "Never include the access token in JSON."
+  "Never include the raw bundle bytes in JSON."
   [plugin json-generator]
-  (next-method (dissoc plugin :access_token) json-generator))
+  (next-method (dissoc plugin :bundle) json-generator))
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
 (defmethod serdes/make-spec "CustomVizPlugin"
-  [_model-name {:keys [include-custom-viz-token]}]
-  {:copy      [:repo_url :display_name :identifier
-               :pinned_version :resolved_commit :enabled :icon
-               :manifest :metabase_version]
-   :skip      [:dev_bundle_url :error_message]
+  [_model-name _opts]
+  ;; The uploaded zip bundle and its hash are intentionally skipped: they're
+  ;; binary, multi-MB blobs and YAML serdes is the wrong transport for them.
+  ;; Callers that need to ship a plugin between instances should re-upload the
+  ;; zip via the API on the destination side.
+  {:copy      [:display_name :identifier :enabled :icon :manifest :metabase_version]
+   :skip      [:bundle :bundle_hash :dev_bundle_url :error_message]
    :defaults  {:enabled true}
-   :transform {:created_at   (serdes/date)
-               :status       {:export (constantly ::serdes/skip)
-                              :import (constantly "pending")}
-               :access_token {:export (if include-custom-viz-token
-                                        identity
-                                        (constantly ::serdes/skip))
-                              :import identity}}})
+   :transform {:created_at (serdes/date)
+               :status     {:export (constantly ::serdes/skip)
+                            :import (constantly "pending")}}})
 
 (defmethod serdes/entity-id "CustomVizPlugin" [_ {:keys [identifier]}]
   identifier)

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin.clj
@@ -18,8 +18,8 @@
   (derive :hook/timestamped?))
 
 (defmethod mi/can-read? :model/CustomVizPlugin
-  ([_instance]   true)
-  ([_model _pk]  true))
+  ([_instance]   api/*current-user-id*)
+  ([_model _pk]  api/*current-user-id*))
 
 (defmethod mi/can-write? :model/CustomVizPlugin
   ([_instance]   api/*is-superuser?*)

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
@@ -30,10 +30,6 @@
     (when (some (fn [path-filter] (re-matches path-filter path)) path-filters)
       (source.p/read-file original-snapshot path)))
 
-  (read-file-bytes [_ path]
-    (when (some (fn [path-filter] (re-matches path-filter path)) path-filters)
-      (source.p/read-file-bytes original-snapshot path)))
-
   (write-files! [_ message files]
     (source.p/write-files! original-snapshot message
                            (filter (fn [file-spec]

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -195,19 +195,6 @@
               (recur (conj files (.getPathString tree-walk)))
               files)))))
 
-(defn read-file-bytes
-  "Reads the contents of a specific file from the git snapshot as a byte array.
-
-  Takes a GitSnapshot containing a :git Git instance and :version specifying which commit to read from, and a path
-  string indicating the relative path to the file from the repository root.
-
-  Returns the file contents as a byte array, or nil if the file does not exist at the specified path."
-  ^bytes [{:keys [^Git git ^String version]} ^String path]
-  (let [repo (.getRepository git)]
-    (when-let [object-id (.resolve repo (str version ":" path))]
-      (let [loader (.open repo object-id)]
-        (.getBytes loader)))))
-
 (defn read-file
   "Reads the contents of a specific file from the git snapshot.
 
@@ -215,19 +202,11 @@
   string indicating the relative path to the file from the repository root.
 
   Returns the file contents as a UTF-8 string, or nil if the file does not exist at the specified path."
-  [snapshot ^String path]
-  (when-let [bytes (read-file-bytes snapshot path)]
-    (String. ^bytes bytes "UTF-8")))
-
-(defn file-size
-  "Returns the size in bytes of `path` in the git snapshot, or nil if the file
-  does not exist. Reads the blob size from the object header without loading
-  the full contents into memory, so it is safe to use for size-limit checks
-  against untrusted repositories."
-  ^Long [{:keys [^Git git ^String version]} ^String path]
+  [{:keys [^Git git ^String version]} ^String path]
   (let [repo (.getRepository git)]
     (when-let [object-id (.resolve repo (str version ":" path))]
-      (.getSize (.open repo object-id)))))
+      (let [loader (.open repo object-id)]
+        (String. (.getBytes loader) "UTF-8")))))
 
 (defn push-branch!
   "Pushes a local branch to the remote repository.
@@ -428,9 +407,6 @@
   (read-file [this path]
     (read-file this path))
 
-  (read-file-bytes [this path]
-    (read-file-bytes this path))
-
   (write-files! [this message files]
     (write-files! this message files))
 
@@ -440,12 +416,9 @@
 (def ^:private jgit (atom {}))
 
 (defn- stale-cache-error?
-  "Returns true if the exception indicates a stale git cache, e.g. 'Missing commit' after a force-push, or
-  'Cannot resolve ref' when the cached Git instance's HEAD points at a ref no longer present locally."
+  "Returns true if the exception indicates a stale git cache (e.g., after a force-push on the remote)."
   [^Exception e]
-  (when-let [msg (ex-message e)]
-    (or (str/includes? msg "Missing commit")
-        (str/includes? msg "Cannot resolve ref"))))
+  (some-> (ex-message e) (str/includes? "Missing commit")))
 
 (defn- clear-cached-repo!
   "Clears a cached git repository from memory and disk."
@@ -453,13 +426,6 @@
   (log/info "Clearing stale git cache" {:repo-path (str repo-path)})
   (swap! jgit dissoc (.getPath repo-path))
   (FileUtils/deleteDirectory repo-path))
-
-(defn purge-cached-repo!
-  "Purges a cached git repository from memory and disk given the remote URL and token.
-   Intended for cleanup when a plugin is deleted."
-  [^String remote-url ^String token]
-  (let [path (repo-path {:remote-url remote-url :token token})]
-    (clear-cached-repo! path)))
 
 (defn- get-jgit [^File path {:keys [remote-url token] :as args}]
   (if-let [obj (get @jgit (.getPath path))]
@@ -473,22 +439,18 @@
 
 (defn- snapshot*
   "Internal snapshot implementation. Returns a GitSnapshot or throws."
-  [source ref]
+  [source]
   (fetch! source)
-  (if-let [version (commit-sha source ref)]
-    (->GitSnapshot (:git source) (:remote-url source) (:branch source) version (:token source) (:managed-dirs source))
-    (throw (ex-info (str "Cannot resolve ref: " (:branch source)) {}))))
+  (let [version (commit-sha source (:branch source))]
+    (if version
+      (->GitSnapshot (:git source) (:remote-url source) (:branch source) version (:token source) (:managed-dirs source))
+      (throw (ex-info (str "Invalid branch: " (:branch source)) {})))))
 
-(defn snapshot-at-ref
-  "Creates a snapshot at a specific ref (branch, tag, commit SHA, or \"HEAD\").
-
-  Fetches latest refs from remote, then resolves the given ref-str to a commit SHA
-  and returns a GitSnapshot. Recovers from stale cache errors by clearing the cached
-  repository and retrying once. Throws if the ref cannot be resolved after retry."
-
-  [{:keys [remote-url token] :as source} ref]
+(defn- snapshot
+  "Creates a snapshot, recovering from stale cache errors by re-cloning."
+  [{:keys [remote-url token] :as source}]
   (try
-    (snapshot* source ref)
+    (snapshot* source)
     (catch Exception e
       (if (stale-cache-error? e)
         (let [path (repo-path {:remote-url remote-url :token token})]
@@ -496,7 +458,7 @@
           (let [fresh-git (get-jgit path {:remote-url remote-url :token token})
                 fresh-source (assoc source :git fresh-git)]
             (log/info "Retrying snapshot after clearing stale cache")
-            (snapshot* fresh-source ref)))
+            (snapshot* fresh-source)))
         (throw e)))))
 
 (defrecord GitSource [git remote-url branch token managed-dirs]
@@ -510,7 +472,7 @@
     (default-branch this))
 
   (snapshot [this]
-    (snapshot-at-ref this (:branch this))))
+    (snapshot this)))
 
 (defn git-source
   "Creates a new GitSource instance for a git repository.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/protocol.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/protocol.clj
@@ -58,13 +58,6 @@
 
     Returns the version of the written files.")
 
-  (read-file-bytes [snapshot path]
-    "Reads the contents of a file from the snapshot as a byte array.
-
-    Takes a SourceSnapshot instance implementing this protocol and a path (the relative path to the file to read).
-
-    Returns the file contents as a byte array, or nil if the file doesn't exist.")
-
   (version [snapshot]
     "Gets a version identifier for the current state of the snapshot.
 

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -1138,7 +1138,6 @@
                         root-targets
                         {:include-field-values false
                          :include-database-secrets false
-                         :include-custom-viz-token false
                          :continue-on-error false
                          :skip-archived true})]
       (eduction (map (fn [[model ids]]

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -165,7 +165,6 @@
                            :settings        (not (:no-settings opts))
                            :field_values    (:include-field-values opts)
                            :secrets         (:include-database-secrets opts)
-                           :custom_viz_token (:include-custom-viz-token opts)
                            :success         (boolean success)
                            :error_message   error-message}))
 
@@ -188,7 +187,6 @@
    {:keys                     [collection dirname]
     include-field-values?     :field_values
     include-database-secrets? :database_secrets
-    include-custom-viz-token? :custom_viz_token
     all-collections?          :all_collections
     data-model?               :data_model
     settings?                 :settings
@@ -213,7 +211,6 @@
        [:data_model        {:default true}  (mu/with ms/BooleanValue {:description "Serialize Metabase data model"})]
        [:field_values      {:default false} (mu/with ms/BooleanValue {:description "Serialize cached field values"})]
        [:database_secrets  {:default false} (mu/with ms/BooleanValue {:description "Serialize details how to connect to each db"})]
-       [:custom_viz_token  {:default false} (mu/with ms/BooleanValue {:description "Serialize custom viz plugin access tokens"})]
        [:continue_on_error {:default false} (mu/with ms/BooleanValue {:description "Do not break execution on errors"})]
        [:full_stacktrace   {:default false} (mu/with ms/BooleanValue {:description "Show full stacktraces in the logs"})]]]
   (api/check-superuser)
@@ -225,7 +222,6 @@
                             :no-settings              (not settings?)
                             :include-field-values     include-field-values?
                             :include-database-secrets include-database-secrets?
-                            :include-custom-viz-token include-custom-viz-token?
                             :continue-on-error        continue-on-error?
                             :full-stacktrace          full-stacktrace?}
         export-dirname (or dirname

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -133,7 +133,6 @@
                              :settings        (not (:no-settings opts))
                              :field_values    (boolean (:include-field-values opts))
                              :secrets         (boolean (:include-database-secrets opts))
-                             :custom_viz_token (boolean (:include-custom-viz-token opts))
                              :success         (nil? @err)
                              :error_message   (when @err
                                                 (u/strip-error @err nil))})

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -125,15 +125,18 @@
       (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "active-viz"
                                                :display_name "Active Viz"
                                                :status       :active
-                                               :enabled      true}
+                                               :enabled      true
+                                               :bundle_hash  "active-hash"}
                      :model/CustomVizPlugin _ {:identifier   "disabled-viz"
                                                :display_name "Disabled Viz"
                                                :status       :active
-                                               :enabled      false}
+                                               :enabled      false
+                                               :bundle_hash  "disabled-hash"}
                      :model/CustomVizPlugin _ {:identifier   "error-viz"
                                                :display_name "Error Viz"
                                                :status       :error
-                                               :enabled      true}]
+                                               :enabled      true
+                                               :bundle_hash  "error-hash"}]
         (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
               identifiers (set (map :identifier result))]
           (is (contains? identifiers "active-viz"))
@@ -215,14 +218,13 @@
       (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "dev-sec"
                                                       :display_name "dev-sec"
                                                       :status       :active}]
-        (testing "SECURITY: rejects file:// dev URL via API in prod mode"
-          (with-redefs [config/is-test? false config/is-dev? false]
-            (is (= 400
-                   (:status-code
-                    (ex-data
-                     (try
-                       (cache/set-or-clear-dev-bundle! id "file:///etc/passwd")
-                       (catch Exception e e))))))))
+        (testing "SECURITY: rejects file:// dev URL"
+          (is (= 400
+                 (:status-code
+                  (ex-data
+                   (try
+                     (cache/set-or-clear-dev-bundle! id "file:///etc/passwd")
+                     (catch Exception e e)))))))
         (testing "SECURITY: rejects ftp:// dev URL via API"
           (is (= 400
                  (:status-code
@@ -434,11 +436,13 @@
                                                  :display_name      "Compatible"
                                                  :status            :active
                                                  :enabled           true
+                                                 :bundle_hash       "compat-hash"
                                                  :metabase_version  ">=1.59"}
                        :model/CustomVizPlugin _ {:identifier        "incompat-viz"
                                                  :display_name      "Incompatible"
                                                  :status            :active
                                                  :enabled           true
+                                                 :bundle_hash       "incompat-hash"
                                                  :metabase_version  ">=1.99"}]
           (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
                 identifiers (set (map :identifier result))]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -35,17 +35,17 @@
 
   `entries` is a seq of `[name content]` pairs; content may be a string or byte[]."
   ^bytes [entries]
-  (with-open [baos (ByteArrayOutputStream.)
-              gz   (GzipCompressorOutputStream. baos)
-              tar  (TarArchiveOutputStream. gz)]
-    (doseq [[name content] entries
-            :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
-                  entry     (doto (TarArchiveEntry. ^String name)
-                              (.setSize (alength bs)))]]
-      (.putArchiveEntry tar entry)
-      (.write tar bs 0 (alength bs))
-      (.closeArchiveEntry tar))
-    (.finish tar)
+  (let [baos (ByteArrayOutputStream.)]
+    (with-open [gz  (GzipCompressorOutputStream. baos)
+                tar (TarArchiveOutputStream. gz)]
+      (doseq [[name content] entries
+              :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
+                    entry     (doto (TarArchiveEntry. ^String name)
+                                (.setSize (alength bs)))]]
+        (.putArchiveEntry tar entry)
+        (.write tar bs 0 (alength bs))
+        (.closeArchiveEntry tar))
+      (.finish tar))
     (.toByteArray baos)))
 
 (defn- valid-bundle-bytes

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -4,16 +4,13 @@
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
+   [metabase-enterprise.custom-viz-plugin.test-util :as cvp.tu]
    [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util.json :as json]
-   [toucan2.core :as t2])
-  (:import
-   (java.io ByteArrayOutputStream)
-   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
-   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,36 +24,6 @@
 (defmacro ^:private with-dev-mode-enabled [& body]
   `(with-redefs [custom-viz.settings/custom-viz-plugin-dev-mode-enabled (constantly true)]
      ~@body))
-
-;;; ------------------------------------------------ Bundle fixtures ------------------------------------------------
-
-(defn- make-tgz-bytes
-  "Build a minimal valid plugin tar.gz archive in memory.
-
-  `entries` is a seq of `[name content]` pairs; content may be a string or byte[]."
-  ^bytes [entries]
-  (let [baos (ByteArrayOutputStream.)]
-    (with-open [gz  (GzipCompressorOutputStream. baos)
-                tar (TarArchiveOutputStream. gz)]
-      (doseq [[name content] entries
-              :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
-                    entry     (doto (TarArchiveEntry. ^String name)
-                                (.setSize (alength bs)))]]
-        (.putArchiveEntry tar entry)
-        (.write tar bs 0 (alength bs))
-        (.closeArchiveEntry tar))
-      (.finish tar))
-    (.toByteArray baos)))
-
-(defn- valid-bundle-bytes
-  "Build a tar.gz archive with a valid manifest and a trivial index.js."
-  [identifier & [{:keys [icon metabase-version]}]]
-  (make-tgz-bytes
-   [["metabase-plugin.json" (json/encode
-                             (cond-> {:name identifier}
-                               icon             (assoc :icon icon)
-                               metabase-version (assoc-in [:metabase :version] metabase-version)))]
-    ["dist/index.js" "console.log('hi')"]]))
 
 (defn- multipart-upload!
   "POST a multipart `bundle-bytes` tar.gz to `path` as user `user`, expecting `status`."
@@ -106,7 +73,7 @@
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
                (multipart-upload! :rasta 403 (str "ee/custom-viz-plugin/" id "/bundle")
-                                  (valid-bundle-bytes "auth-test-5"))))))))
+                                  (cvp.tu/valid-bundle-bytes "auth-test-5"))))))))
 
 (deftest feature-flag-test
   (testing "endpoints require :custom-viz premium feature"
@@ -181,7 +148,7 @@
                                                :status       :active}]
         (is (re-find #"identifier.*already exists"
                      (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/"
-                                        (valid-bundle-bytes "dup-viz"))))))))
+                                        (cvp.tu/valid-bundle-bytes "dup-viz"))))))))
 
 ;;; ------------------------------------------------ CRUD ------------------------------------------------
 
@@ -275,7 +242,7 @@
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "successful registration creates plugin and persists manifest fields"
-        (let [zip  (make-tgz-bytes
+        (let [zip  (cvp.tu/make-tgz-bytes
                     [["metabase-plugin.json" (json/encode
                                               {:name     "new-register-viz"
                                                :icon     "icon.svg"
@@ -296,7 +263,7 @@
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "POST returns 400 when zip is missing metabase-plugin.json"
-        (let [zip  (make-tgz-bytes [["dist/index.js" "console.log('hi')"]])
+        (let [zip  (cvp.tu/make-tgz-bytes [["dist/index.js" "console.log('hi')"]])
               resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
           (is (re-find #"metabase-plugin\.json" (or (:message resp) (str resp)))))))))
 
@@ -304,7 +271,7 @@
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "POST returns 400 when zip is missing dist/index.js"
-        (let [zip  (make-tgz-bytes
+        (let [zip  (cvp.tu/make-tgz-bytes
                     [["metabase-plugin.json" (json/encode {:name "no-bundle-viz"})]])
               resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
           (is (re-find #"index\.js" (or (:message resp) (str resp)))))))))
@@ -313,7 +280,7 @@
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "POST returns 400 when manifest has no name field"
-        (let [zip  (make-tgz-bytes
+        (let [zip  (cvp.tu/make-tgz-bytes
                     [["metabase-plugin.json" (json/encode {:icon "icon.svg"})]
                      ["dist/index.js" "console.log('hi')"]])
               resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
@@ -374,7 +341,7 @@
                                                       :status       :active
                                                       :bundle       (.getBytes "old" "UTF-8")
                                                       :bundle_hash  "oldhash"}]
-        (let [zip    (make-tgz-bytes
+        (let [zip    (cvp.tu/make-tgz-bytes
                       [["metabase-plugin.json" (json/encode
                                                 {:name "replace-viz"
                                                  :icon "new-icon.svg"})]
@@ -394,7 +361,7 @@
                                                       :display_name "mismatch-viz"
                                                       :status       :active
                                                       :bundle_hash  "abc"}]
-        (let [zip  (valid-bundle-bytes "some-other-identifier")
+        (let [zip  (cvp.tu/valid-bundle-bytes "some-other-identifier")
               resp (multipart-upload! :crowberto 400
                                       (str "ee/custom-viz-plugin/" id "/bundle") zip)]
           (is (re-find #"does not match" (or (:message resp) (str resp)))))))))
@@ -496,7 +463,7 @@
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "registering a plugin records a custom-viz-plugin-create audit event"
         (let [resp  (multipart-upload! :crowberto 200 "ee/custom-viz-plugin/"
-                                       (valid-bundle-bytes "audit-create-viz" {:icon "icon.svg"}))
+                                       (cvp.tu/valid-bundle-bytes "audit-create-viz" {:icon "icon.svg"}))
               entry (mt/latest-audit-log-entry "custom-viz-plugin-create" (:id resp))]
           (is (partial=
                {:topic    :custom-viz-plugin-create
@@ -575,7 +542,7 @@
                                                       :bundle       (.getBytes "old" "UTF-8")
                                                       :bundle_hash  "old-sha"}]
         (multipart-upload! :crowberto 200 (str "ee/custom-viz-plugin/" id "/bundle")
-                           (valid-bundle-bytes "audit-replace-viz"))
+                           (cvp.tu/valid-bundle-bytes "audit-replace-viz"))
         (let [entry (mt/latest-audit-log-entry "custom-viz-plugin-update" id)]
           (is (partial=
                {:topic    :custom-viz-plugin-update

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -26,9 +26,12 @@
      ~@body))
 
 (defn- multipart-upload!
-  "POST a multipart `bundle-bytes` tar.gz to `path` as user `user`, expecting `status`."
-  [user status path ^bytes bundle-bytes]
-  (mt/user-http-request user :post status path
+  "Send a multipart `bundle-bytes` tar.gz to `path` as user `user`, expecting `status`.
+
+  Defaults to POST (the create-new-plugin endpoint); pass `:method :put` for the
+  replace-bundle endpoint."
+  [user status path ^bytes bundle-bytes & {:keys [method] :or {method :post}}]
+  (mt/user-http-request user method status path
                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
                         {:file bundle-bytes}))
 
@@ -73,7 +76,8 @@
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
                (multipart-upload! :rasta 403 (str "ee/custom-viz-plugin/" id "/bundle")
-                                  (cvp.tu/valid-bundle-bytes "auth-test-5"))))))))
+                                  (cvp.tu/valid-bundle-bytes "auth-test-5")
+                                  :method :put)))))))
 
 (deftest feature-flag-test
   (testing "endpoints require :custom-viz premium feature"
@@ -335,7 +339,7 @@
 
 (deftest replace-bundle-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "POST /:id/bundle replaces an existing plugin's bundle and refreshes derived fields"
+    (testing "PUT /:id/bundle replaces an existing plugin's bundle and refreshes derived fields"
       (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "replace-viz"
                                                       :display_name "old name"
                                                       :status       :active
@@ -347,7 +351,8 @@
                                                  :icon "new-icon.svg"})]
                        ["dist/index.js" "console.log('new')"]])
               resp   (multipart-upload! :crowberto 200
-                                        (str "ee/custom-viz-plugin/" id "/bundle") zip)
+                                        (str "ee/custom-viz-plugin/" id "/bundle") zip
+                                        :method :put)
               row    (t2/select-one :model/CustomVizPlugin :id id)]
           (is (= "replace-viz" (:identifier resp)))
           (is (= "new-icon.svg" (:icon row)))
@@ -356,14 +361,15 @@
 
 (deftest replace-bundle-identifier-mismatch-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "POST /:id/bundle refuses a zip whose manifest name differs from the plugin's identifier"
+    (testing "PUT /:id/bundle refuses a zip whose manifest name differs from the plugin's identifier"
       (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "mismatch-viz"
                                                       :display_name "mismatch-viz"
                                                       :status       :active
                                                       :bundle_hash  "abc"}]
         (let [zip  (cvp.tu/valid-bundle-bytes "some-other-identifier")
               resp (multipart-upload! :crowberto 400
-                                      (str "ee/custom-viz-plugin/" id "/bundle") zip)]
+                                      (str "ee/custom-viz-plugin/" id "/bundle") zip
+                                      :method :put)]
           (is (re-find #"does not match" (or (:message resp) (str resp)))))))))
 
 ;;; ------------------------------------------------ Update / Refresh ------------------------------------------------
@@ -542,7 +548,8 @@
                                                       :bundle       (.getBytes "old" "UTF-8")
                                                       :bundle_hash  "old-sha"}]
         (multipart-upload! :crowberto 200 (str "ee/custom-viz-plugin/" id "/bundle")
-                           (cvp.tu/valid-bundle-bytes "audit-replace-viz"))
+                           (cvp.tu/valid-bundle-bytes "audit-replace-viz")
+                           :method :put)
         (let [entry (mt/latest-audit-log-entry "custom-viz-plugin-update" id)]
           (is (partial=
                {:topic    :custom-viz-plugin-update

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -2,17 +2,18 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.custom-viz-plugin.api :as custom-viz-plugin.api]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
-   [toucan2.core :as t2]))
-
-;; private fn under test
-(def ^:private parse-repo-name @#'custom-viz-plugin.api/parse-repo-name)
+   [metabase.util.json :as json]
+   [toucan2.core :as t2])
+  (:import
+   (java.io ByteArrayOutputStream)
+   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
+   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
@@ -25,45 +26,85 @@
   `(with-redefs [custom-viz.settings/custom-viz-plugin-dev-mode-enabled (constantly true)]
      ~@body))
 
+;;; ------------------------------------------------ Bundle fixtures ------------------------------------------------
+
+(defn- ^bytes make-tgz-bytes
+  "Build a minimal valid plugin tar.gz archive in memory.
+
+  `entries` is a seq of `[name content]` pairs; content may be a string or byte[]."
+  [entries]
+  (with-open [baos (ByteArrayOutputStream.)
+              gz   (GzipCompressorOutputStream. baos)
+              tar  (TarArchiveOutputStream. gz)]
+    (doseq [[name content] entries
+            :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
+                  entry     (doto (TarArchiveEntry. ^String name)
+                              (.setSize (alength bs)))]]
+      (.putArchiveEntry tar entry)
+      (.write tar bs 0 (alength bs))
+      (.closeArchiveEntry tar))
+    (.finish tar)
+    (.toByteArray baos)))
+
+(defn- valid-bundle-bytes
+  "Build a tar.gz archive with a valid manifest and a trivial index.js."
+  [identifier & [{:keys [icon metabase-version]}]]
+  (make-tgz-bytes
+   [["metabase-plugin.json" (json/encode
+                             (cond-> {:name identifier}
+                               icon             (assoc :icon icon)
+                               metabase-version (assoc-in [:metabase :version] metabase-version)))]
+    ["dist/index.js" "console.log('hi')"]]))
+
+(defn- multipart-upload!
+  "POST a multipart `bundle-bytes` tar.gz to `path` as user `user`, expecting `status`."
+  [user status path ^bytes bundle-bytes]
+  (mt/user-http-request user :post status path
+                        {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                        {:file bundle-bytes}))
+
 ;;; ------------------------------------------------ Auth & Permissions ------------------------------------------------
 
 (deftest authorization-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "non-admin cannot list plugins"
+    (testing "non-admin cannot list plugins (admin list)"
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :get 403 "ee/custom-viz-plugin/"))))
     (testing "admin can list plugins"
       (is (sequential? (mt/user-http-request :crowberto :get 200 "ee/custom-viz-plugin/"))))
     (testing "non-admin cannot delete plugins"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/viz"
-                                                      :identifier   "auth-test"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-test"
                                                       :display_name "auth-test"
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :delete 403 (str "ee/custom-viz-plugin/" id))))))
     (testing "non-admin cannot update plugins"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/viz2"
-                                                      :identifier   "auth-test-2"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-test-2"
                                                       :display_name "auth-test-2"
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 (str "ee/custom-viz-plugin/" id)
                                      {:enabled false})))))
     (testing "non-admin cannot set dev URL"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/viz3"
-                                                      :identifier   "auth-test-3"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-test-3"
                                                       :display_name "auth-test-3"
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 (str "ee/custom-viz-plugin/" id "/dev-url")
                                      {:dev_bundle_url "http://localhost:5174"})))))
     (testing "non-admin cannot refresh plugins"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/viz4"
-                                                      :identifier   "auth-test-4"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-test-4"
                                                       :display_name "auth-test-4"
                                                       :status       :active}]
         (is (= "You don't have permissions to do that."
-               (mt/user-http-request :rasta :post 403 (str "ee/custom-viz-plugin/" id "/refresh"))))))))
+               (mt/user-http-request :rasta :post 403 (str "ee/custom-viz-plugin/" id "/refresh"))))))
+    (testing "non-admin cannot upload a new bundle"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-test-5"
+                                                      :display_name "auth-test-5"
+                                                      :status       :active}]
+        (is (= "You don't have permissions to do that."
+               (multipart-upload! :rasta 403 (str "ee/custom-viz-plugin/" id "/bundle")
+                                  (valid-bundle-bytes "auth-test-5"))))))))
 
 (deftest feature-flag-test
   (testing "endpoints require :custom-viz premium feature"
@@ -79,18 +120,15 @@
     (testing "/list is available to non-admin users"
       (is (sequential? (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list"))))
     (testing "/list only returns active and enabled plugins"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/active-viz"
-                                               :identifier   "active-viz"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "active-viz"
                                                :display_name "Active Viz"
                                                :status       :active
                                                :enabled      true}
-                     :model/CustomVizPlugin _ {:repo_url     "https://github.com/test/disabled-viz"
-                                               :identifier   "disabled-viz"
+                     :model/CustomVizPlugin _ {:identifier   "disabled-viz"
                                                :display_name "Disabled Viz"
                                                :status       :active
                                                :enabled      false}
-                     :model/CustomVizPlugin _ {:repo_url     "https://github.com/test/error-viz"
-                                               :identifier   "error-viz"
+                     :model/CustomVizPlugin _ {:identifier   "error-viz"
                                                :display_name "Error Viz"
                                                :status       :error
                                                :enabled      true}]
@@ -99,72 +137,53 @@
           (is (contains? identifiers "active-viz"))
           (is (not (contains? identifiers "disabled-viz")))
           (is (not (contains? identifiers "error-viz"))))))
-    (testing "/list does not expose access_token"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/token-viz"
-                                               :identifier   "token-viz"
-                                               :display_name "Token Viz"
+    (testing "/list does not expose the raw bundle blob"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "bundle-viz"
+                                               :display_name "Bundle Viz"
                                                :status       :active
-                                               :enabled      true}]
+                                               :enabled      true
+                                               :bundle_hash  "abcd"}]
         (let [result (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")]
           (doseq [plugin result]
-            (is (not (contains? plugin :access_token)))))))))
+            (is (not (contains? plugin :bundle)))))))))
 
-;;; ------------------------------------------------ access_token not exposed ------------------------------------------------
+;;; ------------------------------------------------ Bundle bytes not exposed ------------------------------------------------
 
-(deftest access-token-not-exposed-test
+(deftest bundle-bytes-not-exposed-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/token-sec"
-                                                    :identifier   "token-sec"
-                                                    :display_name "Token Sec"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "bytes-sec"
+                                                    :display_name "Bytes Sec"
                                                     :status       :active
                                                     :enabled      true
-                                                    :access_token "super-secret-pat"}]
-      (testing "GET / (admin list) does not expose access_token"
+                                                    :bundle       (.getBytes "pretend-zip-bytes" "UTF-8")
+                                                    :bundle_hash  "feedface"}]
+      (testing "GET / (admin list) does not expose :bundle"
         (let [plugins (mt/user-http-request :crowberto :get 200 "ee/custom-viz-plugin/")]
           (doseq [plugin plugins]
-            (is (not (contains? plugin :access_token))))))
-      (testing "PUT /:id response does not expose access_token"
+            (is (not (contains? plugin :bundle))))))
+      (testing "PUT /:id response does not expose :bundle"
         (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id)
                                          {:enabled false})]
-          (is (not (contains? resp :access_token)))))
-      (testing "POST /:id/refresh response does not expose access_token"
-        (with-redefs [cache/fetch-and-save! (constantly nil)]
-          (let [resp (mt/user-http-request :crowberto :post 200 (str "ee/custom-viz-plugin/" id "/refresh"))]
-            (is (not (contains? resp :access_token)))))))))
+          (is (not (contains? resp :bundle))))))))
 
 ;;; ------------------------------------------------ Duplicate Validation ------------------------------------------------
 
-(deftest duplicate-repo-url-test
-  (mt/with-premium-features #{:custom-viz}
-    (testing "registering a plugin with an already-used repo_url returns a 400 with a friendly message"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/dup-viz"
-                                               :identifier   "dup-viz"
-                                               :display_name "dup-viz"
-                                               :status       :active}]
-        (with-redefs [cache/fetch-and-save! (constantly nil)]
-          (is (re-find #"repo URL.*already exists"
-                       (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/"
-                                             {:repo_url "https://github.com/test/dup-viz"}))))))))
-
 (deftest duplicate-identifier-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "registering a plugin whose repo name resolves to an already-used identifier returns a 400"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/org-a/my-viz"
-                                               :identifier   "my-viz"
-                                               :display_name "my-viz"
+    (testing "uploading a bundle whose identifier already exists returns a 400"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "dup-viz"
+                                               :display_name "dup-viz"
                                                :status       :active}]
-        (with-redefs [cache/fetch-and-save! (constantly nil)]
-          (is (re-find #"identifier.*already exists"
-                       (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/"
-                                             {:repo_url "https://github.com/org-b/my-viz"}))))))))
+        (is (re-find #"identifier.*already exists"
+                     (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/"
+                                        (valid-bundle-bytes "dup-viz"))))))))
 
 ;;; ------------------------------------------------ CRUD ------------------------------------------------
 
 (deftest delete-test
   (mt/with-premium-features #{:custom-viz}
     (testing "admin can delete a plugin"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/delete-viz"
-                                                      :identifier   "delete-viz"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "delete-viz"
                                                       :display_name "Delete Viz"
                                                       :status       :active}]
         (mt/user-http-request :crowberto :delete 204 (str "ee/custom-viz-plugin/" id))
@@ -175,21 +194,13 @@
 (deftest update-test
   (mt/with-premium-features #{:custom-viz}
     (testing "admin can disable a plugin"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url       "https://github.com/test/update-viz"
-                                                      :identifier     "update-viz"
-                                                      :display_name   "Update Viz"
-                                                      :pinned_version "main"
-                                                      :status         :active
-                                                      :enabled        true}]
-        (with-redefs [cache/fetch-plugin-data! (fn [_]
-                                                 {:commit-sha  "sha456"
-                                                  :parsed      {}
-                                                  :version-str nil
-                                                  :snapshot    {}})]
-          (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id)
-                                           {:enabled false :pinned_version "master"})]
-            (is (false? (:enabled resp)))
-            (is (= "master" (:pinned_version resp)))))))
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "update-viz"
+                                                      :display_name "Update Viz"
+                                                      :status       :active
+                                                      :enabled      true}]
+        (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id)
+                                         {:enabled false})]
+          (is (false? (:enabled resp))))))
     (testing "404 for non-existent plugin"
       (mt/user-http-request :crowberto :put 404 "ee/custom-viz-plugin/99999"
                             {:enabled false}))))
@@ -199,8 +210,7 @@
 (deftest dev-url-security-test
   (mt/with-premium-features #{:custom-viz}
     (with-dev-mode-enabled
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-sec"
-                                                      :identifier   "dev-sec"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "dev-sec"
                                                       :display_name "dev-sec"
                                                       :status       :active}]
         (testing "SECURITY: rejects file:// dev URL via API in prod mode"
@@ -234,12 +244,11 @@
     (let [manifest {:name   "sec-test"
                     :icon   "icon.svg"
                     :assets ["icon.svg"]}]
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url         "https://github.com/test/sec-test"
-                                                      :identifier       "sec-test"
-                                                      :display_name     "sec-test"
-                                                      :status           :active
-                                                      :resolved_commit  "abc123"
-                                                      :manifest         manifest}]
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "sec-test"
+                                                      :display_name "sec-test"
+                                                      :status       :active
+                                                      :bundle_hash  "abc123"
+                                                      :manifest     manifest}]
         (testing "SECURITY: rejects unsupported asset types"
           (let [resp (mt/user-http-request :crowberto :get 404 (str "ee/custom-viz-plugin/" id "/asset")
                                            :path "script.js")]
@@ -256,80 +265,63 @@
           (mt/user-http-request :crowberto :get 404 "ee/custom-viz-plugin/99999/asset"
                                 :path "icon.svg"))))))
 
-;;; ------------------------------------------------ parse-repo-name ------------------------------------------------
-
-(deftest parse-repo-name-test
-  (testing "extracts repo name from HTTPS URL"
-    (is (= "custom-heatmap" (parse-repo-name "https://github.com/user/custom-heatmap"))))
-  (testing "strips .git suffix from HTTPS URL"
-    (is (= "custom-heatmap" (parse-repo-name "https://github.com/user/custom-heatmap.git"))))
-  (testing "extracts repo name from SSH git URL"
-    (is (= "custom-heatmap" (parse-repo-name "git@github.com:user/custom-heatmap.git"))))
-  (testing "SSH URL without .git suffix"
-    (is (= "custom-heatmap" (parse-repo-name "git@github.com:user/custom-heatmap"))))
-  (testing "handles nested paths"
-    (is (= "my-viz" (parse-repo-name "https://gitlab.com/org/subgroup/my-viz"))))
-  (testing "handles trailing slash"
-    ;; URI path for trailing slash is "/user/repo/" — last after split is ""
-    ;; but this is an edge case; the API validates NonBlankString for repo_url
-    (is (some? (parse-repo-name "https://github.com/user/repo")))))
-
 ;;; ------------------------------------------------ Plugin Registration ------------------------------------------------
 
 (deftest register-plugin-test
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "successful registration creates plugin and persists manifest fields"
-        (with-redefs [cache/fetch-plugin-data! (fn [_]
-                                                 {:commit-sha  "sha123"
-                                                  :parsed      {:name "Pretty Name" :icon "icon.svg"}
-                                                  :version-str ">=1.59.0"
-                                                  :snapshot    {}})]
-          (let [repo-url "https://github.com/test/new-register-viz"
-                resp     (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/"
-                                               {:repo_url repo-url})
-                row      (t2/select-one :model/CustomVizPlugin :repo_url repo-url)]
-            (is (= "new-register-viz" (:identifier resp))
-                "identifier should be derived from repo name")
-            (is (= repo-url (:repo_url resp)))
-            (is (false? (:dev_only resp))
-                "git-registered plugins are not dev-only")
-            (is (= "Pretty Name" (:display_name row))
-                "display_name should come from manifest :name when present")
-            (is (= "sha123" (:resolved_commit row)))
-            (is (= "icon.svg" (:icon row)))
-            (is (= ">=1.59.0" (:metabase_version row)))
-            (is (= :active (:status row)))))))))
+        (let [zip  (make-tgz-bytes
+                    [["metabase-plugin.json" (json/encode
+                                              {:name     "new-register-viz"
+                                               :icon     "icon.svg"
+                                               :metabase {:version ">=1.59.0"}})]
+                     ["dist/index.js" "console.log('hi')"]])
+              resp (multipart-upload! :crowberto 200 "ee/custom-viz-plugin/" zip)
+              row  (t2/select-one :model/CustomVizPlugin :identifier "new-register-viz")]
+          (is (= "new-register-viz" (:identifier resp)))
+          (is (false? (:dev_only resp))
+              "upload-registered plugins are not dev-only")
+          (is (= "new-register-viz" (:display_name row)))
+          (is (= "icon.svg" (:icon row)))
+          (is (= ">=1.59.0" (:metabase_version row)))
+          (is (= :active (:status row)))
+          (is (some? (:bundle_hash row)) "bundle_hash is populated"))))))
 
-(deftest register-plugin-falls-back-to-identifier-when-manifest-name-missing-test
+(deftest register-plugin-missing-manifest-test
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
-      (with-redefs [cache/fetch-plugin-data! (fn [_]
-                                               {:commit-sha  "sha456"
-                                                :parsed      {}
-                                                :version-str nil
-                                                :snapshot    {}})]
-        (let [repo-url "https://github.com/test/no-name-viz"
-              _        (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/"
-                                             {:repo_url repo-url})
-              row      (t2/select-one :model/CustomVizPlugin :repo_url repo-url)]
-          (is (= "no-name-viz" (:display_name row))
-              "display_name falls back to the derived identifier when manifest :name is missing"))))))
+      (testing "POST returns 400 when zip is missing metabase-plugin.json"
+        (let [zip  (make-tgz-bytes [["dist/index.js" "console.log('hi')"]])
+              resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
+          (is (re-find #"metabase-plugin\.json" (or (:message resp) (str resp)))))))))
 
-(deftest register-plugin-rejects-fetch-failure-test
+(deftest register-plugin-missing-bundle-test
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
-      (testing "POST returns 400 and persists no row when fetch fails"
-        (with-redefs [cache/fetch-plugin-data! (fn [_]
-                                                 (throw (ex-info "Connection refused"
-                                                                 {:status-code 400})))]
-          (let [repo-url "https://github.com/test/fail-register-viz"
-                resp     (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/"
-                                               {:repo_url repo-url})]
-            (is (re-find #"Connection refused" (or (:message resp) (str resp)))
-                "error message should be returned in the response body")
-            (is (nil? (t2/select-one :model/CustomVizPlugin :repo_url repo-url))
-                "no plugin row should be persisted on failure")))))))
+      (testing "POST returns 400 when zip is missing dist/index.js"
+        (let [zip  (make-tgz-bytes
+                    [["metabase-plugin.json" (json/encode {:name "no-bundle-viz"})]])
+              resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
+          (is (re-find #"index\.js" (or (:message resp) (str resp)))))))))
+
+(deftest register-plugin-invalid-manifest-test
+  (mt/with-premium-features #{:custom-viz}
+    (mt/with-model-cleanup [:model/CustomVizPlugin]
+      (testing "POST returns 400 when manifest has no name field"
+        (let [zip  (make-tgz-bytes
+                    [["metabase-plugin.json" (json/encode {:icon "icon.svg"})]
+                     ["dist/index.js" "console.log('hi')"]])
+              resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/" zip)]
+          (is (re-find #"\"name\"" (or (:message resp) (str resp)))))))))
+
+(deftest register-plugin-not-a-zip-test
+  (mt/with-premium-features #{:custom-viz}
+    (mt/with-model-cleanup [:model/CustomVizPlugin]
+      (testing "POST returns 400 when the uploaded bytes are not a zip"
+        (let [resp (multipart-upload! :crowberto 400 "ee/custom-viz-plugin/"
+                                      (.getBytes "this is plain text, not a zip" "UTF-8"))]
+          (is (some? resp)))))))
 
 (deftest register-dev-plugin-test
   (mt/with-premium-features #{:custom-viz}
@@ -368,60 +360,59 @@
               (is (str/includes? resp "name")
                   "error should mention the missing name field"))))))))
 
+;;; ------------------------------------------------ Bundle Replace ------------------------------------------------
+
+(deftest replace-bundle-test
+  (mt/with-premium-features #{:custom-viz}
+    (testing "POST /:id/bundle replaces an existing plugin's bundle and refreshes derived fields"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "replace-viz"
+                                                      :display_name "old name"
+                                                      :status       :active
+                                                      :bundle       (.getBytes "old" "UTF-8")
+                                                      :bundle_hash  "oldhash"}]
+        (let [zip    (make-tgz-bytes
+                      [["metabase-plugin.json" (json/encode
+                                                {:name "replace-viz"
+                                                 :icon "new-icon.svg"})]
+                       ["dist/index.js" "console.log('new')"]])
+              resp   (multipart-upload! :crowberto 200
+                                        (str "ee/custom-viz-plugin/" id "/bundle") zip)
+              row    (t2/select-one :model/CustomVizPlugin :id id)]
+          (is (= "replace-viz" (:identifier resp)))
+          (is (= "new-icon.svg" (:icon row)))
+          (is (not= "oldhash" (:bundle_hash row))
+              "bundle_hash should change when a new bundle is uploaded"))))))
+
+(deftest replace-bundle-identifier-mismatch-test
+  (mt/with-premium-features #{:custom-viz}
+    (testing "POST /:id/bundle refuses a zip whose manifest name differs from the plugin's identifier"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "mismatch-viz"
+                                                      :display_name "mismatch-viz"
+                                                      :status       :active
+                                                      :bundle_hash  "abc"}]
+        (let [zip  (valid-bundle-bytes "some-other-identifier")
+              resp (multipart-upload! :crowberto 400
+                                      (str "ee/custom-viz-plugin/" id "/bundle") zip)]
+          (is (re-find #"does not match" (or (:message resp) (str resp)))))))))
+
 ;;; ------------------------------------------------ Update / Refresh ------------------------------------------------
 
-(deftest update-pinned-version-triggers-refresh-test
+(deftest refresh-upload-plugin-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "updating pinned_version triggers fetch-and-save!"
-      (let [fetched? (atom false)]
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/pin-test"
-                                                        :identifier      "pin-test"
-                                                        :display_name    "pin-test"
-                                                        :status          :active
-                                                        :pinned_version  nil}]
-          (with-redefs [cache/fetch-and-save! (fn [plugin & _]
-                                                (reset! fetched? true)
-                                                (t2/select-one :model/CustomVizPlugin :id (:id plugin)))]
-            (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id)
-                                  {:pinned_version "v1.0.0"})
-            (is (true? @fetched?))))))))
-
-(deftest update-same-pinned-version-no-refresh-test
-  (mt/with-premium-features #{:custom-viz}
-    (testing "setting same pinned_version does not trigger refresh"
-      (let [fetched? (atom false)]
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/pin-same"
-                                                        :identifier      "pin-same"
-                                                        :display_name    "pin-same"
-                                                        :status          :active
-                                                        :pinned_version  "v1.0.0"}]
-          (with-redefs [cache/fetch-and-save! (fn [plugin & _]
-                                                (reset! fetched? true)
-                                                (t2/select-one :model/CustomVizPlugin :id (:id plugin)))]
-            (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id)
-                                  {:pinned_version "v1.0.0"})
-            (is (false? @fetched?))))))))
-
-(deftest refresh-git-plugin-test
-  (mt/with-premium-features #{:custom-viz}
-    (testing "refresh calls fetch-and-save! for git-based plugins"
-      (let [fetched? (atom false)]
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/refresh-git"
-                                                        :identifier   "refresh-git"
-                                                        :display_name "refresh-git"
-                                                        :status       :active}]
-          (with-redefs [cache/fetch-and-save! (fn [plugin & _]
-                                                (reset! fetched? true)
-                                                (t2/select-one :model/CustomVizPlugin :id (:id plugin)))]
-            (mt/user-http-request :crowberto :post 200 (str "ee/custom-viz-plugin/" id "/refresh"))
-            (is (true? @fetched?))))))))
+    (testing "refresh returns 400 for upload-backed plugins (users should POST a new bundle instead)"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "refresh-upload"
+                                                      :display_name "refresh-upload"
+                                                      :status       :active
+                                                      :bundle_hash  "abc"}]
+        (let [resp (mt/user-http-request :crowberto :post 400
+                                         (str "ee/custom-viz-plugin/" id "/refresh"))]
+          (is (re-find #"upload a new bundle" (or (:message resp) (str resp)))))))))
 
 (deftest refresh-dev-plugin-test
   (mt/with-premium-features #{:custom-viz}
     (with-dev-mode-enabled
       (testing "refresh re-fetches manifest for dev-only plugins"
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url       "dev://local/dev-refresh"
-                                                        :identifier     "dev-refresh"
+        (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier     "dev-refresh"
                                                         :display_name   "dev-refresh"
                                                         :status         :active
                                                         :dev_bundle_url "http://localhost:5174"}]
@@ -437,14 +428,12 @@
     (testing "/list excludes plugins with incompatible metabase_version"
       (with-redefs [config/mb-version-info {:tag "v1.60.0"}
                     config/is-dev?         false]
-        (mt/with-temp [:model/CustomVizPlugin _ {:repo_url          "https://github.com/test/compat-viz"
-                                                 :identifier        "compat-viz"
+        (mt/with-temp [:model/CustomVizPlugin _ {:identifier        "compat-viz"
                                                  :display_name      "Compatible"
                                                  :status            :active
                                                  :enabled           true
                                                  :metabase_version  ">=1.59"}
-                       :model/CustomVizPlugin _ {:repo_url          "https://github.com/test/incompat-viz"
-                                                 :identifier        "incompat-viz"
+                       :model/CustomVizPlugin _ {:identifier        "incompat-viz"
                                                  :display_name      "Incompatible"
                                                  :status            :active
                                                  :enabled           true
@@ -458,11 +447,10 @@
 
 (deftest bundle-endpoint-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/bundle-test"
-                                                    :identifier      "bundle-test"
-                                                    :display_name    "bundle-test"
-                                                    :status          :active
-                                                    :resolved_commit "abc123"}]
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "bundle-test"
+                                                    :display_name "bundle-test"
+                                                    :status       :active
+                                                    :bundle_hash  "abc123"}]
       (testing "returns bundle with correct content-type and ETag"
         (with-redefs [cache/resolve-dev-bundle (constantly nil)
                       cache/resolve-bundle     (constantly {:content "console.log('hello')" :hash "deadbeef"})]
@@ -476,12 +464,11 @@
 
 (deftest bundle-and-list-auth-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/auth-bundle"
-                                                    :identifier      "auth-bundle"
-                                                    :display_name    "auth-bundle"
-                                                    :status          :active
-                                                    :enabled         true
-                                                    :resolved_commit "abc123"}]
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "auth-bundle"
+                                                    :display_name "auth-bundle"
+                                                    :status       :active
+                                                    :enabled      true
+                                                    :bundle_hash  "abc123"}]
       (with-redefs [cache/resolve-dev-bundle (constantly nil)
                     cache/resolve-bundle     (constantly {:content "console.log('hi')" :hash "h1"})]
         (testing "authenticated non-admin user can access /bundle"
@@ -502,26 +489,21 @@
   (mt/with-premium-features #{:custom-viz :audit-app}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "registering a plugin records a custom-viz-plugin-create audit event"
-        (with-redefs [cache/fetch-plugin-data! (fn [_]
-                                                 {:commit-sha  "sha123"
-                                                  :parsed      {}
-                                                  :version-str nil
-                                                  :snapshot    {}})]
-          (let [resp  (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/"
-                                            {:repo_url "https://github.com/test/audit-create-viz"})
-                entry (mt/latest-audit-log-entry "custom-viz-plugin-create" (:id resp))]
-            (is (partial=
-                 {:topic    :custom-viz-plugin-create
-                  :user_id  (mt/user->id :crowberto)
-                  :model    "CustomVizPlugin"
-                  :model_id (:id resp)
-                  :details  {:identifier      "audit-create-viz"
-                             :display_name    "audit-create-viz"
-                             :repo_url        "https://github.com/test/audit-create-viz"
-                             :status          "active"
-                             :enabled         true
-                             :resolved_commit "sha123"}}
-                 entry))))))))
+        (let [resp  (multipart-upload! :crowberto 200 "ee/custom-viz-plugin/"
+                                       (valid-bundle-bytes "audit-create-viz" {:icon "icon.svg"}))
+              entry (mt/latest-audit-log-entry "custom-viz-plugin-create" (:id resp))]
+          (is (partial=
+               {:topic    :custom-viz-plugin-create
+                :user_id  (mt/user->id :crowberto)
+                :model    "CustomVizPlugin"
+                :model_id (:id resp)
+                :details  {:identifier   "audit-create-viz"
+                           :display_name "audit-create-viz"
+                           :status       "active"
+                           :enabled      true}}
+               entry))
+          (is (some? (get-in entry [:details :bundle_hash]))
+              "bundle_hash should be recorded in audit details"))))))
 
 (deftest audit-log-create-dev-test
   (mt/with-premium-features #{:custom-viz :audit-app}
@@ -544,8 +526,7 @@
 (deftest audit-log-delete-test
   (mt/with-premium-features #{:custom-viz :audit-app}
     (testing "deleting a plugin records a custom-viz-plugin-delete audit event"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/audit-delete-viz"
-                                                      :identifier   "audit-delete-viz"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "audit-delete-viz"
                                                       :display_name "Audit Delete Viz"
                                                       :status       :active}]
         (mt/user-http-request :crowberto :delete 204 (str "ee/custom-viz-plugin/" id))
@@ -556,15 +537,13 @@
               :model_id id
               :details  {:identifier   "audit-delete-viz"
                          :display_name "Audit Delete Viz"
-                         :repo_url     "https://github.com/test/audit-delete-viz"
                          :status       "active"}}
              (mt/latest-audit-log-entry "custom-viz-plugin-delete" id)))))))
 
 (deftest audit-log-update-test
   (mt/with-premium-features #{:custom-viz :audit-app}
     (testing "updating a plugin records a custom-viz-plugin-update audit event with changed fields"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/audit-update-viz"
-                                                      :identifier   "audit-update-viz"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "audit-update-viz"
                                                       :display_name "Audit Update Viz"
                                                       :status       :active
                                                       :enabled      true}]
@@ -581,29 +560,27 @@
                   :new      {:enabled false}}
                  (select-keys (:details entry) [:previous :new]))))))))
 
-(deftest audit-log-refresh-test
+(deftest audit-log-replace-bundle-test
   (mt/with-premium-features #{:custom-viz :audit-app}
-    (testing "refreshing a plugin records a custom-viz-plugin-update audit event"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/audit-refresh-viz"
-                                                      :identifier      "audit-refresh-viz"
-                                                      :display_name    "audit-refresh-viz"
-                                                      :status          :active
-                                                      :resolved_commit "old-sha"}]
-        (with-redefs [cache/fetch-and-save! (fn [plugin & _]
-                                              (t2/update! :model/CustomVizPlugin (:id plugin)
-                                                          {:resolved_commit "new-sha"})
-                                              (t2/select-one :model/CustomVizPlugin :id (:id plugin)))]
-          (mt/user-http-request :crowberto :post 200 (str "ee/custom-viz-plugin/" id "/refresh"))
-          (let [entry (mt/latest-audit-log-entry "custom-viz-plugin-update" id)]
-            (is (partial=
-                 {:topic    :custom-viz-plugin-update
-                  :user_id  (mt/user->id :crowberto)
-                  :model    "CustomVizPlugin"
-                  :model_id id}
-                 entry))
-            (is (= {:previous {:resolved_commit "old-sha"}
-                    :new      {:resolved_commit "new-sha"}}
-                   (select-keys (:details entry) [:previous :new])))))))))
+    (testing "replacing a bundle records a custom-viz-plugin-update audit event"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "audit-replace-viz"
+                                                      :display_name "audit-replace-viz"
+                                                      :status       :active
+                                                      :bundle       (.getBytes "old" "UTF-8")
+                                                      :bundle_hash  "old-sha"}]
+        (multipart-upload! :crowberto 200 (str "ee/custom-viz-plugin/" id "/bundle")
+                           (valid-bundle-bytes "audit-replace-viz"))
+        (let [entry (mt/latest-audit-log-entry "custom-viz-plugin-update" id)]
+          (is (partial=
+               {:topic    :custom-viz-plugin-update
+                :user_id  (mt/user->id :crowberto)
+                :model    "CustomVizPlugin"
+                :model_id id}
+               entry))
+          (is (= "old-sha" (get-in entry [:details :previous :bundle_hash]))
+              "old bundle_hash is recorded under :previous")
+          (is (not= "old-sha" (get-in entry [:details :new :bundle_hash]))
+              "new bundle_hash differs from the old one"))))))
 
 ;;; ------------------------------------------------ Dev Mode Gating ------------------------------------------------
 
@@ -614,16 +591,14 @@
              (mt/user-http-request :crowberto :post 403 "ee/custom-viz-plugin/dev"
                                    {:dev_bundle_url "http://localhost:5174"}))))
     (testing "PUT /:id/dev-url returns 403 when dev mode is disabled"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-gate"
-                                                      :identifier   "dev-gate"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "dev-gate"
                                                       :display_name "dev-gate"
                                                       :status       :active}]
         (is (= "Custom visualization plugin dev mode is not enabled."
                (mt/user-http-request :crowberto :put 403 (str "ee/custom-viz-plugin/" id "/dev-url")
                                      {:dev_bundle_url "http://localhost:5174"})))))
     (testing "GET /:id/dev-sse returns 403 when dev mode is disabled"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-gate-sse"
-                                                      :identifier   "dev-gate-sse"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "dev-gate-sse"
                                                       :display_name "dev-gate-sse"
                                                       :status       :active}]
         (is (= "Custom visualization plugin dev mode is not enabled."
@@ -639,13 +614,12 @@
 
 (deftest list-excludes-dev-plugins-when-dev-mode-disabled-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/git-viz-list"
-                                             :identifier   "git-viz-list"
-                                             :display_name "Git Viz"
+    (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "upload-viz-list"
+                                             :display_name "Upload Viz"
                                              :status       :active
-                                             :enabled      true}
-                   :model/CustomVizPlugin _ {:repo_url       "dev://local/dev-viz-list"
-                                             :identifier     "dev-viz-list"
+                                             :enabled      true
+                                             :bundle_hash  "abc"}
+                   :model/CustomVizPlugin _ {:identifier     "dev-viz-list"
                                              :display_name   "Dev Viz"
                                              :status         :active
                                              :enabled        true
@@ -653,11 +627,11 @@
       (testing "dev-only plugins are hidden from /list when dev mode is off"
         (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
               identifiers (set (map :identifier result))]
-          (is (contains? identifiers "git-viz-list"))
+          (is (contains? identifiers "upload-viz-list"))
           (is (not (contains? identifiers "dev-viz-list")))))
       (testing "dev-only plugins are visible in /list when dev mode is on"
         (with-dev-mode-enabled
           (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
                 identifiers (set (map :identifier result))]
-            (is (contains? identifiers "git-viz-list"))
+            (is (contains? identifiers "upload-viz-list"))
             (is (contains? identifiers "dev-viz-list"))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -487,9 +487,9 @@
         (testing "authenticated non-admin user can access /bundle"
           (is (= "console.log('hi')"
                  (mt/user-http-request :rasta :get 200 (str "ee/custom-viz-plugin/" id "/bundle")))))
-        #_(testing "unauthenticated user cannot access /bundle"
-            (is (= "Unauthenticated"
-                   (client/client :get 401 (str "ee/custom-viz-plugin/" id "/bundle"))))))
+        (testing "unauthenticated user cannot access /bundle"
+          (is (= "Unauthenticated"
+                 (client/client :get 401 (str "ee/custom-viz-plugin/" id "/bundle"))))))
       (testing "authenticated non-admin user can access /list"
         (is (sequential? (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list"))))
       (testing "unauthenticated user cannot access /list"

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -15,6 +15,8 @@
    (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
    (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
 
+(set! *warn-on-reflection* true)
+
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
 (use-fixtures :each
@@ -28,11 +30,11 @@
 
 ;;; ------------------------------------------------ Bundle fixtures ------------------------------------------------
 
-(defn- ^bytes make-tgz-bytes
+(defn- make-tgz-bytes
   "Build a minimal valid plugin tar.gz archive in memory.
 
   `entries` is a seq of `[name content]` pairs; content may be a string or byte[]."
-  [entries]
+  ^bytes [entries]
   (with-open [baos (ByteArrayOutputStream.)
               gz   (GzipCompressorOutputStream. baos)
               tar  (TarArchiveOutputStream. gz)]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -246,22 +246,24 @@
   (mt/with-premium-features #{:custom-viz}
     (mt/with-model-cleanup [:model/CustomVizPlugin]
       (testing "successful registration creates plugin and persists manifest fields"
-        (let [zip  (cvp.tu/make-tgz-bytes
-                    [["metabase-plugin.json" (json/encode
-                                              {:name     "new-register-viz"
-                                               :icon     "icon.svg"
-                                               :metabase {:version ">=1.59.0"}})]
-                     ["dist/index.js" "console.log('hi')"]])
-              resp (multipart-upload! :crowberto 200 "ee/custom-viz-plugin/" zip)
-              row  (t2/select-one :model/CustomVizPlugin :identifier "new-register-viz")]
-          (is (= "new-register-viz" (:identifier resp)))
-          (is (false? (:dev_only resp))
-              "upload-registered plugins are not dev-only")
-          (is (= "new-register-viz" (:display_name row)))
-          (is (= "icon.svg" (:icon row)))
-          (is (= ">=1.59.0" (:metabase_version row)))
-          (is (= :active (:status row)))
-          (is (some? (:bundle_hash row)) "bundle_hash is populated"))))))
+        (with-redefs [config/mb-version-info {:tag "v1.60.0"}
+                      config/is-dev?         false]
+          (let [zip  (cvp.tu/make-tgz-bytes
+                      [["metabase-plugin.json" (json/encode
+                                                {:name     "new-register-viz"
+                                                 :icon     "icon.svg"
+                                                 :metabase {:version ">=1.59.0"}})]
+                       ["dist/index.js" "console.log('hi')"]])
+                resp (multipart-upload! :crowberto 200 "ee/custom-viz-plugin/" zip)
+                row  (t2/select-one :model/CustomVizPlugin :identifier "new-register-viz")]
+            (is (= "new-register-viz" (:identifier resp)))
+            (is (false? (:dev_only resp))
+                "upload-registered plugins are not dev-only")
+            (is (= "new-register-viz" (:display_name row)))
+            (is (= "icon.svg" (:icon row)))
+            (is (= ">=1.59.0" (:metabase_version row)))
+            (is (= :active (:status row)))
+            (is (some? (:bundle_hash row)) "bundle_hash is populated")))))))
 
 (deftest register-plugin-missing-manifest-test
   (mt/with-premium-features #{:custom-viz}

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -121,7 +121,16 @@
                                                :bundle_hash  "abcd"}]
         (let [result (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")]
           (doseq [plugin result]
-            (is (not (contains? plugin :bundle)))))))))
+            (is (not (contains? plugin :bundle)))))))
+    (testing "/list bundle_url is suffixed with ?v=<bundle_hash> so a re-uploaded bundle bypasses the immutable browser cache"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "cachebust-viz"
+                                               :display_name "Cachebust Viz"
+                                               :status       :active
+                                               :enabled      true
+                                               :bundle_hash  "deadbeefcafe"}]
+        (let [result (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
+              entry  (first (filter #(= "cachebust-viz" (:identifier %)) result))]
+          (is (re-find #"\?v=deadbeefcafe$" (:bundle_url entry))))))))
 
 ;;; ------------------------------------------------ Bundle bytes not exposed ------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -298,6 +298,15 @@
                                       (.getBytes "this is plain text, not a zip" "UTF-8"))]
           (is (some? resp)))))))
 
+(deftest register-plugin-oversize-rejected-by-multipart-test
+  (testing "uploads larger than max-bundle-bytes are rejected by Ring multipart middleware (413, before reaching the handler)"
+    (mt/with-premium-features #{:custom-viz}
+      (mt/with-model-cleanup [:model/CustomVizPlugin]
+        ;; one byte over the cap is enough — the multipart layer aborts streaming
+        ;; before the body is fully buffered.
+        (let [oversized (byte-array (inc cache/max-bundle-bytes))]
+          (multipart-upload! :crowberto 413 "ee/custom-viz-plugin/" oversized))))))
+
 (deftest register-dev-plugin-test
   (mt/with-premium-features #{:custom-viz}
     (with-dev-mode-enabled

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -3,14 +3,11 @@
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
+   [metabase-enterprise.custom-viz-plugin.test-util :as cvp.tu]
    [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.util.json :as json]
-   [toucan2.core :as t2])
-  (:import
-   (java.io ByteArrayOutputStream)
-   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
-   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -19,37 +16,11 @@
     (mt/with-temporary-setting-values [custom-viz-enabled true]
       (thunk))))
 
-;;; ------------------------------------------------ Bundle fixtures ------------------------------------------------
-
-(defn- make-tgz-bytes
-  ^bytes [entries]
-  (let [baos (ByteArrayOutputStream.)]
-    (with-open [gz  (GzipCompressorOutputStream. baos)
-                tar (TarArchiveOutputStream. gz)]
-      (doseq [[name content] entries
-              :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
-                    entry     (doto (TarArchiveEntry. ^String name)
-                                (.setSize (alength bs)))]]
-        (.putArchiveEntry tar entry)
-        (.write tar bs 0 (alength bs))
-        (.closeArchiveEntry tar))
-      (.finish tar))
-    (.toByteArray baos)))
-
-(defn- valid-bundle-bytes
-  [identifier & [{:keys [icon metabase-version]}]]
-  (let [manifest (cond-> {:name identifier}
-                   icon             (assoc :icon icon)
-                   metabase-version (assoc-in [:metabase :version] metabase-version))]
-    (make-tgz-bytes
-     [["metabase-plugin.json" (json/encode manifest)]
-      ["dist/index.js" "console.log('hi')"]])))
-
 ;;; ------------------------------------------------ validate-bundle! ------------------------------------------------
 
 (deftest validate-bundle-happy-path-test
   (testing "validate-bundle! returns parsed manifest and a stable sha256"
-    (let [bytes (valid-bundle-bytes "my-viz" {:icon "icon.svg"})
+    (let [bytes (cvp.tu/valid-bundle-bytes "my-viz" {:icon "icon.svg"})
           res   (cache/validate-bundle! bytes)]
       (is (= "my-viz" (get-in res [:manifest :name])))
       (is (= "icon.svg" (get-in res [:manifest :icon])))
@@ -61,7 +32,7 @@
 
 (deftest validate-bundle-captures-version-test
   (testing "metabase.version from the manifest is echoed as :version-str"
-    (let [bytes (valid-bundle-bytes "ver-viz" {:metabase-version ">=1.60"})
+    (let [bytes (cvp.tu/valid-bundle-bytes "ver-viz" {:metabase-version ">=1.60"})
           res   (cache/validate-bundle! bytes)]
       (is (= ">=1.60" (:version-str res))))))
 
@@ -77,20 +48,20 @@
 
 (deftest validate-bundle-requires-manifest-test
   (testing "archive without metabase-plugin.json is rejected"
-    (let [bytes (make-tgz-bytes [["dist/index.js" "console.log('hi')"]])]
+    (let [bytes (cvp.tu/make-tgz-bytes [["dist/index.js" "console.log('hi')"]])]
       (is (thrown-with-msg? Exception #"metabase-plugin\.json"
                             (cache/validate-bundle! bytes))))))
 
 (deftest validate-bundle-requires-index-js-test
   (testing "archive without dist/index.js is rejected"
-    (let [bytes (make-tgz-bytes
+    (let [bytes (cvp.tu/make-tgz-bytes
                  [["metabase-plugin.json" (json/encode {:name "no-bundle"})]])]
       (is (thrown-with-msg? Exception #"index\.js"
                             (cache/validate-bundle! bytes))))))
 
 (deftest validate-bundle-requires-manifest-name-test
   (testing "manifest without :name is rejected"
-    (let [bytes (make-tgz-bytes
+    (let [bytes (cvp.tu/make-tgz-bytes
                  [["metabase-plugin.json" (json/encode {:icon "icon.svg"})]
                   ["dist/index.js" "console.log('hi')"]])]
       (is (thrown-with-msg? Exception #"\"name\""
@@ -98,7 +69,7 @@
 
 (deftest validate-bundle-rejects-invalid-json-manifest-test
   (testing "non-JSON manifest is rejected"
-    (let [bytes (make-tgz-bytes
+    (let [bytes (cvp.tu/make-tgz-bytes
                  [["metabase-plugin.json" "not json at all"]
                   ["dist/index.js" "console.log('hi')"]])]
       (is (thrown-with-msg? Exception #"not valid JSON"
@@ -108,7 +79,7 @@
   (testing "plugin requiring incompatible Metabase version is rejected"
     (with-redefs [config/mb-version-info {:tag "v1.60.0"}
                   config/is-dev?         false]
-      (let [bytes (valid-bundle-bytes "bad-ver" {:metabase-version ">=1.99.0"})]
+      (let [bytes (cvp.tu/valid-bundle-bytes "bad-ver" {:metabase-version ">=1.99.0"})]
         (is (thrown-with-msg? Exception #"version"
                               (cache/validate-bundle! bytes)))))))
 
@@ -179,7 +150,7 @@
   (testing "insert-bundle! creates an :active row with derived fields from the manifest"
     (mt/with-premium-features #{:custom-viz}
       (mt/with-model-cleanup [:model/CustomVizPlugin]
-        (let [validated (cache/validate-bundle! (valid-bundle-bytes "new-viz" {:icon "icon.svg"}))
+        (let [validated (cache/validate-bundle! (cvp.tu/valid-bundle-bytes "new-viz" {:icon "icon.svg"}))
               row       (cache/insert-bundle! "new-viz" validated)]
           (is (some? (:id row)))
           (is (= :active (:status row)))
@@ -198,7 +169,7 @@
                                                       :error_message "something"
                                                       :bundle        (.getBytes "old" "UTF-8")
                                                       :bundle_hash   "oldhash"}]
-        (let [validated (cache/validate-bundle! (valid-bundle-bytes "save-viz" {:icon "new.svg"}))
+        (let [validated (cache/validate-bundle! (cvp.tu/valid-bundle-bytes "save-viz" {:icon "new.svg"}))
               row       (cache/save-bundle! {:id id} validated)]
           (is (= :active (:status row))
               "plugin should be active after a successful save")

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -3,38 +3,116 @@
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
-   [metabase-enterprise.remote-sync.source.git :as rs.git]
    [metabase.config.core :as config]
    [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.util.json :as json]
+   [toucan2.core :as t2])
+  (:import
+   (java.io ByteArrayOutputStream)
+   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
+   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
+
+(set! *warn-on-reflection* true)
 
 (use-fixtures :each
   (fn [thunk]
     (mt/with-temporary-setting-values [custom-viz-enabled true]
       (thunk))))
 
-;;; ------------------------------------------------ URL Validation ------------------------------------------------
+;;; ------------------------------------------------ Bundle fixtures ------------------------------------------------
 
-(deftest validate-repo-url-test
-  (testing "accepts http URLs"
-    (is (nil? (cache/validate-repo-url! "http://github.com/user/repo"))))
-  (testing "accepts https URLs"
-    (is (nil? (cache/validate-repo-url! "https://github.com/user/repo"))))
-  (testing "accepts file:// URLs in test mode"
-    (is (nil? (cache/validate-repo-url! "file:///tmp/repo"))))
-  (testing "SECURITY: rejects ssh:// URLs"
-    (is (thrown-with-msg? Exception #"http or https"
-                          (cache/validate-repo-url! "ssh://git@github.com/user/repo"))))
-  (testing "SECURITY: rejects ftp:// URLs"
-    (is (thrown-with-msg? Exception #"http or https"
-                          (cache/validate-repo-url! "ftp://evil.com/repo"))))
-  (testing "SECURITY: rejects gopher:// URLs"
-    (is (thrown-with-msg? Exception #"http or https"
-                          (cache/validate-repo-url! "gopher://evil.com/repo"))))
-  (testing "SECURITY: rejects file:// URLs in prod mode"
-    (with-redefs [config/is-test? false]
-      (is (thrown-with-msg? Exception #"http or https"
-                            (cache/validate-repo-url! "file:///etc/passwd"))))))
+(defn- make-tgz-bytes
+  ^bytes [entries]
+  (with-open [baos (ByteArrayOutputStream.)
+              gz   (GzipCompressorOutputStream. baos)
+              tar  (TarArchiveOutputStream. gz)]
+    (doseq [[name content] entries
+            :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
+                  entry     (doto (TarArchiveEntry. ^String name)
+                              (.setSize (alength bs)))]]
+      (.putArchiveEntry tar entry)
+      (.write tar bs 0 (alength bs))
+      (.closeArchiveEntry tar))
+    (.finish tar)
+    (.toByteArray baos)))
+
+(defn- valid-bundle-bytes
+  [identifier & [{:keys [icon metabase-version]}]]
+  (let [manifest (cond-> {:name identifier}
+                   icon             (assoc :icon icon)
+                   metabase-version (assoc-in [:metabase :version] metabase-version))]
+    (make-tgz-bytes
+     [["metabase-plugin.json" (json/encode manifest)]
+      ["dist/index.js" "console.log('hi')"]])))
+
+;;; ------------------------------------------------ validate-bundle! ------------------------------------------------
+
+(deftest validate-bundle-happy-path-test
+  (testing "validate-bundle! returns parsed manifest and a stable sha256"
+    (let [bytes (valid-bundle-bytes "my-viz" {:icon "icon.svg"})
+          res   (cache/validate-bundle! bytes)]
+      (is (= "my-viz" (get-in res [:manifest :name])))
+      (is (= "icon.svg" (get-in res [:manifest :icon])))
+      (is (bytes? (:bytes res)))
+      (is (string? (:hash res)))
+      (is (= 64 (count (:hash res))) "sha256 hex is 64 chars")
+      (testing "hash is deterministic"
+        (is (= (:hash res) (:hash (cache/validate-bundle! bytes))))))))
+
+(deftest validate-bundle-captures-version-test
+  (testing "metabase.version from the manifest is echoed as :version-str"
+    (let [bytes (valid-bundle-bytes "ver-viz" {:metabase-version ">=1.60"})
+          res   (cache/validate-bundle! bytes)]
+      (is (= ">=1.60" (:version-str res))))))
+
+(deftest validate-bundle-rejects-empty-test
+  (testing "empty bytes"
+    (is (thrown-with-msg? Exception #"empty"
+                          (cache/validate-bundle! (byte-array 0))))))
+
+(deftest validate-bundle-rejects-non-archive-test
+  (testing "plain text is not a tar.gz archive"
+    (is (thrown-with-msg? Exception #"tar\.gz"
+                          (cache/validate-bundle! (.getBytes "not an archive" "UTF-8"))))))
+
+(deftest validate-bundle-requires-manifest-test
+  (testing "archive without metabase-plugin.json is rejected"
+    (let [bytes (make-tgz-bytes [["dist/index.js" "console.log('hi')"]])]
+      (is (thrown-with-msg? Exception #"metabase-plugin\.json"
+                            (cache/validate-bundle! bytes))))))
+
+(deftest validate-bundle-requires-index-js-test
+  (testing "archive without dist/index.js is rejected"
+    (let [bytes (make-tgz-bytes
+                 [["metabase-plugin.json" (json/encode {:name "no-bundle"})]])]
+      (is (thrown-with-msg? Exception #"index\.js"
+                            (cache/validate-bundle! bytes))))))
+
+(deftest validate-bundle-requires-manifest-name-test
+  (testing "manifest without :name is rejected"
+    (let [bytes (make-tgz-bytes
+                 [["metabase-plugin.json" (json/encode {:icon "icon.svg"})]
+                  ["dist/index.js" "console.log('hi')"]])]
+      (is (thrown-with-msg? Exception #"\"name\""
+                            (cache/validate-bundle! bytes))))))
+
+(deftest validate-bundle-rejects-invalid-json-manifest-test
+  (testing "non-JSON manifest is rejected"
+    (let [bytes (make-tgz-bytes
+                 [["metabase-plugin.json" "not json at all"]
+                  ["dist/index.js" "console.log('hi')"]])]
+      (is (thrown-with-msg? Exception #"not valid JSON"
+                            (cache/validate-bundle! bytes))))))
+
+(deftest validate-bundle-rejects-incompatible-version-test
+  (testing "plugin requiring incompatible Metabase version is rejected"
+    (with-redefs [config/mb-version-info {:tag "v1.60.0"}
+                  config/is-dev?         false]
+      (let [bytes (valid-bundle-bytes "bad-ver" {:metabase-version ">=1.99.0"})]
+        (is (thrown-with-msg? Exception #"version"
+                              (cache/validate-bundle! bytes)))))))
+
+;;; ------------------------------------------------ dev-base-url URL validation ------------------------------------------------
 
 (deftest dev-base-url-test
   (testing "accepts http URLs"
@@ -60,8 +138,7 @@
 
 (deftest set-or-clear-dev-bundle!-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/viz"
-                                                    :identifier   "test-viz"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "test-viz"
                                                     :display_name "test-viz"
                                                     :status       :active}]
       (testing "sets a valid http URL"
@@ -92,12 +169,11 @@
       (let [manifest {:name   "test-viz"
                       :icon   "icon.svg"
                       :assets ["icon.svg" "thumb.png"]}]
-        (mt/with-temp [:model/CustomVizPlugin plugin {:repo_url         "https://github.com/test/viz"
-                                                      :identifier       "test-viz"
-                                                      :display_name     "test-viz"
-                                                      :status           :active
-                                                      :resolved_commit  "abc123"
-                                                      :manifest         manifest}]
+        (mt/with-temp [:model/CustomVizPlugin plugin {:identifier   "test-viz"
+                                                      :display_name "test-viz"
+                                                      :status       :active
+                                                      :bundle_hash  "abc123"
+                                                      :manifest     manifest}]
           (testing "returns nil for assets not in manifest whitelist"
             (is (nil? (cache/resolve-asset plugin "not-listed.png"))))
           (testing "returns nil for path traversal attempts"
@@ -105,119 +181,57 @@
           (testing "returns nil for absolute path attempts"
             (is (nil? (cache/resolve-asset plugin "/etc/passwd")))))))))
 
-;;; ------------------------------------------------ fetch-and-save! state consistency ------------------------------------------------
+;;; ------------------------------------------------ insert-bundle!/save-bundle! state consistency ------------------------------------------------
 
-(deftest fetch-and-save!-success-test
-  (testing "successful fetch updates plugin to :active with manifest data"
-    (mt/with-premium-features #{:custom-viz}
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/fetch-ok"
-                                                      :identifier   "fetch-ok"
-                                                      :display_name "fetch-ok"
-                                                      :status       :error}]
-        (with-redefs [rs.git/git-source      (constantly nil)
-                      rs.git/snapshot-at-ref  (constantly {:version "abc123"})
-                      rs.git/file-size        (constantly 100)
-                      rs.git/read-file        (fn [_snapshot path]
-                                                (case path
-                                                  "dist/index.js"          "console.log('hi')"
-                                                  "metabase-plugin.json"   "{\"name\":\"My Viz\",\"icon\":\"icon.svg\"}"
-                                                  nil))]
-          (let [result (cache/fetch-and-save! {:id id :repo_url "https://github.com/test/fetch-ok"
-                                               :identifier "fetch-ok"})]
-            (is (= :active (:status result))
-                "plugin should be active after successful fetch")
-            (is (nil? (:error_message result))
-                "error_message should be cleared on success")
-            (is (= "abc123" (:resolved_commit result)))
-            (is (= "My Viz" (:display_name result))
-                "display_name should come from manifest")
-            (is (= "icon.svg" (:icon result))
-                "icon should come from manifest")))))))
-
-(deftest fetch-and-save!-insert-test
-  (testing "fetch-and-save! inserts a new row when no :id is provided"
+(deftest insert-bundle-test
+  (testing "insert-bundle! creates an :active row with derived fields from the manifest"
     (mt/with-premium-features #{:custom-viz}
       (mt/with-model-cleanup [:model/CustomVizPlugin]
-        (with-redefs [rs.git/git-source      (constantly nil)
-                      rs.git/snapshot-at-ref  (constantly {:version "abc123"})
-                      rs.git/file-size        (constantly 100)
-                      rs.git/read-file        (fn [_snapshot path]
-                                                (case path
-                                                  "dist/index.js"        "console.log('hi')"
-                                                  "metabase-plugin.json" "{\"name\":\"New Viz\"}"
-                                                  nil))]
-          (let [result (cache/fetch-and-save! {:repo_url   "https://github.com/test/insert-new"
-                                               :identifier "insert-new"})]
-            (is (some? (:id result)) "should return a row with an id")
-            (is (= :active (:status result)))
-            (is (= "New Viz" (:display_name result)))
-            (is (= "abc123" (:resolved_commit result)))))))))
+        (let [validated (cache/validate-bundle! (valid-bundle-bytes "new-viz" {:icon "icon.svg"}))
+              row       (cache/insert-bundle! "new-viz" validated)]
+          (is (some? (:id row)))
+          (is (= :active (:status row)))
+          (is (= "new-viz" (:identifier row)))
+          (is (= "new-viz" (:display_name row)))
+          (is (= "icon.svg" (:icon row)))
+          (is (= (:hash validated) (:bundle_hash row))
+              "bundle_hash matches the validated sha256"))))))
 
-(deftest fetch-and-save!-failure-throws-test
-  (testing "failed fetch throws — caller decides how to handle"
+(deftest save-bundle-test
+  (testing "save-bundle! replaces an existing row's derived fields"
     (mt/with-premium-features #{:custom-viz}
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/fetch-fail"
-                                                      :identifier   "fetch-fail"
-                                                      :display_name "fetch-fail"
-                                                      :status       :active}]
-        (with-redefs [rs.git/git-source     (fn [& _] (throw (ex-info "Connection refused" {})))]
-          (is (thrown-with-msg? Exception #"Connection refused"
-                                (cache/fetch-and-save! {:id id :repo_url "https://github.com/test/fetch-fail"
-                                                        :identifier "fetch-fail"}))))))))
-
-(deftest fetch-and-save!-missing-bundle-throws-test
-  (testing "missing index.js in repo throws"
-    (mt/with-premium-features #{:custom-viz}
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/no-bundle"
-                                                      :identifier   "no-bundle"
-                                                      :display_name "no-bundle"
-                                                      :status       :active}]
-        (with-redefs [rs.git/git-source      (constantly nil)
-                      rs.git/snapshot-at-ref  (constantly {:version "abc123"})
-                      rs.git/read-file        (constantly nil)]
-          (is (thrown-with-msg? Exception #"index\.js.*not found"
-                                (cache/fetch-and-save! {:id id :repo_url "https://github.com/test/no-bundle"
-                                                        :identifier "no-bundle"}))))))))
-
-(deftest fetch-and-save!-incompatible-version-throws-test
-  (testing "plugin requiring incompatible Metabase version throws"
-    (mt/with-premium-features #{:custom-viz}
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/bad-ver"
-                                                      :identifier   "bad-ver"
-                                                      :display_name "bad-ver"
-                                                      :status       :active}]
-        (with-redefs [rs.git/git-source      (constantly nil)
-                      rs.git/snapshot-at-ref  (constantly {:version "abc123"})
-                      rs.git/file-size        (constantly 100)
-                      rs.git/read-file        (fn [_snapshot path]
-                                                (case path
-                                                  "dist/index.js"        "console.log('hi')"
-                                                  "metabase-plugin.json" (str "{\"name\":\"Bad Ver\","
-                                                                              "\"metabase\":{\"version\":\">=1.99.0\"}}")
-                                                  nil))
-                      config/mb-version-info {:tag "v1.60.0"}
-                      config/is-dev?         false]
-          (is (thrown-with-msg? Exception #"version"
-                                (cache/fetch-and-save! {:id id :repo_url "https://github.com/test/bad-ver"
-                                                        :identifier "bad-ver"}))))))))
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier    "save-viz"
+                                                      :display_name  "old"
+                                                      :status        :error
+                                                      :error_message "something"
+                                                      :bundle        (.getBytes "old" "UTF-8")
+                                                      :bundle_hash   "oldhash"}]
+        (let [validated (cache/validate-bundle! (valid-bundle-bytes "save-viz" {:icon "new.svg"}))
+              row       (cache/save-bundle! {:id id} validated)]
+          (is (= :active (:status row))
+              "plugin should be active after a successful save")
+          (is (nil? (:error_message row))
+              "error_message should be cleared")
+          (is (= "new.svg" (:icon row)))
+          (is (= (:hash validated) (:bundle_hash row)))
+          (is (not= "oldhash" (:bundle_hash row))))))))
 
 ;;; ------------------------------------------------ resolve-bundle precedence ------------------------------------------------
 
 (deftest resolve-bundle-dev-url-takes-precedence-test
-  (testing "resolve-bundle prefers dev URL over git when both are available"
+  (testing "resolve-bundle prefers dev URL over the uploaded bundle when both are present"
     (mt/with-premium-features #{:custom-viz}
       (with-redefs [custom-viz.settings/custom-viz-plugin-dev-mode-enabled (constantly true)]
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/precedence"
-                                                        :identifier      "precedence"
-                                                        :display_name    "precedence"
-                                                        :status          :active
-                                                        :resolved_commit "abc123"
-                                                        :dev_bundle_url  "http://localhost:5174"}]
+        (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier     "precedence"
+                                                        :display_name   "precedence"
+                                                        :status         :active
+                                                        :bundle_hash    "abc123"
+                                                        :dev_bundle_url "http://localhost:5174"}]
           (let [dev-called? (atom false)
-                git-called? (atom false)]
+                fs-called?  (atom false)]
             (with-redefs [cache/fetch-dev-bundle (fn [_] (reset! dev-called? true) {:content "dev-js" :hash "d1"})
-                          cache/get-bundle      (fn [_] (reset! git-called? true) {:content "git-js" :hash "g1"})]
+                          cache/get-bundle      (fn [_] (reset! fs-called? true) {:content "fs-js" :hash "g1"})]
               (let [result (cache/resolve-bundle {:id id})]
                 (is (true? @dev-called?) "dev bundle fetch should be called")
-                (is (false? @git-called?) "git bundle should not be called when dev URL is set")
+                (is (false? @fs-called?) "filesystem bundle should not be called when dev URL is set")
                 (is (= "dev-js" (:content result)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -23,17 +23,17 @@
 
 (defn- make-tgz-bytes
   ^bytes [entries]
-  (with-open [baos (ByteArrayOutputStream.)
-              gz   (GzipCompressorOutputStream. baos)
-              tar  (TarArchiveOutputStream. gz)]
-    (doseq [[name content] entries
-            :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
-                  entry     (doto (TarArchiveEntry. ^String name)
-                              (.setSize (alength bs)))]]
-      (.putArchiveEntry tar entry)
-      (.write tar bs 0 (alength bs))
-      (.closeArchiveEntry tar))
-    (.finish tar)
+  (let [baos (ByteArrayOutputStream.)]
+    (with-open [gz  (GzipCompressorOutputStream. baos)
+                tar (TarArchiveOutputStream. gz)]
+      (doseq [[name content] entries
+              :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
+                    entry     (doto (TarArchiveEntry. ^String name)
+                                (.setSize (alength bs)))]]
+        (.putArchiveEntry tar entry)
+        (.write tar bs 0 (alength bs))
+        (.closeArchiveEntry tar))
+      (.finish tar))
     (.toByteArray baos)))
 
 (defn- valid-bundle-bytes

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -120,8 +120,6 @@
     (is (= "http://localhost:5174/" (cache/dev-base-url "http://localhost:5174/"))))
   (testing "accepts https URLs"
     (is (= "https://dev.example.com/" (cache/dev-base-url "https://dev.example.com"))))
-  (testing "accepts file:// URLs in test mode"
-    (is (= "file:///tmp/bundle/" (cache/dev-base-url "file:///tmp/bundle"))))
   (testing "SECURITY: rejects ftp:// URLs"
     (is (thrown-with-msg? Exception #"http or https"
                           (cache/dev-base-url "ftp://evil.com/bundle"))))
@@ -131,10 +129,9 @@
   (testing "SECURITY: rejects URLs with no scheme"
     (is (thrown? Exception
                  (cache/dev-base-url "localhost:5174"))))
-  (testing "SECURITY: rejects file:// URLs in prod mode"
-    (with-redefs [config/is-test? false]
-      (is (thrown-with-msg? Exception #"http or https"
-                            (cache/dev-base-url "file:///etc/passwd"))))))
+  (testing "SECURITY: rejects file:// URLs"
+    (is (thrown-with-msg? Exception #"http or https"
+                          (cache/dev-base-url "file:///etc/passwd")))))
 
 (deftest set-or-clear-dev-bundle!-test
   (mt/with-premium-features #{:custom-viz}
@@ -152,14 +149,9 @@
         (cache/set-or-clear-dev-bundle! id "http://localhost:5174")
         (cache/set-or-clear-dev-bundle! id "")
         (is (nil? (t2/select-one-fn :dev_bundle_url :model/CustomVizPlugin :id id))))
-      (testing "accepts file:// URLs in test mode"
-        (cache/set-or-clear-dev-bundle! id "file:///tmp/bundle")
-        (is (= "file:///tmp/bundle"
-               (t2/select-one-fn :dev_bundle_url :model/CustomVizPlugin :id id))))
-      (testing "SECURITY: rejects file:// URLs in prod mode"
-        (with-redefs [config/is-test? false]
-          (is (thrown-with-msg? Exception #"http or https"
-                                (cache/set-or-clear-dev-bundle! id "file:///etc/passwd"))))))))
+      (testing "SECURITY: rejects file:// URLs"
+        (is (thrown-with-msg? Exception #"http or https"
+                              (cache/set-or-clear-dev-bundle! id "file:///etc/passwd")))))))
 
 ;;; ------------------------------------------------ Asset Whitelist ------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -32,9 +32,11 @@
 
 (deftest validate-bundle-captures-version-test
   (testing "metabase.version from the manifest is echoed as :version-str"
-    (let [bytes (cvp.tu/valid-bundle-bytes "ver-viz" {:metabase-version ">=1.60"})
-          res   (cache/validate-bundle! bytes)]
-      (is (= ">=1.60" (:version-str res))))))
+    (with-redefs [config/mb-version-info {:tag "v1.60.0"}
+                  config/is-dev?         false]
+      (let [bytes (cvp.tu/valid-bundle-bytes "ver-viz" {:metabase-version ">=1.60"})
+            res   (cache/validate-bundle! bytes)]
+        (is (= ">=1.60" (:version-str res)))))))
 
 (deftest validate-bundle-rejects-empty-test
   (testing "empty bytes"

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -179,6 +179,19 @@
           (is (= (:hash validated) (:bundle_hash row)))
           (is (not= "oldhash" (:bundle_hash row))))))))
 
+;;; ------------------------------------------------ integrity check on serve ------------------------------------------------
+
+(deftest get-bundle-rejects-mismatched-hash-test
+  (testing "SECURITY: get-bundle refuses to serve when stored bytes don't match bundle_hash"
+    (mt/with-premium-features #{:custom-viz}
+      (mt/with-temp [:model/CustomVizPlugin plugin {:identifier   "tampered-viz"
+                                                    :display_name "tampered-viz"
+                                                    :status       :active
+                                                    :bundle       (cvp.tu/valid-bundle-bytes "tampered-viz")
+                                                    :bundle_hash  "deadbeef"}]
+        (is (nil? (cache/get-bundle plugin))
+            "mismatch between bundle bytes and bundle_hash must not be served")))))
+
 ;;; ------------------------------------------------ resolve-bundle precedence ------------------------------------------------
 
 (deftest resolve-bundle-dev-url-takes-precedence-test

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -75,6 +75,19 @@
       (is (thrown-with-msg? Exception #"not valid JSON"
                             (cache/validate-bundle! bytes))))))
 
+(deftest validate-bundle-rejects-tar-bomb-test
+  (testing "SECURITY: validate-bundle! rejects archives that expand beyond the uncompressed cap"
+    ;; A megabyte of NUL compresses to a few hundred bytes. With a tight cap on
+    ;; uncompressed bytes the bomb is refused at extraction time.
+    (let [bomb-payload (byte-array (* 32 1024 1024))
+          bytes        (cvp.tu/make-tgz-bytes
+                        [["metabase-plugin.json" (json/encode {:name "bomb-viz"})]
+                         ["dist/index.js" "console.log('hi')"]
+                         ["dist/assets/big.bin" bomb-payload]])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"max uncompressed bytes"
+                            (cache/validate-bundle! bytes))))))
+
 (deftest validate-bundle-rejects-incompatible-version-test
   (testing "plugin requiring incompatible Metabase version is rejected"
     (with-redefs [config/mb-version-info {:tag "v1.60.0"}

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/core_test.clj
@@ -40,7 +40,7 @@
 (deftest ee-resolve-bundle-delegates-test
   (testing "EE resolve-bundle delegates to cache/resolve-bundle"
     (mt/with-premium-features #{:custom-viz}
-      (let [plugin {:id 42 :repo_url "https://github.com/test/viz"}]
+      (let [plugin {:id 42 :identifier "viz"}]
         (with-redefs [cache/resolve-bundle (fn [p] (when (= p plugin) {:content "js-code" :hash "abc"}))]
           (is (= {:content "js-code" :hash "abc"}
                  (custom-viz-plugin/resolve-bundle plugin))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -13,8 +13,7 @@
 
 (deftest timestamped-test
   (testing "CustomVizPlugin gets auto-populated timestamps"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/ts-test"
-                                                    :identifier   "ts-test"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "ts-test"
                                                     :display_name "ts-test"
                                                     :status       :active}]
       (let [plugin (t2/select-one :model/CustomVizPlugin :id id)]
@@ -33,8 +32,7 @@
         (binding [api/*current-user-id* nil]
           (is (false? (boolean (mi/can-read? plugin))))))))
   (testing "write requires superuser"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/perm-test-2"
-                                                    :identifier   "perm-test-2"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "perm-test-2"
                                                     :display_name "perm-test-2"
                                                     :status       :active}]
       (let [plugin (t2/select-one :model/CustomVizPlugin :id id)]
@@ -48,21 +46,20 @@
     (binding [api/*is-superuser?* false]
       (is (false? (mi/can-create? :model/CustomVizPlugin {}))))))
 
-(deftest to-json-strips-access-token-test
-  (testing "JSON serialization never includes access_token"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/json-test"
-                                                    :identifier   "json-test"
+(deftest to-json-strips-bundle-test
+  (testing "JSON serialization never includes the raw bundle bytes"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "json-test"
                                                     :display_name "json-test"
                                                     :status       :active
-                                                    :access_token "secret-token"}]
+                                                    :bundle       (.getBytes "pretend-zip-bytes" "UTF-8")
+                                                    :bundle_hash  "feedface"}]
       (let [plugin   (t2/select-one :model/CustomVizPlugin :id id)
             json-str (json/encode plugin)]
-        (is (not (re-find #"secret-token" json-str)))))))
+        (is (not (re-find #"pretend-zip-bytes" json-str)))))))
 
 (deftest status-keyword-transform-test
   (testing "status is stored as string and returned as keyword"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/status-test"
-                                                    :identifier   "status-test"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "status-test"
                                                     :display_name "status-test"
                                                     :status       :active}]
       (is (= :active (:status (t2/select-one :model/CustomVizPlugin :id id))))
@@ -95,8 +92,7 @@
 
 (deftest load-find-local-test
   (testing "load-find-local finds plugin by identifier"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/find-local"
-                                                    :identifier   "find-local"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "find-local"
                                                     :display_name "find-local"
                                                     :status       :active}]
       (let [found (serdes/load-find-local [{:model "CustomVizPlugin" :id "find-local"}])]
@@ -104,20 +100,15 @@
         (is (= id (:id found)))))))
 
 (deftest make-spec-test
-  (testing "make-spec generates correct copy/skip/transform fields"
+  (testing "make-spec copies identity fields but skips the binary bundle and transient dev/error state"
     (let [spec (serdes/make-spec "CustomVizPlugin" {})]
       (is (contains? (set (:copy spec)) :identifier))
-      (is (contains? (set (:copy spec)) :repo_url))
+      (is (contains? (set (:copy spec)) :display_name))
+      (is (contains? (set (:copy spec)) :manifest))
+      (is (contains? (set (:skip spec)) :bundle))
+      (is (contains? (set (:skip spec)) :bundle_hash))
       (is (contains? (set (:skip spec)) :dev_bundle_url))
       (is (contains? (set (:skip spec)) :error_message))))
-  (testing "access_token is skipped by default"
-    (let [spec   (serdes/make-spec "CustomVizPlugin" {})
-          export (get-in spec [:transform :access_token :export])]
-      (is (= ::serdes/skip (export "my-secret-token")))))
-  (testing "access_token is included when include-custom-viz-token is true"
-    (let [spec   (serdes/make-spec "CustomVizPlugin" {:include-custom-viz-token true})
-          export (get-in spec [:transform :access_token :export])]
-      (is (= "my-secret-token" (export "my-secret-token")))))
   (testing "status is always exported as skip and imported as pending"
     (let [spec          (serdes/make-spec "CustomVizPlugin" {})
           status-export (get-in spec [:transform :status :export])

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -8,6 +8,8 @@
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (deftest table-name-test
   (is (= :custom_viz_plugin (t2/table-name :model/CustomVizPlugin))))
 

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -22,6 +22,15 @@
         (is (some? (:updated_at plugin)))))))
 
 (deftest permissions-test
+  (testing "read is available to any authenticated user"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "perm-test"
+                                                    :display_name "perm-test"
+                                                    :status       :active}]
+      (let [plugin (t2/select-one :model/CustomVizPlugin :id id)]
+        (binding [api/*current-user-id* 1]
+          (is (true? (boolean (mi/can-read? plugin)))))
+        (binding [api/*current-user-id* nil]
+          (is (false? (boolean (mi/can-read? plugin))))))))
   (testing "write requires superuser"
     (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/perm-test-2"
                                                     :identifier   "perm-test-2"

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -23,7 +23,8 @@
 
 (deftest permissions-test
   (testing "read is available to any authenticated user"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "perm-test"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/ts-test"
+                                                    :identifier   "perm-test"
                                                     :display_name "perm-test"
                                                     :status       :active}]
       (let [plugin (t2/select-one :model/CustomVizPlugin :id id)]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -24,8 +24,7 @@
 
 (deftest permissions-test
   (testing "read is available to any authenticated user"
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/ts-test"
-                                                    :identifier   "perm-test"
+    (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "perm-test"
                                                     :display_name "perm-test"
                                                     :status       :active}]
       (let [plugin (t2/select-one :model/CustomVizPlugin :id id)]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/models/custom_viz_plugin_test.clj
@@ -102,13 +102,12 @@
         (is (= id (:id found)))))))
 
 (deftest make-spec-test
-  (testing "make-spec copies identity fields but skips the binary bundle and transient dev/error state"
+  (testing "make-spec copies identity fields and bundle_hash, skips dev/error state"
     (let [spec (serdes/make-spec "CustomVizPlugin" {})]
       (is (contains? (set (:copy spec)) :identifier))
       (is (contains? (set (:copy spec)) :display_name))
       (is (contains? (set (:copy spec)) :manifest))
-      (is (contains? (set (:skip spec)) :bundle))
-      (is (contains? (set (:skip spec)) :bundle_hash))
+      (is (contains? (set (:copy spec)) :bundle_hash))
       (is (contains? (set (:skip spec)) :dev_bundle_url))
       (is (contains? (set (:skip spec)) :error_message))))
   (testing "status is always exported as skip and imported as pending"
@@ -117,3 +116,21 @@
           status-import (get-in spec [:transform :status :import])]
       (is (= ::serdes/skip (status-export :active)))
       (is (= "pending" (status-import nil))))))
+
+(deftest bundle-b64-round-trip-test
+  (testing "bundle bytes base64-encode on export and decode back to bytes on import"
+    (let [spec   (serdes/make-spec "CustomVizPlugin" {})
+          export (get-in spec [:transform :bundle :export])
+          import (get-in spec [:transform :bundle :import])
+          bytes  (.getBytes "pretend tgz bytes" "UTF-8")
+          out    (export bytes)]
+      (is (string? out))
+      (is (not= (String. bytes "UTF-8") out)
+          "exported value should be b64-encoded, not the raw string")
+      (is (= (seq bytes) (seq (import out))))))
+  (testing "nil bundle round-trips as nil"
+    (let [spec   (serdes/make-spec "CustomVizPlugin" {})
+          export (get-in spec [:transform :bundle :export])
+          import (get-in spec [:transform :bundle :import])]
+      (is (nil? (export nil)))
+      (is (nil? (import nil))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/render_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/render_test.clj
@@ -53,8 +53,7 @@
           (is (= :table
                  (card/detect-pulse-chart-type card nil multi-col-data)))))
       (testing "custom viz with registered plugin but no bundle falls back to :table"
-        (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/no-bundle"
-                                                 :identifier   "no-bundle"
+        (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "no-bundle"
                                                  :display_name "No Bundle"
                                                  :status       :active
                                                  :enabled      true}]
@@ -62,8 +61,7 @@
             (is (= :table
                    (card/detect-pulse-chart-type card nil multi-col-data))))))
       (testing "disabled custom viz plugin falls back to :table"
-        (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/disabled"
-                                                 :identifier   "disabled-chart"
+        (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "disabled-chart"
                                                  :display_name "Disabled"
                                                  :status       :active
                                                  :enabled      false}]
@@ -71,8 +69,7 @@
             (is (= :table
                    (card/detect-pulse-chart-type card nil multi-col-data))))))
       (testing "custom viz with registered plugin and bundle falls back to :table when :custom-viz feature is disabled"
-        (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/feature-off"
-                                                 :identifier   "feature-off"
+        (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "feature-off"
                                                  :display_name "Feature Off"
                                                  :status       :active
                                                  :enabled      true}]
@@ -82,8 +79,7 @@
                 (is (= :table
                        (card/detect-pulse-chart-type card nil multi-col-data))))))))
       (testing "custom viz with registered plugin and bundle still falls back to :table (static custom viz not supported)"
-        (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/has-bundle"
-                                                 :identifier   "has-bundle"
+        (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "has-bundle"
                                                  :display_name "Has Bundle"
                                                  :status       :active
                                                  :enabled      true}]
@@ -99,8 +95,7 @@
     (testing "custom-viz-bundles resolves plugin bundle and assets"
       (let [bundle-content "function customViz(){}"
             asset-bytes    (.getBytes "fake-png-data")]
-        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/bundle-resolve"
-                                                        :identifier   "bundle-resolve"
+        (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier   "bundle-resolve"
                                                         :display_name "Bundle Resolve"
                                                         :status       :active
                                                         :enabled      true
@@ -126,8 +121,7 @@
 (deftest custom-viz-bundles-no-manifest-test
   (mt/with-premium-features #{:custom-viz}
     (testing "custom-viz-bundles returns bundle with empty assets when plugin has no manifest"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/no-manifest"
-                                               :identifier   "no-manifest"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "no-manifest"
                                                :display_name "No Manifest"
                                                :status       :active
                                                :enabled      true}]
@@ -141,8 +135,7 @@
 (deftest custom-viz-bundles-asset-edge-cases-test
   (mt/with-premium-features #{:custom-viz}
     (testing "custom-viz-bundles skips assets whose bytes cannot be resolved"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/missing-asset"
-                                               :identifier   "missing-asset"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "missing-asset"
                                                :display_name "Missing Asset"
                                                :status       :active
                                                :enabled      true
@@ -159,8 +152,7 @@
             (is (contains? assets "present.png"))
             (is (not (contains? assets "missing.png")))))))
     (testing "custom-viz-bundles falls back to application/octet-stream when content-type is unknown"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/unknown-ct"
-                                               :identifier   "unknown-ct"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "unknown-ct"
                                                :display_name "Unknown CT"
                                                :status       :active
                                                :enabled      true
@@ -200,8 +192,7 @@
 (deftest javascript-visualization-passes-resolved-bundles-for-custom-display-test
   (mt/with-premium-features #{:custom-viz}
     (testing "*javascript-visualization* receives resolved bundles when display is :custom:*"
-      (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/wired-through"
-                                               :identifier   "wired-through"
+      (mt/with-temp [:model/CustomVizPlugin _ {:identifier   "wired-through"
                                                :display_name "Wired Through"
                                                :status       :active
                                                :enabled      true}]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/test_util.clj
@@ -10,10 +10,10 @@
 
 (set! *warn-on-reflection* true)
 
-(defn ^bytes make-tgz-bytes
+(defn make-tgz-bytes
   "Build a tar.gz archive in memory from a seq of `[name content]` pairs.
    `content` may be a String or a byte array."
-  [entries]
+  ^bytes [entries]
   ;; The gzip/tar streams must be closed (not just finished) before the byte
   ;; array is final — gzip only emits its trailer on close. Keep `baos` out
   ;; of `with-open` so we can still read from it after the streams close.
@@ -30,11 +30,11 @@
       (.finish tar))
     (.toByteArray baos)))
 
-(defn ^bytes valid-bundle-bytes
+(defn valid-bundle-bytes
   "Build a minimal valid plugin tar.gz archive: manifest at the root with the
    given `identifier` as `name`, a trivial `dist/index.js`, and optional
    `:icon` / `:metabase-version` overrides merged into the manifest."
-  [identifier & [{:keys [icon metabase-version]}]]
+  ^bytes [identifier & [{:keys [icon metabase-version]}]]
   (let [manifest (cond-> {:name identifier}
                    icon             (assoc :icon icon)
                    metabase-version (assoc-in [:metabase :version] metabase-version))]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/test_util.clj
@@ -1,0 +1,43 @@
+(ns metabase-enterprise.custom-viz-plugin.test-util
+  "Shared helpers for custom-viz-plugin tests: building in-memory tar+gzip
+   archives that match the format `validate-bundle!` expects."
+  (:require
+   [metabase.util.json :as json])
+  (:import
+   (java.io ByteArrayOutputStream)
+   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
+   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
+
+(set! *warn-on-reflection* true)
+
+(defn ^bytes make-tgz-bytes
+  "Build a tar.gz archive in memory from a seq of `[name content]` pairs.
+   `content` may be a String or a byte array."
+  [entries]
+  ;; The gzip/tar streams must be closed (not just finished) before the byte
+  ;; array is final — gzip only emits its trailer on close. Keep `baos` out
+  ;; of `with-open` so we can still read from it after the streams close.
+  (let [baos (ByteArrayOutputStream.)]
+    (with-open [gz  (GzipCompressorOutputStream. baos)
+                tar (TarArchiveOutputStream. gz)]
+      (doseq [[name content] entries
+              :let [^bytes bs (if (bytes? content) content (.getBytes (str content) "UTF-8"))
+                    entry     (doto (TarArchiveEntry. ^String name)
+                                (.setSize (alength bs)))]]
+        (.putArchiveEntry tar entry)
+        (.write tar bs 0 (alength bs))
+        (.closeArchiveEntry tar))
+      (.finish tar))
+    (.toByteArray baos)))
+
+(defn ^bytes valid-bundle-bytes
+  "Build a minimal valid plugin tar.gz archive: manifest at the root with the
+   given `identifier` as `name`, a trivial `dist/index.js`, and optional
+   `:icon` / `:metabase-version` overrides merged into the manifest."
+  [identifier & [{:keys [icon metabase-version]}]]
+  (let [manifest (cond-> {:name identifier}
+                   icon             (assoc :icon icon)
+                   metabase-version (assoc-in [:metabase :version] metabase-version))]
+    (make-tgz-bytes
+     [["metabase-plugin.json" (json/encode manifest)]
+      ["dist/index.js" "console.log('hi')"]])))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/wrapping_source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/wrapping_source_test.clj
@@ -4,8 +4,6 @@
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]))
 
-(set! *warn-on-reflection* true)
-
 (defrecord MockSourceSnapshot [files]
   source.p/SourceSnapshot
   (list-files [_]
@@ -13,9 +11,6 @@
 
   (read-file [_ path]
     (get files path))
-
-  (read-file-bytes [_ path]
-    (some-> (get files path) (.getBytes "UTF-8")))
 
   (write-files! [_ _message new-files]
     (into {} (map (juxt :path :content) new-files))
@@ -106,8 +101,6 @@
                         [])
                       (read-file [_ _path]
                         nil)
-                      (read-file-bytes [_ _path]
-                        nil)
                       (write-files! [_ _message files]
                         (reset! written-files files)
                         nil)
@@ -131,8 +124,6 @@
                         [])
                       (read-file [_ _path]
                         nil)
-                      (read-file-bytes [_ _path]
-                        nil)
                       (write-files! [_ _message files]
                         (reset! written-files files)
                         nil)
@@ -155,8 +146,6 @@
                           (list-files [_]
                             [])
                           (read-file [_this _path]
-                            nil)
-                          (read-file-bytes [_this _path]
                             nil)
                           (write-files! [_this _message _files]
                             nil)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
@@ -21,9 +21,6 @@
   (read-file [_ _path]
     nil)
 
-  (read-file-bytes [_ _path]
-    nil)
-
   (write-files! [_ message files]
     (let [realized-files (vec files)]
       (reset! written-files {:message message :files realized-files}))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -9,8 +9,6 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(set! *warn-on-reflection* true)
-
 (defn generate-collection-yaml
   "Generate YAML content for a collection with the given `entity-id` and `name`.
   Optionally accepts `:parent-id` for nested collections and `:namespace` for
@@ -193,17 +191,6 @@ width: fixed
       :branch-error (throw (Exception. "Invalid branch specified"))
       ;; Default success case - return file content from atom
       (get-in @files-atom [branch path] "")))
-
-  (read-file-bytes [_this path]
-    (case fail-mode
-      :read-file-error (throw (Exception. "Failed to read file"))
-      :network-error (throw (java.net.UnknownHostException. "Remote host not found"))
-      :auth-error (throw (Exception. "Authentication failed"))
-      :repo-not-found (throw (Exception. "Repository not found"))
-      :branch-error (throw (Exception. "Invalid branch specified"))
-      ;; Default success case - return file content as bytes
-      (when-let [content (get-in @files-atom [branch path])]
-        (.getBytes ^String content "UTF-8"))))
 
   (write-files! [_this _message files]
     (case fail-mode

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -22,6 +22,8 @@
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (comment
   ;; Use this spell in your test body to add the given fixtures to the round trip baseline.
   (round-trip-test/add-to-baseline!))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2635,8 +2635,7 @@
 (deftest custom-viz-plugin-test
   (mt/with-empty-h2-app-db!
     (t2/delete! :model/CustomVizPlugin)
-    (ts/with-temp-dpc [:model/CustomVizPlugin {plugin-id :id} {:repo_url     "https://github.com/example/test-viz-plugin"
-                                                               :display_name "Test Plugin"
+    (ts/with-temp-dpc [:model/CustomVizPlugin {plugin-id :id} {:display_name "Test Plugin"
                                                                :identifier   "test-plugin"
                                                                :status       :active
                                                                :manifest     "{}"}]
@@ -2646,7 +2645,6 @@
         (let [ser (serdes/extract-one "CustomVizPlugin" {} (t2/select-one :model/CustomVizPlugin :id plugin-id))]
           (is (=? {:serdes/meta [{:model "CustomVizPlugin"
                                   :id    "test-plugin"}]
-                   :repo_url     "https://github.com/example/test-viz-plugin"
                    :display_name "Test Plugin"
                    :identifier   "test-plugin"
                    :manifest     {}
@@ -2654,7 +2652,8 @@
                   ser))
           (is (not (contains? ser :id)))
           (is (not (contains? ser :status)))
-          (is (not (contains? ser :access_token)))
+          (is (not (contains? ser :bundle)))
+          (is (not (contains? ser :bundle_hash)))
 
           (testing "has no dependencies"
             (is (empty? (serdes/dependencies ser)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2638,7 +2638,9 @@
     (ts/with-temp-dpc [:model/CustomVizPlugin {plugin-id :id} {:display_name "Test Plugin"
                                                                :identifier   "test-plugin"
                                                                :status       :active
-                                                               :manifest     "{}"}]
+                                                               :manifest     "{}"
+                                                               :bundle       (.getBytes "pretend tgz bytes" "UTF-8")
+                                                               :bundle_hash  "deadbeef"}]
       ;; Uncomment to regenerate baseline:
       ;; (round-trip-test/add-to-baseline!)
       (testing "custom viz plugin extraction"
@@ -2648,12 +2650,12 @@
                    :display_name "Test Plugin"
                    :identifier   "test-plugin"
                    :manifest     {}
+                   :bundle_hash  "deadbeef"
+                   :bundle       string?
                    :created_at   string?}
                   ser))
           (is (not (contains? ser :id)))
           (is (not (contains? ser :status)))
-          (is (not (contains? ser :bundle)))
-          (is (not (contains? ser :bundle_hash)))
 
           (testing "has no dependencies"
             (is (empty? (serdes/dependencies ser)))))))))

--- a/resources/migrations/061/20260409_custom_viz_plugin.yaml
+++ b/resources/migrations/061/20260409_custom_viz_plugin.yaml
@@ -14,7 +14,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: custom_viz_plugin
-            remarks: Stores registered custom visualization plugin repositories
+            remarks: Stores registered custom visualization plugins uploaded as zip bundles
             columns:
               - column:
                   name: id
@@ -24,31 +24,18 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: repo_url
-                  type: varchar(512)
-                  remarks: Git repository URL
+                  name: identifier
+                  type: varchar(254)
+                  remarks: Unique identifier used as visualization display type. Comes from the manifest "name" field.
                   constraints:
-                    unique: true
                     nullable: false
-              - column:
-                  name: access_token
-                  type: ${text.type}
-                  remarks: Encrypted access token for private repositories
-                  constraints:
-                    nullable: true
+                    unique: true
               - column:
                   name: display_name
                   type: varchar(254)
                   remarks: Human-readable name from the plugin manifest
                   constraints:
                     nullable: false
-              - column:
-                  name: identifier
-                  type: varchar(254)
-                  remarks: Unique identifier used as visualization display type
-                  constraints:
-                    nullable: false
-                    unique: true
               - column:
                   name: status
                   type: varchar(32)
@@ -62,15 +49,15 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: pinned_version
-                  type: varchar(254)
-                  remarks: Git ref (branch, tag, or commit SHA) to pin the plugin to
+                  name: bundle
+                  type: ${blob.type}
+                  remarks: Raw bytes of the uploaded zip bundle. Null for dev-only plugins served from a dev server.
                   constraints:
                     nullable: true
               - column:
-                  name: resolved_commit
+                  name: bundle_hash
                   type: varchar(64)
-                  remarks: Resolved commit SHA of the currently cached version
+                  remarks: SHA-256 hex of the uploaded bundle, used as the on-disk cache key and HTTP ETag. Null for dev-only plugins.
                   constraints:
                     nullable: true
               - column:
@@ -101,7 +88,7 @@ databaseChangeLog:
               - column:
                   name: manifest
                   type: ${text.type}
-                  remarks: JSON manifest from metabase-plugin.json in the plugin repository
+                  remarks: JSON manifest from metabase-plugin.json in the uploaded bundle
               - column:
                   name: metabase_version
                   type: varchar(254)
@@ -110,3 +97,21 @@ databaseChangeLog:
                   name: dev_bundle_url
                   type: varchar(1024)
                   remarks: Dev server URL for hot-reload development (e.g. http://localhost:5174)
+  - changeSet:
+      id: v61.2026-04-24T10:00:01
+      author: bronsa
+      comment: Use longblob for custom_viz_plugin.bundle on MySQL/MariaDB so it can hold multi-MB zip uploads
+      changes:
+        - modifyDataType:
+            tableName: custom_viz_plugin
+            columnName: bundle
+            newDataType: longblob
+      rollback:
+        - modifyDataType:
+            tableName: custom_viz_plugin
+            columnName: bundle
+            newDataType: ${blob.type}
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -586,9 +586,10 @@
 (mu/defn- middleware-forms
   "Middleware to apply to base handler. Supports:
 
-    {:multipart true}  — wraps with multipart-params middleware
-    {:scope \"agent:workspaces\"} — wraps with scope enforcement middleware
-    {:scope :unchecked} — skips both enforce-scope and ensure-scopes-checked
+    {:multipart true}                         — wraps with multipart-params middleware
+    {:multipart {:max-file-size N, ...}}      — same, passing options to wrap-multipart-params
+    {:scope \"agent:workspaces\"}               — wraps with scope enforcement middleware
+    {:scope :unchecked}                       — skips both enforce-scope and ensure-scopes-checked
 
    Endpoints without `:scope` get [[metabase.api.macros.scope/ensure-scopes-checked]] to prevent scoped
    tokens from reaching endpoints that haven't opted in."
@@ -597,10 +598,13 @@
         scope-middleware (cond
                            (= scope :unchecked) []
                            (some? scope) [(list 'metabase.api.macros.scope/enforce-scope scope)]
-                           :else ['metabase.api.macros.scope/ensure-scopes-checked])]
+                           :else ['metabase.api.macros.scope/ensure-scopes-checked])
+        multipart        (:multipart metadata)]
     (cond-> (vec scope-middleware)
-      (:multipart metadata)
-      (conj 'ring.middleware.multipart-params/wrap-multipart-params))))
+      multipart
+      (conj (if (map? multipart)
+              `(fn [handler#] (ring.middleware.multipart-params/wrap-multipart-params handler# ~multipart))
+              'ring.middleware.multipart-params/wrap-multipart-params)))))
 
 (mu/defn- apply-middleware :- ::handler
   [handler    :- ::handler

--- a/src/metabase/app_db/encryption.clj
+++ b/src/metabase/app_db/encryption.clj
@@ -41,19 +41,6 @@
         (t2/update! :conn conn :secret
                     {:id id}
                     {:value (encrypt-bytes-fn value)}))
-      ;; `custom_viz_plugin.access_token` is declared on an enterprise model, so we can't reference the
-      ;; model keyword from this OSS namespace. Read and write via the raw table instead, decrypting and
-      ;; re-encrypting the stored ciphertext directly — we don't need the JSON round-trip because the
-      ;; value is opaque to this code.
-      (doseq [{:keys [id access_token]} (t2/select [:custom_viz_plugin :id :access_token])]
-        (when access_token
-          (let [plaintext (encryption/maybe-decrypt access_token)]
-            (when (encryption/possibly-encrypted-string? plaintext)
-              (throw (ex-info (trs "Can''t decrypt custom_viz_plugin.access_token with MB_ENCRYPTION_SECRET_KEY")
-                              {:custom-viz-plugin-id id})))
-            (t2/update! :conn conn :custom_viz_plugin
-                        {:id id}
-                        {:access_token (encrypt-str-fn plaintext)}))))
       (t2/delete! :conn conn :model/QueryCache))))
 
 (defn encrypt-db

--- a/src/metabase/audit_app/models/audit_log.clj
+++ b/src/metabase/audit_app/models/audit_log.clj
@@ -147,7 +147,7 @@
 
 (defmethod model-details :model/CustomVizPlugin
   [plugin _event-type]
-  (select-keys plugin [:identifier :display_name :repo_url :status :enabled :resolved_commit]))
+  (select-keys plugin [:identifier :display_name :status :enabled :bundle_hash]))
 
 (defmethod model-details :model/RemoteSyncTask
   [task _event-type]

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -404,7 +404,11 @@
    can resolve `getAssetUrl` calls without HTTP."
   [card]
   (when-let [identifier (render.util/custom-viz-identifier (:display card))]
-    (let [{:keys [manifest] :as plugin} (t2/select-one :model/CustomVizPlugin :identifier identifier :enabled true)]
+    (let [{:keys [manifest] :as plugin}
+          ;; do not load the (potentially multi-MB) :bundle blob just to read the manifest;
+          ;; resolve-bundle / resolve-asset re-fetch bytes from the cache as needed.
+          (t2/select-one [:model/CustomVizPlugin :id :identifier :enabled :manifest :bundle_hash :dev_bundle_url]
+                         :identifier identifier :enabled true)]
       (when-let [content (some-> plugin
                                  custom-viz-plugin/resolve-bundle
                                  :content)]

--- a/src/metabase/cmd/core.clj
+++ b/src/metabase/cmd/core.clj
@@ -203,7 +203,6 @@
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]
               ["-f" "--include-field-values"     "Include field values along with field metadata."]
               ["-s" "--include-database-secrets" "Include database connection details (in plain text; use caution)."]
-              [nil  "--include-custom-viz-token" "Include custom visualization plugin access tokens (in plain text; use caution)."]
               ["-e" "--continue-on-error"        "Do not break execution on errors."]
               [""   "--full-stacktrace"          "Output full stacktraces on errors."]]}
   [path & options]

--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -16,6 +16,15 @@
    (when-let [entry (.getNextEntry tar)]
      (cons entry (entries tar)))))
 
+(defn tar-input-stream
+  "Open a `TarArchiveInputStream` over a tar+gzip `source`. `source` can be
+  anything `io/input-stream` coerces — a `File`, a byte array, a raw
+  `InputStream`. The caller is responsible for closing the returned stream."
+  ^TarArchiveInputStream [source]
+  (-> (io/input-stream source)
+      (GzipCompressorInputStream.)
+      (TarArchiveInputStream.)))
+
 (defn tgz
   "Compress directory `src` to a tar+gzip file `dst`."
   [^File src ^File dst]
@@ -41,16 +50,16 @@
     dst))
 
 (defn untgz
-  "Uncompress tar+gzip file `archive` to a directory `dst`.
-  Skips hidden entries, returns number of unpacked entries (files + dirs)."
-  [^File archive ^File dst]
-  (with-open [tar (-> (io/input-stream archive)
-                      (GzipCompressorInputStream.)
-                      (TarArchiveInputStream.))]
-    (let [tar-entries (entries tar)
-          dst-path    (.toPath dst)]
+  "Uncompress tar+gzip `archive` into directory `dst`.
+
+  `archive` can be anything `io/input-stream` coerces — a `File`, a byte array,
+  or a raw `InputStream`. Skips hidden entries. Returns the number of unpacked
+  entries (files + dirs)."
+  [archive ^File dst]
+  (with-open [tar (tar-input-stream archive)]
+    (let [dst-path (.toPath dst)]
       (count
-       (for [^TarArchiveEntry e tar-entries
+       (for [^TarArchiveEntry e (entries tar)
              :let [actual-name (last (.split (.getName e) "/"))]
              ;; skip hidden files
              :when (not (str/starts-with? actual-name "."))]

--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -92,10 +92,10 @@
                                   (throw (ex-info (format "Archive exceeds max entries (%d)" max-entries)
                                                   {:status-code 400 :max-entries max-entries})))
                      f          (.toFile (.resolveIn e dst-path))
-                     next-total (if (.isFile e)
-                                  (do (io/make-parents f)
-                                      (with-open [out (io/output-stream f)]
-                                        (copy-tar-entry! tar out total-bytes max-uncompressed-bytes)))
-                                  (do (.mkdirs f) total-bytes))]
+                     next-total (long (if (.isFile e)
+                                        (do (io/make-parents f)
+                                            (with-open [out (io/output-stream f)]
+                                              (copy-tar-entry! tar out total-bytes max-uncompressed-bytes)))
+                                        (do (.mkdirs f) total-bytes)))]
                  (recur next-count next-total))))
            entry-count))))))

--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str])
   (:import
-   (java.io File)
+   (java.io File OutputStream)
    (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveInputStream TarArchiveOutputStream)
    (org.apache.commons.compress.compressors.gzip GzipCompressorInputStream GzipCompressorOutputStream GzipParameters)))
 
@@ -49,23 +49,53 @@
         (.closeArchiveEntry tar)))
     dst))
 
+(defn- copy-tar-entry!
+  "Stream the current tar entry into `out`, returning the new running total of
+   uncompressed bytes seen so far. Throws ex-info as soon as the running total
+   would exceed `max-bytes` (when set), so a tar bomb cannot exhaust disk."
+  ^long [^TarArchiveInputStream tar ^OutputStream out ^long start-total max-bytes]
+  (let [buf (byte-array 8192)]
+    (loop [total start-total]
+      (let [n (.read tar buf)]
+        (if (pos? n)
+          (let [next-total (+ total n)]
+            (when (and max-bytes (> next-total ^long max-bytes))
+              (throw (ex-info (format "Archive expands beyond max uncompressed bytes (%d)" max-bytes)
+                              {:status-code 400 :max-uncompressed-bytes max-bytes})))
+            (.write out buf 0 n)
+            (recur next-total))
+          total)))))
+
 (defn untgz
   "Uncompress tar+gzip `archive` into directory `dst`.
 
   `archive` can be anything `io/input-stream` coerces — a `File`, a byte array,
   or a raw `InputStream`. Skips hidden entries. Returns the number of unpacked
-  entries (files + dirs)."
-  [archive ^File dst]
-  (with-open [tar (tar-input-stream archive)]
-    (let [dst-path (.toPath dst)]
-      (count
-       (for [^TarArchiveEntry e (entries tar)
-             :let [actual-name (last (.split (.getName e) "/"))]
-             ;; skip hidden files
-             :when (not (str/starts-with? actual-name "."))]
-         (let [f (.toFile (.resolveIn e dst-path))]
-           (if (.isFile e)
-             (do (io/make-parents f)
-                 (io/copy tar f))
-             (.mkdirs f))
-           true))))))
+  entries (files + dirs).
+
+  Optional `opts` (default unset, no behavior change):
+  - `:max-uncompressed-bytes` — abort with ex-info when total extracted bytes
+    would exceed this. Defends against tar bombs.
+  - `:max-entries` — abort with ex-info when entry count would exceed this."
+  ([archive ^File dst]
+   (untgz archive dst nil))
+  ([archive ^File dst {:keys [max-uncompressed-bytes max-entries]}]
+   (with-open [tar (tar-input-stream archive)]
+     (let [dst-path (.toPath dst)]
+       (loop [entry-count 0 total-bytes 0]
+         (if-let [^TarArchiveEntry e (.getNextEntry tar)]
+           (let [actual-name (last (.split (.getName e) "/"))]
+             (if (str/starts-with? actual-name ".")
+               (recur entry-count total-bytes)
+               (let [next-count (inc entry-count)
+                     _          (when (and max-entries (> next-count ^long max-entries))
+                                  (throw (ex-info (format "Archive exceeds max entries (%d)" max-entries)
+                                                  {:status-code 400 :max-entries max-entries})))
+                     f          (.toFile (.resolveIn e dst-path))
+                     next-total (if (.isFile e)
+                                  (do (io/make-parents f)
+                                      (with-open [out (io/output-stream f)]
+                                        (copy-tar-entry! tar out total-bytes max-uncompressed-bytes)))
+                                  (do (.mkdirs f) total-bytes))]
+                 (recur next-count next-total))))
+           entry-count))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -51,9 +51,7 @@
           user-id            (atom nil)
           secret-val         "surprise!"
           secret-id-enc      (atom nil)
-          secret-id-unenc    (atom nil)
-          plugin-token       {:token "secret-token"}
-          plugin-id          (atom nil)]
+          secret-id-unenc    (atom nil)]
       (mt/test-drivers #{:postgres :h2 :mysql}
         (let [data-source (dump-to-h2-test/persistent-data-source driver/*driver* db-name)]
           ;; `database.details` use mi/transform-encrypted-json as transformation
@@ -105,15 +103,7 @@
                                                                                    :kind       "password"
                                                                                    :value      (.getBytes secret-val StandardCharsets/UTF_8)
                                                                                    :creator_id @user-id}))]
-                  (reset! secret-id-enc (u/the-id secret)))
-                (when config/ee-available?
-                  (let [plugin (first (t2/insert-returning-instances! :model/CustomVizPlugin
-                                                                      {:repo_url     "https://github.com/test/rotate"
-                                                                       :identifier   "rotate-test"
-                                                                       :display_name "rotate-test"
-                                                                       :status       :active
-                                                                       :access_token plugin-token}))]
-                    (reset! plugin-id (u/the-id plugin)))))
+                  (reset! secret-id-enc (u/the-id secret))))
 
               (testing "rotating with the same key is a noop"
                 (encryption-test/with-secret-key k1
@@ -139,21 +129,13 @@
                   (encryption-test/with-secret-key k2
                     (is (= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (= {:db "/tmp/test.db"} (t2/select-one-fn :details :model/Database :id 1)))
-                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))
-                    (when config/ee-available?
-                      (is (= plugin-token
-                             (t2/select-one-fn :access_token :model/CustomVizPlugin :id @plugin-id))
-                          "CustomVizPlugin.access_token should round-trip under the new key"))))
+                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))
                 (testing "but not with old key"
                   (encryption-test/with-secret-key k1
                     (is (not= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (not= "{\"db\":\"/tmp/test.db\"}" (t2/select-one-fn :details :model/Database :id 1)))
                     (is (not (mt/secret-value-equals? secret-val
-                                                      (t2/select-one-fn :value :model/Secret :id @secret-id-unenc))))
-                    (when config/ee-available?
-                      (is (not= plugin-token
-                                (t2/select-one-fn :access_token :model/CustomVizPlugin :id @plugin-id))
-                          "CustomVizPlugin.access_token should NOT round-trip under the old key")))))
+                                                      (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))))
 
               (testing "full rollback when a database details looks encrypted with a different key than the current one"
                 (encryption-test/with-secret-key k3

--- a/test/metabase/util/compress_test.clj
+++ b/test/metabase/util/compress_test.clj
@@ -55,6 +55,51 @@
         (.closeArchiveEntry tar)))
     archive))
 
+(defn- create-multi-entry-tgz
+  "Create a tar.gz archive with `n` entries each holding `content`."
+  ^File [n ^bytes content]
+  (let [archive (File/createTempFile "archive" ".tar.gz")]
+    (with-open [tar (-> (io/output-stream archive)
+                        (GzipCompressorOutputStream.)
+                        (TarArchiveOutputStream. 512 "UTF-8"))]
+      (dotimes [i n]
+        (let [entry (doto (TarArchiveEntry. (format "file-%d" i))
+                      (.setSize (alength content)))]
+          (.putArchiveEntry tar entry)
+          (.write tar content)
+          (.closeArchiveEntry tar))))
+    archive))
+
+(deftest untgz-max-uncompressed-bytes-test
+  (testing "untgz aborts when total uncompressed bytes exceed :max-uncompressed-bytes"
+    (let [content (.getBytes (apply str (repeat 1024 \a)) "UTF-8")
+          archive (create-multi-entry-tgz 10 content) ;; 10 KiB total uncompressed
+          out     (doto (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))
+                    .mkdirs)]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"max uncompressed bytes"
+                              (u.compress/untgz archive out {:max-uncompressed-bytes 4096})))
+        (testing "no limit means no error"
+          (is (= 10 (u.compress/untgz archive out))))
+        (finally
+          (io/delete-file archive true)
+          (run! #(io/delete-file % true) (reverse (file-seq out))))))))
+
+(deftest untgz-max-entries-test
+  (testing "untgz aborts when entry count exceeds :max-entries"
+    (let [content (.getBytes "x" "UTF-8")
+          archive (create-multi-entry-tgz 10 content)
+          out     (doto (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))
+                    .mkdirs)]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"max entries"
+                              (u.compress/untgz archive out {:max-entries 5})))
+        (finally
+          (io/delete-file archive true)
+          (run! #(io/delete-file % true) (reverse (file-seq out))))))))
+
 (deftest untgz-path-traversal-test
   (testing "untgz rejects tar entries with path traversal"
     (let [content (.getBytes "content" "UTF-8")

--- a/test_resources/serialization_baseline/custom_viz_plugins/test_plugin.yaml
+++ b/test_resources/serialization_baseline/custom_viz_plugins/test_plugin.yaml
@@ -1,4 +1,5 @@
-repo_url: https://github.com/example/test-viz-plugin
+bundle: null
+bundle_hash: null
 display_name: Test Plugin
 identifier: test-plugin
 manifest: {}

--- a/test_resources/serialization_baseline/custom_viz_plugins/test_plugin.yaml
+++ b/test_resources/serialization_baseline/custom_viz_plugins/test_plugin.yaml
@@ -1,5 +1,3 @@
-bundle: null
-bundle_hash: null
 display_name: Test Plugin
 identifier: test-plugin
 manifest: {}


### PR DESCRIPTION
Replaces the git-sync source for custom viz plugins with a direct bundle upload — Metabase no longer needs to clone or hold credentials for an external repo. Admins upload a tar.gz via `POST /api/ee/custom-viz-plugin/` and replace via `PUT /:id/bundle`. The bundle is stored on the row alongside its SHA-256 hash and lazily extracted to a per-instance on-disk cache on first serve. Manifest, layout, and Metabase-version compatibility are validated at upload time. Dev hot-reload via `dev_bundle_url` is kept (no upload required).

Hardening: 5 MiB compressed cap enforced at the multipart layer (Ring 413s mid-stream, no `/tmp` blow-up); 25 MiB uncompressed / 256 entries cap aborts tar bombs mid-extraction; SHA-256 verification on read catches DB corruption or partial tampering. Audit log records create / update / delete with the bundle hash. Pro+ gated.

Closes https://linear.app/metabase/issue/GDGT-2348/be-support-for-zip-upload-instead-of-git