### PR TITLE
Fix release-tag.yml after release-channel removal (DEV-1864)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -291,8 +291,8 @@ jobs:
         git tag -f ${{ inputs.tag_name }} ${{ needs.check-version.outputs.oss }}
         git push origin tag -f ${{ inputs.tag_name }}
 
-  update-version-info:
-    if: ${{ !inputs.dot-x-tag }}
+  update-version-info-latest:
+    if: ${{ inputs.tag_name == 'latest' }} # only update version-info.json for the 'latest' tag
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     needs: check-version
     timeout-minutes: 5
@@ -315,11 +315,9 @@ jobs:
           .github
     - name: Prepare release scripts
       uses: ./.github/actions/prepare-release-scripts
-    - name: Generate new version info
+    - name: Update latest in version-info.json
       uses: actions/github-script@v7
-      id: new_version_info
       with:
-        result-encoding: string
         script: | # js
           const { updateVersionInfoLatest } = require('${{ github.workspace }}/release/dist/index.cjs');
           const fs = require('fs');

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -321,7 +321,7 @@ jobs:
       with:
         result-encoding: string
         script: | # js
-          const { updateVersionInfoChannel } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { updateVersionInfoLatest } = require('${{ github.workspace }}/release/dist/index.cjs');
           const fs = require('fs');
 
           const edition = '${{ matrix.edition }}';
@@ -330,8 +330,7 @@ jobs:
             ? '${{ needs.check-version.outputs.ee }}'
             : '${{ needs.check-version.outputs.oss }}';
 
-          const newVersionInfo = await updateVersionInfoChannel({
-            channel: '${{ inputs.tag_name }}',
+          const newVersionInfo = await updateVersionInfoLatest({
             newVersion: canonical_version,
             rollout: ${{ inputs.tag_rollout }},
           });

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -126,3 +126,23 @@ export async function getVersionInfo({
 
   return newVersionJson;
 }
+
+// for promoting a released version to `latest` in version-info.json
+export async function updateVersionInfoLatest({
+  newVersion,
+  rollout = 100,
+}: {
+  newVersion: string;
+  rollout?: number;
+}) {
+  const url = getVersionInfoUrl(newVersion);
+  const existingFile = (await fetch(url).then(r =>
+    r.json(),
+  )) as VersionInfoFile;
+
+  return updateVersionInfoLatestJson({
+    newLatestVersion: newVersion,
+    existingVersionInfo: existingFile,
+    rollout,
+  });
+}

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -1,5 +1,14 @@
+import fetch from "node-fetch";
+
 import type { VersionInfoFile } from "./types";
-import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoLatestJson } from "./version-info";
+import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoLatest, updateVersionInfoLatestJson } from "./version-info";
+
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockFetch = jest.mocked(fetch);
 
 describe("version-info", () => {
   describe("generateVersionInfoJson", () => {
@@ -232,6 +241,86 @@ describe("version-info", () => {
         highlights: ["Old Issue 1", "Old Issue 2"],
         // no rollout
       });
+    });
+  });
+
+  describe("updateVersionInfoLatest", () => {
+    const existingFile = {
+      latest: {
+        version: "v0.2.4",
+        released: "2022-01-01",
+        patch: true,
+        highlights: ["Old Issue 1"],
+      },
+      older: [
+        {
+          version: "v0.2.5",
+          released: "2023-01-01",
+          patch: true,
+          highlights: ["New Issue"],
+        },
+      ],
+    } as VersionInfoFile;
+
+    beforeEach(() => {
+      process.env.AWS_S3_STATIC_BUCKET = "my.metabase.com";
+      process.env.AWS_REGION = "us-north-9";
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({
+        json: async () => existingFile,
+      } as Awaited<ReturnType<typeof fetch>>);
+    });
+
+    it("fetches the OSS version-info.json for a v0.* version", async () => {
+      await updateVersionInfoLatest({ newVersion: "v0.2.5" });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://my.metabase.com.s3.us-north-9.amazonaws.com/version-info.json",
+      );
+    });
+
+    it("fetches the EE version-info-ee.json for a v1.* version", async () => {
+      const eeFile = {
+        latest: { ...existingFile.latest, version: "v1.2.4" },
+        older: [{ ...existingFile.older[0], version: "v1.2.5" }],
+      } as VersionInfoFile;
+      mockFetch.mockResolvedValue({
+        json: async () => eeFile,
+      } as Awaited<ReturnType<typeof fetch>>);
+
+      await updateVersionInfoLatest({ newVersion: "v1.2.5" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://my.metabase.com.s3.us-north-9.amazonaws.com/version-info-ee.json",
+      );
+    });
+
+    it("promotes the new version to latest via updateVersionInfoLatestJson", async () => {
+      const result = await updateVersionInfoLatest({
+        newVersion: "v0.2.5",
+        rollout: 42,
+      });
+
+      expect(result.latest).toEqual({
+        version: "v0.2.5",
+        released: "2023-01-01",
+        patch: true,
+        highlights: ["New Issue"],
+        rollout: 42,
+      });
+      expect(result.older).toContainEqual({
+        version: "v0.2.4",
+        released: "2022-01-01",
+        patch: true,
+        highlights: ["Old Issue 1"],
+      });
+    });
+
+    it("defaults rollout to 100 when omitted", async () => {
+      const result = await updateVersionInfoLatest({ newVersion: "v0.2.5" });
+
+      expect(result.latest.rollout).toEqual(100);
     });
   });
 


### PR DESCRIPTION
The `update-version-info` job in release-tag.yml required `updateVersionInfoChannel`, which was removed alongside the rest of the release-channel CI infra. `tag_name` is now effectively always `latest`, so add a small async wrapper `updateVersionInfoLatest` that fetches the live version-info.json and delegates to the surviving `updateVersionInfoLatestJson`, and point the workflow at it.



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
