### PR TITLE
Reject invalid queries for admins on impersonated DBs

### DIFF
--- a/e2e/test/scenarios/admin/database-routing/database-routing-usage.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-usage.cy.spec.ts
@@ -393,7 +393,16 @@ describe("admin > database > database routing", { tags: ["@external"] }, () => {
       });
 
       signInAs(DB_ROUTER_USERS.userA);
-      H.visitQuestion(questionId);
+      const alias = "cardQuery" + questionId;
+      const metadataAlias = `${alias}-queryMetadata`;
+      cy.intercept("POST", `/api/card/**/${questionId}/query`).as(alias);
+      cy.intercept("GET", `/api/card/**/${questionId}/query_metadata`).as(
+        metadataAlias,
+      );
+      cy.visit(`/question/${questionId}`);
+      // Longer timeout: first impersonation validation triggers cold Python context init
+      cy.wait("@" + metadataAlias, { timeout: 30000 });
+      cy.wait("@" + alias, { timeout: 30000 });
       cy.get('[data-column-id="name"]').should("contain", "destination_one");
       cy.get('[data-column-id="color"]').should("contain", "blue");
       cy.get('[data-column-id="color"]').should("not.contain", "red");

--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -10,19 +10,26 @@
    [metabase.util.i18n :refer [tru]]))
 
 (defenterprise apply-impersonation
-  "Pre-processing middleware. Adds a key to the query. Currently used solely for caching."
+  "Pre-processing middleware. Validates that native queries on impersonated databases are single SELECT statements,
+  and adds an impersonation role key to the query for non-admin users. Currently used solely for caching."
   ;; run this even when the `:advanced-permissions` feature is not enabled, so that we can assert that it *is* enabled
   ;; if impersonation is configured. (Throwing here is better than silently ignoring the configured impersonation.)
   :feature :none
   [query]
-  (if-let [role (when-not qp.i/*skip-middleware-because-app-db-access*
-                  (impersonation.driver/connection-impersonation-role
-                   (lib.metadata/database (qp.store/metadata-provider))))]
-    (do
-      (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
-      (-> (driver/validate-impersonated-query driver/*driver* query)
-          (assoc :impersonation/role role)))
-    query))
+  (if qp.i/*skip-middleware-because-app-db-access*
+    query
+    (let [database              (lib.metadata/database (qp.store/metadata-provider))
+          impersonation-enabled? (impersonation.driver/impersonation-enabled-for-db? database)
+          role                  (impersonation.driver/connection-impersonation-role database)]
+      (cond-> query
+        ;; Validate for ALL users if impersonation is configured on this DB
+        impersonation-enabled?
+        (as-> q
+              (do (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
+                  (driver/validate-impersonated-query driver/*driver* q)))
+        ;; Only assign the role for non-admin impersonated users
+        role
+        (assoc :impersonation/role role)))))
 
 (defenterprise apply-impersonation-postprocessing
   "Post-processing middleware. Binds the dynamic var"

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -971,3 +971,47 @@
                       "SET ROLE NONE; DROP TABLE table"
                       "SELECT set_config('role', 'none', false); DROP TABLE table"
                       "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;")))))))))))
+
+(deftest reject-non-select-statements-for-admin-on-impersonated-db-test
+  (testing "Admin users are also validated on impersonated databases"
+    (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+              role-a (u/lower-case-en (mt/random-name))]
+          (tx/with-temp-roles! driver/*driver*
+            (impersonation-granting-details driver/*driver* (mt/db))
+            {role-a {venues-table {}}}
+            (impersonation-default-user driver/*driver*)
+            (impersonation-default-role driver/*driver*)
+            (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                     :details (impersonation-details driver/*driver* (mt/db))}]
+              (mt/with-db database
+                (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                  (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                (sync/sync-database! database {:scan :schema})
+                (impersonation.util-test/with-impersonations-for-user! :crowberto
+                  {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                   :attributes     {"impersonation_attr" role-a}}
+                  (testing "A single SELECT statement works for admin"
+                    (let [mp (mt/metadata-provider)
+                          run-native-query (fn [table] (->> (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                                                                (lib/aggregate (lib/count)))
+                                                            (qp.compile/compile-with-inline-parameters)
+                                                            :query
+                                                            (lib/native-query mp)
+                                                            (qp/process-query)
+                                                            (mt/rows)))]
+                      (is (= [[100]] (run-native-query :venues)))))
+                  (testing "Invalid queries are rejected for admin too"
+                    (are [sql] (thrown?
+                                java.lang.Exception
+                                (-> (lib/native-query (mt/metadata-provider) sql)
+                                    (qp/process-query)
+                                    (mt/rows)))
+                      "SELECT ("
+                      "SELECT 1; SELECT 2"
+                      "SET ROLE NONE"
+                      "DROP TABLE table"
+                      "SET ROLE NONE; DROP TABLE table"
+                      "SELECT set_config('role', 'none', false); DROP TABLE table"
+                      "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;")))))))))))

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -14,6 +14,7 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.lib.util :as lib.util]
+   [metabase.query-processor.error-type :as qp.error-type]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -255,7 +256,8 @@
                         (if is-single-select?
                           (assoc stage :native sql)
                           (throw (ex-info (tru "Invalid impersonated native query. Must be a single select statement.")
-                                          {:sql (:native stage)}))))
+                                          {:type qp.error-type/invalid-query
+                                           :sql  (:native stage)}))))
                       stage))
                   stages))))
 

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -251,13 +251,17 @@
                     (if (lib.util/native-stage? stage)
                       (let [{:keys [is-single-select? sql error]}
                             (sql-tools/is-single-select-stmt? driver (:native stage))]
-                        (when error
-                          (log/warnf "Failed to parse native query: %s\n: Query: %s" error (:native stage)))
-                        (if is-single-select?
-                          (assoc stage :native sql)
-                          (throw (ex-info (tru "Invalid impersonated native query. Must be a single select statement.")
-                                          {:type qp.error-type/invalid-query
-                                           :sql  (:native stage)}))))
+                        (cond error
+                              (do
+                                (log/warnf "Failed to parse native query: %s\n: Query: %s" error (:native stage))
+                                (throw (ex-info (tru "Unable to parse native query. There might be something wrong with your query.")
+                                                {:type qp.error-type/invalid-query
+                                                 :sql  (:native stage)})))
+                              (not is-single-select?)
+                              (throw (ex-info (tru "Invalid impersonated native query. Must be a single select statement.")
+                                              {:type qp.error-type/invalid-query
+                                               :sql  (:native stage)}))
+                              :else (assoc stage :native sql)))
                       stage))
                   stages))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/72858

### Description

We were only rejecting non-select statements for impersonated users. A query that is accepted by the actual DB might not be accepted by the parser. So it would succeed for an admin user, but not for the impersonated user. This PR makes it so that we parse the query for any impersonated database so that the behaviour is consistent for admin and impersonated users. 

### How to verify

1. Connect to a redshift database
2. Set up impersonation on it
3. Try to execute `select 1;;` as the admin and impersonated user, both queries should error.

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
