### PR TITLE
Re-infer result_metadata when stored metadata is stripped

### DIFF
--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -224,9 +224,13 @@ saved later when it is ready."
            (log/debug "Not inferring result metadata for Card: query was not updated")
            card)
 
-         ;; passing in metadata => use that metadata, but replace any placeholder idents in it.
-         (or (and (not-empty changes) (contains? changes :result_metadata))
-             (and (empty? changes) metadata))
+         ;; passing in non-nil metadata => use that metadata, but replace any placeholder idents in it.
+         ;; if the provided metadata is `nil` (for example, because `normalize-card` silently stripped invalid
+         ;; stored metadata earlier in `before-insert`/`before-update`), fall through to inference instead of
+         ;; persisting the `nil`.
+         (and (some? metadata)
+              (or (and (not-empty changes) (contains? changes :result_metadata))
+                  (empty? changes)))
          (do
            (log/debug "Not inferring result metadata for Card: metadata was passed in to insert!/update!")
            card)


### PR DESCRIPTION
## Summary

Branch 2 of `populate-result-metadata` ("caller provided metadata, trust it") short-circuits even when the provided `:result_metadata` is `nil` after normalization. When `queries.schema/normalize-card` silently nulls a Card's `:result_metadata` because a column failed `::lib.schema.metadata/lib-or-legacy-column` validation, a subsequent update flow would persist the `nil` to the DB — overwriting whatever valid metadata was already there.

This PR tightens branch 2 to require non-nil metadata. If the provided metadata is `nil` after normalization, we fall through to the inference branch (branch 4) and recompute from the query. Native queries continue to land on branch 3 (nil metadata is the correct outcome for them).

## Background

Discovered while investigating a CI failure in `audit-db-installation-test` on #71386 where `tenants_with_most_views` was being stored with `:result_metadata nil`. The symptom was reproducible locally with a REPL trace:

- Serdes processed the card **twice**: once via `load-insert!`, once via `load-update!` (because it's also referenced as a dependency from another entity in the bundle).
- `load-insert!` path: `normalize-card` nulled the YAML's invalid `:result_metadata`, `populate-result-metadata` branch 4 inferred 4 valid columns, insert wrote them. ✅
- `load-update!` path: same YAML came in with `:result_metadata` in `changes`, `normalize-card` nulled it again, `populate-result-metadata` branch 2 fired ("trust the caller"), returned the card unchanged with `:result_metadata nil`, update overwrote the 4 valid columns with `NULL`. ❌

The root cause in the YAML was a `:field_ref [:aggregation 0]` that `serdes/import-mbql` rewrites into MBQL-5 form `[:aggregation {:lib/uuid "..."}]`, dropping the aggregation index and failing the legacy-column schema. The feature branch addressed that in the YAML directly (#71386 commit 1999e70c7ff). This PR fixes the underlying resilience issue so any future card with invalid stored metadata will self-heal via inference instead of silently writing `NULL`.

## Design notes

- Branch 3 (native) is unchanged: native MBQL still gets `:result_metadata nil` because the QP can't infer columns without executing the query.
- Branch 4 (inference) is unchanged: same `infer-metadata-with-model-overrides` call, same `u/ignore-exceptions` swallow-to-nil fallback.
- The change only affects the case where normalize-card stripped invalid metadata. Cards with valid metadata continue to take branch 2 as before.

## Test plan

- [x] `./bin/test-agent :only '[metabase.queries.models.card-test metabase.queries.models.card.metadata-test]'` — 79 tests, 227 assertions, green.
- [x] `./bin/test-agent :only '[metabase-enterprise.audit-app.audit-test]'` — all green with the code fix alone (YAML on feature branch left with the invalid block) proving the fix recovers without needing the data-side workaround.
- [x] `./bin/test-agent :only '[metabase-enterprise.serialization.v2.round-trip-test metabase-enterprise.serialization.v2.extract-test]'` — 58 tests, 464 assertions, green.
- [ ] CI full suite.

## Scope

This is a standalone fix. Marking as draft to give it a separate review cycle from the feature branch that surfaced it.