### PR TITLE
Added tests for remote sync env variable support

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/init.clj
@@ -46,7 +46,7 @@
           (when (str/blank? branch)
             (throw (ex-info "Remote sync is enabled with read-only type, but no branch is set." {})))
           (when (remote-sync.object/dirty?)
-            (if (str/includes? (settings/remote-sync-allow) "overwrite-unpublished")
+            (if (some-> (settings/remote-sync-allow) (str/includes? "overwrite-unpublished"))
               (impl/async-import! branch true {})
               (throw (ex-info "Remote sync is enabled with read-only type, but there are unpublished changes. To force an overwrite, set `MB_REMOTE_SYNC_ALLOW=overwrite-unpublished`" {}))))))
 

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/init_test.clj
@@ -1,0 +1,102 @@
+(ns metabase-enterprise.remote-sync.init-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.remote-sync.impl :as impl]
+   [metabase-enterprise.remote-sync.init :as init]
+   [metabase-enterprise.remote-sync.models.remote-sync-object :as remote-sync.object]
+   [metabase.collections.models.collection :as collection]
+   [metabase.test :as mt]))
+
+(defn- capture-async-import! []
+  (let [calls (atom [])]
+    [calls (fn [branch force? args] (swap! calls conj [branch force? args]) nil)]))
+
+(deftest remote-sync-init-disabled-with-remote-synced-collection-clears-test
+  (testing "When remote sync is disabled, existing remote-synced collections are cleared"
+    (mt/with-temporary-setting-values [:remote-sync-url nil
+                                       :remote-sync-type nil
+                                       :remote-sync-branch nil]
+      (mt/with-temp [:model/Collection _ {:name "Synced" :is_remote_synced true}]
+        (is (true? (collection/has-remote-synced-collection?)))
+        (#'init/remote-sync-init)
+        (is (false? (collection/has-remote-synced-collection?)))))))
+
+(deftest remote-sync-init-disabled-without-remote-synced-collection-is-noop-test
+  (testing "When remote sync is disabled and no remote-synced collection exists, nothing happens"
+    (mt/with-temporary-setting-values [:remote-sync-url nil]
+      (let [[calls capture] (capture-async-import!)]
+        (with-redefs [impl/async-import! capture]
+          (#'init/remote-sync-init)
+          (is (empty? @calls)))))))
+
+(deftest remote-sync-init-read-only-without-branch-throws-test
+  (testing "Read-only with enabled sync but no branch throws"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-only
+                                       :remote-sync-branch nil]
+      (with-redefs [remote-sync.object/dirty? (constantly false)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"no branch is set"
+                              (#'init/remote-sync-init)))))))
+
+(deftest remote-sync-init-read-only-dirty-without-allow-throws-test
+  (testing "Read-only with dirty unpublished changes throws unless override is set"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-only
+                                       :remote-sync-branch "main"
+                                       :remote-sync-allow nil]
+      (with-redefs [remote-sync.object/dirty? (constantly true)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"unpublished changes"
+                              (#'init/remote-sync-init)))))))
+
+(deftest remote-sync-init-read-only-dirty-with-allow-imports-test
+  (testing "Read-only with dirty unpublished changes plus overwrite-unpublished override triggers import"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-only
+                                       :remote-sync-branch "main"
+                                       :remote-sync-allow "overwrite-unpublished"]
+      (let [[calls capture] (capture-async-import!)]
+        (with-redefs [remote-sync.object/dirty? (constantly true)
+                      impl/async-import! capture]
+          (mt/with-temp [:model/Collection _ {:name "Synced" :is_remote_synced true}]
+            (#'init/remote-sync-init)
+            (is (= [["main" true {}]] @calls))))))))
+
+(deftest remote-sync-init-no-remote-synced-collection-imports-test
+  (testing "When remote sync is enabled but no remote-synced collection exists, import is triggered"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-only
+                                       :remote-sync-branch "develop"
+                                       :remote-sync-allow nil]
+      (let [[calls capture] (capture-async-import!)]
+        (with-redefs [remote-sync.object/dirty? (constantly false)
+                      impl/async-import! capture]
+          ;; Make sure no remote-synced collection exists for the test
+          (collection/clear-remote-synced-collection!)
+          (#'init/remote-sync-init)
+          (is (= [["develop" true {}]] @calls)))))))
+
+(deftest remote-sync-init-no-branch-warns-but-does-not-throw-test
+  (testing "When remote sync is enabled (read-write) but no branch, no import happens, no throw"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-write
+                                       :remote-sync-branch nil]
+      (let [[calls capture] (capture-async-import!)]
+        (with-redefs [remote-sync.object/dirty? (constantly false)
+                      impl/async-import! capture]
+          (collection/clear-remote-synced-collection!)
+          (#'init/remote-sync-init)
+          (is (empty? @calls)))))))
+
+(deftest remote-sync-init-enabled-with-remote-synced-collection-no-import-test
+  (testing "When a remote-synced collection already exists, no automatic import is triggered"
+    (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"
+                                       :remote-sync-type :read-write
+                                       :remote-sync-branch "main"]
+      (let [[calls capture] (capture-async-import!)]
+        (with-redefs [remote-sync.object/dirty? (constantly false)
+                      impl/async-import! capture]
+          (mt/with-temp [:model/Collection _ {:name "Synced" :is_remote_synced true}]
+            (#'init/remote-sync-init)
+            (is (empty? @calls))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
@@ -137,6 +137,42 @@
 
 ;;; ------------------------------------------------- Root Collection Remote Sync -------------------------------------------------
 
+(deftest check-and-update-remote-settings-env-var-aware-test
+  (testing "Settings sourced from env vars are not overwritten by check-and-update-remote-settings!"
+    (with-redefs [settings/check-git-settings! (constantly true)]
+      (mt/with-temp-env-var-value! [mb-remote-sync-url "file://env/url.git"
+                                    mb-remote-sync-token "env-token"
+                                    mb-remote-sync-branch "env-branch"]
+        (testing "Updating URL, token, and branch via API has no effect when sourced from env"
+          (settings/check-and-update-remote-settings!
+           {:remote-sync-url    "file://api/url.git"
+            :remote-sync-token  "api-token"
+            :remote-sync-branch "api-branch"
+            :remote-sync-type   :read-only})
+          (is (= "file://env/url.git" (settings/remote-sync-url)))
+          (is (= "env-token" (settings/remote-sync-token)))
+          (is (= "env-branch" (settings/remote-sync-branch))))
+        (testing "Clearing URL (blank) does not wipe env-backed URL/token/branch"
+          (settings/check-and-update-remote-settings! {:remote-sync-url ""})
+          (is (= "file://env/url.git" (settings/remote-sync-url)))
+          (is (= "env-token" (settings/remote-sync-token)))
+          (is (= "env-branch" (settings/remote-sync-branch)))))))
+
+  (testing "Non-env-sourced settings are still updated normally"
+    (with-redefs [settings/check-git-settings! (constantly true)]
+      (mt/with-temporary-setting-values [:remote-sync-url nil
+                                         :remote-sync-token nil
+                                         :remote-sync-branch nil
+                                         :remote-sync-type nil]
+        (settings/check-and-update-remote-settings!
+         {:remote-sync-url    "file://api/url.git"
+          :remote-sync-token  "api-token"
+          :remote-sync-branch "api-branch"
+          :remote-sync-type   :read-only})
+        (is (= "file://api/url.git" (settings/remote-sync-url)))
+        (is (= "api-token" (settings/remote-sync-token)))
+        (is (= "api-branch" (settings/remote-sync-branch)))))))
+
 (deftest root-collection-is-not-remote-synced-test
   (testing "Root collection for shared-tenant-collection namespace is never remote-synced (individual children can be toggled)"
     (let [root-coll (collection.root/root-collection-with-ui-details :shared-tenant-collection)]

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1804,6 +1804,18 @@
             (is (= initial-perms-count final-perms-count)
                 "No new permissions should be created for collections inside personal collections")))))))
 
+(deftest has-remote-synced-collection?-test
+  (testing "Returns false when no remote-synced collections exist"
+    (collection/clear-remote-synced-collection!)
+    (is (false? (collection/has-remote-synced-collection?))))
+  (testing "Returns true when at least one remote-synced collection exists"
+    (mt/with-temp [:model/Collection _ {:name "Synced" :is_remote_synced true}]
+      (is (true? (collection/has-remote-synced-collection?)))))
+  (testing "Returns false after clearing remote-synced collections"
+    (mt/with-temp [:model/Collection _ {:name "Synced" :is_remote_synced true}]
+      (collection/clear-remote-synced-collection!)
+      (is (false? (collection/has-remote-synced-collection?))))))
+
 (deftest non-remote-synced-dependencies-no-dependencies-test
   (testing "when model has no dependencies"
     (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:name "Remote-Synced Collection" :is_remote_synced true}

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1927,3 +1927,21 @@
     (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "ENV_PRIMARY"]
       (with-setting-row-in-db [:old-test-setting-name "DB_LEGACY"]
         (is (= "ENV_PRIMARY" (test-setting-with-deprecated-name)))))))
+
+(deftest get-raw-value-source-test
+  (testing "Returns :default when only the default is set"
+    (mt/with-temporary-setting-values [test-setting-2 nil]
+      (is (= :default (setting/get-raw-value-source :test-setting-2)))))
+  (testing "Returns nil when no value is available from any source"
+    (mt/with-temporary-setting-values [test-setting-1 nil]
+      (is (nil? (setting/get-raw-value-source :test-setting-1)))))
+  (testing "Returns :database when set via the database"
+    (mt/with-temporary-setting-values [test-setting-1 "DB_VALUE"]
+      (is (= :database (setting/get-raw-value-source :test-setting-1)))))
+  (testing "Returns :env when provided via env var"
+    (mt/with-temp-env-var-value! [mb-test-setting-1 "ENV_VALUE"]
+      (is (= :env (setting/get-raw-value-source :test-setting-1)))))
+  (testing "Env var takes precedence over database value"
+    (mt/with-temporary-setting-values [test-setting-1 "DB_VALUE"]
+      (mt/with-temp-env-var-value! [mb-test-setting-1 "ENV_VALUE"]
+        (is (= :env (setting/get-raw-value-source :test-setting-1)))))))


### PR DESCRIPTION
### Description

Adds tests for changes in #68583

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
