### PR TITLE
Metrics Viewer bug fixes

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopoverContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopoverContent.tsx
@@ -113,7 +113,7 @@ export function FilterPopoverContent({
       return null;
     }
     return (
-      <Box w={FILTER_WIDTH}>
+      <Box miw={FILTER_WIDTH}>
         <FilterPickerBody
           definition={selected.definition}
           dimension={navState.dimension}

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -24,8 +24,11 @@ import type {
 import { getProjectionInfo } from "../../../utils/definition-builder";
 import type { DimensionFilterValue } from "../../../utils/dimension-filters";
 import type { MetricSlot } from "../../../utils/metric-slots";
-import { buildDimensionItemsFromDefinitions } from "../../../utils/series";
-import { DISPLAY_TYPE_REGISTRY, getTabConfig } from "../../../utils/tab-config";
+import {
+  buildDimensionItemsFromDefinitions,
+  shouldShowStackSeries,
+} from "../../../utils/series";
+import { getTabConfig } from "../../../utils/tab-config";
 import { DimensionPillBar } from "../../DimensionPillBar";
 import { MetricControls } from "../../MetricControls";
 import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
@@ -181,8 +184,12 @@ export function MetricsViewerTabContent({
     [updateProjectionConfig],
   );
 
-  const showStackSeries =
-    DISPLAY_TYPE_REGISTRY[tab.display].supportsStacking && rawSeries.length > 1;
+  const showStackSeries = shouldShowStackSeries(
+    tab.display,
+    rawSeries,
+    formulaEntities,
+    definitions,
+  );
 
   const isTimeTab = tab.type === "time";
 

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -59,6 +59,23 @@ import { nextSyntheticCardId, parseSourceId } from "./source-ids";
 import { DISPLAY_TYPE_REGISTRY } from "./tab-config";
 import { getDimensionIcon } from "./tabs";
 
+export function shouldShowStackSeries(
+  display: MetricsViewerDisplayType,
+  rawSeries: SingleSeries[],
+  formulaEntities: MetricsViewerFormulaEntity[],
+  definitions: Record<MetricSourceId, MetricsViewerDefinitionEntry>,
+): boolean {
+  const hasBreakout = formulaEntities.some(
+    (entity) =>
+      isMetricEntry(entity) &&
+      entryHasBreakout(getEffectiveDefinitionEntry(entity, definitions)),
+  );
+  return (
+    DISPLAY_TYPE_REGISTRY[display].supportsStacking &&
+    (rawSeries.length > 1 || hasBreakout)
+  );
+}
+
 interface BuildSeriesParams {
   formulaEntities: MetricsViewerFormulaEntity[];
   definitions: Record<MetricSourceId, MetricsViewerDefinitionEntry>;

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -28,6 +28,7 @@ import {
   buildDimensionItemsFromDefinitions,
   computeSourceBreakoutColors,
   getSelectedMetricsInfo,
+  shouldShowStackSeries,
   splitByBreakout,
 } from "./series";
 
@@ -679,5 +680,61 @@ describe("buildDimensionItemsFromDefinitions", () => {
       expect(expressionItem.icon).toBeUndefined();
       expect(expressionItem.metricSources).toHaveLength(2);
     });
+  });
+});
+
+describe("shouldShowStackSeries", () => {
+  const metricMeta = createMetricMetadata([REVENUE_METRIC]);
+
+  const metricEntity: MetricsViewerFormulaEntity = {
+    id: "metric:1" as MetricSourceId,
+    type: "metric",
+    definition: null,
+  };
+
+  const oneSeries = [createMockSingleSeries({ name: "Series 1" })];
+  const twoSeries = [
+    createMockSingleSeries({ name: "Series 1" }),
+    createMockSingleSeries({ name: "Series 2" }),
+  ];
+
+  function makeDefinitions(withBreakout: boolean) {
+    const definition = withBreakout
+      ? setupDefinitionWithBreakout(metricMeta, REVENUE_METRIC.id, 0)
+      : setupDefinition(metricMeta, REVENUE_METRIC.id);
+    return {
+      ["metric:1" as MetricSourceId]: {
+        id: "metric:1" as MetricSourceId,
+        definition,
+      },
+    };
+  }
+
+  it("returns false when the display does not support stacking", () => {
+    const definitions = makeDefinitions(false);
+    expect(
+      shouldShowStackSeries("map", twoSeries, [metricEntity], definitions),
+    ).toBe(false);
+  });
+
+  it("returns false when the display supports stacking but there is one series and no breakout", () => {
+    const definitions = makeDefinitions(false);
+    expect(
+      shouldShowStackSeries("line", oneSeries, [metricEntity], definitions),
+    ).toBe(false);
+  });
+
+  it("returns true when there are multiple raw series", () => {
+    const definitions = makeDefinitions(false);
+    expect(
+      shouldShowStackSeries("line", twoSeries, [metricEntity], definitions),
+    ).toBe(true);
+  });
+
+  it("returns true when there is one raw series but the metric has a breakout", () => {
+    const definitions = makeDefinitions(true);
+    expect(
+      shouldShowStackSeries("line", oneSeries, [metricEntity], definitions),
+    ).toBe(true);
   });
 });

--- a/frontend/src/metabase/metrics-viewer/utils/tabs.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tabs.ts
@@ -39,7 +39,10 @@ export function getDimensionIcon(dimension: DimensionMetadata): IconName {
   if (LibMetric.isDateOrDateTime(dimension) || LibMetric.isTime(dimension)) {
     return "calendar";
   }
-  if (LibMetric.isCategory(dimension)) {
+  if (
+    LibMetric.isCategory(dimension) ||
+    LibMetric.isStringOrStringLike(dimension)
+  ) {
     return "string";
   }
   if (LibMetric.isNumeric(dimension) || LibMetric.isCoordinate(dimension)) {
@@ -416,7 +419,12 @@ function collectUniqueExactDimensions(
   type: MetricsViewerTabType,
 ): Map<
   string,
-  { displayName: string; slotIndices: number[]; canListValues: boolean }
+  {
+    displayName: string;
+    slotIndices: number[];
+    canListValues: boolean;
+    isPreferred: boolean | undefined;
+  }
 > {
   const unique = new Map<
     string,
@@ -424,6 +432,7 @@ function collectUniqueExactDimensions(
       displayName: string;
       slotIndices: number[];
       canListValues: boolean;
+      isPreferred: boolean | undefined;
     }
   >();
 
@@ -449,6 +458,7 @@ function collectUniqueExactDimensions(
           displayName: info.displayName,
           slotIndices: [slotIndex],
           canListValues: info.canListValues ?? false,
+          isPreferred: info.isPreferred,
         });
       }
     }
@@ -514,14 +524,16 @@ export function computeDefaultTabs(
       config.type,
     );
 
-    const sortedDimensions = [...uniqueDimensions.entries()].sort(
-      ([, infoA], [, infoB]) => {
-        if (infoA.canListValues === infoB.canListValues) {
-          return 0;
-        }
-        return infoA.canListValues ? -1 : 1;
-      },
+    const filteredDimensions = [...uniqueDimensions.entries()].filter(
+      ([, info]) => info.isPreferred !== false, // undefined is okay - means there is no preferred predicate
     );
+
+    const sortedDimensions = filteredDimensions.sort(([, infoA], [, infoB]) => {
+      if (infoA.canListValues === infoB.canListValues) {
+        return 0;
+      }
+      return infoA.canListValues ? -1 : 1;
+    });
 
     for (const [
       dimensionId,

--- a/frontend/src/metabase/metrics-viewer/utils/tabs.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tabs.unit.spec.ts
@@ -1,9 +1,17 @@
+import type { MetricSourceId } from "../types/viewer-state";
+
+import {
+  createMetricMetadata,
+  createMockMetricDimension,
+  createMockNormalizedMetric,
+  setupDefinition,
+} from "./__tests__/test-helpers";
 import type {
   AvailableDimension,
   AvailableDimensionsResult,
 } from "./dimension-picker";
 import { buildDimensionPickerSections } from "./dimension-picker";
-import { resolveCommonTabLabel } from "./tabs";
+import { computeDefaultTabs, resolveCommonTabLabel } from "./tabs";
 
 describe("resolveCommonTabLabel", () => {
   it("returns null for empty array", () => {
@@ -34,6 +42,40 @@ describe("resolveCommonTabLabel", () => {
     expect(resolveCommonTabLabel(["Created At", "Order Date"])).toBe(
       "Created At",
     );
+  });
+});
+
+describe("computeDefaultTabs", () => {
+  const CATEGORY_SELECTION_METRIC = createMockNormalizedMetric({
+    id: 101,
+    name: "Category Selection",
+    dimensions: [
+      createMockMetricDimension({
+        id: "dim-category",
+        display_name: "Category",
+        effective_type: "type/Text",
+        semantic_type: "type/Category",
+      }),
+      createMockMetricDimension({
+        id: "dim-status",
+        display_name: "Status",
+        effective_type: "type/Text",
+        semantic_type: null,
+      }),
+    ],
+  });
+
+  const sourceId: MetricSourceId = `metric:${CATEGORY_SELECTION_METRIC.id}`;
+  const metadata = createMetricMetadata([CATEGORY_SELECTION_METRIC]);
+  const definition = setupDefinition(metadata, CATEGORY_SELECTION_METRIC.id);
+
+  it("only auto-creates category tabs for preferred category dimensions", () => {
+    const tabs = computeDefaultTabs({ [sourceId]: definition }, [
+      { slotIndex: 0, entityIndex: 0, sourceId },
+    ]);
+
+    // Status should not be included because it's not preferred
+    expect(tabs.map((tab) => tab.label)).toEqual(["Category", "Totals"]);
   });
 });
 

--- a/frontend/src/metabase/metrics/common/utils/dimension-descriptors.ts
+++ b/frontend/src/metabase/metrics/common/utils/dimension-descriptors.ts
@@ -6,7 +6,10 @@ import type {
 import * as LibMetric from "metabase-lib/metric";
 
 import type { DimensionType } from "./dimension-types";
-import { getDimensionType } from "./dimension-types";
+import {
+  PREFERRED_DIMENSION_PREDICATES,
+  getDimensionType,
+} from "./dimension-types";
 
 export interface DimensionDescriptor {
   dimensionMetadata: DimensionMetadata;
@@ -17,6 +20,7 @@ export interface DimensionDescriptor {
   group?: DimensionGroup;
   isDefault: boolean;
   canListValues: boolean;
+  isPreferred?: boolean;
 }
 
 const dimensionDescriptorCache = new WeakMap<
@@ -48,6 +52,9 @@ export function getDimensionDescriptors(
       continue;
     }
 
+    const isPreferred =
+      PREFERRED_DIMENSION_PREDICATES[dimensionType]?.(dimension);
+
     const valuesInfo = LibMetric.dimensionValuesInfo(definition, dimension);
     const displayInfo = LibMetric.displayInfo(definition, dimension);
     if (!valuesInfo.id || result.has(valuesInfo.id)) {
@@ -63,6 +70,7 @@ export function getDimensionDescriptors(
       group: displayInfo.group,
       isDefault: defaultDimensionIds.has(valuesInfo.id),
       canListValues: valuesInfo.canListValues,
+      isPreferred,
     });
   }
 

--- a/frontend/src/metabase/metrics/common/utils/dimension-types.ts
+++ b/frontend/src/metabase/metrics/common/utils/dimension-types.ts
@@ -34,14 +34,25 @@ export const DIMENSION_PREDICATES: Record<DimensionType, DimensionPredicate> = {
   time: LibMetric.isDateOrDateTime,
   geo: isGeoDimension,
   category: (dimension) =>
-    LibMetric.isCategory(dimension) &&
+    (LibMetric.isCategory(dimension) ||
+      LibMetric.isStringOrStringLike(dimension)) &&
     !isGeoDimension(dimension) &&
-    !LibMetric.isBoolean(dimension),
+    !LibMetric.isBoolean(dimension) &&
+    !LibMetric.isID(dimension),
   boolean: LibMetric.isBoolean,
   numeric: (dimension) =>
     LibMetric.isNumeric(dimension) &&
     !LibMetric.isID(dimension) &&
     !LibMetric.isCoordinate(dimension),
+};
+
+export const PREFERRED_DIMENSION_PREDICATES: Partial<
+  Record<DimensionType, DimensionPredicate>
+> = {
+  category: (dimension) =>
+    LibMetric.isCategory(dimension) &&
+    !isGeoDimension(dimension) &&
+    !LibMetric.isBoolean(dimension),
 };
 
 export interface DimensionTypeEntry {

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.ts
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.ts
@@ -61,7 +61,8 @@ function pickAllOfType(
     .filter(
       (dimension) =>
         dimension.dimensionType === dimensionType &&
-        (!options?.requireListValues || dimension.canListValues),
+        (!options?.requireListValues || dimension.canListValues) &&
+        dimension.isPreferred !== false, // undefined is okay - means there is no preferred predicate
     )
     .sort((first, second) => {
       if (first.canListValues !== second.canListValues) {

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.unit.spec.ts
@@ -1,0 +1,57 @@
+import {
+  createMetricMetadata,
+  createMockMetricDimension,
+  createMockNormalizedMetric,
+  setupDefinition,
+} from "metabase/metrics-viewer/utils/__tests__/test-helpers";
+
+import { getDefaultDimensions } from "./utils";
+
+type MetricDimensionOptions = NonNullable<
+  Parameters<typeof createMockMetricDimension>[0]
+>;
+
+type MetricDimensionOptionsWithFieldValues = MetricDimensionOptions & {
+  has_field_values?: "list" | "search" | "none";
+};
+
+function createDimension(options: MetricDimensionOptionsWithFieldValues) {
+  return createMockMetricDimension(options as MetricDimensionOptions);
+}
+
+describe("getDefaultDimensions", () => {
+  const CATEGORY_SELECTION_METRIC = createMockNormalizedMetric({
+    id: 101,
+    name: "Category Selection",
+    dimensions: [
+      createDimension({
+        id: "dim-category",
+        display_name: "Category",
+        effective_type: "type/Text",
+        semantic_type: "type/Category",
+        has_field_values: "list",
+      }),
+      createDimension({
+        id: "dim-status",
+        display_name: "Status",
+        effective_type: "type/Text",
+        semantic_type: null,
+        has_field_values: "list",
+      }),
+    ],
+  });
+
+  const metadata = createMetricMetadata([CATEGORY_SELECTION_METRIC]);
+  const definition = setupDefinition(metadata, CATEGORY_SELECTION_METRIC.id);
+
+  it("only returns preferred category dimensions for overview cards", () => {
+    expect(getDefaultDimensions(definition)).toEqual([
+      {
+        dimensionId: "dim-category",
+        dimensionType: "category",
+        label: "Category",
+        // Status should not be included because it's not preferred
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes [UXW-3810: Fixed date range filter is cut off](https://linear.app/metabase/issue/UXW-3810/fixed-date-range-filter-is-cut-off)
Closes [UXW-3820: Can no longer stack series on a single metric with a breakout](https://linear.app/metabase/issue/UXW-3820/can-no-longer-stack-series-on-a-single-metric-with-a-breakout)
Closes [UXW-3766: Metrics viewer is too restrictive on categorical dimensions](https://linear.app/metabase/issue/UXW-3766/metrics-viewer-is-too-restrictive-on-categorical-dimensions)

### Description

Fixes a few bugs in the Metrics Viewer:

1. Fixed date range filter is cut off: straightforward fix, changed `width` to `min-width` in FilterPopoverContent
2. Can no longer stack series on a single metric with a breakout: show stack button if there is a breakout or multiple series - extracted this into a helper and added tests
3. Too restrictive on categorical dimensions: there's a tension between consumers. `AddDimensionPopover` and `BreakoutDimensionPicker` should show all reasonable dimensions, while `computeDefaultTabs` and `getDefaultDimensions` should be more restrictive. Previously, we were filtering dimensions to those with semantic type of Category, which is a good proxy for a dimension with low cardinality - this is appropriate for `computeDefaultTabs` but not `AddDimensionPopover`. The fix is to loosen the dimension predicate for `AddDimensionPopover` and add a concept of a "preferred" dimension that filters to Category for `computeDefaultTabs`.

### How to verify

Follow the steps in the demo

### Demo

[Demo](https://www.loom.com/share/6fd8d79c6fa7474b82ebb464ed477f8a)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
