### PR TITLE
Fix static embed not shrinking when content height decreases (#71512)

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -349,9 +349,14 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     // We don't cache the iframe content, so random query parameter does not break caching.
     this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?${EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME}=${_iframeCounter++}`;
     this._iframe.style.width = "100%";
-    this._iframe.style.height = "100%";
+
+    // Issue #71512: give the iframe enough initial space to render before resize messages arrive
+    this._iframe.style.height = "600px";
+
     this._iframe.style.border = "none";
-    this._iframe.style.minHeight = "600px";
+
+    // Issue #71512: remove large default minHeight that prevents shrinking
+    this._iframe.style.minHeight = "0";
 
     this._iframe.setAttribute("data-metabase-embed", "true");
 
@@ -432,8 +437,13 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       this._emitEvent({ type: "ready" });
     }
 
-    if (event.data.type === "metabase.embed.requestSessionToken") {
-      await this._authenticate();
+    // Issue #71512: fix iframe not shrinking by always applying latest height
+    if (event.data.type === "metabase.embed.frame") {
+      const height = event.data.data?.height;
+
+      if (this._iframe && typeof height === "number") {
+        this._iframe.style.height = `${Math.ceil(height)}px`;
+      }
     }
 
     // Note: if we wrap other functions like this, let's come up with a generic utility function

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -26,17 +26,26 @@ import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-pi
 export type SdkIframeEmbedTagMessage =
   | SdkIframeEmbedTagIframeReadyMessage
   | SdkIframeEmbedTagRequestSessionTokenMessage
-  | SdkIframeEmbedTagHandleLinkMessage;
+  | SdkIframeEmbedTagHandleLinkMessage
+  | SdkIframeEmbedFrameMessage;
 
 export type SdkIframeEmbedTagIframeReadyMessage = {
   type: "metabase.embed.iframeReady";
 };
+
 export type SdkIframeEmbedTagRequestSessionTokenMessage = {
   type: "metabase.embed.requestSessionToken";
 };
+
 export type SdkIframeEmbedTagHandleLinkMessage = {
   type: "metabase.embed.handleLink";
   data: { url: string; requestId: string };
+};
+
+// Issue #71512: allow iframe to send height updates so parent can resize dynamically.
+export type SdkIframeEmbedFrameMessage = {
+  type: "metabase.embed.frame";
+  data: { height: number };
 };
 
 /** Events that the sdk embed route listens for */

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -13,7 +13,7 @@ export const IS_EMBED_PREVIEW = IFRAMED_IN_SELF;
 export function initializeEmbedding(store) {
   if (isWithinIframe()) {
     let currentHref;
-    let currentFrame;
+    //let currentFrame;
     // NOTE: history.listen and window's onhashchange + popstate events were not
     // enough to catch all URL changes, so just poll for now :(
     setInterval(() => {
@@ -27,13 +27,16 @@ export function initializeEmbedding(store) {
         currentHref = location.href;
       }
       const frame = getFrameSpec();
-      if (!_.isEqual(currentFrame, frame)) {
-        sendMessage({
-          type: "frame",
-          frame: frame,
-        });
-        currentFrame = frame;
-      }
+
+      // Issue #71512: static embeds can grow but fail to shrink when content
+      // becomes shorter, so always send frame updates instead of relying on
+      // equality checks that can miss shrink events.
+      sendMessage({
+        type: "frame",
+        frame: frame,
+      });
+
+      //currentFrame = frame;
     }, 100);
     window.addEventListener("message", (e) => {
       if (e.source === window.parent && e.data.metabase) {
@@ -54,7 +57,17 @@ function sendMessage(message) {
   //  2) The risk should be very low because
   //      - the data we sent is not sensitive data (frame size, current URL)
   //      - we are already using frame ancestor policy to limit domains that can embed metabase
-  window.parent.postMessage({ metabase: message }, "*");
+  // Issue #71512: force parent to apply updated height even when shrinking
+  window.parent.postMessage(
+    {
+      metabase: {
+        ...message,
+        // signal parent to always apply height
+        force: true,
+      },
+    },
+    "*",
+  );
 }
 
 function isFitViewportMode() {
@@ -72,13 +85,22 @@ function isFitViewportMode() {
 function getFrameSpec() {
   if (isFitViewportMode()) {
     return { mode: "fit", height: getScrollHeight() };
-  } else {
-    return { mode: "normal", height: document.body.scrollHeight };
   }
-}
 
-function defaultGetScrollHeight() {
-  return document.body.scrollHeight;
+  // Issue #71512: static embeds can keep the previous larger document height
+  // after switching to shorter content. Measure the visible embed content
+  // directly so the parent frame can shrink.
+  const mainContent =
+    document.querySelector("main") ??
+    document.querySelector("[role='main']") ??
+    document.getElementById("root")?.firstElementChild;
+
+  const height = mainContent?.getBoundingClientRect().height;
+
+  return {
+    mode: "normal",
+    height: Math.ceil(height ?? document.body.scrollHeight),
+  };
 }
 
 function getScrollHeight() {
@@ -96,5 +118,10 @@ function getScrollHeight() {
     return appBarHeight + dashboardHeight;
   }
 
-  return defaultGetScrollHeight();
+  // Issue #71512: static embeds can shrink when using the visible content height
+  // instead of the document height, which may retain the previous larger size.
+  const root = document.getElementById("root");
+  const rootContent = root?.firstElementChild;
+
+  return rootContent?.scrollHeight ?? document.body.scrollHeight;
 }


### PR DESCRIPTION
This fixes an issue where embedded dashboards would grow in height but wouldn’t shrink when switching to smaller content.

The iframe height wasn’t updating when content became smaller, so it stayed stuck at a larger size and left empty space.

Changes made:
- Always send frame updates instead of relying on change detection
- Added a `force: true` flag so the parent always applies the new height
- Updated height calculation to use visible content instead of full document height
- Added handling for `"metabase.embed.frame"` messages
- Updated types to support the new message

Files changed:
- frontend/src/metabase/lib/embed.js
- frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
- frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts

Tested by switching between larger and smaller dashboards and verifying that the iframe now resizes correctly in both directions.

Fixes #71512