### PR TITLE
Turn off Cypress video compression

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -188,7 +188,7 @@ const defaultConfig = {
   viewportWidth: 1280,
   // enable video recording in run mode
   video: process.env["CYPRESS_VIDEO"] !== "false",
-  videoCompression: true,
+  videoCompression: false,
 };
 
 const mainConfig = {


### PR DESCRIPTION
Resolves DEV-1860

As per https://docs.cypress.io/app/guides/screenshots-and-videos#Video-encoding

> If your spec files have a long run duration and videoCompression is enabled, you might notice a time gap between a finished spec and a new spec starting during cypress run. During this time, Cypress is encoding the captured video and possibly uploading it to Cypress Cloud.

It's confirmed that the video compression adds an overhead. I'm seeing approx 30 seconds faster runs per CI group when I turn it off. Artifact size grows 3-5x so we have to keep an eye on it. There should be no other downsides.