### PR TITLE
Store MCP Apps drill-through queries in database

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpExploreButton.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpExploreButton.tsx
@@ -1,0 +1,38 @@
+import type { App } from "@modelcontextprotocol/ext-apps/react";
+import { t } from "ttag";
+
+import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import { Button, Icon } from "metabase/ui";
+import { serializedQuestion } from "metabase/utils/urls/questions";
+
+interface McpExploreButtonProps {
+  app: App | null;
+  instanceUrl: string;
+}
+
+export function McpExploreButton({ app, instanceUrl }: McpExploreButtonProps) {
+  const { question } = useSdkQuestionContext();
+
+  if (!question || !instanceUrl) {
+    return null;
+  }
+
+  const handleExplore = async () => {
+    const url = instanceUrl + serializedQuestion(question.card());
+
+    if (app) {
+      await app.openLink({ url });
+    }
+  };
+
+  return (
+    <Button
+      variant="default"
+      size="xs"
+      leftSection={<Icon name="click" size={12} />}
+      onClick={handleExplore}
+    >
+      {t`Explore`}
+    </Button>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import { QueryExplorerBar } from "metabase/metrics-viewer/components/QueryExplorerBar";
+import { DatePicker } from "metabase/querying/common/components/DatePicker";
+import {
+  Box,
+  Button,
+  DefaultSelectItem,
+  Flex,
+  Icon,
+  Popover,
+} from "metabase/ui";
+
+import { useChartTypes } from "./hooks/useChartTypes";
+import { useDateFilter } from "./hooks/useDateFilter";
+import { useTemporalGranularity } from "./hooks/useTemporalGranularity";
+
+export function McpQueryBar() {
+  const { question, updateQuestion, queryResults } = useSdkQuestionContext();
+  const [isBucketOpen, setIsBucketOpen] = useState(false);
+  const [isDateFilterOpen, setIsDateFilterOpen] = useState(false);
+
+  const {
+    sensibleChartTypes,
+    hasOnlyTable,
+    selectedChartType,
+    handleDisplayChange,
+  } = useChartTypes(question, queryResults, updateQuestion);
+
+  const {
+    temporalColumn,
+    rawTemporalColumn,
+    currentUnit,
+    availableItems,
+    bucketLabel,
+    handleBucketChange,
+  } = useTemporalGranularity(question, updateQuestion);
+
+  const {
+    dateFilterClause,
+    dateFilterValue,
+    dateFilterLabel,
+    datePickerUnits,
+    handleDateFilterChange,
+    handleDateFilterClear,
+  } = useDateFilter(question, updateQuestion, rawTemporalColumn);
+
+  if (
+    !question ||
+    !queryResults ||
+    sensibleChartTypes.length === 0 ||
+    hasOnlyTable
+  ) {
+    return null;
+  }
+
+  const filterControl = rawTemporalColumn ? (
+    <Popover opened={isDateFilterOpen} onChange={setIsDateFilterOpen}>
+      <Popover.Target>
+        <Button
+          w={160}
+          justify="space-between"
+          fw="bold"
+          py="xs"
+          px="sm"
+          variant="subtle"
+          color="text-primary"
+          rightSection={<Icon name="chevrondown" size={12} />}
+          onClick={() => setIsDateFilterOpen(!isDateFilterOpen)}
+        >
+          {dateFilterLabel}
+        </Button>
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <DatePicker
+          value={dateFilterValue}
+          availableUnits={datePickerUnits}
+          onChange={(value) => {
+            handleDateFilterChange(value);
+            setIsDateFilterOpen(false);
+          }}
+          renderSubmitButton={({ value }) => (
+            <Flex justify="space-between" w="100%">
+              {dateFilterClause ? (
+                <Button
+                  variant="subtle"
+                  c="text-secondary"
+                  onClick={() => {
+                    handleDateFilterClear();
+                    setIsDateFilterOpen(false);
+                  }}
+                >
+                  {t`All time`}
+                </Button>
+              ) : (
+                <div />
+              )}
+              <Button
+                type="submit"
+                variant="filled"
+                disabled={!value}
+              >{t`Apply`}</Button>
+            </Flex>
+          )}
+        />
+      </Popover.Dropdown>
+    </Popover>
+  ) : undefined;
+
+  const granularityControl =
+    temporalColumn && availableItems.length > 0 ? (
+      <Popover opened={isBucketOpen} onChange={setIsBucketOpen}>
+        <Popover.Target>
+          <Button
+            w={120}
+            justify="space-between"
+            fw="bold"
+            py="xs"
+            px="sm"
+            variant="subtle"
+            color="text-primary"
+            rightSection={<Icon name="chevrondown" size={12} />}
+            onClick={() => setIsBucketOpen(!isBucketOpen)}
+          >
+            {bucketLabel}
+          </Button>
+        </Popover.Target>
+
+        <Popover.Dropdown>
+          <Box p="sm" miw={180}>
+            <DefaultSelectItem
+              value="none"
+              label={t`All time`}
+              selected={!currentUnit}
+              onClick={() => {
+                handleBucketChange(null);
+                setIsBucketOpen(false);
+              }}
+              role="option"
+            />
+            {availableItems.map(({ bucket, unit, label }) => (
+              <DefaultSelectItem
+                key={unit}
+                value={unit}
+                label={label}
+                selected={currentUnit === unit}
+                onClick={() => {
+                  handleBucketChange(bucket);
+                  setIsBucketOpen(false);
+                }}
+                role="option"
+              />
+            ))}
+          </Box>
+        </Popover.Dropdown>
+      </Popover>
+    ) : undefined;
+
+  return (
+    <QueryExplorerBar
+      chartTypes={sensibleChartTypes}
+      currentChartType={selectedChartType ?? ""}
+      onChartTypeChange={handleDisplayChange}
+      filterControl={filterControl}
+      granularityControl={granularityControl}
+    />
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -10,6 +10,7 @@ import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 import { b64_to_utf8 } from "metabase/utils/encoding";
 import type { Card } from "metabase-types/api";
 
+import { McpExploreButton } from "./McpExploreButton";
 import { McpQueryBar } from "./McpQueryBar";
 import { McpQuestionTitle } from "./McpQuestionTitle";
 import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
@@ -124,9 +125,18 @@ export function McpUiAppRoute() {
           withChartTypeSelector={false}
           onDrillThrough={handleDrillThrough}
         >
-          <Box mb="xs">
+          {/* Title row: question title (left) + explore button (right) */}
+          <Flex
+            justify="space-between"
+            align="center"
+            pr="md"
+            mb="xs"
+            style={{ flexShrink: 0 }}
+          >
             <McpQuestionTitle />
-          </Box>
+
+            <McpExploreButton app={app} instanceUrl={instanceUrl} />
+          </Flex>
 
           {/* Visualization fills the remaining space */}
           <Flex flex={1} mih={0} style={{ overflow: "hidden" }}>

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -10,6 +10,7 @@ import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 import { b64_to_utf8 } from "metabase/utils/encoding";
 import type { Card } from "metabase-types/api";
 
+import { McpQueryBar } from "./McpQueryBar";
 import { McpQuestionTitle } from "./McpQuestionTitle";
 import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
@@ -132,9 +133,9 @@ export function McpUiAppRoute() {
             <SdkQuestion.QuestionVisualization height="calc(500px - 8rem)" />
           </Flex>
 
-          {/* Query bar placeholder — implemented in McpQueryBar (next PR) */}
+          {/* Metric-viewer-style query bar: chart type + time granularity */}
           <Flex justify="center" py="xs" style={{ flexShrink: 0 }}>
-            <Box h="3.3rem" />
+            <McpQueryBar />
           </Flex>
         </SdkQuestion>
       </div>

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -17,7 +17,6 @@ import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
 import { buildMcpAppsTheme } from "./utils/buildMcpAppsTheme";
 
-
 const store = getSdkStore();
 
 const DEFAULT_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -17,6 +17,7 @@ import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
 import { buildMcpAppsTheme } from "./utils/buildMcpAppsTheme";
 
+
 const store = getSdkStore();
 
 const DEFAULT_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -5,7 +5,7 @@ import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion"
 import { getSdkStore } from "embedding-sdk-bundle/store";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
-import { Box, Flex } from "metabase/ui";
+import { Flex } from "metabase/ui";
 import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 import { b64_to_utf8 } from "metabase/utils/encoding";
 import type { Card } from "metabase-types/api";
@@ -125,7 +125,6 @@ export function McpUiAppRoute() {
           withChartTypeSelector={false}
           onDrillThrough={handleDrillThrough}
         >
-          {/* Title row: question title (left) + explore button (right) */}
           <Flex
             justify="space-between"
             align="center"
@@ -133,7 +132,9 @@ export function McpUiAppRoute() {
             mb="xs"
             style={{ flexShrink: 0 }}
           >
-            <McpQuestionTitle />
+            <div>
+              <McpQuestionTitle />
+            </div>
 
             <McpExploreButton app={app} instanceUrl={instanceUrl} />
           </Flex>

--- a/frontend/src/metabase/embedding/mcp/api.ts
+++ b/frontend/src/metabase/embedding/mcp/api.ts
@@ -1,0 +1,40 @@
+/* eslint-disable metabase/no-literal-metabase-strings */
+
+type StoreDrillQueryRequest = {
+  instanceUrl: string;
+  sessionToken: string;
+  mcpSessionId: string;
+  encodedQuery: string;
+};
+
+/**
+ * Stores the drill-through's query on the server,
+ * keyed by the MCP session ID.
+ *
+ * We cannot use RTK Query here as we are not in
+ * Metabase's React tree.
+ */
+export async function storeDrillQuery({
+  instanceUrl,
+  sessionToken,
+  mcpSessionId,
+  encodedQuery,
+}: StoreDrillQueryRequest): Promise<void> {
+  const response = await fetch(`${instanceUrl}/api/mcp/ui/drills`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Metabase-Session": sessionToken,
+    },
+    body: JSON.stringify({
+      encodedQuery,
+      mcpSessionId,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `storeDrillQuery failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/frontend/src/metabase/embedding/mcp/hooks/useChartTypes.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useChartTypes.ts
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+
+import { getSensibleVisualizations } from "metabase/query_builder/components/chart-type-selector";
+import type Question from "metabase-lib/v1/Question";
+import type { Dataset } from "metabase-types/api";
+
+const CHART_TYPES = [
+  { type: "line" as const, icon: "line" as const },
+  { type: "bar" as const, icon: "bar" as const },
+  { type: "area" as const, icon: "area" as const },
+];
+
+const TABLE_CHART_TYPE = { type: "table" as const, icon: "table2" as const };
+
+export type McpChartType = "line" | "bar" | "area" | "table";
+
+const isMcpChartType = (type: string): type is McpChartType =>
+  [...CHART_TYPES, TABLE_CHART_TYPE].some((c) => c.type === type);
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+type ChartTypeEntry = (typeof CHART_TYPES)[number] | typeof TABLE_CHART_TYPE;
+
+interface UseChartTypesResult {
+  sensibleChartTypes: ChartTypeEntry[];
+  hasOnlyTable: boolean;
+  selectedChartType: McpChartType | null;
+  handleDisplayChange: (type: string) => void;
+}
+
+export function useChartTypes(
+  question: Question | undefined,
+  queryResults: Dataset[] | null | undefined,
+  updateQuestion: UpdateQuestion,
+): UseChartTypesResult {
+  const { sensibleVisualizations } = useMemo(
+    () => getSensibleVisualizations({ result: queryResults?.[0] ?? null }),
+    [queryResults],
+  );
+
+  const rowCount = queryResults?.[0]?.data?.rows?.length ?? 0;
+
+  const sensibleChartTypes = [
+    ...CHART_TYPES.filter(({ type }) => sensibleVisualizations.includes(type)),
+
+    // Does not make sense to show table viz if there is just one row.
+    ...(rowCount >= 2 ? [TABLE_CHART_TYPE] : []),
+  ];
+
+  const hasOnlyTable =
+    sensibleChartTypes.length === 1 && sensibleChartTypes[0].type === "table";
+
+  const rawDisplay = question?.display() ?? "";
+
+  const selectedChartType: McpChartType | null = isMcpChartType(rawDisplay)
+    ? rawDisplay
+    : null;
+
+  const handleDisplayChange = (type: string) => {
+    if (!question) {
+      return;
+    }
+
+    const nextQuestion = question
+      .setDisplay(type as McpChartType)
+      .lockDisplay();
+
+    updateQuestion(nextQuestion, { run: false });
+  };
+
+  return {
+    sensibleChartTypes,
+    hasOnlyTable,
+    selectedChartType,
+    handleDisplayChange,
+  };
+}

--- a/frontend/src/metabase/embedding/mcp/hooks/useDateFilter.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useDateFilter.ts
@@ -1,0 +1,101 @@
+import { t } from "ttag";
+
+import type { DatePickerValue } from "metabase/querying/common/types";
+import { getDateFilterDisplayName } from "metabase/querying/common/utils/dates";
+import {
+  getDateFilterClause,
+  getDatePickerUnits,
+  getDatePickerValue,
+} from "metabase/querying/filters/utils/dates";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+export interface UseDateFilterResult {
+  dateFilterClause: Lib.FilterClause | null;
+  dateFilterValue: DatePickerValue | undefined;
+  dateFilterLabel: string;
+  datePickerUnits: ReturnType<typeof getDatePickerUnits>;
+  handleDateFilterChange: (value: DatePickerValue) => void;
+  handleDateFilterClear: () => void;
+}
+
+export function useDateFilter(
+  question: Question | undefined,
+  updateQuestion: UpdateQuestion,
+  rawTemporalColumn: Lib.ColumnMetadata | null,
+): UseDateFilterResult {
+  const empty: UseDateFilterResult = {
+    dateFilterClause: null,
+    dateFilterValue: undefined,
+    dateFilterLabel: t`All time`,
+    datePickerUnits: [],
+
+    handleDateFilterChange: () => {},
+    handleDateFilterClear: () => {},
+  };
+
+  if (!question) {
+    return empty;
+  }
+
+  const query = question.query();
+  const stageIndex = -1;
+
+  const allFilters = Lib.filters(query, stageIndex);
+
+  let dateFilterClause: Lib.FilterClause | null = null;
+  let dateFilterValue: DatePickerValue | undefined = undefined;
+
+  for (const filter of allFilters) {
+    const _datePickerValue = getDatePickerValue(query, stageIndex, filter);
+
+    if (_datePickerValue != null) {
+      dateFilterClause = filter;
+      dateFilterValue = _datePickerValue;
+
+      break;
+    }
+  }
+
+  const dateFilterLabel = dateFilterValue
+    ? getDateFilterDisplayName(dateFilterValue)
+    : t`All time`;
+
+  const datePickerUnits = rawTemporalColumn
+    ? getDatePickerUnits(query, stageIndex, rawTemporalColumn)
+    : [];
+
+  const handleDateFilterChange = (value: DatePickerValue) => {
+    if (!rawTemporalColumn) {
+      return;
+    }
+
+    const newFilterClause = getDateFilterClause(rawTemporalColumn, value);
+    const newQuery = dateFilterClause
+      ? Lib.replaceClause(query, stageIndex, dateFilterClause, newFilterClause)
+      : Lib.filter(query, stageIndex, newFilterClause);
+
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  const handleDateFilterClear = () => {
+    if (!dateFilterClause) {
+      return;
+    }
+
+    const newQuery = Lib.removeClause(query, stageIndex, dateFilterClause);
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  return {
+    dateFilterClause,
+    dateFilterValue,
+    dateFilterLabel,
+    datePickerUnits,
+
+    handleDateFilterChange,
+    handleDateFilterClear,
+  };
+}

--- a/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
@@ -1,10 +1,10 @@
-/* eslint-disable metabase/no-literal-metabase-strings */
-
 import type { App } from "@modelcontextprotocol/ext-apps/react";
 import { useCallback } from "react";
 
 import { utf8_to_b64 } from "metabase/utils/encoding";
 import type { Card } from "metabase-types/api";
+
+import { storeDrillQuery } from "../api";
 
 interface McpGlobalConfig {
   instanceUrl?: string;
@@ -45,10 +45,22 @@ export function useHandleMcpDrillThrough(app: App | null): DrillThroughHandler {
             JSON.stringify(nextCard.dataset_query),
           );
 
-          // Store the card server-side in the MCP session.
-          // Works in all MCP clients (Claude Desktop, Cursor, VS Code).
+          const { instanceUrl, sessionToken, mcpSessionId } =
+            (window.metabaseConfig as McpGlobalConfig | undefined) ?? {};
+
+          if (!instanceUrl || !sessionToken || !mcpSessionId) {
+            return;
+          }
+
+          // Store the card server-side in the MCP session. This is universal —
+          // works in all MCP clients (Claude Desktop, Cursor, VS Code).
           // The render_drill_through tool will consume it with no LLM-visible payload.
-          await storePendingCard(encodedQuery);
+          await storeDrillQuery({
+            instanceUrl,
+            sessionToken,
+            mcpSessionId,
+            encodedQuery,
+          });
 
           // Uses the same term as the tool description ("show a drill-through result")
           // so the LLM always calls render_drill_through.
@@ -68,32 +80,4 @@ export function useHandleMcpDrillThrough(app: App | null): DrillThroughHandler {
     },
     [app],
   );
-}
-
-/**
- * Store a base64-encoded query via POST /api/mcp/ui/drills.
- * The render_drill_through tool will consume it when the LLM calls it.
- * This is universal — works in all MCP clients (Claude Desktop, Cursor, VS Code).
- */
-async function storePendingCard(encodedQuery: string): Promise<void> {
-  const { instanceUrl, sessionToken, mcpSessionId } =
-    (window.metabaseConfig as McpGlobalConfig | undefined) ?? {};
-
-  const response = await fetch(`${instanceUrl}/api/mcp/ui/drills`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Metabase-Session": sessionToken ?? "",
-      "Mcp-Session-Id": mcpSessionId ?? "",
-    },
-    body: JSON.stringify({
-      encodedQuery,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `storePendingCard failed: ${response.status} ${response.statusText}`,
-    );
-  }
 }

--- a/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
@@ -9,6 +9,7 @@ import type { Card } from "metabase-types/api";
 interface McpGlobalConfig {
   instanceUrl?: string;
   sessionToken?: string;
+  mcpSessionId?: string;
 }
 
 // Drills that refine the current visualization without changing what it is.
@@ -75,7 +76,7 @@ export function useHandleMcpDrillThrough(app: App | null): DrillThroughHandler {
  * This is universal — works in all MCP clients (Claude Desktop, Cursor, VS Code).
  */
 async function storePendingCard(encodedQuery: string): Promise<void> {
-  const { instanceUrl, sessionToken } =
+  const { instanceUrl, sessionToken, mcpSessionId } =
     (window.metabaseConfig as McpGlobalConfig | undefined) ?? {};
 
   const response = await fetch(`${instanceUrl}/api/mcp/ui/drills`, {
@@ -83,6 +84,7 @@ async function storePendingCard(encodedQuery: string): Promise<void> {
     headers: {
       "Content-Type": "application/json",
       "X-Metabase-Session": sessionToken ?? "",
+      "Mcp-Session-Id": mcpSessionId ?? "",
     },
     body: JSON.stringify({
       encodedQuery,

--- a/frontend/src/metabase/embedding/mcp/hooks/useTemporalGranularity.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useTemporalGranularity.ts
@@ -1,0 +1,117 @@
+import { t } from "ttag";
+
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import type { TemporalUnit } from "metabase-types/api";
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+export interface TemporalGranularityItem {
+  bucket: Lib.Bucket;
+  unit: TemporalUnit;
+  label: string;
+}
+
+export interface UseTemporalGranularityResult {
+  temporalColumn: Lib.ColumnMetadata | null;
+  rawTemporalColumn: Lib.ColumnMetadata | null;
+  currentUnit: TemporalUnit | undefined;
+  availableItems: TemporalGranularityItem[];
+  bucketLabel: string;
+  handleBucketChange: (bucket: Lib.Bucket | null) => void;
+}
+
+/**
+ * Handlers for showing and updating time granularity controls
+ * via the query explorer bar.
+ */
+export function useTemporalGranularity(
+  question: Question | undefined,
+  updateQuestion: UpdateQuestion,
+): UseTemporalGranularityResult {
+  if (!question) {
+    return {
+      temporalColumn: null,
+      rawTemporalColumn: null,
+      currentUnit: undefined,
+      availableItems: [],
+      bucketLabel: t`All time`,
+      handleBucketChange: () => {},
+    };
+  }
+
+  const query = question.query();
+  const stageIndex = -1;
+
+  const breakoutClauses = Lib.breakouts(query, stageIndex);
+
+  let temporalClause: Lib.BreakoutClause | null = null;
+  let temporalColumn: Lib.ColumnMetadata | null = null;
+
+  for (const clause of breakoutClauses) {
+    const column = Lib.breakoutColumn(query, stageIndex, clause);
+
+    if (column && Lib.isTemporalBucketable(query, stageIndex, column)) {
+      temporalClause = clause;
+      temporalColumn = column;
+      break;
+    }
+  }
+
+  // Strip the temporal bucket from the column — date filters operate on the
+  // raw date column, not the bucketed version used in the breakout.
+  const rawTemporalColumn = temporalColumn
+    ? Lib.withTemporalBucket(temporalColumn, null)
+    : null;
+
+  const currentBucket = temporalColumn
+    ? Lib.temporalBucket(temporalColumn)
+    : null;
+
+  const currentUnit = currentBucket
+    ? (Lib.displayInfo(query, stageIndex, currentBucket)
+        .shortName as TemporalUnit)
+    : undefined;
+
+  const availableBuckets = temporalColumn
+    ? Lib.availableTemporalBuckets(query, stageIndex, temporalColumn)
+    : [];
+
+  const availableItems: TemporalGranularityItem[] = availableBuckets.map(
+    (bucket) => {
+      const info = Lib.displayInfo(query, stageIndex, bucket);
+      const unit = info.shortName as TemporalUnit;
+
+      return { bucket, unit, label: Lib.describeTemporalUnit(unit) };
+    },
+  );
+
+  const bucketLabel = currentUnit
+    ? t`by ${Lib.describeTemporalUnit(currentUnit).toLowerCase()}`
+    : t`All time`;
+
+  const handleBucketChange = (bucket: Lib.Bucket | null) => {
+    if (!temporalClause || !temporalColumn) {
+      return;
+    }
+
+    const newColumn = Lib.withTemporalBucket(temporalColumn, bucket);
+    const newQuery = Lib.replaceClause(
+      query,
+      stageIndex,
+      temporalClause,
+      newColumn,
+    );
+
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  return {
+    temporalColumn,
+    rawTemporalColumn,
+    currentUnit,
+    availableItems,
+    bucketLabel,
+    handleBucketChange,
+  };
+}

--- a/resources/frontend_client/mcp_apps_template.html
+++ b/resources/frontend_client/mcp_apps_template.html
@@ -85,7 +85,8 @@
     <script>
       window.metabaseConfig = {
         instanceUrl: {{{instanceUrl}}},
-        sessionToken: {{{sessionToken}}}
+        sessionToken: {{{sessionToken}}},
+        mcpSessionId: {{{mcpSessionId}}}
       };
     </script>
   </body>

--- a/resources/migrations/061/20260424_mcp_ui_query_handle.yaml
+++ b/resources/migrations/061/20260424_mcp_ui_query_handle.yaml
@@ -1,0 +1,49 @@
+## Create mcp_ui_query_handle table.
+## Stores base64-encoded query payloads for MCP UI sessions, replacing the
+## in-memory atom that broke under load-balanced deployments.
+## Two ID schemes coexist in this table:
+##   - Random UUID: used by construct_query; the UUID is returned to the LLM
+##     as a capability token (not guessable by other sessions).
+##   - "drill:{session_id}": used by drill-through; deterministic per session,
+##     never surfaced to the LLM.
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v61.2026-04-24T00:00:00
+      author: phoomparin
+      comment: Create mcp_ui_query_handle table for db-backed query payload storage
+      changes:
+        - createTable:
+            tableName: mcp_ui_query_handle
+            columns:
+              - column:
+                  name: id
+                  type: varchar(255)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: session_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: encoded_query
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: mcp_ui_query_handle
+            indexName: idx_mcp_ui_query_handle_session_id
+            columns:
+              - column:
+                  name: session_id
+      rollback:
+        - dropTable:
+            tableName: mcp_ui_query_handle

--- a/resources/migrations/061/20260424_mcp_ui_query_handle.yaml
+++ b/resources/migrations/061/20260424_mcp_ui_query_handle.yaml
@@ -1,49 +1,36 @@
-## Create mcp_ui_query_handle table.
-## Stores base64-encoded query payloads for MCP UI sessions, replacing the
-## in-memory atom that broke under load-balanced deployments.
-## Two ID schemes coexist in this table:
-##   - Random UUID: used by construct_query; the UUID is returned to the LLM
-##     as a capability token (not guessable by other sessions).
-##   - "drill:{session_id}": used by drill-through; deterministic per session,
-##     never surfaced to the LLM.
+## Stores pending drill-through query payloads for MCP UI sessions.
+## Replaces the in-memory atom that broke under load-balanced deployments.
+## One row per session (upserted), so the last drill always wins.
 
 databaseChangeLog:
-
   - changeSet:
       id: v61.2026-04-24T00:00:00
       author: phoomparin
-      comment: Create mcp_ui_query_handle table for db-backed query payload storage
+      comment: Create mcp_ui_query_handle table for drill-through payload for MCP Apps
       changes:
         - createTable:
             tableName: mcp_ui_query_handle
+            remarks: Stores the pending drill-through query payload for an MCP session; one row per session
             columns:
               - column:
                   name: id
                   type: varchar(255)
+                  remarks: MCP session ID; primary key since there is at most one pending drill per session
                   constraints:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: session_id
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
                   name: encoded_query
                   type: ${text.type}
+                  remarks: Base64-encoded MBQL query payload for the pending drill-through
                   constraints:
                     nullable: false
               - column:
                   name: created_at
                   type: ${timestamp_type}
+                  remarks: When this handle was stored; useful for debugging and future TTL cleanup
                   constraints:
                     nullable: false
-        - createIndex:
-            tableName: mcp_ui_query_handle
-            indexName: idx_mcp_ui_query_handle_session_id
-            columns:
-              - column:
-                  name: session_id
       rollback:
         - dropTable:
             tableName: mcp_ui_query_handle

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -72,10 +72,11 @@
 (defn- handle-tools-list [id _params token-scopes]
   (jsonrpc-response id {:tools (mcp.tools/list-tools token-scopes)}))
 
-(defn- handle-tools-call [id params token-scopes]
+(defn- handle-tools-call [id params session-id token-scopes]
   (let [tool-name (:name params)
         arguments (or (:arguments params) {})]
-    (jsonrpc-response id (mcp.tools/call-tool token-scopes tool-name arguments))))
+    (binding [mcp.session/*current-session-id* session-id]
+      (jsonrpc-response id (mcp.tools/call-tool token-scopes tool-name arguments)))))
 
 (defn- handle-resources-list [id _params token-scopes]
   (jsonrpc-response id (mcp.resources/list-resources token-scopes)))
@@ -100,7 +101,7 @@
     (case method
       "notifications/initialized" nil
       "tools/list"                (handle-tools-list id params token-scopes)
-      "tools/call"                (handle-tools-call id params token-scopes)
+      "tools/call"                (handle-tools-call id params session-id token-scopes)
       "resources/list"            (handle-resources-list id params token-scopes)
       "resources/read"            (handle-resources-read id params session-id token-scopes)
       "ping"                      (handle-ping id params)
@@ -275,12 +276,19 @@
   "Handle POST /api/mcp/ui/drills — store a base64-encoded query for the upcoming render_drill_through
    tool call. The frontend calls this immediately after a drill-through action, before sending
    app.sendMessage, so the tool can retrieve the query without the LLM carrying the payload."
-  [user-id request]
-  (let [encoded-query (get (:body request) :encodedQuery)]
-    (if (and (string? encoded-query) (not (str/blank? encoded-query)))
-      (do (mcp.session/store-pending-card! user-id encoded-query)
-          {:status 204 :headers {"Content-Type" "application/json"} :body ""})
-      (json-response 400 {:error "Missing or invalid encodedQuery"}))))
+  [_user-id request]
+  (let [session-id    (get-in request [:headers "mcp-session-id"])
+        encoded-query (get (:body request) :encodedQuery)]
+    (cond
+      (str/blank? session-id)
+      (json-response 400 {:error "Missing Mcp-Session-Id header"})
+
+      (not (and (string? encoded-query) (not (str/blank? encoded-query))))
+      (json-response 400 {:error "Missing or invalid encodedQuery"})
+
+      :else
+      (do (mcp.session/store-drill-handle! session-id encoded-query)
+          {:status 204 :headers {"Content-Type" "application/json"} :body ""}))))
 
 ;;; -------------------------------------------------- Throttling --------------------------------------------------
 

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -278,11 +278,12 @@
    tool call. The frontend calls this immediately after a drill-through action, before sending
    app.sendMessage, so the tool can retrieve the query without the LLM carrying the payload."
   [_user-id request]
-  (let [session-id    (get-in request [:headers "mcp-session-id"])
-        encoded-query (get (:body request) :encodedQuery)]
+  (let [body          (:body request)
+        session-id    (:mcpSessionId body)
+        encoded-query (:encodedQuery body)]
     (cond
       (str/blank? session-id)
-      (json-response 400 {:error "Missing Mcp-Session-Id header"})
+      (json-response 400 {:error "Missing mcpSessionId"})
 
       (not (and (string? encoded-query) (not (str/blank? encoded-query))))
       (json-response 400 {:error "Missing or invalid encodedQuery"})

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -89,7 +89,8 @@
        :scope-denied) (jsonrpc-error id -32602 "Resource not found")
       :ok             (let [user-id     api/*current-user-id*
                             session-key (when user-id (mcp.session/get-or-create-session-key! session-id user-id))]
-                        (jsonrpc-response id (mcp.resources/read-resource uri {:session-key session-key}))))))
+                        (jsonrpc-response id (mcp.resources/read-resource uri {:session-key session-key
+                                                                               :session-id  session-id}))))))
 
 (defn- handle-ping [id _params]
   (jsonrpc-response id {}))
@@ -333,7 +334,7 @@
            ;; fail origin validation — but there's no DNS-rebinding risk here since
            ;; the request is authenticated via session token.
            drill-request?  (and (= :post (:request-method request))
-                                (= "/ui/drills" (:uri request)))
+                                (= "/ui/drills" ((some-fn :path-info :uri) request)))
            origin-error    (when-not drill-request?
                              (validate-origin request))
            bearer-token    (oauth-server/extract-bearer-token request)

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -3,7 +3,6 @@
    that renders interactive Metabase visualizations via the Embedding SDK."
   (:require
    [clojure.java.io :as io]
-   [metabase.api.common :as api]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
    [metabase.system.core :as system]
@@ -159,11 +158,18 @@
  {:name        "visualize_query"
   :description "Visualize a previously constructed query as an interactive chart or table."
   :inputSchema {:type       "object"
-                :properties {:query {:type "string" :minLength 1}}
-                :required   ["query"]}
+                :properties {:query        {:type "string" :minLength 1}
+                             :query_handle {:type "string" :minLength 1}}
+                :anyOf      [{"required" ["query"]} {"required" ["query_handle"]}]}
   :response-fn (fn [arguments]
-                 {:content          [{:type "text" :text "Visualizing query..."}]
-                  :structuredContent {:query (:query arguments)}})})
+                 (let [encoded (or (:query arguments)
+                                   (when-let [h (:query_handle arguments)]
+                                     (mcp.session/resolve-query-handle h)))]
+                   (if encoded
+                     {:content          [{:type "text" :text "Visualizing query..."}]
+                      :structuredContent {:query encoded}}
+                     {:content [{:type "text" :text "Query handle not found. Try running construct_query again."}]
+                      :isError true})))})
 
 (register-ui-tool!
  :visualize-query
@@ -173,7 +179,7 @@
                     "no arguments needed. The query is pre-loaded from session context.")
   :inputSchema {:type "object" :properties {} :required []}
   :response-fn (fn [_arguments]
-                 (let [encoded-query (mcp.session/consume-pending-card! api/*current-user-id*)]
+                 (let [encoded-query (mcp.session/consume-drill-handle! mcp.session/*current-session-id*)]
                    (if encoded-query
                      {:content          [{:type "text" :text "Rendering drill-through visualization..."}]
                       :structuredContent {:query encoded-query}}

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -47,7 +47,8 @@
 
 (defn render-embed-mcp-template
   "Render the embed-mcp.html Mustache template with the given vars map.
-   Expected keys: :instanceUrl (JSON-encoded), :instanceUrlRaw, :sessionToken (JSON-encoded or nil)."
+   Expected keys: :instanceUrl (JSON-encoded), :instanceUrlRaw, :sessionToken (JSON-encoded or nil),
+   :mcpSessionId (JSON-encoded or nil)."
   [vars]
   (cond
     (io/resource embed-mcp-template-path)
@@ -147,11 +148,13 @@
   :description "Interactive Metabase SDK visualization for a query"
   :render-fn   (fn [opts]
                  (let [site-url    (system/site-url)
-                       session-key (:session-key opts)]
+                       session-key (:session-key opts)
+                       session-id  (:session-id opts)]
                    (render-embed-mcp-template
                     {:instanceUrl    (json/encode site-url)
                      :instanceUrlRaw site-url
-                     :sessionToken   (when session-key (json/encode session-key))})))})
+                     :sessionToken   (when session-key (json/encode session-key))
+                     :mcpSessionId   (when session-id (json/encode session-id))})))})
 
 (register-ui-tool!
  :visualize-query

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -161,18 +161,14 @@
  {:name        "visualize_query"
   :description "Visualize a previously constructed query as an interactive chart or table."
   :inputSchema {:type       "object"
-                :properties {:query        {:type "string" :minLength 1}
-                             :query_handle {:type "string" :minLength 1}}
-                :anyOf      [{"required" ["query"]} {"required" ["query_handle"]}]}
+                :properties {:query {:type "string" :minLength 1}}
+                :required   ["query"]}
   :response-fn (fn [arguments]
-                 (let [encoded (or (:query arguments)
-                                   (when-let [h (:query_handle arguments)]
-                                     (mcp.session/resolve-query-handle h)))]
-                   (if encoded
-                     {:content          [{:type "text" :text "Visualizing query..."}]
-                      :structuredContent {:query encoded}}
-                     {:content [{:type "text" :text "Query handle not found. Try running construct_query again."}]
-                      :isError true})))})
+                 (if-let [encoded (:query arguments)]
+                   {:content          [{:type "text" :text "Visualizing query..."}]
+                    :structuredContent {:query encoded}}
+                   {:content [{:type "text" :text "Missing query argument."}]
+                    :isError true}))})
 
 (register-ui-tool!
  :visualize-query

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -75,6 +75,14 @@
 
 ;;; -------------------------------------------------- Lifecycle --------------------------------------------------
 
+(declare delete-session-handles!)
+
+(def ^:dynamic *current-session-id*
+  "The MCP session ID for the current request. Bound by the tools/call handler so that
+   tool response-fns can look up session-scoped state (e.g. query handles) without the
+   session ID needing to flow through every layer of the call stack."
+  nil)
+
 (defn create!
   "Create a new MCP session. Returns a UUID string.
    No database row is written — the session is just an opaque correlator until
@@ -127,36 +135,76 @@
     (or (nil? owner) (= owner user-id))))
 
 (defn delete!
-  "Delete the `core_session` backing this MCP session, if one was ever created.
-   Scoped to `user-id` so that one user cannot delete another user's session."
+  "Delete the `core_session` backing this MCP session (if one was ever created)
+   and all associated query handles. Scoped to `user-id` so that one user cannot
+   delete another user's session."
   [session-id user-id]
   (let [key-hashed (session/hash-session-key (derive-embedding-session-key session-id))]
     (t2/query {:delete-from :core_session
                :where       [:and
                              [:= :key_hashed key-hashed]
-                             [:= :user_id user-id]]})))
+                             [:= :user_id user-id]]})
+    (delete-session-handles! session-id)))
 
-;;; -------------------------------------------- Pending Card Store -----------------------------------------------
-;; Prototype: in-memory store for drill-through cards, keyed by user-id.
-;; The frontend stores a base64-encoded query here before calling app.sendMessage,
-;; so the render_drill_through tool can retrieve it without the LLM needing to
-;; carry the base64 payload in the conversation context.
-;; Last write wins per user — acceptable for prototype purposes.
+;;; -------------------------------------------- Query Handle Store -----------------------------------------------
+;; DB-backed store for base64-encoded query payloads, keyed by an opaque handle ID.
+;; Replaces the in-memory atom that broke under load-balanced (multi-pod) deployments.
+;;
+;; Two ID schemes share the mcp_ui_query_handle table:
+;;   - Random UUID  — used by construct_query. Returned to the LLM as a short
+;;     capability token; the LLM passes it to visualize_query / execute_query.
+;;     Safe across concurrent tabs because UUID is unguessable by other sessions.
+;;   - "drill:{session_id}" — used by drill-through. Deterministic per session so
+;;     render_drill_through can look it up with no ID travelling through LLM context.
+;;     Upserted (last write wins) so a second drill in the same session overwrites
+;;     the first — correct behaviour since only one drill can be pending at a time.
 
-(defonce ^:private pending-card-store
-  (atom {}))
+(defn store-query-handle!
+  "Insert a base64-encoded query into mcp_ui_query_handle and return the new handle id
+   (a random UUID). Used by construct_query."
+  [session-id encoded-query]
+  (let [id (str (UUID/randomUUID))]
+    (t2/query {:insert-into :mcp_ui_query_handle
+               :values      [{:id            id
+                              :session_id    session-id
+                              :encoded_query encoded-query
+                              :created_at    :%now}]})
+    id))
 
-(defn store-pending-card!
-  "Store a base64-encoded query as the pending drill-through card for `user-id`."
-  [user-id encoded-query]
-  (swap! pending-card-store assoc user-id encoded-query))
+(defn- drill-handle-id [session-id] (str "drill:" session-id))
 
-(defn consume-pending-card!
-  "Retrieve and remove the pending drill-through card for `user-id`.
-   Returns nil if no pending card exists."
-  [user-id]
-  (let [result (volatile! nil)]
-    (swap! pending-card-store (fn [store]
-                                (vreset! result (get store user-id))
-                                (dissoc store user-id)))
-    @result))
+(defn store-drill-handle!
+  "Upsert the drill-through query payload for `session-id`. Last write wins."
+  [session-id encoded-query]
+  (let [id (drill-handle-id session-id)]
+    (t2/query {:insert-into :mcp_ui_query_handle
+               :values      [{:id            id
+                              :session_id    session-id
+                              :encoded_query encoded-query
+                              :created_at    :%now}]
+               :on-conflict [:id]
+               :do-update-set [:encoded_query :created_at]})))
+
+(defn consume-drill-handle!
+  "Retrieve and delete the drill-through query payload for `session-id`.
+   Returns nil if no pending drill exists."
+  [session-id]
+  (let [id  (drill-handle-id session-id)
+        row (t2/select-one :mcp_ui_query_handle :id id)]
+    (when row
+      (t2/delete! :mcp_ui_query_handle :id id)
+      (:encoded_query row))))
+
+(defn resolve-query-handle
+  "Return the encoded query for `handle-id`, or nil if not found.
+   Used by visualize_query and execute_query to resolve construct_query handles."
+  [handle-id]
+  (:encoded_query (t2/select-one :mcp_ui_query_handle :id handle-id)))
+
+(defn delete-session-handles!
+  "Delete all query handles belonging to `session-id`. Called on session teardown."
+  [session-id]
+  (t2/delete! :mcp_ui_query_handle :session_id session-id)
+  ;; Drill handles use "drill:{session_id}" as their id rather than session_id as a
+  ;; column value, so we also delete them by their computed id.
+  (t2/delete! :mcp_ui_query_handle :id (drill-handle-id session-id)))

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -136,38 +136,31 @@
 ;; DB-backed store for base64-encoded drill-through query payloads.
 ;; Replaces the in-memory atom that broke under load-balanced (multi-pod) deployments.
 ;;
-;; Drill handles use the deterministic key "drill:{session_id}" so that
-;; render_drill_through can look up the payload without any ID travelling through
-;; LLM context. Upserted (last write wins): only one drill can be pending at a time.
-
-(defn- drill-handle-id [session-id] (str "drill:" session-id))
+;; The table is keyed by session_id — at most one pending drill per session.
+;; Upserted (last write wins) so a second drill overwrites the first.
 
 (defn store-drill-handle!
   "Upsert the drill-through query payload for `session-id`. Last write wins."
   [session-id encoded-query]
-  (let [id (drill-handle-id session-id)]
-    (t2/query {:insert-into :mcp_ui_query_handle
-               :values      [{:id            id
-                              :session_id    session-id
+  (t2/query {:insert-into   :mcp_ui_query_handle
+             :values        [{:id            session-id
                               :encoded_query encoded-query
                               :created_at    :%now}]
-               :on-conflict [:id]
-               :do-update-set [:encoded_query :created_at]})))
+             :on-conflict   [:id]
+             :do-update-set [:encoded_query :created_at]}))
 
 (defn consume-drill-handle!
   "Retrieve and delete the drill-through query payload for `session-id`.
    Returns nil if no pending drill exists."
   [session-id]
-  (let [id  (drill-handle-id session-id)
-        row (t2/select-one :mcp_ui_query_handle :id id)]
-    (when row
-      (t2/delete! :mcp_ui_query_handle :id id)
-      (:encoded_query row))))
+  (when-let [row (t2/select-one :mcp_ui_query_handle :id session-id)]
+    (t2/delete! :mcp_ui_query_handle :id session-id)
+    (:encoded_query row)))
 
 (defn- delete-session-handles!
   "Delete the drill-through query handle for `session-id`. Called on session teardown."
   [session-id]
-  (t2/delete! :mcp_ui_query_handle :id (drill-handle-id session-id)))
+  (t2/delete! :mcp_ui_query_handle :id session-id))
 
 (defn delete!
   "Delete the `core_session` backing this MCP session (if one was ever created)

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -75,8 +75,6 @@
 
 ;;; -------------------------------------------------- Lifecycle --------------------------------------------------
 
-(declare delete-session-handles!)
-
 (def ^:dynamic *current-session-id*
   "The MCP session ID for the current request. Bound by the tools/call handler so that
    tool response-fns can look up session-scoped state (e.g. query handles) without the
@@ -134,42 +132,13 @@
         owner      (t2/select-one-fn :user_id :core_session :key_hashed key-hashed)]
     (or (nil? owner) (= owner user-id))))
 
-(defn delete!
-  "Delete the `core_session` backing this MCP session (if one was ever created)
-   and all associated query handles. Scoped to `user-id` so that one user cannot
-   delete another user's session."
-  [session-id user-id]
-  (let [key-hashed (session/hash-session-key (derive-embedding-session-key session-id))]
-    (t2/query {:delete-from :core_session
-               :where       [:and
-                             [:= :key_hashed key-hashed]
-                             [:= :user_id user-id]]})
-    (delete-session-handles! session-id)))
-
 ;;; -------------------------------------------- Query Handle Store -----------------------------------------------
-;; DB-backed store for base64-encoded query payloads, keyed by an opaque handle ID.
+;; DB-backed store for base64-encoded drill-through query payloads.
 ;; Replaces the in-memory atom that broke under load-balanced (multi-pod) deployments.
 ;;
-;; Two ID schemes share the mcp_ui_query_handle table:
-;;   - Random UUID  — used by construct_query. Returned to the LLM as a short
-;;     capability token; the LLM passes it to visualize_query / execute_query.
-;;     Safe across concurrent tabs because UUID is unguessable by other sessions.
-;;   - "drill:{session_id}" — used by drill-through. Deterministic per session so
-;;     render_drill_through can look it up with no ID travelling through LLM context.
-;;     Upserted (last write wins) so a second drill in the same session overwrites
-;;     the first — correct behaviour since only one drill can be pending at a time.
-
-(defn store-query-handle!
-  "Insert a base64-encoded query into mcp_ui_query_handle and return the new handle id
-   (a random UUID). Used by construct_query."
-  [session-id encoded-query]
-  (let [id (str (UUID/randomUUID))]
-    (t2/query {:insert-into :mcp_ui_query_handle
-               :values      [{:id            id
-                              :session_id    session-id
-                              :encoded_query encoded-query
-                              :created_at    :%now}]})
-    id))
+;; Drill handles use the deterministic key "drill:{session_id}" so that
+;; render_drill_through can look up the payload without any ID travelling through
+;; LLM context. Upserted (last write wins): only one drill can be pending at a time.
 
 (defn- drill-handle-id [session-id] (str "drill:" session-id))
 
@@ -195,16 +164,19 @@
       (t2/delete! :mcp_ui_query_handle :id id)
       (:encoded_query row))))
 
-(defn resolve-query-handle
-  "Return the encoded query for `handle-id`, or nil if not found.
-   Used by visualize_query and execute_query to resolve construct_query handles."
-  [handle-id]
-  (:encoded_query (t2/select-one :mcp_ui_query_handle :id handle-id)))
-
-(defn delete-session-handles!
-  "Delete all query handles belonging to `session-id`. Called on session teardown."
+(defn- delete-session-handles!
+  "Delete the drill-through query handle for `session-id`. Called on session teardown."
   [session-id]
-  (t2/delete! :mcp_ui_query_handle :session_id session-id)
-  ;; Drill handles use "drill:{session_id}" as their id rather than session_id as a
-  ;; column value, so we also delete them by their computed id.
   (t2/delete! :mcp_ui_query_handle :id (drill-handle-id session-id)))
+
+(defn delete!
+  "Delete the `core_session` backing this MCP session (if one was ever created)
+   and any associated query handles. Scoped to `user-id` so that one user cannot
+   delete another user's session."
+  [session-id user-id]
+  (let [key-hashed (session/hash-session-key (derive-embedding-session-key session-id))]
+    (t2/query {:delete-from :core_session
+               :where       [:and
+                             [:= :key_hashed key-hashed]
+                             [:= :user_id user-id]]})
+    (delete-session-handles! session-id)))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -10,6 +10,7 @@
    [metabase.config.core :as config]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.mcp.scope :as mcp.scope]
+   [metabase.mcp.session :as mcp.session]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
    [metabase.util.json :as json])
@@ -93,6 +94,40 @@
       error            error
       :else            (str "Agent API error: " (:status response)))))
 
+;;; ------------------------------------------- Query Handle Transforms -------------------------------------------
+
+(defn- resolve-query-arg
+  "If `arguments` contains :query_handle, look it up in mcp_ui_query_handle and replace
+   it with the :query base64 string. Returns updated arguments, or ::handle-not-found if
+   the handle id doesn't exist in the store."
+  [arguments]
+  (if-let [handle-id (:query_handle arguments)]
+    (if-let [encoded (mcp.session/resolve-query-handle handle-id)]
+      (-> arguments (dissoc :query_handle) (assoc :query encoded))
+      ::handle-not-found)
+    arguments))
+
+(defn- store-construct-query-result
+  "Post-process construct_query's response body: store the base64 payload in
+   mcp_ui_query_handle and return {:query_handle uuid} instead of {:query base64}.
+   The LLM carries a short opaque ID rather than hundreds of base64 characters,
+   eliminating hallucination of the payload across conversation turns."
+  [body]
+  (if-let [encoded (:query body)]
+    {:query_handle (mcp.session/store-query-handle!
+                    mcp.session/*current-session-id*
+                    encoded)}
+    body))
+
+;; Tools whose raw response body should be transformed before being wrapped in text-content.
+(def ^:private tool-body-transforms
+  {"construct_query" store-construct-query-result})
+
+;; Tools that accept :query_handle as an alternative to a raw :query base64 string.
+;; The handle is resolved to the base64 payload before dispatch to the agent API.
+(def ^:private tools-accepting-query-handle
+  #{"execute_query"})
+
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
@@ -149,8 +184,11 @@
    For POST, `params` becomes the request body; for GET/DELETE, `params` becomes query-params.
 
    Propagates `token-scopes` from the original MCP request so that scope restrictions
-   are preserved through the synthetic request."
-  [method path token-scopes params]
+   are preserved through the synthetic request.
+
+   `body-transform-fn`, when provided, is applied to the response body before
+   wrapping with text-content. Used to post-process construct_query results."
+  [method path token-scopes params & {:keys [body-transform-fn]}]
   (let [result (promise)]
     (deliver-agent-api-response result method path token-scopes params)
     (let [response (deref result 30000 {:status 504 :body {:message "Timeout"}})]
@@ -160,7 +198,8 @@
         response
 
         (= 200 (:status response))
-        (text-content (:body response))
+        (text-content (cond-> (:body response)
+                        body-transform-fn (body-transform-fn)))
 
         :else
         (error-content (extract-error-message response))))))
@@ -194,11 +233,13 @@
    request body. For GET/DELETE requests, remaining args are sent as query params."
   [tool-def arguments token-scopes]
   (let [{:keys [method path]} (:endpoint tool-def)
+        tool-name             (:name tool-def)
         method                (keyword (u/lower-case-en method))
         [resolved-path
          remaining-args]      (interpolate-path path arguments)
         api-path              (strip-api-prefix resolved-path)]
-    (invoke-agent-api method api-path token-scopes remaining-args)))
+    (invoke-agent-api method api-path token-scopes remaining-args
+                      :body-transform-fn (get tool-body-transforms tool-name))))
 
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.
@@ -214,8 +255,13 @@
     (if-let [tool-def (get (tool-index) tool-name)]
       (if-not (mcp.scope/matches? token-scopes (:scope tool-def))
         (error-content (str "Insufficient scope to call tool: " tool-name))
-        (try
-          (dispatch-via-agent-api tool-def arguments token-scopes)
-          (catch Exception e
-            (error-content (or (ex-message e) "Internal error")))))
+        (let [arguments (if (tools-accepting-query-handle tool-name)
+                          (resolve-query-arg arguments)
+                          arguments)]
+          (if (= arguments ::handle-not-found)
+            (error-content "Query handle not found. The query may have expired — try running construct_query again.")
+            (try
+              (dispatch-via-agent-api tool-def arguments token-scopes)
+              (catch Exception e
+                (error-content (or (ex-message e) "Internal error")))))))
       (error-content (str "Unknown tool: " tool-name)))))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -10,7 +10,6 @@
    [metabase.config.core :as config]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.mcp.scope :as mcp.scope]
-   [metabase.mcp.session :as mcp.session]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
    [metabase.util.json :as json])
@@ -94,40 +93,6 @@
       error            error
       :else            (str "Agent API error: " (:status response)))))
 
-;;; ------------------------------------------- Query Handle Transforms -------------------------------------------
-
-(defn- resolve-query-arg
-  "If `arguments` contains :query_handle, look it up in mcp_ui_query_handle and replace
-   it with the :query base64 string. Returns updated arguments, or ::handle-not-found if
-   the handle id doesn't exist in the store."
-  [arguments]
-  (if-let [handle-id (:query_handle arguments)]
-    (if-let [encoded (mcp.session/resolve-query-handle handle-id)]
-      (-> arguments (dissoc :query_handle) (assoc :query encoded))
-      ::handle-not-found)
-    arguments))
-
-(defn- store-construct-query-result
-  "Post-process construct_query's response body: store the base64 payload in
-   mcp_ui_query_handle and return {:query_handle uuid} instead of {:query base64}.
-   The LLM carries a short opaque ID rather than hundreds of base64 characters,
-   eliminating hallucination of the payload across conversation turns."
-  [body]
-  (if-let [encoded (:query body)]
-    {:query_handle (mcp.session/store-query-handle!
-                    mcp.session/*current-session-id*
-                    encoded)}
-    body))
-
-;; Tools whose raw response body should be transformed before being wrapped in text-content.
-(def ^:private tool-body-transforms
-  {"construct_query" store-construct-query-result})
-
-;; Tools that accept :query_handle as an alternative to a raw :query base64 string.
-;; The handle is resolved to the base64 payload before dispatch to the agent API.
-(def ^:private tools-accepting-query-handle
-  #{"execute_query"})
-
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
@@ -184,11 +149,8 @@
    For POST, `params` becomes the request body; for GET/DELETE, `params` becomes query-params.
 
    Propagates `token-scopes` from the original MCP request so that scope restrictions
-   are preserved through the synthetic request.
-
-   `body-transform-fn`, when provided, is applied to the response body before
-   wrapping with text-content. Used to post-process construct_query results."
-  [method path token-scopes params & {:keys [body-transform-fn]}]
+   are preserved through the synthetic request."
+  [method path token-scopes params]
   (let [result (promise)]
     (deliver-agent-api-response result method path token-scopes params)
     (let [response (deref result 30000 {:status 504 :body {:message "Timeout"}})]
@@ -198,8 +160,7 @@
         response
 
         (= 200 (:status response))
-        (text-content (cond-> (:body response)
-                        body-transform-fn (body-transform-fn)))
+        (text-content (:body response))
 
         :else
         (error-content (extract-error-message response))))))
@@ -233,13 +194,11 @@
    request body. For GET/DELETE requests, remaining args are sent as query params."
   [tool-def arguments token-scopes]
   (let [{:keys [method path]} (:endpoint tool-def)
-        tool-name             (:name tool-def)
         method                (keyword (u/lower-case-en method))
         [resolved-path
          remaining-args]      (interpolate-path path arguments)
         api-path              (strip-api-prefix resolved-path)]
-    (invoke-agent-api method api-path token-scopes remaining-args
-                      :body-transform-fn (get tool-body-transforms tool-name))))
+    (invoke-agent-api method api-path token-scopes remaining-args)))
 
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.
@@ -255,13 +214,8 @@
     (if-let [tool-def (get (tool-index) tool-name)]
       (if-not (mcp.scope/matches? token-scopes (:scope tool-def))
         (error-content (str "Insufficient scope to call tool: " tool-name))
-        (let [arguments (if (tools-accepting-query-handle tool-name)
-                          (resolve-query-arg arguments)
-                          arguments)]
-          (if (= arguments ::handle-not-found)
-            (error-content "Query handle not found. The query may have expired — try running construct_query again.")
-            (try
-              (dispatch-via-agent-api tool-def arguments token-scopes)
-              (catch Exception e
-                (error-content (or (ex-message e) "Internal error")))))))
+        (try
+          (dispatch-via-agent-api tool-def arguments token-scopes)
+          (catch Exception e
+            (error-content (or (ex-message e) "Internal error")))))
       (error-content (str "Unknown tool: " tool-name)))))


### PR DESCRIPTION
Closes EMB-1623

### Description

Replaces the JVM-local in-memory atom that stored pending drill-through queries with a \`mcp_ui_query_handle\` database table. Previously, a drill stored on instance A was invisible to instance B in a load-balanced deployment.

**Changes:**

- New \`mcp_ui_query_handle\` table (Liquibase migration) — stores drill payloads keyed by \`"drill:{session_id}"\` (upserted, last write wins)
- \`POST /api/mcp/ui/drills\` endpoint — frontend calls this immediately after a drill action to store the encoded query server-side; bypasses origin validation since the sandboxed iframe sends \`Origin: null\`
- \`render_drill_through\` MCP tool — consumes and deletes the stored drill payload; the LLM calls it with no arguments when the user asks to see a drill result
- \`*current-session-id*\` dynamic var bound per \`tools/call\` dispatch so tool response-fns can access session context without threading it through every layer
- \`mcpSessionId\` injected into \`window.metabaseConfig\` via the Mustache template so the iframe can include it in the drill store request
- Frontend: \`storeDrillQuery\` in \`embedding/mcp/api.ts\` posts the payload before sending \`app.sendMessage\`; uses plain \`fetch\` (not RTK Query) since the iframe runs outside the Redux Provider

### How to verify

1. Click a "go" drill on a chart in an MCP client — \`render_drill_through\` should render the drill target.
2. Verify it works correctly when multiple Metabase instances are running (drill stored on one pod, rendered on another).

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)