### PR TITLE
Update minimum app db versions in documentation

### DIFF
--- a/docs/installation-and-operation/configuring-application-database.md
+++ b/docs/installation-and-operation/configuring-application-database.md
@@ -58,7 +58,7 @@ java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar
 
 We recommend [PostgreSQL](#postgresql), but you can also use [MySQL](https://www.mysql.com/) or [MariaDB](https://www.mariadb.org/).
 
-The minimum recommended version is MySQL 8.0.17 or MariaDB 10.2.2. The `utf8mb4` character set is required.
+The minimum recommended version is MySQL 8.4.0 or MariaDB 10.6.0. The `utf8mb4` character set is required.
 
 We don't support ApsaraDB MySQL. You can instead use ApsaraDB PostgreSQL.
 

--- a/docs/installation-and-operation/migrating-from-h2.md
+++ b/docs/installation-and-operation/migrating-from-h2.md
@@ -31,9 +31,9 @@ You could also choose to run Metabase on a [Metabase Cloud](https://www.metabase
 
 We recommend using PostgreSQL for your application database.
 
-- [PostgreSQL](https://www.postgresql.org/). Minimum version: `12`. Postgres is our preferred choice for Metabase's application database.
-- [MySQL](https://www.mysql.com/). Minimum version: `8.0.17`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
-- [MariaDB](https://mariadb.org/). Minimum version: `10.4.0`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
+- [PostgreSQL](https://www.postgresql.org/). Minimum version: `14`. Postgres is our preferred choice for Metabase's application database.
+- [MySQL](https://www.mysql.com/). Minimum version: `8.4.0`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
+- [MariaDB](https://mariadb.org/). Minimum version: `10.6.0`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
 
 ## How can I tell if my Metabase instance uses H2?
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73203

### Description

The documentation listing the required app DB versions is out of date. PR #70446 changed the minimum required app DB versions.

This PR updates the documentation to match the new minimum versions.