### PR TITLE
[mage] Run Kondo in fix-unused-requires as a Babashka pod

### DIFF
--- a/mage/src/mage/fix_unused_requires.clj
+++ b/mage/src/mage/fix_unused_requires.clj
@@ -1,27 +1,20 @@
 (ns mage.fix-unused-requires
   "Fix unused requires reported by clj-kondo by removing them from source files."
   (:require
-   [babashka.process :as p]
-   [clojure.edn :as edn]
+   [babashka.pods :as pods]
    [clojure.string :as str]
    [mage.color :as c]
-   [mage.util :as u]
    [rewrite-clj.zip :as z]))
 
 (set! *warn-on-reflection* true)
 
+(pods/load-pod 'clj-kondo/clj-kondo "2026.04.15" {})
+(require '[pod.borkdude.clj-kondo :as clj-kondo])
+
 (defn- run-kondo
   "Run clj-kondo on the given files and return the EDN output."
   [files]
-  (let [{:keys [out exit]}
-        (p/sh {:out :string
-               :err :inherit
-               :dir u/project-root-directory}
-              "clojure" "-M:kondo"
-              "--config" "{:output {:format :edn}}"
-              "--lint" (str/join ":" files))]
-    (when (and (not= exit 0) (seq out))
-      (edn/read-string out))))
+  (clj-kondo/run! {:lint files}))
 
 (defn- unused-namespace-findings
   "Filter findings to only unused-namespace warnings."


### PR DESCRIPTION
Since `mage fix-unused-requires` has been added as a step of `lint-staged` pre-commit hook, the avg hook running time has increased to 8 seconds on my machine. I'm now running `git commit -n` much more often because having such a long delay before a commit is quite annoying.

The proposed solution runs Clj-kondo (which powers the unused requires cleanup) within Mage's babashka process itself, without shelling out to a separate `clojure` call. The solution is similar to what I've already implemented in `mage cljfmt-files` 

As a resutl, the waiting time for lint-staging a single file has dropped to 3-5 seconds on my machine. Much more palatable.

As a potential problem, I can see that if many files need to be linted this way, it may/will become slower than a `clojure` subshell. Perhaps, some threshold of 10-20 files could make sense.
