### PR TITLE
Store construct_query result server-side to prevent LLM hallucination

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -381,7 +381,7 @@
   (str
    "Construct a Metabase MBQL query from a structured program. The body is the program itself — no envelope — shaped:\n"
    "`{\"source\": {...}, \"operations\": [...]}`\n"
-   "Returns `{\"query\": \"<base64>\"}` — pass the string to `execute_query`.\n"
+   "Returns `{\"query_handle\": \"<uuid>\"}` — pass it as `query_handle` to `execute_query` or `visualize_query`.\n"
    "\n"
    "IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). "
    "Do not invent IDs. The backend repairs minor mistakes (aliases, casing, over-wrapping) before validation, "

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -168,17 +168,32 @@
   :description (str "Visualize a previously constructed query as an interactive chart or table. "
                     "This renders the final answer in the UI. Do not call execute_query after "
                     "visualize_query; showing the visualization is enough.")
+  ;; Both fields are optional rather than expressing "at least one of" via a top-level `anyOf`.
+  ;; This is because some MCP clients, e.g. the MCP inspector (mcpjam) rejects top-level combinators.
+  ;; The response-fn enforces the at-least-one contract at runtime.
   :inputSchema {:type       "object"
-                :properties {:query {:type "string" :minLength 1}}
-                :required   ["query"]}
+                :properties {:query        {:type "string" :minLength 1
+                                            :description "Base64-encoded MBQL query (use query_handle instead when available)"}
+                             :query_handle {:type "string" :format "uuid"
+                                            :description "Handle returned by construct_query; preferred over raw query"}}}
   :response-fn (fn [arguments _opts]
-                 (if-let [encoded (:query arguments)]
-                   {:content          [{:type "text" :text (str "Visualizing query in the interactive UI. "
-                                                                "Do not call execute_query after this; "
-                                                                "the visualization is the final result.")}]
-                    :structuredContent {:query encoded}}
-                   {:content [{:type "text" :text "Missing query argument."}]
-                    :isError true}))})
+                 (let [query   (:query arguments)
+                       handle  (:query_handle arguments)
+                       encoded (or query (some-> handle mcp.session/read-handle))]
+                   (cond
+                     (and (nil? query) (nil? handle))
+                     {:content [{:type "text" :text "Provide either 'query' or 'query_handle'."}]
+                      :isError true}
+
+                     encoded
+                     {:content           [{:type "text" :text (str "Visualizing query in the interactive UI. "
+                                                                   "Do not call execute_query after this; "
+                                                                   "the visualization is the final result.")}]
+                      :structuredContent {:query encoded}}
+
+                     :else
+                     {:content [{:type "text" :text "Query handle not found. Try running construct_query again."}]
+                      :isError true})))})
 
 (register-ui-tool!
  :visualize-query

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -143,20 +143,26 @@
 
 ;;; -------------------------------------------- Query Handle Store -----------------------------------------------
 ;; DB-backed store for base64-encoded MBQL query payloads referenced by MCP tool
-;; calls. Each row carries a fresh UUID handle that the iframe passes to the agent
-;; so the LLM never carries the encoded query.
+;; calls. Each row carries a fresh UUID handle that the iframe (drill-through) or
+;; agent (construct_query) passes through downstream so the LLM never carries the
+;; encoded query.
 
 (defn store-handle!
   "Insert a new handle row binding `encoded-query` to the MCP session, and return
-   the freshly minted handle UUID. Materializes the backing `core_session` so
-   cleanup happens via cascade when the session row is reaped."
+   the freshly minted handle UUID.
+
+   When `user-id` is non-nil, materializes the backing `core_session` so cleanup
+   happens via cascade when the session row is reaped. When nil — e.g. agent flows
+   that don't render an iframe — the row is stored without a `core_session_id` and
+   relies on explicit `delete!` for cleanup."
   [session-id user-id encoded-query]
-  (let [core-session (get-or-create-embedding-session! session-id user-id)
-        handle-id    (str (UUID/randomUUID))]
+  (let [core-session-id (when user-id
+                          (:id (get-or-create-embedding-session! session-id user-id)))
+        handle-id       (str (UUID/randomUUID))]
     (t2/insert! :model/McpQueryHandle
                 {:id              handle-id
                  :mcp_session_id  session-id
-                 :core_session_id (:id core-session)
+                 :core_session_id core-session-id
                  :encoded_query   encoded-query})
     handle-id))
 

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -10,9 +10,11 @@
    [metabase.config.core :as config]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.mcp.scope :as mcp.scope]
+   [metabase.mcp.session :as mcp.session]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.log :as log])
   (:import
    (java.io ByteArrayOutputStream)
    (java.net URLEncoder)
@@ -93,6 +95,45 @@
       error            error
       :else            (str "Agent API error: " (:status response)))))
 
+;;; ------------------------------------------- Query Handle Transforms -------------------------------------------
+
+(defn- resolve-query-arg
+  "Resolve the query argument for tools that accept a handle.
+   If :query_handle is present, look it up and replace with :query.
+   If :query is itself a UUID (the LLM passed the handle in the wrong field), resolve
+   it too — but log a warning so we can track how often this antipattern fires.
+   Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
+  [tool-name arguments]
+  (cond
+    (:query_handle arguments)
+    (if-let [encoded (mcp.session/read-handle (:query_handle arguments))]
+      (-> arguments (dissoc :query_handle) (assoc :query encoded))
+      ::handle-not-found)
+
+    (mcp.session/valid-id? (:query arguments))
+    (do (log/warnf "MCP tool %s: agent passed a UUID handle in :query; resolving as :query_handle"
+                   tool-name)
+        (if-let [encoded (mcp.session/read-handle (:query arguments))]
+          (assoc arguments :query encoded)
+          ::handle-not-found))
+
+    :else
+    arguments))
+
+(defn- make-store-construct-query-result
+  "Build a body-transform fn for construct_query. Stores the base64 payload server-side
+   under the calling MCP session and returns {:query_handle uuid} instead of {:query base64},
+   so the LLM carries a short opaque UUID rather than the full base64 string."
+  [session-id user-id]
+  (fn [body]
+    (if-let [encoded (:query body)]
+      {:query_handle (mcp.session/store-handle! session-id user-id encoded)}
+      body)))
+
+;; Tools that accept :query_handle as an alternative to a raw base64 :query string.
+(def ^:private tools-accepting-query-handle
+  #{"execute_query" "visualize_query"})
+
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
@@ -149,8 +190,11 @@
    For POST, `params` becomes the request body; for GET/DELETE, `params` becomes query-params.
 
    Propagates `token-scopes` from the original MCP request so that scope restrictions
-   are preserved through the synthetic request."
-  [method path token-scopes params]
+   are preserved through the synthetic request.
+
+   `body-transform-fn`, when provided, is applied to the 200 response body before
+   wrapping with text-content. Used to post-process construct_query results."
+  [method path token-scopes params & {:keys [body-transform-fn]}]
   (let [result (promise)]
     (deliver-agent-api-response result method path token-scopes params)
     (let [response (deref result 30000 {:status 504 :body {:message "Timeout"}})]
@@ -160,7 +204,8 @@
         response
 
         (= 200 (:status response))
-        (text-content (:body response))
+        (text-content (cond-> (:body response)
+                        body-transform-fn (body-transform-fn)))
 
         :else
         (error-content (extract-error-message response))))))
@@ -192,13 +237,18 @@
    Looks up method/path from the tool definition, interpolates path params,
    and calls `invoke-agent-api`. For POST requests, remaining args are sent as the
    request body. For GET/DELETE requests, remaining args are sent as query params."
-  [tool-def arguments token-scopes]
+  [tool-def arguments token-scopes session-id]
   (let [{:keys [method path]} (:endpoint tool-def)
+        tool-name             (:name tool-def)
         method                (keyword (u/lower-case-en method))
         [resolved-path
          remaining-args]      (interpolate-path path arguments)
-        api-path              (strip-api-prefix resolved-path)]
-    (invoke-agent-api method api-path token-scopes remaining-args)))
+        api-path              (strip-api-prefix resolved-path)
+        body-transform-fn     (when (= tool-name "construct_query")
+                                (make-store-construct-query-result
+                                 session-id api/*current-user-id*))]
+    (invoke-agent-api method api-path token-scopes remaining-args
+                      :body-transform-fn body-transform-fn)))
 
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.
@@ -215,8 +265,13 @@
     (if-let [tool-def (get (tool-index) tool-name)]
       (if-not (mcp.scope/matches? token-scopes (:scope tool-def))
         (error-content (str "Insufficient scope to call tool: " tool-name))
-        (try
-          (dispatch-via-agent-api tool-def arguments token-scopes)
-          (catch Exception e
-            (error-content (or (ex-message e) "Internal error")))))
+        (let [arguments (if (tools-accepting-query-handle tool-name)
+                          (resolve-query-arg tool-name arguments)
+                          arguments)]
+          (if (= arguments ::handle-not-found)
+            (error-content "Query handle not found. The query may have expired — try running construct_query again.")
+            (try
+              (dispatch-via-agent-api tool-def arguments token-scopes session-id)
+              (catch Exception e
+                (error-content (or (ex-message e) "Internal error")))))))
       (error-content (str "Unknown tool: " tool-name)))))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -427,7 +427,8 @@
       (is (str/includes? (:text (first (:content result))) "Missing required path parameter")))))
 
 (deftest tools-list-no-refs-test
-  (testing "tool inputSchemas have no $ref, no $defs, and root type is always object"
+  (testing "tool inputSchemas have no $ref, no $defs, root type is always object,
+            and no top-level oneOf/anyOf/allOf (rejected by mcpjam)"
     (let [tools (mcp.tools/list-tools nil)]
       (doseq [tool tools]
         (when-let [schema (:inputSchema tool)]
@@ -438,7 +439,10 @@
               (is (not (contains? schema :$defs))
                   (str (:name tool) " should have no $defs"))
               (is (= "object" (:type schema))
-                  (str (:name tool) " root type should be object")))))))))
+                  (str (:name tool) " root type should be object"))
+              (doseq [k [:oneOf :anyOf :allOf]]
+                (is (not (contains? schema k))
+                    (str (:name tool) " should have no top-level " k))))))))))
 
 (deftest tools-call-get-table-query-params-test
   (testing "get_table passes query params correctly (with-fields default true)"
@@ -469,7 +473,7 @@
                                         {:source     {:type "table" :id (mt/id :orders)}
                                          :operations [["limit" 5]]})
               execute-data   (call-tool session-id "execute_query"
-                                        {:query (:query construct-data)})]
+                                        {:query_handle (:query_handle construct-data)})]
           (is (true? @streamed?) "execute_query should use the streaming response path")
           (is (=? {:status    "completed"
                    :row_count 5
@@ -501,6 +505,48 @@
               (mcp-request (jsonrpc-request "tools/call"
                                             {:name      "render_drill_through"
                                              :arguments {:handle (str (random-uuid))}})
+                           {"mcp-session-id" session-id}))))))
+
+(deftest tools-call-visualize-query-test
+  (testing "visualize_query echoes the inline query"
+    (let [[session-id _] (initialize!)]
+      (is (=? {:status 200
+               :body   {:result {:structuredContent {:query "ZW5jb2RlZA=="}}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "visualize_query"
+                                             :arguments {:query "ZW5jb2RlZA=="}})
+                           {"mcp-session-id" session-id})))))
+
+  (testing "visualize_query resolves a stored handle"
+    (let [user-id        (mt/user->id :crowberto)
+          [session-id _] (initialize!)
+          handle         (mt/with-current-user user-id
+                           (mcp.session/store-handle! session-id user-id "ZW5jb2RlZA=="))]
+      (is (=? {:status 200
+               :body   {:result {:structuredContent {:query "ZW5jb2RlZA=="}}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "visualize_query"
+                                             :arguments {:query_handle handle}})
+                           {"mcp-session-id" session-id})))))
+
+  (testing "visualize_query asks for an argument when neither query nor handle is provided"
+    (let [[session-id _] (initialize!)]
+      (is (=? {:status 200
+               :body   {:result {:isError true
+                                 :content [{:text #(str/includes? % "Provide either")}]}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "visualize_query"
+                                             :arguments {}})
+                           {"mcp-session-id" session-id})))))
+
+  (testing "visualize_query returns 'handle not found' when query_handle is unknown"
+    (let [[session-id _] (initialize!)]
+      (is (=? {:status 200
+               :body   {:result {:isError true
+                                 :content [{:text #(str/includes? % "Query handle not found")}]}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "visualize_query"
+                                             :arguments {:query_handle (str (random-uuid))}})
                            {"mcp-session-id" session-id}))))))
 
 ;;; --------------------------------------------- OAuth Bearer Auth -------------------------------------------------


### PR DESCRIPTION
Closes EMB-1632

> [!IMPORTANT]
> ~This PR is AI-generated. Please feel free to make any backend changes~ done

### Description

When `construct_query` returns a long base64-encoded MBQL string, smaller models (e.g. Sonnet 4.6) hallucinate the payload when passing it to `visualize_query` or `execute_query` in a subsequent tool call.

This fix stores the query in the database on `construct_query` and returns a short UUID handle instead. Downstream tools resolve the handle server-side. The LLM never sees the raw base64. Tool calls now passes UUID `query_handle` instead of base64 `query`.

Builds on the `mcp_ui_query_handle` table introduced by https://github.com/metabase/metabase/pull/73278. It adds a `session_id` column so UUID handles can also be cleaned up on session teardown.

### Demos

<img width="400" alt="CleanShot 2569-05-01 at 01 55 40@2x" src="https://github.com/user-attachments/assets/878ef5b9-942a-4f47-89e3-801930bd4dcd" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing as you will run into the https://github.com/anthropics/claude-ai-mcp/issues/40 bug, where Claude Desktop strips all HTTP domains (e.g. `localhost:3000`) and nothing will load.

You cannot use the PR environment with Claude Connector either, as it is behind Tailscale and Claude cannot talk to it. You must use `mcp-remote` to test with PR environment.

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73210.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case.

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73210.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  },
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. ask the agent to construct and visualize a query (e.g. "show me orders by month").
4. Confirm `construct_query` returns `{"query_handle": "<uuid>"}` instead of a raw base64 string.
5. Confirm `visualize_query` renders the correct chart using that handle.
6. Ask the agent to run a second query in the same session — both handles should resolve independently.