### PR TITLE
fixed ResizeObserver regression

### DIFF
--- a/frontend/src/metabase/static-viz/index.tsx
+++ b/frontend/src/metabase/static-viz/index.tsx
@@ -125,7 +125,7 @@ export function RenderChart(
     options.applicationColors,
   );
 
-  if (enterpriseOverrides) {
+  if (typeof enterpriseOverrides === "function") {
     enterpriseOverrides();
   }
 

--- a/frontend/src/metabase/static-viz/mock-environment.ts
+++ b/frontend/src/metabase/static-viz/mock-environment.ts
@@ -48,6 +48,7 @@ defineGlobal("Element", MockElement);
 
 const mockWindow = new MockEventTarget();
 defineGlobal("window", mockWindow);
+Object.assign(mockWindow, { ResizeObserver });
 
 const createMockDocument = () => {
   const document = new MockEventTarget();

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1221,4 +1221,3 @@
                    "ID"
                    "Product ID [external remap]"]
                   (map (comp :title second) (-> table :content second (nth 2) second last)))))))))
-

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1221,3 +1221,4 @@
                    "ID"
                    "Product ID [external remap]"]
                   (map (comp :title second) (-> table :content second (nth 2) second last)))))))))
+


### PR DESCRIPTION
Closes [UXW-3877: Fix GraalVM ResizeObserverImpl failures in static-viz tests](https://linear.app/metabase/issue/UXW-3877/fix-graalvm-resizeobserverimpl-failures-in-static-viz-tests)

Two regressions in commit **72ba6a81c11 — "static viz typing (#73193)"**:

1. **`window.ResizeObserver` was undefined.** The old `mock-environment.js` did `Object.assign(global.window, global)` which mirrored `ResizeObserver` onto `window`. The new `.ts` rewrite only set it on `globalThis`, but the bundle reads `window.ResizeObserver` at `lib-static-viz.bundle.js:176752`.
   - **Fix**: in `frontend/src/metabase/static-viz/mock-environment.ts`, `Object.assign(mockWindow, { ResizeObserver })` after defining `window`.

2. **`enterpriseOverrides` callability check weakened.** The old `index.js` used `typeof enterpriseOverrides === "function"`. The new `index.tsx` used `if (enterpriseOverrides)` — but in OSS builds `ee-overrides` aliases to `metabase/utils/noop.ts` which has *no exports*, so the default import resolves to the (truthy) module object, passing the truthy check but failing as `not a function`.
   - **Fix**: restored `typeof enterpriseOverrides === "function"` in `frontend/src/metabase/static-viz/index.tsx`.