### PR TITLE
Fix static-viz `window.X` polyfills (ResizeObserver crash)

### DIFF
--- a/frontend/src/metabase/static-viz/mock-environment.ts
+++ b/frontend/src/metabase/static-viz/mock-environment.ts
@@ -1,15 +1,5 @@
 import ResizeObserver from "resize-observer-polyfill";
 
-const defineGlobal = (name: PropertyKey, value: unknown): void => {
-  Object.defineProperty(globalThis, name, {
-    value,
-    writable: true,
-    configurable: true,
-  });
-};
-
-defineGlobal("ResizeObserver", ResizeObserver);
-
 class MockEventTarget {
   listeners: Record<string, unknown[]> = {};
   addEventListener(): void {}
@@ -18,7 +8,6 @@ class MockEventTarget {
     return false;
   }
 }
-defineGlobal("EventTarget", MockEventTarget);
 
 class MockElement extends MockEventTarget {
   tagName: string;
@@ -44,9 +33,26 @@ class MockElement extends MockEventTarget {
     return this.attributes[name];
   }
 }
-defineGlobal("Element", MockElement);
 
 const mockWindow = new MockEventTarget();
+
+// Mirrors the old mock-environment.js, where `Object.assign(global.window, global)`
+// surfaced every polyfilled global on `window`. Code paths that read `window.X`
+// (e.g. metabase/utils/resize-observer reads `window.ResizeObserver`) get bundled
+// into the static-viz bundle and would otherwise see `undefined` under GraalVM.
+const defineGlobal = (name: PropertyKey, value: unknown): void => {
+  const descriptor: PropertyDescriptor = {
+    value,
+    writable: true,
+    configurable: true,
+  };
+  Object.defineProperty(globalThis, name, descriptor);
+  Object.defineProperty(mockWindow, name, descriptor);
+};
+
+defineGlobal("ResizeObserver", ResizeObserver);
+defineGlobal("EventTarget", MockEventTarget);
+defineGlobal("Element", MockElement);
 defineGlobal("window", mockWindow);
 
 const createMockDocument = () => {
@@ -79,7 +85,6 @@ const createMockDocument = () => {
 
 const mockDocument = createMockDocument();
 defineGlobal("document", mockDocument);
-Object.assign(mockWindow, { document: mockDocument });
 
 const mockNavigator = {
   userAgent: "GraalJS",
@@ -100,7 +105,6 @@ const mockNavigator = {
   },
 };
 defineGlobal("navigator", mockNavigator);
-Object.assign(mockWindow, { navigator: mockNavigator });
 
 defineGlobal("location", {
   href: "",


### PR DESCRIPTION
The TS rewrite of `mock-environment.ts` (#73193) dropped the `Object.assign(global.window, global)` that the old JS version did, so `window.ResizeObserver` is `undefined` under GraalVM. `metabase/utils/resize-observer` reads `window.ResizeObserver` and constructs it at module load, so any fresh polyglot context evaluating `lib-static-viz` throws.

```
Exception in thread "dirigiste-pool-controller-0" java.lang.RuntimeException: TypeError: TypeError: ResizeObserverImpl is not a constructor
        at io.aleph.dirigiste.Pool.addObject(Pool.java:277)
        ...
Caused by: TypeError: TypeError: ResizeObserverImpl is not a constructor
        at <js>.createResizeObserver(lib-static-viz.bundle.js:176750)
        at <js>.10836(lib-static-viz.bundle.js:176775)
        at <js>.__webpack_require__(lib-static-viz.bundle.js:224603)
        ...
        at metabase.channel.render.js.engine\$load_resource.invokeStatic(engine.clj:75)
        at metabase.channel.render.js.svg\$load_viz_bundle.invokeStatic(svg.clj:45)
```

Fix: have `defineGlobal` write to `mockWindow` too, so `window.X` mirrors `globalThis.X` again.

Failing run: https://github.com/metabase/metabase/actions/runs/24978505622