### PR TITLE
Support trusted publisher on the Embedding SDK release workflow

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -299,6 +299,9 @@ jobs:
     needs: [build-sdk, determine-sdk-version]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
     env:
       sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
     steps:
@@ -380,17 +383,20 @@ jobs:
             echo "masterTag=nightly" >> $GITHUB_OUTPUT
           fi
 
+      # Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
+      # Node 22.x line bundles npm 10.x, so pin Node 24.x which ships npm 11.x.
+      - name: Setup Node.js for npm publish with trusted publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
-
           TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
-
-        env:
-          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
       # ⚠️ This step should only be executed on the latest stable (gold) release branch.
       # Only uncomment this when the new release branch becomes stable (gold).
       # - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -300,8 +300,9 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 20
     permissions:
-      id-token: write
-      contents: read
+      id-token: write # OIDC handshake for npm trusted publishing
+      actions: read # actions/download-artifact reads the Actions API via GITHUB_TOKEN
+      pull-requests: write # gh pr review --approve step uses GITHUB_TOKEN
     env:
       sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
     steps:


### PR DESCRIPTION
closes EMB-1643

[We decide not to backport.
](https://metaboat.slack.com/archives/C063Q3F1HPF/p1777280250390749?thread_ts=1776423332.037269&cid=C063Q3F1HPF)

~Before merging this, we need to ensure we've set up the trusted publishing on npmjs.com first.~ ✅ done.

1. Log into npmjs.com as a maintainer of `@metabase/embedding-sdk-react`
2. Package page → Settings → Publishing access → Trusted publishers → Add
3. Provider: GitHub Actions. Fields:
   - Organization: `metabase`
   - Repository: `metabase`
   - Workflow filename: `release-embedding-sdk.yml`
   - Environment: leave blank (we don't use Github environments here)
4. Save

#### How to verify
[Test run](https://github.com/metabase/metabase/actions/runs/24998222308) with the commit https://github.com/metabase/metabase/pull/73214/changes/b0cf5ae0c7ce99276da660c5d0092efc5b0deb94 (will be removed after). It was deployed successfully with proper a provenance statement.
<img width="257" height="248" alt="image" src="https://github.com/user-attachments/assets/8fc0675d-6e70-48a1-b6f3-5e977432b937" />
