### PR TITLE
Properly pass mantine-color-scheme

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
@@ -6,6 +6,7 @@ import cx from "classnames";
 import type React from "react";
 import { forwardRef } from "react";
 
+import { useComputedColorScheme } from "metabase/ui";
 import { saveDomImageStyles } from "metabase/visualizations/lib/image-exports";
 
 import S from "./PublicComponentStylesWrapper.style.css";
@@ -24,14 +25,23 @@ export const PublicComponentStylesWrapper = forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
 >(function PublicComponentStylesWrapper(props, ref) {
+  // Mantine scopes its CSS variables to `cssVariablesSelector=".mb-wrapper"`,
+  // so the variables for the active color scheme only apply when the wrapper
+  // itself carries `data-mantine-color-scheme`. Read the resolved scheme from
+  // the parent MantineProvider so portals (e.g. the filter-changed toast in
+  // guest embeds with `theme.preset: "dark"`) inherit it instead of being
+  // pinned to light (EMB-1560).
+  const colorScheme = useComputedColorScheme("light", {
+    getInitialValueInEffect: false,
+  });
+
   return (
     <PublicComponentStylesWrapperInner
       {...props}
       ref={ref}
       dir="ltr"
       className={cx("mb-wrapper", S.publicComponentWrapper, props.className)}
-      // Mantine's cssVariablesSelector expects data-mantine-color-scheme to be set on the target element
-      data-mantine-color-scheme="light"
+      data-mantine-color-scheme={colorScheme}
     />
   );
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.unit.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+
+import { ThemeProvider } from "metabase/ui";
+
+import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
+
+const setup = (resolvedColorScheme: "light" | "dark") =>
+  render(
+    <ThemeProvider resolvedColorScheme={resolvedColorScheme}>
+      <PublicComponentStylesWrapper data-testid="wrapper">
+        <span>content</span>
+      </PublicComponentStylesWrapper>
+    </ThemeProvider>,
+  );
+
+describe("PublicComponentStylesWrapper", () => {
+  it("inherits the parent MantineProvider's light color scheme", () => {
+    setup("light");
+    expect(screen.getByTestId("wrapper")).toHaveAttribute(
+      "data-mantine-color-scheme",
+      "light",
+    );
+  });
+
+  it("inherits the parent MantineProvider's dark color scheme (EMB-1560)", () => {
+    setup("dark");
+    expect(screen.getByTestId("wrapper")).toHaveAttribute(
+      "data-mantine-color-scheme",
+      "dark",
+    );
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure } from "@mantine/hooks";
-import { type CSSProperties, type PropsWithChildren, useMemo } from "react";
+import { type PropsWithChildren, useMemo } from "react";
 import { jt, t } from "ttag";
 
 import { ERROR_DOC_LINKS } from "embedding-sdk-bundle/errors";
@@ -10,7 +10,6 @@ import type { SdkErrorComponentProps } from "embedding-sdk-bundle/types";
 import { Alert } from "metabase/common/components/Alert";
 import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
 import { Anchor, Box, Center, Code, Flex, Portal } from "metabase/ui";
-import { color } from "metabase/ui/colors";
 
 export const SdkError = ({
   message,
@@ -93,16 +92,8 @@ export function SdkPortalErrorWrapper({ children }: PropsWithChildren) {
   );
 }
 
-const FORCE_DARK_TEXT_COLOR = {
-  // The Alert component has a light background, we need to force a dark text
-  // color. The sdk aliases text-primary to the primary color, which in dark themes
-  // is a light color, making the text un-readable
-  "--mb-color-text-primary": color("text-primary"),
-  "--mb-color-text-secondary": color("text-secondary"),
-} as CSSProperties;
-
 const DefaultErrorMessage = ({ message, onClose }: SdkErrorComponentProps) => (
-  <Box p="sm" style={FORCE_DARK_TEXT_COLOR} maw={600}>
+  <Box p="sm" maw={600}>
     <Alert variant="error" icon="warning" onClose={onClose}>
       <Box
         style={{

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkThemeProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkThemeProvider.tsx
@@ -6,20 +6,37 @@ import { DEFAULT_FONT } from "embedding-sdk-bundle/config";
 import { useEmbeddingThemeOverride } from "embedding-sdk-bundle/hooks/private/use-embedding-theme-override";
 import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
 import { useSetting } from "metabase/common/hooks";
-import type { MetabaseEmbeddingTheme } from "metabase/embedding-sdk/theme";
+import {
+  type MetabaseEmbeddingTheme,
+  isEmbeddingThemeV1,
+} from "metabase/embedding-sdk/theme";
 import { useSelector } from "metabase/redux";
 import { getFont } from "metabase/styled-components/selectors";
 import { getMetabaseSdkCssVariables } from "metabase/styled-components/theme/css-variables";
 import { ThemeProvider, useMantineTheme } from "metabase/ui";
 import { ThemeProviderContext } from "metabase/ui/components/theme/ThemeProvider/context";
+import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 
 interface Props {
   theme?: MetabaseEmbeddingTheme;
   children: React.ReactNode;
 }
 
+const getResolvedColorSchemeFromTheme = (
+  theme: MetabaseEmbeddingTheme | undefined,
+): ResolvedColorScheme | undefined => {
+  if (!isEmbeddingThemeV1(theme)) {
+    return undefined;
+  }
+  return theme.preset === "dark" || theme.preset === "light"
+    ? theme.preset
+    : undefined;
+};
+
 export const SdkThemeProvider = ({ theme, children }: Props) => {
   const themeOverride = useEmbeddingThemeOverride(theme);
+
+  const resolvedColorScheme = getResolvedColorSchemeFromTheme(theme);
 
   const { withCssVariables, withGlobalClasses } =
     useContext(ThemeProviderContext);
@@ -40,6 +57,7 @@ export const SdkThemeProvider = ({ theme, children }: Props) => {
         >
           <ThemeProvider
             theme={themeOverride}
+            resolvedColorScheme={resolvedColorScheme}
             cssVariablesSelector=".mb-wrapper"
           >
             {isInstanceToRender && <GlobalSdkCssVariables />}

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,4 +1,10 @@
-export { rem, useCombobox, useMantineTheme, useMatches } from "@mantine/core";
+export {
+  rem,
+  useCombobox,
+  useComputedColorScheme,
+  useMantineTheme,
+  useMatches,
+} from "@mantine/core";
 export type {
   MenuDropdownProps,
   ComboboxStore,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72360
Closes [EMB-1560: Guest embed: filter change bar ignores theme.preset: "dark" — data-mantine-color-scheme stays "light"](https://linear.app/metabase/issue/EMB-1560/guest-embed-filter-change-bar-ignores-themepreset-dark-data-mantine)

### Description

Properly propagates the data-mantine-color-scheme parameter, painting previously pale popovers in the proper palette.

### How to verify

Create a host HTML page (any local server works, e.g. `python3 -m http.server`) with the embed.js snippet:

   ```html
   <!doctype html>
   <html>
     <head>
       <script>
         window.metabaseConfig = {
           instanceUrl: "http://localhost:3000",
           isGuest: true,
           theme: { preset: "dark" },
         };
       </script>
       <script src="http://localhost:3000/app/embed.js"></script>
     </head>
     <body>
       <metabase-dashboard dashboard-id="<YOUR_DASHBOARD_ID>"></metabase-dashboard>
     </body>
   </html>
   ```

2. Open the page. The dashboard should render in dark mode.

3. Change a filter value. The "1 filter changed — Cancel | Apply" toast appears at the bottom of the dashboard.

4. **Before the fix**: the toast renders with a light gray background. DevTools → inspect the `.mb-wrapper` ancestor of the toast — it has `data-mantine-color-scheme="light"`.

   **After the fix**: that wrapper now has `data-mantine-color-scheme="dark"`, and Mantine's dark CSS variables scoped to `.mb-wrapper[data-mantine-color-scheme="dark"]` apply.

### Demo

Before
<img width="1546" height="916" alt="image" src="https://github.com/user-attachments/assets/b4078f5e-5cb3-4951-aeba-70a21ba5bd84" />


After
<img width="1546" height="916" alt="image" src="https://github.com/user-attachments/assets/447c86f3-2eb1-49a9-b793-b6d401941cd2" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
