### PR TITLE
Replace hardcoded dashboard-id 9 in iframe auth e2e (backport to x.59)

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -41,7 +41,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
                 "instanceUrl": "http://localhost:4000",
               });
             </script>
-            <metabase-dashboard dashboard-id='9' />
+            <metabase-dashboard dashboard-id='${ORDERS_DASHBOARD_ID}' />
           </body>
           </html>
             `);
@@ -75,7 +75,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
                 "jwtProviderUri": "http://auth-provider/sso?response=json",
               });
             </script>
-            <metabase-dashboard dashboard-id='9' />
+            <metabase-dashboard dashboard-id='${ORDERS_DASHBOARD_ID}' />
           </body>
           </html>
             `);


### PR DESCRIPTION
Backport of 2d82272f7fb

Replaces hardcoded `dashboard-id='9'` with `ORDERS_DASHBOARD_ID` in `authentication.cy.spec.ts`

Closes [EMB-1638](https://linear.app/metabase/issue/EMB-1638).
