### PR TITLE
docs(sdk): Update SDK version to 0.61.0-alpha.0

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.61.0-alpha",
+  "version": "0.61.0-alpha.0",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
This is a mirror of https://github.com/metabase/metabase/pull/73225, but for `master` because that PR was made when I was testing an unmerged branch. The version 0.61.0-alpha.0 has already been deployed, so we need to update it against `master`.

Update Readme version references and published npm package version to 0.61.0-alpha.0
