### PR TITLE
fix: cloud migration error should allow restart

### DIFF
--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
@@ -116,7 +116,11 @@ export const CloudPanel = ({
         )}
 
         {migration && migrationState === "error" && (
-          <MigrationError migration={migration} />
+          <MigrationError
+            migration={migration}
+            restartMigration={handleCreateMigration}
+            isRestarting={createCloudMigrationResult.isLoading}
+          />
         )}
 
         {createCloudMigrationResult.isError && (

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
@@ -133,11 +133,13 @@ describe("CloudPanel", () => {
     const { mockMigrationStart, metabaseStoreLink } = setup();
 
     await expectErrorState();
-    await expectInitState();
-    await userEvent.click(screen.getByRole("button", { name: "Try for free" }));
+    expect(
+      screen.queryByRole("heading", { name: "Migrate to Metabase Cloud" }),
+    ).not.toBeInTheDocument();
 
-    await expectStartConfirmationModal();
-    await userEvent.click(screen.getByRole("button", { name: /Migrate now/ }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Restart the process/ }),
+    );
 
     fetchMockCloudMigrationGetSequence([
       { ...INIT_RESPONSE, id: 2 },

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationError.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationError.tsx
@@ -1,7 +1,7 @@
 import { c, t } from "ttag";
 
 import { Link } from "metabase/common/components/Link";
-import { Box, Flex, Icon, Text } from "metabase/ui";
+import { Box, Button, Flex, Icon, Text } from "metabase/ui";
 import { color } from "metabase/ui/colors";
 import type { CloudMigration } from "metabase-types/api/cloud-migration";
 
@@ -10,37 +10,57 @@ import { getMigrationEventTime } from "./utils";
 
 interface MigrationErrorProps {
   migration: CloudMigration;
+  restartMigration: () => void;
+  isRestarting: boolean;
 }
 
-export const MigrationError = ({ migration }: MigrationErrorProps) => {
+export const MigrationError = ({
+  migration,
+  restartMigration,
+  isRestarting,
+}: MigrationErrorProps) => {
   const failedAt = getMigrationEventTime(migration.updated_at);
 
   return (
-    <MigrationCard>
-      <Flex gap="md">
-        <LargeIconContainer color={color("error")}>
-          <Icon size="1.5rem" name="warning" />
-        </LargeIconContainer>
-        <Box>
-          <Text fw="bold">{t`Migration to Metabase Cloud failed`}</Text>
-          <Text mt="1rem">
-            {c("{0} is an email address")
-              .jt`Please try again later, and reach out to us at ${
-              /* eslint-disable i18next/no-literal-string */
-              (
-                <Link key="email" variant="brand" to="mailto:help@metabase.com">
-                  help@metabase.com
-                </Link>
-              )
-              /* eslint-enable i18next/no-literal-string */
-            } if you need help.`}
-          </Text>
-          <Text
-            size="sm"
-            mt=".5rem"
-          >{t`Migration to Metabase Cloud failed on ${failedAt}.`}</Text>
-        </Box>
-      </Flex>
-    </MigrationCard>
+    <>
+      <MigrationCard>
+        <Flex gap="md">
+          <LargeIconContainer color={color("error")}>
+            <Icon size="1.5rem" name="warning" />
+          </LargeIconContainer>
+          <Box>
+            <Text fw="bold">{t`Migration to Metabase Cloud failed`}</Text>
+            <Text mt="1rem">
+              {c("{0} is an email address")
+                .jt`Please try again later, and reach out to us at ${
+                /* eslint-disable i18next/no-literal-string */
+                (
+                  <Link
+                    key="email"
+                    variant="brand"
+                    to="mailto:help@metabase.com"
+                  >
+                    help@metabase.com
+                  </Link>
+                )
+                /* eslint-enable i18next/no-literal-string */
+              } if you need help.`}
+            </Text>
+            <Text
+              size="sm"
+              mt=".5rem"
+            >{t`Migration to Metabase Cloud failed on ${failedAt}.`}</Text>
+          </Box>
+        </Flex>
+      </MigrationCard>
+
+      <Button
+        variant="subtle"
+        onClick={restartMigration}
+        disabled={isRestarting}
+        px="0"
+        mt="1rem"
+      >{t`Restart the process`}</Button>
+    </>
   );
 };

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/utils.ts
@@ -15,7 +15,6 @@ export type InProgressCloudMigration = Omit<CloudMigration, "state"> & {
 export const getStartedVisibleStates = new Set<InternalCloudMigrationState>([
   "uninitialized",
   "cancelled",
-  "error",
 ]);
 
 export const progressStates = new Set<InternalCloudMigrationState>([


### PR DESCRIPTION
Currently if the last migration attempt hits an error state it is not possible to cancel and start again.

This commit should fix that case by showing the the "Restart the process" link.

It also removes the "Try for free" panel on error state, it shouldn't be there.

Fix https://linear.app/metabase/issue/CLO-5361/migration-flow-gets-stuck-in-initialized-state
