### PR TITLE
BOT-1398 Backport data parts persistence from #73107

### DIFF
--- a/src/metabase/metabot/agent/streaming.clj
+++ b/src/metabase/metabot/agent/streaming.clj
@@ -21,6 +21,16 @@
 (def adhoc-viz-type "AI-SDK data type for ad-hoc visualizations." "adhoc_viz")
 (def static-viz-type "AI-SDK data type for static visualizations." "static_viz")
 
+(defn persistable-data-part?
+  "True if `part` should be written to MetabotMessage.data. `state` parts are
+  skipped because their value is salvaged separately into MetabotConversation.state;
+  duplicating the blob in every message would bloat storage. Non-data parts are
+  always persistable here; the caller is responsible for filtering stream-level
+  metadata (`:start`, `:usage`, `:finish`) separately."
+  [part]
+  (not (and (= :data (:type part))
+            (= state-type (:data-type part)))))
+
 ;;; Query URL Encoding
 
 (defn query->url-hash

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -4,7 +4,6 @@
    [clojure.core.async :as a]
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -14,7 +13,6 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.metabot.agent.core :as agent]
-   [metabase.metabot.agent.streaming :as streaming]
    [metabase.metabot.api.describe]
    [metabase.metabot.api.document]
    [metabase.metabot.api.metabot]
@@ -22,6 +20,7 @@
    [metabase.metabot.context :as metabot.context]
    [metabase.metabot.envelope :as metabot.envelope]
    [metabase.metabot.feedback :as metabot.feedback]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.provider-util :as provider-util]
    [metabase.metabot.schema :as metabot.schema]
    [metabase.metabot.self :as metabot.self]
@@ -33,7 +32,6 @@
    [metabase.settings.core :as setting]
    [metabase.slackbot.api]
    [metabase.util :as u]
-   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -76,72 +74,6 @@
                                        (apply +))
                  :ai_proxied      (boolean ai-proxy?)})))
 
-(defn- extract-usage
-  "Extract usage from parts, taking the last `:usage` per model.
-
-  The agent loop emits cumulative usage — each `:usage` part subsumes all prior
-  usage for that model — so we simply take the last one per model rather than
-  summing. Returns a map keyed by model name:
-  {\"model-name\" {:prompt X :completion Y}}"
-  [parts]
-  (transduce
-   (filter #(= :usage (:type %)))
-   (completing
-    (fn [acc {:keys [usage model]}]
-      (let [model (or model "unknown")]
-        (assoc acc model {:prompt     (:promptTokens usage 0)
-                          :completion (:completionTokens usage 0)}))))
-   {}
-   parts))
-
-(defn- strip-tool-output-bloat
-  "For :tool-output parts, keep only :output in the result map.
-  Both LLM adapters only read (get-in part [:result :output]) when replaying history.
-  Everything else (:structured-output, :resources, :data-parts, :reactions, etc.)
-  is transient runtime data consumed during streaming and can be very large."
-  [{:keys [type] :as part}]
-  (cond-> part
-    (= :tool-output type) (update :result select-keys [:output])))
-
-(defn- store-native-parts!
-  "Store assistant response parts directly to the database.
-
-  Takes AI SDK parts (after aisdk-xf combining) and stores them in the native format,
-  avoiding the intermediate 'aisdk messages' format.
-
-  Parts format: [{:type :text :text \"...\"} {:type :tool-input ...} ...]"
-  [conversation-id profile-id parts]
-  (let [state-part (u/seek #(and (= :data (:type %))
-                                 (= "state" (:data-type %)))
-                           parts)
-        usage      (extract-usage parts)
-        ai-proxy?  (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
-        ;; Filter out :start, :usage, :finish stream metadata. Data parts are
-        ;; persisted (so the analytics view can surface them) except :state,
-        ;; which is salvaged to MetabotConversation.state above.
-        content    (->> parts
-                        (remove #(#{:start :usage :finish} (:type %)))
-                        (filter streaming/persistable-data-part?)
-                        (mapv strip-tool-output-bloat))]
-    (prometheus/observe! :metabase-metabot/message-persist-bytes
-                         {:profile-id (or profile-id "unknown")}
-                         (u/string-byte-count (json/encode content)))
-    (t2/with-transaction [_conn]
-      (when state-part
-        (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
-                                  (constantly {:user_id api/*current-user-id*
-                                               :state   (:data state-part)})))
-      (t2/insert! :model/MetabotMessage
-                  {:conversation_id conversation-id
-                   :data            content
-                   :usage           usage
-                   :role            :assistant
-                   :profile_id      profile-id
-                   :total_tokens    (->> (vals usage)
-                                         (map #(+ (:prompt %) (:completion %)))
-                                         (reduce + 0))
-                   :ai_proxied      (boolean ai-proxy?)}))))
-
 (defn- streaming-writer-rf
   "Creates a reducing function that writes AI SDK lines to an OutputStream.
 
@@ -162,22 +94,6 @@
          (.flush os)
          (catch org.eclipse.jetty.io.EofException _
            (reduced acc)))))))
-
-(defn- combine-text-parts-xf []
-  (fn [rf]
-    (let [pending (volatile! nil)]
-      (fn
-        ([] (rf))
-        ([result]
-         (let [p @pending]
-           (rf (if p (rf result p) result))))
-        ([result part]
-         (let [prev @pending]
-           (if (and prev (= :text (:type prev) (:type part)))
-             (do (vswap! pending update :text str (:text part))
-                 result)
-             (do (vreset! pending part)
-                 (if prev (rf result prev) result)))))))))
 
 (defn- native-agent-streaming-request
   "Handle streaming request using native Clojure agent.
@@ -214,7 +130,9 @@
           (catch org.eclipse.jetty.io.EofException _
             (log/debug "Client disconnected during native agent streaming"))
           (finally
-            (store-native-parts! conversation-id profile-id (into [] (combine-text-parts-xf) @parts-atom))))))))
+            (metabot.persistence/store-native-parts!
+             conversation-id profile-id
+             (into [] (metabot.persistence/combine-text-parts-xf) @parts-atom))))))))
 
 (defn streaming-request
   "Handles an incoming request, making all required tool invocation, LLM call loops, etc."

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -14,6 +14,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.metabot.agent.core :as agent]
+   [metabase.metabot.agent.streaming :as streaming]
    [metabase.metabot.api.describe]
    [metabase.metabot.api.document]
    [metabase.metabot.api.metabot]
@@ -115,10 +116,12 @@
                            parts)
         usage      (extract-usage parts)
         ai-proxy?  (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
-        ;; Filter out :start, :usage, :finish, :data - these are metadata, not message content
-        ;; :data is like `:navigate_to`
+        ;; Filter out :start, :usage, :finish stream metadata. Data parts are
+        ;; persisted (so the analytics view can surface them) except :state,
+        ;; which is salvaged to MetabotConversation.state above.
         content    (->> parts
-                        (remove #(#{:start :usage :finish :data} (:type %)))
+                        (remove #(#{:start :usage :finish} (:type %)))
+                        (filter streaming/persistable-data-part?)
                         (mapv strip-tool-output-bloat))]
     (prometheus/observe! :metabase-metabot/message-persist-bytes
                          {:profile-id (or profile-id "unknown")}

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -1,10 +1,110 @@
 (ns metabase.metabot.persistence
   "Persistence for Metabot conversations and messages."
   (:require
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.app-db.core :as app-db]
+   [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
+
+(defn extract-usage
+  "Extract usage from parts, taking the last `:usage` per model.
+
+  The agent loop emits cumulative usage — each `:usage` part subsumes all prior
+  usage for that model — so we simply take the last one per model rather than
+  summing. Returns a map keyed by model name:
+  {\"model-name\" {:prompt X :completion Y}}"
+  [parts]
+  (transduce
+   (filter #(= :usage (:type %)))
+   (completing
+    (fn [acc {:keys [usage model]}]
+      (let [model (or model "unknown")]
+        (assoc acc model {:prompt     (:promptTokens usage 0)
+                          :completion (:completionTokens usage 0)}))))
+   {}
+   parts))
+
+(defn strip-tool-output-bloat
+  "For :tool-output parts, keep only :output in the result map.
+  Both LLM adapters only read (get-in part [:result :output]) when replaying history.
+  Everything else (:structured-output, :resources, :data-parts, :reactions, etc.)
+  is transient runtime data consumed during streaming and can be very large."
+  [{:keys [type] :as part}]
+  (cond-> part
+    (= :tool-output type) (update :result select-keys [:output])))
+
+(defn combine-text-parts-xf
+  "Transducer that merges consecutive `:text` parts into a single `:text` part.
+  Non-text parts pass through unchanged. Used before persistence so streaming
+  text deltas consolidate into one stored block."
+  []
+  (fn [rf]
+    (let [pending (volatile! nil)]
+      (fn
+        ([] (rf))
+        ([result]
+         (let [p @pending]
+           (rf (if p (rf result p) result))))
+        ([result part]
+         (let [prev @pending]
+           (if (and prev (= :text (:type prev) (:type part)))
+             (do (vswap! pending update :text str (:text part))
+                 result)
+             (do (vreset! pending part)
+                 (if prev (rf result prev) result)))))))))
+
+(defn store-native-parts!
+  "Store assistant response parts directly to the database in native format.
+
+  Takes raw AI SDK parts (ideally after `combine-text-parts-xf` merging) and
+  stores them without the lossy AI-SDK-line round-trip used by `store-message!`.
+  Returns the inserted MetabotMessage primary key.
+
+  Kwargs (all optional):
+  - `:channel-id`, `:slack-msg-id` — slackbot metadata stamped on the message row
+  - `:user-id` — user id for the message row (defaults to omitted)
+  - `:ai-proxy?` — explicit override; otherwise derived from `llm-metabot-provider`"
+  [conversation-id profile-id parts & {:keys [channel-id slack-msg-id user-id ai-proxy?]}]
+  (let [state-part (u/seek #(and (= :data (:type %))
+                                 (= "state" (:data-type %)))
+                           parts)
+        usage      (extract-usage parts)
+        ai-proxy?  (if (some? ai-proxy?)
+                     ai-proxy?
+                     (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider)))
+        ;; Filter out :start, :usage, :finish stream metadata. Data parts are
+        ;; persisted (so the analytics view can surface them) except :state,
+        ;; which is saved to MetabotConversation.state above.
+        content    (->> parts
+                        (remove #(#{:start :usage :finish} (:type %)))
+                        (filter streaming/persistable-data-part?)
+                        (mapv strip-tool-output-bloat))]
+    (prometheus/observe! :metabase-metabot/message-persist-bytes
+                         {:profile-id (or profile-id "unknown")}
+                         (u/string-byte-count (json/encode content)))
+    (t2/with-transaction [_conn]
+      (when state-part
+        (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
+                                  (constantly {:user_id api/*current-user-id*
+                                               :state   (:data state-part)})))
+      (t2/insert-returning-pk! :model/MetabotMessage
+                               (cond-> {:conversation_id conversation-id
+                                        :data            content
+                                        :usage           usage
+                                        :role            :assistant
+                                        :profile_id      profile-id
+                                        :total_tokens    (->> (vals usage)
+                                                              (map #(+ (:prompt %) (:completion %)))
+                                                              (reduce + 0))
+                                        :ai_proxied      (boolean ai-proxy?)}
+                                 channel-id   (assoc :channel_id channel-id)
+                                 slack-msg-id (assoc :slack_msg_id slack-msg-id)
+                                 user-id      (assoc :user_id user-id))))))
 
 (defn store-message!
   "Persist messages to MetabotConversation and MetabotMessage tables."

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -11,10 +11,8 @@
    [metabase.metabot.core :as metabot]
    [metabase.metabot.envelope :as metabot.envelope]
    [metabase.metabot.persistence :as metabot.persistence]
-   [metabase.metabot.self.core :as self.core]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.usage :as metabot.usage]
-   [metabase.metabot.util :as metabot.u]
    [metabase.permissions.core :as perms]
    [metabase.slackbot.channel :as slackbot.channel]
    [metabase.slackbot.client :as slackbot.client]
@@ -223,15 +221,16 @@
                  :state      {}
                  :profile-id :slackbot
                  :context    context}))
-    (let [parts     @parts-atom
-          lines     (into [] (self.core/aisdk-line-xf) parts)
-          pk        (metabot.persistence/store-message!
-                     conversation-id "slackbot"
-                     (metabot.u/aisdk->messages :assistant lines)
-                     :channel-id   channel-id
-                     :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
-                     :user-id      api/*current-user-id*
-                     :ai-proxy?   (metabot/metabase-provider? (metabot.settings/llm-metabot-provider)))]
+    ;; Stores raw native parts (not the lossy AI-SDK-message round-trip) so
+    ;; tool-output :structured-output survives for analytics extraction.
+    (let [parts @parts-atom
+          pk    (metabot.persistence/store-native-parts!
+                 conversation-id "slackbot"
+                 (into [] (metabot.persistence/combine-text-parts-xf) parts)
+                 :channel-id   channel-id
+                 :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
+                 :user-id      api/*current-user-id*
+                 :ai-proxy?    (metabot/metabase-provider? (metabot.settings/llm-metabot-provider)))]
       (when stored-msg-id
         (reset! stored-msg-id pk)))))
 

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -169,8 +169,14 @@
    - get-res-slack-msg-id: Function that returns the Slack message ts for the bot's response"
   [conversation-id prompt thread bot-user-id channel-id extra-history
    {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id request-prompt stored-msg-id]}]
-  (let [data-idx        (volatile! -1)
-        message         (metabot.envelope/user-message prompt)
+  (let [message         (metabot.envelope/user-message prompt)
+        ai-proxy?       (metabot/metabase-provider? (metabot.settings/llm-metabot-provider))
+        ;; Persist the user message before setup so failed conversations are captured.
+        _               (metabot.persistence/store-message! conversation-id "slackbot" [message]
+                                                            :channel-id   channel-id
+                                                            :slack-msg-id req-slack-msg-id
+                                                            :ai-proxy?    ai-proxy?)
+        data-idx        (volatile! -1)
         request-message (metabot.envelope/user-message (or request-prompt prompt))
         capabilities    (compute-capabilities)
         thread-history  (thread->history thread bot-user-id conversation-id)
@@ -180,10 +186,6 @@
                           :capabilities               capabilities
                           :slack_channel_id           channel-id})
         messages        (conj (vec history) request-message)
-        _               (metabot.persistence/store-message! conversation-id "slackbot" [message]
-                                                            :channel-id   channel-id
-                                                            :slack-msg-id req-slack-msg-id
-                                                            :ai-proxy?    (metabot/metabase-provider? (metabot.settings/llm-metabot-provider)))
         parts-atom      (atom [])
         dispatch-xf     (comp
                          (u/tee-xf parts-atom)
@@ -215,24 +217,28 @@
 
                                    nil)
                                  nil)))]
-    (transduce dispatch-xf (constantly nil) nil
-               (agent/run-agent-loop
-                {:messages   messages
-                 :state      {}
-                 :profile-id :slackbot
-                 :context    context}))
-    ;; Stores raw native parts (not the lossy AI-SDK-message round-trip) so
-    ;; tool-output :structured-output survives for analytics extraction.
-    (let [parts @parts-atom
-          pk    (metabot.persistence/store-native-parts!
-                 conversation-id "slackbot"
-                 (into [] (metabot.persistence/combine-text-parts-xf) parts)
-                 :channel-id   channel-id
-                 :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
-                 :user-id      api/*current-user-id*
-                 :ai-proxy?    (metabot/metabase-provider? (metabot.settings/llm-metabot-provider)))]
-      (when stored-msg-id
-        (reset! stored-msg-id pk)))))
+    (try
+      (transduce dispatch-xf (constantly nil) nil
+                 (agent/run-agent-loop
+                  {:messages   messages
+                   :state      {}
+                   :profile-id :slackbot
+                   :context    context}))
+      (finally
+        ;; Persist whatever parts we collected, even if the pipeline threw.
+        ;; Stores raw native parts (not the lossy AI-SDK-message round-trip) so
+        ;; tool-output :structured-output survives for analytics extraction.
+        (let [parts @parts-atom]
+          (when (seq parts)
+            (let [pk (metabot.persistence/store-native-parts!
+                      conversation-id "slackbot"
+                      (into [] (metabot.persistence/combine-text-parts-xf) parts)
+                      :channel-id   channel-id
+                      :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
+                      :user-id      api/*current-user-id*
+                      :ai-proxy?    ai-proxy?)]
+              (when stored-msg-id
+                (reset! stored-msg-id pk)))))))))
 
 (def ^:private viz-data-types
   "DATA part types that represent visualizations."

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -7,7 +7,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.agent.memory :as memory]
-   [metabase.metabot.api :as api]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self :as self]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.test-util :as mut]
@@ -331,7 +331,7 @@
                         :data      {:queries map?
                                     :charts  map?}}]
                       (mt/with-log-level [metabase.metabot.agent.core :warn]
-                        (into [] (#'api/combine-text-parts-xf)
+                        (into [] (metabot.persistence/combine-text-parts-xf)
                               (agent/run-agent-loop
                                {:messages   [{:role    :user
                                               :content "Show me the first 10 orders"}]
@@ -430,7 +430,7 @@
           (is (=? [{:type :text :text "Hello after retry"}
                    {:type :data :data-type "state"}]
                   (mt/with-log-level [metabase.metabot.self :fatal]
-                    (into [] (#'api/combine-text-parts-xf)
+                    (into [] (metabot.persistence/combine-text-parts-xf)
                           (agent/run-agent-loop
                            {:messages   [{:role :user :content "Hi"}]
                             :state      {}

--- a/test/metabase/metabot/agent/streaming_test.clj
+++ b/test/metabase/metabot/agent/streaming_test.clj
@@ -168,6 +168,13 @@
     (is (= "adhoc_viz" streaming/adhoc-viz-type))
     (is (= "static_viz" streaming/static-viz-type))))
 
+(deftest persistable-data-part?-test
+  (testing "state parts are not persisted (value lives on MetabotConversation.state)"
+    (is (false? (streaming/persistable-data-part? (streaming/state-part {:queries {}})))))
+  (testing "other parts are persisted"
+    (is (true? (streaming/persistable-data-part? (streaming/navigate-to-part "/question/1"))))
+    (is (true? (streaming/persistable-data-part? {:type :text :text "hi"})))))
+
 ;;; Transducer Tests
 
 (deftest expand-reactions-xf-test

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -705,6 +705,42 @@
       (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
              (:usage msg))))))
 
+(deftest store-native-parts-data-part-filtering-test
+  (testing "persistable data parts land in MetabotMessage.data; state is salvaged to conversation and excluded from data"
+    (binding [mb.api/*current-user-id* (mt/user->id :crowberto)]
+      (let [conv-id (str (random-uuid))]
+        (try
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+            (#'api/store-native-parts!
+             conv-id "internal"
+             [{:type :start :id "msg-1"}
+              {:type :text :text "Hi"}
+              {:type :data :data-type "navigate_to" :data "/question/1"}
+              {:type :data :data-type "todo_list" :version 1 :data [{:id "1" :content "x" :status "pending" :priority "low"}]}
+              {:type :data :data-type "code_edit" :version 1 :data {:buffer_id "b" :value "v"}}
+              {:type :data :data-type "transform_suggestion" :version 1 :data {}}
+              {:type :data :data-type "adhoc_viz" :version 1 :data {:query {} :link "/q"}}
+              {:type :data :data-type "static_viz" :version 1 :data {:entity_id 1}}
+              {:type :data :data-type "state" :data {:step 1}}
+              {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 1 :completionTokens 1}}
+              {:type :finish}])
+            (let [msg        (t2/select-one :model/MetabotMessage :conversation_id conv-id)
+                  conv       (t2/select-one :model/MetabotConversation :id conv-id)
+                  data-types (into #{} (keep :data-type) (:data msg))
+                  part-types (into #{} (map :type) (:data msg))]
+              (is (= #{"navigate_to" "todo_list" "code_edit" "transform_suggestion" "adhoc_viz" "static_viz"}
+                     data-types)
+                  "all persistable data parts (not state) should be in :data")
+              (is (contains? part-types "text")
+                  "text parts survive")
+              (is (not-any? part-types #{"start" "usage" "finish"})
+                  "stream metadata is dropped")
+              (is (= {:step 1} (:state conv))
+                  "state value is salvaged to MetabotConversation.state")))
+          (finally
+            (t2/delete! :model/MetabotMessage :conversation_id conv-id)
+            (t2/delete! :model/MetabotConversation :id conv-id)))))))
+
 (deftest strip-tool-output-bloat-test
   (testing "strips transient keys from tool-output results, keeping only :output"
     (is (= {:type :tool-output :id "call-1" :result {:output "<result>XML</result>"}}

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -15,6 +15,7 @@
    [metabase.metabot.api :as api]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
+   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self :as metabot.self]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.settings :as metabot.settings]
@@ -157,7 +158,7 @@
                             http/post                                (fn [url opts]
                                                                        (real-http-post url (assoc opts :decompress-body false)))
                             metabot.context/create-context           identity
-                            api/store-native-parts!                  (fn [_conv-id _prof-id parts]
+                            metabot.persistence/store-native-parts!  (fn [_conv-id _prof-id parts]
                                                                        (reset! stored-parts parts))
                             sr/async-cancellation-poll-interval-ms   5]
                 (testing "Closing stream body will drop connection to LLM"
@@ -618,7 +619,7 @@
 (deftest extract-usage-test
   (testing "takes last cumulative usage per model"
     (is (= {"gpt-4" {:prompt 250 :completion 50}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :text :text "hi"}
              {:type :usage :usage {:promptTokens 100 :completionTokens 20} :model "gpt-4"}
              {:type :tool-input :id "t1"}
@@ -628,27 +629,27 @@
   (testing "handles multiple models independently"
     (is (= {"model-a" {:prompt 100 :completion 20}
             "model-b" {:prompt 200 :completion 40}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :usage :usage {:promptTokens 100 :completionTokens 20} :model "model-a"}
              {:type :usage :usage {:promptTokens 200 :completionTokens 40} :model "model-b"}]))))
 
   (testing "returns empty map when no usage parts"
-    (is (= {} (#'api/extract-usage [{:type :text :text "hi"}]))))
+    (is (= {} (metabot.persistence/extract-usage [{:type :text :text "hi"}]))))
 
   (testing "missing model defaults to unknown"
     (is (= {"unknown" {:prompt 50 :completion 10}}
-           (#'api/extract-usage
+           (metabot.persistence/extract-usage
             [{:type :usage :usage {:promptTokens 50 :completionTokens 10}}])))))
 
 (deftest combine-text-parts-xf-test
   (testing "passes through non-text parts"
     (is (= [{:type :tool, :id 1} {:type :tool, :id 2}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :tool, :id 1} {:type :tool, :id 2}]))))
 
   (testing "combines consecutive text parts"
     (is (= [{:type :text, :text "hello world"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "hello "}
                   {:type :text, :text "world"}]))))
 
@@ -656,7 +657,7 @@
     (is (= [{:type :text, :text "ab"}
             {:type :tool, :id 1}
             {:type :text, :text "cd"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "a"}
                   {:type :text, :text "b"}
                   {:type :tool, :id 1}
@@ -664,11 +665,11 @@
                   {:type :text, :text "d"}]))))
 
   (testing "handles empty input"
-    (is (= [] (into [] (#'api/combine-text-parts-xf) []))))
+    (is (= [] (into [] (metabot.persistence/combine-text-parts-xf) []))))
 
   (testing "handles single text part"
     (is (= [{:type :text, :text "solo"}]
-           (into [] (#'api/combine-text-parts-xf)
+           (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "solo"}])))))
 
 (defn- store-and-check!
@@ -678,7 +679,7 @@
     (let [conv-id (str (random-uuid))]
       (try
         (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider provider]
-          (#'api/store-native-parts!
+          (metabot.persistence/store-native-parts!
            conv-id "internal"
            [{:type :start :id "msg-1"}
             {:type :text :text "Hello"}
@@ -711,7 +712,7 @@
       (let [conv-id (str (random-uuid))]
         (try
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-sonnet-4-6"]
-            (#'api/store-native-parts!
+            (metabot.persistence/store-native-parts!
              conv-id "internal"
              [{:type :start :id "msg-1"}
               {:type :text :text "Hi"}
@@ -744,7 +745,7 @@
 (deftest strip-tool-output-bloat-test
   (testing "strips transient keys from tool-output results, keeping only :output"
     (is (= {:type :tool-output :id "call-1" :result {:output "<result>XML</result>"}}
-           (#'api/strip-tool-output-bloat
+           (metabot.persistence/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-1"
              :result {:output            "<result>XML</result>"
@@ -753,10 +754,10 @@
                       :data-parts        [{:type :data :data-type "navigate_to"}]}}))))
   (testing "leaves non-tool-output parts untouched"
     (let [text-part {:type :text :text "hello"}]
-      (is (= text-part (#'api/strip-tool-output-bloat text-part)))))
+      (is (= text-part (metabot.persistence/strip-tool-output-bloat text-part)))))
   (testing "handles result with no :output key"
     (is (= {:type :tool-output :id "call-2" :result {}}
-           (#'api/strip-tool-output-bloat
+           (metabot.persistence/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-2"
              :result {:structured-output {:some "data"}}})))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -174,7 +174,7 @@
                @posted-message))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
-  (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
+  (testing "user + assistant persists receive ai-proxy? = true for metabase/ prefixed provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
             store-opts (atom [])]
@@ -187,6 +187,10 @@
                             metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)
+                              nil)
+                            metabot.persistence/store-native-parts!
+                            (fn [_conv-id _profile-id _parts & {:as opts}]
+                              (swap! store-opts conj opts)
                               nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
@@ -194,13 +198,13 @@
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user + assistant store-message! calls both received ai-proxy? = true"
+            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = true"
               (is (=? [{:ai-proxy? true}
                        {:ai-proxy? true}]
                       @store-opts)))))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
-  (testing "store-message! receives ai-proxy? = false for direct BYOK provider"
+  (testing "user + assistant persists receive ai-proxy? = false for direct BYOK provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
             store-opts (atom [])]
@@ -211,6 +215,10 @@
               (with-redefs [metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)
+                              nil)
+                            metabot.persistence/store-native-parts!
+                            (fn [_conv-id _profile-id _parts & {:as opts}]
+                              (swap! store-opts conj opts)
                               nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
@@ -218,7 +226,7 @@
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user + assistant store-message! calls both received ai-proxy? = false"
+            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = false"
               (is (=? [{:ai-proxy? false}
                        {:ai-proxy? false}]
                       @store-opts)))))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -203,6 +203,29 @@
                        {:ai-proxy? true}]
                       @store-opts)))))))))
 
+(deftest slackbot-streaming-persists-failed-conversations-test
+  (testing "User message is persisted even if setup throws after it (BOT-1279)"
+    (tu/with-slackbot-setup
+      (let [event-body tu/base-dm-event
+            stored     (promise)]
+        (tu/with-slackbot-mocks
+          {:ai-text "Hello!"}
+          (fn [_ctx]
+            (with-redefs [metabot.persistence/store-message!
+                          (fn [_conv-id _profile-id _messages & {:as opts}]
+                            (deliver stored opts)
+                            nil)
+                          ;; Force setup to throw *after* the user message has been stored.
+                          slackbot.persistence/message-history
+                          (fn [& _] (throw (ex-info "boom" {})))]
+              (mt/client :post 200 "metabot/slack/events"
+                         (tu/slack-request-options event-body)
+                         event-body)
+              (let [opts (deref stored 5000 ::timeout)]
+                (testing "user store-message! was called before the failure"
+                  (is (not= ::timeout opts))
+                  (is (some? (:slack-msg-id opts))))))))))))
+
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
   (testing "user + assistant persists receive ai-proxy? = false for direct BYOK provider"
     (tu/with-slackbot-setup


### PR DESCRIPTION
Closes [BOT-1398: Backport writing `data` parts to the db to v60](https://linear.app/metabase/issue/BOT-1398/backport-writing-data-parts-to-the-db-to-v60)

### Description

Manual backport of data parts persistence from
* #73107
* #73078

And also changes from 56caf94 to persist slackbot conversation even when the agent loop throws.

This does not backport the full changes from #73107, only the backend changes to persist data parts in the MetabotMessage table.

### How to verify

* Start metabase from this branch, interact with metabot and get it to 
  * construct a notebook query (`navigate_to`)
  * create an sql query (`code_edit`)
  * etc
* verify that data parts are persisted to `metabot_message` table
* upgrade to feat/ai-usage-analytics branch
* verify that data parts are visible in the ai usage analytics conversations view in the admin ui

### Demo

```
(->> (t2/select :model/MetabotMessage)
     (keep :data)
     (mapcat (fn [parts]
               (keep #(when (= "data" (:type %)) %)
                     parts))))

({:type "data",
  :data-type "navigate_to",
  :data
 "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImxpYi90eXBlIjoibWJxbC9xdWVyeSIsImxpYi9tZXRhZGF0YSI6bnVsbCwic3RhZ2VzIjpbeyJsaWIvdHlwZSI6Im1icWwuc3RhZ2UvbWJxbCIsInNvdXJjZS10YWJsZSI6MiwiYWdncmVnYXRpb24iOltbIm1ldHJpYyIseyJsaWIvdXVpZCI6ImNlM2RlZDBmLTY3NTQtNGI0ZC1hMTgyLTgyN2ZkNDNhYzkzZCJ9LDE5XV0sImJyZWFrb3V0IjpbWyJmaWVsZCIseyJsaWIvdXVpZCI6IjAyMWI1MTdlLTM4MGMtNGUxZC04MTllLWIwNDRlZTg5YTVmYiIsImVmZmVjdGl2ZS10eXBlIjoidHlwZS9UZXh0IiwiYmFzZS10eXBlIjoidHlwZS9UZXh0Iiwic291cmNlLWZpZWxkIjoxMX0sNTNdXX1dLCJkYXRhYmFzZSI6MX0sImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwiZGlzcGxheSI6ImJhciJ9"}
{:type "data",
  :data-type "code_edit",
  :version 1,
  :data
  {:buffer_id "qb",
   :mode "rewrite",
   :value
  "SELECT\n    p.\"CATEGORY\"                        AS category,\n    COUNT(o.\"ID\")                       AS order_count,\n    SUM(o.\"QUANTITY\")                   AS total_quantity,\n    SUM(o.\"TOTAL\")                      AS total_revenue\nFROM PUBLIC.ORDERS o\nINNER JOIN PUBLIC.PRODUCTS p ON o.\"PRODUCT_ID\" = p.\"ID\"\nGROUP BY p.\"CATEGORY\"\nORDER BY order_count DESC"}}
{:type "data",
  :data-type "todo_list",
  :version 1,
  :data
  [{:id "1",
    :content "Create transform to capitalize names in People table",
    :status "in_progress",
    :priority "high"}]}
...)
```

#### After upgrade

<img width="833" height="689" alt="Screenshot 2026-04-27 at 11 49 31 AM" src="https://github.com/user-attachments/assets/34b29a44-2320-4612-b8c9-da12b4afea0b" />

#### Slackbot data part

<img width="757" height="196" alt="Screenshot 2026-04-28 at 5 52 46 PM" src="https://github.com/user-attachments/assets/d0ab7e4b-11ad-45d7-94dc-a5cf61426286" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
