### PR TITLE
Short-circut permission group membership queries when there is no user

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -19,18 +19,20 @@
   (table/only-sandboxed-perms? (or table (field/table field))))
 
 (defn- table-id->sandbox
-  "Find the GTAP for current user that apply to table `table-id`."
+  "Find the GTAP for current user that apply to table `table-id`. Returns nil when there is no current user (e.g. when
+  called from a background sync), since sandboxes are scoped to a user's group memberships."
   [table-id]
-  (let [group-ids (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id api/*current-user-id*)
-        sandboxes (when (seq group-ids)
-                    (t2/select :model/Sandbox
-                               :group_id [:in group-ids]
-                               :table_id table-id))]
-    (when sandboxes
-      (sandboxing/assert-one-sandbox-per-table sandboxes)
-      ;; there should be only one gtap per table and we only need one table here
-      ;; see docs in [[metabase.permissions.models.permissions]] for more info
-      (t2/hydrate (first sandboxes) :card))))
+  (when api/*current-user-id*
+    (let [group-ids (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id api/*current-user-id*)
+          sandboxes (when (seq group-ids)
+                      (t2/select :model/Sandbox
+                                 :group_id [:in group-ids]
+                                 :table_id table-id))]
+      (when sandboxes
+        (sandboxing/assert-one-sandbox-per-table sandboxes)
+        ;; there should be only one gtap per table and we only need one table here
+        ;; see docs in [[metabase.permissions.models.permissions]] for more info
+        (t2/hydrate (first sandboxes) :card)))))
 
 (defn- field->sandbox-attributes-for-current-user
   "Returns the gtap attributes for current user that applied to `field`.


### PR DESCRIPTION
### Description

The `table-id->sandbox` query gets called from background processes sometimes where `api/*current-user-id*` leading to a `where user_id is null` query on the not null `permission_group_membership.user_id` table.

This detects that and doesn't bother with the query

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
