### PR TITLE
Handle clickhouse dbnames containing commas

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.clickhouse
   "Driver for ClickHouse databases"
-  (:refer-clojure :exclude [not-empty])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -21,8 +20,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
-   [metabase.util.performance :refer [not-empty]])
+   [metabase.util.log :as log])
   (:import
    (com.clickhouse.client.api.query QuerySettings)
    (java.sql Connection SQLException Statement PreparedStatement)
@@ -103,6 +101,17 @@
        (sql-jdbc.execute/set-time-zone-if-supported! driver conn session-timezone))
      (f conn))))
 
+(defn- first-db-name
+  "Extract a single database name from a legacy `dbname` value. Older configurations stored
+  multiple databases here, separated by spaces, commas, or both (matching the
+  `:db-filters-patterns` syntax). These values weren't migrated, so we have to keep handling
+  them. The chosen name is just the connection's default database — other databases are
+  reached by qualifying queries (#70798, #73175)."
+  [s]
+  (->> (str/split (or s "") #"[\s,]+")
+       (remove str/blank?)
+       first))
+
 (defmethod sql-jdbc.conn/connection-details->spec :clickhouse
   [_ details]
   (let [;; ensure defaults merge on top of nils
@@ -110,11 +119,7 @@
                            default-connection-details
                            details)
         {:keys [user password dbname host port ssl clickhouse-settings max-open-connections]} details
-        ;; Handling legacy `dbname` values here. `dbname` used to be a space-separated string of
-        ;; the database names. These `dbname` values weren't migrated so they still need to be handled
-        ;; here. This is the original version that takes the first db. This value is just the default
-        ;; db, we hit other dbs by including the db in the queries (#70798).
-        dbname (first (str/split (str/trim dbname) #" "))
+        dbname (first-db-name dbname)
         host   (cond ; JDBCv1 used to accept schema in the `host` configuration option
                  (str/starts-with? host "http://")  (subs host 7)
                  (str/starts-with? host "https://") (subs host 8)
@@ -148,9 +153,11 @@
     (try
       ;; Default SELECT 1 is not enough for Metabase test suite,
       ;; as it works slightly differently than expected there
-      (let [spec  (sql-jdbc.conn/connection-details->spec driver details)
-            dbname (first (str/split (str/trim (or (not-empty (:dbname details)) (:db details) "default")) #" "))
-            db    (ddl.i/format-name driver dbname)]
+      (let [spec   (sql-jdbc.conn/connection-details->spec driver details)
+            dbname (or (first-db-name (:dbname details))
+                       (first-db-name (:db details))
+                       "default")
+            db     (ddl.i/format-name driver dbname)]
         (sql-jdbc.execute/do-with-connection-with-options
          driver spec nil
          (fn [^java.sql.Connection conn]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -487,17 +487,27 @@
                        (qp/process-query)
                        (mt/rows))))))))))
 
+(defn- check-legacy-dbname [dbname exp-name]
+  (let [details (assoc (:details (mt/db)) :dbname dbname)
+        spec    (sql-jdbc.conn/connection-details->spec :clickhouse details)]
+    (is (true? (driver/can-connect? :clickhouse details)))
+    (is (= (format "//localhost:8123/%s" exp-name)
+           (:subname spec)))))
+
 (deftest ^:parallel handle-db-names-with-spaces-test
   (mt/test-driver :clickhouse
-    (are [dbname exp-name] (let [details (assoc (:details (mt/db)) :dbname dbname)
-                                 spec   (sql-jdbc.conn/connection-details->spec :clickhouse details)]
-                             (is (true? (driver/can-connect? :clickhouse details)))
-                             (is (= (format "//localhost:8123/%s" exp-name)
-                                    (:subname spec))))
+    (are [dbname exp-name] (check-legacy-dbname dbname exp-name)
       "test_data default fake_db" "test_data"
-      "test_data" "test_data"
-      "" ""
-      nil "default")))
+      "test_data"                 "test_data"
+      ""                          ""
+      nil                         "default")))
+
+(deftest ^:parallel handle-db-names-with-commas-test
+  (mt/test-driver :clickhouse
+    (are [dbname exp-name] (check-legacy-dbname dbname exp-name)
+      "test_data, fake_db" "test_data"
+      "test_data,fake_db"  "test_data"
+      "test_data,"         "test_data")))
 
 ;; TODO (lbrdnk 2026-01-23): Excplicit exceptions from [[metabase.driver.util/parsed-query]] are shutdown
 ;;                           at the moment to avoid potential log flooding. We should revisit this during further


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73175
Closes QUE2-533

### Description

Two changes between 0.58.10 and 0.59.4 combine into the regression:
the clickhouse-jdbc upgrade 0.8.4 → 0.9.7 stopped silently tolerating
comma-bearing dbnames in the JDBC URL, and #70822's legacy-shim split
only handled space-separated values, so `"helpdesk_tasks, foo"` was
turned into `"helpdesk_tasks,"` (trailing comma) and rejected.

This PR treats commas like whitespaces.
  
### How to verify

See the new test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
