### PR TITLE
BOT-1401 Add some more BE tests for AI usage analytics

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
@@ -215,6 +215,59 @@
                      :model/AiUsageLog _ (usage-log conv-2 lucky-id)]
         (is (= 2 (:metabot-users (sut/metabot-stats))))))))
 
+(deftest metabot-stats-mixed-user-id-stamping-dedups-test
+  (testing "stamped + unstamped messages from the same user must collapse to one distinct user"
+    (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
+          rasta-id  (mt/user->id :rasta)
+          mixed-msg (fn [conv-id stamp-user?]
+                      (cond-> {:conversation_id conv-id
+                               :created_at      yesterday
+                               :role            "user"
+                               :profile_id      "mixed"
+                               :total_tokens    100
+                               :ai_proxied      true}
+                        stamp-user? (assoc :user_id rasta-id)))
+          usage-log {:user_id rasta-id
+                     :created_at yesterday
+                     :source "mixed-test"
+                     :total_tokens 100
+                     :prompt_tokens 100
+                     :ai_proxied true}]
+      (t/with-clock clock
+        (mt/with-temp [:model/MetabotConversation {conv-id :id} {:user_id rasta-id}
+                       :model/MetabotMessage _ (mixed-msg conv-id true)
+                       :model/MetabotMessage _ (mixed-msg conv-id false)
+                       :model/AiUsageLog _ (assoc usage-log :conversation_id conv-id)]
+          (is (= 1 (:metabot-users (sut/metabot-stats)))))))))
+
+(deftest metabot-stats-counts-distinct-participants-in-shared-conversation-test
+  (testing "two participants in a single conversation are both counted in :metabot-users"
+    (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
+          rasta-id  (mt/user->id :rasta)
+          lucky-id  (mt/user->id :lucky)
+          msg       (fn [conv-id user-id]
+                      {:conversation_id conv-id
+                       :user_id         user-id
+                       :created_at      yesterday
+                       :role            "user"
+                       :profile_id      "shared"
+                       :total_tokens    100
+                       :ai_proxied      true})
+          log       {:created_at yesterday
+                     :source "shared-test"
+                     :total_tokens 100
+                     :prompt_tokens 100
+                     :ai_proxied true}]
+      (t/with-clock clock
+        (mt/with-temp [:model/MetabotConversation {conv-id :id} {:user_id rasta-id}
+                       :model/MetabotMessage _ (msg conv-id rasta-id)
+                       :model/MetabotMessage _ (msg conv-id lucky-id)
+                       :model/AiUsageLog _ (assoc log :conversation_id conv-id :user_id rasta-id)
+                       :model/AiUsageLog _ (assoc log :conversation_id conv-id :user_id lucky-id)]
+          (is (= 2 (:metabot-users (sut/metabot-stats)))))))))
+
 (deftest metabot-usage-anthropic-provider-test
   (search.tu/with-index-disabled
     (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
@@ -201,11 +201,42 @@
                                            (format "%s&sort-by=message_count&sort-dir=asc" response-path))]
         (is (= [convo-3 convo-1 convo-2] (map :conversation_id (:data response))))))))
 
+(deftest list-conversations-sorting-desc-test
+  (testing "sort-dir=desc reverses the sort order — same fixture as the asc test"
+    (with-list-conversations-fixture!
+      (fn [{:keys [response-path convo-1 convo-2 convo-3]}]
+        (let [response (mt/user-http-request :crowberto :get 200
+                                             (format "%s&sort-by=message_count&sort-dir=desc" response-path))]
+          (is (= [convo-2 convo-1 convo-3]
+                 (map :conversation_id (:data response)))))))))
+
 (deftest list-conversations-invalid-sort-test
   (with-list-conversations-fixture!
     (fn [{:keys [response-path]}]
       (is (some? (:errors (mt/user-http-request :crowberto :get 400
                                                 (format "%s&sort-by=drop_table" response-path))))))))
+
+(deftest list-conversations-invalid-sort-dir-test
+  (testing "sort-dir is constrained to the {asc, desc} enum"
+    (with-list-conversations-fixture!
+      (fn [{:keys [response-path]}]
+        (is (some? (:errors (mt/user-http-request :crowberto :get 400
+                                                  (format "%s&sort-dir=sideways" response-path)))))))))
+
+(deftest list-conversations-user-with-no-conversations-test
+  (testing "filtering by a user-id that has no conversations returns an empty data set, not an error"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temp [:model/User {empty-user-id :id} {:email "no-convos-user@metabase.com"}]
+        (is (=? {:total 0
+                 :data  []}
+                (mt/user-http-request :crowberto :get 200
+                                      (format "ee/metabot-analytics/conversations?user-id=%s"
+                                              empty-user-id))))))))
+
+(deftest list-conversations-requires-audit-app-feature-test
+  (testing "GET /api/ee/metabot-analytics/conversations is gated by :audit-app and 402s without it"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :crowberto :get 402 "ee/metabot-analytics/conversations"))))
 
 (defn- with-filters-fixture!
   [thunk]
@@ -261,6 +292,12 @@
                                                  group-id user-a-id)))))
         (testing "malformed date returns 400"
           (mt/user-http-request :crowberto :get 400 (str base-path "?date=not-a-real-range")))))))
+
+(deftest get-conversation-detail-requires-audit-app-feature-test
+  (testing "GET /api/ee/metabot-analytics/conversations/:id is gated by :audit-app and 402s without it"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :crowberto :get 402
+                            (format "ee/metabot-analytics/conversations/%s" (random-uuid))))))
 
 (deftest get-conversation-detail-test
   (mt/with-premium-features #{:audit-app}

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_ai_usage_log_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_ai_usage_log_test.clj
@@ -1,0 +1,172 @@
+(ns metabase-enterprise.metabot-analytics.v-ai-usage-log-test
+  "Tests for the `v_ai_usage_log` SQL view."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private default-model "anthropic/claude-sonnet-4-6")
+
+(defn- query-view
+  "Query v_ai_usage_log for rows by usage_log_id."
+  [usage-log-ids]
+  (t2/query {:select [:*]
+             :from   [:v_ai_usage_log]
+             :where  [:in :usage_log_id usage-log-ids]}))
+
+(defn- find-row [rows usage-log-id]
+  (some #(when (= (:usage_log_id %) usage-log-id) %) rows))
+
+(deftest one-row-per-usage-log-test
+  (testing "view emits exactly one row per ai_usage_log row, columns passed through"
+    (let [convo-id (str (random-uuid))]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-id :user_id user-id}
+                     :model/AiUsageLog {log-id-1 :id} {:source "agent"
+                                                       :model default-model
+                                                       :profile_id "nlq"
+                                                       :conversation_id convo-id
+                                                       :user_id user-id
+                                                       :prompt_tokens 100
+                                                       :completion_tokens 40
+                                                       :total_tokens 140
+                                                       :request_id "req-1"}
+                     :model/AiUsageLog {log-id-2 :id} {:source "slackbot"
+                                                       :model default-model
+                                                       :profile_id "slackbot"
+                                                       :conversation_id convo-id
+                                                       :user_id user-id
+                                                       :prompt_tokens 50
+                                                       :completion_tokens 25
+                                                       :total_tokens 75
+                                                       :request_id "req-2"}]
+        (let [rows (query-view [log-id-1 log-id-2])
+              r1   (find-row rows log-id-1)
+              r2   (find-row rows log-id-2)]
+          (is (= 2 (count rows)))
+          (is (=? {:source            "agent"
+                   :model             default-model
+                   :profile_id        "nlq"
+                   :conversation_id   convo-id
+                   :user_id           user-id
+                   :prompt_tokens     100
+                   :completion_tokens 40
+                   :total_tokens      140
+                   :request_id        "req-1"}
+                  r1))
+          (is (=? {:source     "slackbot"
+                   :request_id "req-2"
+                   :total_tokens 75}
+                  r2)))))))
+
+(deftest user-display-name-test
+  (testing "user_display_name shows 'first last' when populated, falls back to email when null"
+    (mt/with-temp [:model/User {named-id :id}   {:first_name "Alice" :last_name "Smith"
+                                                 :email "alice@metabase.com"}
+                   :model/User {unnamed-id :id} {:first_name nil :last_name nil
+                                                 :email "anon@metabase.com"}
+                   :model/AiUsageLog {named-log :id} {:source "agent"
+                                                      :model default-model
+                                                      :user_id named-id
+                                                      :prompt_tokens 1
+                                                      :completion_tokens 1
+                                                      :total_tokens 2}
+                   :model/AiUsageLog {unnamed-log :id} {:source "agent"
+                                                        :model default-model
+                                                        :user_id unnamed-id
+                                                        :prompt_tokens 1
+                                                        :completion_tokens 1
+                                                        :total_tokens 2}]
+      (let [rows (query-view [named-log unnamed-log])]
+        (is (= "Alice Smith" (:user_display_name (find-row rows named-log))))
+        (is (= "anon@metabase.com" (:user_display_name (find-row rows unnamed-log))))))))
+
+(deftest user-display-name-null-when-user-missing-test
+  (testing "user_display_name is null when there is no user_id (LEFT JOIN miss)"
+    (mt/with-temp [:model/AiUsageLog {log-id :id} {:source "example-question-generation"
+                                                   :model default-model
+                                                   :prompt_tokens 1
+                                                   :completion_tokens 1
+                                                   :total_tokens 2}]
+      (is (nil? (:user_display_name (find-row (query-view [log-id]) log-id)))))))
+
+(deftest group-name-skips-all-users-and-picks-alphabetical-first-test
+  (testing "group_name returns the alphabetically first non-'All Users' group; null if none"
+    (mt/with-temp [:model/User             {user-id :id} {}
+                   :model/PermissionsGroup {z-id :id}    {:name "Zebra Team"}
+                   :model/PermissionsGroup {a-id :id}    {:name "Analytics Team"}
+                   :model/PermissionsGroupMembership _   {:group_id z-id :user_id user-id}
+                   :model/PermissionsGroupMembership _   {:group_id a-id :user_id user-id}
+                   :model/AiUsageLog {log-id :id} {:source "agent"
+                                                   :model default-model
+                                                   :user_id user-id
+                                                   :prompt_tokens 1
+                                                   :completion_tokens 1
+                                                   :total_tokens 2}]
+      (is (= "Analytics Team"
+             (:group_name (find-row (query-view [log-id]) log-id))))))
+  (testing "group_name is null when the user only belongs to All Users (group id = 1)"
+    (mt/with-temp [:model/User {user-id :id} {}
+                   :model/AiUsageLog {log-id :id} {:source "agent"
+                                                   :model default-model
+                                                   :user_id user-id
+                                                   :prompt_tokens 1
+                                                   :completion_tokens 1
+                                                   :total_tokens 2}]
+      (is (nil? (:group_name (find-row (query-view [log-id]) log-id)))))))
+
+(deftest ip-address-from-conversation-test
+  (testing "ip_address is surfaced from the joined metabot_conversation row"
+    (let [convo-with-ip (str (random-uuid))
+          convo-no-ip   (str (random-uuid))]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-with-ip :user_id user-id :ip_address "10.0.0.42"}
+                     :model/MetabotConversation _ {:id convo-no-ip   :user_id user-id}
+                     :model/AiUsageLog {with-ip-log :id} {:source "agent"
+                                                          :model default-model
+                                                          :conversation_id convo-with-ip
+                                                          :user_id user-id
+                                                          :prompt_tokens 1
+                                                          :completion_tokens 1
+                                                          :total_tokens 2}
+                     :model/AiUsageLog {no-ip-log :id} {:source "agent"
+                                                        :model default-model
+                                                        :conversation_id convo-no-ip
+                                                        :user_id user-id
+                                                        :prompt_tokens 1
+                                                        :completion_tokens 1
+                                                        :total_tokens 2}]
+        (let [rows (query-view [with-ip-log no-ip-log])]
+          (is (= "10.0.0.42" (:ip_address (find-row rows with-ip-log))))
+          (is (nil? (:ip_address (find-row rows no-ip-log)))))))))
+
+(deftest ip-address-null-when-no-conversation-test
+  (testing "ip_address is null when the usage log row is not tied to a conversation (LEFT JOIN miss)"
+    (mt/with-temp [:model/AiUsageLog {log-id :id} {:source "example-question-generation"
+                                                   :model default-model
+                                                   :prompt_tokens 1
+                                                   :completion_tokens 1
+                                                   :total_tokens 2}]
+      (let [row (find-row (query-view [log-id]) log-id)]
+        (is (nil? (:conversation_id row)))
+        (is (nil? (:ip_address row)))))))
+
+(deftest tenant-id-passthrough-test
+  (testing "tenant_id passes through from ai_usage_log; null when not set"
+    (mt/with-temp [:model/Tenant     {tenant-id :id} {:name "Acme Corp" :slug "acme-corp"}
+                   :model/AiUsageLog {tenant-log :id} {:source "agent"
+                                                       :model default-model
+                                                       :tenant_id tenant-id
+                                                       :prompt_tokens 1
+                                                       :completion_tokens 1
+                                                       :total_tokens 2}
+                   :model/AiUsageLog {no-tenant-log :id} {:source "agent"
+                                                          :model default-model
+                                                          :prompt_tokens 1
+                                                          :completion_tokens 1
+                                                          :total_tokens 2}]
+      (let [rows (query-view [tenant-log no-tenant-log])]
+        (is (= tenant-id (:tenant_id (find-row rows tenant-log))))
+        (is (nil? (:tenant_id (find-row rows no-tenant-log))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_messages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_messages_test.clj
@@ -1,0 +1,132 @@
+(ns metabase-enterprise.metabot-analytics.v-metabot-messages-test
+  "Tests for the `v_metabot_messages` SQL view."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- query-view
+  "Query v_metabot_messages, returning only rows for the given conversation IDs."
+  [conversation-ids]
+  (t2/query {:select   [:*]
+             :from     [:v_metabot_messages]
+             :where    [:in :conversation_id conversation-ids]
+             :order-by [[:created_at :asc] [:message_id :asc]]}))
+
+(defn- find-row [rows message-id]
+  (some #(when (= (:message_id %) message-id) %) rows))
+
+(deftest columns-and-passthrough-test
+  (testing "view exposes the expected columns and passes through profile_id, role, total_tokens, slack metadata"
+    (let [convo-id (str (random-uuid))]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-id :user_id user-id}
+                     :model/MetabotMessage {msg-id :id} {:conversation_id convo-id
+                                                         :role            "assistant"
+                                                         :profile_id      "nlq"
+                                                         :total_tokens    42
+                                                         :slack_msg_id    "1700000000.000099"
+                                                         :channel_id      "C-VIEW"
+                                                         :data            []}]
+        (let [row (find-row (query-view [convo-id]) msg-id)]
+          (is (=? {:message_id      msg-id
+                   :conversation_id convo-id
+                   :role            "assistant"
+                   :profile_id      "nlq"
+                   :total_tokens    42
+                   :user_id         user-id
+                   :slack_msg_id    "1700000000.000099"
+                   :channel_id      "C-VIEW"}
+                  row))
+          (is (some? (:created_at row))))))))
+
+(deftest deleted-messages-excluded-test
+  (testing "soft-deleted messages (deleted_at IS NOT NULL) are filtered out of the view"
+    (let [convo-id (str (random-uuid))
+          now      (java.time.OffsetDateTime/now)]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-id :user_id user-id}
+                     :model/MetabotMessage {kept-id    :id} {:conversation_id convo-id
+                                                             :role "user"
+                                                             :profile_id "nlq"
+                                                             :total_tokens 0
+                                                             :data []}
+                     :model/MetabotMessage {deleted-id :id} {:conversation_id convo-id
+                                                             :role "assistant"
+                                                             :profile_id "nlq"
+                                                             :total_tokens 0
+                                                             :data []
+                                                             :deleted_at now}]
+        (let [rows (query-view [convo-id])]
+          (is (= 1 (count rows)))
+          (is (some? (find-row rows kept-id)))
+          (is (nil?  (find-row rows deleted-id))))))))
+
+(deftest user-id-coalesces-to-conversation-owner-test
+  (testing "user_id falls back to metabot_conversation.user_id when metabot_message.user_id is null"
+    (let [convo-id (str (random-uuid))]
+      (mt/with-temp [:model/User {originator-id :id} {}
+                     :model/User {participant-id :id} {}
+                     :model/MetabotConversation _ {:id convo-id :user_id originator-id}
+                     ;; legacy row — message has no :user_id stamped
+                     :model/MetabotMessage {legacy-id :id} {:conversation_id convo-id
+                                                            :role "user"
+                                                            :profile_id "nlq"
+                                                            :total_tokens 0
+                                                            :data []}
+                     ;; new-style row — message author is stamped
+                     :model/MetabotMessage {stamped-id :id} {:conversation_id convo-id
+                                                             :role "user"
+                                                             :user_id participant-id
+                                                             :profile_id "nlq"
+                                                             :total_tokens 0
+                                                             :data []}]
+        (let [rows (query-view [convo-id])]
+          (testing "legacy row: user_id falls back to conversation originator"
+            (is (= originator-id (:user_id (find-row rows legacy-id)))))
+          (testing "stamped row: user_id is the message author, not the originator"
+            (is (= participant-id (:user_id (find-row rows stamped-id))))))))))
+
+(deftest excludes-rows-from-other-conversations-test
+  (testing "the JOIN to metabot_conversation does not duplicate rows or leak across conversations"
+    (let [convo-1 (str (random-uuid))
+          convo-2 (str (random-uuid))]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-1 :user_id user-id}
+                     :model/MetabotConversation _ {:id convo-2 :user_id user-id}
+                     :model/MetabotMessage {m1 :id} {:conversation_id convo-1
+                                                     :role "user"
+                                                     :profile_id "nlq"
+                                                     :total_tokens 0
+                                                     :data []}
+                     :model/MetabotMessage {m2 :id} {:conversation_id convo-1
+                                                     :role "assistant"
+                                                     :profile_id "nlq"
+                                                     :total_tokens 0
+                                                     :data []}
+                     :model/MetabotMessage {m3 :id} {:conversation_id convo-2
+                                                     :role "user"
+                                                     :profile_id "internal"
+                                                     :total_tokens 0
+                                                     :data []}]
+        (let [rows-1 (query-view [convo-1])
+              rows-2 (query-view [convo-2])]
+          (is (= #{m1 m2} (into #{} (map :message_id) rows-1)))
+          (is (= #{m3}    (into #{} (map :message_id) rows-2))))))))
+
+(deftest passes-through-conversation-not-message-created-at-test
+  (testing "created_at is the message's own timestamp, not the conversation's"
+    (let [convo-id (str (random-uuid))
+          msg-time (java.time.OffsetDateTime/parse "2026-02-15T10:30:00Z")]
+      (mt/with-temp [:model/User {user-id :id} {}
+                     :model/MetabotConversation _ {:id convo-id :user_id user-id}
+                     :model/MetabotMessage {msg-id :id} {:conversation_id convo-id
+                                                         :role "user"
+                                                         :profile_id "nlq"
+                                                         :total_tokens 0
+                                                         :data []
+                                                         :created_at msg-time}]
+        (let [row (find-row (query-view [convo-id]) msg-id)]
+          (is (= (.toInstant msg-time) (.toInstant ^java.time.OffsetDateTime (:created_at row)))))))))

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -130,3 +130,106 @@
         (is (= team-id (:slack_team_id conversation)))
         (is (= channel-id (:slack_channel_id conversation)))
         (is (= thread-ts (:slack_thread_ts conversation)))))))
+
+(deftest combine-text-parts-xf-merges-consecutive-text-test
+  (testing "consecutive :text parts coalesce; non-text parts split runs"
+    (let [parts [{:type :text :text "Hello, "}
+                 {:type :text :text "world"}
+                 {:type :text :text "!"}
+                 {:type :tool-input :id "c1" :function "search"}
+                 {:type :text :text "After "}
+                 {:type :text :text "tool."}]
+          out   (into [] (metabot-persistence/combine-text-parts-xf) parts)]
+      (is (= [{:type :text :text "Hello, world!"}
+              {:type :tool-input :id "c1" :function "search"}
+              {:type :text :text "After tool."}]
+             out))))
+  (testing "single text part flushes on completion"
+    (is (= [{:type :text :text "lone"}]
+           (into [] (metabot-persistence/combine-text-parts-xf) [{:type :text :text "lone"}]))))
+  (testing "empty input"
+    (is (= [] (into [] (metabot-persistence/combine-text-parts-xf) [])))))
+
+(deftest store-native-parts-persists-slack-metadata-on-conversation-test
+  (testing "store-native-parts! lands slack-team-id / channel-id / slack-thread-ts on the conversation row,
+            and slack-msg-id / channel-id / user-id on the message row, on first insert"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))
+            team-id         "T-NATIVE"
+            channel-id      "C-NATIVE"
+            thread-ts       "1700000000.000001"
+            slack-msg-id    "1700000000.000099"
+            user-id         (mt/user->id :rasta)]
+        (mt/with-current-user user-id
+          (metabot-persistence/store-native-parts!
+           conversation-id
+           "metabot-1"
+           [{:type :text :text "hello from slack"}]
+           :slack-team-id team-id
+           :channel-id channel-id
+           :slack-thread-ts thread-ts
+           :slack-msg-id slack-msg-id
+           :user-id user-id))
+        (let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)
+              message      (t2/select-one :model/MetabotMessage :conversation_id conversation-id)]
+          (is (= user-id (:user_id conversation)))
+          (is (= team-id (:slack_team_id conversation)))
+          (is (= channel-id (:slack_channel_id conversation)))
+          (is (= thread-ts (:slack_thread_ts conversation)))
+          (is (= channel-id (:channel_id message)))
+          (is (= slack-msg-id (:slack_msg_id message)))
+          (is (= user-id (:user_id message))))))))
+
+(deftest store-native-parts-does-not-overwrite-slack-metadata-test
+  (testing "slack metadata on the conversation row is set once and never overwritten by a later writer"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          (metabot-persistence/store-native-parts!
+           conversation-id "metabot-1" [{:type :text :text "first"}]
+           :slack-team-id "T-FIRST"
+           :channel-id "C-FIRST"
+           :slack-thread-ts "1700000000.000001"))
+        (mt/with-current-user (mt/user->id :lucky)
+          (metabot-persistence/store-native-parts!
+           conversation-id "metabot-1" [{:type :text :text "second"}]
+           :slack-team-id "T-SECOND"
+           :channel-id "C-SECOND"
+           :slack-thread-ts "1700000000.999999"))
+        (let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)]
+          (is (= "T-FIRST" (:slack_team_id conversation)))
+          (is (= "C-FIRST" (:slack_channel_id conversation)))
+          (is (= "1700000000.000001" (:slack_thread_ts conversation))))))))
+
+(deftest conversation-detail-filters-soft-deleted-messages-and-orders-ascending-test
+  (testing "conversation-detail returns only non-deleted messages, ordered by :created_at ascending"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))
+            user-id         (mt/user->id :rasta)
+            now             (java.time.OffsetDateTime/now)
+            insert!         (fn [{:keys [text created-at deleted-at external-id role]
+                                  :or   {role "assistant"}}]
+                              (t2/insert-returning-pks!
+                               :model/MetabotMessage
+                               (cond-> {:conversation_id conversation-id
+                                        :role            role
+                                        :profile_id      "metabot-1"
+                                        :external_id     (or external-id (str (random-uuid)))
+                                        :total_tokens    0
+                                        :data            [{:type "text" :text text :id (str (random-uuid))}]
+                                        :created_at      created-at}
+                                 deleted-at (assoc :deleted_at deleted-at))))]
+        (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
+        (insert! {:text "second" :created-at (.plusSeconds now 2)})
+        (insert! {:text "first"  :created-at (.plusSeconds now 1)})
+        (insert! {:text "deleted-third"
+                  :created-at (.plusSeconds now 3)
+                  :deleted-at now})
+        (let [detail (metabot-persistence/conversation-detail conversation-id)
+              texts  (mapv :message (:chat_messages detail))]
+          (is (= conversation-id (:conversation_id detail)))
+          (is (= ["first" "second"] texts)))))))
+
+(deftest conversation-detail-returns-nil-for-missing-conversation-test
+  (testing "conversation-detail returns nil when the conversation does not exist"
+    (is (nil? (metabot-persistence/conversation-detail (str (random-uuid)))))))

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.analytics.prometheus-test :as prometheus-test]
+   [metabase.channel.settings :as channel.settings]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.feedback :as metabot.feedback]
    [metabase.server.settings :as server.settings]
@@ -1117,6 +1118,100 @@
         (is (nil? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id lucky-id))
             "no feedback row is written for a lurker")
         (finally (tear-down-slackbot-feedback! conv-id))))))
+
+(deftest handle-feedback-modal-submission-resolves-via-channel-and-ts-fallback-test
+  (testing "buttons predating :message_external_id still resolve via (channel_id, message_ts)"
+    (let [rasta-id           (mt/user->id :rasta)
+          conv-id            (str (random-uuid))
+          external-id        (str (random-uuid))
+          channel-id         "C-FALLBACK"
+          message-ts         "1700000000.123456"
+          harbormaster-calls (atom [])]
+      (try
+        (t2/insert! :model/MetabotConversation {:id conv-id :user_id rasta-id})
+        (let [message-id (first (t2/insert-returning-pks!
+                                 :model/MetabotMessage
+                                 {:conversation_id conv-id
+                                  :role            "assistant"
+                                  :profile_id      "slackbot"
+                                  :external_id     external-id
+                                  :channel_id      channel-id
+                                  :slack_msg_id    message-ts
+                                  :total_tokens    5
+                                  :data            [{:_type "TEXT" :role "assistant" :content "hi"}]}))]
+          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
+                                                                   (swap! harbormaster-calls conj feedback)
+                                                                   true)]
+            (let [;; external-id intentionally omitted from the button payload — only channel + ts are present
+                  payload (modal-submission-payload {:conv-id     conv-id
+                                                     :external-id nil
+                                                     :user-id     rasta-id
+                                                     :positive    true
+                                                     :freeform    "from a legacy button"
+                                                     :channel-id  channel-id
+                                                     :message-ts  message-ts})
+                  result  (#'slackbot/handle-feedback-modal-submission payload)]
+              @result
+              (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
+                (is (some? row) "fallback resolved the message and persisted feedback")
+                (is (true? (:positive row)))
+                (is (= "from a legacy button" (:freeform_feedback row))))
+              (is (= 1 (count @harbormaster-calls)))
+              (is (=? {:feedback {:message_id external-id :positive true}}
+                      (first @harbormaster-calls))
+                  "harbormaster receives the resolved external_id, not the channel/ts pair"))))
+        (finally (tear-down-slackbot-feedback! conv-id))))))
+
+;; -------------------------------- conversation-permalink ---------------------------------------
+
+(deftest conversation-permalink-returns-nil-when-slack-not-configured-test
+  (testing "conversation-permalink does not call Slack when slack-configured? is false"
+    (let [client-calls (atom 0)]
+      (with-redefs [channel.settings/slack-configured?     (constantly false)
+                    slackbot.client/get-permalink          (fn [& _]
+                                                             (swap! client-calls inc)
+                                                             {:ok true :permalink "should-not-be-returned"})]
+        (is (nil? (slackbot/conversation-permalink "C123" "1.0")))
+        (is (zero? @client-calls)
+            "no slack client call when not configured")))))
+
+(deftest conversation-permalink-returns-nil-when-channel-or-ts-missing-test
+  (testing "conversation-permalink short-circuits to nil when channel or ts is missing — no client call"
+    (let [client-calls (atom 0)]
+      (with-redefs [channel.settings/slack-configured?     (constantly true)
+                    channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                    slackbot.client/get-permalink          (fn [& _]
+                                                             (swap! client-calls inc)
+                                                             {:ok true})]
+        (is (nil? (slackbot/conversation-permalink nil "1.0")))
+        (is (nil? (slackbot/conversation-permalink "C123" nil)))
+        (is (zero? @client-calls))))))
+
+(deftest conversation-permalink-happy-path-test
+  (testing "conversation-permalink returns the Slack permalink string when ok is true"
+    (with-redefs [channel.settings/slack-configured?     (constantly true)
+                  channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                  slackbot.client/get-permalink (fn [_client {:keys [channel ts]}]
+                                                  {:ok        true
+                                                   :permalink (format "https://slack.example/%s/%s" channel ts)})]
+      (is (= "https://slack.example/C123/1.0"
+             (slackbot/conversation-permalink "C123" "1.0"))))))
+
+(deftest conversation-permalink-returns-nil-when-slack-says-not-ok-test
+  (testing "conversation-permalink returns nil when Slack responds with {:ok false}"
+    (with-redefs [channel.settings/slack-configured?     (constantly true)
+                  channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                  slackbot.client/get-permalink          (fn [& _]
+                                                           {:ok false :error "channel_not_found"})]
+      (is (nil? (slackbot/conversation-permalink "C123" "1.0"))))))
+
+(deftest conversation-permalink-swallows-client-exception-test
+  (testing "exceptions from the Slack client are caught — function returns nil rather than propagating"
+    (with-redefs [channel.settings/slack-configured?     (constantly true)
+                  channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                  slackbot.client/get-permalink          (fn [& _]
+                                                           (throw (ex-info "slack down" {})))]
+      (is (nil? (slackbot/conversation-permalink "C123" "1.0"))))))
 
 ;; -------------------------------- Visualization Integration Tests --------------------------------
 


### PR DESCRIPTION
Closes [BOT-1401: Add some more BE tests](https://linear.app/metabase/issue/BOT-1401/add-some-more-be-tests)

### Description

Add some more BE tests for:

* `v_metabot_messages` view
* `v_ai_usage_log` view
* `slackbot/conversation-permalink`
* `metabot-stats` with multi-user convos
* `list-conversations` edge cases
* persistence tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
