### PR TITLE
Apply the query explorer bar to MCP Apps

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
@@ -1,0 +1,95 @@
+import type { App } from "@modelcontextprotocol/ext-apps/react";
+
+import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import * as Urls from "metabase/urls";
+
+import { QueryExplorerBar } from "./QueryExplorerBar";
+import { useChartTypes } from "./hooks/useChartTypes";
+import { useDateFilter } from "./hooks/useDateFilter";
+import { useTemporalGranularity } from "./hooks/useTemporalGranularity";
+
+interface McpQueryBarProps {
+  app: App | null;
+  instanceUrl: string;
+}
+
+export function McpQueryBar({ app, instanceUrl }: McpQueryBarProps) {
+  const { question, updateQuestion, queryResults } = useSdkQuestionContext();
+
+  const {
+    sensibleChartTypes,
+    hasOnlyTable,
+    selectedChartType,
+    handleDisplayChange,
+  } = useChartTypes(question, queryResults, updateQuestion);
+
+  const {
+    temporalColumn,
+    rawTemporalColumn,
+    currentUnit,
+    availableItems,
+    bucketLabel,
+    handleBucketChange,
+  } = useTemporalGranularity(question, updateQuestion);
+
+  const {
+    dateFilterClause,
+    dateFilterValue,
+    dateFilterLabel,
+    datePickerUnits,
+    handleDateFilterChange,
+    handleDateFilterClear,
+  } = useDateFilter(question, updateQuestion, rawTemporalColumn);
+
+  if (
+    !question ||
+    !queryResults ||
+    sensibleChartTypes.length === 0 ||
+    hasOnlyTable
+  ) {
+    return null;
+  }
+
+  const timeRange =
+    rawTemporalColumn !== null
+      ? {
+          label: dateFilterLabel,
+          value: dateFilterValue,
+          availableUnits: datePickerUnits,
+          hasActiveFilter: !!dateFilterClause,
+          onChange: handleDateFilterChange,
+          onClear: handleDateFilterClear,
+        }
+      : undefined;
+
+  const timeGranularity =
+    temporalColumn !== null && availableItems.length > 0
+      ? {
+          label: bucketLabel,
+          currentUnit,
+          availableItems,
+          onChange: handleBucketChange,
+        }
+      : undefined;
+
+  async function handleExploreClicked() {
+    if (!instanceUrl || !question || !app) {
+      return;
+    }
+
+    const url = instanceUrl + Urls.serializedQuestion(question.card());
+
+    await app.openLink({ url });
+  }
+
+  return (
+    <QueryExplorerBar
+      chartTypes={sensibleChartTypes}
+      currentChartType={selectedChartType ?? ""}
+      onChartTypeChange={handleDisplayChange}
+      timeRange={timeRange}
+      timeGranularity={timeGranularity}
+      onExplore={handleExploreClicked}
+    />
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -10,6 +10,7 @@ import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 import { b64_to_utf8 } from "metabase/utils/encoding";
 import type { Card } from "metabase-types/api";
 
+import { McpQueryBar } from "./McpQueryBar";
 import { McpQuestionTitle } from "./McpQuestionTitle";
 import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
@@ -135,9 +136,8 @@ export function McpUiAppRoute() {
               <SdkQuestion.QuestionVisualization height={visualizationHeight} />
             </Flex>
 
-            {/* TODO(EMB-1620): add query explorer bar */}
             <Flex px="lg">
-              <Box h="3.3rem" />
+              <McpQueryBar app={app} instanceUrl={instanceUrl} />
             </Flex>
           </Flex>
         </SdkQuestion>

--- a/frontend/src/metabase/embedding/mcp/hooks/constants.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/constants.ts
@@ -1,0 +1,1 @@
+export const LAST_QUERY_STAGE_INDEX = -1;

--- a/frontend/src/metabase/embedding/mcp/hooks/useChartTypes.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useChartTypes.ts
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+
+import { getSensibleVisualizations } from "metabase/query_builder/components/chart-type-selector";
+import type Question from "metabase-lib/v1/Question";
+import type { Dataset } from "metabase-types/api";
+
+const CHART_TYPES = [
+  { type: "line" as const, icon: "line" as const },
+  { type: "bar" as const, icon: "bar" as const },
+  { type: "area" as const, icon: "area" as const },
+];
+
+const TABLE_CHART_TYPE = { type: "table" as const, icon: "table2" as const };
+
+export type McpChartType = "line" | "bar" | "area" | "table";
+
+const isMcpChartType = (type: string): type is McpChartType =>
+  [...CHART_TYPES, TABLE_CHART_TYPE].some(
+    (chartType) => chartType.type === type,
+  );
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+type ChartTypeEntry = (typeof CHART_TYPES)[number] | typeof TABLE_CHART_TYPE;
+
+interface UseChartTypesResult {
+  sensibleChartTypes: ChartTypeEntry[];
+  hasOnlyTable: boolean;
+  selectedChartType: McpChartType | null;
+  handleDisplayChange: (type: string) => void;
+}
+
+export function useChartTypes(
+  question: Question | undefined,
+  queryResults: Dataset[] | null | undefined,
+  updateQuestion: UpdateQuestion,
+): UseChartTypesResult {
+  const queryResult = queryResults?.[0] ?? null;
+
+  const { sensibleVisualizations } = useMemo(
+    () => getSensibleVisualizations({ result: queryResult }),
+    [queryResult],
+  );
+
+  const rowCount = queryResult?.data?.rows?.length ?? 0;
+  const tableVisible = rowCount >= 2;
+
+  const sensibleChartTypes = [
+    ...CHART_TYPES.filter(({ type }) => {
+      if (!sensibleVisualizations.includes(type)) {
+        return false;
+      }
+
+      // Hide area when table is shown as they occupy the same slot.
+      if (type === "area" && tableVisible) {
+        return false;
+      }
+
+      return true;
+    }),
+
+    ...(tableVisible ? [TABLE_CHART_TYPE] : []),
+  ];
+
+  const hasOnlyTable =
+    sensibleChartTypes.length === 1 && sensibleChartTypes[0].type === "table";
+
+  const rawDisplay = question?.display() ?? "";
+
+  const selectedChartType: McpChartType | null = isMcpChartType(rawDisplay)
+    ? rawDisplay
+    : null;
+
+  const handleDisplayChange = (type: string) => {
+    if (!question) {
+      return;
+    }
+
+    const nextQuestion = question
+      .setDisplay(type as McpChartType)
+      .lockDisplay();
+
+    updateQuestion(nextQuestion, { run: false });
+  };
+
+  return {
+    sensibleChartTypes,
+    hasOnlyTable,
+    selectedChartType,
+    handleDisplayChange,
+  };
+}

--- a/frontend/src/metabase/embedding/mcp/hooks/useDateFilter.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useDateFilter.ts
@@ -1,0 +1,103 @@
+import { t } from "ttag";
+
+import type { DatePickerValue } from "metabase/querying/common/types";
+import { getDateFilterDisplayName } from "metabase/querying/common/utils/dates";
+import {
+  getDateFilterClause,
+  getDatePickerUnits,
+  getDatePickerValue,
+} from "metabase/querying/filters/utils/dates";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+import { LAST_QUERY_STAGE_INDEX } from "./constants";
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+export interface UseDateFilterResult {
+  dateFilterClause: Lib.FilterClause | null;
+  dateFilterValue: DatePickerValue | undefined;
+  dateFilterLabel: string;
+  datePickerUnits: ReturnType<typeof getDatePickerUnits>;
+  handleDateFilterChange: (value: DatePickerValue) => void;
+  handleDateFilterClear: () => void;
+}
+
+export function useDateFilter(
+  question: Question | undefined,
+  updateQuestion: UpdateQuestion,
+  rawTemporalColumn: Lib.ColumnMetadata | null,
+): UseDateFilterResult {
+  const empty: UseDateFilterResult = {
+    dateFilterClause: null,
+    dateFilterValue: undefined,
+    dateFilterLabel: t`All time`,
+    datePickerUnits: [],
+
+    handleDateFilterChange: () => {},
+    handleDateFilterClear: () => {},
+  };
+
+  if (!question) {
+    return empty;
+  }
+
+  const query = question.query();
+  const stageIndex = LAST_QUERY_STAGE_INDEX;
+
+  const allFilters = Lib.filters(query, stageIndex);
+
+  let dateFilterClause: Lib.FilterClause | null = null;
+  let dateFilterValue: DatePickerValue | undefined = undefined;
+
+  for (const filter of allFilters) {
+    const nextDateFilterValue = getDatePickerValue(query, stageIndex, filter);
+
+    if (nextDateFilterValue != null) {
+      dateFilterClause = filter;
+      dateFilterValue = nextDateFilterValue;
+
+      break;
+    }
+  }
+
+  const dateFilterLabel = dateFilterValue
+    ? getDateFilterDisplayName(dateFilterValue)
+    : t`All time`;
+
+  const datePickerUnits = rawTemporalColumn
+    ? getDatePickerUnits(query, stageIndex, rawTemporalColumn)
+    : [];
+
+  const handleDateFilterChange = (value: DatePickerValue) => {
+    if (!rawTemporalColumn) {
+      return;
+    }
+
+    const newFilterClause = getDateFilterClause(rawTemporalColumn, value);
+    const newQuery = dateFilterClause
+      ? Lib.replaceClause(query, stageIndex, dateFilterClause, newFilterClause)
+      : Lib.filter(query, stageIndex, newFilterClause);
+
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  const handleDateFilterClear = () => {
+    if (!dateFilterClause) {
+      return;
+    }
+
+    const newQuery = Lib.removeClause(query, stageIndex, dateFilterClause);
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  return {
+    dateFilterClause,
+    dateFilterValue,
+    dateFilterLabel,
+    datePickerUnits,
+
+    handleDateFilterChange,
+    handleDateFilterClear,
+  };
+}

--- a/frontend/src/metabase/embedding/mcp/hooks/useTemporalGranularity.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useTemporalGranularity.ts
@@ -1,0 +1,119 @@
+import { t } from "ttag";
+
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import type { TemporalUnit } from "metabase-types/api";
+
+import { LAST_QUERY_STAGE_INDEX } from "./constants";
+
+type UpdateQuestion = (question: Question, opts: { run: boolean }) => void;
+
+export interface TemporalGranularityItem {
+  bucket: Lib.Bucket;
+  unit: TemporalUnit;
+  label: string;
+}
+
+export interface UseTemporalGranularityResult {
+  temporalColumn: Lib.ColumnMetadata | null;
+  rawTemporalColumn: Lib.ColumnMetadata | null;
+  currentUnit: TemporalUnit | undefined;
+  availableItems: TemporalGranularityItem[];
+  bucketLabel: string;
+  handleBucketChange: (bucket: Lib.Bucket | null) => void;
+}
+
+/**
+ * Handlers for showing and updating time granularity controls
+ * via the query explorer bar.
+ */
+export function useTemporalGranularity(
+  question: Question | undefined,
+  updateQuestion: UpdateQuestion,
+): UseTemporalGranularityResult {
+  if (!question) {
+    return {
+      temporalColumn: null,
+      rawTemporalColumn: null,
+      currentUnit: undefined,
+      availableItems: [],
+      bucketLabel: t`All time`,
+      handleBucketChange: () => {},
+    };
+  }
+
+  const query = question.query();
+  const stageIndex = LAST_QUERY_STAGE_INDEX;
+
+  const breakoutClauses = Lib.breakouts(query, stageIndex);
+
+  let temporalClause: Lib.BreakoutClause | null = null;
+  let temporalColumn: Lib.ColumnMetadata | null = null;
+
+  for (const clause of breakoutClauses) {
+    const column = Lib.breakoutColumn(query, stageIndex, clause);
+
+    if (column && Lib.isTemporalBucketable(query, stageIndex, column)) {
+      temporalClause = clause;
+      temporalColumn = column;
+      break;
+    }
+  }
+
+  // Strip the temporal bucket from the column — date filters operate on the
+  // raw date column, not the bucketed version used in the breakout.
+  const rawTemporalColumn = temporalColumn
+    ? Lib.withTemporalBucket(temporalColumn, null)
+    : null;
+
+  const currentBucket = temporalColumn
+    ? Lib.temporalBucket(temporalColumn)
+    : null;
+
+  const currentUnit = currentBucket
+    ? (Lib.displayInfo(query, stageIndex, currentBucket)
+        .shortName as TemporalUnit)
+    : undefined;
+
+  const availableBuckets = temporalColumn
+    ? Lib.availableTemporalBuckets(query, stageIndex, temporalColumn)
+    : [];
+
+  const availableItems: TemporalGranularityItem[] = availableBuckets.map(
+    (bucket) => {
+      const info = Lib.displayInfo(query, stageIndex, bucket);
+      const unit = info.shortName as TemporalUnit;
+
+      return { bucket, unit, label: Lib.describeTemporalUnit(unit) };
+    },
+  );
+
+  const bucketLabel = currentUnit
+    ? t`by ${Lib.describeTemporalUnit(currentUnit).toLowerCase()}`
+    : t`All time`;
+
+  const handleBucketChange = (bucket: Lib.Bucket | null) => {
+    if (!temporalClause || !temporalColumn) {
+      return;
+    }
+
+    const newColumn = Lib.withTemporalBucket(temporalColumn, bucket);
+    const newQuery = Lib.replaceClause(
+      query,
+      stageIndex,
+      temporalClause,
+      newColumn,
+    );
+
+    updateQuestion(question.setQuery(newQuery), { run: true });
+  };
+
+  return {
+    temporalColumn,
+    rawTemporalColumn,
+    currentUnit,
+    availableItems,
+    bucketLabel,
+    handleBucketChange,
+  };
+}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1620/apply-the-query-explorer-bar-to-mcp-apps

### Description

Wires up the shared `QueryExplorerBar` component into MCP Apps via a new `McpQueryBar` component. Adds hooks for chart type selection, time range filtering, and temporal granularity — all passed as config objects to the bar's props-based API.

Chart types are capped at 3: area is hidden when the table is visible (and vice versa), with table always shown last.

### Screenshot

Demo of query explorer bar (before the 3-chart-type cap)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bbad44d6-8c99-4407-b260-905d50693594" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing as you will run into the https://github.com/anthropics/claude-ai-mcp/issues/40 bug, where Claude Desktop strips all HTTP domains (e.g. `localhost:3000`) and nothing will load.

You cannot use the PR environment with Claude Connector either, as it is behind Tailscale and Claude cannot talk to it. You must use `mcp-remote` to test with PR environment.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73272.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case.

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73272.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  },
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. Ask it to visualize time-series things, e.g. "Visualize an order with Metabase. Group by Created At. Bin by year."
4. Confirm the query bar shows up to 3 chart type icons (line, bar, and either area or table)
5. Switch chart types and confirm the visualization updates
6. Use the time range picker to filter by date and confirm the chart re-renders
7. Use the granularity picker to change the time bucket and confirm the axis updates