### PR TITLE
Track publishing phase for data complexity score

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -464,11 +464,13 @@
                                                :synonym-threshold synonym-similarity-threshold}
                                         model-meta (assoc :embedding-model model-meta))}]
         (log-scores! result)
-        (let [published? (try
-                           (emit-snowplow! result)
-                           (catch Throwable t
-                             (log/warn t "Failed to publish complexity score to Snowplow")
-                             false))]
+        (let [published? (time-phase! "publish" "all"
+                                      (fn []
+                                        (try
+                                          (emit-snowplow! result)
+                                          (catch Throwable t
+                                            (log/warn t "Failed to publish complexity score to Snowplow")
+                                            false))))]
           ;; `emit-snowplow!` returns true only when every event reached the tracker (false when
           ;; Snowplow is disabled or any emission failed) — scheduler/boot callers gate
           ;; `data-complexity-scoring-last-fingerprint` on this so a disabled collector or any

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -406,7 +406,7 @@
                          {:description "Duration (ms) of a full Data Complexity Score run end-to-end (enumerate + score for all three catalogs + Snowplow publish)."
                           :buckets     [1 10 50 100 500 1000 5000 10000 30000 60000]})
    (prometheus/histogram :metabase-data-complexity/phase-duration-ms
-                         {:description "Duration (ms) of one stage (`enumerate` = DB fetch, `score` = in-memory scoring) for one catalog within a Data Complexity Score run."
+                         {:description "Duration (ms) of one stage (`enumerate` = DB fetch, `score` = in-memory scoring, `publish` = Snowplow emit) for one catalog within a Data Complexity Score run."
                           :labels      [:stage :catalog]
                           :buckets     [1 10 50 100 500 1000 5000 10000 30000 60000]})
 


### PR DESCRIPTION
## Summary

- The outer `metabase_data_complexity_scoring_duration_ms` histogram already includes Snowplow emission, but `phase-duration-ms` only covered the enumerate + per-catalog scoring steps. On boot the cold Snowplow connection dominates the total (tens of seconds for 27 events), so dashboards saw a tall total spike with no matching phase bars and the gap was unattributed.
- Wraps `emit-snowplow!` in `time-phase! "publish" "all"` so total ≈ sum-of-phases, and updates the `phase-duration-ms` description to mention the new `publish` stage.
- The existing `try/catch` around the emit is preserved inside the closure, so failure handling and `emit-snowplow-failure-is-swallowed-test` are unchanged.

## Test plan

- [x] Verify `metabase_data_complexity_phase_duration_ms{stage="publish",catalog="all"}` appears alongside the existing `enumerate` / `score` series after a local scoring run.
- [x] On a panel comparing `metabase_data_complexity_scoring_duration_ms_sum` against `sum by (instance) (metabase_data_complexity_phase_duration_ms_sum)` the two should now track each other (small overhead from logging / model-meta lookup is fine).
- [x] `complexity_test.clj` still passes — Snowplow failure path returns `:snowplow-published? false` and logs a warning.