### PR TITLE
chore: backport .gitignore additions from master (x.60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ cypress.env.json
 /lein-plugins/*/target
 /local
 /locales/metabase-*.pot
+# Pseudo-locale generated at build time
+/locales/en-ZZ.po
 /logs
 /modules/drivers/*/resources/namespaces.edn
 /modules/drivers/*/target


### PR DESCRIPTION
## Summary

Backport `.gitignore` additions from master to avoid a pile of "untracked" local build artifacts (`.d.css`, `resources/python-sources/sqlglot/`, `resources/frontend_client/app/embedding-sdk/`, pseudo-locale, etc.) showing up whenever I switch to release branches.

<img width="498" height="522" alt="image" src="https://github.com/user-attachments/assets/cbb89afd-94e4-4a59-8356-d505ba86ebd0" />



## Related PRs

- x.58 → https://github.com/metabase/metabase/pull/73284
- x.59 → https://github.com/metabase/metabase/pull/73285