### PR TITLE
Init custom theme with selected theme colors in embedding wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Appearance/ThemeSelectorSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Appearance/ThemeSelectorSection.tsx
@@ -6,9 +6,27 @@ import { Box, Flex, Icon, SimpleGrid, Tooltip } from "metabase/ui";
 import type { EmbeddingTheme } from "metabase-types/api/embedding-theme";
 
 import type { SdkIframeEmbedSetupTheme } from "../../types";
+import { getConfigurableThemeColors } from "../../utils/theme-colors";
 
 import { ColorCustomizationSection } from "./ColorCustomizationSection";
 import { ThemeCard, getThemeColors } from "./ThemeCard";
+
+const pickConfigurableColors = (
+  colors: Partial<MetabaseColors> | undefined,
+): Partial<MetabaseColors> | undefined => {
+  if (!colors) {
+    return undefined;
+  }
+
+  const picked: Partial<MetabaseColors> = {};
+  for (const { key } of getConfigurableThemeColors()) {
+    if (colors[key] !== undefined) {
+      picked[key] = colors[key];
+    }
+  }
+
+  return Object.keys(picked).length > 0 ? picked : undefined;
+};
 
 type ThemeSelection =
   | { type: "default" }
@@ -19,6 +37,7 @@ interface ThemeSelectorSectionProps {
   savedThemes: EmbeddingTheme[];
   theme: SdkIframeEmbedSetupTheme | undefined;
   onThemeChange: (themeId: number | undefined) => void;
+  onCustomSelect: (initialColors: Partial<MetabaseColors> | undefined) => void;
   onColorChange: (colors: Partial<MetabaseColors>) => void;
   onColorReset: () => void;
 }
@@ -27,6 +46,7 @@ export const ThemeSelectorSection = ({
   savedThemes,
   theme,
   onThemeChange,
+  onCustomSelect,
   onColorChange,
   onColorReset,
 }: ThemeSelectorSectionProps) => {
@@ -60,8 +80,15 @@ export const ThemeSelectorSection = ({
   };
 
   const handleCustomClick = () => {
+    const previouslySelectedSavedTheme =
+      selection.type === "saved"
+        ? savedThemes.find((t) => t.id === selection.themeId)
+        : undefined;
+
     setSelection({ type: "custom" });
-    onThemeChange(undefined);
+    onCustomSelect(
+      pickConfigurableColors(previouslySelectedSavedTheme?.settings.colors),
+    );
   };
 
   const hasThemes = savedThemes.length > 0;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Appearance/ThemeSelectorSection.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Appearance/ThemeSelectorSection.unit.spec.tsx
@@ -39,12 +39,14 @@ function setup({
   savedThemes = SAVED_THEMES,
   theme = undefined,
   onThemeChange = jest.fn(),
+  onCustomSelect = jest.fn(),
   onColorChange = jest.fn(),
   onColorReset = jest.fn(),
 }: {
   savedThemes?: EmbeddingTheme[];
   theme?: Parameters<typeof ThemeSelectorSection>[0]["theme"];
   onThemeChange?: jest.Mock;
+  onCustomSelect?: jest.Mock;
   onColorChange?: jest.Mock;
   onColorReset?: jest.Mock;
 } = {}) {
@@ -53,12 +55,19 @@ function setup({
       savedThemes={savedThemes}
       theme={theme}
       onThemeChange={onThemeChange}
+      onCustomSelect={onCustomSelect}
       onColorChange={onColorChange}
       onColorReset={onColorReset}
     />,
   );
 
-  return { ...utils, onThemeChange, onColorChange, onColorReset };
+  return {
+    ...utils,
+    onThemeChange,
+    onCustomSelect,
+    onColorChange,
+    onColorReset,
+  };
 }
 
 describe("ThemeSelectorSection", () => {
@@ -169,6 +178,72 @@ describe("ThemeSelectorSection", () => {
       expect(screen.getByText("Brand color")).toBeInTheDocument();
       expect(screen.getByText("Text color")).toBeInTheDocument();
       expect(screen.getByText("Background color")).toBeInTheDocument();
+    });
+
+    it("initializes Custom from no theme when no theme was previously selected", async () => {
+      const { onCustomSelect } = setup();
+
+      await userEvent.click(screen.getByTestId("theme-card-Custom"));
+
+      expect(onCustomSelect).toHaveBeenCalledTimes(1);
+      expect(onCustomSelect).toHaveBeenCalledWith(undefined);
+    });
+
+    it("initializes Custom with the configurable colors of the previously selected saved theme", async () => {
+      const { onCustomSelect } = setup();
+
+      await userEvent.click(screen.getByTestId("theme-card-Dark Theme"));
+      await userEvent.click(screen.getByTestId("theme-card-Custom"));
+
+      expect(onCustomSelect).toHaveBeenCalledTimes(1);
+      expect(onCustomSelect).toHaveBeenCalledWith({
+        brand: "#BB86FC",
+        "text-primary": "#FFFFFF",
+        background: "#121212",
+      });
+    });
+
+    it("ignores non-configurable settings (e.g. fontFamily) when initializing Custom from a saved theme", async () => {
+      const themesWithExtras: EmbeddingTheme[] = [
+        {
+          id: 10,
+          name: "Extras Theme",
+          settings: {
+            fontFamily: "Inter",
+            colors: {
+              brand: "#111111",
+              "text-primary": "#222222",
+              background: "#333333",
+              // Not in the configurable set:
+              "text-secondary": "#999999",
+            },
+          },
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+      ];
+
+      const { onCustomSelect } = setup({ savedThemes: themesWithExtras });
+
+      await userEvent.click(screen.getByTestId("theme-card-Extras Theme"));
+      await userEvent.click(screen.getByTestId("theme-card-Custom"));
+
+      expect(onCustomSelect).toHaveBeenLastCalledWith({
+        brand: "#111111",
+        "text-primary": "#222222",
+        background: "#333333",
+      });
+    });
+
+    it("initializes Custom from no theme when switching from Instance theme", async () => {
+      const { onCustomSelect } = setup();
+
+      // Select a saved theme, then go back to Instance theme, then click Custom
+      await userEvent.click(screen.getByTestId("theme-card-Dark Theme"));
+      await userEvent.click(screen.getByTestId("theme-card-Instance theme"));
+      await userEvent.click(screen.getByTestId("theme-card-Custom"));
+
+      expect(onCustomSelect).toHaveBeenLastCalledWith(undefined);
     });
 
     it("hides color inputs when switching from Custom to Instance theme", async () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -345,6 +345,15 @@ const AppearanceSection = () => {
     [updateSettings],
   );
 
+  const initializeCustomTheme = useCallback(
+    (initialColors: Partial<MetabaseColors> | undefined) => {
+      updateSettings({
+        theme: initialColors ? { colors: initialColors } : undefined,
+      } satisfies Partial<typeof settings>);
+    },
+    [updateSettings],
+  );
+
   const updateThemePreset = useCallback(
     (preset: MetabaseThemePreset) => {
       updateSettings({ theme: { preset } } satisfies Partial<typeof settings>);
@@ -420,6 +429,7 @@ const AppearanceSection = () => {
             savedThemes={savedThemes ?? []}
             theme={theme}
             onThemeChange={updateThemeId}
+            onCustomSelect={initializeCustomTheme}
             onColorChange={updateColors}
             onColorReset={resetTheme}
           />


### PR DESCRIPTION
Closes [EMB-1642: Use previously selected theme when choosing custom](https://linear.app/metabase/issue/EMB-1642/use-previously-selected-theme-when-choosing-custom)

### Description

When selecting "Custom" in the embedding wizard, the colors should be initialized with whatever theme was previously selected, if any.

### How to verify

1. Create a new embed
2. in the last wizard section, select a theme, then custom

The colors should be initialized with the theme colors.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
