### PR TITLE
Fix broken e2e reproduction 63416

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -52,6 +52,9 @@ export function getEmbeddedDashboardCardMenu(index = 0) {
 }
 
 export function getDashboardCardMenu(index = 0) {
+  cy.log("Wait for the card results to load");
+  getDashboardCard(index).findByTestId("loading-indicator").should("not.exist");
+  cy.log("Click on the card menu");
   return getDashboardCard(index).findByTestId("dashcard-menu");
 }
 

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -141,7 +141,7 @@ export function downloadAndAssert({
     }
   }
 
-  cy.get("[aria-label='Download results']").click();
+  cy.findByLabelText("Download results").should("be.visible").click();
 
   popover().within(() => {
     cy.findByText(`.${fileType}`).click();

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1636,11 +1636,13 @@ describe("issue 63416", () => {
         ],
       });
 
+      cy.wrap(dashboard.id).as("dashboardId");
+
       H.visitDashboard(dashboard.id);
     });
   });
 
-  it("should download visualizer dashboard card without additional dataset with proper parameter values (metabase#63416)", () => {
+  it("should download visualizer dashboard card without additional dataset with proper parameter values (metabase#63416)", function () {
     H.editDashboard();
 
     H.showDashcardVisualizerModalSettings(0, {
@@ -1660,7 +1662,7 @@ describe("issue 63416", () => {
       fileType: "csv",
       isDashboard: true,
       downloadMethod: "POST",
-      downloadUrl: "/api/dashboard/10/dashcard/*/card/*/query/csv",
+      downloadUrl: `/api/dashboard/${this.dashboardId}/dashcard/*/card/*/query/csv`,
       assertParameters: [{ type: "string/=", value: ["Doohickey"] }],
     });
   });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1648,10 +1648,8 @@ describe("issue 63416", () => {
     H.showDashcardVisualizerModalSettings(0, {
       isVisualizerCard: false,
     });
-    H.modal()
-      .findByLabelText("Description")
-      .type("Make this a visualizer card");
 
+    cy.log("Make this a visualizer card");
     H.saveDashcardVisualizerModal();
 
     H.saveDashboard();


### PR DESCRIPTION
Resolves EMB-1651

## Summary

The most common failure was due to the race condition where Cypress clicks on the `...` menu trigger but then it fails to open a modal itself. We're now waiting for the card content to load first.

<img width="1280" height="633" alt="issue 63416 -- should download visualizer dashboard card without additional dataset with proper parameter values (metabase#63416) (failed)" src="https://github.com/user-attachments/assets/8708efad-c099-40a7-86f1-0262935bf5be" />

When and IF this step succeeds, the test ultimately fails because it was waiting a route with the hard coded dashboard id. We're now using a proper variable for that.

### Stress-test
- https://github.com/metabase/metabase/actions/runs/25047522334 x 10
- https://github.com/metabase/metabase/actions/runs/25047847647 x 50 
- https://github.com/metabase/metabase/actions/runs/25047852322 x 50 (with network throttling)