### PR TITLE
add remap for `embedding-iframe` -> "Embedding Unknown"

### DIFF
--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/most_viewed_authenticated_embeds.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/most_viewed_authenticated_embeds.yaml
@@ -217,10 +217,10 @@ result_metadata:
   lib/desired-column-alias: embedding_client
   lib/from-model?: true
   lib/internal-remap:
-    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview)]
+    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview), Embedding Unknown]
     id: 291
     name: Embedding Client
-    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview]
+    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview, embedding-iframe]
     lib/type: metadata.column.remapping/internal
   lib/original-display-name: Embedding Client
   lib/original-name: embedding_client

--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/most_viewed_guest_embeds.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/most_viewed_guest_embeds.yaml
@@ -215,10 +215,10 @@ result_metadata:
   lib/desired-column-alias: embedding_client
   lib/from-model?: true
   lib/internal-remap:
-    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview)]
+    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview), Embedding Unknown]
     id: 291
     name: Embedding Client
-    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview]
+    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview, embedding-iframe]
     lib/type: metadata.column.remapping/internal
   lib/original-display-name: Embedding Client
   lib/original-name: embedding_client

--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/tenants_with_most_views.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/tenants_with_most_views.yaml
@@ -27,12 +27,40 @@ dataset_query:
     - - field
       - {base-type: type/Integer, effective-type: type/Integer, join-alias: Tenants}
       - [Internal Metabase Database, public, v_tenants, tenant_id]
+    expressions:
+    - - not
+      - {lib/expression-name: is_top_level}
+      - - and
+        - {}
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, entity_type]
+          - card
+        - - not-null
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+          - dashboard
     filters:
     - - not-null
       - {}
       - - field
         - {base-type: type/Integer, effective-type: type/Integer}
         - [Internal Metabase Database, public, v_view_log, tenant_id]
+    - - =
+      - {}
+      - - expression
+        - {base-type: type/Boolean, effective-type: type/Boolean}
+        - is_top_level
+      - true
     - - time-interval
       - {include-current: true}
       - - field

--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_embedding_client.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_embedding_client.yaml
@@ -126,10 +126,10 @@ result_metadata:
   lib/desired-column-alias: embedding_client
   lib/from-model?: true
   lib/internal-remap:
-    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview)]
+    human-readable-values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview), Embedding Unknown]
     id: 291
     name: Embedding Client
-    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview]
+    values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview, embedding-iframe]
     lib/type: metadata.column.remapping/internal
   lib/original-display-name: Embedding Client
   lib/original-name: embedding_client

--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_embedding_host.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_embedding_host.yaml
@@ -26,12 +26,39 @@ dataset_query:
       - - field
         - {base-type: type/Text, effective-type: type/Text, lib/uuid: dff4c1e8-b51b-4250-b6bb-d90b8cd71cc2}
         - embedding_client
+    - - not
+      - {lib/expression-name: is_top_level}
+      - - and
+        - {}
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, entity_type]
+          - card
+        - - not-null
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+          - dashboard
     filters:
     - - =
       - {}
       - - expression
         - {effective-type: type/Boolean}
         - is_embed
+      - true
+    - - =
+      - {}
+      - - expression
+        - {base-type: type/Boolean, effective-type: type/Boolean}
+        - is_top_level
       - true
     - - time-interval
       - {include-current: true}

--- a/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_user_agent.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/embedding_usage/views_by_user_agent.yaml
@@ -26,12 +26,39 @@ dataset_query:
       - - field
         - {base-type: type/Text, effective-type: type/Text, lib/uuid: a7743886-95fd-4560-8c48-737742789d58}
         - embedding_client
+    - - not
+      - {lib/expression-name: is_top_level}
+      - - and
+        - {}
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, entity_type]
+          - card
+        - - not-null
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+        - - =
+          - {}
+          - - field
+            - {base-type: type/Text, effective-type: type/Text}
+            - [Internal Metabase Database, public, v_view_log, context]
+          - dashboard
     filters:
     - - =
       - {}
       - - expression
         - {effective-type: type/Boolean}
         - is_embed
+      - true
+    - - =
+      - {}
+      - - expression
+        - {base-type: type/Boolean, effective-type: type/Boolean}
+        - is_top_level
       - true
     - - time-interval
       - {include-current: true}

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_query_log/fields/embedding_client___fieldvalues.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_query_log/fields/embedding_client___fieldvalues.yaml
@@ -1,8 +1,8 @@
 created_at: '2026-04-22T14:46:17.273549Z'
-human_readable_values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview)]
+human_readable_values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview), Embedding Unknown]
 last_used_at: '2026-04-22T14:46:17.273549Z'
 type: full
-values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview]
+values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview, embedding-iframe]
 serdes/meta:
 - {id: Internal Metabase Database, model: Database}
 - {id: public, model: Schema}

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_view_log/fields/embedding_client___fieldvalues.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_view_log/fields/embedding_client___fieldvalues.yaml
@@ -1,8 +1,8 @@
 created_at: '2026-04-22T14:46:16.631421Z'
-human_readable_values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview)]
+human_readable_values: [Modular embedding SDK, Modular embedding SDK (Preview), Modular embedding, Modular embedding (Preview), Public sharing, Static embedding, Static embedding (Preview), Full app embedding, Full app embedding (Preview), Embedding Unknown]
 last_used_at: '2026-04-22T16:08:52.003887Z'
 type: full
-values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview]
+values: [embedding-sdk-react, embedding-sdk-react-preview, embedding-simple, embedding-simple-preview, embedding-public, embedding-iframe-static, embedding-iframe-static-preview, embedding-iframe-full-app, embedding-iframe-full-app-preview, embedding-iframe]
 serdes/meta:
 - {id: Internal Metabase Database, model: Database}
 - {id: public, model: Schema}


### PR DESCRIPTION

### Description

In [Enhance usage analytics for embedding](https://github.com/metabase/metabase/pull/71386) we changed the headers from `embedding-iframe` to something more specific, the issue is that we didn't remap that value to anything, so the value shows up as empty string and it looks like we're doing a mistake in showing non embedding views in the embedding usage analytics dashboard.

In the first commit I add that mapping so this doesn't happen.

Since I had to change the yml files, I also added `is_top_level` filter to other charts to make them all consistent, as discussed with Roman (second commit)

### How to verify

Change the header of a client to send `embedding-iframe` (which is the old value we were sending)

### Demo
Before:
<img width="563" height="446" alt="image" src="https://github.com/user-attachments/assets/4a99cc9c-32ce-4ce3-b3bd-79ca49581ab3" />
After:
<img width="575" height="443" alt="image" src="https://github.com/user-attachments/assets/1d1178cb-fd09-4b20-89c9-ab0b2e2b7e1f" />


