### PR TITLE
Fix flaky e2e browser navigation test

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -62,28 +62,24 @@ describe("scenarios > models metadata", () => {
         .and("not.contain", "Subtotal");
     });
 
-    it("allows for canceling changes, back navigation (metabase#55162)", () => {
+    it("allows for canceling changes", () => {
       H.openQuestionActions("Edit metadata");
       H.waitForLoaderToBeRemoved();
+
+      const RENAMED_COLUMN = "Pre-tax";
 
       H.openColumnOptions("Subtotal");
-      H.renameColumn("Subtotal", "Pre-tax");
+      H.renameColumn("Subtotal", RENAMED_COLUMN);
       H.setColumnType("No semantic type", "Currency");
 
-      cy.findByTestId("dataset-edit-bar").button("Cancel").click();
+      H.datasetEditBar().button("Cancel").click();
       H.modal().button("Discard changes").click();
+      H.datasetEditBar().should("not.exist");
 
       cy.findAllByTestId("header-cell")
-        .should("contain", "Subtotal")
-        .and("not.contain", "Pre-tax");
-
-      // Ensure back navigation works correctly metabase#55162
-      H.openQuestionActions("Edit metadata");
-      H.waitForLoaderToBeRemoved();
-      cy.go("back");
-      cy.get("@questionId").then((id) => {
-        cy.location("pathname").should("equal", `/model/${id}-gui-model`);
-      });
+        .filter(":contains(Subtotal)")
+        .should("not.contain", "$");
+      cy.findAllByTestId("header-cell").should("not.contain", RENAMED_COLUMN);
     });
 
     it("clears custom metadata when a model is turned back into a question", () => {

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1131,29 +1131,6 @@ describe("issue 56416", () => {
   });
 });
 
-describe("issue 55487", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsNormalUser();
-  });
-
-  it("should be able open object details on browser forward navigation (metabase#55487)", () => {
-    H.visitQuestion(ORDERS_QUESTION_ID);
-
-    cy.findByTestId("table-body").find("[data-column-id='ID']").eq(4).click();
-
-    cy.findByTestId("object-detail").should("be.visible");
-
-    cy.go("back");
-
-    cy.findByTestId("object-detail").should("not.exist");
-
-    cy.go("forward");
-
-    cy.findByTestId("object-detail").should("be.visible");
-  });
-});
-
 describe("issue 42723", () => {
   const questionDetails: StructuredQuestionDetails = {
     display: "line",

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1100,7 +1100,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.get("@questionId").then((PRODUCT_QUESTION_ID) => {
       cy.findByRole("button", { name: /Editor/ }).click();
+      cy.location("pathname").should(
+        "equal",
+        `/question/${PRODUCT_QUESTION_ID}-products/notebook`,
+      );
+
       cy.findByRole("button", { name: /Visualization/ }).click();
+      cy.location("pathname").should(
+        "equal",
+        `/question/${PRODUCT_QUESTION_ID}-products`,
+      );
 
       cy.go("back");
       cy.location("pathname").should(
@@ -1120,8 +1129,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         `/question/${PRODUCT_QUESTION_ID}-products/notebook`,
       );
 
+      cy.log("Turn this question into a model");
       H.openQuestionActions("Turn into a model");
-
       H.modal()
         .findByRole("button", { name: "Turn this into a model" })
         .click();
@@ -1133,8 +1142,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       H.openQuestionActions("Edit metadata");
       H.waitForLoaderToBeRemoved();
-      H.datasetEditBar().findByRole("button", { name: "Cancel" }).click();
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products/columns`,
+      );
 
+      H.datasetEditBar().findByRole("button", { name: "Cancel" }).click();
+      H.datasetEditBar().should("not.exist");
       cy.location("pathname").should(
         "equal",
         `/model/${PRODUCT_QUESTION_ID}-products`,
@@ -1142,6 +1156,10 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       H.openQuestionActions("Edit metadata");
       H.waitForLoaderToBeRemoved();
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products/columns`,
+      );
 
       cy.go("back");
       cy.location("pathname").should(
@@ -1150,66 +1168,81 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       );
 
       cy.go("back");
-
       cy.location("pathname").should(
         "equal",
         `/model/${PRODUCT_QUESTION_ID}-products/columns`,
       );
 
       H.datasetEditBar().findByText("Query").click();
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products/query`,
+      );
 
       cy.go("back");
-
       cy.location("pathname").should(
         "equal",
         `/model/${PRODUCT_QUESTION_ID}-products/columns`,
       );
 
       cy.go("forward");
-
       cy.location("pathname").should(
         "equal",
         `/model/${PRODUCT_QUESTION_ID}-products/query`,
       );
 
       H.datasetEditBar().findByRole("button", { name: "Cancel" }).click();
+      H.datasetEditBar().should("not.exist");
 
       cy.go("back");
-
       cy.location("pathname").should(
         "equal",
         `/model/${PRODUCT_QUESTION_ID}-products/query`,
       );
 
-      cy.go("back");
-
       // This should work, but doesn't (metabase#55486)
+      // cy.go("back");
       // cy.location("pathname").should(
       //   "equal",
       //   `/model/${PRODUCT_QUESTION_ID}-products/columns`,
       // );
 
-      H.datasetEditBar().findByRole("button", { name: "Cancel" }).click();
+      H.datasetEditBar()
+        .findByRole("button", { name: "Cancel" })
+        .should("be.visible")
+        .click();
+      H.datasetEditBar().should("not.exist");
 
-      cy.findAllByTestId("row-id-cell")
+      const PRODUCT_ROW_ID = "1";
+      cy.findByTestId("table-body")
+        .find("[data-column-id='ID']")
         .first()
-        .findByRole("button", { hidden: true })
-        .click({ force: true });
+        .should("be.visible")
+        .and("have.text", PRODUCT_ROW_ID)
+        .click();
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products/${PRODUCT_ROW_ID}`,
+      );
 
-      // Cannot navigate back and forth to details modal (metabase#55487)
-      // cy.go("back");
+      cy.log("Navigate back and forth to details modal (metabase#55487)");
+      cy.go("back");
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products`,
+      );
 
-      // cy.location("pathname").should(
-      //   "equal",
-      //   `/model/${PRODUCT_QUESTION_ID}-products`,
-      // );
+      cy.go("forward");
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products/${PRODUCT_ROW_ID}`,
+      );
 
-      // cy.go("forward");
-
-      // cy.location("pathname").should(
-      //   "equal",
-      //   `/model/${PRODUCT_QUESTION_ID}-products/1`,
-      // );
+      cy.go("back");
+      cy.location("pathname").should(
+        "equal",
+        `/model/${PRODUCT_QUESTION_ID}-products`,
+      );
 
       /**
        * foreign key relation orders should work, but it consistently fails in CI
@@ -1220,13 +1253,6 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       // cy.location("pathname").should("contain", "/question");
       // cy.findByTestId("filter-pill").should("contain.text", "Product ID is 1");
-
-      cy.go("back");
-
-      cy.location("pathname").should(
-        "equal",
-        `/model/${PRODUCT_QUESTION_ID}-products`,
-      );
 
       H.openQuestionActions("Turn back to saved question");
 


### PR DESCRIPTION
Resolves DEV-1649

## Summary

We had some redundancy that I removed once I consolidated the main, long-running, test.

### Stress-test
(notebook)
- https://github.com/metabase/metabase/actions/runs/25052319104 x50
- https://github.com/metabase/metabase/actions/runs/25052329369 x50

(models-metadata)
- https://github.com/metabase/metabase/actions/runs/25052405416 x50
- https://github.com/metabase/metabase/actions/runs/25052410321 x50