### PR TITLE
Remove unused `getColor` helper on entities

### DIFF
--- a/frontend/src/metabase-types/entities/common.ts
+++ b/frontend/src/metabase-types/entities/common.ts
@@ -2,7 +2,6 @@ import type { Collection } from "metabase-types/api";
 
 export type WrappedEntity<Entity> = {
   getName: () => string;
-  getColor: () => string;
   getCollection: () => Collection;
   setArchived: (isArchived: boolean) => void;
   setCollection: (collection: Collection) => void;

--- a/frontend/src/metabase/entities/containers/rtk-query/types/entities.ts
+++ b/frontend/src/metabase/entities/containers/rtk-query/types/entities.ts
@@ -95,7 +95,6 @@ export interface EntityDefinition<Entity, EntityWrapper> {
   normalizeList: (list: unknown) => { list: unknown };
   objectSelectors: {
     getName: (entity: Entity | EntityWrapper) => string;
-    getColor: (entity: Entity | EntityWrapper) => string | undefined;
     getCollection: (entity: Entity | EntityWrapper) => Collection | undefined;
   };
   rtk: {

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -15,7 +15,6 @@ import {
 } from "metabase/entities/collections/utils";
 import { compose, withAction } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
-import { color } from "metabase/ui/colors";
 
 import {
   createEntity,
@@ -178,7 +177,6 @@ export const Dashboards = createEntity({
     getName: (dashboard) => dashboard && dashboard.name,
     getCollection: (dashboard) =>
       dashboard && normalizedCollection(dashboard.collection),
-    getColor: () => color("dashboard"),
   },
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -14,7 +14,6 @@ import {
   getMetadata,
   getMetadataUnfiltered,
 } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 import { createEntity, entityCompatibleQuery, fetchData } from "./utils";
@@ -110,7 +109,6 @@ export const Databases = createEntity({
 
   objectSelectors: {
     getName: (db) => db && db.name,
-    getColor: (db) => color("database"),
   },
 
   selectors: {

--- a/frontend/src/metabase/entities/documents.ts
+++ b/frontend/src/metabase/entities/documents.ts
@@ -7,7 +7,6 @@ import {
 } from "metabase/collections/utils";
 import type { Dispatch } from "metabase/redux/store";
 import { DocumentSchema } from "metabase/schema";
-import { color } from "metabase/ui/utils/colors";
 import type {
   Collection,
   CopyDocumentRequest,
@@ -111,6 +110,5 @@ export const Documents = createEntity({
 
   objectSelectors: {
     getName: (document: Document) => document && document.name,
-    getColor: () => color("brand"),
   },
 });

--- a/frontend/src/metabase/entities/measures.js
+++ b/frontend/src/metabase/entities/measures.js
@@ -5,7 +5,6 @@ import {
 } from "metabase/api";
 import { MeasureSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 
 import { createEntity, entityCompatibleQuery } from "./utils";
 
@@ -58,7 +57,6 @@ export const Measures = createEntity({
 
   objectSelectors: {
     getName: (measure) => measure && measure.name,
-    getColor: () => color("summarize"),
   },
 });
 

--- a/frontend/src/metabase/entities/metrics.js
+++ b/frontend/src/metabase/entities/metrics.js
@@ -5,7 +5,6 @@ import {
 } from "metabase/api";
 import { MetricSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 
 import { createEntity, entityCompatibleQuery } from "./utils";
 
@@ -46,7 +45,6 @@ export const Metrics = createEntity({
 
   objectSelectors: {
     getName: (metric) => metric && metric.name,
-    getColor: () => color("summarize"),
   },
 });
 

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -6,7 +6,6 @@ import {
   useListSubscriptionsQuery,
 } from "metabase/api";
 import { getCollectionType } from "metabase/entities/collections/utils";
-import { color } from "metabase/ui/colors";
 
 import { createEntity, entityCompatibleQuery, undo } from "./utils";
 
@@ -67,7 +66,6 @@ export const Pulses = createEntity({
 
   objectSelectors: {
     getName: (pulse) => pulse && pulse.name,
-    getColor: (pulse) => color("pulse"),
   },
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -19,7 +19,6 @@ import {
   getMetadata,
   getMetadataUnfiltered,
 } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 
 import { createEntity, entityCompatibleQuery, undo } from "./utils";
 
@@ -161,7 +160,6 @@ export const Questions = createEntity({
 
   objectSelectors: {
     getName: (card) => card && card.name,
-    getColor: () => color("text-secondary"),
     getCollection: (card) => card && normalizedCollection(card.collection),
   },
 

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -157,13 +157,6 @@ export const Search = createEntity({
         ? (entity?.objectSelectors?.getName?.(object) ?? object?.name)
         : warnEntityAndReturnObject(object);
     },
-
-    getColor: (object) => {
-      const entity = entityForObject(object);
-      return entity
-        ? (entity?.objectSelectors?.getColor?.(object) ?? null)
-        : warnEntityAndReturnObject(object);
-    },
   },
   // delegate to each entity's actionShouldInvalidateLists
   actionShouldInvalidateLists(action) {

--- a/frontend/src/metabase/entities/segments.js
+++ b/frontend/src/metabase/entities/segments.js
@@ -5,7 +5,6 @@ import {
 } from "metabase/api";
 import { SegmentSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 
 import { createEntity, entityCompatibleQuery } from "./utils";
 
@@ -69,7 +68,6 @@ export const Segments = createEntity({
 
   objectSelectors: {
     getName: (segment) => segment && segment.name,
-    getColor: (segment) => color("filter"),
   },
 });
 

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -30,7 +30,6 @@ import {
   getMetadata,
   getMetadataUnfiltered,
 } from "metabase/selectors/metadata";
-import { color } from "metabase/ui/colors";
 import {
   convertSavedQuestionToVirtualTable,
   getCollectionVirtualSchemaId,
@@ -348,9 +347,7 @@ export const Tables = createEntity({
 
     return state;
   },
-  objectSelectors: {
-    getColor: (table) => color("accent2"),
-  },
+  objectSelectors: {},
 
   selectors: {
     getObject: (state, { entityId }) => getMetadata(state).table(entityId),

--- a/frontend/src/metabase/entities/transforms.ts
+++ b/frontend/src/metabase/entities/transforms.ts
@@ -1,5 +1,4 @@
 import { TransformSchema } from "metabase/schema";
-import { color } from "metabase/ui/utils/colors";
 import type { Transform } from "metabase-types/api";
 
 import { createEntity } from "./utils";
@@ -16,6 +15,5 @@ export const Transforms = createEntity({
 
   objectSelectors: {
     getName: (transform: Transform) => transform && transform.name,
-    getColor: () => color("brand"),
   },
 });

--- a/frontend/src/metabase/entities/utils.ts
+++ b/frontend/src/metabase/entities/utils.ts
@@ -809,9 +809,6 @@ export function createEntity(def: EntityDef): Entity {
     getIcon(_object: EntityObject) {
       return { name: "unknown" };
     },
-    getColor(_object: EntityObject): string | undefined {
-      return undefined;
-    },
     getCollection(object: EntityObject) {
       return object.collection;
     },


### PR DESCRIPTION
Closes DEV-1868

These helpers never get called and are just dead code, in the way of refactoring the entity framework.