### PR TITLE
Added a loading indicator to static dashboard pdf export button

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes } from "react";
+import { useAsyncFn } from "react-use";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
@@ -14,19 +15,20 @@ export const ExportAsPdfButton = (
   const { dashboard } = useDashboardContext();
   const dispatch = useDispatch();
 
-  const saveAsPDF = () => {
-    dispatch(
+  const [{ loading }, saveAsPDF] = useAsyncFn(async () => {
+    await dispatch(
       downloadDashboardToPdf({
         dashboard: checkNotNull(dashboard),
         id: Date.now(),
       }),
     );
-  };
+  }, [dispatch, dashboard]);
 
   return (
     <ToolbarButton
       icon="download"
       onClick={saveAsPDF}
+      loading={loading}
       tooltipLabel={t`Download as PDF`}
       data-testid="export-as-pdf-button"
       {...props}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.unit.spec.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
+import { createMockDashboardState } from "metabase/redux/store/mocks";
+import { createMockDashboard } from "metabase-types/api/mocks";
+
+import { ExportAsPdfButton } from "./ExportAsPdfButton";
+
+jest.mock("metabase/visualizations/lib/save-dashboard-pdf", () => ({
+  saveDashboardPdf: jest.fn(() => new Promise(() => {})),
+}));
+
+jest.mock("metabase/dashboard/analytics", () => ({
+  trackExportDashboardToPDF: jest.fn(),
+}));
+
+const setup = () => {
+  const dashboard = createMockDashboard();
+
+  return renderWithProviders(
+    <MockDashboardContext dashboardId={dashboard.id} dashboard={dashboard}>
+      <ExportAsPdfButton />
+    </MockDashboardContext>,
+    {
+      storeInitialState: {
+        dashboard: createMockDashboardState({
+          dashboardId: dashboard.id,
+          dashboards: {
+            [dashboard.id]: { ...dashboard, dashcards: [] },
+          },
+        }),
+      },
+    },
+  );
+};
+
+describe("ExportAsPdfButton", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a loading indicator while the PDF is being generated", async () => {
+    setup();
+
+    const button = screen.getByTestId("export-as-pdf-button");
+    expect(button).not.toHaveAttribute("data-loading", "true");
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+
+    await waitFor(() => expect(button).toHaveAttribute("data-loading", "true"));
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.config.tsx
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.config.tsx
@@ -6,6 +6,9 @@ export const actionIconOverrides: MantineThemeOverride["components"] = {
   ActionIcon: ActionIcon.extend({
     defaultProps: {
       variant: "subtle",
+      loaderProps: {
+        color: "currentColor",
+      },
     },
     classNames: {
       root: ActionIconStyles.root,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72771
Closes [EMB-1589: Modular Embedding - No Progress Indicator for PDF Exports](https://linear.app/metabase/issue/EMB-1589/modular-embedding-no-progress-indicator-for-pdf-exports)

### Description

Use the `loading` prop on export as pdf button

### How to verify

1. Open a StaticDashboard with `withDownloads` set to `true`
2. Download the PDF
3. Be amazed at the loader

### Demo

https://www.loom.com/share/1843388b654d492b897eaee9ea8833fe

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
