### PR TITLE
Bump axios and @slack/web-api to uncompromised versions

### DIFF
--- a/release/bun.lock
+++ b/release/bun.lock
@@ -6,7 +6,7 @@
       "name": "release-helper",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "@slack/web-api": "^7.15.0",
+        "@slack/web-api": "^7.15.1",
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "esbuild": "^0.25.0",
@@ -29,7 +29,7 @@
     },
   },
   "overrides": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "follow-redirects": "^1.16.0",
     "form-data": "^4.0.4",
   },
@@ -434,7 +434,7 @@
 
     "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
 
-    "@slack/web-api": ["@slack/web-api@7.15.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw=="],
+    "@slack/web-api": ["@slack/web-api@7.15.1", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.15.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.1", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw=="],
 
@@ -478,7 +478,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
+    "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
 

--- a/release/package.json
+++ b/release/package.json
@@ -20,7 +20,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@octokit/rest": "^21.1.1",
-    "@slack/web-api": "^7.15.0",
+    "@slack/web-api": "^7.15.1",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "esbuild": "^0.25.0",
@@ -41,7 +41,7 @@
     "oxfmt": "^0.38.0"
   },
   "resolutions": {
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "follow-redirects": "^1.16.0",
     "form-data": "^4.0.4"
   }

--- a/release/package.json
+++ b/release/package.json
@@ -41,7 +41,7 @@
     "oxfmt": "^0.38.0"
   },
   "resolutions": {
-    "axios": "1.15.1",
+    "axios": "1.15.2",
     "follow-redirects": "^1.16.0",
     "form-data": "^4.0.4"
   }


### PR DESCRIPTION
Closes [GDGT-2368](https://linear.app/metabase/issue/GDGT-2368/bump-axios-and-slack-web-api-to-uncompromised-version)

### Description

Code scanning found several critical security issues in `axios@1.15.0`, which should be resolved by bumping the minor package version. Based on release notes, there shouldn't be any regressions or backward compatibility problems, so I think we should be good to merge.

[Code Scanning](https://github.com/metabase/metabase/security/code-scanning)
[One of the notes from Axios on found security issues](https://github.com/axios/axios/security/advisories/GHSA-pf86-5x62-jrwf)

