### PR TITLE
Persist Data Complexity Score to skip redundant recomputes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -5,7 +5,8 @@
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.api.routes.common :refer [+auth]]))
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
@@ -51,33 +52,34 @@
     [:map
      [:formula-version   pos-int?]
      [:synonym-threshold number?]
-     [:embedding-model {:optional true} EmbeddingModelMeta]]]])
+     [:embedding-model {:optional true} EmbeddingModelMeta]
+     [:calculated-at    ms/TemporalInstant]]]])
 
-;; Per-JVM single-flight guard for the /complexity endpoint. Each scoring run walks the entire
-;; app-db catalog and emits Snowplow events, so concurrent superuser requests on the same node
-;; would just multiply load and noise without producing different results — fast-fail with 409
-;; instead. In a clustered deployment the guard is per-node, so up to one pass per node can still
-;; run concurrently; we accept that since superuser API traffic is low-volume. The Quartz job
-;; already has its own concurrency control (`DisallowConcurrentExecution` + cluster lock for boot
-;; emission), so we deliberately don't share this guard with the task path; a daily cron run that
-;; coincided with an API call shouldn't be cancelled.
+;; Per-JVM single-flight guard for the compute path. Concurrent scoring on one node only adds
+;; load and noise, so we fast-fail the second compute with 409. The Quartz job has its own
+;; cluster-wide guard, so we deliberately don't share this one — a coinciding cron tick should
+;; not cancel an admin's API call.
 (defonce ^:private ^java.util.concurrent.atomic.AtomicBoolean api-scoring-running?
   (java.util.concurrent.atomic.AtomicBoolean. false))
 
 (api.macros/defendpoint :get "/complexity" :- ComplexityScoresResponse
   "Return the current Data Complexity Score for this instance.
-  Superuser-only, expensive, and emits Snowplow events for benchmark consumers. Concurrent
-  requests on the same JVM fast-fail with HTTP 409 — a scoring pass walks the full app-db
-  catalog and one in-flight run per node is enough. The guard is per-JVM, so in a clustered
-  deployment each node can still run one pass concurrently."
-  [_route _query _body]
+  Returns the cached row when the live fingerprint matches; pass `?refresh=true` to force a
+  recompute. Compute paths emit Snowplow events and fast-fail concurrent requests with 409."
+  [_route
+   {:keys [refresh]} :- [:map [:refresh {:default false} [:maybe ms/BooleanValue]]]
+   _body]
   (api/check-superuser)
-  (when-not (.compareAndSet api-scoring-running? false true)
-    (throw (ex-info "Data Complexity Score calculation already in progress" {:status-code 409})))
-  (try
-    (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))
-    (finally
-      (.set api-scoring-running? false))))
+  (let [fingerprint (complexity/current-fingerprint)]
+    (or (when-not refresh (complexity/cached-score fingerprint))
+        (do
+          (when-not (.compareAndSet api-scoring-running? false true)
+            (throw (ex-info "Data Complexity Score calculation already in progress" {:status-code 409})))
+          (try
+            (->> (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))
+                 (complexity/cache-score! fingerprint))
+            (finally
+              (.set api-scoring-running? false)))))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-complexity-score` routes."

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -49,6 +49,50 @@
   value was chosen."
   0.90)
 
+(defn current-fingerprint
+  "String capturing every input that affects an emitted score — formula version, weights,
+  threshold, embedding model.
+  Mirrors the Snowplow `formula_version` + `parameters` fields so a tuning change forces a
+  re-score without having to bump `formula-version`."
+  []
+  (let [embedding-model (semantic-search/active-embedding-model)]
+    (pr-str (into (sorted-map)
+                  (cond-> {:formula-version   formula-version
+                           :synonym-threshold synonym-similarity-threshold
+                           :weights           weights}
+                    embedding-model (assoc :embedding-model embedding-model))))))
+
+;;; -------------------------------------- cache --------------------------------------
+;;;
+;;; Single-row persistence keyed by fingerprint, so a matching live config short-circuits the
+;;; expensive full-catalog walk. Reads and writes both stamp `:meta.:calculated-at` from the
+;;; DB-side timestamp the row was inserted with — same shape from cache hit or miss.
+
+(defn- with-calculated-at [score calculated-at]
+  (assoc-in score [:meta :calculated-at] calculated-at))
+
+(defn cached-score
+  "Cached score (with `:meta.:calculated-at`) when the row's fingerprint matches, else nil."
+  [fingerprint]
+  (t2/select-one-fn (fn [{:keys [score calculated_at]}]
+                      (with-calculated-at score calculated_at))
+                    [:model/DataComplexityScore :score :calculated_at]
+                    :fingerprint fingerprint))
+
+(defn cache-score!
+  "Replace the single cached row with `fingerprint`/`score`.
+  `calculated_at` is left to the DB's `current_timestamp` default and read back via
+  [[t2/insert-returning-instance!]] so we record one canonical timestamp regardless of
+  app-server clock skew."
+  [fingerprint score]
+  (let [{:keys [calculated_at]}
+        (t2/with-transaction [_conn]
+          (t2/delete! :model/DataComplexityScore)
+          (t2/insert-returning-instance! :model/DataComplexityScore
+                                         {:fingerprint fingerprint
+                                          :score       score}))]
+    (with-calculated-at score calculated_at)))
+
 ;;; ----------------------------------- enumeration -----------------------------------
 ;;;
 (defn- table-field-counts

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -1,0 +1,16 @@
+(ns metabase-enterprise.data-complexity-score.models.data-complexity-score
+  "Single-row cache for the most recent Data Complexity Score run.
+  Read by the API when the live fingerprint matches, written by the cron job and the API's
+  compute path."
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/DataComplexityScore [_model] :data_complexity_score)
+
+(doto :model/DataComplexityScore
+  (derive :metabase/model))
+
+(t2/deftransforms :model/DataComplexityScore
+  {:score mi/transform-json})

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
    [metabase-enterprise.data-complexity-score.settings :as settings]
-   [metabase-enterprise.semantic-search.core :as semantic-search]
    [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.config.core :as config]
    [metabase.task.core :as task]
@@ -21,34 +20,23 @@
 (def ^:private job-key     (jobs/key "metabase.task.data-complexity-score.job"))
 (def ^:private trigger-key (triggers/key "metabase.task.data-complexity-score.trigger"))
 
-(defn- current-fingerprint
-  "String capturing everything that changes the meaning of an emitted score — mirror of the Snowplow
-  `formula_version` + `parameters` fields. Includes `weights` so re-tuning forces a re-score
-  without bumping `formula-version`; only structural changes to the scoring algorithm need that."
-  []
-  (let [embedding-model (semantic-search/active-embedding-model)]
-    (pr-str (into (sorted-map)
-                  (cond-> {:formula-version   complexity/formula-version
-                           :synonym-threshold complexity/synonym-similarity-threshold
-                           :weights           complexity/weights}
-                    embedding-model (assoc :embedding-model embedding-model))))))
-
 (defn- run-scoring!
-  "One scoring pass. Gated by [[settings/data-complexity-scoring-enabled]] so admins can silence
-  scoring without unscheduling the job.
+  "One scoring pass.
+  Gated by [[settings/data-complexity-scoring-enabled]] so admins can silence scoring without
+  unscheduling the job.
 
-  `claim-fingerprint` is the fingerprint carried on the scoring claim that authorized this run.
-  Using it (rather than re-sampling [[current-fingerprint]] at commit time) means a config change
-  mid-run cannot make us stamp a fingerprint onto `last-fingerprint` that we didn't actually score.
+  `claim-fingerprint` is the fingerprint that authorized this run; using it (rather than
+  re-sampling [[complexity/current-fingerprint]] at commit time) prevents a mid-run config
+  change from stamping `last-fingerprint`/the cached row with a fingerprint we didn't score.
 
-  Returns the score result (with `::complexity/snowplow-published?` metadata) when scoring ran, or
-  nil when skipped / threw. Only a confirmed Snowplow publish advances `last-fingerprint` — any
-  other outcome leaves it untouched so the next boot or cron retries and telemetry doesn't
-  silently stall behind a transient publish failure."
+  The cached row is refreshed on every successful score so the API has fresh data regardless
+  of Snowplow's status. `last-fingerprint` only advances on a confirmed publish so a disabled
+  collector forces the next boot/cron to retry telemetry."
   [claim-fingerprint]
   (if (settings/data-complexity-scoring-enabled)
     (try
       (let [result (complexity/complexity-scores :metabot-scope (metabot-scope/internal-metabot-scope))]
+        (complexity/cache-score! claim-fingerprint result)
         (if (::complexity/snowplow-published? (meta result))
           (settings/data-complexity-scoring-last-fingerprint! claim-fingerprint)
           (log/warn "Data Complexity Score: Snowplow publish failed; leaving fingerprint unchanged so the next boot or cron retries"))
@@ -113,7 +101,7 @@
   (cluster-lock/with-cluster-lock {:lock ::complexity-score-run
                                    :timeout-seconds 10}
     (binding [config/*disable-setting-cache* true]
-      (let [current (current-fingerprint)]
+      (let [current (complexity/current-fingerprint)]
         (when (and (settings/data-complexity-scoring-enabled)
                    (or (not require-fingerprint-change?)
                        (not= current (settings/data-complexity-scoring-last-fingerprint)))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -34,7 +34,7 @@
 
 (deftest complexity-endpoint-superuser-gets-consistent-totals-test
   (testing "check invariants not covered by schema"
-    (let [resp (mt/user-http-request :crowberto :get 200 endpoint)
+    (let [resp (mt/user-http-request :crowberto :get 200 endpoint :refresh true)
           measurement      (fn [cat k] (get-in resp [cat :components k :measurement]))
           component-score  (fn [cat k] (get-in resp [cat :components k :score]))
           ;; NOTE: `:synonym-pairs` is intentionally included here even though it's *theoretically*
@@ -77,7 +77,7 @@
     (mt/with-premium-features #{}
       (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                {:use_verified_content false :collection_id nil}
-        (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+        (let [resp (mt/user-http-request :crowberto :get 200 endpoint :refresh true)]
           (is (= (:universe resp) (:metabot resp)))))))
   (testing ":metabot is scored separately when :content-verification + use_verified_content are both active"
     ;; Positive path: verified-only filtering restricts Cards to those with an active verified
@@ -91,7 +91,7 @@
                                                  :archived    false}]
         (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                  {:use_verified_content true :collection_id nil}
-          (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+          (let [resp (mt/user-http-request :crowberto :get 200 endpoint :refresh true)]
             (is (< (get-in resp [:metabot  :components :entity-count :measurement])
                    (get-in resp [:universe :components :entity-count :measurement]))
                 ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card")))))))
@@ -137,7 +137,7 @@
                                   (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                                            {:use_verified_content false
                                                             :collection_id cid}
-                                    (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+                                    (let [resp (mt/user-http-request :crowberto :get 200 endpoint :refresh true)]
                                       {:metabot  (get-in resp [:metabot  :components :entity-count :measurement])
                                        :universe (get-in resp [:universe :components :entity-count :measurement])})))
               empty-counts   (counts-with-scope empty-id)
@@ -192,13 +192,15 @@
                       (.countDown scoring-started)
                       (.await release-scoring 10 TimeUnit/SECONDS)
                       stub-scores)]
-        (let [first-request (future (mt/user-http-request :crowberto :get 200 endpoint))]
+        (let [first-request (future (mt/user-http-request :crowberto :get 200 endpoint :refresh true))]
           (try
             (is (.await scoring-started 10 TimeUnit/SECONDS)
                 "first request must reach the guarded section before we fire the second")
             (testing "concurrent superuser request is rejected with 409"
               (is (= "Data Complexity Score calculation already in progress"
-                     (mt/user-http-request :crowberto :get 409 endpoint))))
+                     ;; `:refresh true` so this request actually tries to compute and trips the guard —
+                     ;; without it the call could hit the cache and return 200 from a prior test run.
+                     (mt/user-http-request :crowberto :get 409 endpoint :refresh true))))
             (finally
               (.countDown release-scoring)
               ;; Drain the in-flight request so the guard is released before the next test
@@ -207,8 +209,76 @@
         (testing "only the first request actually ran scoring; the second short-circuited"
           (is (= 1 @call-count)))
         (testing "guard is released after the in-flight request finishes — a follow-up request succeeds"
-          (mt/user-http-request :crowberto :get 200 endpoint)
+          (mt/user-http-request :crowberto :get 200 endpoint :refresh true)
           (is (= 2 @call-count)))))))
+
+(defn- with-empty-cache!
+  "Run `f` with the cache wiped, restoring the prior row afterwards.
+  The cache table is single-row and instance-scoped, so cache-behaviour tests have to pin
+  the starting state explicitly."
+  [f]
+  (mt/initialize-if-needed! :db)
+  (let [snapshot (some-> (t2/select-one :model/DataComplexityScore)
+                         (select-keys [:fingerprint :score :calculated_at]))]
+    (t2/delete! :model/DataComplexityScore)
+    (try
+      (f)
+      (finally
+        (t2/delete! :model/DataComplexityScore)
+        (when snapshot
+          (t2/insert! :model/DataComplexityScore snapshot))))))
+
+(def ^:private marker-score
+  "Stand-in score map shaped to satisfy `ComplexityScoresResponse` — used to seed the cache and
+  assert it round-trips back through the API verbatim."
+  {:library  empty-catalog
+   :universe empty-catalog
+   :metabot  empty-catalog
+   :meta     {:formula-version 99 :synonym-threshold 0.5}})
+
+(deftest complexity-endpoint-cache-hit-test
+  (testing "a fingerprint match short-circuits scoring and returns the cached row"
+    (with-empty-cache!
+      (fn []
+        (let [call-count (atom 0)]
+          (complexity/cache-score! (complexity/current-fingerprint) marker-score)
+          (mt/with-dynamic-fn-redefs [complexity/complexity-scores
+                                      (fn [& _] (swap! call-count inc) stub-scores)]
+            (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
+              (is (= 99 (get-in resp [:meta :formula-version]))
+                  "cached score returned verbatim")
+              (is (zero? @call-count)
+                  "compute path was not invoked"))))))))
+
+(deftest complexity-endpoint-cache-miss-on-fingerprint-mismatch-test
+  (testing "a stale fingerprint forces a recompute and overwrites the cache"
+    (with-empty-cache!
+      (fn []
+        (let [call-count (atom 0)]
+          (complexity/cache-score! "stale-fingerprint-from-an-older-config" marker-score)
+          (mt/with-dynamic-fn-redefs [complexity/complexity-scores
+                                      (fn [& _] (swap! call-count inc) stub-scores)]
+            (mt/user-http-request :crowberto :get 200 endpoint)
+            (is (= 1 @call-count)
+                "compute path ran on the cache miss")
+            (is (= (complexity/current-fingerprint)
+                   (:fingerprint (t2/select-one :model/DataComplexityScore)))
+                "cache row was replaced under the live fingerprint")
+            (mt/user-http-request :crowberto :get 200 endpoint)
+            (is (= 1 @call-count)
+                "follow-up request with no refresh flag hits the freshly-written cache")))))))
+
+(deftest complexity-endpoint-refresh-flag-bypasses-cache-test
+  (testing "?refresh=true recomputes even when a matching cache row exists"
+    (with-empty-cache!
+      (fn []
+        (let [call-count (atom 0)]
+          (complexity/cache-score! (complexity/current-fingerprint) marker-score)
+          (mt/with-dynamic-fn-redefs [complexity/complexity-scores
+                                      (fn [& _] (swap! call-count inc) stub-scores)]
+            (mt/user-http-request :crowberto :get 200 endpoint :refresh true)
+            (is (= 1 @call-count)
+                "?refresh=true bypasses the cache and runs scoring")))))))
 
 (deftest internal-metabot-scope-test
   (testing ":verified-only? is true only when the premium feature + use_verified_content both apply"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -924,7 +924,7 @@
            emission on this node, even when the last-successful fingerprint is stale — prevents
            the boot and cron paths from both computing and publishing for the same fingerprint"
     (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
-      (let [current-fp (#'task.complexity-score/current-fingerprint)
+      (let [current-fp (complexity/current-fingerprint)
             ;; Serialize a sibling/cron claim for the same fingerprint, timestamped just now so
             ;; it's well inside the TTL.
             active-claim (pr-str {:fingerprint current-fp :claimed-at (#'task.complexity-score/now-ms)})
@@ -946,7 +946,7 @@
   (testing "an expired (TTL-exceeded) scoring claim must not permanently suppress scoring — a
            crashed or orphaned claim from a prior run should be replaced and scoring proceed"
     (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
-      (let [current-fp (#'task.complexity-score/current-fingerprint)
+      (let [current-fp (complexity/current-fingerprint)
             ;; 1 hour ago — older than the 30-minute TTL, so this claim is treated as orphaned.
             expired-claim (pr-str {:fingerprint current-fp
                                    :claimed-at (- (#'task.complexity-score/now-ms)
@@ -971,7 +971,7 @@
       ;; Stub scoring so that while this node is mid-run the persisted claim is replaced with a
       ;; sibling's fresh claim (different :owner). This simulates: our run hung past the 30-min
       ;; TTL → sibling saw an expired claim → sibling wrote its own → our run finally returns.
-      (let [sibling-claim (pr-str {:fingerprint (#'task.complexity-score/current-fingerprint)
+      (let [sibling-claim (pr-str {:fingerprint (complexity/current-fingerprint)
                                    :claimed-at  (System/currentTimeMillis)
                                    :owner       "sibling-node-owner-token"})]
         (mt/with-temporary-setting-values [data-complexity-scoring-enabled          true
@@ -990,7 +990,7 @@
            current fingerprint — the shared claim protocol serializes the two paths so they can't
            both compute and publish in parallel"
     (mt/with-dynamic-fn-redefs [metabot-scope/internal-metabot-scope (constantly {})]
-      (let [current-fp (#'task.complexity-score/current-fingerprint)
+      (let [current-fp (complexity/current-fingerprint)
             boot-claim (pr-str {:fingerprint current-fp
                                 :claimed-at  (#'task.complexity-score/now-ms)
                                 :owner       "boot-path-owner-token"})

--- a/resources/migrations/061/20260428_data_complexity_score.yaml
+++ b/resources/migrations/061/20260428_data_complexity_score.yaml
@@ -1,0 +1,42 @@
+## Persisted cache for the Data Complexity Score result.
+## Single-row table — we keep only the most recent run, keyed by fingerprint so the API can
+## return the cached score whenever the live config still matches what was scored last.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/061_update_migrations.yaml
+
+  - changeSet:
+      id: v61.2026-04-28T00:00:00
+      author: christruter
+      comment: Create data_complexity_score table to cache the last calculation
+      changes:
+        - createTable:
+            tableName: data_complexity_score
+            remarks: One-row cache of the most recent Data Complexity Score run. The fingerprint captures every input that affects the result (formula version, weights, threshold, embedding model) so a match means recompute is unnecessary.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: fingerprint
+                  type: ${text.type}
+                  remarks: Scoring fingerprint — formula_version + weights + synonym threshold + embedding model. Identical fingerprints mean identical results.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: score
+                  type: ${text.type}
+                  remarks: JSON-serialized score result (library/universe/metabot catalogs + meta).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: calculated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: When the score was computed (DB clock, not app-server clock).
+                  constraints:
+                    nullable: false

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -38,6 +38,7 @@
     :model/DashboardCard                     metabase.dashboards.models.dashboard-card
     :model/DashboardCardSeries               metabase.dashboards.models.dashboard-card-series
     :model/DashboardTab                      metabase.dashboards.models.dashboard-tab
+    :model/DataComplexityScore               metabase-enterprise.data-complexity-score.models.data-complexity-score
     :model/DataPermissions                   metabase.permissions.models.data-permissions
     :model/Database                          metabase.warehouses.models.database
     :model/DatabaseRouter                    metabase-enterprise.database-routing.models


### PR DESCRIPTION
## Summary
- Adds a `data_complexity_score` table (single row, keyed by scoring fingerprint) and persists the most recent run.
- The `/api/ee/data-complexity-score/complexity` endpoint returns the cached row when the live fingerprint matches; pass `?refresh=true` to force a recompute. The cron task also writes the cache after a successful run, so admins get an instant response after each daily run.
- `calculated_at` is sourced from the DB clock (DB default + `t2/insert-returning-instance!`) and surfaced under `:meta.:calculated-at` in the response so admins can spot stale rows.

## Why
The score walks the full app-db catalog and runs per-name embeddings — one full run is fine, recomputing it on every API hit is wasteful when the inputs haven't changed.

## Notes
- Fingerprint = formula version + weights + threshold + embedding model. Tuning any of these forces a recompute without bumping `formula-version`.
- The Snowplow gate is unchanged — `last-fingerprint` still advances only on a confirmed publish so a disabled collector doesn't silently mark telemetry as up-to-date. The cache is independent of telemetry health.
- `current-fingerprint` moved from the task ns into `complexity.clj` so the API and task share one definition.
- Single-row design keyed by fingerprint — we deliberately don't keep history yet.

## Test plan
- [x] `bin/test-agent :only '[metabase-enterprise.data-complexity-score.api-test]'` (9 tests, 51 assertions, all pass)
- [x] `bin/test-agent` runs of the seven `complexity-test` deftests that touch `current-fingerprint` / `run-scoring!` / `maybe-emit-boot-score!`
- [ ] Verify against a real instance that hitting the endpoint twice in a row is fast on the second call and that `?refresh=true` forces a recompute.