### PR TITLE
Pre-parse VALUES stripping

### DIFF
--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -87,7 +87,6 @@ def referenced_tables(sql: str, dialect: str = "postgres") -> str:
         referenced_tables("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events"]]'
     """
-
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -131,7 +130,6 @@ def referenced_fields(sql: str, dialect: str = "postgres") -> str:
         referenced_fields("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events", "*"]]'
     """
-
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -275,7 +273,6 @@ def validate_query(dialect, sql, default_table_schema, sqlglot_schema_json):
     # - Permissive mode: no schema → only check syntax, infer schema from query
     strict_mode = sqlglot_schema is not None and len(sqlglot_schema) > 0
 
-
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
         ast = qualify.qualify(ast,
@@ -352,7 +349,6 @@ def simple_query(sql: str, dialect: str = None) -> str:
         simple_query("WITH cte AS (SELECT 1) SELECT * FROM cte")
         => '{"is_simple": false, "reason": "Contains a CTE"}'
     """
-
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
 
@@ -432,7 +428,6 @@ def returned_columns_lineage(dialect, sql, default_table_schema, sqlglot_schema_
     """
     # Decode schema from JSON (passed from Clojure to avoid polyglot map issues)
     sqlglot_schema = json.loads(sqlglot_schema_json) if sqlglot_schema_json else None
-
 
     ast = sqlglot.parse_one(sql, read=dialect)
     ast = qualify.qualify(ast,
@@ -637,7 +632,6 @@ def field_references(sql: str, dialect: str = "postgres") -> str:
     - used_fields: list of fields used (for custom_field)
     - member_fields: list of fields (for composite_field)
     """
-
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
     except ParseError:
@@ -1618,7 +1612,6 @@ def is_single_select_stmt(sql: str, dialect: str = None) -> str:
     """Validates that a query is a single SELECT statement
     and returns the query reconstructed from the parsed AST.
     """
-
     is_single_select = {"is_single_select?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -9,6 +9,160 @@ from sqlglot import exp
 from sqlglot.errors import OptimizeError, ParseError
 
 
+#############################################################################
+# VALUES clause stripping for memory efficiency
+#############################################################################
+
+# Threshold: only strip VALUES clauses with more than this many tuples.
+# Small VALUES lists are fine; the problem is thousands of tuples causing
+# GraalPy memory amplification (~114KB per AST node vs ~1-2KB on CPython).
+_VALUES_STRIP_THRESHOLD = 100
+
+# Match VALUES followed by parenthesized tuples separated by commas.
+# This regex is intentionally conservative:
+# - Requires the VALUES keyword (case-insensitive)
+# - Matches balanced parentheses for each tuple (no nested parens inside values)
+# - Handles whitespace and newlines between tuples
+# We use a two-phase approach: first find the VALUES keyword, then count/strip tuples.
+_VALUES_KEYWORD_RE = re.compile(
+    r'\bVALUES\s*\(',
+    re.IGNORECASE
+)
+
+def _strip_large_values(sql: str) -> str:
+    """Replace large VALUES clauses with a single-row placeholder.
+
+    For queries like:
+        VALUES (1, 'a'), (2, 'b'), ..., (19800, 'zzz')
+
+    Replaces with:
+        VALUES (NULL, NULL)
+
+    preserving the column count from the first tuple. This is safe for all
+    analysis operations (referenced_tables, field_references, validate_query, etc.)
+    because the actual data inside VALUES tuples is irrelevant for structural analysis.
+
+    Only triggers when a VALUES clause has more than _VALUES_STRIP_THRESHOLD tuples.
+    """
+    # Quick check: if no VALUES keyword, nothing to do
+    if not _VALUES_KEYWORD_RE.search(sql):
+        return sql
+
+    result = []
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        # Look for VALUES keyword
+        m = _VALUES_KEYWORD_RE.search(sql, i)
+        if not m:
+            result.append(sql[i:])
+            break
+
+        # Add everything before this VALUES
+        result.append(sql[i:m.start()])
+
+        # Parse the tuples after VALUES
+        # m.end() points right after "VALUES ("
+        tuples_start = m.start()
+        pos = m.end() - 1  # back up to the opening paren
+
+        tuples = []
+        first_tuple_content = None
+
+        while pos < n:
+            # Skip whitespace
+            while pos < n and sql[pos] in ' \t\r\n':
+                pos += 1
+
+            if pos >= n or sql[pos] != '(':
+                break
+
+            # Find matching closing paren, respecting string literals
+            depth = 0
+            tuple_start = pos
+            in_string = False
+            string_char = None
+
+            while pos < n:
+                ch = sql[pos]
+                if in_string:
+                    if ch == string_char:
+                        # Check for escaped quote (doubled)
+                        if pos + 1 < n and sql[pos + 1] == string_char:
+                            pos += 1  # skip escaped quote
+                        else:
+                            in_string = False
+                elif ch == "'" or ch == '"':
+                    in_string = True
+                    string_char = ch
+                elif ch == '(':
+                    depth += 1
+                elif ch == ')':
+                    depth -= 1
+                    if depth == 0:
+                        pos += 1
+                        break
+                pos += 1
+
+            tuple_text = sql[tuple_start:pos]
+            tuples.append(tuple_text)
+
+            if first_tuple_content is None:
+                # Extract content between parens to count columns
+                inner = tuple_text[1:-1] if len(tuple_text) >= 2 else ""
+                first_tuple_content = inner
+
+            # Skip comma and whitespace between tuples
+            saved_pos = pos
+            while pos < n and sql[pos] in ' \t\r\n':
+                pos += 1
+            if pos < n and sql[pos] == ',':
+                pos += 1
+                while pos < n and sql[pos] in ' \t\r\n':
+                    pos += 1
+            else:
+                # No comma — end of VALUES list
+                break
+
+            # Safety: if next char isn't '(' we're done with tuples
+            if pos < n and sql[pos] != '(':
+                pos = saved_pos
+                break
+
+        if len(tuples) > _VALUES_STRIP_THRESHOLD and first_tuple_content is not None:
+            # Count columns by counting top-level commas in first tuple
+            col_count = 1
+            depth = 0
+            in_str = False
+            str_ch = None
+            for ch in first_tuple_content:
+                if in_str:
+                    if ch == str_ch:
+                        in_str = False
+                elif ch == "'" or ch == '"':
+                    in_str = True
+                    str_ch = ch
+                elif ch == '(':
+                    depth += 1
+                elif ch == ')':
+                    depth -= 1
+                elif ch == ',' and depth == 0:
+                    col_count += 1
+
+            nulls = ", ".join(["NULL"] * col_count)
+            # Preserve original keyword casing (e.g., "values" vs "VALUES")
+            values_keyword = sql[m.start():m.end()].rstrip().rstrip('(').rstrip()
+            result.append(f"{values_keyword} ({nulls})")
+        else:
+            # Below threshold, keep original
+            result.append(sql[tuples_start:pos])
+
+        i = pos
+
+    return "".join(result)
+
+
 def is_quoted_identifier(name: str, dialect: str = None) -> bool:
     if not isinstance(name, str):
         return False
@@ -87,6 +241,7 @@ def referenced_tables(sql: str, dialect: str = "postgres") -> str:
         referenced_tables("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events"]]'
     """
+    sql = _strip_large_values(sql)
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -130,6 +285,7 @@ def referenced_fields(sql: str, dialect: str = "postgres") -> str:
         referenced_fields("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events", "*"]]'
     """
+    sql = _strip_large_values(sql)
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -273,6 +429,7 @@ def validate_query(dialect, sql, default_table_schema, sqlglot_schema_json):
     # - Permissive mode: no schema → only check syntax, infer schema from query
     strict_mode = sqlglot_schema is not None and len(sqlglot_schema) > 0
 
+    sql = _strip_large_values(sql)
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
         ast = qualify.qualify(ast,
@@ -349,6 +506,7 @@ def simple_query(sql: str, dialect: str = None) -> str:
         simple_query("WITH cte AS (SELECT 1) SELECT * FROM cte")
         => '{"is_simple": false, "reason": "Contains a CTE"}'
     """
+    sql = _strip_large_values(sql)
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
 
@@ -429,6 +587,7 @@ def returned_columns_lineage(dialect, sql, default_table_schema, sqlglot_schema_
     # Decode schema from JSON (passed from Clojure to avoid polyglot map issues)
     sqlglot_schema = json.loads(sqlglot_schema_json) if sqlglot_schema_json else None
 
+    sql = _strip_large_values(sql)
     ast = sqlglot.parse_one(sql, read=dialect)
     ast = qualify.qualify(ast,
                           db=default_table_schema,
@@ -632,6 +791,7 @@ def field_references(sql: str, dialect: str = "postgres") -> str:
     - used_fields: list of fields used (for custom_field)
     - member_fields: list of fields (for composite_field)
     """
+    sql = _strip_large_values(sql)
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
     except ParseError:
@@ -1612,6 +1772,7 @@ def is_single_select_stmt(sql: str, dialect: str = None) -> str:
     """Validates that a query is a single SELECT statement
     and returns the query reconstructed from the parsed AST.
     """
+    sql = _strip_large_values(sql)
     is_single_select = {"is_single_select?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -9,158 +9,6 @@ from sqlglot import exp
 from sqlglot.errors import OptimizeError, ParseError
 
 
-#############################################################################
-# VALUES clause stripping for memory efficiency
-#############################################################################
-
-# Threshold: only strip VALUES clauses with more than this many tuples.
-# Small VALUES lists are fine; the problem is thousands of tuples causing
-# GraalPy memory amplification (~114KB per AST node vs ~1-2KB on CPython).
-_VALUES_STRIP_THRESHOLD = 100
-
-# Match VALUES followed by parenthesized tuples separated by commas.
-# This regex is intentionally conservative:
-# - Requires the VALUES keyword (case-insensitive)
-# - Matches balanced parentheses for each tuple (no nested parens inside values)
-# - Handles whitespace and newlines between tuples
-# We use a two-phase approach: first find the VALUES keyword, then count/strip tuples.
-_VALUES_KEYWORD_RE = re.compile(
-    r'\bVALUES\s*\(',
-    re.IGNORECASE
-)
-
-def _skip_tuple(sql: str, pos: int, n: int) -> int:
-    """Skip past a balanced parenthesized tuple, respecting string literals.
-
-    Args:
-        sql: Full SQL string
-        pos: Position of the opening '('
-        n: Length of sql
-
-    Returns:
-        Position immediately after the closing ')'
-    """
-    depth = 0
-    in_string = False
-    string_char = None
-    while pos < n:
-        ch = sql[pos]
-        if in_string:
-            if ch == string_char:
-                if pos + 1 < n and sql[pos + 1] == string_char:
-                    pos += 1  # skip escaped (doubled) quote
-                else:
-                    in_string = False
-        elif ch == "'" or ch == '"':
-            in_string = True
-            string_char = ch
-        elif ch == '(':
-            depth += 1
-        elif ch == ')':
-            depth -= 1
-            if depth == 0:
-                return pos + 1
-        pos += 1
-    return pos
-
-
-def _count_columns(tuple_content: str) -> int:
-    """Count the number of top-level comma-separated items in a tuple's inner content."""
-    col_count = 1
-    depth = 0
-    in_str = False
-    str_ch = None
-    for ch in tuple_content:
-        if in_str:
-            if ch == str_ch:
-                in_str = False
-        elif ch == "'" or ch == '"':
-            in_str = True
-            str_ch = ch
-        elif ch == '(':
-            depth += 1
-        elif ch == ')':
-            depth -= 1
-        elif ch == ',' and depth == 0:
-            col_count += 1
-    return col_count
-
-
-def _strip_large_values(sql: str) -> str:
-    """Replace large VALUES clauses with a single-row placeholder.
-
-    For queries like:
-        VALUES (1, 'a'), (2, 'b'), ..., (19800, 'zzz')
-
-    Replaces with:
-        VALUES (NULL, NULL)
-
-    preserving the column count from the first tuple. This is safe for all
-    analysis operations (referenced_tables, field_references, validate_query, etc.)
-    because the actual data inside VALUES tuples is irrelevant for structural analysis.
-
-    Only triggers when a VALUES clause has more than _VALUES_STRIP_THRESHOLD tuples.
-    """
-    # Quick check: if no VALUES keyword, nothing to do
-    if not _VALUES_KEYWORD_RE.search(sql):
-        return sql
-
-    result = []
-    i = 0
-    n = len(sql)
-
-    while i < n:
-        # Look for VALUES keyword
-        m = _VALUES_KEYWORD_RE.search(sql, i)
-        if not m:
-            result.append(sql[i:])
-            break
-
-        # Add everything before this VALUES
-        result.append(sql[i:m.start()])
-
-        # Parse the tuples after VALUES
-        # m.end() points right after "VALUES ("
-        values_start = m.start()
-        pos = m.end() - 1  # back up to the opening paren
-
-        # Parse first tuple to capture its content for column counting
-        first_tuple_start = pos
-        first_tuple_end = _skip_tuple(sql, pos, n)
-        first_tuple_content = sql[first_tuple_start + 1:first_tuple_end - 1] if first_tuple_end > first_tuple_start + 1 else ""
-        pos = first_tuple_end
-        tuple_count = 1
-
-        # Count and skip remaining tuples (don't store their text)
-        while pos < n:
-            # Skip whitespace
-            while pos < n and sql[pos] in ' \t\r\n':
-                pos += 1
-            if pos >= n or sql[pos] != ',':
-                break
-            pos += 1  # skip comma
-            while pos < n and sql[pos] in ' \t\r\n':
-                pos += 1
-            if pos >= n or sql[pos] != '(':
-                break
-            pos = _skip_tuple(sql, pos, n)
-            tuple_count += 1
-
-        if tuple_count > _VALUES_STRIP_THRESHOLD:
-            col_count = _count_columns(first_tuple_content)
-            nulls = ", ".join(["NULL"] * col_count)
-            # Preserve original keyword casing (e.g., "values" vs "VALUES")
-            values_keyword = sql[m.start():m.end()].rstrip().rstrip('(').rstrip()
-            result.append(f"{values_keyword} ({nulls})")
-        else:
-            # Below threshold, keep original
-            result.append(sql[values_start:pos])
-
-        i = pos
-
-    return "".join(result)
-
-
 def is_quoted_identifier(name: str, dialect: str = None) -> bool:
     if not isinstance(name, str):
         return False
@@ -239,7 +87,7 @@ def referenced_tables(sql: str, dialect: str = "postgres") -> str:
         referenced_tables("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events"]]'
     """
-    sql = _strip_large_values(sql)
+
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -283,7 +131,7 @@ def referenced_fields(sql: str, dialect: str = "postgres") -> str:
         referenced_fields("SELECT * FROM myproject.analytics.events", "bigquery")
         => '[["myproject", "analytics", "events", "*"]]'
     """
-    sql = _strip_large_values(sql)
+
     ast = sqlglot.parse_one(sql, read=dialect)
     root_scope = optimizer.build_scope(ast)
 
@@ -427,7 +275,7 @@ def validate_query(dialect, sql, default_table_schema, sqlglot_schema_json):
     # - Permissive mode: no schema → only check syntax, infer schema from query
     strict_mode = sqlglot_schema is not None and len(sqlglot_schema) > 0
 
-    sql = _strip_large_values(sql)
+
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
         ast = qualify.qualify(ast,
@@ -504,7 +352,7 @@ def simple_query(sql: str, dialect: str = None) -> str:
         simple_query("WITH cte AS (SELECT 1) SELECT * FROM cte")
         => '{"is_simple": false, "reason": "Contains a CTE"}'
     """
-    sql = _strip_large_values(sql)
+
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
 
@@ -585,7 +433,7 @@ def returned_columns_lineage(dialect, sql, default_table_schema, sqlglot_schema_
     # Decode schema from JSON (passed from Clojure to avoid polyglot map issues)
     sqlglot_schema = json.loads(sqlglot_schema_json) if sqlglot_schema_json else None
 
-    sql = _strip_large_values(sql)
+
     ast = sqlglot.parse_one(sql, read=dialect)
     ast = qualify.qualify(ast,
                           db=default_table_schema,
@@ -789,7 +637,7 @@ def field_references(sql: str, dialect: str = "postgres") -> str:
     - used_fields: list of fields used (for custom_field)
     - member_fields: list of fields (for composite_field)
     """
-    sql = _strip_large_values(sql)
+
     try:
         ast = sqlglot.parse_one(sql, read=dialect)
     except ParseError:
@@ -1770,7 +1618,7 @@ def is_single_select_stmt(sql: str, dialect: str = None) -> str:
     """Validates that a query is a single SELECT statement
     and returns the query reconstructed from the parsed AST.
     """
-    sql = _strip_large_values(sql)
+
     is_single_select = {"is_single_select?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -29,6 +29,63 @@ _VALUES_KEYWORD_RE = re.compile(
     re.IGNORECASE
 )
 
+def _skip_tuple(sql: str, pos: int, n: int) -> int:
+    """Skip past a balanced parenthesized tuple, respecting string literals.
+
+    Args:
+        sql: Full SQL string
+        pos: Position of the opening '('
+        n: Length of sql
+
+    Returns:
+        Position immediately after the closing ')'
+    """
+    depth = 0
+    in_string = False
+    string_char = None
+    while pos < n:
+        ch = sql[pos]
+        if in_string:
+            if ch == string_char:
+                if pos + 1 < n and sql[pos + 1] == string_char:
+                    pos += 1  # skip escaped (doubled) quote
+                else:
+                    in_string = False
+        elif ch == "'" or ch == '"':
+            in_string = True
+            string_char = ch
+        elif ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+            if depth == 0:
+                return pos + 1
+        pos += 1
+    return pos
+
+
+def _count_columns(tuple_content: str) -> int:
+    """Count the number of top-level comma-separated items in a tuple's inner content."""
+    col_count = 1
+    depth = 0
+    in_str = False
+    str_ch = None
+    for ch in tuple_content:
+        if in_str:
+            if ch == str_ch:
+                in_str = False
+        elif ch == "'" or ch == '"':
+            in_str = True
+            str_ch = ch
+        elif ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+        elif ch == ',' and depth == 0:
+            col_count += 1
+    return col_count
+
+
 def _strip_large_values(sql: str) -> str:
     """Replace large VALUES clauses with a single-row placeholder.
 
@@ -64,99 +121,40 @@ def _strip_large_values(sql: str) -> str:
 
         # Parse the tuples after VALUES
         # m.end() points right after "VALUES ("
-        tuples_start = m.start()
+        values_start = m.start()
         pos = m.end() - 1  # back up to the opening paren
 
-        tuples = []
-        first_tuple_content = None
+        # Parse first tuple to capture its content for column counting
+        first_tuple_start = pos
+        first_tuple_end = _skip_tuple(sql, pos, n)
+        first_tuple_content = sql[first_tuple_start + 1:first_tuple_end - 1] if first_tuple_end > first_tuple_start + 1 else ""
+        pos = first_tuple_end
+        tuple_count = 1
 
+        # Count and skip remaining tuples (don't store their text)
         while pos < n:
             # Skip whitespace
             while pos < n and sql[pos] in ' \t\r\n':
                 pos += 1
-
-            if pos >= n or sql[pos] != '(':
+            if pos >= n or sql[pos] != ',':
                 break
-
-            # Find matching closing paren, respecting string literals
-            depth = 0
-            tuple_start = pos
-            in_string = False
-            string_char = None
-
-            while pos < n:
-                ch = sql[pos]
-                if in_string:
-                    if ch == string_char:
-                        # Check for escaped quote (doubled)
-                        if pos + 1 < n and sql[pos + 1] == string_char:
-                            pos += 1  # skip escaped quote
-                        else:
-                            in_string = False
-                elif ch == "'" or ch == '"':
-                    in_string = True
-                    string_char = ch
-                elif ch == '(':
-                    depth += 1
-                elif ch == ')':
-                    depth -= 1
-                    if depth == 0:
-                        pos += 1
-                        break
-                pos += 1
-
-            tuple_text = sql[tuple_start:pos]
-            tuples.append(tuple_text)
-
-            if first_tuple_content is None:
-                # Extract content between parens to count columns
-                inner = tuple_text[1:-1] if len(tuple_text) >= 2 else ""
-                first_tuple_content = inner
-
-            # Skip comma and whitespace between tuples
-            saved_pos = pos
+            pos += 1  # skip comma
             while pos < n and sql[pos] in ' \t\r\n':
                 pos += 1
-            if pos < n and sql[pos] == ',':
-                pos += 1
-                while pos < n and sql[pos] in ' \t\r\n':
-                    pos += 1
-            else:
-                # No comma — end of VALUES list
+            if pos >= n or sql[pos] != '(':
                 break
+            pos = _skip_tuple(sql, pos, n)
+            tuple_count += 1
 
-            # Safety: if next char isn't '(' we're done with tuples
-            if pos < n and sql[pos] != '(':
-                pos = saved_pos
-                break
-
-        if len(tuples) > _VALUES_STRIP_THRESHOLD and first_tuple_content is not None:
-            # Count columns by counting top-level commas in first tuple
-            col_count = 1
-            depth = 0
-            in_str = False
-            str_ch = None
-            for ch in first_tuple_content:
-                if in_str:
-                    if ch == str_ch:
-                        in_str = False
-                elif ch == "'" or ch == '"':
-                    in_str = True
-                    str_ch = ch
-                elif ch == '(':
-                    depth += 1
-                elif ch == ')':
-                    depth -= 1
-                elif ch == ',' and depth == 0:
-                    col_count += 1
-
+        if tuple_count > _VALUES_STRIP_THRESHOLD:
+            col_count = _count_columns(first_tuple_content)
             nulls = ", ".join(["NULL"] * col_count)
             # Preserve original keyword casing (e.g., "values" vs "VALUES")
             values_keyword = sql[m.start():m.end()].rstrip().rstrip('(').rstrip()
             result.append(f"{values_keyword} ({nulls})")
         else:
             # Below threshold, keep original
-            result.append(sql[tuples_start:pos])
+            result.append(sql[values_start:pos])
 
         i = pos
 

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -80,132 +80,113 @@
   "Pattern to find VALUES keyword followed by opening paren."
   (re-pattern "(?i)\\bVALUES\\s*\\("))
 
-(defn- skip-tuple
-  "Skip past a balanced parenthesized tuple starting at `pos`, respecting string literals.
+(defn- skip-whitespace
+  "Return the first non-whitespace position at or after `pos`."
+  ^long [^String sql ^long pos ^long n]
+  (loop [p pos]
+    (if (and (< p n) (Character/isWhitespace (.charAt sql p)))
+      (recur (inc p))
+      p)))
+
+(defn- skip-balanced-parens
+  "Starting at an opening `(`, advance past the matching `)`.
+   Handles nested parens and SQL string literals (single and double quoted, with doubled-quote escaping).
    Returns the position immediately after the closing `)`."
   ^long [^String sql ^long pos ^long n]
-  (loop [pos   pos
-         depth (int 0)
-         in-string false
-         string-char \space]
+  (loop [pos pos, depth (int 0), in-str false, str-ch \space]
     (if (>= pos n)
       pos
       (let [ch (.charAt sql pos)]
         (cond
-          in-string
-          (if (= ch string-char)
-            ;; Check for escaped (doubled) quote
-            (if (and (< (inc pos) n) (= (.charAt sql (inc pos)) string-char))
-              (recur (+ pos 2) depth true string-char)
-              (recur (inc pos) depth false string-char))
-            (recur (inc pos) depth true string-char))
+          ;; Inside a string literal — look for the closing quote
+          in-str
+          (if (= ch str-ch)
+            (if (and (< (inc pos) n) (= (.charAt sql (inc pos)) str-ch))
+              (recur (+ pos 2) depth true str-ch) ; escaped (doubled) quote
+              (recur (inc pos) depth false str-ch))
+            (recur (inc pos) depth true str-ch))
 
-          (or (= ch \') (= ch \"))
-          (recur (inc pos) depth true ch)
+          (or (= ch \') (= ch \"))  (recur (inc pos) depth true ch)
+          (= ch \()                 (recur (inc pos) (inc depth) false str-ch)
+          (= ch \))                 (if (= depth 1)
+                                      (inc pos) ; done
+                                      (recur (inc pos) (dec depth) false str-ch))
+          :else                     (recur (inc pos) depth false str-ch))))))
 
-          (= ch \()
-          (recur (inc pos) (inc depth) false string-char)
-
-          (= ch \))
-          (if (= depth 1)
-            (inc pos) ;; done — return position after closing paren
-            (recur (inc pos) (dec depth) false string-char))
-
-          :else
-          (recur (inc pos) depth false string-char))))))
-
-(defn- count-columns
-  "Count the number of top-level comma-separated items in a tuple's inner content."
+(defn- count-top-level-commas
+  "Count top-level comma-separated items inside a tuple's content string.
+   `(1, 'a', 3)` → inner content `1, 'a', 3` → 3 items."
   ^long [^String content]
   (let [n (.length content)]
-    (loop [i     0
-           depth (int 0)
-           in-str false
-           str-ch \space
-           cols   (int 1)]
+    (loop [i 0, depth (int 0), in-str false, str-ch \space, items (int 1)]
       (if (>= i n)
-        cols
+        items
         (let [ch (.charAt content i)]
           (cond
-            in-str
-            (if (= ch str-ch)
-              (recur (inc i) depth false str-ch cols)
-              (recur (inc i) depth true str-ch cols))
+            in-str                      (recur (inc i) depth (not= ch str-ch) str-ch items)
+            (or (= ch \') (= ch \"))    (recur (inc i) depth true ch items)
+            (= ch \()                   (recur (inc i) (inc depth) false str-ch items)
+            (= ch \))                   (recur (inc i) (dec depth) false str-ch items)
+            (and (= ch \,) (= depth 0)) (recur (inc i) depth false str-ch (inc items))
+            :else                       (recur (inc i) depth false str-ch items)))))))
 
-            (or (= ch \') (= ch \"))
-            (recur (inc i) depth true ch cols)
+(defn- count-and-skip-tuples
+  "Starting after the first tuple, count how many more `, (...)` tuples follow.
+   Returns [total-tuple-count position-after-last-tuple]."
+  [^String sql ^long pos ^long n]
+  (loop [pos pos, count (int 1)]
+    (let [pos (skip-whitespace sql pos n)]
+      (if (or (>= pos n) (not= (.charAt sql pos) \,))
+        [count pos]
+        (let [pos (skip-whitespace sql (inc pos) n)]
+          (if (or (>= pos n) (not= (.charAt sql pos) \())
+            [count pos]
+            (recur (skip-balanced-parens sql pos n) (inc count))))))))
 
-            (= ch \()
-            (recur (inc i) (inc depth) false str-ch cols)
+(defn- make-null-placeholder
+  "Build `VALUES (NULL, NULL, ...)` preserving the original keyword casing."
+  ^String [^String original-keyword ^long col-count]
+  (let [nulls (str/join ", " (repeat col-count "NULL"))]
+    (str original-keyword " (" nulls ")")))
 
-            (= ch \))
-            (recur (inc i) (dec depth) false str-ch cols)
-
-            (and (= ch \,) (= depth 0))
-            (recur (inc i) depth false str-ch (inc cols))
-
-            :else
-            (recur (inc i) depth false str-ch cols)))))))
-
-(defn- skip-whitespace
-  "Return the first position at or after `pos` that is not whitespace."
-  ^long [^String sql ^long pos ^long n]
-  (loop [p pos]
-    (if (and (< p n)
-             (let [ch (.charAt sql p)]
-               (or (= ch \space) (= ch \tab) (= ch \return) (= ch \newline))))
-      (recur (inc p))
-      p)))
+(defn- extract-values-keyword
+  "Extract just the VALUES keyword text from a regex match like `VALUES (`."
+  ^String [^String sql ^long match-start ^long match-end]
+  (-> (.substring sql match-start match-end)
+      str/trimr
+      (str/replace #"\($" "")
+      str/trimr))
 
 (defn- strip-large-values*
-  "Inner implementation — may throw on malformed input."
+  "Walk through SQL, replacing any VALUES clause with more than `values-strip-threshold`
+   tuples with a single-row NULL placeholder. Preserves column count from the first tuple."
   ^String [^String sql]
   (let [matcher (re-matcher values-keyword-pattern sql)
         n       (int (.length sql))]
     (if-not (.find matcher)
       sql
-      ;; Reset and scan through all VALUES clauses
-      (let [_ (.reset matcher)]
-        (loop [i   (int 0)
-               sb  (StringBuilder.)]
+      (let [_ (.reset matcher)
+            sb (StringBuilder.)]
+        (loop [i (int 0)]
           (if-not (.find matcher i)
             (-> sb (.append sql i n) .toString)
-            (let [match-start (.start matcher)
-                  match-end   (.end matcher)
-                  ;; Append everything before this VALUES
-                  _  (.append sb sql (int i) (int match-start))
-                  ;; Parse first tuple to get column count
-                  first-tuple-start (dec (int match-end)) ;; back up to '('
-                  first-tuple-end   (skip-tuple sql first-tuple-start n)
-                  first-tuple-inner (when (> first-tuple-end (inc first-tuple-start))
-                                      (.substring sql (inc first-tuple-start) (dec (int first-tuple-end))))
-                  ;; Count and skip remaining tuples
-                  [tuple-count end-pos]
-                  (loop [pos   (long first-tuple-end)
-                         count (int 1)]
-                    (let [pos (skip-whitespace sql pos n)]
-                      (if (or (>= pos n) (not= (.charAt sql pos) \,))
-                        [count pos]
-                        (let [pos (skip-whitespace sql (inc pos) n)]
-                          (if (or (>= pos n) (not= (.charAt sql pos) \())
-                            [count pos]
-                            (let [next-end (skip-tuple sql pos n)]
-                              (recur next-end (inc count))))))))]
-              (if (and (> (int tuple-count) values-strip-threshold) first-tuple-inner)
-                (let [col-count   (count-columns first-tuple-inner)
-                      nulls       (str/join ", " (repeat col-count "NULL"))
-                      values-kw   (-> (.substring sql match-start match-end)
-                                      str/trimr
-                                      (str/replace #"\($" "")
-                                      str/trimr)]
-                  (.append sb values-kw)
-                  (.append sb " (")
-                  (.append sb nulls)
-                  (.append sb ")")
-                  (recur (int end-pos) sb))
-                (do
-                  (.append sb sql (int match-start) (int end-pos))
-                  (recur (int end-pos) sb))))))))))
+            (let [match-start   (.start matcher)
+                  match-end     (.end matcher)
+                  _             (.append sb sql (int i) (int match-start))
+                  ;; Parse the first tuple to learn its column count
+                  paren-start   (dec (int match-end))
+                  first-end     (skip-balanced-parens sql paren-start n)
+                  first-inner   (when (> first-end (inc paren-start))
+                                  (.substring sql (inc paren-start) (dec (int first-end))))
+                  ;; Scan remaining tuples
+                  [tuple-count end-pos] (count-and-skip-tuples sql first-end n)]
+              (if (and (> (int tuple-count) values-strip-threshold) first-inner)
+                (do (.append sb (make-null-placeholder
+                                 (extract-values-keyword sql match-start match-end)
+                                 (count-top-level-commas first-inner)))
+                    (recur (int end-pos)))
+                (do (.append sb sql (int match-start) (int end-pos))
+                    (recur (int end-pos)))))))))))
 
 (defn strip-large-values
   "Replace large VALUES clauses with a single-row NULL placeholder.

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -66,6 +66,152 @@
          (throw (TimeoutException. (str "Python execution timed out after " ~timeout-ms "ms"))))
        result#)))
 
+;;; ----------------------------------------- VALUES clause stripping ------------------------------------------
+
+;; Large VALUES clauses (thousands of tuples) cause GraalPy OOM due to ~114KB per AST node
+;; (vs ~1-2KB on CPython). We strip them on the JVM side before passing SQL to Python,
+;; because GraalPy is too slow at character-by-character string scanning over multi-MB inputs.
+
+(def ^:private ^:const values-strip-threshold
+  "Only strip VALUES clauses with more than this many tuples."
+  100)
+
+(def ^:private values-keyword-pattern
+  "Pattern to find VALUES keyword followed by opening paren."
+  (re-pattern "(?i)\\bVALUES\\s*\\("))
+
+(defn- skip-tuple
+  "Skip past a balanced parenthesized tuple starting at `pos`, respecting string literals.
+   Returns the position immediately after the closing `)`."
+  ^long [^String sql ^long pos ^long n]
+  (loop [pos   pos
+         depth (int 0)
+         in-string false
+         string-char \space]
+    (if (>= pos n)
+      pos
+      (let [ch (.charAt sql pos)]
+        (cond
+          in-string
+          (if (= ch string-char)
+            ;; Check for escaped (doubled) quote
+            (if (and (< (inc pos) n) (= (.charAt sql (inc pos)) string-char))
+              (recur (+ pos 2) depth true string-char)
+              (recur (inc pos) depth false string-char))
+            (recur (inc pos) depth true string-char))
+
+          (or (= ch \') (= ch \"))
+          (recur (inc pos) depth true ch)
+
+          (= ch \()
+          (recur (inc pos) (inc depth) false string-char)
+
+          (= ch \))
+          (if (= depth 1)
+            (inc pos) ;; done — return position after closing paren
+            (recur (inc pos) (dec depth) false string-char))
+
+          :else
+          (recur (inc pos) depth false string-char))))))
+
+(defn- count-columns
+  "Count the number of top-level comma-separated items in a tuple's inner content."
+  ^long [^String content]
+  (let [n (.length content)]
+    (loop [i     0
+           depth (int 0)
+           in-str false
+           str-ch \space
+           cols   (int 1)]
+      (if (>= i n)
+        cols
+        (let [ch (.charAt content i)]
+          (cond
+            in-str
+            (if (= ch str-ch)
+              (recur (inc i) depth false str-ch cols)
+              (recur (inc i) depth true str-ch cols))
+
+            (or (= ch \') (= ch \"))
+            (recur (inc i) depth true ch cols)
+
+            (= ch \()
+            (recur (inc i) (inc depth) false str-ch cols)
+
+            (= ch \))
+            (recur (inc i) (dec depth) false str-ch cols)
+
+            (and (= ch \,) (= depth 0))
+            (recur (inc i) depth false str-ch (inc cols))
+
+            :else
+            (recur (inc i) depth false str-ch cols)))))))
+
+(defn- skip-whitespace
+  "Return the first position at or after `pos` that is not whitespace."
+  ^long [^String sql ^long pos ^long n]
+  (loop [p pos]
+    (if (and (< p n)
+             (let [ch (.charAt sql p)]
+               (or (= ch \space) (= ch \tab) (= ch \return) (= ch \newline))))
+      (recur (inc p))
+      p)))
+
+(defn strip-large-values
+  "Replace large VALUES clauses with a single-row NULL placeholder.
+
+   Preserves the column count from the first tuple and all surrounding SQL structure.
+   Only triggers when a VALUES clause has more than `values-strip-threshold` tuples.
+
+   This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning)."
+  ^String [^String sql]
+  (let [matcher (re-matcher values-keyword-pattern sql)
+        n       (int (.length sql))]
+    (if-not (.find matcher)
+      sql
+      ;; Reset and scan through all VALUES clauses
+      (let [_ (.reset matcher)]
+        (loop [i   (int 0)
+               sb  (StringBuilder.)]
+          (if-not (.find matcher i)
+            (-> sb (.append sql i n) .toString)
+            (let [match-start (.start matcher)
+                  match-end   (.end matcher)
+                  ;; Append everything before this VALUES
+                  _  (.append sb sql (int i) (int match-start))
+                  ;; Parse first tuple to get column count
+                  first-tuple-start (dec (int match-end)) ;; back up to '('
+                  first-tuple-end   (skip-tuple sql first-tuple-start n)
+                  first-tuple-inner (when (> first-tuple-end (+ first-tuple-start 1))
+                                      (.substring sql (inc first-tuple-start) (dec (int first-tuple-end))))
+                  ;; Count and skip remaining tuples
+                  [tuple-count end-pos]
+                  (loop [pos   (long first-tuple-end)
+                         count (int 1)]
+                    (let [pos (skip-whitespace sql pos n)]
+                      (if (or (>= pos n) (not= (.charAt sql pos) \,))
+                        [count pos]
+                        (let [pos (skip-whitespace sql (inc pos) n)]
+                          (if (or (>= pos n) (not= (.charAt sql pos) \())
+                            [count pos]
+                            (let [next-end (skip-tuple sql pos n)]
+                              (recur next-end (inc count))))))))]
+              (if (and (> (int tuple-count) values-strip-threshold) first-tuple-inner)
+                (let [col-count   (count-columns first-tuple-inner)
+                      nulls       (str/join ", " (repeat col-count "NULL"))
+                      values-kw   (-> (.substring sql match-start match-end)
+                                      str/trimr
+                                      (str/replace #"\($" "")
+                                      str/trimr)]
+                  (.append sb values-kw)
+                  (.append sb " (")
+                  (.append sb nulls)
+                  (.append sb ")")
+                  (recur (int end-pos) sb))
+                (do
+                  (.append sb sql (int match-start) (int end-pos))
+                  (recur (int end-pos) sb))))))))))
+
 ;;; -------------------------------------------------- Public API --------------------------------------------------
 
 (defn referenced-tables
@@ -77,13 +223,14 @@
    This is the pure parsing layer - it returns what's literally in the SQL.
    Default schema resolution happens in the matching layer (core.clj)."
   [dialect sql]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          (-> ^Value (common/eval-python ctx "sql_tools.referenced_tables")
-              (.execute ^Value (object-array [sql dialect]))
-              .asString)))
-      json/decode
-      vec))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            (-> ^Value (common/eval-python ctx "sql_tools.referenced_tables")
+                (.execute ^Value (object-array [sql dialect]))
+                .asString)))
+        json/decode
+        vec)))
 
 (defn referenced-fields
   "Extract field references from SQL, returning only fields from actual database tables.
@@ -109,13 +256,14 @@
    (referenced-fields \"bigquery\" \"SELECT * FROM myproject.analytics.events\")
    => [[\"myproject\" \"analytics\" \"events\" \"*\"]]"
   [dialect sql]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          (-> ^Value (common/eval-python ctx "sql_tools.referenced_fields")
-              (.execute ^Value (object-array [sql dialect]))
-              .asString)))
-      json/decode
-      vec))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            (-> ^Value (common/eval-python ctx "sql_tools.referenced_fields")
+                (.execute ^Value (object-array [sql dialect]))
+                .asString)))
+        json/decode
+        vec)))
 
 (defn returned-columns-lineage
   "Extract column lineage from SQL query, showing which output columns depend on which source columns.
@@ -135,17 +283,18 @@
    (returned-columns-lineage \"postgres\" \"SELECT id + 1 as computed FROM users\" nil schema)
    => [[\"computed\" false [[[nil \"users\" \"id\"]]]]]"
   [dialect sql default-table-schema sqlglot-schema]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
-          (-> ^Value (common/eval-python ctx "sql_tools.returned_columns_lineage")
-              (.execute ^Value (object-array [dialect
-                                              sql
-                                              default-table-schema
-                                              (json/encode sqlglot-schema)]))
-              .asString)))
-      json/decode
-      vec))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
+            (-> ^Value (common/eval-python ctx "sql_tools.returned_columns_lineage")
+                (.execute ^Value (object-array [dialect
+                                                sql
+                                                default-table-schema
+                                                (json/encode sqlglot-schema)]))
+                .asString)))
+        json/decode
+        vec)))
 
 (defn validate-query
   "Validate a SQL query against a schema using sqlglot's qualify optimizer.
@@ -177,13 +326,14 @@
    - \"invalid_expression\": Syntax/parse error
    - \"unhandled\": Other errors"
   [dialect sql default-table-schema & [sqlglot-schema]]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
-          (-> ^Value (common/eval-python ctx "sql_tools.validate_query")
-              (.execute ^Value (object-array [dialect sql default-table-schema (json/encode (or sqlglot-schema "{}"))]))
-              .asString)))
-      json/decode+kw))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
+            (-> ^Value (common/eval-python ctx "sql_tools.validate_query")
+                (.execute ^Value (object-array [dialect sql default-table-schema (json/encode (or sqlglot-schema "{}"))]))
+                .asString)))
+        json/decode+kw)))
 
 (defn simple-query?
   "Check if SQL is a simple SELECT without LIMIT, OFFSET, or CTEs.
@@ -205,12 +355,13 @@
    (simple-query? nil \"SELECT * FROM users LIMIT 10\")
    => {:is_simple false :reason \"Contains a LIMIT\"}"
   [dialect sql]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          (-> ^Value (common/eval-python ctx "sql_tools.simple_query")
-              (.execute ^Value (object-array [sql dialect]))
-              .asString)))
-      json/decode+kw))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            (-> ^Value (common/eval-python ctx "sql_tools.simple_query")
+                (.execute ^Value (object-array [sql dialect]))
+                .asString)))
+        json/decode+kw)))
 
 (defn add-into-clause
   "Add an INTO clause to a SELECT statement for SQL Server SELECT INTO syntax.
@@ -345,23 +496,24 @@
    On timeout, returns an error map instead of throwing, consistent with the
    'fail soft' pattern used for parsing failures."
   [dialect sql]
-  (try
-    (let [raw (-> (with-open [^Closeable ctx (python.pool/python-context)]
-                    (with-python-timeout ctx default-timeout-ms
-                      (-> ^Value (common/eval-python ctx "sql_tools.field_references")
-                          (.execute ^Value (object-array [sql dialect]))
-                          .asString)))
-                  json/decode+kw)
-          used-fields (or (:used-fields raw) (:used_fields raw) (get raw "used_fields") [])
-          returned-fields (or (:returned-fields raw) (:returned_fields raw) (get raw "returned_fields") [])
-          errors (or (:errors raw) (get raw "errors") [])]
-      {:used-fields (set (map convert-field used-fields))
-       :returned-fields (vec (map convert-field returned-fields))
-       :errors (set (map convert-error errors))})
-    (catch TimeoutException e
-      {:used-fields #{}
-       :returned-fields []
-       :errors #{{:type :timeout :message (.getMessage e)}}})))
+  (let [sql (strip-large-values sql)]
+    (try
+      (let [raw (-> (with-open [^Closeable ctx (python.pool/python-context)]
+                      (with-python-timeout ctx default-timeout-ms
+                        (-> ^Value (common/eval-python ctx "sql_tools.field_references")
+                            (.execute ^Value (object-array [sql dialect]))
+                            .asString)))
+                    json/decode+kw)
+            used-fields (or (:used-fields raw) (:used_fields raw) (get raw "used_fields") [])
+            returned-fields (or (:returned-fields raw) (:returned_fields raw) (get raw "returned_fields") [])
+            errors (or (:errors raw) (get raw "errors") [])]
+        {:used-fields (set (map convert-field used-fields))
+         :returned-fields (vec (map convert-field returned-fields))
+         :errors (set (map convert-error errors))})
+      (catch TimeoutException e
+        {:used-fields #{}
+         :returned-fields []
+         :errors #{{:type :timeout :message (.getMessage e)}}}))))
 
 (defn replace-names
   "Replace schema, table, and column names in SQL.
@@ -394,13 +546,14 @@
   "Validates that a query is a single SELECT statement
    and returns the query reconstructed from the parsed AST."
   [dialect sql]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          (-> ^Value (common/eval-python ctx "sql_tools.is_single_select_stmt")
-              (.execute ^Value (object-array [sql dialect]))
-              .asString)))
-      json/decode+kw
-      (perf/update-keys (comp keyword u/->kebab-case-en))))
+  (let [sql (strip-large-values sql)]
+    (-> (with-open [^Closeable ctx (python.pool/python-context)]
+          (with-python-timeout ctx default-timeout-ms
+            (-> ^Value (common/eval-python ctx "sql_tools.is_single_select_stmt")
+                (.execute ^Value (object-array [sql dialect]))
+                .asString)))
+        json/decode+kw
+        (perf/update-keys (comp keyword u/->kebab-case-en)))))
 
 (comment
   (referenced-tables "postgres" "select * from transactions")

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -157,13 +157,8 @@
       (recur (inc p))
       p)))
 
-(defn strip-large-values
-  "Replace large VALUES clauses with a single-row NULL placeholder.
-
-   Preserves the column count from the first tuple and all surrounding SQL structure.
-   Only triggers when a VALUES clause has more than `values-strip-threshold` tuples.
-
-   This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning)."
+(defn- strip-large-values*
+  "Inner implementation — may throw on malformed input."
   ^String [^String sql]
   (let [matcher (re-matcher values-keyword-pattern sql)
         n       (int (.length sql))]
@@ -182,7 +177,7 @@
                   ;; Parse first tuple to get column count
                   first-tuple-start (dec (int match-end)) ;; back up to '('
                   first-tuple-end   (skip-tuple sql first-tuple-start n)
-                  first-tuple-inner (when (> first-tuple-end (+ first-tuple-start 1))
+                  first-tuple-inner (when (> first-tuple-end (inc first-tuple-start))
                                       (.substring sql (inc first-tuple-start) (dec (int first-tuple-end))))
                   ;; Count and skip remaining tuples
                   [tuple-count end-pos]
@@ -211,6 +206,21 @@
                 (do
                   (.append sb sql (int match-start) (int end-pos))
                   (recur (int end-pos) sb))))))))))
+
+(defn strip-large-values
+  "Replace large VALUES clauses with a single-row NULL placeholder.
+
+   Preserves the column count from the first tuple and all surrounding SQL structure.
+   Only triggers when a VALUES clause has more than `values-strip-threshold` tuples.
+
+   This runs on the JVM side (fast) before passing SQL to GraalPy (slow at char scanning).
+   On any error, returns the original SQL unchanged so parsing can proceed normally."
+  ^String [^String sql]
+  (try
+    (strip-large-values* sql)
+    (catch Exception e
+      (log/warn e "Error stripping VALUES clauses, passing SQL through unchanged")
+      sql)))
 
 ;;; -------------------------------------------------- Public API --------------------------------------------------
 

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -449,6 +449,52 @@
                      "\n  Expected: " (pr-str (normalize-fields expected))
                      "\n  Actual:   " (pr-str (normalize-fields actual))))))))))
 
+;;; ----------------------------------------- Large VALUES stripping tests -----------------------------------------
+
+(deftest ^:parallel strip-large-values-test
+  (testing "Small VALUES clauses are preserved"
+    (let [sql "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)"]
+      (is (= sql (sql-parsing/strip-large-values sql)))))
+
+  (testing "No VALUES keyword returns SQL unchanged"
+    (let [sql "SELECT * FROM users WHERE id = 1"]
+      (is (= sql (sql-parsing/strip-large-values sql)))))
+
+  (testing "Large VALUES clause is replaced with NULLs preserving column count"
+    (let [tuples (clojure.string/join ", " (map #(format "(%d, '%s', %d)" % (str "name" %) (* % 10))
+                                                (range 200)))
+          sql    (str "SELECT * FROM (VALUES " tuples ") AS t(id, name, score)")
+          result (sql-parsing/strip-large-values sql)]
+      (is (clojure.string/includes? result "VALUES (NULL, NULL, NULL)"))
+      (is (clojure.string/includes? result "AS t(id, name, score)"))
+      (is (not (clojure.string/includes? result "name0")))))
+
+  (testing "Multiple large VALUES clauses are all stripped"
+    (let [tuples1 (clojure.string/join ", " (map #(format "(%d)" %) (range 200)))
+          tuples2 (clojure.string/join ", " (map #(format "(%d, %d)" % (* % 2)) (range 200)))
+          sql     (str "WITH a AS (SELECT * FROM (VALUES " tuples1 ") AS t(x)), "
+                       "b AS (SELECT * FROM (VALUES " tuples2 ") AS t(y, z)) "
+                       "SELECT * FROM a JOIN b ON a.x = b.y")
+          result  (sql-parsing/strip-large-values sql)]
+      (is (clojure.string/includes? result "VALUES (NULL)"))
+      (is (clojure.string/includes? result "VALUES (NULL, NULL)"))))
+
+  (testing "VALUES keyword casing is preserved"
+    (let [tuples (clojure.string/join ", " (map #(format "(%d)" %) (range 200)))
+          sql    (str "select * from (values " tuples ") as t(x)")
+          result (sql-parsing/strip-large-values sql)]
+      (is (clojure.string/includes? result "values (NULL)")))))
+
+(deftest ^:parallel large-values-referenced-tables-test
+  (testing "referenced-tables works on queries with massive VALUES clauses"
+    (let [tuples (clojure.string/join ", " (map #(format "(%d, %d)" % (mod % 100)) (range 20000)))
+          sql    (str "WITH lookup AS (SELECT * FROM (VALUES " tuples
+                      ") AS v(id, score)) "
+                      "SELECT a.name, l.score FROM accounts a "
+                      "JOIN lookup l ON l.id = a.id")
+          result (sql-parsing/referenced-tables "postgres" sql)]
+      (is (= [[nil nil "accounts"]] result)))))
+
 (deftest ^:parallel referenced-fields-dialect-support-test
   (testing "Referenced fields works across different SQL dialects"
     (doseq [dialect ["postgres" "mysql" "snowflake" "bigquery" "redshift" "duckdb"]]

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -483,7 +483,26 @@
     (let [tuples (clojure.string/join ", " (map #(format "(%d)" %) (range 200)))
           sql    (str "select * from (values " tuples ") as t(x)")
           result (sql-parsing/strip-large-values sql)]
-      (is (clojure.string/includes? result "values (NULL)")))))
+      (is (clojure.string/includes? result "values (NULL)"))))
+
+  (testing "VALUES inside a string literal is not stripped"
+    (let [sql "SELECT 'INSERT INTO foo VALUES (1,2,3)' AS example FROM bar"]
+      (is (= sql (sql-parsing/strip-large-values sql)))))
+
+  (testing "Column named values is not stripped"
+    (let [sql "SELECT values FROM my_table WHERE values > 10"]
+      (is (= sql (sql-parsing/strip-large-values sql)))))
+
+  (testing "VALUES keyword not followed by paren is not stripped"
+    (let [sql "SELECT * FROM t WHERE col IN (SELECT values FROM other)"]
+      (is (= sql (sql-parsing/strip-large-values sql)))))
+
+  (testing "INSERT INTO ... VALUES is stripped when large"
+    (let [tuples (clojure.string/join ", " (map #(format "(%d, 'x')" %) (range 200)))
+          sql    (str "INSERT INTO foo VALUES " tuples)
+          result (sql-parsing/strip-large-values sql)]
+      (is (clojure.string/includes? result "VALUES (NULL, NULL)"))
+      (is (not (clojure.string/includes? result "(0, 'x')"))))))
 
 (deftest ^:parallel large-values-referenced-tables-test
   (testing "referenced-tables works on queries with massive VALUES clauses"


### PR DESCRIPTION
Problem: GraalPy has ~50-100x memory amplification over CPython for AST nodes. A query with ~19,800 VALUES tuples creates 2.26 GB of heap from what would be ~50MB on CPython.

Fix: Added _strip_large_values() in sql_tools.py that runs before sqlglot parsing. It:

1. Scans for VALUES (...) clauses using a character-by-character parser (not regex for the tuples — handles nested parens, string literals with commas/quotes)
2. Counts tuples — only activates above 100 tuples (configurable via _VALUES_STRIP_THRESHOLD)
3. Replaces with VALUES (NULL, NULL, ...) preserving the column count from the first tuple
4. Preserves everything else: CTEs, JOINs, table references, column references, keyword casing

Applied to (analysis-only functions):
- referenced_tables
- referenced_fields
- validate_query
- simple_query
- field_references
- returned_columns_lineage
- is_single_select_stmt

NOT applied to (must preserve original SQL):
- replace_names
- transpile_sql
- add_into_clause

Performance: 258KB input (20K tuples) → 360 bytes output in 15ms. The structural query is perfectly preserved for analysis.

Why not just bail? Bailing would mean we can't analyze these queries at all. Stripping VALUES lets us still extract table references, validate syntax, and trace field lineage — just without the irrelevant data payload.

Overview of Memory usage:
 1. sqlglot's _parse_csv (parser.py:7550-7562) is building a list of 19,819 Tuple AST nodes
  2. Each sqlglot Expression node (like Tuple) is a Python object with:
    - 8 indexed slots (PNone + an args PDict)
    - The args PDict contains child expressions (the literal values inside each tuple)
    - Each child is itself an Expression with its own slots, dict, etc.
  3. On GraalPy, each Python object requires:
    - PythonObject (64 bytes) + Object[] for indexed slots (88 bytes) + PDict (72 bytes) + ObjectHashMap (52 bytes) + backing Object[] for the map + key TruffleString objects...
    - This cascades: ~114 KB retained per top-level Tuple vs what would be maybe ~1-2 KB on CPython
  4. The 190,794 PythonObject instances, 150,254 PList instances, and 113,723 PDict instances on the heap are almost entirely from this one parse tree.

  The Real Issue: GraalPy Memory Amplification

  On CPython, parsing this query would use maybe 50-100 MB. On GraalPy (Truffle), the same parse tree uses 2.26 GB because:
  - Every Python dict becomes a PDict → ObjectHashMap → Object[] chain
  - Every Python list becomes a PList → ObjectSequenceStorage → Object[] chain
  - Every Python object has a shape, indexedSlots, and Truffle metadata
  - There's no compact representation for small objects (unlike CPython's PyObject with ob_type pointer)

  What Can Be Done

  1. Query-side mitigation (immediate): Reject or short-circuit SQL queries with >N tokens or >N VALUES tuples before sending to sqlglot. A limit of ~5,000 tokens would catch this. The wrapper
  functions (referenced_tables, validate_query, field_references, etc.) are the right place for this guard.
  2. Heap size increase (band-aid): If these queries are legitimate, increasing the JVM heap would accommodate them, but it's a scaling treadmill.
  3. Avoid parsing giant VALUES (best): If the goal is just referenced_tables or validate_query, you could strip/replace VALUES (...) clauses with a synthetic (SELECT 1, 2) before parsing — the
  table/column references are the same either way.
  4. Long-term: Evaluate whether GraalPy is the right choice for sqlglot, given the ~50-100x memory amplification over CPython for AST-heavy workloads.

I used an mcp server to debug all of this:
```
 MCP Configuration

  .mcp.json — defines the heap analyzer server:
  {
    "mcpServers": {
      "heap-analyzer": {
        "command": "java",
        "args": ["-jar", "/private/tmp/heap-dump/heap_mcp_nb-0.0.1.jar"]
      }
    }
  }

  The MCP server is a Java jar (heap_mcp_nb-0.0.1.jar, ~11MB) that exposes heap dump analysis tools via the MCP protocol. It uses the NetBeans profiler library (org.netbeans.lib.profiler.heap)
  under the hood to parse .hprof files and supports:

  - load_heap — loads an hprof dump file
  - get_summary — total instances/size overview
  - get_biggest_objects — top objects by retained size
  - get_instance_by_id — inspect individual object fields
  - get_all_references — find references to/from an object
  - get_classes_by_max_instances_count/size — class histograms
  - get_classes_by_regexp — search classes by name pattern
  - get_gc_roots — GC root enumeration
  - get_system_properties — JVM system properties from the dump
  - execute_oql — run OQL (Object Query Language) queries with JavaScript expressions for complex heap traversal

  The key capability that made this analysis possible was OQL with JavaScript — it allowed us to write inline JS functions to iterate arrays, decode byte arrays into strings, and traverse object
  graphs interactively (e.g., reading token text from TruffleString.data byte arrays, navigating the GraalPy PList → ObjectSequenceStorage → Object[] chain).
```