### PR TITLE
fix(sdk-package,sdk-bundle):Fix inconsistent SDK loader height

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
@@ -1,8 +1,10 @@
 import {
+  type CSSProperties,
   type ComponentProps,
   type JSX,
   type JSXElementConstructor,
   type PropsWithChildren,
+  type ReactNode,
   useEffect,
   useId,
   useMemo,
@@ -42,6 +44,31 @@ type Props<TComponentProps> = {
 };
 
 const NOT_STARTED_LOADING_WAIT_TIMEOUT = 1000;
+
+// EMB-875: defaults match FlexibleSizeComponent on the bundle side, so the
+// package-side loader/error box matches the post-init box and prevents a
+// position shift when the SDK bundle finishes loading.
+const DEFAULT_BOUNDED_HEIGHT = "600px";
+const DEFAULT_BOUNDED_WIDTH = "100%";
+
+const Box = ({
+  height,
+  width,
+  children,
+}: {
+  height?: CSSProperties["height"];
+  width?: CSSProperties["width"];
+  children: ReactNode;
+}) => (
+  <div
+    style={{
+      height: height ?? DEFAULT_BOUNDED_HEIGHT,
+      width: width ?? DEFAULT_BOUNDED_WIDTH,
+    }}
+  >
+    {children}
+  </div>
+);
 
 // When the ComponentWrapper is rendered without being wrapped within the MetabaseProvider,
 // the SDK bundle loading is not triggered.
@@ -155,18 +182,37 @@ const ComponentWrapperInner = <TComponentProps,>({
   const { theme } = metabaseProviderProps ?? {};
   const adjustedTheme = useMemo(() => applyThemePreset(theme), [theme]);
 
+  const { height, width } =
+    (componentProps as {
+      height?: CSSProperties["height"];
+      width?: CSSProperties["width"];
+    }) ?? {};
+
   if (isError) {
-    return <Error theme={adjustedTheme} message={SDK_LOADING_ERROR_MESSAGE} />;
+    return (
+      <Box height={height} width={width}>
+        <Error theme={adjustedTheme} message={SDK_LOADING_ERROR_MESSAGE} />
+      </Box>
+    );
   }
 
   if (isNotStartedLoading) {
     return (
-      <Error theme={adjustedTheme} message={SDK_NOT_STARTED_LOADING_MESSAGE} />
+      <Box height={height} width={width}>
+        <Error
+          theme={adjustedTheme}
+          message={SDK_NOT_STARTED_LOADING_MESSAGE}
+        />
+      </Box>
     );
   }
 
   if (isLoading || !metabaseProviderInternalProps.loadingState) {
-    return <Loader theme={adjustedTheme} />;
+    return (
+      <Box height={height} width={width}>
+        <Loader theme={adjustedTheme} />
+      </Box>
+    );
   }
 
   const ComponentProvider = isLoading

--- a/enterprise/frontend/src/embedding-sdk-package/components/private/Loader/Loader.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/Loader/Loader.tsx
@@ -43,6 +43,7 @@ export const Loader = ({
         width: "100%",
         height: "100%",
         display: "flex",
+        alignItems: "center",
         justifyContent: "center",
         ...style,
       }}

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
@@ -1,5 +1,9 @@
 import { type ReactNode, forwardRef } from "react";
 
+import {
+  FlexibleSizeComponent,
+  type FlexibleSizeProps,
+} from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
 import { PublicComponentStylesWrapper } from "embedding-sdk-bundle/components/private/PublicComponentStylesWrapper";
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError";
 import { SdkLoader } from "embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkLoader";
@@ -13,12 +17,16 @@ import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 
 export type PublicComponentWrapperProps = {
   children: ReactNode;
-} & CommonStylingProps;
+} & CommonStylingProps &
+  Pick<FlexibleSizeProps, "height" | "width">;
 
 export const PublicComponentWrapper = forwardRef<
   HTMLDivElement,
   PublicComponentWrapperProps
->(function PublicComponentWrapper({ children, className, style }, ref) {
+>(function PublicComponentWrapper(
+  { children, className, style, height, width },
+  ref,
+) {
   const initStatus = useSdkSelector(getInitStatus);
   const usageProblem = useSdkSelector(getUsageProblem);
   const pluginsReady = useArePluginsReady();
@@ -48,9 +56,21 @@ export const PublicComponentWrapper = forwardRef<
     content = <SdkLoader />;
   }
 
+  // EMB-875: wrap loader/error early returns in FlexibleSizeComponent so the
+  // box matches the post-init tree's box (which renders its own
+  // FlexibleSizeComponent inside). Prevents loader from collapsing in a
+  // 0-height container then jumping to centered after init.
+  const isEarlyReturn = content !== children;
+
   return (
     <PublicComponentStylesWrapper className={className} style={style} ref={ref}>
-      {content}
+      {isEarlyReturn ? (
+        <FlexibleSizeComponent height={height} width={width}>
+          {content}
+        </FlexibleSizeComponent>
+      ) : (
+        content
+      )}
     </PublicComponentStylesWrapper>
   );
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/withPublicComponentWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/withPublicComponentWrapper.tsx
@@ -1,5 +1,7 @@
 import type React from "react";
 
+import type { FlexibleSizeProps } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
+
 import { GuestEmbedGuard } from "./GuestEmbedGuard";
 import { PublicComponentWrapper } from "./PublicComponentWrapper";
 
@@ -11,12 +13,13 @@ export function withPublicComponentWrapper<P extends object>(
     WrappedComponent.displayName || WrappedComponent.name || "Component";
 
   const WithPublicComponentWrapper: React.FC<P> = (props) => {
+    const { height, width } = props as Partial<FlexibleSizeProps>;
     return (
       <GuestEmbedGuard
         componentName={componentName}
         supportsGuestEmbed={supportsGuestEmbed}
       >
-        <PublicComponentWrapper>
+        <PublicComponentWrapper height={height} width={width}>
           <WrappedComponent {...props} />
         </PublicComponentWrapper>
       </GuestEmbedGuard>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61539
closes EMB-875

Double backport so it lands on 60

### Description

Wrap the loader in situations where it doesn't have any parent component that set sensible height or pass users' `height` and `width` to it.

When both the package and the bundle is loaded, the 3rd loader is usually handled by each component. They will already be wrapped with FlexibleSizeComponent, so they will look representable.

### How to verify

Try to render different component in different scenarios.
1. Hard reload browser -> I got the package loader to work this way.
1. Force reload on the app level e.g. using React's `key` prop + throttle the network. -> I usually get to see the bundle loader this way
### Demo
https://www.loom.com/share/3ce4551e28bb4afeb8bea6776a10be09

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ I think automate tests would be pointless as thi is purely UI.
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
