### PR TITLE
Fix timing-data artifact name format

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: steps.extract-timings.outcome == 'success' && steps.extract-timings.outputs.has-changes == 'true'
         with:
-          name: timing-data-${{ inputs.name }}-${{ inputs.split_index }}
+          name: timing-data-${{ inputs.name }}
           path: chunkTimings.json
           retention-days: 1 # gets merged immediately by parent workflow
 


### PR DESCRIPTION
Resolves DEV-1870

### Before
https://github.com/metabase/metabase/actions/runs/24839681143

`timing-data-43-42`

### Now

`timing-data-43`