### PR TITLE
Increase e2e test timeout model actions test

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -774,6 +774,8 @@ describe(
 
           cy.findByText(
             /Error executing Action:.*Invalid impersonated native query\. Must be a single select statement\./,
+            // GraalVM cold start can take >4s, so use a longer timeout
+            { timeout: 30000 },
           );
         });
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-1858/broken-test-e2e-tests-write-actions-on-model-detail-page-postgres

### Description

This test started failing after being merged. I believe it is failing due to the slow graalvm cold start which blocks the impersonation validation. The fix here is to increase the timeout until graalvm has started. 

### How to verify

The test should pass

### Stress-tests

- https://github.com/metabase/metabase/actions/runs/25069584363 x 50
- https://github.com/metabase/metabase/actions/runs/25069556589 x 50 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
