### PR TITLE
Rename Metabot chat admin label and page title to AI chat

### DIFF
--- a/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
@@ -254,11 +254,11 @@ describe("AI Controls > Metabot access and customization", () => {
       cy.visit("/admin/metabot/1/system-prompts/metabot-chat");
 
       cy.findByRole("heading", {
-        name: "Metabot chat prompt instructions",
+        name: "AI chat prompt instructions",
         level: 1,
       }).should("be.visible");
 
-      cy.findByRole("textbox", { name: /Metabot chat prompt instructions/ })
+      cy.findByRole("textbox", { name: /AI chat prompt instructions/ })
         .should("be.visible")
         .click()
         .type("Be concise and helpful.");
@@ -268,7 +268,7 @@ describe("AI Controls > Metabot access and customization", () => {
       // Reload and verify persistence
       cy.reload();
       cy.findByRole("textbox", {
-        name: /Metabot chat prompt instructions/,
+        name: /AI chat prompt instructions/,
       }).should("contain.value", "Be concise and helpful.");
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
@@ -43,7 +43,7 @@ export function AiControlsNavItems() {
         disabled={!isConfigured}
       >
         <AdminNavItem
-          label={t`Metabot chat`}
+          label={t`AI chat`}
           path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/system-prompts/metabot-chat`}
           disabled={!isConfigured}
         />

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -71,7 +71,7 @@ export function MetabotChatPromptPage() {
 
   return (
     <SystemPromptPage
-      title={t`Metabot chat prompt instructions`}
+      title={t`AI chat prompt instructions`}
       description={t`Add instructions here for the sidebar AI chat experience in ${applicationName}. You might want to give instructions about tone, types of entities to prefer, and things like that.`}
       settingKey="metabot-chat-system-prompt"
     />

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -46,7 +46,7 @@ describe("MetabotSystemPromptsPage", () => {
       });
 
       expect(
-        await screen.findByText("Metabot chat prompt instructions"),
+        await screen.findByText("AI chat prompt instructions"),
       ).toBeInTheDocument();
     });
 
@@ -58,7 +58,7 @@ describe("MetabotSystemPromptsPage", () => {
       });
 
       const textarea = await screen.findByRole("textbox", {
-        name: "Metabot chat prompt instructions",
+        name: "AI chat prompt instructions",
       });
 
       await waitFor(() => {
@@ -73,7 +73,7 @@ describe("MetabotSystemPromptsPage", () => {
       });
 
       const textarea = await screen.findByRole("textbox", {
-        name: "Metabot chat prompt instructions",
+        name: "AI chat prompt instructions",
       });
       await userEvent.type(textarea, "New instructions");
 


### PR DESCRIPTION
### Description

Fixes [UXW-3875](https://linear.app/metabase/issue/UXW-3875/re-title-the-metabot-chat-page).

The AI agent name is configurable, so the admin UI shouldn't hardcode "Metabot".

- Admin nav item under **System prompts**: `Metabot chat` → `AI chat`
- System prompts page title: `Metabot chat prompt instructions` → `AI chat prompt instructions`
- Updated unit + E2E test assertions to match the new labels

### How to verify

- [ ] As an admin, open **Settings → Metabot → System prompts**; the sub-nav item now reads "AI chat"
- [ ] Open that page; heading reads "AI chat prompt instructions"
- [ ] Existing prompt content still loads, edits and saves correctly

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
