### PR TITLE
Use generic AI agent wording on Metabot customization page

### DIFF
--- a/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
@@ -116,7 +116,7 @@ describe("AI Controls > Metabot access and customization", () => {
       cy.findByRole("heading", { name: "Customization", level: 1 }).should(
         "be.visible",
       );
-      cy.findByLabelText("Metabot's name")
+      cy.findByLabelText("AI agent's name")
         .should("be.visible")
         .clear()
         .type("HAL 9000");
@@ -126,7 +126,7 @@ describe("AI Controls > Metabot access and customization", () => {
 
       // Reload and verify persistence
       cy.reload();
-      cy.findByLabelText("Metabot's name").should("have.value", "HAL 9000");
+      cy.findByLabelText("AI agent's name").should("have.value", "HAL 9000");
     });
 
     it("should upload a custom Metabot icon and show the illustrations section", () => {
@@ -134,7 +134,7 @@ describe("AI Controls > Metabot access and customization", () => {
 
       cy.visit("/admin/metabot/1/customization");
 
-      H.main().findByText("Metabot's icon").should("be.visible");
+      H.main().findByText("AI agent's icon").should("be.visible");
       cy.findByRole("button", { name: "Upload a custom icon" }).should(
         "be.visible",
       );

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.tsx
@@ -4,28 +4,31 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
+import { useSelector } from "metabase/redux";
+import { getApplicationName } from "metabase/selectors/whitelabel";
 import { TextInput } from "metabase/ui";
 import { useAdminSettingWithDebouncedInput } from "metabase-enterprise/ai-controls/hooks";
 
 import { MetabotIconField } from "./MetabotIconField";
 
 export function MetabotCustomizationPage() {
+  const applicationName = useSelector(getApplicationName);
   const { handleInputChange, inputValue: nameInput } =
     useAdminSettingWithDebouncedInput<string | null>("metabot-name");
 
   return (
     <SettingsPageWrapper title={t`Customization`} mt="sm">
       <SettingsSection
-        description={t`Customize how Metabot appears to users.`}
+        description={t`Customize how ${applicationName}'s AI agent appears to users.`}
         title={t`Identity`}
       >
         <TextInput
-          label={t`Metabot's name`}
+          label={t`AI agent's name`}
           placeholder={t`Metabot`}
           mb="sm"
           value={nameInput || ""}
           onChange={(e) => handleInputChange(e.target.value)}
-          error={nameInput ? undefined : t`Metabot's name is required`}
+          error={nameInput ? undefined : t`AI agent's name is required`}
         />
         <MetabotIconField />
       </SettingsSection>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
@@ -41,7 +41,7 @@ describe("MetabotCustomizationPage", () => {
   it("shows default icon state when no custom icon is set", async () => {
     setup({ metabotIcon: "metabot" });
 
-    await screen.findByText("Metabot's icon");
+    await screen.findByText("AI agent's icon");
     expect(
       screen.queryByRole("button", { name: /Remove custom icon/ }),
     ).not.toBeInTheDocument();
@@ -51,7 +51,7 @@ describe("MetabotCustomizationPage", () => {
   it("shows the remove button and illustrations toggle when a custom icon is set", async () => {
     setup({ metabotIcon: "data:image/png;base64,abc123" });
 
-    await screen.findByText("Metabot's icon");
+    await screen.findByText("AI agent's icon");
     expect(
       screen.getByRole("button", { name: /Remove custom icon/ }),
     ).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
@@ -80,10 +80,10 @@ export function MetabotIconField() {
   return (
     <Stack gap={0}>
       <Text lh="lg" fz="md" mb="xs" fw="bold">
-        {t`Metabot's icon`}
+        {t`AI agent's icon`}
       </Text>
       <Text fz="md" c="text-secondary" lh="lg">
-        {t`Upload a custom icon for Metabot. For best results, use an SVG or PNG with a transparent background.`}
+        {t`Upload a custom icon for the AI agent. For best results, use an SVG or PNG with a transparent background.`}
       </Text>
       {iconError && (
         <Text fz="sm" c="error" mt="xs">


### PR DESCRIPTION
### Description

Fixes [UXW-3876](https://linear.app/metabase/issue/UXW-3876/ai-customization-page-should-be-judicious-in-use-of-metabot-name).

The agent name is configurable, so the customization page shouldn't hardcode "Metabot" in generic copy.

- Identity section description → `Customize how ${applicationName}'s AI agent appears to users.` (via `getApplicationName`, so whitelabel is respected)
- Name field label + validation → "AI agent's name"
- Icon field label + helper → "AI agent's icon" / "Upload a custom icon for the AI agent."
- "Metabot illustrations" intentionally left as-is.

### How to verify

- [ ] `/admin/metabot/1/customization` uses "AI agent" wording in the Identity section
- [ ] Clearing the name field shows "AI agent's name is required"
- [ ] Whitelabeled app name flows into the section description

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
