### PR TITLE
Shorten AI usage controls nav item labels

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
@@ -21,12 +21,12 @@ export function AiControlsNavItems() {
         disabled={!isConfigured}
       >
         <AdminNavItem
-          label={t`AI feature access`}
+          label={t`Access`}
           path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/usage-controls/ai-feature-access`}
           disabled={!isConfigured}
         />
         <AdminNavItem
-          label={t`AI usage limits`}
+          label={t`Limits`}
           path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/usage-controls/ai-usage-limits`}
         />
       </AdminNavItem>


### PR DESCRIPTION
### Description

Fixes [UXW-3873](https://linear.app/metabase/issue/UXW-3873/simplify-nav-item-names-in-ai-usage-controls-nav).

Under the **Usage controls** group, the parent already provides context, so the children can drop the redundant prefix.

- `AI feature access` → `Access`
- `AI usage limits` → `Limits`

Page titles unchanged — only the sidebar labels.

### How to verify

- [ ] Open `/admin/metabot/1/usage-controls/...` — the two children under **Usage controls** read **Access** and **Limits**
- [ ] Both still navigate to the same pages

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

n/a
