### PR TITLE
docs - remove resizing dashboards section from components.md

### DIFF
--- a/docs/embedding/components.md
+++ b/docs/embedding/components.md
@@ -46,10 +46,6 @@ If you surround your attribute value with double quotes, make sure to use single
 ></metabase-dashboard>
 ```
 
-## Resizing dashboards to fit their content
-
-The `<metabase-dashboard>` web component automatically resizes to fit its content. No additional configuration is needed.
-
 ## Question
 
 To render a question (chart):


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/73224

Removed section on resizing dashboards in components.md.
