### PR TITLE
Bump Databricks multi-catalog test timeout to 60m

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -447,7 +447,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: databricks


### PR DESCRIPTION
The 40-minute timeout was consistently being hit, cancelling the job.