### PR TITLE
Show Metabot illustration preview next to the visibility toggle

### DIFF
--- a/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
@@ -134,7 +134,7 @@ describe("AI Controls > Metabot access and customization", () => {
 
       cy.visit("/admin/metabot/1/customization");
 
-      H.main().findByText("Metabot's icon").should("be.visible");
+      H.main().findByText("AI agent's icon").should("be.visible");
       cy.findByRole("button", { name: "Upload a custom icon" }).should(
         "be.visible",
       );

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
@@ -46,6 +46,9 @@ describe("MetabotCustomizationPage", () => {
       screen.queryByRole("button", { name: /Remove custom icon/ }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Metabot illustrations")).not.toBeInTheDocument();
+    expect(
+      screen.queryByAltText("Metabot illustration preview"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the remove button and illustrations toggle when a custom icon is set", async () => {
@@ -56,6 +59,9 @@ describe("MetabotCustomizationPage", () => {
       screen.getByRole("button", { name: /Remove custom icon/ }),
     ).toBeInTheDocument();
     expect(screen.getByText("Metabot illustrations")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Metabot illustration preview"),
+    ).toBeInTheDocument();
   });
 
   it("shows the custom icon preview image when a custom icon is set", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotCustomizationPage.unit.spec.tsx
@@ -41,7 +41,7 @@ describe("MetabotCustomizationPage", () => {
   it("shows default icon state when no custom icon is set", async () => {
     setup({ metabotIcon: "metabot" });
 
-    await screen.findByText("Metabot's icon");
+    await screen.findByText("AI agent's icon");
     expect(
       screen.queryByRole("button", { name: /Remove custom icon/ }),
     ).not.toBeInTheDocument();
@@ -54,7 +54,7 @@ describe("MetabotCustomizationPage", () => {
   it("shows the remove button and illustrations toggle when a custom icon is set", async () => {
     setup({ metabotIcon: "data:image/png;base64,abc123" });
 
-    await screen.findByText("Metabot's icon");
+    await screen.findByText("AI agent's icon");
     expect(
       screen.getByRole("button", { name: /Remove custom icon/ }),
     ).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
@@ -105,8 +105,8 @@ export function MetabotIconField() {
           className={cx(CS.bgLight, CS.bordered, CS.rounded)}
           align="center"
           justify="center"
-          w="2.5rem"
-          h="2.5rem"
+          w="2.25rem"
+          h="2.25rem"
           flex="0 0 auto"
         >
           {iconPreviewSrc ? (

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
@@ -81,10 +81,10 @@ export function MetabotIconField() {
   return (
     <Stack gap={0}>
       <Text lh="lg" fz="md" mb="xs" fw="bold">
-        {t`Metabot's icon`}
+        {t`AI agent's icon`}
       </Text>
       <Text fz="md" c="text-secondary" lh="lg">
-        {t`Upload a custom icon for Metabot. For best results, use an SVG or PNG with a transparent background.`}
+        {t`Upload a custom icon for the AI agent. For best results, use an SVG or PNG with a transparent background.`}
       </Text>
       {iconError && (
         <Text fz="sm" c="error" mt="xs">

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { type ChangeEvent, useRef, useState } from "react";
 import { t } from "ttag";
 
+import EmptyDashboardBot from "assets/img/dashboard-empty.svg";
 import { useAdminSetting } from "metabase/api/utils";
 import CS from "metabase/css/core/index.css";
 import {
@@ -97,26 +98,30 @@ export function MetabotIconField() {
         my="sm"
         py="sm"
         px="md"
+        maw="100%"
+        wrap="wrap"
       >
-        <Box
+        <Flex
           className={cx(CS.bgLight, CS.bordered, CS.rounded)}
-          p="sm"
-          flex="0 0 2.25rem"
+          align="center"
+          justify="center"
+          w="2.5rem"
+          h="2.5rem"
+          flex="0 0 auto"
         >
           {iconPreviewSrc ? (
-            <img
+            <Box
+              component="img"
               src={iconPreviewSrc}
               alt={t`Metabot icon`}
-              style={{
-                width: "1.5rem",
-                height: "1.5rem",
-                objectFit: "contain",
-              }}
+              w="1.5rem"
+              h="1.5rem"
+              style={{ objectFit: "contain" }}
             />
           ) : (
             <Icon name="metabot" />
           )}
-        </Box>
+        </Flex>
         <input
           ref={fileInputRef}
           hidden
@@ -125,23 +130,38 @@ export function MetabotIconField() {
           multiple={false}
           onChange={handleIconUpload}
         />
-        <Button size="sm" onClick={() => fileInputRef.current?.click()}>
+        <Button
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          flex="0 0 auto"
+        >
           {t`Upload a custom icon`}
         </Button>
-        {iconFileName && (
-          <Text fz="sm" c="text-secondary" truncate="end">
-            {iconFileName}
-          </Text>
-        )}
-        {!isDefaultIcon && (
-          <Tooltip label={t`Remove custom icon`}>
-            <ActionIcon
-              onClick={handleIconRemove}
-              aria-label={t`Remove custom icon`}
-            >
-              <Icon name="close" />
-            </ActionIcon>
-          </Tooltip>
+        {(iconFileName || !isDefaultIcon) && (
+          <Flex align="center" gap="md" flex="1 1 0" miw="2rem">
+            {iconFileName && (
+              <Text
+                fz="sm"
+                c="text-secondary"
+                truncate="end"
+                miw={0}
+                title={iconFileName}
+                flex="1 1 0"
+              >
+                {iconFileName}
+              </Text>
+            )}
+            {!isDefaultIcon && (
+              <Tooltip label={t`Remove custom icon`}>
+                <ActionIcon
+                  onClick={handleIconRemove}
+                  aria-label={t`Remove custom icon`}
+                >
+                  <Icon name="close" />
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </Flex>
         )}
       </Flex>
       {!isDefaultIcon && (
@@ -149,10 +169,20 @@ export function MetabotIconField() {
           <Text fz="md" fw="bold">
             {t`Metabot illustrations`}
           </Text>
-          <Group gap="lg">
-            <Text fz="md" c="text-secondary">
-              {t`Show Metabot illustrations in chat sidebar and AI exploration page`}
-            </Text>
+          <Group gap="lg" align="center" wrap="nowrap">
+            <Flex align="center" gap="sm" flex="1" miw={0}>
+              <Box
+                component="img"
+                src={EmptyDashboardBot}
+                alt={t`Metabot illustration preview`}
+                w="3rem"
+                h="3rem"
+                flex="0 0 auto"
+              />
+              <Text fz="md" c="text-secondary" flex="1">
+                {t`Show Metabot illustrations in chat sidebar and AI exploration page`}
+              </Text>
+            </Flex>
             <Switch
               aria-label={t`Show Metabot illustrations`}
               checked={!!showIllustrations}


### PR DESCRIPTION
### Description

Fixes [UXW-3874](https://linear.app/metabase/issue/UXW-3874/add-example-of-metabot-illustration-to-ai-customization-page-setting).

Adds a small preview of `dashboard-empty.svg` next to the **Metabot illustrations** toggle so admins can see what they're hiding/showing. Also tightened the icon-upload row's responsive behavior (long filenames truncate with a hover tooltip; the row wraps cleanly instead of overflowing).

### How to verify

- [ ] `/admin/metabot/1/customization` → upload a custom icon → preview appears next to the toggle
- [ ] Remove the icon → preview disappears with the toggle
- [ ] Narrow viewport → icon row wraps without escaping its container

### Demo

<img width="400" alt="image" src="https://github.com/user-attachments/assets/191114c4-8eaa-4fd8-b22b-bde48a8a6eb2" />

Layout fixes: 

#### Before
<img   width="400" alt="image" src="https://github.com/user-attachments/assets/440db994-f10b-48ac-9154-66800b48ede7" />
<img  width="400" alt="image" src="https://github.com/user-attachments/assets/392a31e6-b2d6-4563-9468-f243e6efd4bd" />    

#### After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fca604c0-8481-4117-b9a6-6ff4589a8f20" />
<img  width="400" alt="image" src="https://github.com/user-attachments/assets/cfe02783-b325-4c08-a4fe-71b8a6d6aacb" /> |


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
