### PR TITLE
H2 mbql5 experiment

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -48,10 +48,7 @@
 ;; we need to gather more data from the experiment (see query-processor/mbql->honeysql)
 ;; before we can switch this over. once that happens, make regular :h2 have
 ;; :sql-mbql5 as a parent and move the :h2-mbql5 methods below to just :h2.
-(driver/register! :h2-mbql5, :parent #{:sql-jdbc
-                                       ::like-escape-char-built-in/like-escape-char-built-in
-                                       :sql-mbql5
-                                       :h2})
+(driver/register! :h2-mbql5, :parent #{:h2 :sql-mbql5})
 
 ;;; this will prevent the H2 driver from showing up in the list of options when adding a new Database.
 (defmethod driver/superseded-by :h2 [_driver] :deprecated)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -42,7 +42,16 @@
 ;; method impls live in this namespace
 (comment h2.actions/keep-me)
 
-(driver/register! :h2, :parent #{:sql-jdbc ::like-escape-char-built-in/like-escape-char-built-in :sql-mbql5})
+(driver/register! :h2, :parent #{:sql-jdbc ::like-escape-char-built-in/like-escape-char-built-in})
+
+;; h2 can be used to generate mbql5 natively, but this is not the default yet.
+;; we need to gather more data from the experiment (see query-processor/mbql->honeysql)
+;; before we can switch this over. once that happens, make regular :h2 have
+;; :sql-mbql5 as a parent and move the :h2-mbql5 methods below to just :h2.
+(driver/register! :h2-mbql5, :parent #{:sql-jdbc
+                                       ::like-escape-char-built-in/like-escape-char-built-in
+                                       :sql-mbql5
+                                       :h2})
 
 ;;; this will prevent the H2 driver from showing up in the list of options when adding a new Database.
 (defmethod driver/superseded-by :h2 [_driver] :deprecated)
@@ -91,6 +100,10 @@
     supported?))
 
 (defmethod sql.qp/->honeysql [:h2 :regex-match-first]
+  [driver [_ arg pattern]]
+  [:regexp_substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)])
+
+(defmethod sql.qp/->honeysql [:h2-mbql5 :regex-match-first]
   [driver [_ _opts arg pattern]]
   [:regexp_substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)])
 
@@ -416,10 +429,25 @@
 (defmethod sql.qp/date [:h2 :week-of-year-iso] [_ _ expr] (extract :iso_week expr))
 
 (defmethod sql.qp/->honeysql [:h2 :log]
+  [driver [_ field]]
+  [:log10 (sql.qp/->honeysql driver field)])
+
+(defmethod sql.qp/->honeysql [:h2-mbql5 :log]
   [driver [_ _opts field]]
   [:log10 (sql.qp/->honeysql driver field)])
 
 (defmethod sql.qp/->honeysql [:h2 ::sql.qp/expression-literal-text-value]
+  [driver [_ value]]
+  ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
+  ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
+  ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST.
+  ;;
+  ;; https://linear.app/metabase/issue/QUE-726/
+  ;; https://github.com/h2database/h2database/issues/1383
+  (->> (sql.qp/->honeysql driver value)
+       (h2x/cast :text)))
+
+(defmethod sql.qp/->honeysql [:h2-mbql5 ::sql.qp/expression-literal-text-value]
   [driver [_ _opts value]]
   ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
   ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -15,6 +15,7 @@
    [metabase.driver.sql.query-processor.deprecated :as sql.qp.deprecated]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.experiment :as experiment]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -2246,10 +2247,7 @@
   [driver query]
   (apply-clauses driver {} query))
 
-(mu/defn mbql->honeysql :- [:or :map [:tuple [:= :inline] :map]]
-  "Build the HoneySQL form we will compile to SQL and execute."
-  [driver :- :keyword
-   query  :- :map]
+(defn- mbql->honeysql* [driver query]
   (if (:lib/type query)
     (binding [driver/*driver* driver]
       (let [inner-query (preprocess driver query)]
@@ -2265,6 +2263,18 @@
           inner-query       (or (:query query) query)
           mbql5-query (driver-api/query-from-legacy-inner-query metadata-provider database-id inner-query)]
       (recur driver mbql5-query))))
+
+(def ^:private experimental-mbql5-drivers {:h2 :h2-mbql5})
+
+(mu/defn mbql->honeysql :- [:or :map [:tuple [:= :inline] :map]]
+  "Build the HoneySQL form we will compile to SQL and execute."
+  [driver :- :keyword
+   query  :- :map]
+  (if-let [experimental-driver (experimental-mbql5-drivers driver)]
+    (experiment/experiment {:name :experimental-mbql5-driver}
+                           (mbql->honeysql* driver query)
+                           (mbql->honeysql* experimental-driver query))
+    (mbql->honeysql* driver query)))
 
 ;;;; MBQL -> Native
 

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -21,10 +21,28 @@
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
+   [metabase.test.data.datasets :as mtd]
+   [metabase.test.data.env :as tx.env]
+   [metabase.test.data.interface :as tx]
    [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+;; temporary hack to run all tests against both the old :h2 and new mbql5 :h2
+;; remove this once :h2 does mbql5 by default!
+(defn- test-driver [driver thunk]
+  (when (contains? (tx.env/test-drivers) driver)
+    (testing (str "\n" driver "\n")
+      (driver/with-driver (tx/the-driver-with-test-extensions driver)
+        (thunk))
+      (when (= driver :h2)
+        (driver/with-driver (tx/the-driver-with-test-extensions :h2-mbql5)
+          (thunk))))))
+
+(use-fixtures :each (fn [f]
+                      (with-redefs [mtd/-test-driver test-driver]
+                        (f))))
 
 (deftest ^:parallel parse-connection-string-test
   (testing "Check that the functions for exploding a connection string's options work as expected"

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -36,11 +36,16 @@
     (testing (str "\n" driver "\n")
       (driver/with-driver (tx/the-driver-with-test-extensions driver)
         (thunk))
+      ;; the above is the original definition of test-driver, but we add in
+      ;; this clause to avoid having to rewrite all the tests below twice:
       (when (= driver :h2)
         (driver/with-driver (tx/the-driver-with-test-extensions :h2-mbql5)
           (thunk))))))
 
 (use-fixtures :each (fn [f]
+                      ;; NB: because of test parallelism, this *will* affect other non-h2
+                      ;; tests, but the check above in the test-driver function will
+                      ;; prevent it from actually doing anything different in those tests.
                       (with-redefs [mtd/-test-driver test-driver]
                         (f))))
 

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -18,10 +18,10 @@
 
 (deftest ^:parallel field->field-filter-clause-test
   (is (=? [:field
+           (meta/id :venues :id)
            {:base-type                                                           :type/BigInteger
             :metabase.query-processor.util.add-alias-info/source-table           (meta/id :venues)
-            :metabase.driver.sql.parameters.substitution/compiling-field-filter? true}
-           (meta/id :venues :id)]
+            :metabase.driver.sql.parameters.substitution/compiling-field-filter? true}]
           (#'sql.params.substitution/field->field-filter-clause
            :h2
            (meta/field-metadata :venues :id)

--- a/test/metabase/test/data/h2_mbql5.clj
+++ b/test/metabase/test/data/h2_mbql5.clj
@@ -1,0 +1,2 @@
+(ns metabase.test.data.h2-mbql5
+  "Placeholder; delete me once experimental-mbql5-driver goes away.")


### PR DESCRIPTION
### Description

We want to make the H2 driver start producing MBQL5 natively instead of producing legacy MBQL and then getting it converted. However, this is a big change and can't be done without some risk. We could deploy it to stats to test it out, but A) a bug would still be disruptive and B) if we roll it back after the first sign of trouble, it would only tell us about one problem. An experiment allows us to see what's going on in the logs and stats without the risk of breakage.

Currently based on https://github.com/metabase/metabase/pull/72794 but will need to be rebased once that lands on master (hopefully soon). That should bring it from 1421 files changed down to 3 or 4.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
