### PR TITLE
hide usage analytics content from unreferenced items

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -853,6 +853,14 @@
         database-filter (when (= entity-type :table)
                           {:filter [:and [:not :database.is_sample] [:not :database.is_audit]]
                            :filter-joins #{:database}})
+        ;; Hide system-managed (internal-user) content like Usage Analytics from the user-facing
+        ;; graph, mirroring the `is_audit` database exclusion above for tables.
+        internal-content-filter (when-let [model (case entity-type
+                                                   :card      :model/Card
+                                                   :dashboard :model/Dashboard
+                                                   nil)]
+                                  {:filter (mi/exclude-internal-content-hsql model :table-alias :entity)
+                                   :filter-joins #{}})
         archived-filter (when (= include-archived-items :exclude)
                           {:filter (case entity-type
                                      (:card :dashboard :document :snippet :segment :measure)
@@ -880,7 +888,8 @@
                                  :filter-joins #{:collection}}))
                             nil))
         filter-results (keep identity
-                             [card-type-filter query-filter database-filter archived-filter personal-filter])]
+                             [card-type-filter query-filter database-filter
+                              internal-content-filter archived-filter personal-filter])]
     {:filters (keep :filter filter-results)
      :filter-joins (reduce set/union #{} (map :filter-joins filter-results))}))
 

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -839,7 +839,7 @@
     #{}))
 
 (defn- build-optional-filters
-  [{:keys [entity-type card-types query include-archived-items include-personal-collections]}
+  [{:keys [query-type entity-type card-types query include-archived-items include-personal-collections]}
    {:keys [name-column location-column]}]
   (let [card-type-filter (when (and (= entity-type :card)
                                     (seq card-types))
@@ -853,12 +853,15 @@
         database-filter (when (= entity-type :table)
                           {:filter [:and [:not :database.is_sample] [:not :database.is_audit]]
                            :filter-joins #{:database}})
-        ;; Hide system-managed (internal-user) content like Usage Analytics from the user-facing
-        ;; graph, mirroring the `is_audit` database exclusion above for tables.
-        internal-content-filter (when-let [model (case entity-type
-                                                   :card      :model/Card
-                                                   :dashboard :model/Dashboard
-                                                   nil)]
+        ;; Hide system-managed (internal-user) content like Usage Analytics from the unreferenced
+        ;; list — analytics dashboards have nothing pointing at them by design and would just be
+        ;; noise. The breaking-items list intentionally still surfaces them, since broken analytics
+        ;; deps are real signals worth showing.
+        internal-content-filter (when-let [model (and (= query-type :unreferenced)
+                                                      (case entity-type
+                                                        :card      :model/Card
+                                                        :dashboard :model/Dashboard
+                                                        nil))]
                                   {:filter (mi/exclude-internal-content-hsql model :table-alias :entity)
                                    :filter-joins #{}})
         archived-filter (when (= include-archived-items :exclude)

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.dependencies.findings :as dependencies.findings]
    [metabase-enterprise.dependencies.test-util :as deps.test]
    [metabase.collections.models.collection :as collection]
+   [metabase.config.core :as config]
    [metabase.core.core :as mbc]
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
@@ -1597,6 +1598,35 @@
                 snippet-ids (set (map :id (:data response)))]
             (is (contains? snippet-ids unreffed-snippet-id))
             (is (contains? snippet-ids archived-snippet-id))))))))
+
+(deftest ^:sequential unreferenced-excludes-internal-content-test
+  (testing "GET /api/ee/dependencies/graph/unreferenced excludes system-managed (internal-user) content"
+    (mt/with-premium-features #{:dependencies}
+      (let [mp (mt/metadata-provider)
+            products (lib.metadata/table mp (mt/id :products))]
+        (mt/with-temp [:model/Card {regular-card-id :id} {:name "Regular Card - intcontent"
+                                                          :type :question
+                                                          :dataset_query (lib/query mp products)}
+                       :model/Card {internal-card-id :id} {:name "Internal Card - intcontent"
+                                                           :type :question
+                                                           :creator_id config/internal-mb-user-id
+                                                           :dataset_query (lib/query mp products)}
+                       :model/Dashboard {regular-dashboard-id :id} {:name "Regular Dashboard - intcontent"}
+                       :model/Dashboard {internal-dashboard-id :id} {:name "Internal Dashboard - intcontent"
+                                                                     :creator_id config/internal-mb-user-id}]
+          (deps.test/synchronously-run-backfill!)
+          (testing "internal-user cards are filtered out"
+            (let [response (mt/user-http-request :crowberto :get 200
+                                                 "ee/dependencies/graph/unreferenced?types=card&query=intcontent")
+                  card-ids (set (map :id (:data response)))]
+              (is (contains? card-ids regular-card-id))
+              (is (not (contains? card-ids internal-card-id)))))
+          (testing "internal-user dashboards are filtered out"
+            (let [response (mt/user-http-request :crowberto :get 200
+                                                 "ee/dependencies/graph/unreferenced?types=dashboard&query=intcontent")
+                  dashboard-ids (set (map :id (:data response)))]
+              (is (contains? dashboard-ids regular-dashboard-id))
+              (is (not (contains? dashboard-ids internal-dashboard-id))))))))))
 
 (deftest ^:sequential unreferenced-archived-segment-test
   (testing "GET /api/ee/dependencies/graph/unreferenced with archived parameter for segments"

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1628,6 +1628,28 @@
               (is (contains? dashboard-ids regular-dashboard-id))
               (is (not (contains? dashboard-ids internal-dashboard-id))))))))))
 
+(deftest ^:sequential breaking-entities-includes-internal-content-test
+  (testing "GET /api/ee/dependencies/graph/breaking still surfaces internal-user (system-managed) content"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-temp [:model/User user {:email "test@test.com"}]
+        (mt/with-model-cleanup [:model/Card :model/Dependency :model/DependencyStatus :model/AnalysisFinding :model/AnalysisFindingError]
+          (let [[internal-model dependent-card]
+                (lib-be/with-metadata-provider-cache
+                  (let [internal-model (create-model-card! user "Internal Model - intbreaking")
+                        dependent-card (create-dependent-card-on-model! user internal-model "Dependent - intbreaking")]
+                    [internal-model dependent-card]))]
+            (t2/update! :model/Card (:id internal-model) {:creator_id config/internal-mb-user-id})
+            (lib-be/with-metadata-provider-cache
+              (break-model-card! (t2/select-one :model/Card :id (:id internal-model))))
+            (lib-be/with-metadata-provider-cache
+              (deps.test/synchronously-run-backfill!)
+              (run-analysis-for-card! (:id dependent-card)))
+            (let [response (mt/user-http-request :crowberto :get 200
+                                                 "ee/dependencies/graph/breaking?types=card&query=intbreaking")
+                  card-ids (set (map :id (:data response)))]
+              (is (contains? card-ids (:id internal-model))
+                  "Internal-user model card should still appear in breaking list"))))))))
+
 (deftest ^:sequential unreferenced-archived-segment-test
   (testing "GET /api/ee/dependencies/graph/unreferenced with archived parameter for segments"
     (mt/with-premium-features #{:dependencies}


### PR DESCRIPTION
### Description

After https://github.com/metabase/metabase/pull/71037 usage analytics content became visible in unreferenced items — even questions inside usage analytics dashboards, this PR attempts to fix this. The PR got merged although e2e tests failed — I assume this is related to auto-quarantine.
