### PR TITLE
[AI Analytics] Quick feedback

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
@@ -206,7 +206,7 @@
     (with-list-conversations-fixture!
       (fn [{:keys [response-path convo-1 convo-2 convo-3]}]
         (let [response (mt/user-http-request :crowberto :get 200
-                                             (format "%s&sort-by=message_count&sort-dir=desc" response-path))]
+                                             (format "%s&sort_by=message_count&sort_dir=desc" response-path))]
           (is (= [convo-2 convo-1 convo-3]
                  (map :conversation_id (:data response)))))))))
 
@@ -221,7 +221,7 @@
     (with-list-conversations-fixture!
       (fn [{:keys [response-path]}]
         (is (some? (:errors (mt/user-http-request :crowberto :get 400
-                                                  (format "%s&sort-dir=sideways" response-path)))))))))
+                                                  (format "%s&sort_dir=sideways" response-path)))))))))
 
 (deftest list-conversations-user-with-no-conversations-test
   (testing "filtering by a user-id that has no conversations returns an empty data set, not an error"
@@ -230,7 +230,7 @@
         (is (=? {:total 0
                  :data  []}
                 (mt/user-http-request :crowberto :get 200
-                                      (format "ee/metabot-analytics/conversations?user-id=%s"
+                                      (format "ee/metabot-analytics/conversations?user_id=%s"
                                               empty-user-id))))))))
 
 (deftest list-conversations-requires-audit-app-feature-test

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -58,12 +58,10 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
 
   const chatMessages = useMemo(() => {
     const isSlackbot =
-      conversation.profile_id === "slackbot" ||
-      conversation.profile_id === "slack";
-
-    return isSlackbot
-      ? (conversation.chat_messages ?? []).map(convertSlackChatMessage)
-      : (conversation.chat_messages ?? []);
+      conversation?.profile_id === "slackbot" ||
+      conversation?.profile_id === "slack";
+    const msgs = conversation?.chat_messages ?? [];
+    return isSlackbot ? msgs.map(convertSlackChatMessage) : msgs;
   }, [conversation]);
 
   if (isLoading || error) {

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -43,6 +43,7 @@ import { useGetMetabotConversationQuery } from "../../api";
 import type { ConversationFeedback, GeneratedQuery } from "../../types";
 
 import { ConversationHeader } from "./ConversationHeader";
+import { convertSlackChatMessage } from "./slack-mrkdwn";
 
 export function ConversationDetailPage({ params }: WithRouterProps) {
   const convoId = params.convoId;
@@ -54,6 +55,16 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
   } = useGetMetabotConversationQuery(convoId, {
     refetchOnMountOrArgChange: true,
   });
+
+  const chatMessages = useMemo(() => {
+    const isSlackbot =
+      conversation.profile_id === "slackbot" ||
+      conversation.profile_id === "slack";
+
+    return isSlackbot
+      ? (conversation.chat_messages ?? []).map(convertSlackChatMessage)
+      : (conversation.chat_messages ?? []);
+  }, [conversation]);
 
   if (isLoading || error) {
     return (
@@ -99,7 +110,7 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
                 <FeedbackCard
                   key={item.id}
                   feedback={item}
-                  chatMessages={conversation.chat_messages ?? []}
+                  chatMessages={chatMessages}
                 />
               ))}
             </Stack>
@@ -117,7 +128,7 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
           </Flex>
           <Card withBorder shadow="none" p="xl">
             <Messages
-              messages={conversation.chat_messages ?? []}
+              messages={chatMessages}
               errorMessages={[]}
               isDoingScience={false}
               debug

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/slack-mrkdwn.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/slack-mrkdwn.ts
@@ -1,0 +1,44 @@
+import { match } from "ts-pattern";
+
+import type { MetabotChatMessage } from "metabase/metabot/state/types";
+
+const URL_WITH_LABEL = /<((?:https?|mailto|tel):[^|>\s]+)\|([^>]+)>/g;
+const BARE_URL = /<((?:https?|mailto|tel):[^|>\s]+)>/g;
+const USER_MENTION = /<@([UW][A-Z0-9]+)>/g;
+const CHANNEL_MENTION_WITH_NAME = /<#[CG][A-Z0-9]+\|([^>]+)>/g;
+const CHANNEL_MENTION = /<#([CG][A-Z0-9]+)>/g;
+const SUBTEAM_MENTION_WITH_NAME = /<!subteam\^[A-Z0-9]+\|([^>]+)>/g;
+const SPECIAL_MENTION = /<!(here|channel|everyone)>/g;
+
+export function slackMrkdwnToMarkdown(text: string): string {
+  return text
+    .replace(URL_WITH_LABEL, (_, url, label) => `[${label}](${url})`)
+    .replace(BARE_URL, (_, url) => `<${url}>`)
+    .replace(USER_MENTION, "@$1")
+    .replace(CHANNEL_MENTION_WITH_NAME, "#$1")
+    .replace(CHANNEL_MENTION, "#$1")
+    .replace(SUBTEAM_MENTION_WITH_NAME, "@$1")
+    .replace(SPECIAL_MENTION, "@$1");
+}
+
+export function convertSlackChatMessage(
+  message: MetabotChatMessage,
+): MetabotChatMessage {
+  return match(message)
+    .with({ role: "user", type: "text" }, (m) => ({
+      ...m,
+      message: slackMrkdwnToMarkdown(m.message),
+    }))
+    .with({ role: "user", type: "action" }, (m) => ({
+      ...m,
+      message: slackMrkdwnToMarkdown(m.message),
+      userMessage: slackMrkdwnToMarkdown(m.userMessage),
+    }))
+    .with({ role: "agent", type: "text" }, (m) => ({
+      ...m,
+      message: slackMrkdwnToMarkdown(m.message),
+    }))
+    .with({ role: "agent", type: "data_part" }, (m) => m)
+    .with({ role: "agent", type: "tool_call" }, (m) => m)
+    .exhaustive();
+}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/slack-mrkdwn.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/slack-mrkdwn.unit.spec.ts
@@ -1,0 +1,59 @@
+import { slackMrkdwnToMarkdown } from "./slack-mrkdwn";
+
+describe("slackMrkdwnToMarkdown", () => {
+  it("converts <url|label> to [label](url)", () => {
+    expect(
+      slackMrkdwnToMarkdown(
+        "see <https://stats.metabase.com/question/4369|Survey Scores> now",
+      ),
+    ).toBe("see [Survey Scores](https://stats.metabase.com/question/4369) now");
+  });
+
+  it("preserves bare <url> as autolinks", () => {
+    expect(slackMrkdwnToMarkdown("visit <https://example.com>")).toBe(
+      "visit <https://example.com>",
+    );
+  });
+
+  it("converts mailto labels to markdown links", () => {
+    expect(slackMrkdwnToMarkdown("<mailto:foo@bar.com|email foo>")).toBe(
+      "[email foo](mailto:foo@bar.com)",
+    );
+  });
+
+  it("strips Slack user mention syntax", () => {
+    expect(slackMrkdwnToMarkdown("hi <@U0A1860HEAG> there")).toBe(
+      "hi @U0A1860HEAG there",
+    );
+  });
+
+  it("renders channel mention with name", () => {
+    expect(slackMrkdwnToMarkdown("come to <#C123ABC|general>")).toBe(
+      "come to #general",
+    );
+  });
+
+  it("renders bare channel mention", () => {
+    expect(slackMrkdwnToMarkdown("come to <#C123ABC>")).toBe(
+      "come to #C123ABC",
+    );
+  });
+
+  it("renders subteam mentions with names", () => {
+    expect(slackMrkdwnToMarkdown("ping <!subteam^S123|frontend>")).toBe(
+      "ping @frontend",
+    );
+  });
+
+  it("renders special mentions like channel/here/everyone", () => {
+    expect(slackMrkdwnToMarkdown("<!here> hi <!channel>")).toBe(
+      "@here hi @channel",
+    );
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(slackMrkdwnToMarkdown("just normal text *with stars*")).toBe(
+      "just normal text *with stars*",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.tsx
@@ -16,6 +16,7 @@ type ConversationFiltersProps = {
   onUserChange: (val: string | null) => void;
   group: string | null;
   onGroupChange: (val: string | null) => void;
+  groupNoFilterValue: string;
   tenant: string | null;
   onTenantChange: (val: string | null) => void;
   userOptions: { value: string; label: string }[];
@@ -31,6 +32,7 @@ export function ConversationFilters({
   onUserChange,
   group,
   onGroupChange,
+  groupNoFilterValue,
   tenant,
   onTenantChange,
   userOptions,
@@ -76,8 +78,10 @@ export function ConversationFilters({
       <Select
         placeholder={t`Group`}
         data={groupOptions}
-        value={group}
-        onChange={onGroupChange}
+        value={group ?? groupNoFilterValue}
+        onChange={(val) =>
+          onGroupChange(val === groupNoFilterValue ? null : val)
+        }
         searchable
         w={180}
         bdrs="sm"

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/index.ts
@@ -1,5 +1,6 @@
 export { ConversationFilters } from "./ConversationFilters";
 export {
+  ALL_USERS_SYNTHETIC,
   DEFAULT_DATE,
   DEFAULT_DATE_FILTER,
   DEFAULT_GROUP,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/index.ts
@@ -1,6 +1,5 @@
 export { ConversationFilters } from "./ConversationFilters";
 export {
-  ALL_USERS_SYNTHETIC,
   DEFAULT_DATE,
   DEFAULT_DATE_FILTER,
   DEFAULT_GROUP,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/url-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/url-state.ts
@@ -4,7 +4,7 @@ import {
   getFirstParamValue,
 } from "metabase/common/hooks/use-url-state";
 
-import { DEFAULT_DATE, DEFAULT_GROUP } from "./useFilterOptions";
+import { DEFAULT_DATE } from "./useFilterOptions";
 
 export type FilterUrlState = {
   date: string | null;
@@ -22,13 +22,13 @@ export const filterUrlStateConfig: UrlStateConfig<FilterUrlState> = {
   parse: (query) => ({
     date: parseString(query.date) ?? DEFAULT_DATE,
     user: parseString(query.user),
-    group: parseString(query.group) ?? DEFAULT_GROUP,
+    group: parseString(query.group),
     tenant: parseString(query.tenant),
   }),
   serialize: ({ date, user, group, tenant }) => ({
     date: date === DEFAULT_DATE ? undefined : (date ?? undefined),
     user: user ?? undefined,
-    group: group === DEFAULT_GROUP ? undefined : (group ?? undefined),
+    group: group ?? undefined,
     tenant: tenant ?? undefined,
   }),
 };

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
@@ -110,19 +110,18 @@ export function useFilterOptions({
 
   const dateFilter = useMemo(() => parseDateFilter(date), [date]);
   const userId = parseId(user);
-  const noFilterSentinel = tenantsFeatureEnabled
+  const groupNoFilterValue = tenantsFeatureEnabled
     ? ALL_USERS_SYNTHETIC
     : DEFAULT_GROUP;
-  const resolvedGroup = group ?? noFilterSentinel;
   const groupId =
-    resolvedGroup === noFilterSentinel ? undefined : parseId(resolvedGroup);
+    group == null || group === groupNoFilterValue ? undefined : parseId(group);
   const tenantId = hasTenants ? parseId(tenant) : undefined;
 
   return {
     dateFilter,
     userId,
-    group: resolvedGroup,
     groupId,
+    groupNoFilterValue,
     tenantId,
     userOptions,
     groupOptions,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
@@ -7,11 +7,13 @@ import { deserializeDateParameterValue } from "metabase/querying/parameters/util
 import { getUserName } from "metabase/utils/user";
 import { useListTenantsQuery } from "metabase-enterprise/api";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
+import type { GroupListQuery } from "metabase-types/api";
 
 import type { FilterUrlState } from "./url-state";
 
 export const DEFAULT_DATE = "past30days";
 export const DEFAULT_GROUP = "1"; // All Users group
+export const ALL_USERS_SYNTHETIC = "all";
 
 export const DEFAULT_DATE_FILTER: DateFilterValue = {
   type: "relative",
@@ -32,6 +34,31 @@ export function parseDateFilter(date: string | null): DateFilterValue {
   return (
     (date ? deserializeDateParameterValue(date) : null) ?? DEFAULT_DATE_FILTER
   );
+}
+
+function sortGroupsTenantsEnabled(
+  groups: readonly GroupListQuery[],
+): GroupListQuery[] {
+  const internal = groups.filter(
+    (g) => g.magic_group_type === "all-internal-users",
+  );
+  const external = groups.filter(
+    (g) => g.magic_group_type === "all-external-users",
+  );
+  const rest = groups.filter(
+    (g) =>
+      g.magic_group_type !== "all-internal-users" &&
+      g.magic_group_type !== "all-external-users",
+  );
+  return [...internal, ...external, ...rest];
+}
+
+function sortGroupsTenantsDisabled(
+  groups: readonly GroupListQuery[],
+): GroupListQuery[] {
+  const defaultGroup = groups.filter((g) => String(g.id) === DEFAULT_GROUP);
+  const rest = groups.filter((g) => String(g.id) !== DEFAULT_GROUP);
+  return [...defaultGroup, ...rest];
 }
 
 export function useFilterOptions({
@@ -57,14 +84,18 @@ export function useFilterOptions({
   );
 
   const groupOptions = useMemo(() => {
-    const groups = (groupsData ?? []).map((g) => ({
+    const rawGroups = groupsData ?? [];
+    const ordered = tenantsFeatureEnabled
+      ? sortGroupsTenantsEnabled(rawGroups)
+      : sortGroupsTenantsDisabled(rawGroups);
+    const options = ordered.map((g) => ({
       value: String(g.id),
       label: g.name,
     }));
-    const defaultGroup = groups.find((g) => g.value === DEFAULT_GROUP);
-    const rest = groups.filter((g) => g.value !== DEFAULT_GROUP);
-    return defaultGroup ? [defaultGroup, ...rest] : groups;
-  }, [groupsData]);
+    return tenantsFeatureEnabled
+      ? [{ value: ALL_USERS_SYNTHETIC, label: t`All users` }, ...options]
+      : options;
+  }, [groupsData, tenantsFeatureEnabled]);
 
   const tenantOptions = useMemo(
     () =>
@@ -79,12 +110,18 @@ export function useFilterOptions({
 
   const dateFilter = useMemo(() => parseDateFilter(date), [date]);
   const userId = parseId(user);
-  const groupId = group === DEFAULT_GROUP ? undefined : parseId(group);
+  const noFilterSentinel = tenantsFeatureEnabled
+    ? ALL_USERS_SYNTHETIC
+    : DEFAULT_GROUP;
+  const resolvedGroup = group ?? noFilterSentinel;
+  const groupId =
+    resolvedGroup === noFilterSentinel ? undefined : parseId(resolvedGroup);
   const tenantId = hasTenants ? parseId(tenant) : undefined;
 
   return {
     dateFilter,
     userId,
+    group: resolvedGroup,
     groupId,
     tenantId,
     userOptions,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -16,11 +16,7 @@ import {
   VIEW_USAGE_LOG,
 } from "../../constants";
 import { useAuditTable } from "../../hooks/useAuditTable";
-import {
-  ALL_USERS_SYNTHETIC,
-  ConversationFilters,
-  useFilterOptions,
-} from "../ConversationFilters";
+import { ConversationFilters, useFilterOptions } from "../ConversationFilters";
 import {
   type UrlState as ConversationsUrlState,
   urlStateConfig as conversationsUrlStateConfig,
@@ -128,20 +124,20 @@ const labelUnknownIpAddress = (value: unknown) =>
 
 export function ConversationStatsPage({ location }: WithRouterProps) {
   const dispatch = useDispatch();
-  const [{ date, user, group: groupParam, tenant, metric }, { patchUrlState }] =
+  const [{ date, user, group, tenant, metric }, { patchUrlState }] =
     useUrlState(location, statsUrlStateConfig);
 
   const {
     dateFilter,
     userId,
-    group,
     groupId,
+    groupNoFilterValue,
     tenantId,
     userOptions,
     groupOptions,
     tenantOptions,
     hasTenants,
-  } = useFilterOptions({ date, user, group: groupParam, tenant });
+  } = useFilterOptions({ date, user, group, tenant });
 
   const conversationsAudit = useAuditTable(VIEW_CONVERSATIONS);
   const usageLogAudit = useAuditTable(VIEW_USAGE_LOG);
@@ -185,14 +181,14 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             sort_direction: "desc",
             date,
             user,
-            group: groupParam,
+            group,
             tenant,
             ...filterOverrides,
           }),
         }),
       );
     },
-    [dispatch, date, user, groupParam, tenant],
+    [dispatch, date, user, group, tenant],
   );
 
   const handleDayClick = useCallback(
@@ -227,9 +223,8 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             user={user}
             onUserChange={(val) => patchUrlState({ user: val })}
             group={group}
-            onGroupChange={(val) =>
-              patchUrlState({ group: val === ALL_USERS_SYNTHETIC ? null : val })
-            }
+            onGroupChange={(val) => patchUrlState({ group: val })}
+            groupNoFilterValue={groupNoFilterValue}
             tenant={tenant}
             onTenantChange={(val) => patchUrlState({ tenant: val })}
             userOptions={userOptions}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -16,7 +16,11 @@ import {
   VIEW_USAGE_LOG,
 } from "../../constants";
 import { useAuditTable } from "../../hooks/useAuditTable";
-import { ConversationFilters, useFilterOptions } from "../ConversationFilters";
+import {
+  ALL_USERS_SYNTHETIC,
+  ConversationFilters,
+  useFilterOptions,
+} from "../ConversationFilters";
 import {
   type UrlState as ConversationsUrlState,
   urlStateConfig as conversationsUrlStateConfig,
@@ -124,19 +128,20 @@ const labelUnknownIpAddress = (value: unknown) =>
 
 export function ConversationStatsPage({ location }: WithRouterProps) {
   const dispatch = useDispatch();
-  const [{ date, user, group, tenant, metric }, { patchUrlState }] =
+  const [{ date, user, group: groupParam, tenant, metric }, { patchUrlState }] =
     useUrlState(location, statsUrlStateConfig);
 
   const {
     dateFilter,
     userId,
+    group,
     groupId,
     tenantId,
     userOptions,
     groupOptions,
     tenantOptions,
     hasTenants,
-  } = useFilterOptions({ date, user, group, tenant });
+  } = useFilterOptions({ date, user, group: groupParam, tenant });
 
   const conversationsAudit = useAuditTable(VIEW_CONVERSATIONS);
   const usageLogAudit = useAuditTable(VIEW_USAGE_LOG);
@@ -180,14 +185,14 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             sort_direction: "desc",
             date,
             user,
-            group,
+            group: groupParam,
             tenant,
             ...filterOverrides,
           }),
         }),
       );
     },
-    [dispatch, date, user, group, tenant],
+    [dispatch, date, user, groupParam, tenant],
   );
 
   const handleDayClick = useCallback(
@@ -222,7 +227,9 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             user={user}
             onUserChange={(val) => patchUrlState({ user: val })}
             group={group}
-            onGroupChange={(val) => patchUrlState({ group: val })}
+            onGroupChange={(val) =>
+              patchUrlState({ group: val === ALL_USERS_SYNTHETIC ? null : val })
+            }
             tenant={tenant}
             onTenantChange={(val) => patchUrlState({ tenant: val })}
             userOptions={userOptions}
@@ -288,7 +295,9 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             {...sharedChartProps}
             titles={groupTitles}
             display="row"
-            buildQuery={buildGroupBreakoutQuery}
+            buildQuery={(opts) =>
+              buildGroupBreakoutQuery({ ...opts, excludeAllUsers: !hasTenants })
+            }
             h={500}
           />
           <BreakoutChart

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/query-utils.ts
@@ -272,6 +272,10 @@ type BreakoutQueryOpts = StatsFilters & {
   groupMembersTable: TableMetadata | CardMetadata;
 };
 
+type GroupBreakoutQueryOpts = BreakoutQueryOpts & {
+  excludeAllUsers: boolean;
+};
+
 export function excludeAllUsersGroup(query: Query): Query {
   const col = findColumn(query, "group_id", Lib.filterableColumns);
   if (!col) {
@@ -301,13 +305,14 @@ export function buildGroupBreakoutQuery({
   groupId,
   tenantId,
   metric,
-}: BreakoutQueryOpts): Query {
+  excludeAllUsers,
+}: GroupBreakoutQueryOpts): Query {
   let q = Lib.queryFromTableOrCardMetadata(provider, table);
   q = applyDateFilter(q, dateFilter);
   q = applyIdFilter(q, "user_id", userId);
   q = applyIdFilter(q, "tenant_id", tenantId);
   q = joinGroupMembers(q, groupMembersTable);
-  q = excludeAllUsersGroup(q);
+  q = excludeAllUsers ? excludeAllUsersGroup(q) : q;
   q = applyIdFilter(q, "group_id", groupId);
   q = applyUsageStatsAggregation(q, metric);
   q = breakoutByJoinedGroupName(q);

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
@@ -9,39 +9,27 @@ import { MetabotAdminLayout } from "metabase/metabot/components/MetabotAdmin/Met
 import { Card, Flex, Title } from "metabase/ui";
 
 import { useListMetabotConversationsQuery } from "../../api";
-import {
-  ALL_USERS_SYNTHETIC,
-  ConversationFilters,
-  useFilterOptions,
-} from "../ConversationFilters";
+import { ConversationFilters, useFilterOptions } from "../ConversationFilters";
 
 import { ConversationsTable } from "./ConversationsTable";
 import { PAGE_SIZE, urlStateConfig } from "./utils";
 
 export function ConversationsPage({ location }: WithRouterProps) {
   const [
-    {
-      page,
-      sort_column,
-      sort_direction,
-      date,
-      user,
-      group: groupParam,
-      tenant,
-    },
+    { page, sort_column, sort_direction, date, user, group, tenant },
     { patchUrlState },
   ] = useUrlState(location, urlStateConfig);
 
   const {
     userId,
-    group,
     groupId,
+    groupNoFilterValue,
     tenantId,
     userOptions,
     groupOptions,
     tenantOptions,
     hasTenants,
-  } = useFilterOptions({ date, user, group: groupParam, tenant });
+  } = useFilterOptions({ date, user, group, tenant });
 
   const {
     data: conversationsData,
@@ -81,12 +69,8 @@ export function ConversationsPage({ location }: WithRouterProps) {
             user={user}
             onUserChange={(val) => patchUrlState({ user: val, page: 0 })}
             group={group}
-            onGroupChange={(val) =>
-              patchUrlState({
-                group: val === ALL_USERS_SYNTHETIC ? null : val,
-                page: 0,
-              })
-            }
+            onGroupChange={(val) => patchUrlState({ group: val, page: 0 })}
+            groupNoFilterValue={groupNoFilterValue}
             tenant={tenant}
             onTenantChange={(val) => patchUrlState({ tenant: val, page: 0 })}
             userOptions={userOptions}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
@@ -9,26 +9,39 @@ import { MetabotAdminLayout } from "metabase/metabot/components/MetabotAdmin/Met
 import { Card, Flex, Title } from "metabase/ui";
 
 import { useListMetabotConversationsQuery } from "../../api";
-import { ConversationFilters, useFilterOptions } from "../ConversationFilters";
+import {
+  ALL_USERS_SYNTHETIC,
+  ConversationFilters,
+  useFilterOptions,
+} from "../ConversationFilters";
 
 import { ConversationsTable } from "./ConversationsTable";
 import { PAGE_SIZE, urlStateConfig } from "./utils";
 
 export function ConversationsPage({ location }: WithRouterProps) {
   const [
-    { page, sort_column, sort_direction, date, user, group, tenant },
+    {
+      page,
+      sort_column,
+      sort_direction,
+      date,
+      user,
+      group: groupParam,
+      tenant,
+    },
     { patchUrlState },
   ] = useUrlState(location, urlStateConfig);
 
   const {
     userId,
+    group,
     groupId,
     tenantId,
     userOptions,
     groupOptions,
     tenantOptions,
     hasTenants,
-  } = useFilterOptions({ date, user, group, tenant });
+  } = useFilterOptions({ date, user, group: groupParam, tenant });
 
   const {
     data: conversationsData,
@@ -68,7 +81,12 @@ export function ConversationsPage({ location }: WithRouterProps) {
             user={user}
             onUserChange={(val) => patchUrlState({ user: val, page: 0 })}
             group={group}
-            onGroupChange={(val) => patchUrlState({ group: val, page: 0 })}
+            onGroupChange={(val) =>
+              patchUrlState({
+                group: val === ALL_USERS_SYNTHETIC ? null : val,
+                page: 0,
+              })
+            }
             tenant={tenant}
             onTenantChange={(val) => patchUrlState({ tenant: val, page: 0 })}
             userOptions={userOptions}

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminLayout.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminLayout.tsx
@@ -14,7 +14,7 @@ export const MetabotAdminLayout = ({
   <AdminSettingsLayout sidebar={<MetabotNavPane />} fullWidth={fullWidth}>
     <ErrorBoundary>
       {fullWidth ? (
-        <Box py="lg" px="xl" maw="100rem">
+        <Box py="lg" px="xl" maw="100rem" mx="auto">
           {children}
         </Box>
       ) : (

--- a/frontend/src/metabase/metabot/constants.ts
+++ b/frontend/src/metabase/metabot/constants.ts
@@ -40,6 +40,12 @@ export const METABOT_PROFILES = {
       return t`SQL`;
     },
   },
+  // deprecated
+  slack: {
+    get label() {
+      return t`Slackbot`;
+    },
+  },
   slackbot: {
     get label() {
       return t`Slackbot`;

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v1/h2-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v1/h2-ai_usage_log.sql
@@ -7,6 +7,7 @@ SELECT
     a.source,
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
+        WHEN 'agent'                             THEN 'Metabot'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v1/mysql-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v1/mysql-ai_usage_log.sql
@@ -7,6 +7,7 @@ SELECT
     a.source,
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
+        WHEN 'agent'                             THEN 'Metabot'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v1/postgres-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v1/postgres-ai_usage_log.sql
@@ -7,6 +7,7 @@ SELECT
     a.source,
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
+        WHEN 'agent'                             THEN 'Metabot'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v1/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v1/h2-metabot_conversations.sql
@@ -51,6 +51,7 @@ SELECT
      LIMIT 1)                                                         AS source,
     (SELECT CASE aul.source
                 WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
                 WHEN 'document_generate_content'         THEN 'Documents'
                 WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
                 WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v1/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v1/mysql-metabot_conversations.sql
@@ -51,6 +51,7 @@ SELECT
      LIMIT 1)                                                         AS source,
     (SELECT CASE aul.source
                 WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
                 WHEN 'document_generate_content'         THEN 'Documents'
                 WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
                 WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v1/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v1/postgres-metabot_conversations.sql
@@ -51,6 +51,7 @@ SELECT
      LIMIT 1)                                                         AS source,
     (SELECT CASE aul.source
                 WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
                 WHEN 'document_generate_content'         THEN 'Documents'
                 WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
                 WHEN 'slack'                             THEN 'Slackbot'


### PR DESCRIPTION
- Fixed group filter if tenants are enabled (previously didn't allow filtering by the all users group even though it was selected by default - the value was really omitted as a filter. this is correct / fine without tenants enabled, but erroneous if it is)
- added a CASE for `agent` for `soure_name` in our views, this lets it get merged with `metabot_agent` for historical data
- centers the content on large screens
- handles converting slack markdown to our internal markdown format