### PR TITLE
fix result metadata in new usage analytics models

### DIFF
--- a/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
@@ -72,6 +72,21 @@ result_metadata:
   visibility_type: normal
 - base_type: type/Text
   coercion_strategy: null
+  description: Display label for the originating surface (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
+  display_name: Source Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, source_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, source_name]
+  name: source_name
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
   description: Provider/model identifier returned by the LLM (e.g. anthropic/claude-sonnet-4-20250514).
   display_name: Model
   effective_type: type/Text

--- a/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
@@ -24,95 +24,246 @@ dataset_query:
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
-- description: Primary key from ai_usage_log.id.
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Primary key from ai_usage_log.id.
   display_name: Usage Log ID
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, usage_log_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, usage_log_id]
   name: usage_log_id
   semantic_type: type/PK
+  settings: null
   visibility_type: normal
-- description: Timestamp of this LLM round-trip.
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: Timestamp of this LLM round-trip.
   display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, created_at]
+  - {temporal-unit: default}
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, created_at]
   name: created_at
   semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
   visibility_type: normal
-- description: Originating surface for the call (e.g. metabot_agent, slackbot, document_generate_content, oss-sql-gen).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Originating surface for the call (e.g. metabot_agent, slackbot, document_generate_content, oss-sql-gen).
   display_name: Source
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, source]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, source]
   name: source
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Provider/model identifier returned by the LLM (e.g. anthropic/claude-sonnet-4-20250514).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Provider/model identifier returned by the LLM (e.g. anthropic/claude-sonnet-4-20250514).
   display_name: Model
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, model]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, model]
   name: model
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Metabot profile that issued the call (e.g. internal, slackbot).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Metabot profile that issued the call (e.g. internal, slackbot).
   display_name: Profile ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, profile_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, profile_id]
   name: profile_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Prompt tokens consumed for this call.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Prompt tokens consumed for this call.
   display_name: Prompt Tokens
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, prompt_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, prompt_tokens]
   name: prompt_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Completion tokens generated for this call.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Completion tokens generated for this call.
   display_name: Completion Tokens
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, completion_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, completion_tokens]
   name: completion_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Total tokens for this call (prompt + completion).
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Total tokens for this call (prompt + completion).
   display_name: Total Tokens
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, total_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, total_tokens]
   name: total_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: ID of the owning Metabot conversation, if any (null for non-conversational and most Slack-originated calls).
+- base_type: type/Text
+  coercion_strategy: null
+  description: ID of the owning Metabot conversation, if any (null for non-conversational and most Slack-originated calls).
   display_name: Conversation ID
-  fk_target_field_id:
-  - Internal Metabase Database
-  - public
-  - v_metabot_conversations
-  - conversation_id
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, conversation_id]
+  - null
+  fk_target_field_id: [Internal Metabase Database, public, v_metabot_conversations, conversation_id]
+  id: [Internal Metabase Database, public, v_ai_usage_log, conversation_id]
   name: conversation_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: ID of the user who triggered the call (null for system/Quartz calls).
+- base_type: type/Integer
+  coercion_strategy: null
+  description: ID of the user who triggered the call (null for system/Quartz calls).
   display_name: User ID
-  fk_target_field_id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - user_id
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, user_id]
+  - null
+  fk_target_field_id: [Internal Metabase Database, public, v_users, user_id]
+  id: [Internal Metabase Database, public, v_ai_usage_log, user_id]
   name: user_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: Synthetic 'user_<id>' string used as a stable bucket key in by-user breakouts.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Synthetic 'user_<id>' string used as a stable bucket key in by-user breakouts.
   display_name: User Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, user_qualified_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, user_qualified_id]
   name: user_qualified_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Display name of the user (full name when set, otherwise email).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Display name of the user (full name when set, otherwise email).
   display_name: User Display Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, user_display_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, user_display_name]
   name: user_display_name
   semantic_type: type/Name
+  settings: null
   visibility_type: normal
-- description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
   display_name: Group Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, group_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, group_name]
   name: group_name
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: IP address of the originating Metabot conversation, when one exists.
+- base_type: type/Text
+  coercion_strategy: null
+  description: IP address of the originating Metabot conversation, when one exists.
   display_name: IP Address
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, ip_address]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, ip_address]
   name: ip_address
   semantic_type: null
+  settings: null
   visibility_type: normal
-- description: Tenant ID associated with the call, if any.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Tenant ID associated with the call, if any.
   display_name: Tenant ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, tenant_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, tenant_id]
   name: tenant_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: Stable identifier for a single user turn; multiple usage_log rows share a request_id across agent iterations.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Stable identifier for a single user turn; multiple usage_log rows share a request_id across agent iterations.
   display_name: Request ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_ai_usage_log, request_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_ai_usage_log, request_id]
   name: request_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
 visualization_settings:
   column_settings: null

--- a/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/ai_usage_log.yaml
@@ -8,19 +8,13 @@ collection_id: vG58R8k-QddHWA7_47umn
 collection_position: 23
 query_type: query
 database_id: Internal Metabase Database
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 parameters: []
 parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   stages:
-  - source-table:
-    - Internal Metabase Database
-    - public
-    - v_ai_usage_log
+  - source-table: [Internal Metabase Database, public, v_ai_usage_log]
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
@@ -284,8 +278,5 @@ visualization_settings:
   column_settings: null
 card_schema: 23
 serdes/meta:
-- id: joMVMZY847nXW3WBi-zIn
-  label: ai_usage_log
-  model: Card
-metabase_version: v1.57.1-SNAPSHOT (9afffd8)
+- {id: joMVMZY847nXW3WBi-zIn, label: ai_usage_log, model: Card}
 type: model

--- a/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
@@ -8,19 +8,13 @@ collection_id: vG58R8k-QddHWA7_47umn
 collection_position: 22
 query_type: query
 database_id: Internal Metabase Database
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 parameters: []
 parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   stages:
-  - source-table:
-    - Internal Metabase Database
-    - public
-    - v_metabot_conversations
+  - source-table: [Internal Metabase Database, public, v_metabot_conversations]
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
@@ -345,8 +339,5 @@ visualization_settings:
   column_settings: null
 card_schema: 23
 serdes/meta:
-- id: tWs1LULVO8OZmog7zsif2
-  label: metabot_conversations
-  model: Card
-metabase_version: v1.57.1-SNAPSHOT (9afffd8)
+- {id: tWs1LULVO8OZmog7zsif2, label: metabot_conversations, model: Card}
 type: model

--- a/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
@@ -223,6 +223,21 @@ result_metadata:
   visibility_type: normal
 - base_type: type/Text
   coercion_strategy: null
+  description: Display label for the Metabot profile that handled this conversation (e.g. Internal, Embedding, Slackbot, SQL); humanized version of profile_id.
+  display_name: Profile Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, profile_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, profile_name]
+  name: profile_name
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
   description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
   display_name: Group Name
   effective_type: type/Text
@@ -248,6 +263,21 @@ result_metadata:
   fk_target_field_id: null
   id: [Internal Metabase Database, public, v_metabot_conversations, source]
   name: source
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: Display label for the surface that originated the conversation (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
+  display_name: Source Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, source_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, source_name]
+  name: source_name
   semantic_type: type/Category
   settings: null
   visibility_type: normal

--- a/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/metabot_conversations.yaml
@@ -24,105 +24,292 @@ dataset_query:
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
-- description: UUID of the conversation.
+- base_type: type/Text
+  coercion_strategy: null
+  description: UUID of the conversation.
   display_name: Conversation ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, conversation_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, conversation_id]
   name: conversation_id
   semantic_type: type/PK
+  settings: null
   visibility_type: normal
-- description: Timestamp the conversation was created.
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: Timestamp the conversation was created.
   display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, created_at]
+  - {temporal-unit: default}
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, created_at]
   name: created_at
   semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
   visibility_type: normal
-- description: ID of the user who owns the conversation.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: ID of the user who owns the conversation.
   display_name: User ID
-  fk_target_field_id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - user_id
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, user_id]
+  - null
+  fk_target_field_id: [Internal Metabase Database, public, v_users, user_id]
+  id: [Internal Metabase Database, public, v_metabot_conversations, user_id]
   name: user_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: AI-generated summary of the conversation, when available.
+- base_type: type/Text
+  coercion_strategy: null
+  description: AI-generated summary of the conversation, when available.
   display_name: Summary
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, summary]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, summary]
   name: summary
   semantic_type: type/Description
+  settings: null
   visibility_type: normal
-- description: Display name of the owning user (full name when set, otherwise email).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Display name of the owning user (full name when set, otherwise email).
   display_name: User Display Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, user_display_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, user_display_name]
   name: user_display_name
   semantic_type: type/Name
+  settings: null
   visibility_type: normal
-- description: Total non-deleted messages in the conversation (user + assistant).
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Total non-deleted messages in the conversation (user + assistant).
   display_name: Message Count
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, message_count]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, message_count]
   name: message_count
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Count of user-role messages in the conversation.
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Count of user-role messages in the conversation.
   display_name: User Message Count
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, user_message_count]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, user_message_count]
   name: user_message_count
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Count of assistant-role messages in the conversation.
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Count of assistant-role messages in the conversation.
   display_name: Assistant Message Count
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, assistant_message_count]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, assistant_message_count]
   name: assistant_message_count
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Total tokens consumed across the conversation (prompt + completion).
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Total tokens consumed across the conversation (prompt + completion).
   display_name: Total Tokens
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, total_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, total_tokens]
   name: total_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Prompt tokens consumed across the conversation.
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Prompt tokens consumed across the conversation.
   display_name: Prompt Tokens
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, prompt_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, prompt_tokens]
   name: prompt_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Completion tokens generated across the conversation.
+- base_type: type/BigInteger
+  coercion_strategy: null
+  description: Completion tokens generated across the conversation.
   display_name: Completion Tokens
+  effective_type: type/BigInteger
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, completion_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, completion_tokens]
   name: completion_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: Timestamp of the most recent non-deleted message in the conversation.
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: Timestamp of the most recent non-deleted message in the conversation.
   display_name: Last Message At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, last_message_at]
+  - {temporal-unit: default}
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, last_message_at]
   name: last_message_at
   semantic_type: null
+  settings: null
+  unit: default
   visibility_type: normal
-- description: Metabot profile (e.g. default, embedded) that handled this conversation; taken from the first assistant message.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Metabot profile (e.g. default, embedded) that handled this conversation; taken from the first assistant message.
   display_name: Profile ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, profile_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, profile_id]
   name: profile_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
   display_name: Group Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, group_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, group_name]
   name: group_name
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Surface that originated the conversation (e.g. web, slack, embed); taken from the first ai_usage_log entry.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Surface that originated the conversation (e.g. web, slack, embed); taken from the first ai_usage_log entry.
   display_name: Source
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, source]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, source]
   name: source
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: IP address recorded on the metabot_conversation row, if any.
+- base_type: type/Text
+  coercion_strategy: null
+  description: IP address recorded on the metabot_conversation row, if any.
   display_name: IP Address
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, ip_address]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, ip_address]
   name: ip_address
   semantic_type: null
+  settings: null
   visibility_type: normal
-- description: Tenant ID associated with the conversation's AI usage, if any.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Tenant ID associated with the conversation's AI usage, if any.
   display_name: Tenant ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, tenant_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, tenant_id]
   name: tenant_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: Display name of the tenant associated with the conversation, if any.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Display name of the tenant associated with the conversation, if any.
   display_name: Tenant Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, tenant_name]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, tenant_name]
   name: tenant_name
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: LLM model used for the conversation; taken from the first ai_usage_log entry.
+- base_type: type/Text
+  coercion_strategy: null
+  description: LLM model used for the conversation; taken from the first ai_usage_log entry.
   display_name: Model
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_conversations, model]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_conversations, model]
   name: model
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
 visualization_settings:
   column_settings: null

--- a/resources/instance_analytics/collections/main/usage_analytics/metabot_messages.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/metabot_messages.yaml
@@ -8,19 +8,13 @@ collection_id: vG58R8k-QddHWA7_47umn
 collection_position: 21
 query_type: query
 database_id: Internal Metabase Database
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_messages
+table_id: [Internal Metabase Database, public, v_metabot_messages]
 parameters: []
 parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   stages:
-  - source-table:
-    - Internal Metabase Database
-    - public
-    - v_metabot_messages
+  - source-table: [Internal Metabase Database, public, v_metabot_messages]
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
@@ -164,8 +158,5 @@ visualization_settings:
   column_settings: null
 card_schema: 23
 serdes/meta:
-- id: H20MNO_ZroDFEmgYzMLcZ
-  label: metabot_messages
-  model: Card
-metabase_version: v1.57.1-SNAPSHOT (9afffd8)
+- {id: H20MNO_ZroDFEmgYzMLcZ, label: metabot_messages, model: Card}
 type: model

--- a/resources/instance_analytics/collections/main/usage_analytics/metabot_messages.yaml
+++ b/resources/instance_analytics/collections/main/usage_analytics/metabot_messages.yaml
@@ -24,55 +24,141 @@ dataset_query:
     lib/type: mbql.stage/mbql
   lib/type: mbql/query
 result_metadata:
-- description: Primary key from metabot_message.id.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Primary key from metabot_message.id.
   display_name: Message ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, message_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, message_id]
   name: message_id
   semantic_type: type/PK
+  settings: null
   visibility_type: normal
-- description: UUID of the owning conversation.
+- base_type: type/Text
+  coercion_strategy: null
+  description: UUID of the owning conversation.
   display_name: Conversation ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, conversation_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, conversation_id]
   name: conversation_id
   semantic_type: null
+  settings: null
   visibility_type: normal
-- description: Timestamp when the message was stored.
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: Timestamp when the message was stored.
   display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, created_at]
+  - {temporal-unit: default}
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, created_at]
   name: created_at
   semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
   visibility_type: normal
-- description: Role of the message sender (e.g. user, assistant).
+- base_type: type/Text
+  coercion_strategy: null
+  description: Role of the message sender (e.g. user, assistant).
   display_name: Role
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, role]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, role]
   name: role
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Metabot profile (e.g. default, embedded) that produced the message.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Metabot profile (e.g. default, embedded) that produced the message.
   display_name: Profile ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, profile_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, profile_id]
   name: profile_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
-- description: Total tokens consumed for this message (prompt + completion).
+- base_type: type/Integer
+  coercion_strategy: null
+  description: Total tokens consumed for this message (prompt + completion).
   display_name: Total Tokens
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, total_tokens]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, total_tokens]
   name: total_tokens
   semantic_type: type/Quantity
+  settings: null
   visibility_type: normal
-- description: ID of the user who owns this conversation.
+- base_type: type/Integer
+  coercion_strategy: null
+  description: ID of the user who owns this conversation.
   display_name: User ID
-  fk_target_field_id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - user_id
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, user_id]
+  - null
+  fk_target_field_id: [Internal Metabase Database, public, v_users, user_id]
+  id: [Internal Metabase Database, public, v_metabot_messages, user_id]
   name: user_id
   semantic_type: type/FK
+  settings: null
   visibility_type: normal
-- description: Slack message timestamp; null for web-originated messages.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Slack message timestamp; null for web-originated messages.
   display_name: Slack Msg ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, slack_msg_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, slack_msg_id]
   name: slack_msg_id
   semantic_type: null
+  settings: null
   visibility_type: normal
-- description: Slack channel ID; null for web-originated messages.
+- base_type: type/Text
+  coercion_strategy: null
+  description: Slack channel ID; null for web-originated messages.
   display_name: Channel ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - [Internal Metabase Database, public, v_metabot_messages, channel_id]
+  - null
+  fk_target_field_id: null
+  id: [Internal Metabase Database, public, v_metabot_messages, channel_id]
   name: channel_id
   semantic_type: type/Category
+  settings: null
   visibility_type: normal
 visualization_settings:
   column_settings: null

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/completion_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/completion_tokens.yaml
@@ -12,9 +12,9 @@ base_type: type/Integer
 effective_type: type/Integer
 semantic_type: type/Quantity
 dimensions: []
-position: 6
+position: 7
 custom_position: 0
-database_position: 6
+database_position: 7
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/completion_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/completion_tokens.yaml
@@ -3,10 +3,7 @@ display_name: Completion Tokens
 description: Completion tokens generated for this call.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 7
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: completion_tokens
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: completion_tokens, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/conversation_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/conversation_id.yaml
@@ -3,10 +3,7 @@ display_name: Conversation ID
 description: ID of the owning Metabot conversation, if any (null for non-conversational and most Slack-originated calls).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -22,14 +19,10 @@ custom_position: 0
 database_position: 9
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: conversation_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: conversation_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/conversation_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/conversation_id.yaml
@@ -17,9 +17,9 @@ fk_target_field_id:
 - v_metabot_conversations
 - conversation_id
 dimensions: []
-position: 8
+position: 9
 custom_position: 0
-database_position: 8
+database_position: 9
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/group_name.yaml
@@ -3,10 +3,7 @@ display_name: Group Name
 description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 13
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: group_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: group_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/group_name.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 12
+position: 13
 custom_position: 0
-database_position: 12
+database_position: 13
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/ip_address.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/ip_address.yaml
@@ -11,9 +11,9 @@ database_type: varchar
 base_type: type/Text
 effective_type: type/Text
 dimensions: []
-position: 13
+position: 14
 custom_position: 0
-database_position: 13
+database_position: 14
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/ip_address.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/ip_address.yaml
@@ -3,10 +3,7 @@ display_name: IP Address
 description: IP address of the originating Metabot conversation, when one exists.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -16,14 +13,10 @@ custom_position: 0
 database_position: 14
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: ip_address
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: ip_address, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/model.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/model.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 3
+position: 4
 custom_position: 0
-database_position: 3
+database_position: 4
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/model.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/model.yaml
@@ -3,10 +3,7 @@ display_name: Model
 description: Provider/model identifier returned by the LLM (e.g. anthropic/claude-sonnet-4-20250514).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 4
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: model
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: model, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/profile_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/profile_id.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 4
+position: 5
 custom_position: 0
-database_position: 4
+database_position: 5
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/profile_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/profile_id.yaml
@@ -3,10 +3,7 @@ display_name: Profile ID
 description: Metabot profile that issued the call (e.g. internal, slackbot).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 5
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: profile_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: profile_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/prompt_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/prompt_tokens.yaml
@@ -3,10 +3,7 @@ display_name: Prompt Tokens
 description: Prompt tokens consumed for this call.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 6
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: prompt_tokens
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: prompt_tokens, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/prompt_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/prompt_tokens.yaml
@@ -12,9 +12,9 @@ base_type: type/Integer
 effective_type: type/Integer
 semantic_type: type/Quantity
 dimensions: []
-position: 5
+position: 6
 custom_position: 0
-database_position: 5
+database_position: 6
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/request_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/request_id.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 15
+position: 16
 custom_position: 0
-database_position: 15
+database_position: 16
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/request_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/request_id.yaml
@@ -3,10 +3,7 @@ display_name: Request ID
 description: Stable identifier for a single user turn; multiple usage_log rows share a request_id across agent iterations.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 16
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: request_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: request_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/source_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/source_name.yaml
@@ -3,10 +3,7 @@ display_name: Source Name
 description: Display label for the originating surface (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 3
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: source_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: source_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/source_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/source_name.yaml
@@ -1,28 +1,29 @@
-name: ip_address
-display_name: IP Address
-description: IP address recorded on the metabot_conversation row, if any.
-created_at: '2026-04-24T19:39:29.987038Z'
+name: source_name
+display_name: Source Name
+description: Display label for the originating surface (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
+created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
-- v_metabot_conversations
+- v_ai_usage_log
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
+semantic_type: type/Category
 dimensions: []
-position: 17
+position: 3
 custom_position: 0
-database_position: 17
+database_position: 3
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database
   model: Database
 - id: public
   model: Schema
-- id: v_metabot_conversations
+- id: v_ai_usage_log
   model: Table
-- id: ip_address
+- id: source_name
   model: Field
 database_is_generated: false
 database_is_nullable: true

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/tenant_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/tenant_id.yaml
@@ -3,10 +3,7 @@ display_name: Tenant ID
 description: Tenant ID associated with the call, if any.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 15
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: tenant_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: tenant_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/tenant_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/tenant_id.yaml
@@ -12,9 +12,9 @@ base_type: type/Integer
 effective_type: type/Integer
 semantic_type: type/FK
 dimensions: []
-position: 14
+position: 15
 custom_position: 0
-database_position: 14
+database_position: 15
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/total_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/total_tokens.yaml
@@ -12,9 +12,9 @@ base_type: type/Integer
 effective_type: type/Integer
 semantic_type: type/Quantity
 dimensions: []
-position: 7
+position: 8
 custom_position: 0
-database_position: 7
+database_position: 8
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/total_tokens.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/total_tokens.yaml
@@ -3,10 +3,7 @@ display_name: Total Tokens
 description: Total tokens for this call (prompt + completion).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 8
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: total_tokens
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: total_tokens, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_display_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_display_name.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Name
 dimensions: []
-position: 11
+position: 12
 custom_position: 0
-database_position: 11
+database_position: 12
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_display_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_display_name.yaml
@@ -3,10 +3,7 @@ display_name: User Display Name
 description: Display name of the user (full name when set, otherwise email).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: text
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 12
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: user_display_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: user_display_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_id.yaml
@@ -17,9 +17,9 @@ fk_target_field_id:
 - v_users
 - user_id
 dimensions: []
-position: 9
+position: 10
 custom_position: 0
-database_position: 9
+database_position: 10
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_id.yaml
@@ -3,10 +3,7 @@ display_name: User ID
 description: ID of the user who triggered the call (null for system/Quartz calls).
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -22,14 +19,10 @@ custom_position: 0
 database_position: 10
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: user_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: user_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_qualified_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_qualified_id.yaml
@@ -3,10 +3,7 @@ display_name: User Qualified ID
 description: Synthetic 'user_<id>' string used as a stable bucket key in by-user breakouts.
 created_at: '2026-04-24T19:39:29.861736Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_ai_usage_log
+table_id: [Internal Metabase Database, public, v_ai_usage_log]
 database_type: text
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 11
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
-- id: user_qualified_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
+- {id: user_qualified_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_qualified_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/fields/user_qualified_id.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 10
+position: 11
 custom_position: 0
-database_position: 10
+database_position: 11
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/v_ai_usage_log.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_ai_usage_log/v_ai_usage_log.yaml
@@ -7,12 +7,8 @@ active: true
 field_order: database
 initial_sync_status: complete
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_ai_usage_log
-  model: Table
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_ai_usage_log, model: Table}
 data_authority: unconfigured
 data_layer: internal
-is_writable: true

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/group_name.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 13
+position: 14
 custom_position: 0
-database_position: 13
+database_position: 14
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/group_name.yaml
@@ -3,10 +3,7 @@ display_name: Group Name
 description: Name of one permissions group the user belongs to (excluding All Users); used for cohort breakdowns.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 14
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: group_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: group_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/ip_address.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/ip_address.yaml
@@ -3,10 +3,7 @@ display_name: IP Address
 description: IP address recorded on the metabot_conversation row, if any.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -16,14 +13,10 @@ custom_position: 0
 database_position: 17
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: ip_address
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: ip_address, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/model.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/model.yaml
@@ -3,10 +3,7 @@ display_name: Model
 description: LLM model used for the conversation; taken from the first ai_usage_log entry.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 20
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: model
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: model, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/model.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/model.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 18
+position: 20
 custom_position: 0
-database_position: 18
+database_position: 20
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/profile_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/profile_name.yaml
@@ -3,10 +3,7 @@ display_name: Profile Name
 description: Display label for the Metabot profile that handled this conversation (e.g. Internal, Embedding, Slackbot, SQL); humanized version of profile_id.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: text
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 13
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: profile_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: profile_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/profile_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/profile_name.yaml
@@ -1,19 +1,20 @@
-name: ip_address
-display_name: IP Address
-description: IP address recorded on the metabot_conversation row, if any.
+name: profile_name
+display_name: Profile Name
+description: Display label for the Metabot profile that handled this conversation (e.g. Internal, Embedding, Slackbot, SQL); humanized version of profile_id.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_metabot_conversations
-database_type: varchar
+database_type: text
 base_type: type/Text
 effective_type: type/Text
+semantic_type: type/Category
 dimensions: []
-position: 17
+position: 13
 custom_position: 0
-database_position: 17
+database_position: 13
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database
@@ -22,7 +23,7 @@ serdes/meta:
   model: Schema
 - id: v_metabot_conversations
   model: Table
-- id: ip_address
+- id: profile_name
   model: Field
 database_is_generated: false
 database_is_nullable: true

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source.yaml
@@ -3,10 +3,7 @@ display_name: Source
 description: Surface that originated the conversation (e.g. web, slack, embed); taken from the first ai_usage_log entry.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: varchar
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 15
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: source
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: source, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 14
+position: 15
 custom_position: 0
-database_position: 14
+database_position: 15
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source_name.yaml
@@ -3,10 +3,7 @@ display_name: Source Name
 description: Display label for the surface that originated the conversation (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: text
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 16
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: source_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: source_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/source_name.yaml
@@ -1,19 +1,20 @@
-name: ip_address
-display_name: IP Address
-description: IP address recorded on the metabot_conversation row, if any.
+name: source_name
+display_name: Source Name
+description: Display label for the surface that originated the conversation (e.g. Metabot, Documents, Slackbot, SQL); humanized version of source.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_metabot_conversations
-database_type: varchar
+database_type: text
 base_type: type/Text
 effective_type: type/Text
+semantic_type: type/Category
 dimensions: []
-position: 17
+position: 16
 custom_position: 0
-database_position: 17
+database_position: 16
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database
@@ -22,7 +23,7 @@ serdes/meta:
   model: Schema
 - id: v_metabot_conversations
   model: Table
-- id: ip_address
+- id: source_name
   model: Field
 database_is_generated: false
 database_is_nullable: true

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_id.yaml
@@ -3,10 +3,7 @@ display_name: Tenant ID
 description: Tenant ID associated with the conversation's AI usage, if any.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: int4
 base_type: type/Integer
 effective_type: type/Integer
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 18
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: tenant_id
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: tenant_id, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_id.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_id.yaml
@@ -12,9 +12,9 @@ base_type: type/Integer
 effective_type: type/Integer
 semantic_type: type/FK
 dimensions: []
-position: 16
+position: 18
 custom_position: 0
-database_position: 16
+database_position: 18
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_name.yaml
@@ -12,9 +12,9 @@ base_type: type/Text
 effective_type: type/Text
 semantic_type: type/Category
 dimensions: []
-position: 17
+position: 19
 custom_position: 0
-database_position: 17
+database_position: 19
 has_field_values: auto-list
 serdes/meta:
 - id: Internal Metabase Database

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_name.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/fields/tenant_name.yaml
@@ -3,10 +3,7 @@ display_name: Tenant Name
 description: Display name of the tenant associated with the conversation, if any.
 created_at: '2026-04-24T19:39:29.987038Z'
 visibility_type: normal
-table_id:
-- Internal Metabase Database
-- public
-- v_metabot_conversations
+table_id: [Internal Metabase Database, public, v_metabot_conversations]
 database_type: text
 base_type: type/Text
 effective_type: type/Text
@@ -17,14 +14,10 @@ custom_position: 0
 database_position: 19
 has_field_values: auto-list
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
-- id: tenant_name
-  model: Field
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
+- {id: tenant_name, model: Field}
 database_is_generated: false
 database_is_nullable: true
 database_is_pk: false

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/v_metabot_conversations.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_conversations/v_metabot_conversations.yaml
@@ -7,12 +7,8 @@ active: true
 field_order: database
 initial_sync_status: complete
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_conversations
-  model: Table
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_conversations, model: Table}
 data_authority: unconfigured
 data_layer: internal
-is_writable: true

--- a/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_messages/v_metabot_messages.yaml
+++ b/resources/instance_analytics/databases/internal_metabase_database/schemas/public/tables/v_metabot_messages/v_metabot_messages.yaml
@@ -7,12 +7,8 @@ active: true
 field_order: database
 initial_sync_status: complete
 serdes/meta:
-- id: Internal Metabase Database
-  model: Database
-- id: public
-  model: Schema
-- id: v_metabot_messages
-  model: Table
+- {id: Internal Metabase Database, model: Database}
+- {id: public, model: Schema}
+- {id: v_metabot_messages, model: Table}
 data_authority: unconfigured
 data_layer: internal
-is_writable: true


### PR DESCRIPTION
Fix missing result metadata fields in usage analytics model yaml files. at minimum this was breaking populating the notebook query editor sort drop down which should show all the available fields / columns