### PR TITLE
fix(search): index batch failure when function-attr throws

### DIFF
--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -112,15 +112,21 @@
   "Execute all function attributes for a given spec and return computed values.
   If a function returns a map, its entries are merged directly into the result —
   this allows a single function to populate multiple document keys (e.g. :temporal-info
-  returns both :has_temporal_dim and :non_temporal_dim_ids in one call)."
+  returns both :has_temporal_dim and :non_temporal_dim_ids in one call).
+
+  When a function attr declares `:provides`, the attr-key itself is not a column in
+  the index — it's a logical grouping whose `:provides` keys are the real columns.
+  In that case, on non-map results (e.g. when the function threw and `false` was
+  returned), skip writing instead of poisoning the document with an unknown column."
   [spec record]
   (reduce-kv
    (fn [acc attr-key attr-def]
      (if (search.spec/function-attr? attr-def)
        (let [result (execute-function-attr attr-key attr-def record)]
-         (if (map? result)
-           (merge acc result)
-           (assoc acc (keyword (u/->snake_case_en (name attr-key))) result)))
+         (cond
+           (map? result)                          (merge acc result)
+           (seq (search.spec/function-attr-provides attr-def)) acc
+           :else                                  (assoc acc (keyword (u/->snake_case_en (name attr-key))) result)))
        acc))
    {}
    (:attrs spec)))

--- a/test/metabase/search/ingestion_test.clj
+++ b/test/metabase/search/ingestion_test.clj
@@ -90,6 +90,23 @@
                (#'search.ingestion/embeddable-text record))
             "Transformation functions should not be applied to embeddable text for semantic search")))))
 
+(deftest execute-all-function-attrs-test
+  (testing "function-attr returning a map merges its keys into the document"
+    (let [spec {:attrs {:temporal-info {:fn       (constantly {:has_temporal_dim true :non_temporal_dim_ids "[1 2]"})
+                                        :provides [:has-temporal-dim :non-temporal-dim-ids]}}}]
+      (is (= {:has_temporal_dim true :non_temporal_dim_ids "[1 2]"}
+             (#'search.ingestion/execute-all-function-attrs spec {})))))
+
+  (testing "function-attr without :provides falls back to writing snake_case attr-key on non-map results"
+    (let [spec {:attrs {:native-query {:fn (constantly "SELECT 1")}}}]
+      (is (= {:native_query "SELECT 1"}
+             (#'search.ingestion/execute-all-function-attrs spec {})))))
+
+  (testing "function-attr with :provides skips writing when result is not a map"
+    (let [spec {:attrs {:temporal-info {:fn       (fn [_] (throw (ex-info "boom" {})))
+                                        :provides [:has-temporal-dim :non-temporal-dim-ids]}}}]
+      (is (= {} (#'search.ingestion/execute-all-function-attrs spec {}))))))
+
 (deftest search-term-columns-test
   (testing "search-term-columns with vector format"
     (is (= #{:name :description}


### PR DESCRIPTION
Closes #73351

Fixes the bug in `metabase.search.ingestion/execute-all-function-attrs` where a thrown exception in a `function-attr` (e.g. `extract-temporal-info` on cards with malformed `dataset_query`) caused the catch path to write the snake-cased attr-key (`:temporal_info`) into the document. Since `:temporal_info` is intentionally not a column in the search index (its attr-types entry is nil; only `:has-temporal-dim` and `:non-temporal-dim-ids` are real columns), HoneySQL's batch INSERT — which unions keys across all rows — failed for the whole 150-card batch with `column "temporal_info" of relation "search_index__…" does not exist`