### PR TITLE
Move v59 embedding_theme migration to v61

### DIFF
--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3482,57 +3482,6 @@ databaseChangeLog:
         - customChange:
             class: "metabase.app_db.custom_migrations.DropMedallionNamesForDataLayer"
 
-  - changeSet:
-      id: v59.2026-04-08T12:00:00
-      author: heypoom
-      comment: Add embedding_theme table for embedding theme editor
-      changes:
-        - createTable:
-            tableName: embedding_theme
-            remarks: Stores themes created via the embedding theme editor
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  remarks: Unique ID
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity
-                  constraints:
-                    nullable: true
-                    unique: true
-              - column:
-                  name: name
-                  type: varchar(255)
-                  remarks: Name of the embed theme
-                  constraints:
-                    nullable: false
-              - column:
-                  name: settings
-                  type: ${text.type}
-                  remarks: JSON object of theme settings
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: Timestamp when the theme was created
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  remarks: Timestamp when the theme was last updated
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/061/20260408_embedding_theme.yaml
+++ b/resources/migrations/061/20260408_embedding_theme.yaml
@@ -1,0 +1,80 @@
+## Create embedding_theme table for the embedding theme editor.
+##
+## Originally landed as v59.2026-04-08T12:00:00 in 059_update_migrations.yaml on the
+## emb-956 integration branch, but the v59 release was already cut so this migration
+## only ships in v61+ JARs. Moved to v61 so cross-version rollback works.
+## The createTable carries a changeSetExecuted precondition so instances that already
+## ran the old v59 ID get MARK_RAN, and a follow-up changeset deletes the orphaned
+## v59 row from databasechangelog.
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v61.2026-04-08T12:00:00
+      author: heypoom
+      comment: Add embedding_theme table for embedding theme editor
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v59.2026-04-08T12:00:00
+              author: heypoom
+              changeLogFile: migrations/059_update_migrations.yaml
+      changes:
+        - createTable:
+            tableName: embedding_theme
+            remarks: Stores themes created via the embedding theme editor
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  remarks: Unique ID
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: entity_id
+                  type: char(21)
+                  remarks: Random NanoID tag for unique identity
+                  constraints:
+                    nullable: true
+                    unique: true
+              - column:
+                  name: name
+                  type: varchar(255)
+                  remarks: Name of the embed theme
+                  constraints:
+                    nullable: false
+              - column:
+                  name: settings
+                  type: ${text.type}
+                  remarks: JSON object of theme settings
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the theme was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the theme was last updated
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v61.2026-04-08T12:00:01
+      author: sfragnaud
+      comment: >-
+        Clean up the orphaned v59 embedding_theme changeset row from databasechangelog.
+        It was authored as v59.2026-04-08T12:00:00 but only ships in v61+ JARs, so
+        leaving it recorded would block downgrades past v59.
+      changes:
+        - sql:
+            sql: DELETE FROM ${databasechangelog.name} WHERE id = 'v59.2026-04-08T12:00:00'
+      rollback: # nothing to undo - this row should not exist in v61


### PR DESCRIPTION
Closes [EMB-1655: Fix theme editor migration version IDs](https://linear.app/metabase/issue/EMB-1655/fix-theme-editor-migration-version-ids)

### Description

- Move the embedding_theme migration from `059_update_migrations.yaml` to a new v61 file at `resources/migrations/061/20260408_embedding_theme.yaml` with id `v61.2026-04-08T12:00:00`.
- Add a follow-up changeset (`v61.2026-04-08T12:00:01`) that deletes the orphaned `v59.2026-04-08T12:00:00` row from `databasechangelog` so downgrades past v59 don't break.
- Guard the createTable with a `not changeSetExecuted` precondition + `onFail: MARK_RAN` so instances that already ran the bad v59 migration (staging) don't fail on "table exists".
- `bin/check-migration-versions` (the CI gate that originally caught this) now passes against master.