### PR TITLE
Clean palette violations

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -54,6 +54,7 @@ const elements = [
   createElement({ type: "shared", name: "api" }),
   // shared
   createElement({ type: "shared", name: "common", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "palette", enforceOutgoing: true }),
   createElement({ type: "shared", name: "querying" }),
   createElement({ type: "shared", name: "visualizations" }),
   // feature
@@ -81,6 +82,7 @@ const elements = [
     "frontend/src/metabase/app-public.ts",
     "frontend/src/metabase/App.tsx",
     "frontend/src/metabase/App.styled.tsx",
+    "frontend/src/metabase/AppKBarProvider.tsx",
     "frontend/src/metabase/routes.jsx",
     "frontend/src/metabase/routes-embed.tsx",
     "frontend/src/metabase/routes-public.tsx",

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -1,5 +1,4 @@
 import type { Location } from "history";
-import { KBarProvider } from "kbar";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
@@ -33,6 +32,7 @@ import { StatusListing } from "metabase/status/components/StatusListing";
 import { initializeIframeResizer } from "metabase/utils/dom";
 
 import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
+import { AppKBarProvider } from "./AppKBarProvider";
 import ErrorBoundary from "./ErrorBoundary";
 import { useTokenRefresh } from "./api/utils/use-token-refresh";
 import { Metabot } from "./metabot/components/Metabot";
@@ -112,7 +112,7 @@ function App({
   return (
     <ErrorBoundary onError={onError}>
       <ScrollToTop>
-        <KBarProvider>
+        <AppKBarProvider>
           <KeyboardTriggeredErrorModal />
           <AppContainer className={CS.spread}>
             <AppBanner />
@@ -133,7 +133,7 @@ function App({
             </AppContentContainer>
           </AppContainer>
           <Palette />
-        </KBarProvider>
+        </AppKBarProvider>
       </ScrollToTop>
     </ErrorBoundary>
   );

--- a/frontend/src/metabase/AppKBarProvider.tsx
+++ b/frontend/src/metabase/AppKBarProvider.tsx
@@ -1,0 +1,46 @@
+import { KBarProvider, useKBar, useRegisterActions } from "kbar";
+import { type PropsWithChildren, useMemo } from "react";
+
+import { getAdminPaths } from "metabase/admin/app/selectors";
+import { getPerformanceAdminPaths } from "metabase/admin/performance/constants/complex";
+import type { PaletteAction } from "metabase/palette/types";
+import { PLUGIN_CACHING } from "metabase/plugins";
+import { useSelector } from "metabase/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
+
+export const AppKBarProvider = ({ children }: PropsWithChildren) => (
+  <KBarProvider>
+    <AppPaletteActions />
+    {children}
+  </KBarProvider>
+);
+
+const AppPaletteActions = () => {
+  const isAdmin = useSelector(getUserIsAdmin);
+  const adminPaths = useSelector(getAdminPaths);
+  const { searchQuery } = useKBar((state) => ({
+    searchQuery: state.searchQuery,
+  }));
+  const hasQuery = searchQuery.length > 0;
+
+  const adminActions = useMemo<PaletteAction[]>(() => {
+    const adminSubpaths = isAdmin
+      ? getPerformanceAdminPaths(PLUGIN_CACHING.getTabMetadata())
+      : [];
+
+    return [...adminPaths, ...adminSubpaths].map((adminPath) => ({
+      id: `admin-page-${adminPath.key}`,
+      name: adminPath.name,
+      icon: "gear",
+      perform: () => {},
+      section: "admin",
+      extra: {
+        href: adminPath.path,
+      },
+    }));
+  }, [isAdmin, adminPaths]);
+
+  useRegisterActions(hasQuery ? adminActions : [], [adminActions, hasQuery]);
+
+  return null;
+};

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -11,7 +11,6 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
-import { getAdminPaths } from "metabase/admin/app/reducers";
 import { useCommandPalette } from "metabase/palette/hooks/useCommandPalette";
 import { useCommandPaletteBasicActions } from "metabase/palette/hooks/useCommandPaletteBasicActions";
 import {
@@ -132,7 +131,14 @@ export const commonSetup = ({
   const adminState = isAdmin
     ? createMockAdminState({
         app: createMockAdminAppState({
-          paths: getAdminPaths(),
+          paths: [
+            {
+              name: "Permissions",
+              path: "/admin/permissions",
+              key: "permissions",
+            },
+            { name: "Settings", path: "/admin/settings", key: "settings" },
+          ],
         }),
       })
     : createMockAdminState();

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -4,14 +4,11 @@ import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { useDebounce } from "react-use";
 import { jt, t } from "ttag";
 
-import { getAdminPaths } from "metabase/admin/app/selectors";
-import { getPerformanceAdminPaths } from "metabase/admin/performance/constants/complex";
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { getIcon } from "metabase/common/utils/icon";
 import { ROOT_COLLECTION } from "metabase/entities/collections/constants";
 import { Search } from "metabase/entities/search";
-import { PLUGIN_CACHING } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { trackSearchClick } from "metabase/search/analytics";
 import {
@@ -102,7 +99,6 @@ export const useCommandPalette = ({
     }
   }, [isVisible, refetchRecents, disabled]);
 
-  const adminPaths = useSelector(getAdminPaths);
   const settingValues = useSelector(getSettings);
 
   const docsAction = useMemo<PaletteAction[]>(() => {
@@ -271,30 +267,6 @@ export const useCommandPalette = ({
     hasQuery,
   ]);
 
-  const adminActions = useMemo<PaletteAction[]>(() => {
-    if (disabled) {
-      return [];
-    }
-
-    // Subpaths - i.e. paths to items within the main Admin tabs - are needed
-    // in the command palette but are not part of the main list of admin paths
-    const adminSubpaths = isAdmin
-      ? getPerformanceAdminPaths(PLUGIN_CACHING.getTabMetadata())
-      : [];
-
-    const paths = [...adminPaths, ...adminSubpaths];
-    return paths.map((adminPath) => ({
-      id: `admin-page-${adminPath.key}`,
-      name: `${adminPath.name}`,
-      icon: "gear",
-      perform: () => {},
-      section: "admin",
-      extra: {
-        href: adminPath.path,
-      },
-    }));
-  }, [disabled, isAdmin, adminPaths]);
-
   const settingsActions = useMemo<PaletteAction[]>(() => {
     if (disabled || !canUserAccessSettings) {
       return [];
@@ -324,8 +296,7 @@ export const useCommandPalette = ({
       }));
   }, [disabled, canUserAccessSettings, isAdmin, settingValues]);
 
-  useRegisterActions(hasQuery ? [...adminActions, ...settingsActions] : [], [
-    adminActions,
+  useRegisterActions(hasQuery ? settingsActions : [], [
     settingsActions,
     hasQuery,
   ]);

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -10,7 +10,6 @@ import {
 } from "@testing-library/react";
 import type { History } from "history";
 import { createMemoryHistory } from "history";
-import { KBarProvider } from "kbar";
 import { useCallback, useMemo, useState } from "react";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
@@ -19,6 +18,7 @@ import { routerMiddleware, routerReducer } from "react-router-redux";
 import _ from "underscore";
 
 import { AppColorSchemeProvider } from "metabase/AppColorSchemeProvider";
+import { AppKBarProvider } from "metabase/AppKBarProvider";
 import { Api } from "metabase/api";
 import { UndoListing } from "metabase/common/components/UndoListing";
 import { baseStyle } from "metabase/css/core/base.styled";
@@ -331,7 +331,7 @@ function MaybeKBar({
   if (!hasKBar) {
     return children;
   }
-  return <KBarProvider>{children}</KBarProvider>;
+  return <AppKBarProvider>{children}</AppKBarProvider>;
 }
 
 function MaybeDNDProvider({


### PR DESCRIPTION
Provide app paths via provider rather than importing it, fixes a couple of violations