### PR TITLE
GDGT-2333 Verify OSS call to action/upsell

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -144,6 +144,7 @@ describe("admin > custom visualizations", () => {
         cy.findByRole("heading", {
           name: /Build your own visualizations/,
         }).should("be.visible");
+        cy.findByRole("link", { name: "Try for free" }).should("be.visible");
         H.getAddVisualizationLink().should("not.exist");
       });
     });

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizEmptyState.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizEmptyState.tsx
@@ -1,0 +1,109 @@
+import { t } from "ttag";
+
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import { useAdminSetting } from "metabase/api/utils";
+import { useMetadataToasts } from "metabase/metadata/hooks";
+import {
+  Button,
+  Card,
+  Group,
+  Icon,
+  type IconName,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
+
+const CUSTOM_VIZ_ENABLED_SETTING = "custom-viz-enabled";
+
+export function CustomVizEmptyState() {
+  const { updateSetting } = useAdminSetting(CUSTOM_VIZ_ENABLED_SETTING);
+  const { sendErrorToast } = useMetadataToasts();
+
+  const handleEnable = async () => {
+    const { error } = await updateSetting({
+      key: CUSTOM_VIZ_ENABLED_SETTING,
+      value: true,
+      toast: false,
+    });
+
+    if (error) {
+      sendErrorToast(t`Failed to enable custom visualizations`);
+    } else {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <SettingsPageWrapper title={t`Custom visualizations`}>
+      <Card bg="background-primary" p={48} maw={640} withBorder>
+        <Stack gap="3rem">
+          <Stack gap="md">
+            <Stack gap="sm">
+              <Title order={3}>{t`Enable custom visualizations`}</Title>
+              <Text c="text-secondary" lh="1.25rem">
+                {t`Show your data the way you need to with custom visualizations. Use the custom viz SDK to build visualization plugins and link them here from a Git repository.`}
+              </Text>
+              <Text fw="bold" lh="1.25rem">
+                {t`Be aware that custom visualizations can execute arbitrary code, and should only be added from trusted sources.`}
+              </Text>
+            </Stack>
+            <Group gap="sm">
+              <Button variant="filled" onClick={handleEnable}>
+                {t`Enable custom visualizations`}
+              </Button>
+            </Group>
+          </Stack>
+          <SimpleGrid cols={2} spacing="sm">
+            <FeatureCard
+              icon="lineandbar"
+              title={t`Custom chart types`}
+              description={t`Create visualization types designed for your specific data and use cases`}
+            />
+            <FeatureCard
+              icon="code_block"
+              title={t`SDK-based development`}
+              description={t`Build plugins with the Custom Visualizations SDK`}
+            />
+            <FeatureCard
+              icon="git_branch"
+              title={t`Git-based distribution`}
+              description={t`Publish custom visualizations by linking to a Git repository`}
+            />
+            <FeatureCard
+              icon="gear"
+              title={t`Full control`}
+              description={t`Enable, disable, and manage custom visualization plugins`}
+            />
+          </SimpleGrid>
+        </Stack>
+      </Card>
+    </SettingsPageWrapper>
+  );
+}
+
+type FeatureCardProps = {
+  icon: IconName;
+  title: string;
+  description: string;
+};
+
+function FeatureCard({ icon, title, description }: FeatureCardProps) {
+  return (
+    <Paper bg="background-secondary" p="md" radius="md" shadow="none">
+      <Group gap="sm" align="flex-start" wrap="nowrap">
+        <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
+        <Stack gap="xs">
+          <Text fw="bold" lh="1rem">
+            {title}
+          </Text>
+          <Text c="text-secondary" lh="1rem">
+            {description}
+          </Text>
+        </Stack>
+      </Group>
+    </Paper>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
@@ -4,6 +4,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { isCustomVizDisplay } from "metabase-types/guards/visualization";
 
 import { CustomVizDevPage } from "./components/CustomVizDevPage";
+import { CustomVizEmptyState } from "./components/CustomVizEmptyState";
 import { CustomVizPage } from "./components/CustomVizPage";
 import { ManageCustomVizPage } from "./components/ManageCustomVizPage";
 import {
@@ -23,6 +24,7 @@ export function initializePlugin() {
       ManageCustomVizPage,
       CustomVizPage,
       CustomVizDevPage,
+      CustomVizEmptyState,
       useAutoLoadCustomVizPlugin,
       useCustomVizPlugins,
       loadCustomVizPlugin,

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -2,22 +2,8 @@ import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellCustomViz } from "metabase/admin/upsells";
-import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
-import {
-  Button,
-  Card,
-  Group,
-  Icon,
-  type IconName,
-  Paper,
-  SimpleGrid,
-  Stack,
-  Text,
-  Title,
-} from "metabase/ui";
 
 export function CustomVisualizationsManagePage() {
   const customVizLoaded = useHasTokenFeature("custom-viz");
@@ -32,7 +18,7 @@ export function CustomVisualizationsManagePage() {
   }
 
   if (!customVizLoaded) {
-    return <CustomVizEmptyState />;
+    return <PLUGIN_CUSTOM_VIZ.CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.ManageCustomVizPage />;
@@ -55,7 +41,7 @@ export function CustomVisualizationsFormPage({
   }
 
   if (!customVizFeatureLoaded) {
-    return <CustomVizEmptyState />;
+    return <PLUGIN_CUSTOM_VIZ.CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizPage params={params} />;
@@ -74,100 +60,8 @@ export function CustomVisualizationsDevelopmentPage() {
   }
 
   if (!customVizFeatureLoaded) {
-    return <CustomVizEmptyState />;
+    return <PLUGIN_CUSTOM_VIZ.CustomVizEmptyState />;
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizDevPage />;
-}
-
-const CUSTOM_VIZ_ENABLED_SETTING = "custom-viz-enabled";
-
-function CustomVizEmptyState() {
-  const { updateSetting } = useAdminSetting(CUSTOM_VIZ_ENABLED_SETTING);
-  const { sendErrorToast } = useMetadataToasts();
-
-  const handleEnable = async () => {
-    const { error } = await updateSetting({
-      key: CUSTOM_VIZ_ENABLED_SETTING,
-      value: true,
-      toast: false,
-    });
-
-    if (error) {
-      sendErrorToast(t`Failed to enable custom visualizations`);
-    } else {
-      window.location.reload();
-    }
-  };
-
-  return (
-    <SettingsPageWrapper title={t`Custom visualizations`}>
-      <Card bg="background-primary" p={48} maw={640} withBorder>
-        <Stack gap="3rem">
-          <Stack gap="md">
-            <Stack gap="sm">
-              <Title order={3}>{t`Enable custom visualizations`}</Title>
-              <Text c="text-secondary" lh="1.25rem">
-                {t`Show your data the way you need to with custom visualizations. Use the custom viz SDK to build visualization plugins and link them here from a Git repository.`}
-              </Text>
-              <Text fw="bold" lh="1.25rem">
-                {t`Be aware that custom visualizations can execute arbitrary code, and should only be added from trusted sources.`}
-              </Text>
-            </Stack>
-            <Group gap="sm">
-              <Button variant="filled" onClick={handleEnable}>
-                {t`Enable custom visualizations`}
-              </Button>
-            </Group>
-          </Stack>
-          <SimpleGrid cols={2} spacing="sm">
-            <FeatureCard
-              icon="lineandbar"
-              title={t`Custom chart types`}
-              description={t`Create visualization types designed for your specific data and use cases`}
-            />
-            <FeatureCard
-              icon="code_block"
-              title={t`SDK-based development`}
-              description={t`Build plugins with the Custom Visualizations SDK`}
-            />
-            <FeatureCard
-              icon="git_branch"
-              title={t`Git-based distribution`}
-              description={t`Publish custom visualizations by linking to a Git repository`}
-            />
-            <FeatureCard
-              icon="gear"
-              title={t`Full control`}
-              description={t`Enable, disable, and manage custom visualization plugins`}
-            />
-          </SimpleGrid>
-        </Stack>
-      </Card>
-    </SettingsPageWrapper>
-  );
-}
-
-type FeatureCardProps = {
-  icon: IconName;
-  title: string;
-  description: string;
-};
-
-function FeatureCard({ icon, title, description }: FeatureCardProps) {
-  return (
-    <Paper bg="background-secondary" p="md" radius="md" shadow="none">
-      <Group gap="sm" align="flex-start" wrap="nowrap">
-        <Icon name={icon} size={16} c="brand" style={{ flexShrink: 0 }} />
-        <Stack gap="xs">
-          <Text fw="bold" lh="1rem">
-            {title}
-          </Text>
-          <Text c="text-secondary" lh="1rem">
-            {description}
-          </Text>
-        </Stack>
-      </Group>
-    </Paper>
-  );
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -4,6 +4,7 @@ import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellCustomViz } from "metabase/admin/upsells";
 import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
+import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import {
   Button,
@@ -83,14 +84,20 @@ const CUSTOM_VIZ_ENABLED_SETTING = "custom-viz-enabled";
 
 function CustomVizEmptyState() {
   const { updateSetting } = useAdminSetting(CUSTOM_VIZ_ENABLED_SETTING);
+  const { sendErrorToast } = useMetadataToasts();
 
   const handleEnable = async () => {
-    await updateSetting({
+    const { error } = await updateSetting({
       key: CUSTOM_VIZ_ENABLED_SETTING,
       value: true,
       toast: false,
     });
-    window.location.reload();
+
+    if (error) {
+      sendErrorToast(t`Failed to enable custom visualizations`);
+    } else {
+      window.location.reload();
+    }
   };
 
   return (

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -21,6 +21,7 @@ const getDefaultPluginCustomViz = () => ({
   ManageCustomVizPage: PluginPlaceholder as ComponentType<any>,
   CustomVizPage: PluginPlaceholder as ComponentType<any>,
   CustomVizDevPage: PluginPlaceholder as ComponentType<any>,
+  CustomVizEmptyState: PluginPlaceholder as ComponentType<any>,
 
   // Hooks & functions
   useAutoLoadCustomVizPlugin: (_display: string | undefined) => ({


### PR DESCRIPTION
Closes [GDGT-2333](https://linear.app/metabase/issue/GDGT-2333/verify-oss-call-to-actionupsell)

### Description

The goal was to verify the upsell call. What happens is:

1. Run fresh OSS jar (make sure you don't have token env variables set)
2. Go to http://localhost:3000/admin/settings/custom-visualizations
3. Click "Try for free"

It takes you to `https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_campaign=custom-viz&utm_content=settings-custom-viz&source_plan=oss` which seems correct.

----

I noticed a few things while working on it, so this PR:
- Adds error handling when enabling custom visualizations
- Adds extra assertions in existing tests
- Moves `CustomVizEmptyState` to `PLUGIN_CUSTOM_VIZ`
