### PR TITLE
Document :module test runner flag in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ If you do not have `clojure-eval` available to you or `clj-nrepl-eval`, do not f
 ./bin/test-agent :only '[metabase.foo-test metabase.bar-test]'  # multiple namespaces
 ```
 
-For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. The test runner resolves these to test directories: `enterprise/foo` → `enterprise/backend/test/metabase_enterprise/foo`, otherwise `test/metabase/<name>` (see `metabase.test-runner/parse-options`).
+For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. See `metabase.test-runner/module-folders` for how module names map to test directories.
 
 ```bash
 ./bin/test-agent :module enterprise/workspaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,16 @@ If you do not have `clojure-eval` available to you or `clj-nrepl-eval`, do not f
 ./bin/test-agent :only '[metabase.foo-test metabase.bar-test]'  # multiple namespaces
 ```
 
-Once again, do not use `clj -X:dev:test` directly — its progress-bar output is hard to parse.
+For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. The test runner resolves these to test directories: `enterprise/foo` → `enterprise/backend/test/metabase_enterprise/foo`, otherwise `test/metabase/<name>` (see `metabase.test-runner/parse-options`).
+
+```bash
+./bin/test-agent :module enterprise/workspaces
+./bin/test-agent :modules '[sql-parsing query-processor]'
+# Driver tests need DRIVERS env + driver aliases, so invoke clj directly:
+DRIVERS=mysql,h2,postgres clj -X:dev:test:ee:ee-dev:drivers:drivers-dev :module enterprise/workspaces
+```
+
+Once again, do not use `clj -X:dev:test` directly for ordinary runs — its progress-bar output is hard to parse. The driver case above is the exception, since `test-agent` doesn't forward the `:drivers:drivers-dev` aliases.
 
 ## Tool Preferences
 


### PR DESCRIPTION
## Summary
- Adds a "module-scoped runs" subsection to **Running Backend Tests** in `CLAUDE.md` covering the `:module` / `:modules` args to `metabase.test-runner/find-and-run-tests-cli`.
- Useful for validating a branch's blast radius — run only the tests under the module(s) the branch touched, rather than the whole suite.
- Notes the driver-tests caveat: `DRIVERS=...` plus `:drivers:drivers-dev` aliases are needed, and `bin/test-agent` doesn't forward those, so a raw `clj -X` invocation is the right form there. (Follow-up #73372 fixes the helper itself, after which this note is dropped.)

## Test plan
- [x] No code changes — docs only. Rendered Markdown reads cleanly.