### PR TITLE
Support driver tests with bin/test-agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,16 @@ If you do not have `clojure-eval` available to you or `clj-nrepl-eval`, do not f
 ./bin/test-agent :only '[metabase.foo-test metabase.bar-test]'  # multiple namespaces
 ```
 
-Once again, do not use `clj -X:dev:test` directly — its progress-bar output is hard to parse.
+For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. The test runner resolves these to test directories: `enterprise/foo` → `enterprise/backend/test/metabase_enterprise/foo`, otherwise `test/metabase/<name>` (see `metabase.test-runner/parse-options`).
+
+```bash
+./bin/test-agent :module enterprise/workspaces
+./bin/test-agent :modules '[sql-parsing query-processor]'
+# Driver tests need DRIVERS env + driver aliases, so invoke clj directly:
+DRIVERS=mysql,h2,postgres clj -X:dev:test:ee:ee-dev:drivers:drivers-dev :module enterprise/workspaces
+```
+
+Once again, do not use `clj -X:dev:test` directly for ordinary runs — its progress-bar output is hard to parse. The driver case above is the exception, since `test-agent` doesn't forward the `:drivers:drivers-dev` aliases.
 
 ## Tool Preferences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,11 @@ For module-scoped runs — useful when validating a branch's blast radius — pa
 ```bash
 ./bin/test-agent :module enterprise/workspaces
 ./bin/test-agent :modules '[sql-parsing query-processor]'
-# Driver tests need DRIVERS env + driver aliases, so invoke clj directly:
-DRIVERS=mysql,h2,postgres clj -X:dev:test:ee:ee-dev:drivers:drivers-dev :module enterprise/workspaces
+# Driver tests: --drivers=LIST adds the driver aliases and sets DRIVERS=LIST in one step.
+./bin/test-agent --drivers=mysql,h2,postgres :module enterprise/workspaces
 ```
 
-Once again, do not use `clj -X:dev:test` directly for ordinary runs — its progress-bar output is hard to parse. The driver case above is the exception, since `test-agent` doesn't forward the `:drivers:drivers-dev` aliases.
+Once again, do not use `clj -X:dev:test` directly — its progress-bar output is hard to parse.
 
 ## Tool Preferences
 

--- a/bin/test-agent
+++ b/bin/test-agent
@@ -11,10 +11,13 @@
 #   bin/test-agent :only '[metabase.foo-test]'
 #   bin/test-agent :only '[metabase.foo-test/some-test]'
 #   bin/test-agent --oss :only '[metabase.foo-test]'   # run without EE extensions
+#   bin/test-agent --drivers=mysql,h2,postgres :module enterprise/workspaces  # run driver tests
 #   bin/test-agent                          # runs all tests (rarely what you want)
 #
 # Options:
-#   --oss    Run without enterprise extensions (uses :oss:oss-dev instead of :ee:ee-dev)
+#   --oss             Run without enterprise extensions (uses :oss:oss-dev instead of :ee:ee-dev)
+#   --drivers=LIST    Add driver aliases (:drivers:drivers-dev) and set DRIVERS=LIST.
+#                     LIST is a comma-separated list of driver names, e.g. mysql,h2,postgres.
 #
 # Any extra arguments are forwarded directly to the clojure test command.
 # The :test alias uses port 0 (OS-assigned random port) so parallel runs never collide.
@@ -23,16 +26,32 @@ set -euo pipefail
 
 export HAWK_MODE=cli/ci
 
-# Check for --oss flag
-ALIASES=":dev:ee:ee-dev:test"
+# Parse our own flags; forward everything else to clojure.
+INCLUDE_OSS=false
+INCLUDE_DRIVERS=false
+DRIVERS_VAL=""
 args=()
 for arg in "$@"; do
   if [[ "$arg" == "--oss" ]]; then
-    ALIASES=":dev:ci:test:oss:oss-dev"
+    INCLUDE_OSS=true
+  elif [[ "$arg" == --drivers=* ]]; then
+    INCLUDE_DRIVERS=true
+    DRIVERS_VAL="${arg#--drivers=}"
   else
     args+=("$arg")
   fi
 done
+
+if $INCLUDE_OSS; then
+  ALIASES=":dev:ci:test:oss:oss-dev"
+else
+  ALIASES=":dev:ee:ee-dev:test"
+fi
+
+if $INCLUDE_DRIVERS; then
+  ALIASES="${ALIASES}:drivers:drivers-dev"
+  export DRIVERS="$DRIVERS_VAL"
+fi
 
 # Filter noise and strip ANSI escape sequences
 clean_output() {


### PR DESCRIPTION
## Summary
Two related changes for backend test ergonomics, bundled together:

1. **CLAUDE.md** — adds a "module-scoped runs" subsection to **Running Backend Tests** covering `:module` / `:modules`, the args to `metabase.test-runner/find-and-run-tests-cli`. Useful for validating a branch's blast radius — run only the tests under the module(s) the branch touched, rather than the whole suite.
2. **bin/test-agent** — adds a `--drivers=LIST` flag that appends `:drivers:drivers-dev` to the alias set and exports `DRIVERS=LIST` in one step. LIST is a comma-separated list of driver names (e.g. `mysql,h2,postgres`).

Together, the two changes let you say:

```bash
./bin/test-agent --drivers=mysql,h2,postgres :module enterprise/workspaces
```

…instead of dropping down to a raw `clj -X` invocation when driver tests are involved.

## History
This PR supersedes #73371. It originally stacked on top of that one, but since the doc edit and the helper change cover the same surface area (the doc references the new flag) it's cleaner as one consolidated change.

## Test plan
- [x] `bash -n bin/test-agent` passes (verified locally).
- [x] `shellcheck bin/test-agent` clean (verified locally).
- [x] Plain `./bin/test-agent :only '[...]'` still works without the flag — `bash -x` trace shows unchanged command (`:dev:ee:ee-dev:test`, no `DRIVERS` export).
- [x] `--drivers=LIST` alone composes correctly — trace shows `:dev:ee:ee-dev:test:drivers:drivers-dev` + `DRIVERS=LIST`.
- [x] `--oss --drivers=LIST` correctly stacks both alias sets — trace shows `:dev:ci:test:oss:oss-dev:drivers:drivers-dev` + `DRIVERS=LIST`.
- [x] `clojure -A:dev:ee:ee-dev:test:drivers:drivers-dev -Spath` resolves successfully (the composed alias set is valid).
- [x] CI green: 142/142 passed (after one flaky rerun cleared MySQL EE app-db + e2e group 29). The MySQL EE app-db job exercises the same `:drivers:drivers-dev` machinery the new flag invokes.
- [x] Rendered CLAUDE.md reads cleanly.