### PR TITLE
Add QueryExplorerBar pure UI component for MCP Apps

### DIFF
--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/ChartTypePicker.module.css
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/ChartTypePicker.module.css
@@ -1,0 +1,3 @@
+.selected {
+  box-shadow: 0 1px 2px var(--mb-color-shadow);
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/ChartTypePicker.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/ChartTypePicker.tsx
@@ -1,0 +1,47 @@
+import type { IconName } from "metabase/ui";
+import { ActionIcon, Flex, Icon } from "metabase/ui";
+
+import S from "./ChartTypePicker.module.css";
+
+type ChartTypeOption = {
+  type: string;
+  icon: IconName;
+};
+
+type ChartTypePickerProps = {
+  chartTypes: ChartTypeOption[];
+  value: string;
+  onChange: (type: string) => void;
+};
+
+export function ChartTypePicker({
+  chartTypes,
+  value,
+  onChange,
+}: ChartTypePickerProps) {
+  return (
+    <Flex
+      h={32}
+      align="center"
+      gap="xs"
+      bg="background-secondary"
+      px="xs"
+      bdrs="md"
+    >
+      {chartTypes.map(({ type, icon }) => (
+        <ActionIcon
+          w="2rem"
+          key={type}
+          size={24}
+          variant={value === type ? "filled" : "subtle"}
+          bg={value === type ? "background-primary" : undefined}
+          onClick={() => onChange(type)}
+          aria-label={type}
+          className={value === type ? S.selected : undefined}
+        >
+          <Icon name={icon} c={value === type ? "brand" : "text-primary"} />
+        </ActionIcon>
+      ))}
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.stories.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import {
+  QueryExplorerBar,
+  type QueryExplorerBarChartType,
+  type QueryExplorerBarProps,
+} from "./QueryExplorerBar";
+
+const CHART_TYPES: QueryExplorerBarChartType[] = [
+  { type: "line", icon: "line" },
+  { type: "area", icon: "area" },
+  { type: "bar", icon: "bar" },
+];
+
+export default {
+  title: "Embedding/MCP/QueryExplorerBar",
+  component: QueryExplorerBar,
+  argTypes: {
+    currentChartType: {
+      control: "select",
+      options: ["table", "line", "area", "bar"],
+    },
+  },
+} satisfies Meta<typeof QueryExplorerBar>;
+
+const Template: StoryFn<QueryExplorerBarProps> = (args) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      background: "var(--mb-color-background-primary)",
+    }}
+  >
+    <div
+      style={{
+        height: "300px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        marginBottom: "24px",
+      }}
+    >
+      placeholder for where the chart would be
+    </div>
+
+    <div
+      style={{
+        padding: "12px",
+        borderRadius: "8px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <QueryExplorerBar {...args} />
+    </div>
+  </div>
+);
+
+export const Default = {
+  render: Template,
+  args: {
+    chartTypes: CHART_TYPES,
+    currentChartType: "bar",
+    onChartTypeChange: () => {},
+    timeRange: {
+      label: "All time",
+      value: undefined,
+      availableUnits: [],
+      hasActiveFilter: false,
+      onChange: () => {},
+      onClear: () => {},
+    },
+    timeGranularity: {
+      label: "by month",
+      currentUnit: "month",
+      availableItems: [],
+      onChange: () => {},
+    },
+    onExplore: () => {},
+  },
+};
+
+export const WithTable = {
+  render: Template,
+  args: {
+    ...Default.args,
+    chartTypes: [{ type: "table", icon: "table2" }, ...CHART_TYPES],
+    currentChartType: "table",
+  },
+};

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.tsx
@@ -1,0 +1,80 @@
+import { t } from "ttag";
+
+import { Button, Divider, Flex, Icon } from "metabase/ui";
+
+import { ChartTypePicker } from "./ChartTypePicker";
+import { TimeGranularityControl } from "./TimeGranularityControl";
+import { TimeRangeControl } from "./TimeRangeControl";
+import type { QueryExplorerBarProps } from "./types";
+
+export type {
+  QueryExplorerBarChartType,
+  QueryExplorerBarProps,
+  TimeGranularityConfig,
+  TimeGranularityItem,
+  TimeRangeConfig,
+} from "./types";
+
+export function QueryExplorerBar({
+  chartTypes,
+  currentChartType,
+  onChartTypeChange,
+  timeRange,
+  timeGranularity,
+  onExplore,
+}: QueryExplorerBarProps) {
+  const hasCenterControls = timeRange || timeGranularity;
+
+  return (
+    <Flex
+      w="100%"
+      direction={{ base: "column", xs: "row" }}
+      align={{ base: "flex-start", xs: "center" }}
+      justify={{ base: "flex-start", xs: "space-between" }}
+      gap={{ base: "sm", xs: "xs" }}
+      data-testid="query-explorer-bar"
+    >
+      <Flex align="center" gap="xs">
+        <ChartTypePicker
+          chartTypes={chartTypes}
+          value={currentChartType}
+          onChange={onChartTypeChange}
+        />
+      </Flex>
+
+      {hasCenterControls && (
+        <Flex
+          h={32}
+          align="stretch"
+          bd="1px solid var(--mb-color-border)"
+          bdrs="md"
+          style={{ overflow: "hidden" }}
+        >
+          {timeRange && <TimeRangeControl timeRange={timeRange} />}
+
+          {timeRange && timeGranularity && <Divider orientation="vertical" />}
+
+          {timeGranularity && (
+            <TimeGranularityControl timeGranularity={timeGranularity} />
+          )}
+        </Flex>
+      )}
+
+      {onExplore && (
+        <Flex align="center">
+          <Button
+            variant="default"
+            size="xs"
+            h={32}
+            px="10px"
+            leftSection={<Icon name="click" size={12} />}
+            onClick={onExplore}
+            bg="transparent"
+          >
+            {t`Explore`}
+          </Button>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.unit.spec.tsx
@@ -1,0 +1,164 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders } from "__support__/ui";
+import type * as Lib from "metabase-lib";
+
+import { QueryExplorerBar } from "./QueryExplorerBar";
+
+const CHART_TYPES = [
+  { type: "line", icon: "line" as const },
+  { type: "area", icon: "area" as const },
+  { type: "bar", icon: "bar" as const },
+];
+
+describe("QueryExplorerBar", () => {
+  it("shows chart type buttons", () => {
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="line"
+        onChartTypeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "line" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "area" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "bar" })).toBeInTheDocument();
+  });
+
+  it("calls onChartTypeChange when chart type button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChartTypeChange = jest.fn();
+
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="line"
+        onChartTypeChange={onChartTypeChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "bar" }));
+
+    expect(onChartTypeChange).toHaveBeenCalledWith("bar");
+    expect(onChartTypeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the date picker when the time range button is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="bar"
+        onChartTypeChange={() => {}}
+        timeRange={{
+          label: "Last 30 days",
+          value: undefined,
+          availableUnits: [],
+          hasActiveFilter: false,
+          onChange: () => {},
+          onClear: () => {},
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Last 30 days" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Last 30 days" }));
+
+    expect(screen.getByTestId("date-picker-type-specific")).toBeInTheDocument();
+  });
+
+  it("opens granularity dropdown and calls onChange when an item is selected", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const mockBucket = {} as Lib.Bucket;
+
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="bar"
+        onChartTypeChange={() => {}}
+        timeGranularity={{
+          label: "by month",
+          currentUnit: "month",
+          availableItems: [
+            { bucket: mockBucket, unit: "month", label: "Month" },
+            { bucket: mockBucket, unit: "year", label: "Year" },
+          ],
+          onChange,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "by month" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "by month" }));
+
+    expect(screen.getByRole("option", { name: "Month" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Year" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: "Year" }));
+
+    expect(onChange).toHaveBeenCalledWith(mockBucket);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the table chart type button when provided", () => {
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={[
+          ...CHART_TYPES,
+          { type: "table", icon: "table2" as const },
+        ]}
+        currentChartType="table"
+        onChartTypeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "table" })).toBeInTheDocument();
+  });
+
+  it("calls onExplore when Explore button is clicked", async () => {
+    const user = userEvent.setup();
+    const onExplore = jest.fn();
+
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="line"
+        onChartTypeChange={jest.fn()}
+        onExplore={onExplore}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /explore/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /explore/i }));
+
+    expect(onExplore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show Explore button when onExplore is not provided", () => {
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={CHART_TYPES}
+        currentChartType="line"
+        onChartTypeChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /explore/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeControlPopover.module.css
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeControlPopover.module.css
@@ -1,0 +1,3 @@
+.popoverTargetButton:hover {
+  background-color: var(--mb-color-background-hover);
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeControlPopover.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeControlPopover.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+
+import { Button, Popover } from "metabase/ui";
+
+import S from "./TimeControlPopover.module.css";
+
+export function TimeControlPopover({
+  label,
+  children,
+}: {
+  label: string;
+  children: (closePopover: () => void) => React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Popover opened={isOpen} onChange={setIsOpen}>
+      <Popover.Target>
+        <Button
+          size="xs"
+          h={32}
+          fw="normal"
+          px="md"
+          variant="subtle"
+          color="text-primary"
+          lh="1"
+          classNames={{ root: S.popoverTargetButton }}
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          {label}
+        </Button>
+      </Popover.Target>
+
+      <Popover.Dropdown>{children(() => setIsOpen(false))}</Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeGranularityControl.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeGranularityControl.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+
+import { Box, DefaultSelectItem } from "metabase/ui";
+
+import { TimeControlPopover } from "./TimeControlPopover";
+import type { TimeGranularityConfig } from "./types";
+
+export function TimeGranularityControl({
+  timeGranularity,
+}: {
+  timeGranularity: TimeGranularityConfig;
+}) {
+  return (
+    <TimeControlPopover label={timeGranularity.label}>
+      {(closePopover) => (
+        <Box p="sm" miw={180}>
+          <DefaultSelectItem
+            value="none"
+            label={t`All time`}
+            selected={!timeGranularity.currentUnit}
+            onClick={() => {
+              timeGranularity.onChange(null);
+              closePopover();
+            }}
+            role="option"
+          />
+
+          {timeGranularity.availableItems.map(({ bucket, unit, label }) => (
+            <DefaultSelectItem
+              key={unit}
+              value={unit}
+              label={label}
+              selected={timeGranularity.currentUnit === unit}
+              onClick={() => {
+                timeGranularity.onChange(bucket);
+                closePopover();
+              }}
+              role="option"
+            />
+          ))}
+        </Box>
+      )}
+    </TimeControlPopover>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeRangeControl.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/TimeRangeControl.tsx
@@ -1,0 +1,52 @@
+import { t } from "ttag";
+
+import { DatePicker } from "metabase/querying/common/components/DatePicker";
+import { Button, Flex } from "metabase/ui";
+
+import { TimeControlPopover } from "./TimeControlPopover";
+import type { TimeRangeConfig } from "./types";
+
+export function TimeRangeControl({
+  timeRange,
+}: {
+  timeRange: TimeRangeConfig;
+}) {
+  return (
+    <TimeControlPopover label={timeRange.label}>
+      {(closePopover) => (
+        <DatePicker
+          value={timeRange.value}
+          availableUnits={timeRange.availableUnits}
+          onChange={(value) => {
+            timeRange.onChange(value);
+            closePopover();
+          }}
+          renderSubmitButton={({ value }) => (
+            <Flex justify="space-between" w="100%">
+              {timeRange.hasActiveFilter ? (
+                <Button
+                  variant="subtle"
+                  c="text-secondary"
+                  onClick={() => {
+                    timeRange.onClear();
+                    closePopover();
+                  }}
+                >
+                  {t`All time`}
+                </Button>
+              ) : (
+                <div />
+              )}
+
+              <Button
+                type="submit"
+                variant="filled"
+                disabled={!value}
+              >{t`Apply`}</Button>
+            </Flex>
+          )}
+        />
+      )}
+    </TimeControlPopover>
+  );
+}

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/index.ts
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/index.ts
@@ -1,0 +1,8 @@
+export { QueryExplorerBar } from "./QueryExplorerBar";
+export type {
+  QueryExplorerBarProps,
+  QueryExplorerBarChartType,
+  TimeRangeConfig,
+  TimeGranularityConfig,
+  TimeGranularityItem,
+} from "./QueryExplorerBar";

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/types.ts
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/types.ts
@@ -1,0 +1,43 @@
+import type {
+  DatePickerUnit,
+  DatePickerValue,
+} from "metabase/querying/common/types";
+import type { IconName } from "metabase/ui";
+import type * as Lib from "metabase-lib";
+import type { TemporalUnit } from "metabase-types/api";
+
+export type QueryExplorerBarChartType = {
+  type: string;
+  icon: IconName;
+};
+
+export type TimeRangeConfig = {
+  label: string;
+  value: DatePickerValue | undefined;
+  availableUnits: DatePickerUnit[];
+  hasActiveFilter: boolean;
+  onChange: (value: DatePickerValue) => void;
+  onClear: () => void;
+};
+
+export type TimeGranularityItem = {
+  bucket: Lib.Bucket;
+  unit: TemporalUnit;
+  label: string;
+};
+
+export type TimeGranularityConfig = {
+  label: string;
+  currentUnit: TemporalUnit | undefined;
+  availableItems: TimeGranularityItem[];
+  onChange: (bucket: Lib.Bucket | null) => void;
+};
+
+export type QueryExplorerBarProps = {
+  chartTypes: QueryExplorerBarChartType[];
+  currentChartType: string;
+  onChartTypeChange: (type: string) => void;
+  timeRange?: TimeRangeConfig;
+  timeGranularity?: TimeGranularityConfig;
+  onExplore?: () => void;
+};


### PR DESCRIPTION
Closes EMB-1660
Supersedes EMB-1599

### Description

Adds a `QueryExplorerBar` pure UI component to the MCP module. This will be used in MCP Apps in [EMB-1620: Add the shared query explorer bar to MCP Apps](https://linear.app/metabase/issue/EMB-1620/add-the-shared-query-explorer-bar-to-mcp-apps). This is a new design, different from the existing Metric Explorer.

The bar has three sections: visualization type selectors (left), time range and time granularity pill (center), and an explore button (right).

### Figma Design

See [this Figma link](https://www.figma.com/design/KPrP76F71eBadQggNB3GX4/MCP-UI--Natural-language-querying-for-embedding?node-id=19146-4164&m=dev).

<img width="1018" height="762" alt="CleanShot 2569-04-29 at 21 32 19@2x" src="https://github.com/user-attachments/assets/2b51f5c1-c903-4f15-b261-905d774d699e" />

### How to verify

1. Go to Storybook.
2. Search for `QueryExplorerBar`
3. It should look like the screenshot, matching the above design closely
4. Clicking on the pills should bring up popovers

### Screenshots

Storybook demo

<img width="1156" height="772" alt="CleanShot 2569-04-29 at 22 07 05@2x" src="https://github.com/user-attachments/assets/6373f0ea-7f46-4dcc-af06-2c534e920d24" />

Here's how it will look when used in MCP Apps (from the prototype):

<img width="1310" height="1054" alt="CleanShot 2569-04-29 at 21 35 00@2x" src="https://github.com/user-attachments/assets/de0ed3dd-f659-4e95-9564-fdd145207cec" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
