### PR TITLE
use parseAttributeValue on custom-context to parse stringified JSON values

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -265,7 +265,8 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                         component: "metabase-dashboard",
                         attributes: {
                           token: expiredToken,
-                          "custom-context": "test-custom-context",
+                          "custom-context":
+                            '{"param":"value","nested":{"a":1}}',
                         },
                       },
                     ],
@@ -275,7 +276,7 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     expect(interception.request.body).to.deep.include({
                       entityType: "dashboard",
                       entityId: dashboardId,
-                      customContext: "test-custom-context",
+                      customContext: { param: "value", nested: { a: 1 } },
                     });
                   });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -606,7 +606,10 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     // Only works in React 19
     const objectCustomContext = this["custom-context"];
-    const stringCustomContext = this.getAttribute("custom-context");
+    // parseAttributeValue parses it if it's a stringified JSON
+    const stringCustomContext = parseAttributeValue(
+      this.getAttribute("custom-context"),
+    );
     const customContext = objectCustomContext ?? stringCustomContext;
     const body = {
       entityType,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -320,6 +320,31 @@ describe("embed.js script tag for sdk iframe embedding", () => {
         );
       });
 
+      it("should parse a stringified JSON passed to custom-context", async () => {
+        fetchMock.post("path:/mock-provider", { jwt: "refreshed-token" });
+
+        const { triggerIframeMessage } = setupGuestEmbed({
+          dashboardId: "1",
+          customContext: '{"param":"value","nested":{"a":1}}',
+        });
+
+        triggerIframeMessage({
+          type: "metabase.embed.requestGuestTokenRefresh",
+          data: { expiredToken: "any.expired.token" },
+        });
+        await flushPromises();
+
+        const call = fetchMock.callHistory.lastCall("path:/mock-provider");
+        expect(call?.options).toMatchObject({
+          method: "post",
+          body: JSON.stringify({
+            entityType: "dashboard",
+            entityId: 1,
+            customContext: { param: "value", nested: { a: 1 } },
+          }),
+        });
+      });
+
       it("sends reportAuthenticationError to iframe when provider returns HTTP error", async () => {
         fetchMock.post("path:/mock-provider", 403);
 


### PR DESCRIPTION
closes [EMB-1665: Parse `customContext` strings into objects](https://linear.app/metabase/issue/EMB-1665/parse-customcontext-strings-into-objects)

### Description

All the other attributes are parse if they're json object passed as strings, for some reason we're not doing it for `custom-context`

### How to verify
When using guest embed with token refresh, this should send an object in the body, not a string
```jsx
<metabase-question
  style="flex: 1;"
  question-id={String(QUESTION_ID)}
  custom-context={JSON.stringify({ position: "Right" })}
```

