### PR TITLE
Allow impersonated writes for custom actions

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -773,9 +773,7 @@ describe(
           cy.button(SAMPLE_QUERY_ACTION.name).click();
 
           cy.findByText(
-            /Error executing Action:.*Invalid impersonated native query\. Must be a single select statement\./,
-            // GraalVM cold start can take >4s, so use a longer timeout
-            { timeout: 30000 },
+            "Error executing Action: Error executing write query: ERROR: permission denied for table scoreboard_actions",
           );
         });
 

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -6,6 +6,8 @@
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
    [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
    [metabase-enterprise.test :as met]
+   [metabase.actions.execution :as actions.execution]
+   [metabase.actions.models :as action]
    [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.connection :as driver.conn]
@@ -1015,3 +1017,51 @@
                       "SET ROLE NONE; DROP TABLE table"
                       "SELECT set_config('role', 'none', false); DROP TABLE table"
                       "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;")))))))))))
+
+(deftest reject-multiple-impersonated-action-write-statements-test
+  (testing "Impersonated custom actions with multiple statements are rejected"
+    (mt/test-drivers (mt/normal-driver-select {:+features [:connection-impersonation :actions/custom]})
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+              role-a (u/lower-case-en (mt/random-name))]
+          (tx/with-temp-roles! driver/*driver*
+            (impersonation-granting-details driver/*driver* (mt/db))
+            {role-a {venues-table {}}}
+            (impersonation-default-user driver/*driver*)
+            (impersonation-default-role driver/*driver*)
+            (let [granting-details (impersonation-granting-details driver/*driver* (mt/db))
+                  spec            (sql-jdbc.conn/connection-details->spec driver/*driver* granting-details)
+                  role-quoted     (sql.tx/qualify-and-quote driver/*driver* role-a)]
+              ;; Grant write permissions (INSERT, UPDATE, DELETE) to the impersonation role
+              (jdbc/execute! spec [(format "GRANT INSERT, UPDATE, DELETE ON %s TO %s" venues-table role-quoted)]
+                             {:transaction? false})
+              (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                       :details (impersonation-details driver/*driver* (mt/db))}]
+                (mt/with-db database
+                  (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                    (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                  (sync/sync-database! database {:scan :schema})
+                  (mt/with-actions-enabled
+                    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                                   :attributes     {"impersonation_attr" role-a}}
+                      (let [execute-action-with-sql
+                            (fn [sql]
+                              (mt/with-actions [{_card-id :id} {:type :model :dataset_query (mt/mbql-query venues)}
+                                                {action-id :action-id} {:type          :query
+                                                                        :name          "Test action"
+                                                                        :dataset_query (update (mt/native-query {:query sql})
+                                                                                               :type name)
+                                                                        :database_id   (mt/id)
+                                                                        :parameters    []}]
+                                (actions.execution/execute-action! (action/select-action :id action-id) {})))]
+                        (testing "A single write statement is allowed"
+                          (is (= {:rows-affected 0}
+                                 (execute-action-with-sql
+                                  (format "UPDATE %s SET name = 'test' WHERE id = -1" venues-table)))))
+                        (testing "Multiple statements are rejected"
+                          (are [sql] (thrown?
+                                      java.lang.Exception
+                                      (execute-action-with-sql sql))
+                            (format "UPDATE %s SET name = 'a' WHERE id = -1; UPDATE %s SET name = 'b' WHERE id = -1" venues-table venues-table)
+                            (format "INSERT INTO %s (name) VALUES ('x'); SELECT 1;" venues-table)
+                            (format "SET ROLE NONE; DELETE FROM %s WHERE id = -1;" venues-table)))))))))))))))

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1608,16 +1608,17 @@ def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
 
     return json.dumps(result)
 
-def is_single_select_stmt(sql: str, dialect: str = None) -> str:
-    """Validates that a query is a single SELECT statement
+def is_single_stmt_of_type(sql: str, stmt_type: str = "read", dialect: str = None) -> str:
+    """Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
     and returns the query reconstructed from the parsed AST.
     """
-    is_single_select = {"is_single_select?": False}
+    result = {"is_single_stmt?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)
-        if len(stmts) == 1 and isinstance(stmts[0], exp.Select):
-            is_single_select["is_single_select?"] = True
-            is_single_select["sql"] = stmts[0].sql(dialect=dialect) if dialect else stmts[0].sql()
+        allowed_types = (exp.Select,) if stmt_type == "read" else (exp.Update, exp.Insert, exp.Delete)
+        if len(stmts) == 1 and isinstance(stmts[0], allowed_types):
+            result["is_single_stmt?"] = True
+            result["sql"] = stmts[0].sql(dialect=dialect) if dialect else stmts[0].sql()
     except Exception as e:
-        is_single_select["error"] = str(e)
-    return json.dumps(is_single_select)
+        result["error"] = str(e)
+    return json.dumps(result)

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -7,6 +7,7 @@
    [metabase.driver-api.core :as driver-api]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters.parse :as params.parse]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters.values :as params.values]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.driver.sql.parameters.substitute :as sql.params.substitute]
    [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
@@ -238,32 +239,38 @@
    native-query :- :metabase.lib.schema/native-only-query]
   (sql-tools/validate-query driver native-query))
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                              Convenience Imports                                               |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
 (defn validate-impersonated-query*
-  "Validates a native query by parsing it and ensuring that it is a single select statement."
+  "Validates a native query by parsing it and ensuring that it is a single statement.
+   Checks driver.conn/*connection-type* to determine if it is a regular impersonated query or a custom action.
+   For regular impersonated queries, ensure that it is a single select statement.
+   For custom actions, ensure that it is a single write statement (insert, update, delete)."
   [driver query]
   (update query :stages
           (fn [stages]
             (mapv (fn [stage]
                     (if (lib.util/native-stage? stage)
-                      (let [{:keys [is-single-select? sql error]}
-                            (sql-tools/is-single-select-stmt? driver (:native stage))]
+                      (let [[stmt-type allowed-stmts] (if (= driver.conn/*connection-type* :write-data)
+                                                        ["write" (tru "insert, update, or delete")]
+                                                        ["read" (tru "select")])
+                            {:keys [is-single-stmt? sql error]}
+                            (sql-tools/is-single-stmt-of-type? driver (:native stage) stmt-type)]
                         (cond error
                               (do
                                 (log/warnf "Failed to parse native query: %s\n: Query: %s" error (:native stage))
                                 (throw (ex-info (tru "Unable to parse native query. There might be something wrong with your query.")
                                                 {:type qp.error-type/invalid-query
                                                  :sql  (:native stage)})))
-                              (not is-single-select?)
-                              (throw (ex-info (tru "Invalid impersonated native query. Must be a single select statement.")
+                              (not is-single-stmt?)
+                              (throw (ex-info (tru "Invalid impersonated native query. Must be a single {0} statement." allowed-stmts)
                                               {:type qp.error-type/invalid-query
                                                :sql  (:native stage)}))
                               :else (assoc stage :native sql)))
                       stage))
                   stages))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Convenience Imports                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (p/import-vars
  [sql.params.substitution ->prepared-substitution PreparedStatementSubstitution]

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -533,15 +533,15 @@
           (.execute ^Value (object-array [sql (json/encode replacements) dialect]))
           .asString))))
 
-(defn is-single-select-stmt?
-  "Validates that a query is a single SELECT statement
+(defn is-single-stmt-of-type?
+  "Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
    and returns the query reconstructed from the parsed AST."
-  [dialect sql]
+  [dialect sql stmt-type]
   (let [sql (strip-large-values sql)]
     (-> (with-open [^Closeable ctx (python.pool/python-context)]
           (with-python-timeout ctx default-timeout-ms
-            (-> ^Value (common/eval-python ctx "sql_tools.is_single_select_stmt")
-                (.execute ^Value (object-array [sql dialect]))
+            (-> ^Value (common/eval-python ctx "sql_tools.is_single_stmt_of_type")
+                (.execute ^Value (object-array [sql stmt-type dialect]))
                 .asString)))
         json/decode+kw
         (perf/update-keys (comp keyword u/->kebab-case-en)))))

--- a/src/metabase/sql_tools/core.clj
+++ b/src/metabase/sql_tools/core.clj
@@ -213,7 +213,7 @@
   (interface/transpile-sql-impl (sql-tools.settings/sql-tools-parser-backend)
                                 sql from-dialect to-dialect))
 
-(defn is-single-select-stmt?
-  "Wrapper around `sql-parsing/is-single-select-stmt`."
-  [driver sql]
-  (sql-parsing/is-single-select-stmt? (sqlglot/driver->dialect driver) sql))
+(defn is-single-stmt-of-type?
+  "Wrapper around `sql-parsing/is-single-stmt-of-type?`."
+  [driver sql stmt-type]
+  (sql-parsing/is-single-stmt-of-type? (sqlglot/driver->dialect driver) sql stmt-type))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -175,7 +175,7 @@
         (is (= :skipped status))
         (is (= :missing-dialect reason))))))
 
-(deftest ^:parallel is-single-select-stmt?-test
+(deftest ^:parallel is-single-stmt-of-type?-test
   (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))
@@ -184,20 +184,35 @@
                     (lib/filter (lib/= product-category "Widget")))
           native-query (:query (qp.compile/compile-with-inline-parameters query))]
       (testing "A single SELECT statement returns true and the reconstructed SQL"
-        (are [sql] (=? {:is-single-select? true, :sql string?}
-                       (sql-tools/is-single-select-stmt? driver/*driver* sql))
+        (are [sql] (=? {:is-single-stmt? true, :sql string?}
+                       (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
           native-query
           "SELECT 1"
           "SELECT * FROM table"
           "WITH x AS (SELECT * FROM foo) SELECT * from x"
           "WITH x AS (SELECT a FROM foo), y AS (SELECT b FROM bar), z AS (SELECT c FROM baz) SELECT x.a, y.b, z.c FROM x, y, z")))
-    (testing "All other queries are rejected"
-      (are [sql] (=? {:is-single-select? false}
-                     (sql-tools/is-single-select-stmt? driver/*driver* sql))
+    (testing "All other read queries are rejected"
+      (are [sql] (=? {:is-single-stmt? false}
+                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
         "SELECT ("
         "SELECT 1; SELECT 2"
         "SET ROLE NONE"
         "DROP TABLE table"
         "SET ROLE NONE; DROP TABLE table"
         "SELECT set_config('role', 'none', false); DROP TABLE table"
-        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;"))))
+        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;"))
+    (testing "A single insert, update or delete statement returns true and the reconstructed SQL"
+      (are [sql] (=? {:is-single-stmt? true, :sql string?}
+                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))
+        "INSERT INTO table VALUES (1)"
+        "UPDATE table SET column = 1"
+        "DELETE FROM table WHERE id = 1"))
+    (testing "All other write queries are rejected"
+      (are [sql] (=? {:is-single-stmt? false}
+                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))
+        "SELECT 1"
+        "INSERT INTO table VALUES (1); SELECT 1"
+        "UPDATE table SET column = 1; SELECT 1"
+        "DELETE FROM table WHERE id = 1; SELECT 1"
+        "SET ROLE NONE; INSERT INTO table VALUES (1)"
+        "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1"))))


### PR DESCRIPTION
### Description

Custom actions on impersonated DBs stopped working after adding the impersonation validation that each statement was just a single select. Fixes this by checking if the `driver.conn/*connection-type*` is `:write-data`, and if it is then we validate that it is a single insert, update or delete statement instead. 

### How to verify

1. Configure a DB with impersonation
2. Create a model
3. Add an action that is not a single insert, update, or delete statement
4. See that it fails
5. Add an action that is a single insert, update or delete statement
6. See that it succeeds

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
