### PR TITLE
Show MCP Apps question title without time granularity

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpQuestionTitle.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpQuestionTitle.tsx
@@ -1,21 +1,43 @@
 import { useMemo } from "react";
 
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
+import {
+  describeQueryStage,
+  getInfoStageIndex,
+} from "metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/utils";
 import { Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+/**
+ * Renders a minimal question title without temporal bucket suffixes.
+ * e.g. "Sum of Total by Created At" instead of "Sum of Total by Created At: Month".
+ *
+ * Mirrors the stage-selection logic from AdHocQuestionDescription: uses stage -2
+ * when the last stage is an empty filter stage (common in drill-through queries),
+ * otherwise stage -1.
+ *
+ * Returns null when no meaningful title can be derived.
+ */
+export function getMcpQuestionTitle(question: Question | undefined) {
+  if (!question) {
+    return null;
+  }
+
+  const query = question.query();
+  const stageIndex = getInfoStageIndex(query);
+
+  return (
+    describeQueryStage(query, stageIndex, { stripTemporalBucket: true }) ??
+    Lib.suggestedName(query)
+  );
+}
 
 export function McpQuestionTitle() {
   const { question } = useSdkQuestionContext();
 
   const title = useMemo(() => {
-    if (!question) {
-      return null;
-    }
-
-    const query = question.query();
-
-    // TODO(EMB-1666): Show MCP Apps question title without time granularity instead
-    return question.displayName() ?? Lib.suggestedName(query);
+    return getMcpQuestionTitle(question);
   }, [question]);
 
   if (!title) {

--- a/frontend/src/metabase/embedding/mcp/McpQuestionTitle.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/McpQuestionTitle.unit.spec.ts
@@ -1,0 +1,33 @@
+import * as Lib from "metabase-lib";
+import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+
+import { getMcpQuestionTitle } from "./McpQuestionTitle";
+
+const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: ORDERS_ID },
+      aggregations: [{ type: "operator", operator: "count", args: [] }],
+      breakouts: [
+        {
+          type: "column",
+          name: "CREATED_AT",
+          sourceName: "ORDERS",
+          unit: "month",
+        },
+      ],
+    },
+  ],
+});
+
+const question = Question.create({
+  metadata: SAMPLE_METADATA,
+}).setQuery(query);
+
+describe("getMcpQuestionTitle", () => {
+  it("uses a generated question description without temporal buckets", () => {
+    expect(getMcpQuestionTitle(question)).toBe("Count by Created At");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
-import { msgid, ngettext, t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
+
+import { describeQueryStage, getInfoStageIndex } from "./utils";
 
 type AdHocQuestionDescriptionProps = {
   onClick?: () => void;
@@ -28,47 +29,8 @@ export const getAdHocQuestionDescription = ({
   question,
 }: GetAdhocQuestionDescriptionProps) => {
   const query = question.query();
-  const stageIndex = getInfoStageIndex(query);
-  const aggregations = Lib.aggregations(query, stageIndex);
-  const breakouts = Lib.breakouts(query, stageIndex);
-  const aggregationDescription =
-    aggregations.length === 0
-      ? null
-      : aggregations.length > 2
-        ? ngettext(
-            msgid`${aggregations.length} metric`,
-            `${aggregations.length} metrics`,
-            aggregations.length,
-          )
-        : aggregations
-            .map(
-              (aggregation) =>
-                Lib.displayInfo(query, stageIndex, aggregation).longDisplayName,
-            )
-            .join(t` and `);
-  const breakoutDescription =
-    breakouts.length === 0
-      ? null
-      : breakouts.length > 2
-        ? ngettext(
-            msgid`${breakouts.length} breakout`,
-            `${breakouts.length} breakouts`,
-            breakouts.length,
-          )
-        : breakouts
-            .map(
-              (breakout) =>
-                Lib.displayInfo(query, stageIndex, breakout).longDisplayName,
-            )
-            .join(t` and `);
 
-  if (!aggregationDescription && !breakoutDescription) {
-    return null;
-  }
-
-  return [aggregationDescription, breakoutDescription]
-    .filter(Boolean)
-    .join(t` by `);
+  return describeQueryStage(query, getInfoStageIndex(query));
 };
 
 export const AdHocQuestionDescription = ({
@@ -90,19 +52,4 @@ export const AdHocQuestionDescription = ({
   );
 };
 
-const getInfoStageIndex = (query: Lib.Query): number => {
-  const hasExtraEmptyFilterStage =
-    Lib.stageCount(query) > 1 && !Lib.hasClauses(query, -1);
-
-  if (hasExtraEmptyFilterStage) {
-    /**
-     * If query is multi-stage and the last stage is empty (which means it's
-     * an extra filtering stage - see Lib.ensureFilterStage), the last stage won't
-     * provide any useful information to generate question description.
-     * We have to use the previous, non-empty stage.
-     */
-    return -2;
-  }
-
-  return -1;
-};
+export { describeQueryStage, getInfoStageIndex };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.unit.spec.ts
@@ -1,0 +1,59 @@
+import * as Lib from "metabase-lib";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { ORDERS_ID, PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+
+import { describeQueryStage } from "./utils";
+
+describe("describeQueryStage", () => {
+  it("can strip temporal bucket suffixes from breakout names", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: ORDERS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "CREATED_AT",
+              sourceName: "ORDERS",
+              unit: "month",
+            },
+          ],
+        },
+      ],
+    });
+
+    // Temporal buckets are included by default
+    expect(describeQueryStage(query, 0)).toBe("Count by Created At: Month");
+
+    // When stripTemporalBucket is true, the ": Month" suffix is then removed
+    expect(describeQueryStage(query, 0, { stripTemporalBucket: true })).toBe(
+      "Count by Created At",
+    );
+  });
+
+  it("preserves non-temporal breakout suffixes when stripping temporal buckets", () => {
+    const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+      stages: [
+        {
+          source: { type: "table", id: PRODUCTS_ID },
+          aggregations: [{ type: "operator", operator: "count", args: [] }],
+          breakouts: [
+            {
+              type: "column",
+              name: "RATING",
+              sourceName: "PRODUCTS",
+              bins: 10,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(describeQueryStage(query, 0)).toBe("Count by Rating: 10 bins");
+
+    expect(describeQueryStage(query, 0, { stripTemporalBucket: true })).toBe(
+      "Count by Rating: 10 bins",
+    );
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/utils.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/utils.ts
@@ -1,0 +1,92 @@
+import { msgid, ngettext, t } from "ttag";
+
+import * as Lib from "metabase-lib";
+
+type DescribeQueryStageOptions = {
+  /**
+   * When true, strips temporal bucket suffixes from breakout names
+   * (e.g. "Created At" instead of "Created At: Month"). Useful when the
+   * granularity is shown separately via a UI control.
+   */
+  stripTemporalBucket?: boolean;
+};
+
+/**
+ * Formats a human-readable description of the aggregations and breakouts at a
+ * specific query stage. Used by both the query builder title and MCP app titles.
+ */
+export const describeQueryStage = (
+  query: Lib.Query,
+  stageIndex: number,
+  { stripTemporalBucket = false }: DescribeQueryStageOptions = {},
+): string | null => {
+  const aggregations = Lib.aggregations(query, stageIndex);
+  const breakouts = Lib.breakouts(query, stageIndex);
+
+  let aggregationDescription: string | null = null;
+
+  if (aggregations.length > 2) {
+    aggregationDescription = ngettext(
+      msgid`${aggregations.length} metric`,
+      `${aggregations.length} metrics`,
+      aggregations.length,
+    );
+  } else if (aggregations.length > 0) {
+    aggregationDescription = aggregations
+      .map(
+        (aggregation) =>
+          Lib.displayInfo(query, stageIndex, aggregation).longDisplayName,
+      )
+      .join(t` and `);
+  }
+
+  let breakoutDescription: string | null = null;
+  if (breakouts.length > 2) {
+    breakoutDescription = ngettext(
+      msgid`${breakouts.length} breakout`,
+      `${breakouts.length} breakouts`,
+      breakouts.length,
+    );
+  } else if (breakouts.length > 0) {
+    breakoutDescription = breakouts
+      .map((breakout) => {
+        if (stripTemporalBucket) {
+          const column = Lib.breakoutColumn(query, stageIndex, breakout);
+
+          if (column && Lib.isTemporalBucketable(query, stageIndex, column)) {
+            const unbucketed = Lib.withTemporalBucket(column, null);
+
+            return Lib.displayInfo(query, stageIndex, unbucketed).displayName;
+          }
+        }
+
+        return Lib.displayInfo(query, stageIndex, breakout).longDisplayName;
+      })
+      .join(t` and `);
+  }
+
+  if (!aggregationDescription && !breakoutDescription) {
+    return null;
+  }
+
+  return [aggregationDescription, breakoutDescription]
+    .filter(Boolean)
+    .join(t` by `);
+};
+
+export const getInfoStageIndex = (query: Lib.Query): number => {
+  const hasExtraEmptyFilterStage =
+    Lib.stageCount(query) > 1 && !Lib.hasClauses(query, -1);
+
+  if (hasExtraEmptyFilterStage) {
+    /**
+     * If query is multi-stage and the last stage is empty (which means it's
+     * an extra filtering stage - see Lib.ensureFilterStage), the last stage won't
+     * provide any useful information to generate question description.
+     * We have to use the previous, non-empty stage.
+     */
+    return -2;
+  }
+
+  return -1;
+};


### PR DESCRIPTION
Closes EMB-1666

### Description

Shows "Sum of Total by Created At" instead of "Sum of Total by Created At: Month" - it should drop the temporal bucket suffix (i.e. ": Month") for cleaner display in MCP Apps chat UIs

Nothing should change in the main app or SDK. The only thing that changes is MCP Apps.

### Demo

Notice how there is no ": Quarter" suffix in the title in this screenshot.

<img width="1220" height="1274" alt="CleanShot 2569-05-01 at 01 27 46@2x" src="https://github.com/user-attachments/assets/fa48b29d-2fcb-40ef-ab28-c75938fe1699" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing as you will run into the https://github.com/anthropics/claude-ai-mcp/issues/40 bug, where Claude Desktop strips all HTTP domains (e.g. `localhost:3000`) and nothing will load.

You cannot use the PR environment with Claude Connector either, as it is behind Tailscale and Claude cannot talk to it. You must use `mcp-remote` to test with PR environment.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73397.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case.

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73397.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  },
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. Ask it to visualize a query by time. For example: "visualize orders with metabase, group by created at, binned by quarter"

4. The title should be just "Orders By Created At", instead of "Orders By Created At: Month"
