### PR TITLE
Revert "🤖 backported "BOT-1368 Drop metabase-enterprise.metabot.task.ai-usage-trimmer" (#73072)"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2986,7 +2986,8 @@
 
   enterprise/metabot
   {:team    "Metabot"
-   :api     #{metabase-enterprise.metabot.api}
+   :api     #{metabase-enterprise.metabot.api
+              metabase-enterprise.metabot.init}
    :friends #{enterprise/agent-api
               slackbot
               mcp
@@ -2997,6 +2998,7 @@
               models
               permissions
               premium-features
+              task
               util
               enterprise/dependencies
               enterprise/transforms-python}

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.database-replication.init]
    [metabase-enterprise.dependencies.init]
    [metabase-enterprise.gsheets.init]
+   [metabase-enterprise.metabot.init]
    [metabase-enterprise.remote-sync.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.security-center.init]

--- a/enterprise/backend/src/metabase_enterprise/metabot/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.metabot.init
+  (:require
+   [metabase-enterprise.metabot.task.ai-usage-trimmer]))

--- a/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.metabot.task.ai-usage-trimmer
+  "Scheduled task to delete old ai_usage_log rows (older than 6 months)."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private trimmer-job-key (jobs/key "metabase.task.metabot.ai-usage-trimmer.job"))
+(def ^:private trimmer-trigger-key (triggers/key "metabase.task.metabot.ai-usage-trimmer.trigger"))
+
+(def ^:private retention-months 6)
+
+(defn- trim-old-usage-data!
+  []
+  (log/info "Trimming old AI usage log data.")
+  (let [cutoff (Timestamp/valueOf (.minusMonths (java.time.LocalDateTime/now) retention-months))
+        deleted (t2/delete! :model/AiUsageLog {:where [:< :created_at cutoff]})]
+    (log/infof "AI usage log cleanup complete. Deleted %d rows." (or deleted 0))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Delete old ai_usage_log rows"}
+  AiUsageTrimmer [_ctx]
+  (trim-old-usage-data!))
+
+(defmethod task/init! ::AiUsageTrimmer
+  [_]
+  (let [job (jobs/build
+             (jobs/of-type AiUsageTrimmer)
+             (jobs/with-identity trimmer-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity trimmer-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                   ;; daily at 23:14:37
+                  (cron/cron-schedule "37 14 23 * * ?")))]
+    (task/schedule-task! job trigger)))


### PR DESCRIPTION
Refs [BOT-1409 Restore `ai_usage_log` trimmer with 6-month retention](https://linear.app/metabase/issue/BOT-1409/restore-ai-usage-log-trimmer-with-6-month-retention)

https://metaboat.slack.com/archives/C096M2BBGHH/p1777486515388679?thread_ts=1776445154.403009&cid=C096M2BBGHH

### Description

This reverts commit 500947b7c2d5934cafba108808d33f6cc23b10c4.

Corresponding revert in master is #73400

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
