### PR TITLE
Revert "BOT-1368 Drop metabase-enterprise.metabot.task.ai-usage-trimmer (#72926)"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3059,6 +3059,7 @@
               permissions
               premium-features
               settings
+              task
               util
               enterprise/dependencies
               enterprise/transforms-python}

--- a/enterprise/backend/src/metabase_enterprise/metabot/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/init.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.metabot.init
   (:require
    [metabase-enterprise.metabot.permissions]
-   [metabase-enterprise.metabot.settings]))
+   [metabase-enterprise.metabot.settings]
+   [metabase-enterprise.metabot.task.ai-usage-trimmer]))

--- a/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.metabot.task.ai-usage-trimmer
+  "Scheduled task to delete old ai_usage_log rows (older than 6 months)."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private trimmer-job-key (jobs/key "metabase.task.metabot.ai-usage-trimmer.job"))
+(def ^:private trimmer-trigger-key (triggers/key "metabase.task.metabot.ai-usage-trimmer.trigger"))
+
+(def ^:private retention-months 6)
+
+(defn- trim-old-usage-data!
+  []
+  (log/info "Trimming old AI usage log data.")
+  (let [cutoff (Timestamp/valueOf (.minusMonths (java.time.LocalDateTime/now) retention-months))
+        deleted (t2/delete! :model/AiUsageLog {:where [:< :created_at cutoff]})]
+    (log/infof "AI usage log cleanup complete. Deleted %d rows." (or deleted 0))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Delete old ai_usage_log rows"}
+  AiUsageTrimmer [_ctx]
+  (trim-old-usage-data!))
+
+(defmethod task/init! ::AiUsageTrimmer
+  [_]
+  (let [job (jobs/build
+             (jobs/of-type AiUsageTrimmer)
+             (jobs/with-identity trimmer-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity trimmer-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                   ;; daily at 23:14:37
+                  (cron/cron-schedule "37 14 23 * * ?")))]
+    (task/schedule-task! job trigger)))


### PR DESCRIPTION
Refs [BOT-1409 Restore `ai_usage_log` trimmer with 6-month retention](https://linear.app/metabase/issue/BOT-1409/restore-ai-usage-log-trimmer-with-6-month-retention)

https://metaboat.slack.com/archives/C096M2BBGHH/p1777486515388679?thread_ts=1776445154.403009&cid=C096M2BBGHH

### Description

This reverts commit fc1af36539e63e02ba5ddd78ffa243fadd069a94.

The v60 backport is reverted in #73399

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
