### PR TITLE
Sort Metric Overview by interestingness

### DIFF
--- a/frontend/src/metabase-types/api/measure.ts
+++ b/frontend/src/metabase-types/api/measure.ts
@@ -24,6 +24,9 @@ export type MetricDimension = {
   semantic_type: string | null;
   group?: MetricDimensionGroup;
   sources?: MetricDimensionSource[];
+  /** Score in [0.0, 1.0] from the interestingness feature; null if the dimension's
+      underlying field has not been scored. */
+  dimension_interestingness?: number | null;
 };
 
 export type DimensionMappingTarget = ["field", Record<string, unknown>, number];

--- a/frontend/src/metabase-types/api/metric.ts
+++ b/frontend/src/metabase-types/api/metric.ts
@@ -79,6 +79,11 @@ export type MetricDatasetRequest = {
   definition: JsMetricDefinition;
 };
 
+export type GetMetricRequest = {
+  id: MetricId;
+  sortDimensionsByInterestingness?: boolean;
+};
+
 export type GetMetricDimensionValuesRequest = {
   metricId: MetricId;
   dimensionId: DimensionId;

--- a/frontend/src/metabase/api/metric.ts
+++ b/frontend/src/metabase/api/metric.ts
@@ -5,12 +5,12 @@ import type {
   FieldValue,
   GetMetricDimensionValuesRequest,
   GetMetricDimensionValuesResponse,
+  GetMetricRequest,
   GetRemappedMetricDimensionValueRequest,
   Metric,
   MetricBreakoutValuesRequest,
   MetricBreakoutValuesResponse,
   MetricDatasetRequest,
-  MetricId,
   SearchMetricDimensionValuesRequest,
 } from "metabase-types/api";
 
@@ -35,10 +35,13 @@ export const metricApi = Api.injectEndpoints({
           dispatch(updateMetadata(data, [MetricSchema])),
         ),
     }),
-    getMetric: builder.query<Metric, MetricId>({
-      query: (id) => ({
+    getMetric: builder.query<Metric, GetMetricRequest>({
+      query: ({ id, sortDimensionsByInterestingness }) => ({
         method: "GET",
         url: `/api/metric/${id}`,
+        params: sortDimensionsByInterestingness
+          ? { sort_dimensions_by_interestingness: true }
+          : undefined,
       }),
       providesTags: (metric) => (metric ? provideMetricTags(metric) : []),
       onQueryStarted: (_, { queryFulfilled, dispatch }) =>

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
@@ -46,7 +46,7 @@ async function loadMetricDefinition(
   metricId: MetricId,
 ): Promise<MetricDefinition> {
   const [result] = await Promise.all([
-    dispatch(metricApi.endpoints.getMetric.initiate(metricId)),
+    dispatch(metricApi.endpoints.getMetric.initiate({ id: metricId })),
     dispatch(segmentApi.endpoints.listSegments.initiate()), // Ensure segments are present in Redux before building the metadata provider
   ]);
   if (!result.data) {

--- a/frontend/src/metabase/metrics/common/hooks/use-metric-definition.ts
+++ b/frontend/src/metabase/metrics/common/hooks/use-metric-definition.ts
@@ -5,15 +5,29 @@ import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
+import type { DimensionId } from "metabase-types/api/measure";
 import type { MetricId } from "metabase-types/api/metric";
 
-export function useMetricDefinition(metricId: MetricId | null): {
+export function useMetricDefinition(
+  metricId: MetricId | null,
+  {
+    sortDimensionsByInterestingness,
+  }: { sortDimensionsByInterestingness?: boolean } = {},
+): {
   definition: MetricDefinition | null;
+  /**
+   * Per-dimension `dimension_interestingness` scores from the API response, keyed by
+   * dimension id. The lib-metric `definition` is rebuilt from local Redux metadata and
+   * doesn't carry these scores, so consumers that want to order dimensions by
+   * interestingness need to look them up here.
+   */
+  dimensionScores: Map<DimensionId, number | null>;
   isLoading: boolean;
 } {
-  const { data: metric, isLoading } = useGetMetricQuery(metricId!, {
-    skip: metricId == null,
-  });
+  const { data: metric, isLoading } = useGetMetricQuery(
+    { id: metricId!, sortDimensionsByInterestingness },
+    { skip: metricId == null },
+  );
 
   const metadata = useSelector(getMetadata);
 
@@ -29,5 +43,13 @@ export function useMetricDefinition(metricId: MetricId | null): {
     return LibMetric.fromMetricMetadata(provider, meta);
   }, [metric, metadata, metricId]);
 
-  return { definition, isLoading };
+  const dimensionScores = useMemo(() => {
+    const scores = new Map<DimensionId, number | null>();
+    for (const d of metric?.dimensions ?? []) {
+      scores.set(d.id, d.dimension_interestingness ?? null);
+    }
+    return scores;
+  }, [metric]);
+
+  return { definition, dimensionScores, isLoading };
 }

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/use-metric-dimension-cards.ts
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/use-metric-dimension-cards.ts
@@ -8,11 +8,14 @@ import { getDefaultDimensions } from "./utils";
 const SHOW_MORE_BATCH_SIZE = 4;
 
 export function useMetricDimensionCards(metricId: MetricId) {
-  const { definition, isLoading } = useMetricDefinition(metricId);
+  const { definition, dimensionScores, isLoading } = useMetricDefinition(
+    metricId,
+    { sortDimensionsByInterestingness: true },
+  );
 
   const allDimensions = useMemo(
-    () => (definition ? getDefaultDimensions(definition) : []),
-    [definition],
+    () => (definition ? getDefaultDimensions(definition, dimensionScores) : []),
+    [definition, dimensionScores],
   );
 
   const [visibleCount, setVisibleCount] = useState<number | null>(null);

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.ts
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/utils.ts
@@ -1,14 +1,7 @@
-import type { DimensionDescriptor } from "metabase/metrics/common/utils/dimension-descriptors";
 import { getDimensionDescriptors } from "metabase/metrics/common/utils/dimension-descriptors";
-import type {
-  DimensionType,
-  GeoSubtype,
-} from "metabase/metrics/common/utils/dimension-types";
-import {
-  GEO_SUBTYPE_PRIORITY,
-  getGeoSubtype,
-} from "metabase/metrics/common/utils/dimension-types";
+import type { DimensionType } from "metabase/metrics/common/utils/dimension-types";
 import type { MetricDefinition } from "metabase-lib/metric";
+import type { DimensionId } from "metabase-types/api/measure";
 
 export interface DefaultDimension {
   dimensionId: string;
@@ -16,99 +9,38 @@ export interface DefaultDimension {
   label: string;
 }
 
+/**
+ * Build the dimension list shown on the metric overview page. Descriptors come from the
+ * lib-metric `definition` (which is rebuilt from local metadata and follows the underlying
+ * query's column order). When `scores` is provided — populated from the API response's
+ * `dimension_interestingness` field — the descriptors are sorted by score descending,
+ * with nulls last and ties broken by the original descriptor order.
+ */
 export function getDefaultDimensions(
   definition: MetricDefinition,
+  scores?: Map<DimensionId, number | null>,
 ): DefaultDimension[] {
-  const descriptors = getDimensionDescriptors(definition);
-  if (descriptors.size === 0) {
-    return [];
-  }
-
-  return [
-    ...pickAggregate(descriptors, "time"),
-    ...pickAggregate(descriptors, "geo"),
-    ...pickAllOfType(descriptors, "category", { requireListValues: true }),
-    ...pickAllOfType(descriptors, "boolean"),
-  ];
-}
-
-function toDefaultDimension(descriptor: DimensionDescriptor): DefaultDimension {
-  return {
+  const descriptors = [...getDimensionDescriptors(definition).values()];
+  const ordered = scores
+    ? descriptors
+        .map((d, i) => ({ d, i, score: scores.get(d.id) ?? null }))
+        .sort((a, b) => {
+          if (a.score == null && b.score == null) {
+            return a.i - b.i;
+          }
+          if (a.score == null) {
+            return 1;
+          }
+          if (b.score == null) {
+            return -1;
+          }
+          return b.score - a.score || a.i - b.i;
+        })
+        .map(({ d }) => d)
+    : descriptors;
+  return ordered.map((descriptor) => ({
     dimensionId: descriptor.id,
     dimensionType: descriptor.dimensionType,
     label: descriptor.displayName,
-  };
-}
-
-function pickAggregate(
-  descriptors: Map<string, DimensionDescriptor>,
-  dimensionType: DimensionType,
-): DefaultDimension[] {
-  const best =
-    dimensionType === "geo"
-      ? findBestGeoDimension(descriptors)
-      : findBestDimension(descriptors, dimensionType);
-
-  return best ? [toDefaultDimension(best)] : [];
-}
-
-function pickAllOfType(
-  descriptors: Map<string, DimensionDescriptor>,
-  dimensionType: DimensionType,
-  options?: { requireListValues?: boolean },
-): DefaultDimension[] {
-  return [...descriptors.values()]
-    .filter(
-      (dimension) =>
-        dimension.dimensionType === dimensionType &&
-        (!options?.requireListValues || dimension.canListValues),
-    )
-    .sort((first, second) => {
-      if (first.canListValues !== second.canListValues) {
-        return first.canListValues ? -1 : 1;
-      }
-      return first.displayName.localeCompare(second.displayName);
-    })
-    .map(toDefaultDimension);
-}
-
-function findBestDimension(
-  descriptors: Map<string, DimensionDescriptor>,
-  dimensionType: DimensionType,
-): DimensionDescriptor | null {
-  const matching = [...descriptors.values()].filter(
-    (dimension) => dimension.dimensionType === dimensionType,
-  );
-
-  return (
-    matching.find((dimension) => dimension.isDefault) ?? matching[0] ?? null
-  );
-}
-
-function findBestGeoDimension(
-  descriptors: Map<string, DimensionDescriptor>,
-): DimensionDescriptor | null {
-  const geoDimensions = [...descriptors.values()].filter(
-    (dimension) => dimension.dimensionType === "geo",
-  );
-
-  const subtypeMap = new Map(
-    geoDimensions
-      .map(
-        (dimension) =>
-          [getGeoSubtype(dimension.dimensionMetadata), dimension] as const,
-      )
-      .filter(
-        (entry): entry is readonly [GeoSubtype, DimensionDescriptor] =>
-          entry[0] != null,
-      ),
-  );
-
-  const prioritized = GEO_SUBTYPE_PRIORITY.find((subtype) =>
-    subtypeMap.has(subtype),
-  );
-
-  return prioritized
-    ? (subtypeMap.get(prioritized) ?? null)
-    : (geoDimensions[0] ?? null);
+  }));
 }

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -24,7 +24,7 @@ interface MetricTabsProps {
 
 export function MetricTabs({ card, urls }: MetricTabsProps) {
   const metadata = useSelector(getMetadata);
-  const { data: metric } = useGetMetricQuery(card.id);
+  const { data: metric } = useGetMetricQuery({ id: card.id });
   const hasDimensions =
     metric?.dimensions != null && metric.dimensions.length > 0;
   const tabs = useMemo(

--- a/frontend/src/metabase/metrics/components/MetricPicker/MetricPicker.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPicker/MetricPicker.tsx
@@ -57,7 +57,7 @@ export function MetricPicker({
       return;
     }
     if (item.type === "metric") {
-      await fetchMetric(item.data.id, true);
+      await fetchMetric({ id: item.data.id }, true);
     } else {
       await fetchMeasure(item.data.id, true);
     }

--- a/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
@@ -29,7 +29,7 @@ export function MetricOverviewPage({
     error,
   } = useLoadCardWithMetadata(cardId);
   const { data: metric, isLoading: isMetricLoading } = useGetMetricQuery(
-    cardId!,
+    { id: cardId!, sortDimensionsByInterestingness: true },
     { skip: cardId == null },
   );
 

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -85,18 +85,33 @@
      :offset offset
      :data   metrics}))
 
-(mu/defn- hydrated-metric [id :- ms/PositiveInt]
+(mu/defn- hydrated-metric
+  [id :- ms/PositiveInt
+   {:keys [sort-dimensions-by-interestingness?]} :- [:map
+                                                     [:sort-dimensions-by-interestingness? {:optional true} :boolean]]]
   (api/read-check (t2/select-one :model/Card :id id :type "metric"))
   (metrics/sync-dimensions! :metadata/metric id)
-  (-> (t2/select-one :model/Card :id id :type "metric")
-      metrics.perms/filter-dimensions-for-user))
+  (cond-> (-> (t2/select-one :model/Card :id id :type "metric")
+              metrics.perms/filter-dimensions-for-user
+              metrics.perms/annotate-dimensions-with-interestingness)
+    sort-dimensions-by-interestingness?
+    metrics.perms/sort-dimensions-by-interestingness))
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-query-params-use-kebab-case]}
 (api.macros/defendpoint :get "/:id" :- ::MetricWithDimensions
   "Fetch a `Metric` with ID.
 
-  Returns the metric with hydrated dimensions and dimension mappings."
-  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
-  (let [metric (hydrated-metric id)]
+  Returns the metric with hydrated dimensions and dimension mappings.
+
+  Pass `sort_dimensions_by_interestingness=true` to sort `:dimensions` descending by the
+  underlying field's `dimension_interestingness` score (fields without a score go last).
+  Snake_case here matches the rest of Metabase's JSON/URL surface; there is no automatic
+  case conversion on the wire."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   {:keys [sort_dimensions_by_interestingness]}
+   :- [:map
+       [:sort_dimensions_by_interestingness {:default false} [:maybe ms/BooleanValue]]]]
+  (let [metric (hydrated-metric id {:sort-dimensions-by-interestingness? sort_dimensions_by_interestingness})]
     (assoc metric :result_column_name (metrics/aggregation-column-name (:database_id metric) (:dataset_query metric)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -267,7 +282,7 @@
   [{:keys [id dimension-key]} :- [:map
                                   [:id            ms/PositiveInt]
                                   [:dimension-key ms/UUIDString]]]
-  (let [metric (hydrated-metric id)]
+  (let [metric (hydrated-metric id {})]
     (metrics/dimension-values
      (:dimensions metric)
      (:dimension_mappings metric)
@@ -282,7 +297,7 @@
                                   [:id            ms/PositiveInt]
                                   [:dimension-key ms/UUIDString]]
    {:keys [query]}            :- [:map [:query ms/NonBlankString]]]
-  (let [metric (hydrated-metric id)]
+  (let [metric (hydrated-metric id {})]
     (metrics/dimension-search-values
      (:dimensions metric)
      (:dimension_mappings metric)
@@ -298,7 +313,7 @@
                                   [:id            ms/PositiveInt]
                                   [:dimension-key ms/UUIDString]]
    {:keys [value]}             :- [:map [:value :string]]]
-  (let [metric (hydrated-metric id)]
+  (let [metric (hydrated-metric id {})]
     (metrics/dimension-remapped-value
      (:dimensions metric)
      (:dimension_mappings metric)

--- a/src/metabase/metrics/permissions.clj
+++ b/src/metabase/metrics/permissions.clj
@@ -16,13 +16,13 @@
 ;;; ------------------------------------------------- Batch Lookups -------------------------------------------------
 
 (defn- batch-field-info
-  "Batch-fetch field visibility_type and table_id for a set of field IDs.
-   Returns {field-id -> {:visibility_type keyword, :table_id int}}."
+  "Batch-fetch field visibility_type, table_id, and dimension_interestingness for a set of field IDs.
+   Returns {field-id -> {:visibility_type keyword, :table_id int, :dimension_interestingness double-or-nil}}."
   [field-ids]
   (when (seq field-ids)
     (into {}
-          (map (fn [f] [(:id f) (select-keys f [:visibility_type :table_id])]))
-          (t2/select [:model/Field :id :visibility_type :table_id]
+          (map (fn [f] [(:id f) (select-keys f [:visibility_type :table_id :dimension_interestingness])]))
+          (t2/select [:model/Field :id :visibility_type :table_id :dimension_interestingness]
                      :id [:in field-ids]))))
 
 (defn- batch-table-db-ids
@@ -124,3 +124,44 @@
       (assoc metric
              :dimensions         (filterv #(contains? kept-ids (:id %)) dimensions)
              :dimension_mappings (filterv #(contains? kept-ids (:dimension-id %)) dimension_mappings)))))
+
+;;; ------------------------------------------------- Interestingness -------------------------------------------------
+
+(defn annotate-dimensions-with-interestingness
+  "Return `metric` with each `:dimensions` entry annotated with `:dimension_interestingness`
+   looked up from the dimension's underlying field. Dimensions whose underlying field cannot
+   be resolved get `nil`."
+  [{:keys [dimensions dimension_mappings] :as metric}]
+  (if (empty? dimensions)
+    metric
+    (let [dim->field-id (build-dim->field-id dimensions dimension_mappings)
+          field-info    (batch-field-info (set (vals dim->field-id)))]
+      (assoc metric
+             :dimensions
+             (mapv (fn [dim]
+                     (assoc dim :dimension_interestingness
+                            (some-> (get dim->field-id (:id dim))
+                                    field-info
+                                    :dimension_interestingness)))
+                   dimensions)))))
+
+(defn sort-dimensions-by-interestingness
+  "Return `metric` with its `:dimensions` stably sorted by `:dimension_interestingness`
+   (descending). Dimensions with a nil score are placed at the end. Assumes dimensions
+   have already been annotated via `annotate-dimensions-with-interestingness`.
+
+   Does not modify `:dimension_mappings`, which are keyed by dimension-id and not
+   iterated positionally by consumers."
+  [{:keys [dimensions] :as metric}]
+  (if (empty? dimensions)
+    metric
+    (assoc metric
+           :dimensions
+           (vec (sort-by :dimension_interestingness
+                         (fn [a b]
+                           (cond
+                             (and (nil? a) (nil? b)) 0
+                             (nil? a) 1
+                             (nil? b) -1
+                             :else (compare b a)))
+                         dimensions)))))

--- a/test/metabase/metrics/api_test.clj
+++ b/test/metabase/metrics/api_test.clj
@@ -205,6 +205,56 @@
               (is (#{"list" "search" "none"} (:has-field-values dim))
                   (str "dimension " (:name dim) " has-field-values should be list, search, or none")))))))))
 
+(deftest fetch-metric-sort-dimensions-by-interestingness-test
+  (testing "GET /api/metric/:id?sort_dimensions_by_interestingness=true"
+    (mt/with-temp [:model/Card metric {:name          "Metric for sort test"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      ;; Seed known interestingness scores on the venues fields this metric's dimensions reference.
+      ;; Use a mix so we can distinguish descending sort + nulls-last.
+      (mt/with-temp-vals-in-db :model/Field (mt/id :venues :name)     {:dimension_interestingness 0.9}
+        (mt/with-temp-vals-in-db :model/Field (mt/id :venues :price)    {:dimension_interestingness 0.4}
+          (mt/with-temp-vals-in-db :model/Field (mt/id :venues :category_id) {:dimension_interestingness 0.1}
+            (mt/with-temp-vals-in-db :model/Field (mt/id :venues :latitude)  {:dimension_interestingness nil}
+              (let [field-id-of   (fn [dim] (some-> dim :sources first :field-id))
+                    seeded-fids   {(mt/id :venues :name)        0.9
+                                   (mt/id :venues :price)       0.4
+                                   (mt/id :venues :category_id) 0.1
+                                   (mt/id :venues :latitude)    nil}
+                    default-resp  (mt/user-http-request :rasta :get 200
+                                                        (str "metric/" (:id metric)))
+                    sorted-resp   (mt/user-http-request :rasta :get 200
+                                                        (str "metric/" (:id metric)
+                                                             "?sort_dimensions_by_interestingness=true"))]
+                (testing "without the flag, default order is preserved"
+                  (is (seq (:dimensions default-resp)))
+                  (is (= (map :id (:dimensions default-resp))
+                         (map :id (:dimensions (mt/user-http-request :rasta :get 200
+                                                                     (str "metric/" (:id metric))))))
+                      "repeated calls with no flag yield the same ordering"))
+                (testing "interestingness score is always present on dimensions"
+                  (is (every? #(contains? % :dimension_interestingness)
+                              (:dimensions default-resp))
+                      "every dimension has the key even without the sort flag")
+                  (let [by-fid (into {}
+                                     (map (fn [d] [(field-id-of d) (:dimension_interestingness d)]))
+                                     (:dimensions default-resp))]
+                    (doseq [[fid expected-score] seeded-fids]
+                      (is (= expected-score (get by-fid fid))
+                          (str "score for field " fid " should match seeded value")))))
+                (testing "with the flag, seeded dimensions are ordered by score desc (nulls last)"
+                  (let [scored (->> (:dimensions sorted-resp)
+                                    (map (fn [d] [d (field-id-of d)]))
+                                    (filter (fn [[_ fid]] (contains? seeded-fids fid)))
+                                    (map (fn [[d fid]] [(:id d) fid (get seeded-fids fid)])))
+                        score-order (map #(nth % 2) scored)
+                        non-nil     (remove nil? score-order)]
+                    (is (= non-nil (reverse (sort non-nil)))
+                        "non-nil scores appear in descending order")
+                    (when (some nil? score-order)
+                      (is (not-any? some? (drop-while some? score-order))
+                          "nil scores appear at/after all non-nil scores among seeded dims"))))))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/metric/dataset                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
### Description

With the new dimension_interestingness score, we can sort the Metric Overview page by that score rather than building something custom into the view.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
