### PR TITLE
Extend databricks timeout

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -395,7 +395,7 @@ jobs:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: databricks


### PR DESCRIPTION
These tests are regularly timing out. let's extend them.

see: https://metaboat.slack.com/archives/C084XNEPH6K/p1777504139521309