### PR TITLE
uxw-3931: check table perms with single CTE

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -6,6 +6,7 @@
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
 
 (defenterprise user-published-table-permission
@@ -61,3 +62,26 @@
               {}
               {:current-user-id user-id
                :is-superuser?   is-superuser?})]}])
+
+(defenterprise published-table-perm-grant-rows
+  "Returns a HoneySQL SELECT producing (id, perm_type, perm_value) rows for tables that are
+  published into a collection the user can read. The grant supplies `:perms/create-queries
+  :query-builder`; `:perms/view-data` is intentionally not synthesized — view-data must come from
+  real `data_permissions` entries.
+
+  Returns nil when the caller's permission mapping does not include `:perms/create-queries`."
+  :feature :library
+  [{:keys [user-id is-superuser?]} perm-types active-only?]
+  (when (contains? (set perm-types) :perms/create-queries)
+    {:select [[:mt.id :id]
+              [(h2x/literal :perms/create-queries) :perm_type]
+              [(h2x/literal :query-builder) :perm_value]]
+     :from   [[:metabase_table :mt]]
+     :where  (cond-> [:and
+                      [:= :mt.is_published true]
+                      (collection/visible-collection-filter-clause
+                       :mt.collection_id
+                       {}
+                       {:current-user-id user-id
+                        :is-superuser?   is-superuser?})]
+               active-only? (conj [:= :mt.active true]))}))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/published_tables_test.clj
@@ -2,6 +2,7 @@
   "Tests for the can-access-via-collection? function in the published-tables namespace."
   (:require
    [clojure.test :refer :all]
+   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.permissions.published-tables :as published-tables]
    [metabase.test :as mt]
@@ -81,3 +82,118 @@
                          :is-superuser? false})]
             (is (= #{allowed-table-id}
                    (t2/select-pks-set :model/Table {:where [:and clause [:in :id [allowed-table-id blocked-table-id]]]})))))))))
+
+(deftest published-table-perm-grant-rows-returns-nil-without-create-queries-test
+  (testing "Returns nil when permission-mapping doesn't include :perms/create-queries"
+    (mt/with-premium-features #{:library}
+      (let [user-info {:user-id 1 :is-superuser? false}]
+        (is (nil? (published-tables/published-table-perm-grant-rows
+                   user-info [:perms/view-data] false)))
+        (is (nil? (published-tables/published-table-perm-grant-rows
+                   user-info [:perms/manage-table-metadata] false)))))))
+
+(deftest published-table-perm-grant-rows-returns-nil-without-library-feature-test
+  (testing "OSS stub returns nil even when create-queries is requested"
+    (mt/with-premium-features #{}
+      (let [user-info {:user-id 1 :is-superuser? false}]
+        (is (nil? (published-tables/published-table-perm-grant-rows
+                   user-info [:perms/create-queries] false)))))))
+
+(deftest published-table-perm-grant-rows-produces-create-queries-grants-test
+  (testing "Returns SELECT producing (id, perms/create-queries, query-builder) rows for published+visible tables"
+    (mt/with-premium-features #{:library}
+      (mt/with-temp [:model/Collection {allowed-coll-id :id} {}
+                     :model/Collection {blocked-coll-id :id} {}
+                     :model/PermissionsGroup {group-id :id} {}
+                     :model/User {user-id :id} {}
+                     :model/PermissionsGroupMembership _ {:user_id user-id :group_id group-id}
+                     :model/Database {db-id :id} {}
+                     :model/Table {visible-pub-id :id}
+                     {:db_id db-id :is_published true :collection_id allowed-coll-id :active true}
+                     :model/Table {hidden-pub-id :id}
+                     {:db_id db-id :is_published true :collection_id blocked-coll-id :active true}
+                     :model/Table {unpub-id :id}
+                     {:db_id db-id :is_published false :collection_id allowed-coll-id :active true}
+                     :model/Table {inactive-pub-id :id}
+                     {:db_id db-id :is_published true :collection_id allowed-coll-id :active false}]
+        (mt/with-no-data-perms-for-all-users!
+          (perms/grant-collection-read-permissions! group-id allowed-coll-id)
+          (perms/revoke-collection-permissions! group-id blocked-coll-id)
+          (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
+          (let [user-info {:user-id user-id :is-superuser? false}
+                table-ids #{visible-pub-id hidden-pub-id unpub-id inactive-pub-id}
+                run-grant-rows
+                (fn [active-only?]
+                  (let [select (published-tables/published-table-perm-grant-rows
+                                user-info [:perms/create-queries] active-only?)]
+                    (->> (t2/query (update select :where (fn [w] [:and w [:in :mt.id table-ids]])))
+                         (map (juxt :id :perm_type :perm_value))
+                         set)))]
+            (testing "without active-only? both active and inactive published+visible tables produce grants"
+              (is (= #{[visible-pub-id "perms/create-queries" "query-builder"]
+                       [inactive-pub-id "perms/create-queries" "query-builder"]}
+                     (run-grant-rows false))))
+            (testing "with active-only? inactive tables are excluded"
+              (is (= #{[visible-pub-id "perms/create-queries" "query-builder"]}
+                     (run-grant-rows true))))))))))
+
+(deftest visible-filter-clause-include-published-via-collection-test
+  (testing "visible-filter-clause :model/Table extends visibility via published+collection grants when requested"
+    (mt/with-premium-features #{:library}
+      (mt/with-temp [:model/Collection {allowed-coll-id :id} {}
+                     :model/Collection {blocked-coll-id :id} {}
+                     :model/PermissionsGroup {group-id :id} {}
+                     :model/User {user-id :id} {}
+                     :model/PermissionsGroupMembership _ {:user_id user-id :group_id group-id}
+                     :model/Database {db-id :id} {}
+                     :model/Table {pub-allowed :id}
+                     {:db_id db-id :is_published true :collection_id allowed-coll-id :active true}
+                     :model/Table {pub-blocked :id}
+                     {:db_id db-id :is_published true :collection_id blocked-coll-id :active true}
+                     :model/Table {unpub-allowed :id}
+                     {:db_id db-id :is_published false :collection_id allowed-coll-id :active true}
+                     :model/Table {pub-blocked-by-view-data :id}
+                     {:db_id db-id :is_published true :collection_id allowed-coll-id :active true}
+                     :model/Table {plain-allowed :id}
+                     {:db_id db-id :is_published false :active true}]
+        (mt/with-no-data-perms-for-all-users!
+          (perms/grant-collection-read-permissions! group-id allowed-coll-id)
+          (perms/revoke-collection-permissions! group-id blocked-coll-id)
+          (perms/revoke-collection-permissions! (perms/all-users-group) blocked-coll-id)
+          ;; user has unrestricted view-data on the db, but no create-queries grants
+          (t2/delete! :model/DataPermissions :db_id db-id)
+          (perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
+          (perms/set-database-permission! group-id db-id :perms/create-queries :no)
+          ;; ...except for plain-allowed, which has both via real data_permissions
+          (perms/set-table-permission! group-id plain-allowed :perms/create-queries :query-builder)
+          ;; ...and pub-blocked-by-view-data, where view-data is :blocked overriding the db default
+          (perms/set-table-permission! group-id pub-blocked-by-view-data :perms/view-data :blocked)
+          (let [user-info {:user-id user-id :is-superuser? false}
+                run (fn [opts]
+                      (let [{:keys [clause with]}
+                            (mi/visible-filter-clause :model/Table :id user-info
+                                                      {:perms/view-data :unrestricted
+                                                       :perms/create-queries :query-builder}
+                                                      opts)]
+                        (t2/select-pks-set :model/Table
+                                           (cond-> {:where [:and [:= :db_id db-id] clause]}
+                                             with (assoc :with with)))))]
+            (testing "without :include-published-via-collection? only the data-perms grant lets a table through"
+              (is (= #{plain-allowed} (run nil))))
+            (testing "with :include-published-via-collection? the published+visible-collection table also passes"
+              (is (= #{plain-allowed pub-allowed}
+                     (run {:include-published-via-collection? true}))))
+            (testing "unpublished or non-visible-collection tables do not pass via the published path"
+              (let [visible (run {:include-published-via-collection? true})]
+                (is (not (contains? visible pub-blocked)))
+                (is (not (contains? visible unpub-allowed)))))
+            (testing "view-data :blocked at the table level still excludes the table even when published+visible"
+              (let [visible (run {:include-published-via-collection? true})]
+                (is (not (contains? visible pub-blocked-by-view-data)))))
+            (testing "the returned :clause is a single IN — no top-level :or"
+              (let [{:keys [clause]} (mi/visible-filter-clause
+                                      :model/Table :id user-info
+                                      {:perms/view-data :unrestricted
+                                       :perms/create-queries :query-builder}
+                                      {:include-published-via-collection? true})]
+                (is (= :in (first clause)))))))))))

--- a/src/metabase/permissions/models/data_permissions/sql.clj
+++ b/src/metabase/permissions/models/data_permissions/sql.clj
@@ -1,6 +1,7 @@
 (ns metabase.permissions.models.data-permissions.sql
   "Helper functions for models using data permissions to construct `visisble-query` methods from."
   (:require
+   [metabase.permissions.published-tables :as published-tables]
    [metabase.permissions.schema :as permissions.schema]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu])
@@ -188,11 +189,16 @@
    inefficient BitmapOr scans that occur with OR joins.
 
    Options:
-     :active-only? - when true, only include active tables in the CTE. Default false."
+     :active-only? - when true, only include active tables in the CTE. Default false.
+     :include-published-via-collection? - when true and the EE :library feature is on, treat
+       published tables in collections the user can read as a source of `:perms/create-queries
+       :query-builder` grants by adding a third UNION ALL branch to the table_permissions CTE.
+       View-data is intentionally not synthesized; it must still come from real data_permissions."
   [column-or-exp                                    :- :any
-   {:keys [user-id is-superuser? is-data-analyst?]} :- UserInfo
+   {:keys [user-id is-superuser? is-data-analyst?] :as user-info} :- UserInfo
    permission-mapping                               :- PermissionMapping
-   & [{:keys [active-only?] :or {active-only? false}}]]
+   & [{:keys [active-only? include-published-via-collection?]
+       :or {active-only? false include-published-via-collection? false}}]]
   ;; Superusers see all tables. Data analysts see all tables when checking manage-table-metadata.
   (if (or is-superuser?
           (and is-data-analyst?
@@ -209,29 +215,32 @@
                                                                        [perm-level :least])]
                                            (permission-type-having-clause perm-type level most-or-least)))
                                        permission-mapping))
-          user-groups-clause (user-in-group-clause user-id)]
+          user-groups-clause (user-in-group-clause user-id)
+          published-grant-rows (when include-published-via-collection?
+                                 (published-tables/published-table-perm-grant-rows
+                                  user-info perm-types active-only?))
+          active-clause (when active-only? [:= :mt.active true])
+          permission-branches (cond-> [;; Table-level permissions (direct grant to table)
+                                       {:select [:mt.id :dp.perm_type :dp.perm_value]
+                                        :from   [[:data_permissions :dp]]
+                                        :join   [[:metabase_table :mt] [:= :mt.id :dp.table_id]]
+                                        :where  (into [:and
+                                                       [:not= :dp.table_id nil]
+                                                       user-groups-clause
+                                                       perm-type-filter]
+                                                      (when active-clause [active-clause]))}
+                                       ;; Database-level permissions (applies to all tables in db)
+                                       {:select [:mt.id :dp.perm_type :dp.perm_value]
+                                        :from   [[:data_permissions :dp]]
+                                        :join   [[:metabase_table :mt] [:= :mt.db_id :dp.db_id]]
+                                        :where  (into [:and
+                                                       [:= :dp.table_id nil]
+                                                       user-groups-clause
+                                                       perm-type-filter]
+                                                      (when active-clause [active-clause]))}]
+                                published-grant-rows (conj published-grant-rows))]
       {:with [;; First CTE: collect all permission grants that apply to each table
-              [:table_permissions
-               {:union-all
-                (let [active-clause (when active-only? [:= :mt.active true])]
-                  [;; Table-level permissions (direct grant to table)
-                   {:select [:mt.id :dp.perm_type :dp.perm_value]
-                    :from   [[:data_permissions :dp]]
-                    :join   [[:metabase_table :mt] [:= :mt.id :dp.table_id]]
-                    :where  (into [:and
-                                   [:not= :dp.table_id nil]
-                                   user-groups-clause
-                                   perm-type-filter]
-                                  (when active-clause [active-clause]))}
-                   ;; Database-level permissions (applies to all tables in db)
-                   {:select [:mt.id :dp.perm_type :dp.perm_value]
-                    :from   [[:data_permissions :dp]]
-                    :join   [[:metabase_table :mt] [:= :mt.db_id :dp.db_id]]
-                    :where  (into [:and
-                                   [:= :dp.table_id nil]
-                                   user-groups-clause
-                                   perm-type-filter]
-                                  (when active-clause [active-clause]))}])}]
+              [:table_permissions {:union-all permission-branches}]
               ;; Second CTE: aggregate and filter by permission requirements
               [:permitted_tables
                {:select   [:dp.id]

--- a/src/metabase/permissions/published_tables.clj
+++ b/src/metabase/permissions/published_tables.clj
@@ -44,3 +44,13 @@
   metabase-enterprise.data-studio.permissions.published-tables
   [_table-id-column _user-info]
   nil)
+
+(defenterprise published-table-perm-grant-rows
+  "Returns a HoneySQL SELECT producing (id, perm_type, perm_value) rows representing the permission
+  grants that published+visible-collection tables provide. Used as a UNION ALL branch in the
+  table_permissions CTE built by `visible-table-filter-with-cte`.
+
+  OSS implementation returns nil — published tables only grant access in EE."
+  metabase-enterprise.data-studio.permissions.published-tables
+  [_user-info _perm-types _active-only?]
+  nil)

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -387,22 +387,11 @@
    user-info          :- perms/UserInfo
    permission-mapping :- perms/PermissionMapping
    & [{:keys [include-published-via-collection? active-only?]}]]
-  (let [opts (cond-> {}
-               (some? active-only?) (assoc :active-only? active-only?))
-        {:keys [clause with]} (perms/visible-table-filter-with-cte column-or-exp user-info permission-mapping opts)]
-    (if-let [published-clause (and include-published-via-collection?
-                                   (perms/published-table-visible-clause column-or-exp user-info))]
-      {:clause [:or clause
-                [:and
-                 [:in column-or-exp (perms/visible-table-filter-select
-                                     :id
-                                     user-info
-                                     {:perms/view-data :unrestricted}
-                                     opts)]
-                 published-clause]]
-       :with with}
-      {:clause clause
-       :with with})))
+  (perms/visible-table-filter-with-cte
+   column-or-exp user-info permission-mapping
+   (cond-> {}
+     (some? active-only?) (assoc :active-only? active-only?)
+     include-published-via-collection? (assoc :include-published-via-collection? true))))
 
 ;;; ------------------------------------------------ Serdes Hashing -------------------------------------------------
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73389
for search, table perms were split between the CTE (which handled perms in `data_permissions`) plus a separate clause for published tables.

this change puts the published table permissions into the CTE too, which resulted in a 5x speedup for me locally with 1500 tables in a local postgres (1 user, in 2 groups, with overlapping permissions on those tables).

(actually, just tested with a bit more load to be sure and got a 10-12x speedup with 31 groups and 6k tables - 1-2s without the fix, 60-100ms with the fix.)