### PR TITLE
Move romeovs to devex team

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -16,7 +16,6 @@
       "label": ".Team/Graphy",
       "members": [
         "ranquild",
-        "romeovs",
         "ericnormand",
         "galdre",
         "dpsutton",
@@ -47,7 +46,8 @@
       "label": ".Team/DevEx",
       "members": [
         "fraserdrops",
-        "nemanjaglumac"
+        "nemanjaglumac",
+        "romeovs"
       ]
     },
     {


### PR DESCRIPTION
Moves my username to the devex team so my PR's get labelled correctly.