### PR TITLE
Fix content translation endpoint race on guest embeds (EMB-1478)

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/content-translations.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/content-translations.cy.spec.ts
@@ -1,4 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion, getSignedJwtForResource } from "e2e/support/helpers";
 import { uploadTranslationDictionaryViaAPI } from "e2e/support/helpers/e2e-content-translation-helpers";
 
 const { H } = cy;
@@ -131,6 +132,80 @@ describe("scenarios > embedding > sdk iframe embedding > content-translations", 
             .findByText("Test Sammlung")
             .should("be.visible");
         });
+      });
+    });
+  });
+
+  // Regression test for EMB-1478: a guest embed under a non-English instance
+  // locale used to fire setEndpointsForAuthEmbedding() on the first render
+  // (before isGuestEmbed had propagated through the redux store), corrupting
+  // the dictionary endpoint to the auth path. The signed-out guest visitor
+  // then got 401s on /api/ee/content-translation/dictionary and the title
+  // never translated.
+  describe("guest embed (EMB-1478)", { tags: "@EE" }, () => {
+    it("translates question title for a signed-out guest when site-locale is non-English", () => {
+      H.prepareGuestEmbedSdkIframeEmbedTest({
+        onPrepare: () => {
+          // Required to trigger the bug: useLocale() returns the instance
+          // locale on the first render, and the buggy code path only fires
+          // when that value is non-English.
+          H.updateSetting("site-locale", "de");
+
+          uploadTranslationDictionaryViaAPI([
+            {
+              locale: "de",
+              msgid: "EMB-1478 question",
+              msgstr: "EMB-1478 Frage",
+            },
+          ]);
+
+          createQuestion({
+            name: "EMB-1478 question",
+            enable_embedding: true,
+            embedding_type: "guest-embed",
+            query: {
+              "source-table": ORDERS_ID,
+              limit: 1,
+            },
+          }).then(({ body: question }) => {
+            cy.wrap(question.id).as("questionId");
+          });
+        },
+      });
+
+      // Regex (not glob) so the matcher covers both /dictionary?... and
+      // /dictionary/<jwt>?... — minimatch's `*` does not cross `/`.
+      cy.intercept(
+        "GET",
+        /\/api\/ee\/content-translation\/dictionary(\/|\?)/,
+      ).as("getDictionary");
+
+      cy.get("@questionId").then(async (questionId) => {
+        const token = await getSignedJwtForResource({
+          resourceId: questionId as unknown as number,
+          resourceType: "question",
+        });
+
+        const frame = H.loadSdkIframeEmbedTestPage({
+          metabaseConfig: { isGuest: true },
+          elements: [
+            {
+              component: "metabase-question",
+              attributes: {
+                token,
+                "with-title": true,
+              },
+            },
+          ],
+        });
+
+        // The dictionary fetch must include the JWT segment. Without the fix
+        // it would hit /dictionary?locale=de and return 401 for the guest.
+        cy.wait("@getDictionary")
+          .its("request.url")
+          .should("include", `/dictionary/${token}`);
+
+        frame.findByText("EMB-1478 Frage").should("be.visible");
       });
     });
   });

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
@@ -12,13 +12,13 @@ export const useSetupContentTranslations = ({
   token: SdkEntityToken | null;
 }) => {
   const { locale } = useLocale();
-  const isGuestEmbed = useSdkSelector(getIsGuestEmbedRaw);
+  const isGuestEmbedRaw = useSdkSelector(getIsGuestEmbedRaw);
 
   useEffect(() => {
-    if (locale !== "en" && isGuestEmbed === true && token) {
+    if (locale !== "en" && isGuestEmbedRaw === true && token) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
     }
-  }, [isGuestEmbed, locale, token]);
+  }, [isGuestEmbedRaw, locale, token]);
 };
 
 export const useSetupAuthContentTranslations = () => {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { useSdkSelector } from "embedding-sdk-bundle/store";
-import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
+import { getIsGuestEmbedRaw } from "embedding-sdk-bundle/store/selectors";
 import type { SdkEntityToken } from "embedding-sdk-bundle/types";
 import { useLocale } from "metabase/common/hooks";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
@@ -12,10 +12,10 @@ export const useSetupContentTranslations = ({
   token: SdkEntityToken | null;
 }) => {
   const { locale } = useLocale();
-  const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
+  const isGuestEmbed = useSdkSelector(getIsGuestEmbedRaw);
 
   useEffect(() => {
-    if (locale !== "en" && isGuestEmbed && token) {
+    if (locale !== "en" && isGuestEmbed === true && token) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
     }
   }, [isGuestEmbed, locale, token]);
@@ -23,10 +23,15 @@ export const useSetupContentTranslations = ({
 
 export const useSetupAuthContentTranslations = () => {
   const { locale } = useLocale();
-  const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
+  // Use the raw selector so we can distinguish "not yet known" (null) from
+  // "known to be auth embed" (false). ComponentProvider dispatches
+  // setIsGuestEmbed in a useEffect, so on the first render isGuestEmbed is
+  // still null — firing setEndpointsForAuthEmbedding then would corrupt the
+  // content translation endpoint for guest embeds (EMB-1478).
+  const isGuestEmbed = useSdkSelector(getIsGuestEmbedRaw);
 
   useEffect(() => {
-    if (locale !== "en" && !isGuestEmbed) {
+    if (locale !== "en" && isGuestEmbed === false) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
     }
   }, [locale, isGuestEmbed]);

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
@@ -102,7 +102,7 @@ describe("useSetupAuthContentTranslations", () => {
 });
 
 describe("useSetupContentTranslations", () => {
-  const token = "mock-jwt-token" as never;
+  const token = "mock-jwt-token";
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
@@ -1,0 +1,155 @@
+import { renderHook } from "@testing-library/react";
+
+import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { useLocale } from "metabase/common/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
+
+import {
+  useSetupAuthContentTranslations,
+  useSetupContentTranslations,
+} from "./use-setup-content-translations";
+
+jest.mock("embedding-sdk-bundle/store", () => ({
+  useSdkSelector: jest.fn(),
+}));
+
+jest.mock("metabase/common/hooks", () => ({
+  useLocale: jest.fn(),
+}));
+
+jest.mock("metabase/plugins", () => ({
+  PLUGIN_CONTENT_TRANSLATION: {
+    setEndpointsForAuthEmbedding: jest.fn(),
+    setEndpointsForStaticEmbedding: jest.fn(),
+  },
+}));
+
+const mockUseSdkSelector = useSdkSelector as unknown as jest.Mock;
+const mockUseLocale = useLocale as jest.Mock;
+const mockSetEndpointsForAuthEmbedding =
+  PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding as jest.Mock;
+const mockSetEndpointsForStaticEmbedding =
+  PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding as jest.Mock;
+
+describe("useSetupAuthContentTranslations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not call setEndpointsForAuthEmbedding while isGuestEmbed is null (not yet known)", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(null);
+
+    renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("calls setEndpointsForAuthEmbedding when isGuestEmbed is explicitly false and locale is non-English", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(false);
+
+    renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call setEndpointsForAuthEmbedding when isGuestEmbed is true (guest embed)", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(true);
+
+    renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("does not call setEndpointsForAuthEmbedding when locale is English", () => {
+    mockUseLocale.mockReturnValue({ locale: "en" });
+    mockUseSdkSelector.mockReturnValue(false);
+
+    renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("calls setEndpointsForAuthEmbedding only after isGuestEmbed transitions from null to false", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(null);
+
+    const { rerender } = renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+
+    mockUseSdkSelector.mockReturnValue(false);
+    rerender();
+
+    expect(mockSetEndpointsForAuthEmbedding).toHaveBeenCalledTimes(1);
+  });
+
+  it("never calls setEndpointsForAuthEmbedding when isGuestEmbed transitions from null to true (guest embed race)", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(null);
+
+    const { rerender } = renderHook(() => useSetupAuthContentTranslations());
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+
+    mockUseSdkSelector.mockReturnValue(true);
+    rerender();
+
+    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSetupContentTranslations", () => {
+  const token = "mock-jwt-token" as never;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not call setEndpointsForStaticEmbedding while isGuestEmbed is null (not yet known)", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(null);
+
+    renderHook(() => useSetupContentTranslations({ token }));
+
+    expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("calls setEndpointsForStaticEmbedding with the token when isGuestEmbed is true and locale is non-English", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(true);
+
+    renderHook(() => useSetupContentTranslations({ token }));
+
+    expect(mockSetEndpointsForStaticEmbedding).toHaveBeenCalledWith(token);
+  });
+
+  it("does not call setEndpointsForStaticEmbedding when token is null", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(true);
+
+    renderHook(() => useSetupContentTranslations({ token: null }));
+
+    expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("does not call setEndpointsForStaticEmbedding when locale is English", () => {
+    mockUseLocale.mockReturnValue({ locale: "en" });
+    mockUseSdkSelector.mockReturnValue(true);
+
+    renderHook(() => useSetupContentTranslations({ token }));
+
+    expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("does not call setEndpointsForStaticEmbedding when isGuestEmbed is false (auth embed)", () => {
+    mockUseLocale.mockReturnValue({ locale: "fr" });
+    mockUseSdkSelector.mockReturnValue(false);
+
+    renderHook(() => useSetupContentTranslations({ token }));
+
+    expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71279
[EMB-1478: Content translation endpoint is set wrong on Guest embeds on EE instances](https://linear.app/metabase/issue/EMB-1478/content-translation-endpoint-is-set-wrong-on-guest-embeds-on-ee)

### Description

`ComponentProvider` dispatches `setIsGuestEmbed` from a `useEffect`, so on the first render the SDK store still holds `isGuestEmbed: null`. The `getIsGuestEmbed` selector coerces that to `false` via `Boolean(null)`, which made `useSetupAuthContentTranslations` indistinguishable from a real auth embed. When the instance locale is non-English, that first-render effect fired `setEndpointsForAuthEmbedding()` and locked the dictionary endpoint to `/api/ee/content-translation/dictionary` before the guest hook could install its JWT-scoped URL — and the EE plugin's `setEndpointsForStaticEmbedding` early-returns once the endpoint is set, so the corruption was permanent for the session.

The fix switches both hooks to the raw selector and tightens the guards to `=== true` / `=== false`, so the auth hook waits until the value has actually been dispatched before doing anything.

### How to verify

1. Spin up a Metabase EE instance with the `content_translation` premium feature enabled and upload a small French dictionary (e.g. `fr,Orders,Commandes`) under Admin → Settings → Translate content.
2. **Set the instance site locale to French (or any non-English language)** in Admin → Settings → Localization → Instance language. This is required — the bug only fires when `useLocale()` returns a non-English value on the very first render, which depends on the instance setting (not the embed `locale` prop, which resolves asynchronously through `LocaleProvider`).
3. Embed a question whose name is in the dictionary (e.g. literally `Orders`) as a guest embed, served from a different origin or in an incognito window so the admin session cookie doesn't mask the bug:
   ```html
   <script defer src="http://localhost:3000/app/embed.js"></script>
   <script>
     window.metabaseConfig = {
       isGuest: true,
       instanceUrl: "http://localhost:3000",
       locale: "fr",
     };
   </script>
   <metabase-question token="<jwt>" with-title="true"></metabase-question>
   ```
4. Open DevTools → Network → filter `dictionary`.
   - **Before this PR:** request goes to `/api/ee/content-translation/dictionary?locale=fr` and returns **401 Unauthenticated**. The question title stays in English.
   - **With this PR:** request goes to `/api/ee/content-translation/dictionary/<jwt>?locale=fr` and returns **200**. Title renders as `Commandes`.

### Demo

_n/a_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)