### PR TITLE
fix: gsheets syncing status no longer exists in HM

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -295,7 +295,7 @@
 
           (= "initializing" status)
           (assoc (setting->response saved-setting)
-                 :status "syncing"
+                 :status "initializing"
                  :last_sync_at (if last-sync-at (.getEpochSecond ^Instant (t/instant last-sync-at)) nil)
                  :sync_started_at (.getEpochSecond ^Instant (t/instant (or last-sync-started-at (t/instant)))))
 

--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -278,13 +278,22 @@
       (let [{:keys [status status-reason error last-sync-at last-sync-started-at]
              :as   _} (normalize-gdrive-conn hm-body)]
         (cond
+          (and (= "active" status)
+               last-sync-started-at
+               last-sync-at
+               (t/< (t/instant last-sync-at) (t/instant last-sync-started-at)))
+          (assoc (setting->response saved-setting)
+                 :status "syncing"
+                 :last_sync_at (.getEpochSecond ^Instant (t/instant last-sync-at))
+                 :sync_started_at (.getEpochSecond ^Instant (t/instant last-sync-started-at)))
+
           (= "active" status)
           (assoc (setting->response saved-setting)
                  :status "active"
                  :last_sync_at (when last-sync-at (.getEpochSecond ^Instant (t/instant last-sync-at)))
                  :next_sync_at (when last-sync-at (.getEpochSecond ^Instant (t/+ (t/instant last-sync-at) (t/minutes 15)))))
 
-          (or (= "syncing" status) (= "initializing" status))
+          (= "initializing" status)
           (assoc (setting->response saved-setting)
                  :status "syncing"
                  :last_sync_at (if last-sync-at (.getEpochSecond ^Instant (t/instant last-sync-at)) nil)

--- a/enterprise/backend/src/metabase_enterprise/gsheets/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/settings.clj
@@ -20,6 +20,16 @@
    [:multi {:dispatch :status}
     ["not-connected" [:map]]
 
+    ["initializing"
+     [:map
+      [:url ms/NonBlankString]
+      ;; time in seconds from epoch:
+      [:created_at pos-int?]
+      ;; time in seconds from epoch:
+      [:sync_started_at pos-int?]
+      [:created_by_id pos-int?]
+      [:db_id pos-int?]]]
+
     ["syncing"
      [:map
       [:url ms/NonBlankString]

--- a/enterprise/backend/test/metabase_enterprise/gsheets/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/gsheets/api_test.clj
@@ -219,7 +219,7 @@
                 (is (nil? (:next_sync_at response)))
                 (testing "current state info doesn't get persisted"
                   (is (nil? (:sync_started_at (gsheets)))))))))
-        (testing "when state==syncing, status==syncing"
+        (testing "when state==active with last-sync-started-at after last-sync-at, status==syncing"
           (mt/with-temporary-setting-values [gsheets (assoc mock-gsheet :gdrive/conn-id gdrive-syncing-link)]
             (with-redefs [hm.client/make-request (partial mock-make-request happy-responses)]
               (let [response (mt/user-http-request :crowberto :get 200 "ee/gsheets/connection")]

--- a/enterprise/backend/test/metabase_enterprise/gsheets/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/gsheets/api_test.clj
@@ -207,11 +207,11 @@
             (with-redefs [hm.client/make-request (partial mock-make-request happy-responses)]
               (let [response (mt/user-http-request :crowberto :get 200 "ee/gsheets/connection")]
                 (is (= {:status "not-connected"} response))))))
-        (testing "when state==initializing, status==syncing"
+        (testing "when state==initializing, status==initializing"
           (mt/with-temporary-setting-values [gsheets (assoc mock-gsheet :gdrive/conn-id gdrive-initializing-link)]
             (with-redefs [hm.client/make-request (partial mock-make-request happy-responses)]
               (let [response (mt/user-http-request :crowberto :get 200 "ee/gsheets/connection")]
-                (is (partial= {:status "syncing", :url "test-url" :created_by_id 2}
+                (is (partial= {:status "initializing", :url "test-url" :created_by_id 2}
                               response))
                 (is (pos-int? (:sync_started_at response)))
                 (is (pos-int? (:db_id response)))

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -193,7 +193,7 @@ export const GdriveAddDataPanel = ({
   // Finally, all conditions have been met, and all screens below this line depend only
   // on the status of the attempted connection
 
-  if (status === "active") {
+  if (status === "active" || status === "syncing") {
     return (
       <PanelWrapper title={t`Import Google Sheets`}>
         <DriveConnectionDisplay />
@@ -262,7 +262,7 @@ export const GdriveAddDataPanel = ({
   }
 
   const buttonText = match(status)
-    .with("syncing", () => t`Connecting...`)
+    .with("initializing", () => t`Connecting...`)
     .with("error", () => t`Something went wrong`)
     .exhaustive();
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -75,7 +75,9 @@ export function GdriveDbMenu() {
           </Button>
         </Menu.Target>
         <Menu.Dropdown>
-          <SyncNowButton disabled={status === "syncing"} />
+          <SyncNowButton
+            disabled={status === "syncing" || status === "initializing"}
+          />
           <Menu.Item
             leftSection={<Icon name="close" />}
             fw="bold"
@@ -148,7 +150,7 @@ function MenuSyncStatus() {
 
   return (
     <>
-      {folderStatus === "syncing" ? (
+      {folderStatus === "syncing" || folderStatus === "initializing" ? (
         <SyncingText />
       ) : (
         <Text fw="bold">{t`Next sync ${nextSyncRelative}`}</Text>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -1,18 +1,21 @@
 import dayjs from "dayjs";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-use";
 import { t } from "ttag";
 
 import { skipToken, useGetDatabaseQuery } from "metabase/api";
+import { useDispatch } from "metabase/redux";
 import { Button, Flex, Icon, Loader, Menu, Text } from "metabase/ui";
 import {
   useGetGsheetsFolderQuery,
   useSyncGsheetsFolderMutation,
 } from "metabase-enterprise/api";
+import { EnterpriseApi } from "metabase-enterprise/api/api";
 
 import { GdriveConnectionModal } from "./GdriveConnectionModal";
 import { GdriveErrorMenuItem } from "./GdriveErrorMenuItem";
 import { trackSheetConnectionClick } from "./analytics";
+import { SYNC_POLL_INTERVAL } from "./constants";
 import { getStatus, useShowGdrive } from "./utils";
 
 export function GdriveDbMenu() {
@@ -120,17 +123,30 @@ function SyncNowButton({ disabled }: { disabled: boolean }) {
 }
 
 function MenuSyncStatus() {
-  const { data: folderInfo, error: folderError } = useGetGsheetsFolderQuery(
-    undefined,
-    {
-      refetchOnMountOrArgChange: 5,
-    },
-  );
+  const dispatch = useDispatch();
+  const folderQuery = useGetGsheetsFolderQuery(undefined, {
+    refetchOnMountOrArgChange: 5,
+  });
+  const { data: folderInfo, error: folderError } = folderQuery;
 
   const folderStatus = getStatus({
     status: folderInfo?.status,
     error: folderError,
   });
+
+  const isInProgress =
+    folderStatus === "syncing" || folderStatus === "initializing";
+
+  useEffect(() => {
+    if (isInProgress) {
+      const timeout = setTimeout(() => {
+        dispatch(EnterpriseApi.util.invalidateTags(["gsheets-status"]));
+      }, SYNC_POLL_INTERVAL);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [folderQuery, isInProgress, dispatch]); // need folderQuery so this runs on every refetch
 
   const lastSync = folderInfo?.last_sync_at;
   const nextSync = folderInfo?.next_sync_at;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -34,9 +34,10 @@ export const GdriveSyncStatus = () => {
   const status = getStatus({ status: gdriveFolder?.status, error: apiError });
 
   const previousStatus = usePrevious(status);
+  const wasInitializing = previousStatus === "initializing";
 
   useEffect(() => {
-    if (status === "syncing" && !forceHide) {
+    if (status === "initializing" && !forceHide) {
       const timeout = setTimeout(() => {
         dispatch(EnterpriseApi.util.invalidateTags(["gsheets-status"]));
       }, SYNC_POLL_INTERVAL);
@@ -47,13 +48,13 @@ export const GdriveSyncStatus = () => {
   }, [res, status, dispatch, forceHide]); // need res so this runs on every refetch
 
   useEffect(() => {
-    // if our setting changed to loading from not-connected, show the status
-    if (status === "syncing" && previousStatus === "not-connected") {
+    // This banner only tracks the initial connect lifecycle; background
+    // re-syncs (status === "syncing") are intentionally invisible here.
+    if (status === "initializing") {
       setForceHide(false);
     }
 
-    // if our setting changed to not-connected from loading, force hide
-    if (status === "not-connected" && previousStatus === "syncing") {
+    if (status === "not-connected" && wasInitializing) {
       setForceHide(true);
     }
 
@@ -61,12 +62,11 @@ export const GdriveSyncStatus = () => {
       setDbId(gdriveFolder?.db_id);
     }
 
-    // refetch tables once the sync completes
-    if (status === "active" && previousStatus === "syncing") {
+    if (status === "active" && wasInitializing) {
       dispatch(Api.util.invalidateTags([tag("table")]));
     }
 
-    if (status === "error" && previousStatus === "syncing") {
+    if (status === "error" && wasInitializing) {
       console.error(
         getErrorMessage(
           apiError,
@@ -75,7 +75,7 @@ export const GdriveSyncStatus = () => {
         ),
       );
     }
-  }, [dispatch, status, previousStatus, gdriveFolder, dbId, apiError]);
+  }, [dispatch, status, wasInitializing, gdriveFolder, dbId, apiError]);
 
   if (forceHide || !isCurrentUser) {
     return null;
@@ -129,7 +129,7 @@ function GsheetsSyncStatusView({
               status === "active" ? `/browse/databases/${db_id}` : undefined,
             icon: "google_drive",
             description,
-            isInProgress: status === "syncing",
+            isInProgress: status === "initializing",
             isCompleted: status === "active",
             isAborted: status === "error",
           },

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
@@ -89,7 +89,7 @@ describe("GsheetsSyncStatus", () => {
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
   });
 
-  it("should appear when status changes from not-connected to loading", async () => {
+  it("should appear when status changes from not-connected to initializing", async () => {
     setup({
       initialFolderPayload: { status: "not-connected" },
     });
@@ -98,7 +98,7 @@ describe("GsheetsSyncStatus", () => {
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
 
     setupGdriveGetFolderEndpoint({
-      status: "syncing",
+      status: "initializing",
       created_by_id: USER_ID,
     });
 
@@ -113,7 +113,8 @@ describe("GsheetsSyncStatus", () => {
 
   it("should not render anything for non-admins", () => {
     setup({
-      initialFolderPayload: { status: "syncing", created_by_id: USER_ID },
+      initialFolderPayload: { status: "initializing", created_by_id: USER_ID },
+      isAdmin: false,
     });
 
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
@@ -127,9 +128,9 @@ describe("GsheetsSyncStatus", () => {
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
   });
 
-  it("should render loading state", async () => {
+  it("should render initializing state on mount", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     expect(
@@ -137,9 +138,19 @@ describe("GsheetsSyncStatus", () => {
     ).toBeInTheDocument();
   });
 
-  it("should close when the X is clicked", async () => {
+  it("should not auto-show on mount when status is syncing (page reload mid-sync)", async () => {
     setup({
       initialFolderPayload: { status: "syncing" },
+    });
+
+    await screen.findByText("Test Settings Update");
+
+    expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
+  });
+
+  it("should close when the X is clicked", async () => {
+    setup({
+      initialFolderPayload: { status: "initializing" },
     });
 
     expect(
@@ -154,7 +165,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should render completed state after initial status is loading", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     // initial loading state
@@ -183,7 +194,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should refetch tables when sync completes (UXW-311)", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
     fetchMock.get(`path:/api/database`, []);
     fetchMock.get(`path:/api/table`, []);
@@ -204,7 +215,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should show error from error response", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     // initial loading state
@@ -228,7 +239,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should show from error status", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     // initial loading state
@@ -253,7 +264,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should clear error if the user tries to connect again", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     // initial syncing state
@@ -275,22 +286,22 @@ describe("GsheetsSyncStatus", () => {
     ).toBeInTheDocument();
 
     setupGdriveGetFolderEndpoint({
-      status: "syncing",
+      status: "initializing",
       created_by_id: USER_ID,
     });
 
     // trigger settings update
     await userEvent.click(await screen.findByText("Test Settings Update"));
 
-    // syncing state
+    // initializing state
     expect(
       await screen.findByText("Importing Google Sheets..."),
     ).toBeInTheDocument();
   });
 
-  it("should disappear if state changes from syncing to not-connected without an error", async () => {
+  it("should disappear if state changes from initializing to not-connected without an error", async () => {
     setup({
-      initialFolderPayload: { status: "syncing" },
+      initialFolderPayload: { status: "initializing" },
     });
 
     // initial loading state
@@ -315,7 +326,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should not show the sync component if the user did not connect the folder", async () => {
     setup({
-      initialFolderPayload: { status: "syncing", created_by_id: 99 },
+      initialFolderPayload: { status: "initializing", created_by_id: 99 },
     });
 
     await screen.findByText("Test Settings Update");

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -231,7 +231,13 @@ export type LoadingMessage =
 export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 
 export type GdrivePayload = {
-  status: "not-connected" | "syncing" | "active" | "paused" | "error";
+  status:
+    | "not-connected"
+    | "initializing"
+    | "syncing"
+    | "active"
+    | "paused"
+    | "error";
   url?: string;
   message?: string; // only for errors
   created_at?: number;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -91,7 +91,7 @@ describe("Add data modal (Pro: hosted instance with the attached DWH)", () => {
     setupProUpload({
       isAdmin: true,
       enableGoogleSheets: true,
-      status: "syncing",
+      status: "initializing",
     });
     await assertSheetsOpened();
 

--- a/test_resources/gsheets/mock_hm_responses.edn
+++ b/test_resources/gsheets/mock_hm_responses.edn
@@ -151,7 +151,7 @@
                                :id                          "663f3e8a-bfff-4b3f-ad5f-20ceadf929cc",
                                :last-sync-at                "2025-03-24T22:00:33.636Z",
                                :last-sync-started-at        "2025-03-25T14:54:26.816Z",
-                               :status                      "syncing",
+                               :status                      "active",
                                :status-detail               nil,
                                :type                        "gdrive",
                                :updated-at                  "2025-03-25T14:54:26.824Z"},


### PR DESCRIPTION
This status no longer exists, but MB hadn't been updated yet. This caused the FE to no longer display that a connection was being synchronized. Updated the BE code to derive the syncing status in the same way that HM does.

Fix https://linear.app/metabase/issue/CLO-4883/google-sheets-sync-can-temporarily-show-duplicated-data

There's two other commits in this PR:
- fix: only show gsheets status when initializing
  - because the little status panel in the bottom right would should whenever a user refreshed and the conn was syncing
- fix: poll gsheets while syncing
  - because when a user clicked to sync, it would never update by itself