### PR TITLE
Bump org.eclipse.jetty/jetty-server from 12.0.24 to 12.1.3 (#65034)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -160,10 +160,11 @@
   org.clojure/tools.namespace               {:mvn/version "1.5.0"}
   org.clojure/tools.reader                  {:mvn/version "1.5.2"}
   org.clojure/tools.trace                   {:mvn/version "0.8.0"}              ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "12.0.21"}
-  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.0.21"}
-  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.0.21"}
-  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.0.21"}
+  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.3"}
+  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.3"}
+  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.3"}
+  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.3"}
+  org.eclipse.jgit/org.eclipse.jgit        {:mvn/version "7.3.0.202506031305-r"}; Java implementation of Git version control system
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "24.2.1" :extension "pom"} ; JavaScript engine
   org.graalvm.polyglot/polyglot             {:mvn/version "24.2.1"}             ; GraalVM platform, required by JS engine


### PR DESCRIPTION
This backports the Jetty version bump from PR #65034 to the release-x.55.x branch.

To help enterprise customer in old version https://metaboat.slack.com/archives/C05MPF0TM3L/p1777450811252589

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
