### PR TITLE
GDGT- 2239 Inconsistent viz loading state

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardLoadingView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardLoadingView.tsx
@@ -1,0 +1,84 @@
+import cx from "classnames";
+import { jt, t } from "ttag";
+
+import { ExternalLink } from "metabase/common/components/ExternalLink/ExternalLink";
+import { useLearnUrl } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
+import { Box, Button, HoverCard, Icon, Text, Transition } from "metabase/ui";
+import { duration } from "metabase/utils/formatting";
+import type { LoadingViewProps } from "metabase/visualizations/components/Visualization/LoadingView/LoadingView";
+import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
+import type { CardDisplayType } from "metabase-types/api";
+
+export const DashCardLoadingView = ({
+  isSlow,
+  expectedDuration,
+  display,
+}: LoadingViewProps & { display?: CardDisplayType }) => {
+  const { url, showMetabaseLinks } = useLearnUrl(
+    "metabase-basics/administration/administration-and-operation/making-dashboards-faster",
+  );
+  const getPreamble = () => {
+    if (isSlow === "usually-fast") {
+      return t`This usually loads immediately, but is currently taking longer.`;
+    }
+    if (expectedDuration) {
+      return jt`This usually takes around ${(
+        <span key="duration" className={CS.textNoWrap}>
+          {duration(expectedDuration)}
+        </span>
+      )}.`;
+    }
+  };
+
+  return (
+    <div
+      data-testid="loading-indicator"
+      className={cx(CS.px2, CS.pb2, CS.fullHeight)}
+    >
+      <ChartSkeleton display={display} />
+      <Transition
+        mounted={!!isSlow}
+        transition={{
+          in: { opacity: 1, transform: "scale(1)" },
+          out: { opacity: 0, transform: "scale(0.8)" },
+          transitionProperty: "transform, opacity",
+        }}
+        duration={80}
+      >
+        {(styles) => (
+          <Box style={styles} className={CS.absolute} left={12} bottom={12}>
+            <HoverCard width={288} offset={4} position="bottom-start">
+              <HoverCard.Target>
+                <Button w={24} h={24} p={0} classNames={{ label: cx(CS.flex) }}>
+                  <Icon name="snail" size={12} d="flex" />
+                </Button>
+              </HoverCard.Target>
+              <HoverCard.Dropdown ml={-8}>
+                <div className={cx(CS.p2, CS.textCentered)}>
+                  <Text fw="bold">{t`Waiting for your data`}</Text>
+                  <Text lh="1.5" mt={4}>
+                    {getPreamble()}{" "}
+                    {t`You can use caching to speed up question loading.`}
+                  </Text>
+                  {showMetabaseLinks && (
+                    <Button
+                      mt={12}
+                      variant="subtle"
+                      size="compact-md"
+                      rightSection={<Icon name="external" />}
+                      component={ExternalLink}
+                      href={url}
+                    >
+                      {t`Making dashboards faster`}
+                    </Button>
+                  )}
+                </div>
+              </HoverCard.Dropdown>
+            </HoverCard>
+          </Box>
+        )}
+      </Transition>
+    </div>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -2,11 +2,9 @@ import cx from "classnames";
 import type { LocationDescriptorObject } from "history";
 import { useCallback, useMemo } from "react";
 import { push } from "react-router-redux";
-import { jt, t } from "ttag";
+import { t } from "ttag";
 import _ from "underscore";
 
-import { ExternalLink } from "metabase/common/components/ExternalLink/ExternalLink";
-import { useLearnUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { setParameterValuesFromQueryParams } from "metabase/dashboard/actions/parameters";
 import { useDashboardContext } from "metabase/dashboard/context";
@@ -22,21 +20,14 @@ import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getSetting } from "metabase/selectors/settings";
 import {
-  Box,
-  Button,
   Flex,
   Group,
-  HoverCard,
-  Icon,
   type IconName,
   type IconProps,
   Menu,
-  Text,
   Title,
-  Transition,
 } from "metabase/ui";
 import { isVirtualDashCard } from "metabase/utils/dashboard";
-import { duration } from "metabase/utils/formatting";
 import { measureTextWidth } from "metabase/utils/measure-text";
 import { getVisualizationRaw, isCartesianChart } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -45,7 +36,6 @@ import {
   LEGEND_LABEL_FONT_SIZE,
   LEGEND_LABEL_FONT_WEIGHT,
 } from "metabase/visualizations/components/legend/LegendCaption";
-import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import type {
@@ -64,7 +54,6 @@ import type Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Card,
-  CardDisplayType,
   CardId,
   DashCardId,
   DashboardCard,
@@ -80,6 +69,7 @@ import type {
 import { CollapsibleDashboardParameterList } from "../CollapsibleDashboardParameterList";
 
 import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay";
+import { DashCardLoadingView } from "./DashCardLoadingView";
 import { DashCardMenu } from "./DashCardMenu/DashCardMenu";
 import { DashCardParameterMapper } from "./DashCardParameterMapper/DashCardParameterMapper";
 import S from "./DashCardVisualization.module.css";
@@ -89,79 +79,6 @@ import {
   getMissingColumnsFromVisualizationSettings,
   shouldShowParameterMapper,
 } from "./utils";
-
-const DashCardLoadingView = ({
-  isSlow,
-  expectedDuration,
-  display,
-}: LoadingViewProps & { display?: CardDisplayType }) => {
-  const { url, showMetabaseLinks } = useLearnUrl(
-    "metabase-basics/administration/administration-and-operation/making-dashboards-faster",
-  );
-  const getPreamble = () => {
-    if (isSlow === "usually-fast") {
-      return t`This usually loads immediately, but is currently taking longer.`;
-    }
-    if (expectedDuration) {
-      return jt`This usually takes around ${(
-        <span key="duration" className={CS.textNoWrap}>
-          {duration(expectedDuration)}
-        </span>
-      )}.`;
-    }
-  };
-
-  return (
-    <div
-      data-testid="loading-indicator"
-      className={cx(CS.px2, CS.pb2, CS.fullHeight)}
-    >
-      <ChartSkeleton display={display} />
-      <Transition
-        mounted={!!isSlow}
-        transition={{
-          in: { opacity: 1, transform: "scale(1)" },
-          out: { opacity: 0, transform: "scale(0.8)" },
-          transitionProperty: "transform, opacity",
-        }}
-        duration={80}
-      >
-        {(styles) => (
-          <Box style={styles} className={CS.absolute} left={12} bottom={12}>
-            <HoverCard width={288} offset={4} position="bottom-start">
-              <HoverCard.Target>
-                <Button w={24} h={24} p={0} classNames={{ label: cx(CS.flex) }}>
-                  <Icon name="snail" size={12} d="flex" />
-                </Button>
-              </HoverCard.Target>
-              <HoverCard.Dropdown ml={-8}>
-                <div className={cx(CS.p2, CS.textCentered)}>
-                  <Text fw="bold">{t`Waiting for your data`}</Text>
-                  <Text lh="1.5" mt={4}>
-                    {getPreamble()}{" "}
-                    {t`You can use caching to speed up question loading.`}
-                  </Text>
-                  {showMetabaseLinks && (
-                    <Button
-                      mt={12}
-                      variant="subtle"
-                      size="compact-md"
-                      rightSection={<Icon name="external" />}
-                      component={ExternalLink}
-                      href={url}
-                    >
-                      {t`Making dashboards faster`}
-                    </Button>
-                  )}
-                </div>
-              </HoverCard.Dropdown>
-            </HoverCard>
-          </Box>
-        )}
-      </Transition>
-    </div>
-  );
-};
 
 /**
  * This populates the `data` field of each series with an empty

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState.tsx
@@ -1,0 +1,37 @@
+import cx from "classnames";
+import { t } from "ttag";
+
+import { EDITOR_STYLE_BOUNDARY_CLASS } from "metabase/documents/components/Editor/constants";
+import { Box, Flex, Loader, Text } from "metabase/ui";
+
+import styles from "./CardEmbedNode.module.css";
+
+type Props = {
+  selected?: boolean;
+};
+
+export const CardEmbedLoadingState = ({ selected }: Props) => {
+  return (
+    <Box
+      className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
+        [styles.selected]: selected,
+      })}
+    >
+      <Box className={styles.questionHeader}>
+        <Flex align="center" justify="space-between" gap="0.5rem">
+          <Box className={styles.titleContainer}>
+            <Text size="md" c="text-primary" fw={700}>
+              {t`Loading question...`}
+            </Text>
+          </Box>
+        </Flex>
+      </Box>
+
+      <Box className={styles.questionResults}>
+        <Box className={styles.loadingContainer}>
+          <Loader />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState.tsx
@@ -1,37 +1,15 @@
-import cx from "classnames";
-import { t } from "ttag";
-
-import { EDITOR_STYLE_BOUNDARY_CLASS } from "metabase/documents/components/Editor/constants";
-import { Box, Flex, Loader, Text } from "metabase/ui";
+import { Box, Loader, Stack } from "metabase/ui";
 
 import styles from "./CardEmbedNode.module.css";
 
-type Props = {
-  selected?: boolean;
-};
-
-export const CardEmbedLoadingState = ({ selected }: Props) => {
+export const CardEmbedLoadingState = () => {
   return (
-    <Box
-      className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
-        [styles.selected]: selected,
-      })}
-    >
-      <Box className={styles.questionHeader}>
-        <Flex align="center" justify="space-between" gap="0.5rem">
-          <Box className={styles.titleContainer}>
-            <Text size="md" c="text-primary" fw={700}>
-              {t`Loading question...`}
-            </Text>
-          </Box>
-        </Flex>
-      </Box>
-
+    <Stack align="center" justify="center" h="100%">
       <Box className={styles.questionResults}>
         <Box className={styles.loadingContainer}>
           <Loader />
         </Box>
       </Box>
-    </Box>
+    </Stack>
   );
 };

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -423,7 +423,23 @@ export const CardEmbedComponent = memo(
           data-testid="document-card-embed"
           style={{ position: "relative" }}
         >
-          <CardEmbedLoadingState />
+          <Box
+            className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
+              [styles.selected]: selected,
+            })}
+          >
+            <Box className={styles.questionHeader}>
+              <Flex align="center" justify="space-between" gap="0.5rem">
+                <Box className={styles.titleContainer}>
+                  <Text size="md" c="text-primary" fw={700}>
+                    {t`Loading question...`}
+                  </Text>
+                </Box>
+              </Flex>
+            </Box>
+
+            <CardEmbedLoadingState />
+          </Box>
         </NodeViewWrapper>
       );
     }

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -46,7 +46,6 @@ import {
   Ellipsified,
   Flex,
   Icon,
-  Loader,
   Menu,
   Text,
   TextInput,
@@ -70,6 +69,7 @@ import CS from "../extensions.module.css";
 import { NativeQueryModal } from "../shared/NativeQueryModal";
 import { useDndHelpers } from "../shared/dnd/use-dnd-helpers";
 
+import { CardEmbedLoadingState } from "./CardEmbedLoadingState";
 import { CardEmbedMenuDropdown } from "./CardEmbedMenuDropdown";
 import styles from "./CardEmbedNode.module.css";
 import { PublicDocumentCardMenu } from "./PublicDocumentCardMenu";
@@ -423,26 +423,7 @@ export const CardEmbedComponent = memo(
           data-testid="document-card-embed"
           style={{ position: "relative" }}
         >
-          <Box
-            className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
-              [styles.selected]: selected,
-            })}
-          >
-            <Box className={styles.questionHeader}>
-              <Flex align="center" justify="space-between" gap="0.5rem">
-                <Box className={styles.titleContainer}>
-                  <Text size="md" color="text-primary" fw={700}>
-                    {t`Loading question...`}
-                  </Text>
-                </Box>
-              </Flex>
-            </Box>
-            <Box className={styles.questionResults}>
-              <Box className={styles.loadingContainer}>
-                <Loader />
-              </Box>
-            </Box>
-          </Box>
+          <CardEmbedLoadingState />
         </NodeViewWrapper>
       );
     }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -18,12 +18,15 @@ import { SmallGenericError } from "metabase/common/components/ErrorPages";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
+import { DashCardLoadingView } from "metabase/dashboard/components/DashCard/DashCardLoadingView";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
+import { VisualizationRunningState } from "metabase/querying/components/QueryVisualization";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
+import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
 import { getTokenFeature } from "metabase/setup/selectors";
 import { getFont } from "metabase/styled-components/selectors";
 import type { IconName, IconProps } from "metabase/ui";
@@ -1042,7 +1045,21 @@ export default _.compose(
         PLUGIN_CUSTOM_VIZ.useAutoLoadCustomVizPlugin(display);
 
       if (customVizLoading) {
-        return <LoadingView isSlow={undefined} />;
+        if (props.isDocument) {
+          return <CardEmbedLoadingState />;
+        }
+
+        if (props.isDashboard) {
+          return (
+            <DashCardLoadingView
+              display="table"
+              expectedDuration={props.expectedDuration}
+              isSlow={props.isSlow}
+            />
+          );
+        }
+
+        return <VisualizationRunningState className={cx(CS.spread, CS.z2)} />;
       }
 
       return <VisualizationMemoized {...props} forwardedRef={ref} />;


### PR DESCRIPTION
Closes [GDGT-2239](https://linear.app/metabase/issue/GDGT-2239/inconsistent-viz-loading-state)

### Description

Fixes custom viz loading state - now it uses the same loading state as questions, dashcards, and documents respectively.

### Demo

Before: [demo](https://github.com/user-attachments/assets/0aaad1de-57fa-43ea-881a-ed98e7e6d5ff)
After: [document](https://github.com/user-attachments/assets/55a709f4-924e-485a-82f0-f0b28b6c863c), [dashboard](https://github.com/user-attachments/assets/89f9b325-ec5f-40e0-90b6-2a05a4679307), [question](https://github.com/user-attachments/assets/d15f6d6d-ffd7-441e-8b9c-c47ab2449986)
