### PR TITLE
GDGT-2375, GDGT-2226 Remove trusted sources checkbox from development page

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1564,10 +1564,11 @@ describe("admin > custom visualizations", () => {
     it("should load a dev-only plugin from a local dev server URL and use it in a question", () => {
       H.visitCustomVizDevelopment();
 
-      cy.log("Add button is disabled until the dev server URL is filled in");
-      cy.findByRole("button", { name: /Add/ }).should("be.disabled");
-      cy.findByLabelText(/Dev server URL/).type(devUrl);
-      cy.findByRole("button", { name: /Add/ }).should("be.enabled").click();
+      cy.log("Dev server URL is pre-filled with the default value");
+      cy.findByLabelText(/Dev server URL/).should("have.value", devUrl);
+      cy.findByRole("button", { name: /Enable/ })
+        .should("be.enabled")
+        .click();
 
       cy.log("Verify the dev plugin is registered.");
       H.main().findByText(CUSTOM_VIZ_DEV_PROJECT_NAME).should("be.visible");

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1564,14 +1564,10 @@ describe("admin > custom visualizations", () => {
     it("should load a dev-only plugin from a local dev server URL and use it in a question", () => {
       H.visitCustomVizDevelopment();
 
-      cy.findByLabelText(/Dev server URL/).type(devUrl);
-      cy.log(
-        "It should not be possible to add the plugin until the user understands the risks",
-      );
+      cy.log("Add button is disabled until the dev server URL is filled in");
       cy.findByRole("button", { name: /Add/ }).should("be.disabled");
-      cy.findByLabelText(/I understand/).click();
-
-      cy.findByRole("button", { name: /Add/ }).click();
+      cy.findByLabelText(/Dev server URL/).type(devUrl);
+      cy.findByRole("button", { name: /Add/ }).should("be.enabled").click();
 
       cy.log("Verify the dev plugin is registered.");
       H.main().findByText(CUSTOM_VIZ_DEV_PROJECT_NAME).should("be.visible");

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/AddDevCustomVizForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/AddDevCustomVizForm.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
-import * as Yup from "yup";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import {
   Form,
-  FormCheckbox,
   FormErrorMessage,
   FormProvider,
   FormSubmitButton,
@@ -16,24 +14,12 @@ import { useCreateDevCustomVizPluginMutation } from "metabase-enterprise/api";
 
 type FormState = {
   devBundleUrl: string;
-  acknowledgedRisk: boolean;
 };
 
-const initialValues: FormState = { devBundleUrl: "", acknowledgedRisk: false };
+const initialValues: FormState = { devBundleUrl: "" };
 
 export function AddDevCustomVizForm() {
   const [createDevPlugin] = useCreateDevCustomVizPluginMutation();
-
-  const validationSchema = useMemo(
-    () =>
-      Yup.object({
-        acknowledgedRisk: Yup.boolean().oneOf(
-          [true],
-          t`You must acknowledge the security risk before proceeding.`,
-        ),
-      }),
-    [],
-  );
 
   const handleSubmit = useCallback(
     (values: FormState) =>
@@ -45,11 +31,7 @@ export function AddDevCustomVizForm() {
 
   return (
     <SettingsSection>
-      <FormProvider
-        initialValues={initialValues}
-        validationSchema={validationSchema}
-        onSubmit={handleSubmit}
-      >
+      <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>
         {({ dirty }) => (
           <Form>
             <Stack gap="lg">
@@ -59,10 +41,6 @@ export function AddDevCustomVizForm() {
                 description={t`URL of the local dev server serving the visualization bundle, manifest, and assets.`}
                 placeholder="http://localhost:5174"
                 autoFocus
-              />
-              <FormCheckbox
-                name="acknowledgedRisk"
-                label={t`I understand that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}
               />
               <FormErrorMessage />
               <Group justify="flex-end">

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/AddDevCustomVizForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/AddDevCustomVizForm.tsx
@@ -16,7 +16,9 @@ type FormState = {
   devBundleUrl: string;
 };
 
-const initialValues: FormState = { devBundleUrl: "" };
+const DEFAULT_DEV_BUNDLE_URL = "http://localhost:5174";
+
+const initialValues: FormState = { devBundleUrl: DEFAULT_DEV_BUNDLE_URL };
 
 export function AddDevCustomVizForm() {
   const [createDevPlugin] = useCreateDevCustomVizPluginMutation();
@@ -32,21 +34,21 @@ export function AddDevCustomVizForm() {
   return (
     <SettingsSection>
       <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>
-        {({ dirty }) => (
+        {({ values }) => (
           <Form>
             <Stack gap="lg">
               <FormTextInput
                 name="devBundleUrl"
                 label={t`Dev server URL`}
                 description={t`URL of the local dev server serving the visualization bundle, manifest, and assets.`}
-                placeholder="http://localhost:5174"
+                placeholder={DEFAULT_DEV_BUNDLE_URL}
                 autoFocus
               />
               <FormErrorMessage />
               <Group justify="flex-end">
                 <FormSubmitButton
-                  label={t`Add`}
-                  disabled={!dirty}
+                  label={t`Enable`}
+                  disabled={!values.devBundleUrl}
                   variant="filled"
                 />
               </Group>

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/EditDevCustomVizForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/EditDevCustomVizForm.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { match } from "ts-pattern";
 import { t } from "ttag";
-import * as Yup from "yup";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import {
   Form,
-  FormCheckbox,
   FormErrorMessage,
   FormProvider,
   FormSubmitButton,
@@ -27,28 +25,15 @@ type Props = {
 
 type FormState = {
   devBundleUrl: string;
-  acknowledgedRisk: boolean;
 };
 
 export function EditDevCustomVizForm({ plugin }: Props) {
   const [setDevUrl] = useSetCustomVizPluginDevUrlMutation();
   const [deletePlugin] = useDeleteCustomVizPluginMutation();
 
-  const validationSchema = useMemo(
-    () =>
-      Yup.object({
-        acknowledgedRisk: Yup.boolean().oneOf(
-          [true],
-          t`You must acknowledge the security risk before proceeding.`,
-        ),
-      }),
-    [],
-  );
-
   const initialValues = useMemo<FormState>(
     () => ({
       devBundleUrl: plugin.dev_bundle_url ?? "",
-      acknowledgedRisk: false,
     }),
     [plugin.dev_bundle_url],
   );
@@ -72,7 +57,6 @@ export function EditDevCustomVizForm({ plugin }: Props) {
       <FormProvider
         enableReinitialize
         initialValues={initialValues}
-        validationSchema={validationSchema}
         onSubmit={handleSubmit}
       >
         {({ dirty }) => (
@@ -111,10 +95,6 @@ export function EditDevCustomVizForm({ plugin }: Props) {
                 name="devBundleUrl"
                 label={t`Dev server URL`}
                 placeholder="http://localhost:5174"
-              />
-              <FormCheckbox
-                name="acknowledgedRisk"
-                label={t`I understand that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}
               />
               <FormErrorMessage />
               <Group justify="flex-end">

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/EditDevCustomVizForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/EditDevCustomVizForm.tsx
@@ -74,7 +74,7 @@ export function EditDevCustomVizForm({ plugin }: Props) {
                     .with("active", () => (
                       <Group align="center" flex="0 0 auto" gap="xs">
                         <Icon c="success" name="check" />
-                        <Text c="success" fw={700}>{t`Active`}</Text>
+                        <Text c="success" fw={700}>{t`Enabled`}</Text>
                       </Group>
                     ))
                     .with("error", () => (
@@ -99,10 +99,10 @@ export function EditDevCustomVizForm({ plugin }: Props) {
               <FormErrorMessage />
               <Group justify="flex-end">
                 <Button variant="subtle" color="error" onClick={handleRemove}>
-                  {t`Remove`}
+                  {t`Disable`}
                 </Button>
                 <FormSubmitButton
-                  label={t`Save`}
+                  label={t`Update`}
                   disabled={!dirty}
                   variant="filled"
                 />


### PR DESCRIPTION
Closes [GDGT-2375](https://linear.app/metabase/issue/GDGT-2375/remove-trusted-sources-checkbox-from-development-page)
Closes [GDGT-2226](https://linear.app/metabase/issue/GDGT-2226/add-a-button-to-auto-fill-dev-bundle-url-to-the-default-url)

### Description

- Removes the checkbox ([GDGT-2375](https://linear.app/metabase/issue/GDGT-2375/remove-trusted-sources-checkbox-from-development-page))
- Updates copy from "Add"/"Remove" to "Enable"/"Disable", and from "Save" to "Update" ([GDGT-2375](https://linear.app/metabase/issue/GDGT-2375/remove-trusted-sources-checkbox-from-development-page))
- Adds default value for dev URL in add form ([GDGT-2226](https://linear.app/metabase/issue/GDGT-2226/add-a-button-to-auto-fill-dev-bundle-url-to-the-default-url))

### Demo

[Add form](https://github.com/user-attachments/assets/bb9a0cb0-1a69-49cb-aa48-5fd5be2c9bc5), [edit form](https://github.com/user-attachments/assets/22ab99f4-f4c6-417e-b233-b6cf696df9d8)


