### PR TITLE
fix: flaky usage auditing tests

### DIFF
--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -31,12 +31,6 @@ type UsageAuditingTenants = {
   robertTenant: UsageAuditingTenant;
 };
 
-const USAGE_STATS_METRICS: UsageStatsMetric[] = [
-  "conversations",
-  "messages",
-  "tokens",
-];
-
 const METRIC_TAB_NAMES: Record<UsageStatsMetric, string> = {
   conversations: "Conversations",
   messages: "Messages",
@@ -162,9 +156,6 @@ const DATE_FILTER_CASES: Array<{
   { label: "Yesterday", chartLabels: YESTERDAY_CHART_LABELS },
   { label: "Previous week", chartLabels: PREVIOUS_WEEK_CHART_LABELS },
   { label: "Previous 7 days", chartLabels: RECENT_CHART_LABELS },
-  { label: "Previous 30 days", chartLabels: RECENT_CHART_LABELS },
-  { label: "Previous month", chartLabels: PREVIOUS_MONTH_CHART_LABELS },
-  { label: "Previous 3 months", chartLabels: PREVIOUS_MONTH_CHART_LABELS },
   { label: "Previous 12 months", chartLabels: PREVIOUS_MONTH_CHART_LABELS },
 ];
 
@@ -652,19 +643,18 @@ function clickLastTimeseriesChartDot(title: string): void {
 }
 
 function clickRowChartBarForLabel(title: string, label: string): void {
-  getChartCard(title)
-    .findByText(label)
-    .then(($label) => {
-      const rect = $label[0].getBoundingClientRect();
-      // Row-chart labels are not the click target; click the bar next to the visible label.
-      const target = $label[0].ownerDocument.elementFromPoint(
-        rect.right + 30,
-        rect.top + rect.height / 2,
-      );
+  getChartCard(title).within(() => {
+    cy.findByTestId("row-chart-container").then(($container) => {
+      cy.findByText(label).then(($label) => {
+        const containerRect = $container[0].getBoundingClientRect();
+        const labelRect = $label[0].getBoundingClientRect();
+        const x = labelRect.right - containerRect.left + 30;
+        const y = labelRect.top - containerRect.top + labelRect.height / 2;
 
-      expect(target).to.exist;
-      cy.wrap(target).realClick({ force: true });
+        cy.wrap($container).realClick({ x, y, scrollBehavior: false });
+      });
     });
+  });
 }
 
 function openConversationFromProfile(profileLabel: string): void {
@@ -709,22 +699,50 @@ describe("scenarios > metabot > usage auditing", () => {
     assertConversationChartLabels(RECENT_CHART_LABELS);
   });
 
-  it("renders usage stats charts for every date shortcut on every metric tab", () => {
+  it("renders usage stats charts for every date shortcut on conversations", () => {
     visitUsageStatsPage();
 
-    USAGE_STATS_METRICS.forEach((metric) => {
-      if (metric !== "conversations") {
-        selectMetricTab(metric);
-      }
+    const metric = "conversations";
 
-      DATE_FILTER_CASES.forEach(({ label, chartLabels }) => {
-        cy.log(`${METRIC_TAB_NAMES[metric]} date filter: ${label}`);
-        selectDateFilter(label);
+    DATE_FILTER_CASES.forEach(({ label, chartLabels }) => {
+      cy.log(`${METRIC_TAB_NAMES[metric]} date filter: ${label}`);
+      selectDateFilter(label);
 
-        assertMetricChartsRenderedForDate(metric, label);
-        assertMetricChartLabels(metric, chartLabels);
-        assertMetricChartLabelsAbsent(metric, OUT_OF_BOUNDS_CHART_LABELS);
-      });
+      assertMetricChartsRenderedForDate(metric, label);
+      assertMetricChartLabels(metric, chartLabels);
+      assertMetricChartLabelsAbsent(metric, OUT_OF_BOUNDS_CHART_LABELS);
+    });
+  });
+
+  it("renders usage stats charts for every date shortcut on tokens", () => {
+    visitUsageStatsPage();
+
+    const metric = "tokens";
+    selectMetricTab(metric);
+
+    DATE_FILTER_CASES.forEach(({ label, chartLabels }) => {
+      cy.log(`${METRIC_TAB_NAMES[metric]} date filter: ${label}`);
+      selectDateFilter(label);
+
+      assertMetricChartsRenderedForDate(metric, label);
+      assertMetricChartLabels(metric, chartLabels);
+      assertMetricChartLabelsAbsent(metric, OUT_OF_BOUNDS_CHART_LABELS);
+    });
+  });
+
+  it("renders usage stats charts for every date shortcut on messages", () => {
+    visitUsageStatsPage();
+
+    const metric = "messages";
+    selectMetricTab(metric);
+
+    DATE_FILTER_CASES.forEach(({ label, chartLabels }) => {
+      cy.log(`${METRIC_TAB_NAMES[metric]} date filter: ${label}`);
+      selectDateFilter(label);
+
+      assertMetricChartsRenderedForDate(metric, label);
+      assertMetricChartLabels(metric, chartLabels);
+      assertMetricChartLabelsAbsent(metric, OUT_OF_BOUNDS_CHART_LABELS);
     });
   });
 

--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -862,6 +862,8 @@ describe("scenarios > metabot > usage auditing", () => {
       visitUsageStatsPage("/admin/metabot/usage-auditing?date=past7days~");
       interceptConversationsApi();
 
+      assertMetricChartsRendered("conversations");
+
       clickRowChartBarForLabel(
         TENANT_CONVERSATIONS_CHART_TITLE,
         bobbyTenant.name,
@@ -898,6 +900,8 @@ describe("scenarios > metabot > usage auditing", () => {
   it("drills through from the groups chart to the conversations list", () => {
     visitUsageStatsPage("/admin/metabot/usage-auditing?date=past7days~");
     interceptConversationsApi();
+
+    assertMetricChartsRendered("conversations");
 
     clickRowChartBarForLabel(
       "Groups with most conversations",

--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -116,13 +116,6 @@ const TODAY_CHART_LABELS: CompleteChartLabels = {
   ip: ["10.0.0.1", "10.0.0.6", "10.0.0.7"],
 };
 
-const YESTERDAY_CHART_LABELS: CompleteChartLabels = {
-  source: ["SQL", "Documents"],
-  profile: ["SQL", "Documents"],
-  user: ["Robert Tableton"],
-  ip: ["10.0.0.3", "10.0.0.4"],
-};
-
 const PREVIOUS_WEEK_CHART_LABELS: CompleteChartLabels = {
   source: ["Metabot"],
   profile: ["NLQ"],
@@ -137,13 +130,6 @@ const RECENT_CHART_LABELS: CompleteChartLabels = {
   ip: ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"],
 };
 
-const PREVIOUS_MONTH_CHART_LABELS: CompleteChartLabels = {
-  source: ["SQL"],
-  profile: ["SQL"],
-  user: ["Robert Tableton"],
-  ip: ["10.0.0.8"],
-};
-
 const OUT_OF_BOUNDS_CHART_LABELS: ChartLabels = {
   ip: ["10.0.0.99"],
 };
@@ -153,10 +139,7 @@ const DATE_FILTER_CASES: Array<{
   chartLabels: ChartLabels;
 }> = [
   { label: "Today", chartLabels: TODAY_CHART_LABELS },
-  { label: "Yesterday", chartLabels: YESTERDAY_CHART_LABELS },
   { label: "Previous week", chartLabels: PREVIOUS_WEEK_CHART_LABELS },
-  { label: "Previous 7 days", chartLabels: RECENT_CHART_LABELS },
-  { label: "Previous 12 months", chartLabels: PREVIOUS_MONTH_CHART_LABELS },
 ];
 
 const MAIN_PROFILE_LABELS: string[] = [
@@ -699,7 +682,7 @@ describe("scenarios > metabot > usage auditing", () => {
     assertConversationChartLabels(RECENT_CHART_LABELS);
   });
 
-  it("renders usage stats charts for every date shortcut on conversations", () => {
+  it("renders usage stats charts for selected date shortcuts on conversations", () => {
     visitUsageStatsPage();
 
     const metric = "conversations";
@@ -714,7 +697,7 @@ describe("scenarios > metabot > usage auditing", () => {
     });
   });
 
-  it("renders usage stats charts for every date shortcut on tokens", () => {
+  it("renders usage stats charts for selected date shortcuts on tokens", () => {
     visitUsageStatsPage();
 
     const metric = "tokens";
@@ -730,7 +713,7 @@ describe("scenarios > metabot > usage auditing", () => {
     });
   });
 
-  it("renders usage stats charts for every date shortcut on messages", () => {
+  it("renders usage stats charts for selected date shortcuts on messages", () => {
     visitUsageStatsPage();
 
     const metric = "messages";
@@ -934,6 +917,8 @@ describe("scenarios > metabot > usage auditing", () => {
   it("drills through from conversation charts to the conversations list and updates list filters", () => {
     visitUsageStatsPage();
     interceptConversationsApi();
+
+    assertMetricChartsRendered("conversations");
 
     clickRowChartBarForLabel("Users with most conversations", "Bobby Tables");
 


### PR DESCRIPTION
Closes [BOT-1417: Speed up usage stats date shortcut test](https://linear.app/metabase/issue/BOT-1417/speed-up-usage-stats-date-shortcut-test)
Closes [BOT-1418: Investigate flaky usage auditing tests](https://linear.app/metabase/issue/BOT-1418/investigate-flaky-usage-auditing-tests)

### Description

Fixes flaky tests.

### How to verify

Stress tests: https://github.com/metabase/metabase/actions/runs/25182433422/job/73830882990

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
