### PR TITLE
Move `setCollectionPreview` from entities into a RTK-based hook

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -178,6 +178,7 @@ export type ListCollectionItemsRequest = {
   namespace?: CollectionNamespace;
   collection_type?: CollectionType;
   include_can_run_adhoc_query?: boolean;
+  show_dashboard_questions?: boolean;
 } & PaginationRequest &
   Partial<SortingOptions<ListCollectionItemsSortColumn>>;
 

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -143,7 +143,6 @@ export interface CollectionItem {
   setCollection?: (
     collection: Pick<Collection, "id"> | Pick<Dashboard, "id">,
   ) => void;
-  setCollectionPreview?: (isEnabled: boolean) => void;
   is_shared_tenant_collection?: boolean;
   is_tenant_dashboard?: boolean;
   is_remote_synced?: boolean;

--- a/frontend/src/metabase-types/entities/common.ts
+++ b/frontend/src/metabase-types/entities/common.ts
@@ -4,6 +4,5 @@ export type WrappedEntity<Entity> = {
   getName: () => string;
   getCollection: () => Collection;
   setCollection: (collection: Collection) => void;
-  setCollectionPreview: (isEnabled: boolean) => void;
   setPinned: (isPinned: boolean) => void;
 } & Entity;

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -1,3 +1,5 @@
+import { updateMetadata } from "metabase/redux/metadata";
+import { ObjectUnionSchema } from "metabase/schema";
 import type {
   Collection,
   CreateCollectionRequest,
@@ -23,6 +25,7 @@ import {
   provideCollectionListTags,
   provideCollectionTags,
 } from "./tags";
+import { handleQueryFulfilled } from "./utils/lifecycle";
 
 export const collectionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -68,6 +71,15 @@ export const collectionApi = Api.injectEndpoints({
         ...provideCollectionItemListTags(response?.data ?? [], models),
         { type: "collection", id: `${id}-items` },
       ],
+      // Hydrate the legacy entity store so legacy entity actions (e.g.
+      // Dashboards.actions.setCollection) can read the original object to
+      // build their undo payloads.
+      //
+      // TODO: Remove once entity actions are migrated.
+      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
+        handleQueryFulfilled(queryFulfilled, (response) =>
+          dispatch(updateMetadata(response.data, [ObjectUnionSchema])),
+        ),
     }),
     getCollection: builder.query<Collection, getCollectionRequest>({
       query: ({ id, ignore_error, ...params }) => {

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -24,6 +24,7 @@ import {
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { EntityItem } from "metabase/common/components/EntityItem";
 import { type ArchivableItem, useSetArchive } from "metabase/common/hooks";
+import { useSetCollectionPreview } from "metabase/common/hooks/use-set-collection-preview";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { bookmarks as BookmarkEntity } from "metabase/entities";
 import { entityForObject } from "metabase/entities/utils";
@@ -89,6 +90,7 @@ function ActionMenu({
   const dispatch = useDispatch();
   const archive = useSetArchive();
   const [sendToast] = useToast();
+  const setCollectionPreview = useSetCollectionPreview();
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure();
   const isBookmarked = bookmarks && getIsBookmarked(item, bookmarks);
   const canBookmark = canBookmarkItem(item);
@@ -135,8 +137,8 @@ function ActionMenu({
   }, [createBookmark, deleteBookmark, isBookmarked, item]);
 
   const handleTogglePreview = useCallback(() => {
-    item?.setCollectionPreview?.(!isPreviewEnabled(item));
-  }, [item]);
+    setCollectionPreview(item.id, !isPreviewEnabled(item));
+  }, [item, setCollectionPreview]);
 
   const handleRestore = useCallback(async () => {
     const Entity = entityForObject(item);

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -1,7 +1,8 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
+import { setupCardEndpoints } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import { getIcon, queryIcon, renderWithProviders } from "__support__/ui";
 import { Collections } from "metabase/entities/collections";
@@ -76,8 +77,8 @@ describe("ActionMenu", () => {
           model,
           collection_position: 1,
           collection_preview: true,
-          setCollectionPreview: jest.fn(),
         });
+        setupCardEndpoints(createMockCard({ id: item.id }));
 
         setup({ item });
 
@@ -86,7 +87,20 @@ describe("ActionMenu", () => {
           await screen.findByText("Don’t show visualization"),
         );
 
-        expect(item.setCollectionPreview).toHaveBeenCalledWith(false);
+        await waitFor(() =>
+          expect(
+            fetchMock.callHistory.calls(`path:/api/card/${item.id}`, {
+              method: "PUT",
+            }),
+          ).toHaveLength(1),
+        );
+        const call = fetchMock.callHistory.lastCall(
+          `path:/api/card/${item.id}`,
+          { method: "PUT" },
+        );
+        expect(JSON.parse(call?.options.body as string)).toEqual({
+          collection_preview: false,
+        });
       },
     );
 
@@ -97,15 +111,28 @@ describe("ActionMenu", () => {
           model,
           collection_position: 1,
           collection_preview: false,
-          setCollectionPreview: jest.fn(),
         });
+        setupCardEndpoints(createMockCard({ id: item.id }));
 
         setup({ item });
 
         await userEvent.click(getIcon("ellipsis"));
         await userEvent.click(await screen.findByText("Show visualization"));
 
-        expect(item.setCollectionPreview).toHaveBeenCalledWith(true);
+        await waitFor(() =>
+          expect(
+            fetchMock.callHistory.calls(`path:/api/card/${item.id}`, {
+              method: "PUT",
+            }),
+          ).toHaveLength(1),
+        );
+        const call = fetchMock.callHistory.lastCall(
+          `path:/api/card/${item.id}`,
+          { method: "PUT" },
+        );
+        expect(JSON.parse(call?.options.body as string)).toEqual({
+          collection_preview: true,
+        });
       },
     );
 
@@ -114,7 +141,6 @@ describe("ActionMenu", () => {
         item: createMockCollectionItem({
           model: "dataset",
           collection_position: 1,
-          setCollectionPreview: jest.fn(),
         }),
       });
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.tsx
@@ -90,7 +90,6 @@ export function CollectionContent({
       databases={databases}
       bookmarks={bookmarks}
       collection={collection}
-      collections={collections}
       collectionId={collectionId}
       createBookmark={createBookmark}
       deleteBookmark={deleteBookmark}

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -6,6 +6,7 @@ import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
+import { useListCollectionItemsQuery } from "metabase/api";
 import { deletePermanently } from "metabase/archive/actions";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
 import { trackCollectionBookmarked } from "metabase/collections/analytics";
@@ -35,7 +36,6 @@ import { Bookmarks } from "metabase/entities/bookmarks";
 import { Collections } from "metabase/entities/collections";
 import { Search } from "metabase/entities/search";
 import { useDispatch } from "metabase/redux";
-import type { State } from "metabase/redux/store";
 import { MAX_UPLOAD_SIZE, MAX_UPLOAD_STRING } from "metabase/redux/uploads";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -54,7 +54,7 @@ import { getComposedDragProps } from "./utils";
 
 const itemKeyFn = (item: CollectionItem) => `${item.id}:${item.model}`;
 
-const CollectionContentViewInner = ({
+export const CollectionContentView = ({
   databases,
   bookmarks,
   collection,
@@ -62,8 +62,6 @@ const CollectionContentViewInner = ({
   createBookmark,
   deleteBookmark,
   isAdmin,
-  list,
-  loading,
   uploadFile,
   uploadsEnabled,
   canCreateUploadInDb,
@@ -76,13 +74,26 @@ const CollectionContentViewInner = ({
   createBookmark: CreateBookmark;
   deleteBookmark: DeleteBookmark;
   isAdmin: boolean;
-  list: CollectionItem[] | undefined;
-  loading: boolean;
   uploadFile: UploadFile;
   uploadsEnabled: boolean;
   canCreateUploadInDb: boolean;
   visibleColumns?: CollectionContentTableColumn[];
 }) => {
+  const dispatch = useDispatch();
+
+  const { data: pinnedItemsData, isLoading: loading } =
+    useListCollectionItemsQuery({
+      id: collectionId,
+      pinned_state: "is_pinned",
+      sort_column: "name",
+      sort_direction: "asc",
+    });
+
+  const list = useMemo(
+    () =>
+      pinnedItemsData?.data.map((item) => Search.wrapEntity(item, dispatch)),
+    [pinnedItemsData, dispatch],
+  );
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [selectedItems, setSelectedItems] = useState<CollectionItem[] | null>(
     null,
@@ -135,7 +146,6 @@ const CollectionContentViewInner = ({
     setIsBookmarked(shouldBeBookmarked);
   }, [bookmarks, collectionId]);
 
-  const dispatch = useDispatch();
   const archive = useSetArchive();
   const [sendToast] = useToast();
 
@@ -331,14 +341,3 @@ const CollectionContentViewInner = ({
     </CollectionRoot>
   );
 };
-
-export const CollectionContentView = Search.loadList({
-  query: (_state: State, { collectionId }: { collectionId: CollectionId }) => ({
-    collection: collectionId,
-    pinned_state: "is_pinned",
-    sort_column: "name",
-    sort_direction: "asc",
-  }),
-  loadingAndErrorWrapper: false,
-  wrapped: true,
-})(CollectionContentViewInner);

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 
+import { useListCollectionItemsQuery } from "metabase/api";
 import {
   ALL_MODELS,
   COLLECTION_PAGE_SIZE,
@@ -26,7 +27,7 @@ import { usePagination } from "metabase/common/hooks/use-pagination";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { Search } from "metabase/entities/search";
-import type { State } from "metabase/redux/store";
+import { useDispatch } from "metabase/redux";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Bookmark,
@@ -122,15 +123,12 @@ export const CollectionItemsTable = ({
     SortingOptions<ListCollectionItemsSortColumn>
   >(() => getDefaultSortingOptions(collection));
 
-  const [total, setTotal] = useState<number>();
-
   const { handleNextPage, handlePreviousPage, setPage, page, resetPage } =
     usePagination();
 
   useEffect(() => {
     if (collectionId) {
       resetPage();
-      setTotal(undefined);
     }
   }, [collectionId, resetPage]);
 
@@ -149,6 +147,7 @@ export const CollectionItemsTable = ({
       bookmarks={bookmarks}
       clear={clear}
       collection={collection}
+      collectionId={collectionId}
       createBookmark={createBookmark}
       databases={databases}
       deleteBookmark={deleteBookmark}
@@ -159,13 +158,13 @@ export const CollectionItemsTable = ({
       hasPinnedItems={hasPinnedItems}
       loadingPinnedItems={loadingPinnedItems}
       page={page}
+      pageSize={pageSize}
       selected={selected}
       selectOnlyTheseItems={selectOnlyTheseItems}
       toggleItem={toggleItem}
-      total={total}
       unpinnedItemsSorting={unpinnedItemsSorting}
       unpinnedQuery={{
-        collection: collectionId,
+        id: collectionId,
         models,
         limit: pageSize,
         offset: pageSize * page,
@@ -184,10 +183,7 @@ export const CollectionItemsTable = ({
 };
 
 type CollectionItemsTableContentProps = CollectionItemsTableProps & {
-  list: CollectionItem[] | undefined;
-  loading: boolean;
   page: number;
-  total: number | undefined;
   unpinnedItemsSorting: SortingOptions<ListCollectionItemsSortColumn>;
   unpinnedQuery: ListCollectionItemsRequest;
   onNextPage: () => void;
@@ -198,7 +194,7 @@ type CollectionItemsTableContentProps = CollectionItemsTableProps & {
   visibleColumns: CollectionContentTableColumn[];
 };
 
-const CollectionItemsTableContentInner = ({
+const CollectionItemsTableContent = ({
   bookmarks,
   clear,
   collection,
@@ -210,22 +206,29 @@ const CollectionItemsTableContentInner = ({
   handleCopy,
   handleMove,
   hasPinnedItems,
-  list: unpinnedItems = [],
-  loading: loadingUnpinnedItems,
   loadingPinnedItems,
   page,
   pageSize = COLLECTION_PAGE_SIZE,
   selected,
   selectOnlyTheseItems,
   toggleItem,
-  total,
   unpinnedItemsSorting,
+  unpinnedQuery,
   visibleColumns,
   onClick,
   onNextPage,
   onPreviousPage,
   onUnpinnedItemsSortingChange,
 }: CollectionItemsTableContentProps) => {
+  const dispatch = useDispatch();
+  const { data, isLoading: loadingUnpinnedItems } =
+    useListCollectionItemsQuery(unpinnedQuery);
+
+  const unpinnedItems = useMemo(
+    () => data?.data.map((item) => Search.wrapEntity(item, dispatch)) ?? [],
+    [data, dispatch],
+  );
+  const total = data?.total;
   const visibleColumnsMap = useMemo(
     () => getVisibleColumnsMap(visibleColumns),
     [visibleColumns],
@@ -295,11 +298,3 @@ const CollectionItemsTableContentInner = ({
     </CollectionTable>
   );
 };
-
-const CollectionItemsTableContent = Search.loadList({
-  query: (_state: State, props: CollectionItemsTableContentProps) => {
-    return props.unpinnedQuery;
-  },
-  loadingAndErrorWrapper: false,
-  wrapped: true,
-})(CollectionItemsTableContentInner);

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -6,6 +6,7 @@ export * from "./use-get-personal-collection";
 export * from "./use-has-token-feature";
 export * from "./use-locale";
 export * from "./use-notification-channels";
+export * from "./use-set-collection-preview";
 export * from "./use-setting";
 export * from "./use-temp-storage";
 export * from "./use-temporary-state";

--- a/frontend/src/metabase/common/hooks/use-set-collection-preview.ts
+++ b/frontend/src/metabase/common/hooks/use-set-collection-preview.ts
@@ -1,0 +1,14 @@
+import { useCallback } from "react";
+
+import { useUpdateCardMutation } from "metabase/api";
+import type { CardId } from "metabase-types/api";
+
+export function useSetCollectionPreview() {
+  const [updateCard] = useUpdateCardMutation();
+
+  return useCallback(
+    (id: CardId, collection_preview: boolean) =>
+      updateCard({ id, collection_preview }),
+    [updateCard],
+  );
+}

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -133,9 +133,6 @@ export const Questions = createEntity({
         },
         opts,
       ),
-
-    setCollectionPreview: ({ id }, collection_preview, opts) =>
-      Questions.actions.update({ id }, { collection_preview }, opts),
   },
 
   selectors: {


### PR DESCRIPTION
Closes DEV-1897

- Removes the `setCollectionPreview` helper from `objectActions` and `EntityWrapper`
- Migrates `CollectionContent` to RTK-query too so it can listen to invalidations.