### PR TITLE
Hide Metabot logo on AI exploration page when illustrations are disabled

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.module.css
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.module.css
@@ -77,10 +77,7 @@
 }
 
 .sendButton {
-  width: 2rem;
-  height: 2rem;
-  padding: 0;
-  min-width: unset;
+  color: var(--mb-color-background-primary);
 
   &:disabled,
   &:disabled:hover {

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -8,13 +8,14 @@ import _ from "underscore";
 
 import { useGetSuggestedMetabotPromptsQuery } from "metabase/api";
 import { MetabotLogo } from "metabase/common/components/MetabotLogo";
+import { useSetting } from "metabase/common/hooks";
 import { MetabotPromptInput } from "metabase/metabot/components/MetabotPromptInput";
 import { QueryBuilder } from "metabase/query_builder/containers/QueryBuilder";
 import { useDispatch } from "metabase/redux";
 import { useRouter } from "metabase/router";
 import {
+  ActionIcon,
   Box,
-  Button,
   Icon,
   Paper,
   Stack,
@@ -70,6 +71,7 @@ const MetabotQueryBuilderInner = () => {
 
   const [title] = useState(getTitleText);
   const [hasError, setHasError] = useState(false);
+  const showIllustrations = useSetting("metabot-show-illustrations");
 
   const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery({
     metabot_id: metabotId,
@@ -169,7 +171,7 @@ const MetabotQueryBuilderInner = () => {
     <Box className={S.page}>
       <Box className={S.centeredContainer}>
         <Box className={S.greeting}>
-          <MetabotLogo className={S.greetingIcon} />
+          {showIllustrations && <MetabotLogo className={S.greetingIcon} />}
           <Text fz={{ base: "xl", sm: 32 }} fw={600} c="text-primary">
             {title}
           </Text>
@@ -205,16 +207,18 @@ const MetabotQueryBuilderInner = () => {
               ) : (
                 <div />
               )}
-              <Button
+              <ActionIcon
                 className={S.sendButton}
                 variant="filled"
+                size="2rem"
                 disabled={inputDisabled}
                 loading={isDoingScience}
                 onClick={handleEditorSubmit}
                 data-testid="metabot-send-message"
+                aria-label={t`Send`}
               >
                 <Icon name="arrow_up" />
-              </Button>
+              </ActionIcon>
             </Box>
           </Paper>
 

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.unit.spec.tsx
@@ -1,3 +1,6 @@
+import type { ComponentType } from "react";
+import { Route } from "react-router";
+
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase/api";
@@ -6,7 +9,6 @@ import {
   useUserMetabotPermissions,
 } from "metabase/metabot/hooks";
 import { createMockState } from "metabase/redux/store/mocks";
-import { useRouter } from "metabase/router";
 
 import { MetabotQueryBuilder } from "./MetabotQueryBuilder";
 
@@ -21,20 +23,24 @@ jest.mock("metabase/metabot/hooks", () => ({
   useUserMetabotPermissions: jest.fn(),
 }));
 
-jest.mock("metabase/router", () => ({
-  ...jest.requireActual("metabase/router"),
-  useRouter: jest.fn(),
-}));
+// Hide the QueryBuilder prop type the wrapper inherits — it's irrelevant
+// since the canUseNlq path renders the inner component with no props.
+const TestSubject = MetabotQueryBuilder as ComponentType;
 
-function setup({ showIllustrations }: { showIllustrations: boolean }) {
+type SetupOptions = {
+  showIllustrations?: boolean;
+  prompt?: string;
+  suggestedPrompts?: { prompt: string }[];
+};
+
+function setup({
+  showIllustrations = true,
+  prompt = "",
+  suggestedPrompts = [],
+}: SetupOptions = {}) {
   jest.mocked(useUserMetabotPermissions).mockReturnValue({
     canUseNlq: true,
-    canUseMetabot: true,
-    canUseSqlGeneration: true,
-    canUseOtherTools: true,
-    isLoading: false,
-    isError: false,
-  });
+  } as any);
   jest.mocked(useMetabotAgent).mockReturnValue({
     setVisible: jest.fn(),
     resetConversation: jest.fn(),
@@ -43,24 +49,19 @@ function setup({ showIllustrations }: { showIllustrations: boolean }) {
     setPrompt: jest.fn(),
     metabotId: "default",
     isDoingScience: false,
-    prompt: "",
+    prompt,
     promptInputRef: { current: null },
   } as any);
   jest.mocked(useGetSuggestedMetabotPromptsQuery).mockReturnValue({
-    currentData: { prompts: [] },
+    currentData: { prompts: suggestedPrompts },
   } as any);
-  jest.mocked(useRouter).mockReturnValue({
-    router: { setRouteLeaveHook: jest.fn(() => () => {}) } as any,
-    routes: [],
-    location: {} as any,
-    params: {},
-  });
 
   const settings = mockSettings({
     "metabot-show-illustrations": showIllustrations,
   });
 
-  return renderWithProviders(<MetabotQueryBuilder {...({} as any)} />, {
+  return renderWithProviders(<Route path="/" component={TestSubject} />, {
+    withRouter: true,
     storeInitialState: createMockState({ settings }),
   });
 }
@@ -80,5 +81,26 @@ describe("MetabotQueryBuilder", () => {
     expect(
       screen.queryByRole("img", { name: "Metabot" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders suggested prompts when the API returns them", () => {
+    setup({
+      suggestedPrompts: [
+        { prompt: "Show me top customers" },
+        { prompt: "How many orders this month?" },
+      ],
+    });
+    expect(screen.getByText("Show me top customers")).toBeInTheDocument();
+    expect(screen.getByText("How many orders this month?")).toBeInTheDocument();
+  });
+
+  it("disables the send button when the prompt is empty", () => {
+    setup({ prompt: "" });
+    expect(screen.getByTestId("metabot-send-message")).toBeDisabled();
+  });
+
+  it("enables the send button when the prompt is non-empty", () => {
+    setup({ prompt: "anything" });
+    expect(screen.getByTestId("metabot-send-message")).toBeEnabled();
   });
 });

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.unit.spec.tsx
@@ -1,0 +1,84 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { useGetSuggestedMetabotPromptsQuery } from "metabase/api";
+import {
+  useMetabotAgent,
+  useUserMetabotPermissions,
+} from "metabase/metabot/hooks";
+import { createMockState } from "metabase/redux/store/mocks";
+import { useRouter } from "metabase/router";
+
+import { MetabotQueryBuilder } from "./MetabotQueryBuilder";
+
+jest.mock("metabase/api", () => ({
+  ...jest.requireActual("metabase/api"),
+  useGetSuggestedMetabotPromptsQuery: jest.fn(),
+}));
+
+jest.mock("metabase/metabot/hooks", () => ({
+  ...jest.requireActual("metabase/metabot/hooks"),
+  useMetabotAgent: jest.fn(),
+  useUserMetabotPermissions: jest.fn(),
+}));
+
+jest.mock("metabase/router", () => ({
+  ...jest.requireActual("metabase/router"),
+  useRouter: jest.fn(),
+}));
+
+function setup({ showIllustrations }: { showIllustrations: boolean }) {
+  jest.mocked(useUserMetabotPermissions).mockReturnValue({
+    canUseNlq: true,
+    canUseMetabot: true,
+    canUseSqlGeneration: true,
+    canUseOtherTools: true,
+    isLoading: false,
+    isError: false,
+  });
+  jest.mocked(useMetabotAgent).mockReturnValue({
+    setVisible: jest.fn(),
+    resetConversation: jest.fn(),
+    submitInput: jest.fn(),
+    cancelRequest: jest.fn(),
+    setPrompt: jest.fn(),
+    metabotId: "default",
+    isDoingScience: false,
+    prompt: "",
+    promptInputRef: { current: null },
+  } as any);
+  jest.mocked(useGetSuggestedMetabotPromptsQuery).mockReturnValue({
+    currentData: { prompts: [] },
+  } as any);
+  jest.mocked(useRouter).mockReturnValue({
+    router: { setRouteLeaveHook: jest.fn(() => () => {}) } as any,
+    routes: [],
+    location: {} as any,
+    params: {},
+  });
+
+  const settings = mockSettings({
+    "metabot-show-illustrations": showIllustrations,
+  });
+
+  return renderWithProviders(<MetabotQueryBuilder {...({} as any)} />, {
+    storeInitialState: createMockState({ settings }),
+  });
+}
+
+describe("MetabotQueryBuilder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the Metabot illustration when metabot-show-illustrations is true", () => {
+    setup({ showIllustrations: true });
+    expect(screen.getByRole("img", { name: "Metabot" })).toBeInTheDocument();
+  });
+
+  it("hides the Metabot illustration when metabot-show-illustrations is false", () => {
+    setup({ showIllustrations: false });
+    expect(
+      screen.queryByRole("img", { name: "Metabot" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Fixes [UXW-3927](https://linear.app/metabase/issue/UXW-3927/bug-turning-off-metabot-illustrations-should-affect-the-ai-exploration).

The "Show Metabot illustrations" setting only gated the chat sidebar — the AI exploration page (`/question/ask`) ignored it.

Also swapped the input's send `<Button>` for `<ActionIcon>` so the arrow centers cleanly (Mantine's `<Button>` label was offsetting the inline SVG by a baseline).

### How to verify

- [ ] As an admin, upload a custom Metabot icon under **Admin → AI → Customization** so the "Metabot illustrations" toggle becomes available.
- [ ] Toggle it **off** and visit `/question/ask`. The Metabot face should not appear next to the title.
- [ ] Toggle it **on** again — the face reappears.
- [ ] Confirm the chat sidebar behavior is unchanged.

### Demo

https://github.com/user-attachments/assets/7e87034a-5283-4464-8f8b-bc10d2817ae0

### Checklist

n/a