### PR TITLE
Fix parsing timestamps with time zone in CLJS

### DIFF
--- a/src/metabase/util/time/impl.cljs
+++ b/src/metabase/util/time/impl.cljs
@@ -243,15 +243,15 @@
 ;;; ---------------------------------------------- parsing helpers ---------------------------------------------------
 (defn parse-with-zone
   "Parses a timestamp with Z or a timezone offset at the end.
-  Dayjs will handle this correctly with utc() and keepOffset."
+
+  Returns a dayjs in the input's offset zone, so subsequent `.startOf`/`.format` calls operate on the
+  input's local calendar rather than UTC. Without this, e.g. \"2024-05-13T00:00:00+08:00\" would be
+  truncated to May 12 (in UTC) instead of May 13 (in +08:00). See #72937."
   [value]
-  (let [;; Check if it has a timezone offset
-        has-offset? (re-find #"[Zz]|[+-]\d{2}:?\d{2}$" value)]
-    (if has-offset?
-      ;; Parse as UTC and keep the offset info
-      (.utc dayjs value true)
-      ;; No timezone, parse normally
-      (dayjs value))))
+  (if-let [offset (re-find #"Z|[+-]\d{2}:?\d{2}$" value)]
+    (-> (.utc dayjs value)
+        (.utcOffset offset))
+    (dayjs value)))
 
 (defn localize
   "Given a freshly parsed absolute Day.js instance, convert it to a local one."

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -784,3 +784,93 @@
                    :cljs "Total is less than 92")]
                (map #(:long-display-name (lib/display-info query' %))
                     (lib/filters query'))))))))
+
+(deftest ^:parallel double-summarize-then-drill-twice-test
+  (testing "drilling twice on a double-summarize query keeps the correct date filter (#72937)"
+    (let [;; First summarize: max(subtotal) by day(created-at), product-id.
+          stage-1    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/aggregate (lib/max (meta/field-metadata :orders :subtotal)))
+                         (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                           (lib/with-temporal-bucket :day)))
+                         (lib/breakout (meta/field-metadata :orders :product-id))
+                         lib/append-stage)
+          inner-day  (lib.tu.notebook/find-col-with-spec
+                      stage-1 (lib/returned-columns stage-1) {} {:display-name "Created At: Day"})
+          ;; Second summarize: count by week(created-at) (line-chart "by Week").
+          query      (-> stage-1
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-temporal-bucket inner-day :week)))
+          out-cols   (lib/returned-columns query)
+          week-col   (lib.tu.notebook/find-col-with-spec
+                      query out-cols {} {:display-name "Created At: Week"})
+          count-col  (lib.tu.notebook/find-col-with-spec
+                      query out-cols {} {:display-name "Count"})
+          ;; Step 1 – click a chart point on a particular week.
+          first-ctx  {:column     count-col
+                      :column-ref (lib/ref count-col)
+                      :value      99
+                      :row        [{:column week-col
+                                    :column-ref (lib/ref week-col)
+                                    :value      "2023-03-12T00:00:00Z"}
+                                   {:column count-col
+                                    :column-ref (lib/ref count-col)
+                                    :value      99}]
+                      :dimensions [{:column week-col
+                                    :column-ref (lib/ref week-col)
+                                    :value      "2023-03-12T00:00:00Z"}]}
+          first-drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                    (lib/available-drill-thrus query first-ctx))
+          _           (is (some? first-drill))
+          first-result (lib/drill-thru query first-drill)]
+      (testing "first drill applies a week filter on the outer stage (week boundaries depend on `start-of-week`)"
+        (is (=? {:stages [{}
+                          {:filters     [[:between {}
+                                          [:field {:temporal-unit :week} string?]
+                                          string?
+                                          string?]]
+                           :aggregation (symbol "nil #_\"key is not present.\"")
+                           :breakout    (symbol "nil #_\"key is not present.\"")
+                           :fields      (symbol "nil #_\"key is not present.\"")}]}
+                first-result)))
+      ;; Step 2 – click an aggregated cell ("max") on a row whose CREATED_AT is 2023-03-15.
+      (let [row-cols      (lib/returned-columns first-result)
+            row-day       (lib.tu.notebook/find-col-with-spec
+                           first-result row-cols {} {:display-name "Created At: Day"})
+            row-product   (lib.tu.notebook/find-col-with-spec
+                           first-result row-cols {} {:display-name "Product ID"})
+            row-max       (lib.tu.notebook/find-col-with-spec
+                           first-result row-cols {} {:display-name "Max of Subtotal"})
+            second-ctx    {:column     row-max
+                           :column-ref (lib/ref row-max)
+                           :value      150.0
+                           :row        [{:column row-day
+                                         :column-ref (lib/ref row-day)
+                                         :value      "2023-03-15T00:00:00+08:00"}
+                                        {:column row-product
+                                         :column-ref (lib/ref row-product)
+                                         :value      14}
+                                        {:column row-max
+                                         :column-ref (lib/ref row-max)
+                                         :value      150.0}]
+                           :dimensions [{:column row-day
+                                         :column-ref (lib/ref row-day)
+                                         :value      "2023-03-15T00:00:00+08:00"}
+                                        {:column row-product
+                                         :column-ref (lib/ref row-product)
+                                         :value      14}]}
+            second-drill  (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                        (lib/available-drill-thrus first-result second-ctx))
+            _             (is (some? second-drill))
+            second-result (lib/drill-thru first-result second-drill)]
+        (testing "second drill should filter on 2023-03-15 (not 2023-03-14)"
+          (is (=? {:stages [{:filters     [[:between {}
+                                            [:field {:temporal-unit :day} (meta/id :orders :created-at)]
+                                            "2023-03-15"
+                                            "2023-03-15"]
+                                           [:= {}
+                                            [:field {} (meta/id :orders :product-id)]
+                                            14]]
+                             :aggregation (symbol "nil #_\"key is not present.\"")
+                             :breakout    (symbol "nil #_\"key is not present.\"")
+                             :fields      (symbol "nil #_\"key is not present.\"")}]}
+                  second-result)))))))

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -1173,3 +1173,21 @@
                       (= false
                          (#'lib.fe-util/expandable-temporal-expression? expr)))
           :minute :day)))))
+
+(deftest ^:parallel expand-temporal-expression-preserves-local-date-test
+  (testing "values with a timezone offset must produce a range on the offset's local calendar day, not UTC (#72937)"
+    ;; The drill-thru/underlying-records path calls expand-temporal-expression directly for `:day`, and the FE
+    ;; can pass values stamped with the report-timezone offset (e.g. Asia/Shanghai +08:00). Truncating those to
+    ;; a calendar day must keep the original date — converting to UTC first shifts the day backwards.
+    (let [field-with-unit (fn [unit] [:field {:lib/uuid "3fcaefe5-5c20-4cbc-98ed-6007b67843a3"
+                                              :temporal-unit unit} 111])
+          expr-with       (fn [unit value] [:= {:lib/uuid "4fcaefe5-5c20-4cbc-98ed-6007b67843a4"}
+                                            (field-with-unit unit) value])]
+      (are [unit value start end]
+           (=? [:between map? [:field {:temporal-unit unit} int?] start end]
+               (#'lib.fe-util/expand-temporal-expression (expr-with unit value)))
+        :day   "2024-05-13T00:00:00Z"      "2024-05-13" "2024-05-13"
+        :day   "2024-05-13T00:00:00+08:00" "2024-05-13" "2024-05-13"
+        :day   "2024-05-13T00:00:00-08:00" "2024-05-13" "2024-05-13"
+        :week  "2024-05-13T00:00:00+08:00" "2024-05-12" "2024-05-18"
+        :month "2024-05-01T00:00:00+08:00" "2024-05-01" "2024-05-31"))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72937
Closes QUE2-524

### Description

Preserve the offset of the timestamps.

### How to verify

The repro steps should not end without data, the correct time range should be produced.
Also, see the new tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
