### PR TITLE
Remove tech writers codeowners from autogenerated docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,11 @@ frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embe
 # @metabase/tech-writers
 docs @metabase/tech-writers
 docs/developers-guide # exclude from tech-writer ownership
+docs/api.html # auto-generated
+docs/api.json # auto-generated
+docs/configuring-metabase/environment-variables.md # auto-generated
+docs/configuring-metabase/config-template.md # auto-generated
+docs/installation-and-operation/commands.md # auto-generated
 
 # @metabase/devexp
 .github @metabase/devexp


### PR DESCRIPTION
These docs are auto-generated from source anyway, and there's no reason to block PRs like #73052 on writer review