### PR TITLE
[Metabot] Data source feedback

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1148,7 +1148,7 @@
            sync
            util
            warehouse-schema}
-   :model-imports #{:model/Database :model/Field :model/Table}}
+   :model-imports #{:model/Card :model/Database :model/Field :model/Table}}
 
   logger
   {:team "DevEx"
@@ -1254,7 +1254,6 @@
               settings
               slackbot
               sql-tools
-              store-api
               sync
               system
               task

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2037,7 +2037,6 @@
               analytics-interface
               api
               channel
-              config
               formatter
               lib
               metabot
@@ -2053,8 +2052,7 @@
    :model-imports #{:model/AuthIdentity
                     :model/Card
                     :model/Database
-                    :model/MetabotMessage
-                    :model/User}}
+                    :model/MetabotMessage}}
 
   source-swap
   {:team "Graphy"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -92,6 +92,7 @@
    "MetabotInstanceLimit"
    "MetabotMessage"
    "MetabotPermissions"
+   "MetabotSourceFeedback"
    "ModelIndex"
    "ModelIndexValue"
    "ModerationReview"

--- a/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
@@ -24,14 +24,15 @@
   "Send a message through the real streaming endpoint, returning the HTTP response body.
    The LLM is mocked to return a simple text response with the given model/usage."
   [conversation-id message model prompt-tokens completion-tokens]
-  (let [mock-fn (fn [_]
-                  (mut/mock-llm-response
-                   [{:type :start :id "msg-1"}
-                    {:type :text  :text "Hello!"}
-                    {:type  :usage
-                     :model model
-                     :usage {:promptTokens prompt-tokens :completionTokens completion-tokens}
-                     :id    "msg-1"}]))]
+  (let [message-id (str (random-uuid))
+        mock-fn    (fn [_]
+                     (mut/mock-llm-response
+                      [{:type :start :id message-id}
+                       {:type :text  :text "Hello!"}
+                       {:type  :usage
+                        :model model
+                        :usage {:promptTokens prompt-tokens :completionTokens completion-tokens}
+                        :id    message-id}]))]
     (with-redefs [openrouter/openrouter mock-fn
                   claude/claude         mock-fn
                   openai/openai         mock-fn]

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -1,95 +1,10 @@
 (ns metabase-enterprise.metabot.api-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
-   [metabase.test :as mt]
-   [metabase.util.json :as json]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
-
-(defn- with-owned-message!
-  "Create a conversation + assistant message owned by `user-id` and call `f` with
-   the message's external_id, cleaning up afterwards."
-  [user-id f]
-  (let [conversation-id (str (random-uuid))
-        external-id     (str (random-uuid))]
-    (try
-      (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
-      (t2/insert-returning-pks!
-       :model/MetabotMessage
-       {:conversation_id conversation-id
-        :role            "assistant"
-        :profile_id      "gpt-x"
-        :external_id     external-id
-        :total_tokens    5
-        :data            [{:type "text" :text "hi"}]})
-      (f external-id)
-      (finally
-        (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
-        (t2/delete! :model/MetabotConversation :id conversation-id)))))
-
-(deftest feedback-endpoint-test
-  (let [store-url  "http://hm.example"
-        fake-token "test-fake-token-for-feedback"]
-    (testing "Persists feedback locally and proxies a Harbormaster payload built from DB state"
-      (mt/with-temporary-setting-values [store-api-url store-url]
-        (with-owned-message!
-          (mt/user->id :rasta)
-          (fn [external-id]
-            (let [captured     (atom nil)
-                  body         {:metabot_id        1
-                                :message_id        external-id
-                                :positive          true
-                                :freeform_feedback "ok"}
-                  expected-url (str store-url "/api/v2/metabot/feedback/" fake-token)]
-              (mt/with-dynamic-fn-redefs
-                [premium-features/premium-embedding-token (constantly fake-token)
-                 http/post (fn [url opts]
-                             (reset! captured {:url  url
-                                               :body (json/decode+kw (:body opts))}))]
-                (mt/user-http-request :rasta :post 204 "metabot/feedback" body)
-                (is (= expected-url (:url @captured)))
-                (let [sent (:body @captured)]
-                  (is (= 1 (:metabot_id sent)))
-                  (is (= {:message_id        external-id
-                          :positive          true
-                          :issue_type        nil
-                          :freeform_feedback "ok"}
-                         (:feedback sent)))
-                  (is (map? (:conversation_data sent)))
-                  (is (contains? sent :version))
-                  (is (contains? sent :submission_time))
-                  (is (false? (:is_admin sent))))))))))
-
-    (testing "404s when the message_id does not resolve to a message the caller owns"
-      (mt/user-http-request :rasta :post 404 "metabot/feedback"
-                            {:metabot_id 1
-                             :message_id (str (random-uuid))
-                             :positive   true}))
-
-    (testing "Persists locally and returns 204 when the premium token is missing (Harbormaster errors are swallowed)"
-      (mt/with-temporary-setting-values [store-api-url store-url]
-        (with-owned-message!
-          (mt/user->id :rasta)
-          (fn [external-id]
-            (let [posted? (atom false)
-                  message-row-id (t2/select-one-fn :id :model/MetabotMessage :external_id external-id)]
-              (mt/with-dynamic-fn-redefs
-                [premium-features/premium-embedding-token (constantly nil)
-                 http/post (fn [& _] (reset! posted? true))]
-                (mt/user-http-request :rasta :post 204 "metabot/feedback"
-                                      {:metabot_id        1
-                                       :message_id        external-id
-                                       :positive          true
-                                       :freeform_feedback "ok"})
-                (is (false? @posted?)
-                    "Harbormaster must not be contacted when the premium token is missing")
-                (is (= {:positive true :freeform_feedback "ok"}
-                       (t2/select-one [:model/MetabotFeedback :positive :freeform_feedback]
-                                      :message_id message-row-id))
-                    "Local feedback row should still be persisted")))))))))
 
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -65,6 +65,7 @@
     :model/MetabotInstanceLimit
     :model/MetabotMessage
     :model/MetabotPermissions
+    :model/MetabotSourceFeedback
     :model/ModelIndex
     :model/ModelIndexValue
     :model/ModerationReview

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { Messages } from "metabase/metabot/components/MetabotChat/MetabotChatMessage";
 import { MetabotResetLongChatButton } from "metabase/metabot/components/MetabotChat/MetabotResetLongChatButton";
 import { useMetabotAgent } from "metabase/metabot/hooks";
 import { useMetabotReactions } from "metabase/metabot/hooks/use-metabot-reactions";
+import type { MetabotChatMessage } from "metabase/metabot/state";
 import { Stack } from "metabase/ui";
 
 import S from "./MetabotQuestion.module.css";
+
+const isQuestionNavigationMessage = (message: MetabotChatMessage) =>
+  message.type === "data_part" && message.part.type === "navigate_to";
 
 export function MetabotChatHistory() {
   const metabot = useMetabotAgent();
@@ -14,7 +18,12 @@ export function MetabotChatHistory() {
   const { setNavigateToPath } = useMetabotReactions();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  const hasMessages = messages.length > 0 || errorMessages.length > 0;
+  const chatMessages = useMemo(
+    () => messages.filter((message) => !isQuestionNavigationMessage(message)),
+    [messages],
+  );
+
+  const hasMessages = chatMessages.length > 0 || errorMessages.length > 0;
 
   // Auto-scroll to bottom when new messages are received
   useEffect(() => {
@@ -22,7 +31,7 @@ export function MetabotChatHistory() {
       scrollContainerRef.current.scrollTop =
         scrollContainerRef.current.scrollHeight;
     }
-  }, [messages.length, errorMessages.length, metabot.isDoingScience]);
+  }, [chatMessages.length, errorMessages.length, metabot.isDoingScience]);
 
   return (
     <Stack
@@ -35,7 +44,7 @@ export function MetabotChatHistory() {
     >
       {hasMessages ? (
         <Messages
-          messages={messages}
+          messages={chatMessages}
           errorMessages={errorMessages}
           onRetryMessage={metabot.retryMessage}
           isDoingScience={metabot.isDoingScience}

--- a/frontend/src/metabase-lib/query/query.ts
+++ b/frontend/src/metabase-lib/query/query.ts
@@ -3,7 +3,9 @@ import { type Metadata, metadataProvider } from "metabase-lib";
 import type {
   CardId,
   CardType,
+  ConcreteTableId,
   DatasetQuery,
+  FieldId,
   LegacyDatasetQuery,
   OpaqueDatasetQuery,
   TableId,
@@ -109,6 +111,18 @@ export function swapClauses(
 
 export function sourceTableOrCardId(query: Query): TableId | null {
   return ML.source_table_or_card_id(query);
+}
+
+export function allSourceTableIds(query: Query): ConcreteTableId[] {
+  return ML.all_source_table_ids(query);
+}
+
+export function allSourceCardIds(query: Query): CardId[] {
+  return ML.all_source_card_ids(query);
+}
+
+export function allFieldIds(query: Query): FieldId[] {
+  return ML.all_field_ids(query);
 }
 
 export function canRun(query: Query, cardType: CardType): boolean {

--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -1,6 +1,6 @@
 import type { RowValue } from "./dataset";
 import type { DimensionReference, FieldReference } from "./query";
-import type { Table, TableId } from "./table";
+import type { ConcreteTableId, Table, TableId } from "./table";
 
 export type FieldId = number;
 
@@ -122,6 +122,14 @@ export interface FieldFormattingSettings {
 export interface GetFieldRequest {
   id: FieldId;
   include_editable_data_model?: boolean;
+}
+
+export interface GetFieldTableIdsRequest {
+  field_ids: FieldId[];
+}
+
+export interface GetFieldTableIdsResponse {
+  table_ids: ConcreteTableId[];
 }
 
 export interface UpdateFieldRequest {

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -26,6 +26,7 @@ export * from "./metric";
 export * from "./geojson";
 export * from "./group";
 export * from "./insight";
+export * from "./llm";
 export * from "./logger";
 export * from "./measure";
 export * from "./metabot";

--- a/frontend/src/metabase-types/api/llm.ts
+++ b/frontend/src/metabase-types/api/llm.ts
@@ -1,11 +1,13 @@
 import type { DatabaseId } from "./database";
+import type { TemplateTags } from "./dataset";
 
-export interface ExtractTablesRequest {
+export interface ExtractSourcesRequest {
   database_id: DatabaseId;
   sql: string;
+  template_tags?: TemplateTags;
 }
 
-export interface ExtractTablesColumn {
+export interface ExtractSourcesColumn {
   id: number;
   name: string;
   database_type?: string | null;
@@ -17,15 +19,16 @@ export interface ExtractTablesColumn {
   };
 }
 
-export interface ExtractTablesTable {
+export interface ExtractSourcesTable {
   id: number;
   name: string;
   schema?: string | null;
   display_name?: string | null;
   description?: string | null;
-  columns: ExtractTablesColumn[];
+  columns: ExtractSourcesColumn[];
 }
 
-export interface ExtractTablesResponse {
-  tables: ExtractTablesTable[];
+export interface ExtractSourcesResponse {
+  tables: ExtractSourcesTable[];
+  card_ids: number[];
 }

--- a/frontend/src/metabase-types/api/llm.ts
+++ b/frontend/src/metabase-types/api/llm.ts
@@ -1,0 +1,31 @@
+import type { DatabaseId } from "./database";
+
+export interface ExtractTablesRequest {
+  database_id: DatabaseId;
+  sql: string;
+}
+
+export interface ExtractTablesColumn {
+  id: number;
+  name: string;
+  database_type?: string | null;
+  description?: string | null;
+  semantic_type?: string | null;
+  fk_target?: {
+    table_name: string;
+    field_name: string;
+  };
+}
+
+export interface ExtractTablesTable {
+  id: number;
+  name: string;
+  schema?: string | null;
+  display_name?: string | null;
+  description?: string | null;
+  columns: ExtractTablesColumn[];
+}
+
+export interface ExtractTablesResponse {
+  tables: ExtractTablesTable[];
+}

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -264,7 +264,7 @@ export type MetabotFeedback = {
   freeform_feedback?: string;
 } & ({ positive: true } | { positive: false; issue_type?: MetabotIssueType });
 
-export type MetabotSourceType = "table" | "card";
+export type MetabotSourceType = "table" | "card" | "model";
 
 export type MetabotSourceFeedback = {
   metabot_id: MetabotId;

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -264,6 +264,16 @@ export type MetabotFeedback = {
   freeform_feedback?: string;
 } & ({ positive: true } | { positive: false; issue_type?: MetabotIssueType });
 
+export type MetabotSourceType = "table" | "card";
+
+export type MetabotSourceFeedback = {
+  metabot_id: MetabotId;
+  message_id: string;
+  source_id: number;
+  source_type: MetabotSourceType;
+  positive: boolean;
+};
+
 /* Metabot v3 - Entity Types */
 
 export type MetabotId = number;

--- a/frontend/src/metabase/api/field.ts
+++ b/frontend/src/metabase/api/field.ts
@@ -7,6 +7,8 @@ import type {
   FieldId,
   FieldValue,
   GetFieldRequest,
+  GetFieldTableIdsRequest,
+  GetFieldTableIdsResponse,
   GetFieldValuesResponse,
   GetRemappedFieldValueRequest,
   SearchFieldValuesRequest,
@@ -39,6 +41,17 @@ export const fieldApi = Api.injectEndpoints({
         handleQueryFulfilled(queryFulfilled, (data) =>
           dispatch(updateMetadata(data, FieldSchema)),
         ),
+    }),
+    getFieldTableIds: builder.query<
+      GetFieldTableIdsResponse,
+      GetFieldTableIdsRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/field/table-ids",
+        body,
+      }),
+      providesTags: [listTag("field")],
     }),
     getFieldValues: builder.query<GetFieldValuesResponse, FieldId>({
       query: (fieldId) => ({
@@ -153,6 +166,7 @@ export const fieldApi = Api.injectEndpoints({
 
 export const {
   useGetFieldQuery,
+  useGetFieldTableIdsQuery,
   useGetFieldValuesQuery,
   useGetRemappedFieldValueQuery,
   useSearchFieldValuesQuery,

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -20,6 +20,7 @@ export * from "./entity-id";
 export * from "./field";
 export * from "./google";
 export * from "./ldap";
+export * from "./llm";
 export * from "./login-history";
 export * from "./measure";
 export * from "./metric";

--- a/frontend/src/metabase/api/llm.ts
+++ b/frontend/src/metabase/api/llm.ts
@@ -1,20 +1,23 @@
 import type {
-  ExtractTablesRequest,
-  ExtractTablesResponse,
+  ExtractSourcesRequest,
+  ExtractSourcesResponse,
 } from "metabase-types/api";
 
 import { Api } from "./api";
 
 export const llmApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    extractTables: builder.query<ExtractTablesResponse, ExtractTablesRequest>({
+    extractSources: builder.query<
+      ExtractSourcesResponse,
+      ExtractSourcesRequest
+    >({
       query: (body) => ({
         method: "POST",
-        url: "/api/llm/extract-tables",
+        url: "/api/llm/extract-sources",
         body,
       }),
     }),
   }),
 });
 
-export const { useExtractTablesQuery } = llmApi;
+export const { useExtractSourcesQuery } = llmApi;

--- a/frontend/src/metabase/api/llm.ts
+++ b/frontend/src/metabase/api/llm.ts
@@ -1,0 +1,20 @@
+import type {
+  ExtractTablesRequest,
+  ExtractTablesResponse,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+
+export const llmApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    extractTables: builder.query<ExtractTablesResponse, ExtractTablesRequest>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/llm/extract-tables",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useExtractTablesQuery } = llmApi;

--- a/frontend/src/metabase/api/metabot.ts
+++ b/frontend/src/metabase/api/metabot.ts
@@ -8,6 +8,7 @@ import type {
   MetabotProvider,
   MetabotSettingsResponse,
   MetabotSlackSettings,
+  MetabotSourceFeedback,
   SuggestedMetabotPromptsRequest,
   SuggestedMetabotPromptsResponse,
   UpdateMetabotSettingsRequest,
@@ -123,6 +124,13 @@ export const metabotApi = Api.injectEndpoints({
         body: params,
       }),
     }),
+    submitMetabotSourceFeedback: builder.mutation<void, MetabotSourceFeedback>({
+      query: (params) => ({
+        method: "POST",
+        url: "/api/metabot/source-feedback",
+        body: params,
+      }),
+    }),
     updateMetabotSlackSettings: builder.mutation<
       { ok: boolean },
       MetabotSlackSettings
@@ -157,6 +165,7 @@ export const {
   useRegenerateSuggestedMetabotPromptsMutation,
   useLazyMetabotGenerateContentQuery,
   useSubmitMetabotFeedbackMutation,
+  useSubmitMetabotSourceFeedbackMutation,
   useUpdateMetabotSlackSettingsMutation,
   useGetUserMetabotPermissionsQuery,
 } = metabotApi;

--- a/frontend/src/metabase/common/utils/source-location.ts
+++ b/frontend/src/metabase/common/utils/source-location.ts
@@ -1,0 +1,23 @@
+import { t } from "ttag";
+
+export const getDatabaseLocationLabel = ({
+  databaseName,
+  schema,
+}: {
+  databaseName: string;
+  schema?: string | null;
+}) => (schema ? `${databaseName} (${schema})` : databaseName);
+
+export const getCollectionLocationLabel = (collectionName?: string | null) =>
+  collectionName || t`Our analytics`;
+
+export const getDatabaseLocationParts = ({
+  databaseName,
+  schema,
+}: {
+  databaseName: string;
+  schema?: string | null;
+}) => (schema ? [databaseName, schema] : [databaseName]);
+
+export const getCollectionLocationParts = (collectionName?: string | null) =>
+  collectionName ? [t`Library`, collectionName] : [t`Library`];

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.module.css
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.module.css
@@ -1,0 +1,41 @@
+.sourceDataHeader {
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.sourceDataHeader[data-expanded="false"] {
+  border-bottom-color: transparent;
+}
+
+.sourceDataHeader:focus-visible {
+  outline: 2px solid var(--mb-color-focus);
+  outline-offset: -2px;
+}
+
+.sourceDataRow:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.sourceFeedbackButton {
+  color: var(--mb-color-text-secondary);
+  background-color: var(--mb-color-background);
+  border-color: var(--mb-color-border);
+}
+
+.sourceFeedbackButton:hover {
+  color: var(--mb-color-text-primary);
+  background-color: var(--mb-color-background-hover);
+}
+
+.sourceFeedbackButton[data-active="true"] {
+  color: var(--mb-color-brand);
+}
+
+.sourceItemLink:hover .sourceItemTitleText {
+  color: var(--mb-color-brand);
+}
+
+.sourceItemLink:focus-visible {
+  outline: 2px solid var(--mb-color-focus);
+  outline-offset: 2px;
+}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
@@ -51,13 +51,11 @@ export const AgentDataPartMessage = ({
         />
       );
 
-      return debug ? (
+      return (
         <Stack gap="md">
-          <NavigateToDataPart type={part.type} path={part.value} />
+          {debug && <NavigateToDataPart type={part.type} path={part.value} />}
           {sourcePills}
         </Stack>
-      ) : (
-        sourcePills
       );
     })
     .with({ part: { type: "code_edit" } }, ({ part, metadata }) => {
@@ -69,13 +67,11 @@ export const AgentDataPartMessage = ({
         />
       );
 
-      return debug ? (
+      return (
         <Stack gap="md">
-          <CodeEditDataPart type={part.type} value={part.value} />
+          {debug && <CodeEditDataPart type={part.type} value={part.value} />}
           {sourcePills}
         </Stack>
-      ) : (
-        sourcePills
       );
     })
     .with({ part: { type: "adhoc_viz" } }, ({ part }) =>

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
@@ -6,9 +6,22 @@ import { t } from "ttag";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import type { MetabotAgentDataPartMessage } from "metabase/metabot/state";
-import { ActionIcon, Badge, Box, Button, Flex, Icon, Text } from "metabase/ui";
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Icon,
+  Stack,
+  Text,
+} from "metabase/ui";
 import type { MetabotCodeEdit } from "metabase-types/api";
 
+import {
+  CodeEditTablePills,
+  NavigateToTablePills,
+} from "./MetabotAgentDataSourcePills";
 import { AgentSuggestionMessage } from "./MetabotAgentSuggestionMessage";
 import { AgentTodoListMessage } from "./MetabotAgentTodoMessage";
 
@@ -30,12 +43,41 @@ export const AgentDataPartMessage = ({
     .with({ part: { type: "transform_suggestion" } }, (msg) => (
       <AgentSuggestionMessage message={msg} readonly={readonly} />
     ))
-    .with({ part: { type: "navigate_to" } }, ({ part }) =>
-      debug ? <NavigateToDataPart type={part.type} path={part.value} /> : null,
-    )
-    .with({ part: { type: "code_edit" } }, ({ part }) =>
-      debug ? <CodeEditDataPart type={part.type} value={part.value} /> : null,
-    )
+    .with({ part: { type: "navigate_to" } }, ({ part }) => {
+      const sourcePills = (
+        <NavigateToTablePills
+          path={part.value}
+          messageId={readonly ? undefined : message.externalId}
+        />
+      );
+
+      return debug ? (
+        <Stack gap="md">
+          <NavigateToDataPart type={part.type} path={part.value} />
+          {sourcePills}
+        </Stack>
+      ) : (
+        sourcePills
+      );
+    })
+    .with({ part: { type: "code_edit" } }, ({ part, metadata }) => {
+      const sourcePills = (
+        <CodeEditTablePills
+          value={part.value}
+          buffer={metadata?.codeEditBuffer}
+          messageId={readonly ? undefined : message.externalId}
+        />
+      );
+
+      return debug ? (
+        <Stack gap="md">
+          <CodeEditDataPart type={part.type} value={part.value} />
+          {sourcePills}
+        </Stack>
+      ) : (
+        sourcePills
+      );
+    })
     .with({ part: { type: "adhoc_viz" } }, ({ part }) =>
       debug ? <DataPartJsonCard type={part.type} value={part.value} /> : null,
     )
@@ -121,9 +163,10 @@ const NavigateToDataPart = ({ type, path }: { type: string; path: string }) => (
     direction="row"
     align="center"
     justify="space-between"
+    gap="sm"
   >
-    <Flex align="center">
-      <Icon name="document" c="text-secondary" mr="sm" />
+    <Flex align="center" gap="sm" style={{ minWidth: 0, flex: 1 }}>
+      <Icon name="document" c="text-secondary" />
       <Text fw="bold">{type}</Text>
     </Flex>
     <Button

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
@@ -1,0 +1,653 @@
+import { Fragment, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useExtractTablesQuery,
+  useGetCardQuery,
+  useGetDatabaseQuery,
+  useGetFieldTableIdsQuery,
+  useGetTableQuery,
+  useSubmitMetabotSourceFeedbackMutation,
+} from "metabase/api";
+import { ForwardRefLink } from "metabase/common/components/Link";
+import { useToast } from "metabase/common/hooks";
+import { deserializeCardFromQuery } from "metabase/common/utils/card";
+import {
+  getCollectionLocationParts,
+  getDatabaseLocationParts,
+} from "metabase/common/utils/source-location";
+import { getMetabotId } from "metabase/metabot/state";
+import { useSelector } from "metabase/redux";
+import {
+  ActionIcon,
+  Collapse,
+  Flex,
+  Icon,
+  type IconName,
+  Skeleton,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from "metabase/ui";
+import * as Urls from "metabase/urls";
+import * as Lib from "metabase-lib";
+import Question from "metabase-lib/v1/Question";
+import type {
+  DatasetQuery,
+  MetabotCodeEdit,
+  MetabotCodeEditorBufferContext,
+  MetabotSourceFeedback,
+  NativeDatasetQuery,
+} from "metabase-types/api";
+
+import S from "./MetabotAgentDataPartMessage.module.css";
+
+type DecodedQuery =
+  | {
+      kind: "mbql";
+      tableIds: number[];
+      cardIds: number[];
+      fieldIds: number[];
+    }
+  | {
+      kind: "native";
+      databaseId: number;
+      sql: string;
+    }
+  | { kind: "none" };
+
+const uniqueNumbers = (ids: number[]) =>
+  Array.from(new Set(ids)).sort((a, b) => a - b);
+
+type SourceFeedbackTarget = Pick<
+  MetabotSourceFeedback,
+  "source_id" | "source_type"
+>;
+
+const isNativeDatasetQuery = (
+  datasetQuery: DatasetQuery,
+): datasetQuery is NativeDatasetQuery =>
+  "type" in datasetQuery && datasetQuery.type === "native";
+
+const decodeQueryFromPath = (path: string): DecodedQuery => {
+  try {
+    const datasetQuery = deserializeCardFromQuery(path).dataset_query;
+    if (!datasetQuery) {
+      return { kind: "none" };
+    }
+
+    if (isNativeDatasetQuery(datasetQuery)) {
+      const sql = datasetQuery.native.query;
+      const databaseId = datasetQuery.database;
+      if (typeof sql === "string" && typeof databaseId === "number") {
+        return { kind: "native", databaseId, sql };
+      }
+      return { kind: "none" };
+    }
+
+    const question = Question.create({ dataset_query: datasetQuery });
+    const query = question.query();
+
+    const tableIds = uniqueNumbers(Lib.allSourceTableIds(query));
+    const cardIds = uniqueNumbers(Lib.allSourceCardIds(query));
+    const fieldIds = uniqueNumbers(Lib.allFieldIds(query));
+
+    return {
+      kind: "mbql",
+      tableIds,
+      cardIds,
+      fieldIds,
+    };
+  } catch {
+    return { kind: "none" };
+  }
+};
+
+const SourceItem = ({
+  iconName,
+  label,
+  location,
+  messageId,
+  source,
+  to,
+}: {
+  iconName: IconName;
+  label: string;
+  location?: {
+    parts: string[];
+  };
+  messageId?: string;
+  source: SourceFeedbackTarget;
+  to: string;
+}) => {
+  return (
+    <Flex
+      className={S.sourceDataRow}
+      align="center"
+      justify="space-between"
+      gap="sm"
+      w="100%"
+      mih="3.25rem"
+      p="0.5rem"
+      bg="background-secondary"
+    >
+      <ForwardRefLink
+        aria-label={label}
+        className={S.sourceItemLink}
+        style={{
+          display: "inline-flex",
+          maxWidth: "100%",
+          minWidth: 0,
+          color: "var(--mb-color-text-primary)",
+          textDecoration: "none",
+          borderRadius: "0.25rem",
+        }}
+        to={to}
+        href={to}
+      >
+        <Flex direction="column" gap="0.25rem" miw={0} maw="100%">
+          <Flex gap="sm" align="center" miw={0} maw="100%">
+            <Icon
+              name={iconName}
+              size={12}
+              c="text-primary"
+              style={{ display: "block", flexShrink: 0 }}
+              aria-hidden
+            />
+            <Text
+              component="span"
+              className={S.sourceItemTitleText}
+              miw={0}
+              style={{
+                overflow: "hidden",
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                lineHeight: 1,
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {label}
+            </Text>
+          </Flex>
+          {location && (
+            <Flex
+              align="center"
+              gap="0.25rem"
+              maw="100%"
+              miw={0}
+              pl="1.25rem"
+              c="text-secondary"
+            >
+              {location.parts.map((part, index) => (
+                <Fragment key={`${part}-${index}`}>
+                  {index > 0 && (
+                    <Icon
+                      name="chevronright"
+                      size={8}
+                      c="text-secondary"
+                      style={{ display: "block", flexShrink: 0 }}
+                      aria-hidden
+                    />
+                  )}
+                  <Text
+                    component="span"
+                    miw={0}
+                    c="text-secondary"
+                    style={{
+                      overflow: "hidden",
+                      fontSize: "0.75rem",
+                      lineHeight: 1,
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {part}
+                  </Text>
+                </Fragment>
+              ))}
+            </Flex>
+          )}
+        </Flex>
+      </ForwardRefLink>
+      {messageId && (
+        <SourceFeedbackButtons messageId={messageId} source={source} />
+      )}
+    </Flex>
+  );
+};
+
+const SourceItemSkeleton = ({ hasFeedback }: { hasFeedback?: boolean }) => {
+  return (
+    <Flex
+      className={S.sourceDataRow}
+      align="center"
+      justify="space-between"
+      gap="sm"
+      w="100%"
+      mih="3.25rem"
+      p="0.5rem"
+      bg="background-secondary"
+      aria-hidden
+      data-testid="metabot-source-item-skeleton"
+    >
+      <Flex direction="column" gap="0.375rem" miw={0} maw="100%">
+        <Flex gap="sm" align="center" miw={0} maw="100%">
+          <Skeleton w={12} h={12} radius="xs" />
+          <Skeleton w="7rem" h="0.75rem" radius="xs" />
+        </Flex>
+        <Flex pl="1.25rem">
+          <Skeleton w="10rem" h="0.75rem" radius="xs" />
+        </Flex>
+      </Flex>
+      {hasFeedback && (
+        <Flex gap="xs" align="center" style={{ flexShrink: 0 }}>
+          <Skeleton w={24} h={24} radius="sm" />
+          <Skeleton w={24} h={24} radius="sm" />
+        </Flex>
+      )}
+    </Flex>
+  );
+};
+
+const SourceFeedbackButtons = ({
+  messageId,
+  source,
+}: {
+  messageId: string;
+  source: SourceFeedbackTarget;
+}) => {
+  const [feedback, setFeedback] = useState<boolean | null>(null);
+  const [sendToast] = useToast();
+  const metabotId = useSelector(getMetabotId);
+  const [submitMetabotSourceFeedback, { isLoading }] =
+    useSubmitMetabotSourceFeedbackMutation();
+
+  const submitFeedback = async (positive: boolean) => {
+    if (feedback === positive) {
+      return;
+    }
+
+    const previousFeedback = feedback;
+    setFeedback(positive);
+
+    try {
+      await submitMetabotSourceFeedback({
+        metabot_id: metabotId,
+        message_id: messageId,
+        positive,
+        ...source,
+      }).unwrap();
+    } catch {
+      setFeedback(previousFeedback);
+      sendToast({ icon: "warning", message: t`Failed to submit feedback` });
+    }
+  };
+
+  return (
+    <Flex gap="xs" align="center" style={{ flexShrink: 0 }}>
+      <Tooltip label={t`Source is correct`}>
+        <ActionIcon
+          aria-label={t`Source is correct`}
+          size={24}
+          variant="default"
+          className={S.sourceFeedbackButton}
+          data-active={feedback === true || undefined}
+          bdrs="sm"
+          style={{
+            boxShadow: "0 1px 3px 0 #00000012",
+          }}
+          disabled={isLoading}
+          onClick={() => {
+            void submitFeedback(true);
+          }}
+        >
+          <Icon name="thumbs_up" size={12} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label={t`Source is wrong`}>
+        <ActionIcon
+          aria-label={t`Source is wrong`}
+          size={24}
+          variant="default"
+          className={S.sourceFeedbackButton}
+          data-active={feedback === false || undefined}
+          bdrs="sm"
+          style={{
+            boxShadow: "0 1px 3px 0 #00000012",
+          }}
+          disabled={isLoading}
+          onClick={() => {
+            void submitFeedback(false);
+          }}
+        >
+          <Icon name="thumbs_down" size={12} />
+        </ActionIcon>
+      </Tooltip>
+    </Flex>
+  );
+};
+
+const TableSourceRow = ({
+  id,
+  messageId,
+}: {
+  id: number;
+  messageId?: string;
+}) => {
+  const { data: table, isLoading, isError } = useGetTableQuery({ id });
+  const {
+    data: database,
+    isLoading: isLoadingDatabase,
+    isError: isErrorDatabase,
+  } = useGetDatabaseQuery(
+    table?.db_id != null ? { id: table?.db_id } : skipToken,
+  );
+
+  if (isLoading || isLoadingDatabase) {
+    return <SourceItemSkeleton hasFeedback={Boolean(messageId)} />;
+  }
+
+  if (isError || isErrorDatabase || !database || !table) {
+    return null;
+  }
+
+  const location = table?.collection?.name
+    ? {
+        parts: getCollectionLocationParts(table.collection.name),
+      }
+    : {
+        parts: getDatabaseLocationParts({
+          databaseName: database.name,
+          schema: table?.schema,
+        }),
+      };
+
+  return (
+    <SourceItem
+      iconName="table"
+      label={table.display_name}
+      location={location}
+      messageId={messageId}
+      source={{ source_id: id, source_type: "table" }}
+      to={Urls.tableRowsQuery(table.db_id, id)}
+    />
+  );
+};
+
+const CardPill = ({ id, messageId }: { id: number; messageId?: string }) => {
+  const { data: card, isLoading, isError } = useGetCardQuery({ id });
+
+  if (isLoading) {
+    return <SourceItemSkeleton hasFeedback={Boolean(messageId)} />;
+  }
+
+  if (isError || !card) {
+    return null;
+  }
+
+  const iconName: IconName =
+    card.type === "model"
+      ? "model"
+      : card.type === "metric"
+        ? "metric"
+        : "table2";
+
+  return (
+    <SourceItem
+      iconName={iconName}
+      label={card?.name}
+      location={{
+        parts: getCollectionLocationParts(card.collection?.name),
+      }}
+      messageId={messageId}
+      source={{ source_id: id, source_type: "card" }}
+      to={Urls.card(card)}
+    />
+  );
+};
+
+const SourceDataSection = ({ children }: { children: React.ReactNode }) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <Flex
+      direction="column"
+      miw={0}
+      w="100%"
+      bg="background-secondary"
+      style={{
+        borderRadius: "0.5rem",
+        overflow: "hidden",
+        border: "1px solid var(--mb-color-border)",
+      }}
+    >
+      <UnstyledButton
+        aria-label={
+          isExpanded ? t`Collapse data sources` : t`Expand data sources`
+        }
+        aria-expanded={isExpanded}
+        className={S.sourceDataHeader}
+        data-expanded={isExpanded}
+        type="button"
+        w="100%"
+        mih="1.75rem"
+        px="0.5rem"
+        bg="background-primary"
+        onClick={() => setIsExpanded((isExpanded) => !isExpanded)}
+      >
+        <Flex align="center" justify="space-between" w="100%">
+          <Flex gap="sm" align="center" miw={0}>
+            <Icon name="database" size={12} c="text-secondary" aria-hidden />
+            <Text
+              component="span"
+              miw={0}
+              c="text-secondary"
+              fz="0.75rem"
+              lh="0.75rem"
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {t`Data sources used`}
+            </Text>
+          </Flex>
+          <Icon
+            name={isExpanded ? "chevronup" : "chevrondown"}
+            size={12}
+            c="text-secondary"
+            style={{ flexShrink: 0 }}
+            aria-hidden
+          />
+        </Flex>
+      </UnstyledButton>
+      <Collapse in={isExpanded} mah="11rem" style={{ overflow: "auto" }}>
+        <Flex direction="column" w="100%">
+          {children}
+        </Flex>
+      </Collapse>
+    </Flex>
+  );
+};
+
+const MbqlSourcesRow = ({
+  tableIds,
+  cardIds,
+  fieldIds,
+  messageId,
+}: {
+  tableIds: number[];
+  cardIds: number[];
+  fieldIds: number[];
+  messageId?: string;
+}) => {
+  const {
+    data: fieldTableIdsResponse,
+    isLoading,
+    isError,
+  } = useGetFieldTableIdsQuery(
+    fieldIds.length > 0 ? { field_ids: fieldIds } : skipToken,
+  );
+
+  if (isLoading) {
+    const skeletonCount = Math.max(
+      4,
+      tableIds.length + cardIds.length + fieldIds.length,
+    );
+
+    return (
+      <SourceDataSection>
+        {Array.from({ length: skeletonCount }, (_, index) => (
+          <SourceItemSkeleton
+            key={`source-skeleton-${index}`}
+            hasFeedback={Boolean(messageId)}
+          />
+        ))}
+      </SourceDataSection>
+    );
+  }
+
+  if (isError) {
+    return null;
+  }
+
+  const allTableIds = uniqueNumbers(
+    tableIds.concat(fieldTableIdsResponse?.table_ids ?? []),
+  );
+
+  return (
+    <SourceDataSection>
+      {allTableIds.map((id) => (
+        <TableSourceRow key={`t-${id}`} id={id} messageId={messageId} />
+      ))}
+      {cardIds.map((id) => (
+        <CardPill id={id} key={id} messageId={messageId} />
+      ))}
+    </SourceDataSection>
+  );
+};
+
+const NativeSourcesRow = ({
+  databaseId,
+  messageId,
+  sql,
+}: {
+  databaseId: number;
+  messageId?: string;
+  sql: string;
+}) => {
+  const { data, isLoading } = useExtractTablesQuery({
+    database_id: databaseId,
+    sql,
+  });
+  const { data: database } = useGetDatabaseQuery({ id: databaseId });
+  const tables = data?.tables ?? [];
+
+  if (isLoading) {
+    return (
+      <SourceDataSection>
+        <SourceItemSkeleton hasFeedback={Boolean(messageId)} />
+      </SourceDataSection>
+    );
+  }
+
+  if (tables.length === 0) {
+    return null;
+  }
+
+  return (
+    <SourceDataSection>
+      {tables.map((table) => {
+        const label = table.display_name || table.name;
+        const databaseName = database?.name;
+        const location = databaseName
+          ? {
+              parts: getDatabaseLocationParts({
+                databaseName,
+                schema: table.schema,
+              }),
+            }
+          : undefined;
+
+        return (
+          <SourceItem
+            key={table.id}
+            iconName="table"
+            label={label}
+            location={location}
+            messageId={messageId}
+            source={{ source_id: table.id, source_type: "table" }}
+            to={Urls.tableRowsQuery(databaseId, table.id)}
+          />
+        );
+      })}
+    </SourceDataSection>
+  );
+};
+
+export const NavigateToTablePills = ({
+  messageId,
+  path,
+}: {
+  messageId?: string;
+  path: string;
+}) => {
+  const decoded = useMemo(() => decodeQueryFromPath(path), [path]);
+
+  if (decoded.kind === "none") {
+    return null;
+  }
+
+  if (decoded.kind === "native") {
+    return (
+      <NativeSourcesRow
+        databaseId={decoded.databaseId}
+        messageId={messageId}
+        sql={decoded.sql}
+      />
+    );
+  }
+
+  const hasContent =
+    decoded.tableIds.length > 0 ||
+    decoded.cardIds.length > 0 ||
+    decoded.fieldIds.length > 0;
+  if (!hasContent) {
+    return null;
+  }
+
+  return (
+    <MbqlSourcesRow
+      tableIds={decoded.tableIds}
+      cardIds={decoded.cardIds}
+      fieldIds={decoded.fieldIds}
+      messageId={messageId}
+    />
+  );
+};
+
+export const CodeEditTablePills = ({
+  buffer,
+  messageId,
+  value,
+}: {
+  buffer: MetabotCodeEditorBufferContext | undefined;
+  messageId?: string;
+  value: MetabotCodeEdit;
+}) => {
+  const databaseId = buffer?.source.database_id;
+  if (typeof databaseId !== "number") {
+    return null;
+  }
+
+  return (
+    <NativeSourcesRow
+      databaseId={databaseId}
+      messageId={messageId}
+      sql={value.value}
+    />
+  );
+};

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
@@ -203,7 +203,7 @@ const SourceItem = ({
                     miw={0}
                     c="text-secondary"
                     style={{
-                      overflow: "hidden",
+                      overflowX: "hidden",
                       fontSize: "0.75rem",
                       lineHeight: 1,
                       textOverflow: "ellipsis",

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import {
   skipToken,
-  useExtractTablesQuery,
+  useExtractSourcesQuery,
   useGetCardQuery,
   useGetDatabaseQuery,
   useGetFieldTableIdsQuery,
@@ -39,6 +39,7 @@ import type {
   MetabotCodeEditorBufferContext,
   MetabotSourceFeedback,
   NativeDatasetQuery,
+  TemplateTags,
 } from "metabase-types/api";
 
 import S from "./MetabotAgentDataPartMessage.module.css";
@@ -54,6 +55,7 @@ type DecodedQuery =
       kind: "native";
       databaseId: number;
       sql: string;
+      templateTags?: TemplateTags;
     }
   | { kind: "none" };
 
@@ -81,7 +83,12 @@ const decodeQueryFromPath = (path: string): DecodedQuery => {
       const sql = datasetQuery.native.query;
       const databaseId = datasetQuery.database;
       if (typeof sql === "string" && typeof databaseId === "number") {
-        return { kind: "native", databaseId, sql };
+        return {
+          kind: "native",
+          databaseId,
+          sql,
+          templateTags: datasetQuery.native["template-tags"],
+        };
       }
       return { kind: "none" };
     }
@@ -402,7 +409,10 @@ const CardPill = ({ id, messageId }: { id: number; messageId?: string }) => {
         parts: getCollectionLocationParts(card.collection?.name),
       }}
       messageId={messageId}
-      source={{ source_id: id, source_type: "card" }}
+      source={{
+        source_id: id,
+        source_type: card.type === "model" ? "model" : "card",
+      }}
       to={Urls.card(card)}
     />
   );
@@ -534,17 +544,21 @@ const NativeSourcesRow = ({
   databaseId,
   messageId,
   sql,
+  templateTags,
 }: {
   databaseId: number;
   messageId?: string;
   sql: string;
+  templateTags?: TemplateTags;
 }) => {
-  const { data, isLoading } = useExtractTablesQuery({
+  const { data, isLoading } = useExtractSourcesQuery({
     database_id: databaseId,
     sql,
+    ...(templateTags ? { template_tags: templateTags } : {}),
   });
   const { data: database } = useGetDatabaseQuery({ id: databaseId });
   const tables = data?.tables ?? [];
+  const cardIds = data?.card_ids ?? [];
 
   if (isLoading) {
     return (
@@ -554,7 +568,7 @@ const NativeSourcesRow = ({
     );
   }
 
-  if (tables.length === 0) {
+  if (tables.length === 0 && cardIds.length === 0) {
     return null;
   }
 
@@ -584,6 +598,9 @@ const NativeSourcesRow = ({
           />
         );
       })}
+      {cardIds.map((id) => (
+        <CardPill id={id} key={`c-${id}`} messageId={messageId} />
+      ))}
     </SourceDataSection>
   );
 };
@@ -607,6 +624,7 @@ export const NavigateToTablePills = ({
         databaseId={decoded.databaseId}
         messageId={messageId}
         sql={decoded.sql}
+        templateTags={decoded.templateTags}
       />
     );
   }

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
@@ -1,0 +1,357 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
+import type {
+  MetabotCodeEdit,
+  MetabotCodeEditorBufferContext,
+} from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDatabase,
+  createMockTable,
+} from "metabase-types/api/mocks";
+
+import {
+  CodeEditTablePills,
+  NavigateToTablePills,
+} from "./MetabotAgentDataSourcePills";
+
+const SOURCE_FEEDBACK_ENDPOINT = "path:/api/metabot/source-feedback";
+const EXTRACT_TABLES_ENDPOINT = "path:/api/llm/extract-tables";
+const FIELD_TABLE_IDS_ENDPOINT = "path:/api/field/table-ids";
+
+const ORDERS_TABLE = createMockTable({
+  id: 2,
+  db_id: 1,
+  name: "ORDERS",
+  display_name: "Orders",
+});
+const PRODUCTS_TABLE = createMockTable({
+  id: 3,
+  db_id: 1,
+  name: "PRODUCTS",
+  display_name: "Products",
+});
+const DATABASE = createMockDatabase({ id: 1, name: "Sample Database" });
+
+const CODE_EDIT_VALUE: MetabotCodeEdit = {
+  buffer_id: "qb",
+  mode: "rewrite",
+  value: "SELECT * FROM ORDERS",
+};
+const CODE_EDIT_BUFFER: MetabotCodeEditorBufferContext = {
+  id: "qb",
+  source: {
+    language: "sql",
+    database_id: 1,
+  },
+  cursor: { line: 1, column: 1 },
+};
+
+const createQuestionPath = (datasetQuery: Record<string, unknown>) =>
+  `/question#${btoa(JSON.stringify({ dataset_query: datasetQuery }))}`;
+
+const createMbqlPath = (query: Record<string, unknown>, database = 1) =>
+  createQuestionPath({
+    type: "query",
+    database,
+    query,
+  });
+
+const createNativePath = (sql = "SELECT * FROM ORDERS", database = 1) =>
+  createQuestionPath({
+    type: "native",
+    database,
+    native: { query: sql },
+  });
+
+const setupTableEndpoints = (...tables: (typeof ORDERS_TABLE)[]) => {
+  tables.forEach((table) => {
+    fetchMock.get(`path:/api/table/${table.id}`, table);
+  });
+  fetchMock.get("path:/api/database/1", DATABASE);
+};
+
+const setupNativeEndpoints = ({ delay = 0 }: { delay?: number } = {}) => {
+  fetchMock.post(
+    EXTRACT_TABLES_ENDPOINT,
+    {
+      tables: [
+        {
+          id: ORDERS_TABLE.id,
+          name: ORDERS_TABLE.name,
+          schema: ORDERS_TABLE.schema,
+          display_name: ORDERS_TABLE.display_name,
+          description: null,
+          columns: [],
+        },
+      ],
+    },
+    { delay },
+  );
+  fetchMock.get("path:/api/database/1", DATABASE);
+};
+
+const renderCodeEditPills = (messageId = "message-1") => {
+  setupNativeEndpoints();
+
+  return renderWithProviders(
+    <CodeEditTablePills
+      buffer={CODE_EDIT_BUFFER}
+      messageId={messageId}
+      value={CODE_EDIT_VALUE}
+    />,
+  );
+};
+
+const renderMbqlPills = ({
+  messageId = "message-1",
+  query,
+}: {
+  messageId?: string;
+  query: Record<string, unknown>;
+}) =>
+  renderWithProviders(
+    <NavigateToTablePills messageId={messageId} path={createMbqlPath(query)} />,
+  );
+
+describe("MetabotAgentDataSourcePills", () => {
+  it("sends a feedback request when clicking source feedback buttons", async () => {
+    fetchMock.post(SOURCE_FEEDBACK_ENDPOINT, 204);
+    renderCodeEditPills("message-1");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Source is correct" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT, {
+          body: {
+            metabot_id: FIXED_METABOT_IDS.DEFAULT,
+            message_id: "message-1",
+            source_id: ORDERS_TABLE.id,
+            source_type: "table",
+            positive: true,
+          },
+        }),
+      ).toHaveLength(1),
+    );
+  });
+
+  it("sends a feedback request when changing an already selected source", async () => {
+    fetchMock.post(SOURCE_FEEDBACK_ENDPOINT, 204);
+    renderCodeEditPills("message-2");
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Source is correct" }),
+    );
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT),
+      ).toHaveLength(1),
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Source is wrong" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT),
+      ).toHaveLength(2),
+    );
+    expect(
+      fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT, {
+        body: {
+          metabot_id: FIXED_METABOT_IDS.DEFAULT,
+          message_id: "message-2",
+          source_id: ORDERS_TABLE.id,
+          source_type: "table",
+          positive: false,
+        },
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("does not send feedback again when clicking the selected dislike button", async () => {
+    fetchMock.post(SOURCE_FEEDBACK_ENDPOINT, 204);
+    renderCodeEditPills("message-3");
+
+    const dislikeButton = await screen.findByRole("button", {
+      name: "Source is wrong",
+    });
+    await userEvent.click(dislikeButton);
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT, {
+          body: {
+            metabot_id: FIXED_METABOT_IDS.DEFAULT,
+            message_id: "message-3",
+            source_id: ORDERS_TABLE.id,
+            source_type: "table",
+            positive: false,
+          },
+        }),
+      ).toHaveLength(1),
+    );
+
+    await userEvent.click(dislikeButton);
+
+    expect(fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT)).toHaveLength(
+      1,
+    );
+  });
+
+  it("parses MBQL source tables and resolves field table ids with dedupe", async () => {
+    setupTableEndpoints(ORDERS_TABLE, PRODUCTS_TABLE);
+    fetchMock.post(FIELD_TABLE_IDS_ENDPOINT, {
+      table_ids: [ORDERS_TABLE.id, PRODUCTS_TABLE.id, PRODUCTS_TABLE.id],
+    });
+
+    renderMbqlPills({
+      messageId: "message-4",
+      query: {
+        "source-table": ORDERS_TABLE.id,
+        fields: [
+          ["field", 10, null],
+          ["field", 11, null],
+        ],
+      },
+    });
+
+    expect(
+      await screen.findByRole("link", { name: "Orders" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: "Products" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "Orders" })).toHaveLength(1);
+    expect(screen.getAllByRole("link", { name: "Products" })).toHaveLength(1);
+    expect(
+      fetchMock.callHistory.calls(FIELD_TABLE_IDS_ENDPOINT, {
+        body: { field_ids: [10, 11] },
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("parses native SQL queries and requests extracted tables", async () => {
+    const sql = "SELECT * FROM ORDERS";
+    setupNativeEndpoints();
+
+    renderWithProviders(
+      <NavigateToTablePills
+        messageId="message-5"
+        path={createNativePath(sql)}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Orders" }),
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls(EXTRACT_TABLES_ENDPOINT, {
+        body: {
+          database_id: 1,
+          sql,
+        },
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("shows source links without feedback buttons when message id is not provided", async () => {
+    setupNativeEndpoints();
+
+    renderWithProviders(
+      <NavigateToTablePills path={createNativePath("SELECT * FROM ORDERS")} />,
+    );
+
+    const sourceLink = await screen.findByRole("link", { name: "Orders" });
+
+    expect(sourceLink).toHaveAttribute("href", "/question#?db=1&table=2");
+    expect(
+      screen.queryByLabelText("Source is correct"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Source is wrong")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton while resolving field table ids", async () => {
+    setupTableEndpoints(ORDERS_TABLE);
+    fetchMock.post(
+      FIELD_TABLE_IDS_ENDPOINT,
+      { table_ids: [ORDERS_TABLE.id] },
+      { delay: 50 },
+    );
+
+    renderMbqlPills({
+      messageId: "message-6",
+      query: {
+        fields: [["field", 10, null]],
+      },
+    });
+
+    expect(
+      await screen.findAllByTestId("metabot-source-item-skeleton"),
+    ).not.toHaveLength(0);
+    expect(
+      await screen.findByRole("link", { name: "Orders" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton while loading table source details", async () => {
+    fetchMock.get("path:/api/table/2", ORDERS_TABLE, { delay: 50 });
+    fetchMock.get("path:/api/database/1", DATABASE);
+
+    renderMbqlPills({
+      messageId: "message-7",
+      query: { "source-table": ORDERS_TABLE.id },
+    });
+
+    expect(
+      await screen.findAllByTestId("metabot-source-item-skeleton"),
+    ).not.toHaveLength(0);
+    expect(
+      await screen.findByRole("link", { name: "Orders" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton while loading card source details", async () => {
+    fetchMock.get(
+      "path:/api/card/4",
+      createMockCard({ id: 4, name: "Revenue", type: "metric" }),
+      { delay: 50 },
+    );
+
+    renderMbqlPills({
+      messageId: "message-8",
+      query: { "source-table": "card__4" },
+    });
+
+    expect(
+      await screen.findAllByTestId("metabot-source-item-skeleton"),
+    ).not.toHaveLength(0);
+    expect(
+      await screen.findByRole("link", { name: "Revenue" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton while extracting native SQL tables", async () => {
+    setupNativeEndpoints({ delay: 50 });
+
+    renderWithProviders(
+      <NavigateToTablePills
+        messageId="message-9"
+        path={createNativePath("SELECT * FROM ORDERS")}
+      />,
+    );
+
+    expect(
+      await screen.findAllByTestId("metabot-source-item-skeleton"),
+    ).not.toHaveLength(0);
+    expect(
+      await screen.findByRole("link", { name: "Orders" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
@@ -6,6 +6,7 @@ import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
 import type {
   MetabotCodeEdit,
   MetabotCodeEditorBufferContext,
+  TemplateTags,
 } from "metabase-types/api";
 import {
   createMockCard,
@@ -19,7 +20,7 @@ import {
 } from "./MetabotAgentDataSourcePills";
 
 const SOURCE_FEEDBACK_ENDPOINT = "path:/api/metabot/source-feedback";
-const EXTRACT_TABLES_ENDPOINT = "path:/api/llm/extract-tables";
+const EXTRACT_SOURCES_ENDPOINT = "path:/api/llm/extract-sources";
 const FIELD_TABLE_IDS_ENDPOINT = "path:/api/field/table-ids";
 
 const ORDERS_TABLE = createMockTable({
@@ -60,11 +61,18 @@ const createMbqlPath = (query: Record<string, unknown>, database = 1) =>
     query,
   });
 
-const createNativePath = (sql = "SELECT * FROM ORDERS", database = 1) =>
+const createNativePath = (
+  sql = "SELECT * FROM ORDERS",
+  database = 1,
+  templateTags?: TemplateTags,
+) =>
   createQuestionPath({
     type: "native",
     database,
-    native: { query: sql },
+    native: {
+      query: sql,
+      ...(templateTags ? { "template-tags": templateTags } : {}),
+    },
   });
 
 const setupTableEndpoints = (...tables: (typeof ORDERS_TABLE)[]) => {
@@ -76,7 +84,7 @@ const setupTableEndpoints = (...tables: (typeof ORDERS_TABLE)[]) => {
 
 const setupNativeEndpoints = ({ delay = 0 }: { delay?: number } = {}) => {
   fetchMock.post(
-    EXTRACT_TABLES_ENDPOINT,
+    EXTRACT_SOURCES_ENDPOINT,
     {
       tables: [
         {
@@ -88,6 +96,7 @@ const setupNativeEndpoints = ({ delay = 0 }: { delay?: number } = {}) => {
           columns: [],
         },
       ],
+      card_ids: [],
     },
     { delay },
   );
@@ -237,7 +246,7 @@ describe("MetabotAgentDataSourcePills", () => {
     ).toHaveLength(1);
   });
 
-  it("parses native SQL queries and requests extracted tables", async () => {
+  it("parses native SQL queries and requests extracted sources", async () => {
     const sql = "SELECT * FROM ORDERS";
     setupNativeEndpoints();
 
@@ -252,13 +261,73 @@ describe("MetabotAgentDataSourcePills", () => {
       await screen.findByRole("link", { name: "Orders" }),
     ).toBeInTheDocument();
     expect(
-      fetchMock.callHistory.calls(EXTRACT_TABLES_ENDPOINT, {
+      fetchMock.callHistory.calls(EXTRACT_SOURCES_ENDPOINT, {
         body: {
           database_id: 1,
           sql,
         },
       }),
     ).toHaveLength(1);
+  });
+
+  it("renders extracted native query model sources", async () => {
+    const sql = "SELECT * FROM {{#4-revenue_model}}";
+    const templateTags: TemplateTags = {
+      "#4-revenue_model": {
+        id: "1",
+        name: "#4-revenue_model",
+        "display-name": "Revenue Model",
+        type: "card",
+        "card-id": 4,
+      },
+    };
+    fetchMock.post(EXTRACT_SOURCES_ENDPOINT, {
+      tables: [],
+      card_ids: [4],
+    });
+    fetchMock.get(
+      "path:/api/card/4",
+      createMockCard({ id: 4, name: "Revenue Model", type: "model" }),
+    );
+    fetchMock.get("path:/api/database/1", DATABASE);
+    fetchMock.post(SOURCE_FEEDBACK_ENDPOINT, 204);
+
+    renderWithProviders(
+      <NavigateToTablePills
+        messageId="message-5-model"
+        path={createNativePath(sql, 1, templateTags)}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Revenue Model" }),
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls(EXTRACT_SOURCES_ENDPOINT, {
+        body: {
+          database_id: 1,
+          sql,
+          template_tags: templateTags,
+        },
+      }),
+    ).toHaveLength(1);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Source is correct" }),
+    );
+    await waitFor(() =>
+      expect(
+        fetchMock.callHistory.calls(SOURCE_FEEDBACK_ENDPOINT, {
+          body: {
+            metabot_id: FIXED_METABOT_IDS.DEFAULT,
+            message_id: "message-5-model",
+            source_id: 4,
+            source_type: "model",
+            positive: true,
+          },
+        }),
+      ).toHaveLength(1),
+    );
   });
 
   it("shows source links without feedback buttons when message id is not provided", async () => {

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -9,6 +9,7 @@ import { useToast } from "metabase/common/hooks";
 import { MetabotManagedProviderLimitActions } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import type {
   MetabotAgentChatMessage,
+  MetabotAgentDataPartMessage,
   MetabotAgentTextChatMessage,
   MetabotChatMessage,
   MetabotDataPart,
@@ -37,17 +38,28 @@ const isUserVisibleDataPart = (part: MetabotDataPart): boolean =>
   match(part)
     .with({ type: "todo_list" }, () => true)
     .with({ type: "transform_suggestion" }, () => true)
-    .with({ type: "navigate_to" }, () => false)
-    .with({ type: "code_edit" }, () => false)
+    .with({ type: "navigate_to" }, () => true)
+    .with({ type: "code_edit" }, () => true)
     .with({ type: "adhoc_viz" }, () => false)
     .with({ type: "static_viz" }, () => false)
     .exhaustive();
+
+const isUserVisibleDataPartMessage = (
+  message: MetabotAgentDataPartMessage,
+): boolean =>
+  match(message)
+    .with({ part: { type: "code_edit" } }, ({ metadata }) => {
+      return metadata?.codeEditBuffer?.source.database_id != null;
+    })
+    .otherwise(({ part }) => isUserVisibleDataPart(part));
 
 const isUserVisibleMessage = (message: MetabotChatMessage): boolean =>
   match(message)
     .with({ type: "text" }, () => true)
     .with({ type: "action" }, () => true)
-    .with({ type: "data_part" }, ({ part }) => isUserVisibleDataPart(part))
+    .with({ type: "data_part" }, (message) =>
+      isUserVisibleDataPartMessage(message),
+    )
     .with({ type: "tool_call" }, () => false)
     .exhaustive();
 

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -21,6 +21,7 @@ import type {
   MetabotAgentRequest,
   MetabotAgentResponse,
   MetabotChatContext,
+  MetabotCodeEditorBufferContext,
   MetabotTransformInfo,
 } from "metabase-types/api";
 
@@ -365,6 +366,18 @@ type SendAgentRequestResult = MetabotAgentResponse & {
   processedResponse: ProcessedChatResponse;
 };
 
+const findCodeEditBuffer = (
+  context: MetabotChatContext,
+  bufferId: string,
+): MetabotCodeEditorBufferContext | undefined => {
+  const viewedBuffers = context.user_is_viewing.flatMap((item) =>
+    item.type === "code_editor" ? item.buffers : [],
+  );
+  const buffers = [...viewedBuffers, ...(context.code_editor?.buffers ?? [])];
+
+  return buffers.find((buffer) => buffer.id === bufferId);
+};
+
 export const sendAgentRequest = createAsyncThunk<
   SendAgentRequestResult,
   MetabotAgentRequest & { agentId: MetabotAgentId },
@@ -380,6 +393,7 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
+      let currentMessageExternalId: string | undefined = undefined;
 
       const response = await aiStreamingQuery(
         {
@@ -394,7 +408,16 @@ export const sendAgentRequest = createAsyncThunk<
           onDataPart: function handleDataPart(part) {
             const pushDataPart = (
               message: Omit<MetabotAgentDataPartMessage, "id" | "role">,
-            ) => dispatch(addAgentMessage({ ...message, agentId }));
+            ) =>
+              dispatch(
+                addAgentMessage({
+                  ...message,
+                  ...(currentMessageExternalId
+                    ? { externalId: currentMessageExternalId }
+                    : {}),
+                  agentId,
+                }),
+              );
 
             match(part)
               // only update the convo state if the request is successful
@@ -408,7 +431,16 @@ export const sendAgentRequest = createAsyncThunk<
                 if (part.value.buffer_id === "qb") {
                   dispatch(setIsNativeEditorOpen(true));
                 }
-                pushDataPart({ type: "data_part", part });
+                pushDataPart({
+                  type: "data_part",
+                  part,
+                  metadata: {
+                    codeEditBuffer: findCodeEditBuffer(
+                      request.context,
+                      part.value.buffer_id,
+                    ),
+                  },
+                });
               })
               .with({ type: "navigate_to" }, (part) => {
                 dispatch(setNavigateToPath(part.value));
@@ -448,6 +480,7 @@ export const sendAgentRequest = createAsyncThunk<
               .exhaustive();
           },
           onStartMessagePart: function handleStartMessagePart(part) {
+            currentMessageExternalId ??= part.messageId;
             dispatch(
               setPendingMessageExternalId({
                 agentId,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -393,8 +393,6 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
-      let currentMessageExternalId: string | undefined = undefined;
-
       const response = await aiStreamingQuery(
         {
           url: "/api/metabot/agent-streaming",
@@ -407,17 +405,11 @@ export const sendAgentRequest = createAsyncThunk<
         {
           onDataPart: function handleDataPart(part) {
             const pushDataPart = (
-              message: Omit<MetabotAgentDataPartMessage, "id" | "role">,
-            ) =>
-              dispatch(
-                addAgentMessage({
-                  ...message,
-                  ...(currentMessageExternalId
-                    ? { externalId: currentMessageExternalId }
-                    : {}),
-                  agentId,
-                }),
-              );
+              message: Omit<
+                MetabotAgentDataPartMessage,
+                "id" | "role" | "externalId"
+              >,
+            ) => dispatch(addAgentMessage({ ...message, agentId }));
 
             match(part)
               // only update the convo state if the request is successful
@@ -480,7 +472,6 @@ export const sendAgentRequest = createAsyncThunk<
               .exhaustive();
           },
           onStartMessagePart: function handleStartMessagePart(part) {
-            currentMessageExternalId ??= part.messageId;
             dispatch(
               setPendingMessageExternalId({
                 agentId,

--- a/frontend/src/metabase/metabot/state/reducer.ts
+++ b/frontend/src/metabase/metabot/state/reducer.ts
@@ -81,17 +81,16 @@ export const metabot = createSlice({
       (
         convo,
         action: ConvoPayloadAction<
-          Omit<MetabotAgentChatMessage, "id" | "role">
+          Omit<MetabotAgentChatMessage, "id" | "role" | "externalId">
         >,
       ) => {
         convo.activeToolCalls = [];
         const externalId = convo.pendingMessageExternalId;
-        convo.pendingMessageExternalId = undefined;
         convo.messages.push({
           id: createMessageId(),
           role: "agent",
-          ...(externalId ? { externalId } : {}),
           ...action.payload,
+          ...(externalId ? { externalId } : {}),
           // transforms in message is making this flakily produce possibly infinite
           // typescript errors. since unused ts-expect-error directives produces
           // errors, casting this as any to avoid having to add / remove constantly.
@@ -116,7 +115,6 @@ export const metabot = createSlice({
           lastMessage.message = lastMessage.message + action.payload.text;
         } else {
           const externalId = convo.pendingMessageExternalId;
-          convo.pendingMessageExternalId = undefined;
           convo.messages.push({
             id: createMessageId(),
             role: "agent",

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -2,6 +2,7 @@ import type { KnownDataPart } from "metabase/api/ai-streaming/schemas";
 import type { MetabotProfileId } from "metabase/metabot/constants";
 import type {
   MetabotCodeEdit,
+  MetabotCodeEditorBufferContext,
   MetabotHistory,
   MetabotSuggestedTransform,
   MetabotTransformInfo,
@@ -10,6 +11,7 @@ import type {
 export type MetabotDataPart = Exclude<KnownDataPart, { type: "state" }>;
 
 export type MetabotDataPartMetadata = {
+  codeEditBuffer?: MetabotCodeEditorBufferContext;
   editorTransform?: MetabotTransformInfo;
   suggestionId?: string;
 };
@@ -43,6 +45,7 @@ export type MetabotAgentDataPartMessage = {
   type: "data_part";
   part: MetabotDataPart;
   metadata?: MetabotDataPartMetadata;
+  externalId?: string;
 };
 
 export type MetabotDebugToolCallMessage = {

--- a/frontend/src/metabase/metabot/tests/query-builder-code-edit.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/query-builder-code-edit.unit.spec.tsx
@@ -79,6 +79,8 @@ describe("query builder code edits from omnibot", () => {
     mockedAiStreamingQuery.mockImplementation(async (request, callbacks) => {
       requestBody = request.body;
 
+      callbacks?.onStartMessagePart?.({ messageId: "msg_test_code_edit" });
+      callbacks?.onTextPart?.("Reviewing the query.");
       callbacks?.onDataPart?.({
         type: "code_edit",
         version: 1,
@@ -171,6 +173,22 @@ describe("query builder code edits from omnibot", () => {
         SUGGESTED_SQL,
       );
     });
+
+    expect(
+      typedStore.getState().metabot.conversations.omnibot?.messages,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          externalId: "msg_test_code_edit",
+        }),
+        expect.objectContaining({
+          type: "data_part",
+          externalId: "msg_test_code_edit",
+          part: expect.objectContaining({ type: "code_edit" }),
+        }),
+      ]),
+    );
 
     expect(requestBody?.context).toEqual(
       expect.objectContaining({

--- a/resources/migrations/060/20260501_metabot_source_feedback.yaml
+++ b/resources/migrations/060/20260501_metabot_source_feedback.yaml
@@ -1,0 +1,114 @@
+## Persist Metabot source feedback
+
+databaseChangeLog:
+  - changeSet:
+      id: v60.srcefb
+      author: undrfined
+      comment: metabot_source_feedback table
+      changes:
+        - createTable:
+            tableName: metabot_source_feedback
+            remarks: User feedback on sources used by Metabot responses
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                  remarks: Auto-incrementing primary key
+              - column:
+                  name: message_id
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: FK to the Metabot message whose source was rated
+              - column:
+                  name: user_id
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: The Metabase user who submitted the feedback. Unconstrained int so audit rows survive user deletion.
+              - column:
+                  name: source_id
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: ID of the source object used by the response
+              - column:
+                  name: source_type
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+                  remarks: Type of source object, e.g. table or card
+              - column:
+                  name: positive
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: false
+                  remarks: true = thumbs up, false = thumbs down
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+                  remarks: When the feedback was submitted
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+                  remarks: When the feedback was last updated
+      rollback:
+        - dropTable:
+            tableName: metabot_source_feedback
+
+  - changeSet:
+      id: v60.srcefu
+      author: undrfined
+      comment: Unique constraint on metabot_source_feedback source rating
+      changes:
+        - addUniqueConstraint:
+            tableName: metabot_source_feedback
+            columnNames: message_id, user_id, source_type, source_id
+            constraintName: uq_metabot_source_feedback_message_user_source
+      rollback:
+        - dropUniqueConstraint:
+            tableName: metabot_source_feedback
+            constraintName: uq_metabot_source_feedback_message_user_source
+
+  - changeSet:
+      id: v60.srcefm
+      author: undrfined
+      comment: Index on metabot_source_feedback.message_id
+      changes:
+        - createIndex:
+            tableName: metabot_source_feedback
+            indexName: idx_metabot_source_feedback_message_id
+            columns:
+              - column:
+                  name: message_id
+      rollback:
+        - dropIndex:
+            tableName: metabot_source_feedback
+            indexName: idx_metabot_source_feedback_message_id
+
+  - changeSet:
+      id: v60.srcefk
+      author: undrfined
+      comment: Foreign key from metabot_source_feedback.message_id to metabot_message.id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabot_source_feedback
+            baseColumnNames: message_id
+            constraintName: fk_metabot_source_feedback_message_id
+            referencedTableName: metabot_message
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: metabot_source_feedback
+            constraintName: fk_metabot_source_feedback_message_id

--- a/resources/migrations/060/20260501_metabot_source_feedback.yaml
+++ b/resources/migrations/060/20260501_metabot_source_feedback.yaml
@@ -41,7 +41,7 @@ databaseChangeLog:
                   type: varchar(64)
                   constraints:
                     nullable: false
-                  remarks: Type of source object, e.g. table or card
+                  remarks: Type of source object, e.g. table, card, or model
               - column:
                   name: positive
                   type: ${boolean.type}

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -135,6 +135,7 @@
     :model/MetabotConversation
     :model/MetabotMessage
     :model/MetabotFeedback
+    :model/MetabotSourceFeedback
     :model/MetabotPrompt]
    (when config/ee-available?
      [:model/MetabotPermissions

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2598,6 +2598,21 @@
   [a-query card-id card-type]
   (clj->js (lib.core/dependent-metadata a-query card-id (keyword card-type))))
 
+(defn ^:export all-source-table-ids
+  "Return a JS array of all source table IDs referenced anywhere in `a-query`."
+  [a-query]
+  (clj->js (vec (or (lib.core/all-source-table-ids a-query) #{}))))
+
+(defn ^:export all-source-card-ids
+  "Return a JS array of all source card IDs referenced anywhere in `a-query`."
+  [a-query]
+  (clj->js (vec (or (lib.core/all-source-card-ids a-query) #{}))))
+
+(defn ^:export all-field-ids
+  "Return a JS array of all field IDs referenced anywhere in `a-query`."
+  [a-query]
+  (clj->js (vec (lib.core/all-field-ids a-query))))
+
 (defn ^:export can-run
   "Returns true if the query is runnable.
   `card-type` is optional and defaults to \"question\".

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2611,7 +2611,7 @@
 (defn ^:export all-field-ids
   "Return a JS array of all field IDs referenced anywhere in `a-query`."
   [a-query]
-  (clj->js (vec (lib.core/all-field-ids a-query))))
+  (clj->js (vec (or (lib.core/all-field-ids a-query) #{}))))
 
 (defn ^:export can-run
   "Returns true if the query is runnable.

--- a/src/metabase/llm/api.clj
+++ b/src/metabase/llm/api.clj
@@ -105,7 +105,7 @@
     (metabot.self/list-models provider {:ai-proxy? ai-proxy?})))
 
 (def ^:private table-with-columns-schema
-  "Schema for table metadata with columns returned by /extract-tables."
+  "Schema for table metadata with columns returned by /extract-sources."
   [:map
    [:id pos-int?]
    [:name :string]
@@ -124,24 +124,36 @@
                  [:table_name :string]
                  [:field_name :string]]]]]]])
 
-(api.macros/defendpoint :post "/extract-tables"
-  :- [:map [:tables [:sequential table-with-columns-schema]]]
-  "Parse SQL and return referenced tables with their columns.
+(def ^:private template-tags-schema
+  [:map-of :string
+   [:map
+    [:type :string]
+    [:card-id {:optional true} pos-int?]]])
 
-   Uses Macaw to parse the SQL, resolves table names to IDs,
-   and returns permission-filtered tables with column metadata.
+(api.macros/defendpoint :post "/extract-sources"
+  :- [:map
+      [:tables [:sequential table-with-columns-schema]]
+      [:card_ids [:sequential pos-int?]]]
+  "Parse native query sources and return referenced tables and cards/models.
 
-   This is a lightweight endpoint that does not trigger fingerprinting
-   or field value fetching."
+    Uses Macaw to parse the SQL, resolves table names to IDs,
+    and returns permission-filtered tables with column metadata. Card and model
+    references are extracted from native query template tags.
+
+    This is a lightweight endpoint that does not trigger fingerprinting
+    or field value fetching."
   [_route-params
    _query-params
    body :- [:map
             [:database_id pos-int?]
-            [:sql :string]]]
-  (let [{:keys [database_id sql]} body
+            [:sql :string]
+            [:template_tags {:optional true} template-tags-schema]]]
+  (let [{:keys [database_id sql template_tags]} body
         table-ids (llm.context/extract-tables-from-sql database_id sql)
+        card-ids  (llm.context/extract-card-ids-from-template-tags template_tags)
         tables    (llm.context/get-tables-with-columns database_id table-ids)]
-    {:tables (or tables [])}))
+    {:tables   (or tables [])
+     :card_ids (sort (or (llm.context/get-accessible-card-ids card-ids) #{}))}))
 
 (api.macros/defendpoint :post "/generate-sql"
   :- [:map

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -81,6 +81,20 @@
         #{}))
     #{}))
 
+(defn extract-card-ids-from-template-tags
+  "Extract referenced Card IDs from native query template tags. Card template
+   tags cover both saved questions and models. Returns an empty set when no
+   card tags are present."
+  [template-tags]
+  (if (map? template-tags)
+    (into #{}
+          (keep (fn [[_ tag]]
+                  (when (and (map? tag)
+                             (contains? #{"card" :card} (:type tag)))
+                    (or (:card-id tag) (:card_id tag)))))
+          template-tags)
+    #{}))
+
 ;;; ------------------------------------------ Permission-Filtered Fetch ------------------------------------------
 
 (defn- fetch-accessible-tables
@@ -101,6 +115,17 @@
                             (cond-> {:where clause}
                               with (assoc :with with)))]
       (into {} (map (juxt :id identity)) tables))))
+
+(defn get-accessible-card-ids
+  "Return readable, non-archived Card IDs from `card-ids`."
+  [card-ids]
+  (when (seq card-ids)
+    (->> (t2/select :model/Card
+                    :id [:in card-ids]
+                    :archived false)
+         (filter mi/can-read?)
+         (map :id)
+         set)))
 
 ;;; ----------------------------------------- Metadata Provider Column Fetch -----------------------------------------
 
@@ -464,7 +489,7 @@
                :tables response-tables})))))))
 
 (defn get-tables-with-columns
-  "Fetch tables with their columns for the extract-tables endpoint.
+  "Fetch tables with their columns for the extract-sources endpoint.
    Returns lightweight metadata without triggering fingerprinting or field values.
 
    Parameters:

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -289,6 +289,26 @@
         (log/error "Failed to submit feedback to Harbormaster: " (ex-message e)))))
   api/generic-204-no-content)
 
+(api.macros/defendpoint :post "/source-feedback" :- :nil
+  "Persist Metabot source feedback locally and proxy it to Harbormaster."
+  [_route-params
+   _query-params
+   body :- [:map
+            [:metabot_id   ms/PositiveInt]
+            [:message_id   ms/NonBlankString]
+            [:source_id    ms/PositiveInt]
+            [:source_type  [:enum "table" "card"]]
+            [:positive     :boolean]]]
+  (metabot.config/check-metabot-enabled!)
+  (let [message (metabot.feedback/persist-source-feedback! body)]
+    (try
+      (api/check-400 (metabot.feedback/submit-to-harbormaster!
+                      (metabot.feedback/source-harbormaster-payload body message))
+                     "Cannot submit feedback. The license token and/or Store API URL are missing!")
+      (catch Exception e
+        (log/error "Failed to submit source feedback to Harbormaster: " (ex-message e)))))
+  api/generic-204-no-content)
+
 (def ^:private metabot-provider-schema
   (into [:enum] metabot.settings/supported-metabot-providers))
 

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -297,7 +297,7 @@
             [:metabot_id   ms/PositiveInt]
             [:message_id   ms/NonBlankString]
             [:source_id    ms/PositiveInt]
-            [:source_type  [:enum "table" "card"]]
+            [:source_type  [:enum "table" "card" "model"]]
             [:positive     :boolean]]]
   (metabot.config/check-metabot-enabled!)
   (let [message (metabot.feedback/persist-source-feedback! body)]

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -265,12 +265,10 @@
                         :ip-address (request/ip-address req)}]
     (streaming-request body* request-info)))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :post "/feedback"
-  "Persist Metabot feedback locally and proxy it to Harbormaster."
+(api.macros/defendpoint :post "/feedback"  :- [:map
+                                               [:status [:= 204]]
+                                               [:body :nil]]
+  "Persist Metabot feedback."
   [_route-params
    _query-params
    body :- [:map
@@ -280,19 +278,13 @@
             [:issue_type        {:optional true} [:maybe :string]]
             [:freeform_feedback {:optional true} [:maybe :string]]]]
   (metabot.config/check-metabot-enabled!)
-  (let [message (metabot.feedback/persist-feedback! body)]
-    (try
-      (api/check-400 (metabot.feedback/submit-to-harbormaster!
-                      (metabot.feedback/harbormaster-payload body message))
-                     "Cannot submit feedback. The license token and/or Store API URL are missing!")
-      (catch Exception e
-        (log/error "Failed to submit feedback to Harbormaster: " (ex-message e)))))
+  (metabot.feedback/persist-feedback! body)
   api/generic-204-no-content)
 
 (api.macros/defendpoint :post "/source-feedback" :- [:map
                                                      [:status [:= 204]]
                                                      [:body :nil]]
-  "Persist Metabot source feedback locally and proxy it to Harbormaster."
+  "Persist Metabot source feedback."
   [_route-params
    _query-params
    body :- [:map
@@ -302,13 +294,7 @@
             [:source_type  [:enum "table" "card" "model"]]
             [:positive     :boolean]]]
   (metabot.config/check-metabot-enabled!)
-  (let [message (metabot.feedback/persist-source-feedback! body)]
-    (try
-      (api/check-400 (metabot.feedback/submit-to-harbormaster!
-                      (metabot.feedback/source-harbormaster-payload body message))
-                     "Cannot submit feedback. The license token and/or Store API URL are missing!")
-      (catch Exception e
-        (log/error "Failed to submit source feedback to Harbormaster: " (ex-message e)))))
+  (metabot.feedback/persist-source-feedback! body)
   api/generic-204-no-content)
 
 (def ^:private metabot-provider-schema

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -289,7 +289,9 @@
         (log/error "Failed to submit feedback to Harbormaster: " (ex-message e)))))
   api/generic-204-no-content)
 
-(api.macros/defendpoint :post "/source-feedback" :- :nil
+(api.macros/defendpoint :post "/source-feedback" :- [:map
+                                                     [:status [:= 204]]
+                                                     [:body :nil]]
   "Persist Metabot source feedback locally and proxy it to Harbormaster."
   [_route-params
    _query-params

--- a/src/metabase/metabot/feedback.clj
+++ b/src/metabase/metabot/feedback.clj
@@ -1,67 +1,12 @@
 (ns metabase.metabot.feedback
-  "Local persistence of Metabot feedback, plus a Harbormaster submission path."
+  "Persistence of Metabot feedback."
   (:require
-   [clj-http.client :as http]
-   [clojure.string :as str]
    [metabase.api.common :as api]
    [metabase.app-db.core :as app-db]
-   [metabase.config.core :as config]
-   [metabase.metabot.persistence :as metabot.persistence]
    [metabase.models.interface :as mi]
-   [metabase.premium-features.core :as premium-features]
-   [metabase.store-api.core :as store-api]
-   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
-
-(defn submit-to-harbormaster!
-  "Submit metabot feedback to Harbormaster via the Store API.
-   Returns the HTTP response on success, or nil if the token or Store API URL is missing."
-  [feedback]
-  (let [token    (premium-features/premium-embedding-token)
-        base-url (store-api/store-api-url)]
-    (when-not (or (str/blank? token) (str/blank? base-url))
-      (http/post (str base-url "/api/v2/metabot/feedback/" token)
-                 {:content-type :json
-                  :body         (json/encode feedback)}))))
-
-(defn harbormaster-payload
-  "Build the Harbormaster feedback payload from the request body, the resolved
-  `metabot_message` row, and the submitter (defaults to the current user)."
-  ([body message]
-   (harbormaster-payload body message api/*current-user-id*))
-  ([{:keys [metabot_id message_id positive issue_type freeform_feedback]}
-    {:keys [conversation_id]}
-    submitter-user-id]
-   {:metabot_id        metabot_id
-    :feedback          {:message_id        message_id
-                        :positive          positive
-                        :issue_type        issue_type
-                        :freeform_feedback freeform_feedback}
-    :conversation_data (metabot.persistence/conversation-detail conversation_id)
-    :version           config/mb-version-info
-    :submission_time   (str (java.time.OffsetDateTime/now))
-    :submitter_user_id submitter-user-id
-    :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id submitter-user-id))}))
-
-(defn source-harbormaster-payload
-  "Build the Harbormaster payload for feedback on a source used by a Metabot response."
-  ([body message]
-   (source-harbormaster-payload body message api/*current-user-id*))
-  ([{:keys [metabot_id message_id positive source_id source_type]}
-    {:keys [conversation_id]}
-    submitter-user-id]
-   {:metabot_id        metabot_id
-    :feedback          {:message_id  message_id
-                        :positive    positive
-                        :source_id   source_id
-                        :source_type source_type}
-    :conversation_data (metabot.persistence/conversation-detail conversation_id)
-    :version           config/mb-version-info
-    :submission_time   (str (java.time.OffsetDateTime/now))
-    :submitter_user_id submitter-user-id
-    :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id submitter-user-id))}))
 
 (defn- resolve-rated-message
   "Return the `metabot_message` row (`:id` + `:conversation_id`) identified by

--- a/src/metabase/metabot/feedback.clj
+++ b/src/metabase/metabot/feedback.clj
@@ -4,6 +4,7 @@
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.api.common :as api]
+   [metabase.app-db.core :as app-db]
    [metabase.config.core :as config]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.models.interface :as mi]
@@ -44,6 +45,24 @@
     :submitter_user_id submitter-user-id
     :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id submitter-user-id))}))
 
+(defn source-harbormaster-payload
+  "Build the Harbormaster payload for feedback on a source used by a Metabot response."
+  ([body message]
+   (source-harbormaster-payload body message api/*current-user-id*))
+  ([{:keys [metabot_id message_id positive source_id source_type]}
+    {:keys [conversation_id]}
+    submitter-user-id]
+   {:metabot_id        metabot_id
+    :feedback          {:message_id  message_id
+                        :positive    positive
+                        :source_id   source_id
+                        :source_type source_type}
+    :conversation_data (metabot.persistence/conversation-detail conversation_id)
+    :version           config/mb-version-info
+    :submission_time   (str (java.time.OffsetDateTime/now))
+    :submitter_user_id submitter-user-id
+    :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id submitter-user-id))}))
+
 (defn- resolve-rated-message
   "Return the `metabot_message` row (`:id` + `:conversation_id`) identified by
   `external-id`, plus the enclosing `:model/MetabotConversation` as `:conversation`.
@@ -65,15 +84,25 @@
   (let [base-fields {:positive          positive
                      :issue_type        issue_type
                      :freeform_feedback freeform_feedback}]
-    (t2/with-transaction [_conn]
-      (if (t2/exists? :model/MetabotFeedback :message_id message-row-id :user_id submitter-user-id)
-        (t2/update! :model/MetabotFeedback
-                    {:message_id message-row-id :user_id submitter-user-id}
-                    (assoc base-fields :updated_at (java.time.OffsetDateTime/now)))
-        (t2/insert! :model/MetabotFeedback
-                    (assoc base-fields
-                           :message_id message-row-id
-                           :user_id    submitter-user-id))))))
+    (app-db/update-or-insert! :model/MetabotFeedback
+                              {:message_id message-row-id :user_id submitter-user-id}
+                              (fn [existing]
+                                (cond-> base-fields
+                                  existing (assoc :updated_at (java.time.OffsetDateTime/now)))))))
+
+(defn- upsert-source-feedback!
+  "Insert or update the `metabot_source_feedback` row for one source, message, and submitter."
+  [message-row-id submitter-user-id {:keys [positive source_id source_type]}]
+  (let [conditions  {:message_id  message-row-id
+                     :user_id     submitter-user-id
+                     :source_id   source_id
+                     :source_type source_type}
+        base-fields {:positive positive}]
+    (app-db/update-or-insert! :model/MetabotSourceFeedback
+                              conditions
+                              (fn [existing]
+                                (cond-> base-fields
+                                  existing (assoc :updated_at (java.time.OffsetDateTime/now)))))))
 
 (defn persist-feedback!
   "Upsert a `metabot_feedback` row for the rated message and return the
@@ -87,4 +116,12 @@
   [{:keys [message_id] :as body}]
   (let [message (resolve-rated-message message_id)]
     (upsert-feedback! (:id message) api/*current-user-id* body)
+    message))
+
+(defn persist-source-feedback!
+  "Upsert a `metabot_source_feedback` row for a source used by the rated message.
+   Returns the resolved `metabot_message` row (with its `:conversation`)."
+  [{:keys [message_id] :as body}]
+  (let [message (resolve-rated-message message_id)]
+    (upsert-source-feedback! (:id message) api/*current-user-id* body)
     message))

--- a/src/metabase/metabot/models/metabot_source_feedback.clj
+++ b/src/metabase/metabot/models/metabot_source_feedback.clj
@@ -1,0 +1,39 @@
+(ns metabase.metabot.models.metabot-source-feedback
+  "Persist Metabot source feedback"
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/MetabotSourceFeedback [_model] :metabot_source_feedback)
+
+(doto :model/MetabotSourceFeedback
+  (derive :metabase/model))
+
+(def ^:private valid-source-types
+  #{"table" "card"})
+
+(defn- validate-source-type
+  [{:keys [source_type]}]
+  (mi/assert-enum valid-source-types source_type))
+
+(t2/define-before-insert :model/MetabotSourceFeedback
+  [feedback]
+  (validate-source-type feedback)
+  feedback)
+
+(t2/define-before-update :model/MetabotSourceFeedback
+  [feedback]
+  (when (contains? (t2/changes feedback) :source_type)
+    (validate-source-type feedback))
+  feedback)
+
+(methodical/defmethod t2/batched-hydrate [:model/MetabotSourceFeedback :user]
+  "Batch-hydrate `:user` (id/email/name only) — the feedback submitter."
+  [_model k feedbacks]
+  (mi/instances-with-hydrated-data
+   feedbacks k
+   #(t2/select-pk->fn (fn [u] (select-keys u [:id :email :first_name :last_name]))
+                      [:model/User :id :email :first_name :last_name]
+                      :id (keep :user_id feedbacks))
+   :user_id {:default nil}))

--- a/src/metabase/metabot/models/metabot_source_feedback.clj
+++ b/src/metabase/metabot/models/metabot_source_feedback.clj
@@ -11,7 +11,7 @@
   (derive :metabase/model))
 
 (def ^:private valid-source-types
-  #{"table" "card"})
+  #{"table" "card" "model"})
 
 (defn- validate-source-type
   [{:keys [source_type]}]

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -228,8 +228,8 @@
    Returns nil for blocks that should be skipped (tool-output, unknown types).
 
    `external-id` (the parent row's `metabot_message.external_id`) is attached to
-   agent-text chat messages as `:externalId` — the stable key for feedback; the
-   per-block `:id` stays unique."
+   agent text and data part chat messages as `:externalId` — the stable key for
+   feedback; the per-block `:id` stays unique."
   [external-id block]
   (let [block-type (:type block)
         block-role (:role block)]
@@ -265,12 +265,13 @@
 
       ;; Data part: {:type "data" :data-type "navigate_to" :version 1 :data ...}
       (= "data" block-type)
-      {:id   (str (random-uuid))
-       :role "agent"
-       :type "data_part"
-       :part {:type    (:data-type block)
-              :version (or (:version block) 1)
-              :value   (:data block)}}
+      (cond-> {:id   (str (random-uuid))
+               :role "agent"
+               :type "data_part"
+               :part {:type    (:data-type block)
+                      :version (or (:version block) 1)
+                      :value   (:data block)}}
+        external-id (assoc :externalId external-id))
 
       ;; Tool output — skip here, merged via merge-tool-results
       :else nil)))

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -60,6 +60,7 @@
     :model/MetabotConversation               metabase.metabot.models.metabot-conversation
     :model/MetabotFeedback                   metabase.metabot.models.metabot-feedback
     :model/MetabotMessage                    metabase.metabot.models.metabot-message
+    :model/MetabotSourceFeedback             metabase.metabot.models.metabot-source-feedback
     :model/AiUsageLog                        metabase.metabot.models.ai-usage-log
     :model/DataComplexityScore               metabase-enterprise.data-complexity-score.models.data-complexity-score
     :model/MetabotGroupLimit                 metabase-enterprise.metabot.models.metabot-group-limit

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -7,8 +7,6 @@
    [metabase.analytics.core :as analytics.core]
    [metabase.api.macros :as api.macros]
    [metabase.channel.settings :as channel.settings]
-   [metabase.config.core :as config]
-   [metabase.metabot.config :as metabot.config]
    [metabase.metabot.feedback :as metabot.feedback]
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
@@ -540,38 +538,9 @@
          :label    {:type "plain_text" :text "What kind of issue are you reporting?"}}
         freeform-block]))})
 
-(defn- get-conversation-messages
-  "Retrieve all messages for a conversation from the database."
-  [conversation-id]
-  (when conversation-id
-    (t2/select :model/MetabotMessage
-               :conversation_id conversation-id
-               :deleted_at nil
-               {:order-by [[:created_at :asc]]})))
-
-(defn- build-base-feedback
-  "Build the common feedback payload fields.
-   `:feedback.message_id` is the rated assistant message's `external_id` — the
-   same identifier the web feedback endpoint uses — so Harbormaster can
-   correlate Slack and web submissions on a single stable key. `:is_admin` and
-   `:submitter_user_id` describe the user who submitted the feedback, not the
-   conversation originator."
-  [user-id conversation-id message-external-id positive]
-  {:metabot_id        (metabot.config/normalize-metabot-id "slackbotmetabotmetabo")
-   :feedback          {:positive          positive
-                       :message_id        message-external-id
-                       :freeform_feedback ""}
-   :conversation_data {:messages (get-conversation-messages conversation-id)}
-   :version           config/mb-version-info
-   :submission_time   (str (java.time.OffsetDateTime/now))
-   :submitter_user_id user-id
-   :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id user-id))
-   :source            "slack"})
-
 (defn- handle-feedback-action
   "Handle a metabot feedback button click from Slack.
-   Opens the detail modal immediately (trigger_id expires in 3s). Feedback is
-   submitted to Harbormaster only when the user submits the modal.
+   Opens the detail modal immediately (trigger_id expires in 3s).
    `:message_external_id` in the button payload is the hardened identifier for
    the rated assistant message; `:channel_id` / `:message_ts` are kept in
    private_metadata as a fallback for buttons emitted before that plumbing
@@ -628,10 +597,7 @@
   "Handle submission of the feedback details modal.
    Persists the feedback locally under the Slack submitter's user binding (so
    the `can-read?` participation check in `metabot.feedback/persist-feedback!`
-   runs against the real submitter), then — only on success — forwards to
-   Harbormaster. If the local write throws (authorization rejection, missing
-   message, DB error), the Harbormaster submission is skipped so lurkers and
-   stale payloads cannot bypass the local authorization gate."
+   runs against the real submitter)."
   [payload]
   (let [private-metadata (json/decode (get-in payload [:view :private_metadata]) true)
         {:keys [conversation_id positive user_id]} private-metadata
@@ -651,12 +617,8 @@
                :positive          positive
                :issue_type        issue-type
                :freeform_feedback freeform}))
-           (metabot.feedback/submit-to-harbormaster!
-            (cond-> (build-base-feedback user_id conversation_id external-id positive)
-              true       (assoc-in [:feedback :freeform_feedback] (or freeform ""))
-              issue-type (assoc-in [:feedback :issue_type] issue-type)))
            (catch Exception e
-             (log/warnf e "[slackbot] Feedback submission failed (external_id=%s user_id=%s); skipping Harbormaster"
+             (log/warnf e "[slackbot] Feedback submission failed (external_id=%s user_id=%s)"
                         external-id user_id))))))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}

--- a/src/metabase/warehouse_schema/field.clj
+++ b/src/metabase/warehouse_schema/field.clj
@@ -33,3 +33,15 @@
   (when (seq ids)
     (-> (filter mi/can-read? (t2/select :model/Field :id [:in ids]))
         (t2/hydrate :has_field_values [:dimensions :human_readable_field] :name_field))))
+
+(defn field-ids->table-ids
+  "Get sorted unique table IDs for readable Fields with IDs in `ids`."
+  [ids]
+  (->> (when (seq ids)
+         (t2/hydrate (t2/select [:model/Field :id :table_id] :id [:in ids])
+                     :table))
+       (filter mi/can-read?)
+       (keep :table_id)
+       set
+       sort
+       vec))

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -35,6 +35,9 @@
   "Schema for a valid `Field` visibility type."
   (into [:enum] (map name field/visibility-types)))
 
+(def ^:private max-field-ids-for-table-id-lookup
+  1000)
+
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API
 ;;
@@ -50,6 +53,17 @@
    {include-editable-data-model? :include_editable_data_model} :- [:map
                                                                    [:include_editable_data_model {:default false} ms/BooleanValue]]]
   (schema.field/get-field id {:include-editable-data-model? include-editable-data-model?}))
+
+(api.macros/defendpoint :post "/table-ids" :- [:map
+                                               [:table_ids [:sequential ms/PositiveInt]]]
+  "Get unique Table IDs for a list of Field IDs."
+  [_route-params
+   _query-params
+   {:keys [field_ids]} :- [:map
+                           [:field_ids [:sequential ms/PositiveInt]]]]
+  (api/check-400 (<= (count field_ids) max-field-ids-for-table-id-lookup)
+                 (format "field_ids may contain at most %d IDs." max-field-ids-for-table-id-lookup))
+  {:table_ids (schema.field/field-ids->table-ids field_ids)})
 
 (defn- check-field-in-same-database!
   "Check that `target-field-id` is a valid field in the same database as `source-field-id`. Throws a 400 if

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -179,6 +179,29 @@
                    :opts     {:ai-proxy? true}}
                   @captured)))))))
 
+(deftest extract-sources-test
+  (testing "POST /api/llm/extract-sources returns SQL tables and native card/model references"
+    (mt/with-temp [:model/Database db    {:engine :h2}
+                   :model/Table    table {:db_id  (:id db)
+                                          :name   "orders"
+                                          :schema "PUBLIC"}
+                   :model/Field    _     {:table_id  (:id table)
+                                          :name      "id"
+                                          :base_type :type/Integer}
+                   :model/Card     model {:name          "Orders model"
+                                          :type          :model
+                                          :dataset_query {:database (:id db)
+                                                          :type     :query
+                                                          :query    {:source-table (:id table)}}}]
+      (is (=? {:tables   [{:id   (:id table)
+                           :name "orders"}]
+               :card_ids [(:id model)]}
+              (mt/user-http-request :crowberto :post 200 "llm/extract-sources"
+                                    {:database_id   (:id db)
+                                     :sql           "SELECT * FROM orders"
+                                     :template_tags {"#model" {:type    "card"
+                                                               :card-id (:id model)}}}))))))
+
 ;;; ------------------------------------------- Snowplow Tests -------------------------------------------
 
 (defn- token-usage-event? [event]

--- a/test/metabase/llm/context_test.clj
+++ b/test/metabase/llm/context_test.clj
@@ -394,3 +394,15 @@
     (testing "returns empty set for invalid SQL (graceful failure)"
       (let [result (context/extract-tables-from-sql (mt/id) "THIS IS NOT SQL")]
         (is (= #{} result))))))
+
+(deftest extract-card-ids-from-template-tags-test
+  (testing "extracts card template tag IDs and ignores other tag types"
+    (is (= #{1 2}
+           (context/extract-card-ids-from-template-tags
+            {"#1" {:type "card" :card-id 1}
+             "#2" {:type :card :card_id 2}
+             "id" {:type "dimension"}
+             "orders" {:type "table" :table-id 10}}))))
+
+  (testing "returns an empty set for missing template tags"
+    (is (= #{} (context/extract-card-ids-from-template-tags nil)))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -15,6 +15,7 @@
    [metabase.metabot.api :as api]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
+   [metabase.metabot.feedback :as metabot.feedback]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.self :as metabot.self]
@@ -565,6 +566,38 @@
                          :source_id   1
                          :source_type "table"
                          :positive    true}))))))
+
+(deftest source-feedback-returns-no-content-test
+  (testing "POST /metabot/source-feedback returns 204 after persisting feedback"
+    (let [conversation-id (str (random-uuid))
+          external-id     (str (random-uuid))
+          user-id         (mt/user->id :rasta)]
+      (try
+        (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
+        (let [message-id (first (t2/insert-returning-pks!
+                                 :model/MetabotMessage
+                                 {:conversation_id conversation-id
+                                  :role            "assistant"
+                                  :profile_id      "gpt-x"
+                                  :external_id     external-id
+                                  :total_tokens    5
+                                  :data            [{:type "text" :text "hi"}]}))]
+          (with-redefs [metabot.feedback/submit-to-harbormaster! (constantly {:status 204})]
+            (is (nil? (mt/user-http-request :rasta :post 204 "metabot/source-feedback"
+                                            {:metabot_id  1
+                                             :message_id  external-id
+                                             :source_id   42
+                                             :source_type "table"
+                                             :positive    true}))))
+          (is (some? (t2/select-one :model/MetabotSourceFeedback
+                                    :message_id  message-id
+                                    :user_id     user-id
+                                    :source_id   42
+                                    :source_type "table"))))
+        (finally
+          (t2/delete! :model/MetabotSourceFeedback :user_id user-id :source_id 42 :source_type "table")
+          (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
+          (t2/delete! :model/MetabotConversation :id conversation-id))))))
 
 (deftest metabot-enabled-setting-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -15,7 +15,6 @@
    [metabase.metabot.api :as api]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
-   [metabase.metabot.feedback :as metabot.feedback]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.self :as metabot.self]
@@ -582,13 +581,12 @@
                                   :external_id     external-id
                                   :total_tokens    5
                                   :data            [{:type "text" :text "hi"}]}))]
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (constantly {:status 204})]
-            (is (nil? (mt/user-http-request :rasta :post 204 "metabot/source-feedback"
-                                            {:metabot_id  1
-                                             :message_id  external-id
-                                             :source_id   42
-                                             :source_type "table"
-                                             :positive    true}))))
+          (is (nil? (mt/user-http-request :rasta :post 204 "metabot/source-feedback"
+                                          {:metabot_id  1
+                                           :message_id  external-id
+                                           :source_id   42
+                                           :source_type "table"
+                                           :positive    true})))
           (is (some? (t2/select-one :model/MetabotSourceFeedback
                                     :message_id  message-id
                                     :user_id     user-id

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -556,7 +556,15 @@
              (mt/client :post 401 "metabot/feedback"
                         {:metabot_id 1
                          :message_id "x"
-                         :positive   true}))))))
+                         :positive   true}))))
+    (testing "/source-feedback"
+      (is (= "Unauthenticated"
+             (mt/client :post 401 "metabot/source-feedback"
+                        {:metabot_id  1
+                         :message_id  "x"
+                         :source_id   1
+                         :source_type "table"
+                         :positive    true}))))))
 
 (deftest metabot-enabled-setting-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]

--- a/test/metabase/metabot/feedback_test.clj
+++ b/test/metabase/metabot/feedback_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [metabase.metabot.feedback :as metabot.feedback]
    [metabase.test :as mt]
+   [metabase.test.util :as tu]
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -18,6 +19,16 @@
    :positive          positive
    :issue_type        issue-type
    :freeform_feedback freeform})
+
+(defn- source-payload
+  [{:keys [message-id source-id source-type positive]
+    :or   {source-id   1
+           source-type "table"
+           positive    true}}]
+  {:message_id  message-id
+   :source_id   source-id
+   :source_type source-type
+   :positive    positive})
 
 (defn- insert-message!
   ([conversation-id external-id]
@@ -96,22 +107,25 @@
             (mt/with-current-user user-id
               (metabot.feedback/persist-feedback!
                (payload {:message-id external-id :positive true :freeform "good"}))
-              (let [first-row (t2/select-one :model/MetabotFeedback :message_id msg-id)]
-                ;; clock resolution: ensure the second write lands on a later instant
-                (Thread/sleep 50)
-                (metabot.feedback/persist-feedback!
-                 (payload {:message-id external-id
-                           :positive   false
-                           :issue-type "ui-bug"
-                           :freeform   "actually it's broken"}))
-                (let [updated-row (t2/select-one :model/MetabotFeedback :message_id msg-id)]
-                  (is (= 1 (t2/count :model/MetabotFeedback :message_id msg-id))
-                      "still only one row per message")
-                  (is (false? (:positive updated-row)))
-                  (is (= "ui-bug" (:issue_type updated-row)))
-                  (is (= "actually it's broken" (:freeform_feedback updated-row)))
-                  (is (not= (:updated_at first-row) (:updated_at updated-row))
-                      "updated_at gets bumped on edit")))))
+              (let [first-row   (t2/select-one :model/MetabotFeedback :message_id msg-id)
+                    updated-row (tu/poll-until
+                                 2000
+                                 (do
+                                   (metabot.feedback/persist-feedback!
+                                    (payload {:message-id external-id
+                                              :positive   false
+                                              :issue-type "ui-bug"
+                                              :freeform   "actually it's broken"}))
+                                   (let [updated-row (t2/select-one :model/MetabotFeedback :message_id msg-id)]
+                                     (when (not= (:updated_at first-row) (:updated_at updated-row))
+                                       updated-row))))]
+                (is (= 1 (t2/count :model/MetabotFeedback :message_id msg-id))
+                    "still only one row per message")
+                (is (false? (:positive updated-row)))
+                (is (= "ui-bug" (:issue_type updated-row)))
+                (is (= "actually it's broken" (:freeform_feedback updated-row)))
+                (is (not= (:updated_at first-row) (:updated_at updated-row))
+                    "updated_at gets bumped on edit"))))
           (finally
             (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
             (t2/delete! :model/MetabotConversation :id conversation-id)))))))
@@ -191,6 +205,83 @@
               (is (false? (:positive (get by-user participant-id))))
               (is (= "ui-bug" (:issue_type (get by-user participant-id))))
               (is (= "not for me" (:freeform_feedback (get by-user participant-id))))))
+          (finally
+            (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
+            (t2/delete! :model/MetabotConversation :id conversation-id)))))))
+
+(deftest persist-source-feedback-test
+  (testing "persist-source-feedback! records source id and type for the rated message"
+    (mt/with-temp [:model/User {user-id :id} {}]
+      (let [conversation-id (str (random-uuid))
+            external-id     (str (random-uuid))]
+        (try
+          (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
+          (let [msg-id (insert-message! conversation-id external-id)]
+            (mt/with-current-user user-id
+              (let [returned (metabot.feedback/persist-source-feedback!
+                              (source-payload {:message-id  external-id
+                                               :source-id   42
+                                               :source-type "card"
+                                               :positive    false}))
+                    row      (t2/select-one :model/MetabotSourceFeedback
+                                            :message_id  msg-id
+                                            :user_id     user-id
+                                            :source_id   42
+                                            :source_type "card")]
+                (is (= msg-id (:id returned)))
+                (is (= conversation-id (:conversation_id returned)))
+                (is (some? row))
+                (is (false? (:positive row))))))
+          (finally
+            (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
+            (t2/delete! :model/MetabotConversation :id conversation-id)))))))
+
+(deftest persist-source-feedback-rejects-invalid-source-type-test
+  (testing "persist-source-feedback! rejects unsupported source types"
+    (mt/with-temp [:model/User {user-id :id} {}]
+      (let [conversation-id (str (random-uuid))
+            external-id     (str (random-uuid))]
+        (try
+          (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
+          (let [msg-id (insert-message! conversation-id external-id)]
+            (mt/with-current-user user-id
+              (is (thrown-with-msg? ExceptionInfo
+                                    #"Invalid value"
+                                    (metabot.feedback/persist-source-feedback!
+                                     (source-payload {:message-id  external-id
+                                                      :source-id   42
+                                                      :source-type "dashboard"}))))
+              (is (zero? (t2/count :model/MetabotSourceFeedback :message_id msg-id)))))
+          (finally
+            (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
+            (t2/delete! :model/MetabotConversation :id conversation-id)))))))
+
+(deftest persist-source-feedback-updates-existing-row-test
+  (testing "persist-source-feedback! updates the existing row for the same message, submitter, and source"
+    (mt/with-temp [:model/User {user-id :id} {}]
+      (let [conversation-id (str (random-uuid))
+            external-id     (str (random-uuid))]
+        (try
+          (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
+          (let [msg-id (insert-message! conversation-id external-id)]
+            (mt/with-current-user user-id
+              (metabot.feedback/persist-source-feedback!
+               (source-payload {:message-id external-id :source-id 7 :source-type "table" :positive true}))
+              (let [first-row   (t2/select-one :model/MetabotSourceFeedback :message_id msg-id)
+                    updated-row (tu/poll-until
+                                 2000
+                                 (do
+                                   (metabot.feedback/persist-source-feedback!
+                                    (source-payload {:message-id external-id
+                                                     :source-id   7
+                                                     :source-type "table"
+                                                     :positive    false}))
+                                   (let [updated-row (t2/select-one :model/MetabotSourceFeedback :message_id msg-id)]
+                                     (when (not= (:updated_at first-row) (:updated_at updated-row))
+                                       updated-row))))]
+                (is (= 1 (t2/count :model/MetabotSourceFeedback :message_id msg-id)))
+                (is (false? (:positive updated-row)))
+                (is (not= (:updated_at first-row) (:updated_at updated-row))))))
           (finally
             (t2/delete! :model/MetabotMessage :conversation_id conversation-id)
             (t2/delete! :model/MetabotConversation :id conversation-id)))))))

--- a/test/metabase/metabot/feedback_test.clj
+++ b/test/metabase/metabot/feedback_test.clj
@@ -266,15 +266,18 @@
           (let [msg-id (insert-message! conversation-id external-id)]
             (mt/with-current-user user-id
               (metabot.feedback/persist-source-feedback!
-               (source-payload {:message-id external-id :source-id 7 :source-type "table" :positive true}))
+               (source-payload {:message-id  external-id
+                                :source-id   7
+                                :source-type "model"
+                                :positive    true}))
               (let [first-row   (t2/select-one :model/MetabotSourceFeedback :message_id msg-id)
                     updated-row (tu/poll-until
                                  2000
                                  (do
                                    (metabot.feedback/persist-source-feedback!
-                                    (source-payload {:message-id external-id
+                                    (source-payload {:message-id  external-id
                                                      :source-id   7
-                                                     :source-type "table"
+                                                     :source-type "model"
                                                      :positive    false}))
                                    (let [updated-row (t2/select-one :model/MetabotSourceFeedback :message_id msg-id)]
                                      (when (not= (:updated_at first-row) (:updated_at updated-row))

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -5,7 +5,6 @@
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.channel.settings :as channel.settings]
    [metabase.metabot.agent.core :as agent]
-   [metabase.metabot.feedback :as metabot.feedback]
    [metabase.server.settings :as server.settings]
    [metabase.slackbot.api :as slackbot]
    [metabase.slackbot.client :as slackbot.client]
@@ -760,17 +759,13 @@
       (is (= "freeform_feedback" (:block_id (second (:blocks view))))))))
 
 (deftest handle-feedback-action-authenticated-test
-  (testing "feedback action opens modal with correct private_metadata but does not submit to harbormaster"
-    (let [conversation-id    "conv-123"
-          harbormaster-calls (atom [])
-          open-view-calls    (atom [])]
-      (with-redefs [slackbot/slack-id->user-id                  (constantly (mt/user->id :rasta))
-                    metabot.feedback/submit-to-harbormaster!  (fn [feedback]
-                                                                (swap! harbormaster-calls conj feedback)
-                                                                true)
-                    slackbot.client/open-view                    (fn [_ params]
-                                                                   (swap! open-view-calls conj params)
-                                                                   {:ok true})]
+  (testing "feedback action opens modal with correct private_metadata"
+    (let [conversation-id "conv-123"
+          open-view-calls (atom [])]
+      (with-redefs [slackbot/slack-id->user-id (constantly (mt/user->id :rasta))
+                    slackbot.client/open-view  (fn [_ params]
+                                                 (swap! open-view-calls conj params)
+                                                 {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id conversation-id :positive true})}]
           (#'slackbot/handle-feedback-action
@@ -788,9 +783,7 @@
               (is (= conversation-id (:conversation_id pm)))
               (is (true? (:positive pm)))
               (is (= "C123" (:channel_id pm)))
-              (is (= "123.456" (:message_ts pm)))))
-          (testing "harbormaster was NOT called on button click"
-            (is (= 0 (count @harbormaster-calls)))))))))
+              (is (= "123.456" (:message_ts pm))))))))))
 
 (deftest handle-feedback-action-negative-test
   (testing "negative feedback action opens modal with issue type dropdown"
@@ -813,15 +806,11 @@
 
 (deftest handle-feedback-action-unauthenticated-test
   (testing "feedback action is silently skipped for unauthenticated user"
-    (let [harbormaster-calls (atom [])
-          open-view-calls    (atom [])]
-      (with-redefs [slackbot/slack-id->user-id                  (constantly nil)
-                    metabot.feedback/submit-to-harbormaster!  (fn [feedback]
-                                                                (swap! harbormaster-calls conj feedback)
-                                                                true)
-                    slackbot.client/open-view                    (fn [_ params]
-                                                                   (swap! open-view-calls conj params)
-                                                                   {:ok true})]
+    (let [open-view-calls (atom [])]
+      (with-redefs [slackbot/slack-id->user-id (constantly nil)
+                    slackbot.client/open-view  (fn [_ params]
+                                                 (swap! open-view-calls conj params)
+                                                 {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id "conv-456" :positive false})}
               result (#'slackbot/handle-feedback-action
@@ -832,7 +821,6 @@
                        :message-ts    "123.456"})]
           (is (nil? result) "should return nil when user is not found")
           (testing "nothing was called"
-            (is (= 0 (count @harbormaster-calls)))
             (is (= 0 (count @open-view-calls)))))))))
 
 (defn- setup-slackbot-feedback!
@@ -880,159 +868,72 @@
 
 (deftest handle-feedback-modal-submission-test
   (let [rasta-id (mt/user->id :rasta)]
-    (testing "negative feedback with issue_type and freeform writes a row and forwards to harbormaster"
-      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-            harbormaster-calls (atom [])]
+    (testing "negative feedback with issue_type and freeform writes a row"
+      (let [{:keys [conv-id message-id external-id]} (setup-slackbot-feedback! rasta-id)]
         (try
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id external-id
-                                                     :user-id     rasta-id
-                                                     :positive    false
-                                                     :issue-type  "not-factual"
-                                                     :freeform    "The answer was wrong"})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (testing "local metabot_feedback row is written under the submitter's user_id"
-                (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
-                  (is (some? row))
-                  (is (false? (:positive row)))
-                  (is (= "not-factual" (:issue_type row)))
-                  (is (= "The answer was wrong" (:freeform_feedback row)))))
-              (testing "harbormaster payload carries the resolved external_id and submitter"
-                (is (= 1 (count @harbormaster-calls)))
-                (is (=? {:feedback          {:positive          false
-                                             :message_id        external-id
-                                             :issue_type        "not-factual"
-                                             :freeform_feedback "The answer was wrong"}
-                         :source            "slack"
-                         :submitter_user_id rasta-id}
-                        (first @harbormaster-calls))))))
+          (let [payload (modal-submission-payload {:conv-id     conv-id
+                                                   :external-id external-id
+                                                   :user-id     rasta-id
+                                                   :positive    false
+                                                   :issue-type  "not-factual"
+                                                   :freeform    "The answer was wrong"})
+                result  (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (testing "local metabot_feedback row is written under the submitter's user_id"
+              (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
+                (is (some? row))
+                (is (false? (:positive row)))
+                (is (= "not-factual" (:issue_type row)))
+                (is (= "The answer was wrong" (:freeform_feedback row))))))
           (finally (tear-down-slackbot-feedback! conv-id)))))
 
     (testing "positive feedback with only freeform text submits"
-      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-            harbormaster-calls (atom [])]
+      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)]
         (try
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id external-id
-                                                     :user-id     rasta-id
-                                                     :positive    true
-                                                     :freeform    "Great response!"})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (is (some? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)))
-              (is (= 1 (count @harbormaster-calls)))
-              (is (=? {:feedback          {:positive          true
-                                           :message_id        external-id
-                                           :freeform_feedback "Great response!"}
-                       :source            "slack"
-                       :submitter_user_id rasta-id}
-                      (first @harbormaster-calls)))))
+          (let [payload (modal-submission-payload {:conv-id     conv-id
+                                                   :external-id external-id
+                                                   :user-id     rasta-id
+                                                   :positive    true
+                                                   :freeform    "Great response!"})
+                result  (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (is (some? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id))))
           (finally (tear-down-slackbot-feedback! conv-id)))))
 
-    (testing "positive feedback with nil freeform is stored as-is locally and coerced to empty string for harbormaster"
-      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-            harbormaster-calls (atom [])]
+    (testing "positive feedback with nil freeform is stored as nil locally"
+      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)]
         (try
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id external-id
-                                                     :user-id     rasta-id
-                                                     :positive    true
-                                                     :freeform    nil})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
-                (is (some? row))
-                (is (nil? (:freeform_feedback row))))
-              (is (= 1 (count @harbormaster-calls)))
-              (is (=? {:feedback {:positive          true
-                                  :freeform_feedback ""}
-                       :source   "slack"}
-                      (first @harbormaster-calls)))))
+          (let [payload (modal-submission-payload {:conv-id     conv-id
+                                                   :external-id external-id
+                                                   :user-id     rasta-id
+                                                   :positive    true
+                                                   :freeform    nil})
+                result  (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
+              (is (some? row))
+              (is (nil? (:freeform_feedback row)))))
           (finally (tear-down-slackbot-feedback! conv-id)))))
 
     (testing "negative feedback with only issue type submits"
-      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-            harbormaster-calls (atom [])]
+      (let [{:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)]
         (try
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id external-id
-                                                     :user-id     rasta-id
-                                                     :positive    false
-                                                     :issue-type  "ui-bug"
-                                                     :freeform    nil})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (is (some? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)))
-              (is (= 1 (count @harbormaster-calls)))
-              (is (=? {:feedback {:positive          false
-                                  :issue_type        "ui-bug"
-                                  :freeform_feedback ""}
-                       :source   "slack"}
-                      (first @harbormaster-calls)))))
-          (finally (tear-down-slackbot-feedback! conv-id)))))
-
-    (testing "harbormaster payload includes the conversation's messages"
-      (let [conv-id            (str (random-uuid))
-            external-id        (str (random-uuid))
-            harbormaster-calls (atom [])]
-        (try
-          (t2/insert! :model/MetabotConversation {:id conv-id :user_id rasta-id})
-          (t2/insert! :model/MetabotMessage
-                      {:conversation_id conv-id
-                       :role            "user"
-                       :profile_id      "slackbot"
-                       :total_tokens    0
-                       :data            [{:_type "TEXT" :role "user" :content "What is revenue?"}]})
-          (t2/insert! :model/MetabotMessage
-                      {:conversation_id conv-id
-                       :role            "assistant"
-                       :profile_id      "slackbot"
-                       :external_id     external-id
-                       :total_tokens    10
-                       :data            [{:_type "TEXT" :role "assistant" :content "Here are the results."}]})
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id external-id
-                                                     :user-id     rasta-id
-                                                     :positive    true
-                                                     :freeform    "Great!"})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (is (= 1 (count @harbormaster-calls)))
-              (is (=? {:feedback          {:positive          true
-                                           :message_id        external-id
-                                           :freeform_feedback "Great!"}
-                       :source            "slack"
-                       :conversation_data {:messages [{:role        :user
-                                                       :data        [{:_type "TEXT" :role "user" :content "What is revenue?"}]
-                                                       :profile_id  "slackbot"}
-                                                      {:role        :assistant
-                                                       :data        [{:_type "TEXT" :role "assistant" :content "Here are the results."}]
-                                                       :profile_id  "slackbot"}]}}
-                      (first @harbormaster-calls)))))
+          (let [payload (modal-submission-payload {:conv-id     conv-id
+                                                   :external-id external-id
+                                                   :user-id     rasta-id
+                                                   :positive    false
+                                                   :issue-type  "ui-bug"
+                                                   :freeform    nil})
+                result  (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (is (some? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id))))
           (finally (tear-down-slackbot-feedback! conv-id)))))))
 
 (deftest handle-feedback-modal-submission-multi-user-test
   (testing "two users in the same conversation can submit independent feedback on the same assistant message"
     (let [rasta-id (mt/user->id :rasta)
           lucky-id (mt/user->id :lucky)
-          {:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-          harbormaster-calls (atom [])]
+          {:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)]
       (try
         ;; lucky becomes a participant by authoring a user-turn message in the thread
         (t2/insert! :model/MetabotMessage
@@ -1042,91 +943,75 @@
                      :user_id         lucky-id
                      :total_tokens    0
                      :data            [{:_type "TEXT" :role "user" :content "+1"}]})
-        (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                 (swap! harbormaster-calls conj feedback)
-                                                                 true)]
-          (let [rasta-result (#'slackbot/handle-feedback-modal-submission
-                              (modal-submission-payload {:conv-id     conv-id
-                                                         :external-id external-id
-                                                         :user-id     rasta-id
-                                                         :positive    true
-                                                         :freeform    "nice"}))
-                lucky-result (#'slackbot/handle-feedback-modal-submission
-                              (modal-submission-payload {:conv-id     conv-id
-                                                         :external-id external-id
-                                                         :user-id     lucky-id
-                                                         :positive    false
-                                                         :issue-type  "ui-bug"
-                                                         :freeform    "not for me"}))]
-            @rasta-result
-            @lucky-result)
-          (let [rows     (t2/select :model/MetabotFeedback :message_id message-id
-                                    {:order-by [[:user_id :asc]]})
-                by-user  (into {} (map (juxt :user_id identity)) rows)]
-            (is (= 2 (count rows)) "both submissions produce distinct rows")
-            (is (true?  (:positive (get by-user rasta-id))))
-            (is (= "nice" (:freeform_feedback (get by-user rasta-id))))
-            (is (false? (:positive (get by-user lucky-id))))
-            (is (= "ui-bug" (:issue_type (get by-user lucky-id))))
-            (is (= "not for me" (:freeform_feedback (get by-user lucky-id))))
-            (is (= 2 (count @harbormaster-calls)) "harbormaster is called once per submitter")
-            (is (= #{rasta-id lucky-id} (set (map :submitter_user_id @harbormaster-calls))))))
+        (let [rasta-result (#'slackbot/handle-feedback-modal-submission
+                            (modal-submission-payload {:conv-id     conv-id
+                                                       :external-id external-id
+                                                       :user-id     rasta-id
+                                                       :positive    true
+                                                       :freeform    "nice"}))
+              lucky-result (#'slackbot/handle-feedback-modal-submission
+                            (modal-submission-payload {:conv-id     conv-id
+                                                       :external-id external-id
+                                                       :user-id     lucky-id
+                                                       :positive    false
+                                                       :issue-type  "ui-bug"
+                                                       :freeform    "not for me"}))]
+          @rasta-result
+          @lucky-result)
+        (let [rows    (t2/select :model/MetabotFeedback :message_id message-id
+                                 {:order-by [[:user_id :asc]]})
+              by-user (into {} (map (juxt :user_id identity)) rows)]
+          (is (= 2 (count rows)) "both submissions produce distinct rows")
+          (is (true?  (:positive (get by-user rasta-id))))
+          (is (= "nice" (:freeform_feedback (get by-user rasta-id))))
+          (is (false? (:positive (get by-user lucky-id))))
+          (is (= "ui-bug" (:issue_type (get by-user lucky-id))))
+          (is (= "not for me" (:freeform_feedback (get by-user lucky-id)))))
         (finally (tear-down-slackbot-feedback! conv-id))))))
 
 (deftest handle-feedback-modal-submission-unresolvable-external-id-test
-  (testing "modal submission drops cleanly (no local write, no harbormaster) when external_id cannot be resolved"
-    (let [rasta-id           (mt/user->id :rasta)
-          harbormaster-calls (atom [])]
-      (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                               (swap! harbormaster-calls conj feedback)
-                                                               true)]
-        (let [payload (modal-submission-payload {:conv-id     (str (random-uuid))
-                                                 :external-id nil
-                                                 :user-id     rasta-id
-                                                 :positive    true
-                                                 :freeform    "orphaned"
-                                                 :channel-id  "C-missing"
-                                                 :message-ts  "0.000"})
-              result  (#'slackbot/handle-feedback-modal-submission payload)]
-          (is (nil? result) "handler returns nil and does not schedule async work")
-          (is (zero? (count @harbormaster-calls)) "harbormaster is not called for an unresolvable submission")
-          (is (zero? (t2/count :model/MetabotFeedback :user_id rasta-id
-                               {:where [:in :message_id
-                                        {:select [:id] :from [:metabot_message]
-                                         :where [:= :external_id "nothing-to-match"]}]}))
-              "no feedback row written for unresolvable submissions"))))))
+  (testing "modal submission drops cleanly (no local write) when external_id cannot be resolved"
+    (let [rasta-id (mt/user->id :rasta)
+          payload  (modal-submission-payload {:conv-id     (str (random-uuid))
+                                              :external-id nil
+                                              :user-id     rasta-id
+                                              :positive    true
+                                              :freeform    "orphaned"
+                                              :channel-id  "C-missing"
+                                              :message-ts  "0.000"})
+          result   (#'slackbot/handle-feedback-modal-submission payload)]
+      (is (nil? result) "handler returns nil and does not schedule async work")
+      (is (zero? (t2/count :model/MetabotFeedback :user_id rasta-id
+                           {:where [:in :message_id
+                                    {:select [:id] :from [:metabot_message]
+                                     :where [:= :external_id "nothing-to-match"]}]}))
+          "no feedback row written for unresolvable submissions"))))
 
 (deftest handle-feedback-modal-submission-lurker-test
-  (testing "modal submission from a non-participant is rejected locally and harbormaster is not called"
+  (testing "modal submission from a non-participant is rejected locally"
     (let [rasta-id (mt/user->id :rasta)
           lucky-id (mt/user->id :lucky)
-          {:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)
-          harbormaster-calls (atom [])]
+          {:keys [conv-id external-id message-id]} (setup-slackbot-feedback! rasta-id)]
       (try
         ;; lucky has authored no messages, so can-read? on the conversation rejects
-        (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                 (swap! harbormaster-calls conj feedback)
-                                                                 true)]
-          (let [result (#'slackbot/handle-feedback-modal-submission
-                        (modal-submission-payload {:conv-id     conv-id
-                                                   :external-id external-id
-                                                   :user-id     lucky-id
-                                                   :positive    true
-                                                   :freeform    "lurking"}))]
-            @result))
-        (is (zero? (count @harbormaster-calls)) "harbormaster is skipped when the local write is rejected")
+        (let [result (#'slackbot/handle-feedback-modal-submission
+                      (modal-submission-payload {:conv-id     conv-id
+                                                 :external-id external-id
+                                                 :user-id     lucky-id
+                                                 :positive    true
+                                                 :freeform    "lurking"}))]
+          @result)
         (is (nil? (t2/select-one :model/MetabotFeedback :message_id message-id :user_id lucky-id))
             "no feedback row is written for a lurker")
         (finally (tear-down-slackbot-feedback! conv-id))))))
 
 (deftest handle-feedback-modal-submission-resolves-via-channel-and-ts-fallback-test
   (testing "buttons predating :message_external_id still resolve via (channel_id, message_ts)"
-    (let [rasta-id           (mt/user->id :rasta)
-          conv-id            (str (random-uuid))
-          external-id        (str (random-uuid))
-          channel-id         "C-FALLBACK"
-          message-ts         "1700000000.123456"
-          harbormaster-calls (atom [])]
+    (let [rasta-id    (mt/user->id :rasta)
+          conv-id     (str (random-uuid))
+          external-id (str (random-uuid))
+          channel-id  "C-FALLBACK"
+          message-ts  "1700000000.123456"]
       (try
         (t2/insert! :model/MetabotConversation {:id conv-id :user_id rasta-id})
         (let [message-id (first (t2/insert-returning-pks!
@@ -1139,27 +1024,20 @@
                                   :slack_msg_id    message-ts
                                   :total_tokens    5
                                   :data            [{:_type "TEXT" :role "assistant" :content "hi"}]}))]
-          (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
-                                                                   (swap! harbormaster-calls conj feedback)
-                                                                   true)]
-            (let [;; external-id intentionally omitted from the button payload — only channel + ts are present
-                  payload (modal-submission-payload {:conv-id     conv-id
-                                                     :external-id nil
-                                                     :user-id     rasta-id
-                                                     :positive    true
-                                                     :freeform    "from a legacy button"
-                                                     :channel-id  channel-id
-                                                     :message-ts  message-ts})
-                  result  (#'slackbot/handle-feedback-modal-submission payload)]
-              @result
-              (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
-                (is (some? row) "fallback resolved the message and persisted feedback")
-                (is (true? (:positive row)))
-                (is (= "from a legacy button" (:freeform_feedback row))))
-              (is (= 1 (count @harbormaster-calls)))
-              (is (=? {:feedback {:message_id external-id :positive true}}
-                      (first @harbormaster-calls))
-                  "harbormaster receives the resolved external_id, not the channel/ts pair"))))
+          (let [;; external-id intentionally omitted from the button payload — only channel + ts are present
+                payload (modal-submission-payload {:conv-id     conv-id
+                                                   :external-id nil
+                                                   :user-id     rasta-id
+                                                   :positive    true
+                                                   :freeform    "from a legacy button"
+                                                   :channel-id  channel-id
+                                                   :message-ts  message-ts})
+                result  (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
+              (is (some? row) "fallback resolved the message and persisted feedback")
+              (is (true? (:positive row)))
+              (is (= "from a legacy button" (:freeform_feedback row))))))
         (finally (tear-down-slackbot-feedback! conv-id))))))
 
 ;; -------------------------------- conversation-permalink ---------------------------------------

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -1023,21 +1023,21 @@
                                   :channel_id      channel-id
                                   :slack_msg_id    message-ts
                                   :total_tokens    5
-                                  :data            [{:_type "TEXT" :role "assistant" :content "hi"}]}))]
-          (let [;; external-id intentionally omitted from the button payload — only channel + ts are present
-                payload (modal-submission-payload {:conv-id     conv-id
-                                                   :external-id nil
-                                                   :user-id     rasta-id
-                                                   :positive    true
-                                                   :freeform    "from a legacy button"
-                                                   :channel-id  channel-id
-                                                   :message-ts  message-ts})
-                result  (#'slackbot/handle-feedback-modal-submission payload)]
-            @result
-            (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
-              (is (some? row) "fallback resolved the message and persisted feedback")
-              (is (true? (:positive row)))
-              (is (= "from a legacy button" (:freeform_feedback row))))))
+                                  :data            [{:_type "TEXT" :role "assistant" :content "hi"}]}))
+              ;; external-id intentionally omitted from the button payload — only channel + ts are present
+              payload    (modal-submission-payload {:conv-id     conv-id
+                                                    :external-id nil
+                                                    :user-id     rasta-id
+                                                    :positive    true
+                                                    :freeform    "from a legacy button"
+                                                    :channel-id  channel-id
+                                                    :message-ts  message-ts})
+              result     (#'slackbot/handle-feedback-modal-submission payload)]
+          @result
+          (let [row (t2/select-one :model/MetabotFeedback :message_id message-id :user_id rasta-id)]
+            (is (some? row) "fallback resolved the message and persisted feedback")
+            (is (true? (:positive row)))
+            (is (= "from a legacy button" (:freeform_feedback row)))))
         (finally (tear-down-slackbot-feedback! conv-id))))))
 
 ;; -------------------------------- conversation-permalink ---------------------------------------

--- a/test/metabase/warehouse_schema_rest/api/field_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/field_test.clj
@@ -78,6 +78,29 @@
       (is (=? {:target {:id (mt/id :categories :id)}}
               (mt/user-http-request :rasta :get 200 (format "field/%d" (mt/id :venues :category_id))))))))
 
+(deftest ^:parallel get-field-table-ids-test
+  (testing "POST /api/field/table-ids"
+    (is (= {:table_ids (sort [(mt/id :categories) (mt/id :venues)])}
+           (mt/user-http-request :rasta :post 200 "field/table-ids"
+                                 {:field_ids [(mt/id :venues :name)
+                                              (mt/id :venues :category_id)
+                                              (mt/id :categories :name)]})))))
+
+(deftest ^:parallel get-field-table-ids-empty-and-missing-test
+  (testing "POST /api/field/table-ids accepts empty and missing field IDs"
+    (is (= {:table_ids []}
+           (mt/user-http-request :rasta :post 200 "field/table-ids"
+                                 {:field_ids []})))
+    (is (= {:table_ids []}
+           (mt/user-http-request :rasta :post 200 "field/table-ids"
+                                 {:field_ids [2147483647]})))))
+
+(deftest ^:parallel get-field-table-ids-too-many-test
+  (testing "POST /api/field/table-ids rejects oversized field ID requests"
+    (is (= "field_ids may contain at most 1000 IDs."
+           (mt/user-http-request :rasta :post 400 "field/table-ids"
+                                 {:field_ids (vec (range 1 1002))})))))
+
 (deftest ^:parallel get-field-summary-test
   (testing "GET /api/field/:id/summary"
     ;; TODO -- why doesn't this come back as a dictionary ?


### PR DESCRIPTION
Closes [BOT-1407: Implement data source feedback](https://linear.app/metabase/issue/BOT-1407/implement-data-source-feedback)

### Description

Adds ability to give feedback on sources that metabot uses. Each time `navigate_to` or `code_edit` data parts are being emitted by metabot, in the UI we'll show a list of sources collected from mbql/sql query. For SQL queries we're using the `/llm/extract-tables` endpoint; for mbql it's using [the values from the query itself](https://github.com/metabase/metabase/pull/73497/changes#diff-3a74839f332cac6f74e7f5f32f42b115aaded1ac8f6e33439dc650a3cef662ebR2598-R2612)

### How to verify

1. Send a message to metabot that will prompt it to use `navigate_to` or `code_edit` tool with some sources
2. See the sources being listed with 👍 / 👎  buttons to give feedback on sources.

### Demo

https://www.loom.com/share/9a095e36efaf41feb8077fbc908446df?from_recorder=1&focus_title=1

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~

