### PR TITLE
Hydrate entities in RTK fetches

### DIFF
--- a/frontend/src/metabase/api/action.ts
+++ b/frontend/src/metabase/api/action.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { ActionSchema } from "metabase/schema";
 import type {
   CreateActionRequest,
   GetActionRequest,
@@ -18,6 +19,7 @@ import {
   provideActionListTags,
   provideActionTags,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const actionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -28,6 +30,7 @@ export const actionApi = Api.injectEndpoints({
         params,
       }),
       providesTags: (collections = []) => provideActionListTags(collections),
+      onQueryStarted: hydrateLegacyEntities([ActionSchema]),
     }),
     getAction: builder.query<WritebackAction, GetActionRequest>({
       query: ({ id }) => ({
@@ -35,6 +38,7 @@ export const actionApi = Api.injectEndpoints({
         url: `/api/action/${id}`,
       }),
       providesTags: (action) => (action ? provideActionTags(action) : []),
+      onQueryStarted: hydrateLegacyEntities(ActionSchema),
     }),
     createAction: builder.mutation<WritebackAction, CreateActionRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/bookmark.ts
+++ b/frontend/src/metabase/api/bookmark.ts
@@ -1,3 +1,4 @@
+import { BookmarkSchema } from "metabase/schema";
 import type {
   Bookmark,
   CreateBookmarkRequest,
@@ -12,6 +13,7 @@ import {
   listTag,
   provideBookmarkListTags,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const bookmarkApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -21,6 +23,7 @@ export const bookmarkApi = Api.injectEndpoints({
         url: "/api/bookmark",
       }),
       providesTags: (bookmarks = []) => provideBookmarkListTags(bookmarks),
+      onQueryStarted: hydrateLegacyEntities([BookmarkSchema]),
     }),
     createBookmark: builder.mutation<Bookmark, CreateBookmarkRequest>({
       query: ({ id, type }) => ({

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -1,5 +1,4 @@
 import { PLUGIN_API } from "metabase/plugins";
-import { updateMetadata } from "metabase/redux/metadata";
 import { QueryMetadataSchema, QuestionSchema } from "metabase/schema";
 import type {
   Card,
@@ -32,6 +31,7 @@ import {
   provideCardTags,
   provideParameterValuesTags,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 import { handleQueryFulfilled } from "./utils/lifecycle";
 
 const PERSISTED_MODEL_REFRESH_DELAY = 200;
@@ -66,10 +66,7 @@ export const cardApi = Api.injectEndpoints({
           params,
         }),
         providesTags: (cards = []) => provideCardListTags(cards),
-        onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-          handleQueryFulfilled(queryFulfilled, (data) =>
-            dispatch(updateMetadata(data, [QuestionSchema])),
-          ),
+        onQueryStarted: hydrateLegacyEntities([QuestionSchema]),
       }),
       getCard: builder.query<Card, GetCardRequest>({
         query: ({ id, ignore_error, ...params }) => ({
@@ -79,10 +76,7 @@ export const cardApi = Api.injectEndpoints({
           noEvent: ignore_error,
         }),
         providesTags: (card) => (card ? provideCardTags(card) : []),
-        onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-          handleQueryFulfilled(queryFulfilled, (data) =>
-            dispatch(updateMetadata(data, QuestionSchema)),
-          ),
+        onQueryStarted: hydrateLegacyEntities(QuestionSchema),
       }),
       getCardQueryMetadata: builder.query<CardQueryMetadata, CardId>({
         query: (id) => ({
@@ -91,10 +85,7 @@ export const cardApi = Api.injectEndpoints({
         }),
         providesTags: (metadata, _error, id) =>
           metadata ? provideCardQueryMetadataTags(id, metadata) : [],
-        onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-          handleQueryFulfilled(queryFulfilled, (data) =>
-            dispatch(updateMetadata(data, QueryMetadataSchema)),
-          ),
+        onQueryStarted: hydrateLegacyEntities(QueryMetadataSchema),
       }),
       getCardQuery: builder.query<Dataset, CardQueryRequest>({
         query: ({ cardId, ...body }) => ({

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -1,5 +1,4 @@
-import { updateMetadata } from "metabase/redux/metadata";
-import { ObjectUnionSchema } from "metabase/schema";
+import { CollectionSchema, ObjectUnionSchema } from "metabase/schema";
 import type {
   Collection,
   CreateCollectionRequest,
@@ -25,7 +24,7 @@ import {
   provideCollectionListTags,
   provideCollectionTags,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const collectionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -42,6 +41,7 @@ export const collectionApi = Api.injectEndpoints({
         }),
         providesTags: (collections = []) =>
           provideCollectionListTags(collections),
+        onQueryStarted: hydrateLegacyEntities([CollectionSchema]),
       },
     ),
     listCollectionsTree: builder.query<
@@ -71,15 +71,10 @@ export const collectionApi = Api.injectEndpoints({
         ...provideCollectionItemListTags(response?.data ?? [], models),
         { type: "collection", id: `${id}-items` },
       ],
-      // Hydrate the legacy entity store so legacy entity actions (e.g.
-      // Dashboards.actions.setCollection) can read the original object to
-      // build their undo payloads.
-      //
-      // TODO: Remove once entity actions are migrated.
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (response) =>
-          dispatch(updateMetadata(response.data, [ObjectUnionSchema])),
-        ),
+      onQueryStarted: hydrateLegacyEntities<ListCollectionItemsResponse>(
+        [ObjectUnionSchema],
+        (response) => response.data,
+      ),
     }),
     getCollection: builder.query<Collection, getCollectionRequest>({
       query: ({ id, ignore_error, ...params }) => {
@@ -92,6 +87,7 @@ export const collectionApi = Api.injectEndpoints({
       },
       providesTags: (collection) =>
         collection ? provideCollectionTags(collection) : [],
+      onQueryStarted: hydrateLegacyEntities(CollectionSchema),
     }),
     createCollection: builder.mutation<Collection, CreateCollectionRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -1,4 +1,8 @@
-import { CollectionSchema, ObjectUnionSchema } from "metabase/schema";
+import {
+  CollectionSchema,
+  ObjectUnionSchema,
+  SnippetCollectionSchema,
+} from "metabase/schema";
 import type {
   Collection,
   CreateCollectionRequest,
@@ -32,6 +36,16 @@ const flattenCollectionTree = (tree: Collection[]): Collection[] =>
     ...flattenCollectionTree(collection.children ?? []),
   ]);
 
+// Snippet collections live in their own entity slice (`snippetCollections`),
+// so hydrating them through `CollectionSchema` would clobber regular
+// collections. Hydrate through the matching schema instead.
+const collectionSchemaForRequest = (
+  request: { namespace?: string | null } | void,
+) =>
+  request?.namespace === "snippets"
+    ? SnippetCollectionSchema
+    : CollectionSchema;
+
 export const collectionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     /**
@@ -47,7 +61,11 @@ export const collectionApi = Api.injectEndpoints({
         }),
         providesTags: (collections = []) =>
           provideCollectionListTags(collections),
-        onQueryStarted: hydrateLegacyEntities([CollectionSchema]),
+        onQueryStarted: (request, lifecycle) =>
+          hydrateLegacyEntities([collectionSchemaForRequest(request)])(
+            request,
+            lifecycle,
+          ),
       },
     ),
     listCollectionsTree: builder.query<
@@ -63,10 +81,11 @@ export const collectionApi = Api.injectEndpoints({
         ...provideCollectionListTags(collections),
         "collection-tree",
       ],
-      onQueryStarted: hydrateLegacyEntities<Collection[]>(
-        [CollectionSchema],
-        flattenCollectionTree,
-      ),
+      onQueryStarted: (request, lifecycle) =>
+        hydrateLegacyEntities<Collection[]>(
+          [collectionSchemaForRequest(request)],
+          flattenCollectionTree,
+        )(request, lifecycle),
     }),
     listCollectionItems: builder.query<
       ListCollectionItemsResponse,
@@ -97,7 +116,11 @@ export const collectionApi = Api.injectEndpoints({
       },
       providesTags: (collection) =>
         collection ? provideCollectionTags(collection) : [],
-      onQueryStarted: hydrateLegacyEntities(CollectionSchema),
+      onQueryStarted: (request, lifecycle) =>
+        hydrateLegacyEntities(collectionSchemaForRequest(request))(
+          request,
+          lifecycle,
+        ),
     }),
     createCollection: builder.mutation<Collection, CreateCollectionRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -26,6 +26,12 @@ import {
 } from "./tags";
 import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
+const flattenCollectionTree = (tree: Collection[]): Collection[] =>
+  tree.flatMap((collection) => [
+    collection,
+    ...flattenCollectionTree(collection.children ?? []),
+  ]);
+
 export const collectionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     /**
@@ -57,6 +63,10 @@ export const collectionApi = Api.injectEndpoints({
         ...provideCollectionListTags(collections),
         "collection-tree",
       ],
+      onQueryStarted: hydrateLegacyEntities<Collection[]>(
+        [CollectionSchema],
+        flattenCollectionTree,
+      ),
     }),
     listCollectionItems: builder.query<
       ListCollectionItemsResponse,

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -1,6 +1,5 @@
 import { PLUGIN_API } from "metabase/plugins";
-import { updateMetadata } from "metabase/redux/metadata";
-import { QueryMetadataSchema } from "metabase/schema";
+import { DashboardSchema, QueryMetadataSchema } from "metabase/schema";
 import type {
   CopyDashboardRequest,
   CreateDashboardRequest,
@@ -36,7 +35,7 @@ import {
   provideValidDashboardFilterFieldTags,
   tag,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const dashboardApi = Api.injectEndpoints({
   endpoints: (builder) => {
@@ -71,6 +70,7 @@ export const dashboardApi = Api.injectEndpoints({
         }),
         providesTags: (dashboards) =>
           dashboards ? provideDashboardListTags(dashboards) : [],
+        onQueryStarted: hydrateLegacyEntities([DashboardSchema]),
       }),
       getDashboard: builder.query<Dashboard, GetDashboardRequest>({
         query: ({ id, ignore_error }) => ({
@@ -80,6 +80,7 @@ export const dashboardApi = Api.injectEndpoints({
         }),
         providesTags: (dashboard) =>
           dashboard ? provideDashboardTags(dashboard) : [],
+        onQueryStarted: hydrateLegacyEntities(DashboardSchema),
       }),
       getDashboardQueryMetadata: builder.query<
         DashboardQueryMetadata,
@@ -92,10 +93,7 @@ export const dashboardApi = Api.injectEndpoints({
         }),
         providesTags: (metadata) =>
           metadata ? provideDashboardQueryMetadataTags(metadata) : [],
-        onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-          handleQueryFulfilled(queryFulfilled, (data) =>
-            dispatch(updateMetadata(data, QueryMetadataSchema)),
-          ),
+        onQueryStarted: hydrateLegacyEntities(QueryMetadataSchema),
       }),
       getRemappedDashboardParameterValue: builder.query<
         FieldValue,

--- a/frontend/src/metabase/api/document.ts
+++ b/frontend/src/metabase/api/document.ts
@@ -1,5 +1,7 @@
 import { Api } from "metabase/api/api";
 import { idTag, listTag } from "metabase/api/tags";
+import { hydrateLegacyEntities } from "metabase/api/utils/hydrate-legacy-entities";
+import { DocumentSchema } from "metabase/schema";
 import type {
   CopyDocumentRequest,
   CreateDocumentRequest,
@@ -19,6 +21,7 @@ export const documentApi = Api.injectEndpoints({
       }),
       providesTags: (result, error, { id }) =>
         !error ? [idTag("document", id)] : [],
+      onQueryStarted: hydrateLegacyEntities(DocumentSchema),
     }),
     createDocument: builder.mutation<Document, CreateDocumentRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/measure.ts
+++ b/frontend/src/metabase/api/measure.ts
@@ -1,4 +1,3 @@
-import { updateMetadata } from "metabase/redux/metadata";
 import { MeasureSchema } from "metabase/schema";
 import type {
   CreateMeasureRequest,
@@ -22,7 +21,7 @@ import {
   provideMeasureTags,
   tag,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const measureApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -32,10 +31,7 @@ export const measureApi = Api.injectEndpoints({
         url: "/api/measure",
       }),
       providesTags: (measures = []) => provideMeasureListTags(measures),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, [MeasureSchema])),
-        ),
+      onQueryStarted: hydrateLegacyEntities([MeasureSchema]),
     }),
     getMeasure: builder.query<Measure, MeasureId>({
       query: (id) => ({
@@ -43,10 +39,7 @@ export const measureApi = Api.injectEndpoints({
         url: `/api/measure/${id}`,
       }),
       providesTags: (measure) => (measure ? provideMeasureTags(measure) : []),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, MeasureSchema)),
-        ),
+      onQueryStarted: hydrateLegacyEntities(MeasureSchema),
     }),
     getMeasureDimensionValues: builder.query<
       GetMeasureDimensionValuesResponse,

--- a/frontend/src/metabase/api/metric.ts
+++ b/frontend/src/metabase/api/metric.ts
@@ -1,4 +1,3 @@
-import { updateMetadata } from "metabase/redux/metadata";
 import { MetricSchema } from "metabase/schema";
 import type {
   Dataset,
@@ -20,7 +19,7 @@ import {
   provideMetricListTags,
   provideMetricTags,
 } from "./tags/utils";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const metricApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -30,10 +29,7 @@ export const metricApi = Api.injectEndpoints({
         url: "/api/metric",
       }),
       providesTags: (metrics = []) => provideMetricListTags(metrics),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, [MetricSchema])),
-        ),
+      onQueryStarted: hydrateLegacyEntities([MetricSchema]),
     }),
     getMetric: builder.query<Metric, MetricId>({
       query: (id) => ({
@@ -41,10 +37,7 @@ export const metricApi = Api.injectEndpoints({
         url: `/api/metric/${id}`,
       }),
       providesTags: (metric) => (metric ? provideMetricTags(metric) : []),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, MetricSchema)),
-        ),
+      onQueryStarted: hydrateLegacyEntities(MetricSchema),
     }),
     getMetricDimensionValues: builder.query<
       GetMetricDimensionValuesResponse,

--- a/frontend/src/metabase/api/segment.ts
+++ b/frontend/src/metabase/api/segment.ts
@@ -1,4 +1,3 @@
-import { updateMetadata } from "metabase/redux/metadata";
 import { SegmentSchema } from "metabase/schema";
 import type {
   CreateSegmentRequest,
@@ -16,7 +15,7 @@ import {
   provideSegmentTags,
   tag,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const segmentApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -26,10 +25,7 @@ export const segmentApi = Api.injectEndpoints({
         url: "/api/segment",
       }),
       providesTags: (segments = []) => provideSegmentListTags(segments),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, [SegmentSchema])),
-        ),
+      onQueryStarted: hydrateLegacyEntities([SegmentSchema]),
     }),
     getSegment: builder.query<Segment, SegmentId>({
       query: (id) => ({
@@ -37,10 +33,7 @@ export const segmentApi = Api.injectEndpoints({
         url: `/api/segment/${id}`,
       }),
       providesTags: (segment) => (segment ? provideSegmentTags(segment) : []),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, SegmentSchema)),
-        ),
+      onQueryStarted: hydrateLegacyEntities(SegmentSchema),
     }),
     createSegment: builder.mutation<Segment, CreateSegmentRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/snippet.ts
+++ b/frontend/src/metabase/api/snippet.ts
@@ -1,4 +1,3 @@
-import { updateMetadata } from "metabase/redux/metadata";
 import { SnippetSchema } from "metabase/schema";
 import type {
   CreateSnippetRequest,
@@ -16,7 +15,7 @@ import {
   provideSnippetListTags,
   provideSnippetTags,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const snippetApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -30,10 +29,7 @@ export const snippetApi = Api.injectEndpoints({
         params,
       }),
       providesTags: (snippets = []) => provideSnippetListTags(snippets),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, [SnippetSchema])),
-        ),
+      onQueryStarted: hydrateLegacyEntities([SnippetSchema]),
     }),
     getSnippet: builder.query<NativeQuerySnippet, NativeQuerySnippetId>({
       query: (id) => ({
@@ -41,10 +37,7 @@ export const snippetApi = Api.injectEndpoints({
         url: `/api/native-query-snippet/${id}`,
       }),
       providesTags: (snippet) => (snippet ? provideSnippetTags(snippet) : []),
-      onQueryStarted: (_, { queryFulfilled, dispatch }) =>
-        handleQueryFulfilled(queryFulfilled, (data) =>
-          dispatch(updateMetadata(data, SnippetSchema)),
-        ),
+      onQueryStarted: hydrateLegacyEntities(SnippetSchema),
     }),
     createSnippet: builder.mutation<NativeQuerySnippet, CreateSnippetRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/subscription.ts
+++ b/frontend/src/metabase/api/subscription.ts
@@ -1,3 +1,4 @@
+import { PulseSchema } from "metabase/schema";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
@@ -15,6 +16,7 @@ import {
   provideSubscriptionListTags,
   provideSubscriptionTags,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const subscriptionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -29,6 +31,7 @@ export const subscriptionApi = Api.injectEndpoints({
       }),
       providesTags: (subscriptions = []) =>
         provideSubscriptionListTags(subscriptions),
+      onQueryStarted: hydrateLegacyEntities([PulseSchema]),
     }),
     getSubscription: builder.query<DashboardSubscription, number>({
       query: (id) => ({
@@ -37,6 +40,7 @@ export const subscriptionApi = Api.injectEndpoints({
       }),
       providesTags: (subscription) =>
         subscription ? provideSubscriptionTags(subscription) : [],
+      onQueryStarted: hydrateLegacyEntities(PulseSchema),
     }),
     createSubscription: builder.mutation<
       DashboardSubscription,

--- a/frontend/src/metabase/api/timeline-event.ts
+++ b/frontend/src/metabase/api/timeline-event.ts
@@ -1,3 +1,4 @@
+import { TimelineEventSchema } from "metabase/schema";
 import type {
   CreateTimelineEventRequest,
   TimelineEvent,
@@ -13,6 +14,7 @@ import {
   provideTimelineEventTags,
   tag,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const timelineEventApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -22,6 +24,7 @@ export const timelineEventApi = Api.injectEndpoints({
         url: `/api/timeline-event/${id}`,
       }),
       providesTags: (event) => (event ? provideTimelineEventTags(event) : []),
+      onQueryStarted: hydrateLegacyEntities(TimelineEventSchema),
     }),
     createTimelineEvent: builder.mutation<
       TimelineEvent,

--- a/frontend/src/metabase/api/timeline.ts
+++ b/frontend/src/metabase/api/timeline.ts
@@ -1,3 +1,4 @@
+import { TimelineSchema } from "metabase/schema";
 import type {
   CreateTimelineRequest,
   GetTimelineRequest,
@@ -17,6 +18,7 @@ import {
   provideTimelineTags,
   tag,
 } from "./tags";
+import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
 
 export const timelineApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -27,6 +29,7 @@ export const timelineApi = Api.injectEndpoints({
         params,
       }),
       providesTags: (timelines = []) => provideTimelineListTags(timelines),
+      onQueryStarted: hydrateLegacyEntities([TimelineSchema]),
     }),
     listCollectionTimelines: builder.query<
       Timeline[],
@@ -38,6 +41,7 @@ export const timelineApi = Api.injectEndpoints({
         params,
       }),
       providesTags: (timelines = []) => provideTimelineListTags(timelines),
+      onQueryStarted: hydrateLegacyEntities([TimelineSchema]),
     }),
     getTimeline: builder.query<Timeline, GetTimelineRequest>({
       query: ({ id, ...params }) => ({
@@ -47,6 +51,7 @@ export const timelineApi = Api.injectEndpoints({
       }),
       providesTags: (timeline) =>
         timeline ? provideTimelineTags(timeline) : [],
+      onQueryStarted: hydrateLegacyEntities(TimelineSchema),
     }),
     createTimeline: builder.mutation<Timeline, CreateTimelineRequest>({
       query: (body) => ({

--- a/frontend/src/metabase/api/utils/hydrate-legacy-entities.ts
+++ b/frontend/src/metabase/api/utils/hydrate-legacy-entities.ts
@@ -1,0 +1,34 @@
+import type { Schema } from "normalizr";
+
+import { updateMetadata } from "metabase/redux/metadata";
+
+import { handleQueryFulfilled } from "./lifecycle";
+
+/**
+ * Bridges RTK Query responses into the entity store.
+ *
+ * Legacy code paths still in use, ie. notably `Entity.actions.update`,
+ * which reads the original object via `getObject` to build undo payloads
+ * require those slices to be hydrated.
+ *
+ * TODO: Delete this helper, and remove every call site, when the legacy entity
+ * system is gone.
+ */
+export const hydrateLegacyEntities =
+  <Response>(
+    schema: Schema,
+    pick: (response: Response) => unknown = (response) => response,
+  ) =>
+  (
+    _arg: unknown,
+    {
+      queryFulfilled,
+      dispatch,
+    }: {
+      queryFulfilled: Promise<{ data: Response }>;
+      dispatch: (action: ReturnType<typeof updateMetadata>) => unknown;
+    },
+  ) =>
+    handleQueryFulfilled(queryFulfilled, (data) =>
+      dispatch(updateMetadata(pick(data), schema)),
+    );

--- a/frontend/src/metabase/api/utils/hydrate-legacy-entities.ts
+++ b/frontend/src/metabase/api/utils/hydrate-legacy-entities.ts
@@ -1,6 +1,6 @@
 import type { Schema } from "normalizr";
 
-import { updateMetadata } from "metabase/redux/metadata";
+import { updateMetadata } from "metabase/redux/metadata-typed";
 
 import { handleQueryFulfilled } from "./lifecycle";
 

--- a/frontend/src/metabase/api/utils/index.ts
+++ b/frontend/src/metabase/api/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./errors";
+export * from "./hydrate-legacy-entities";
 export * from "./settings";
 export * from "./use-token-refresh";

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/enterprise.unit.spec.tsx
@@ -149,7 +149,7 @@ describe("DataStudioLayout", () => {
   });
 
   describe("transform dirty indicator", () => {
-    it("should show dirty indicator on Exit tab when transforms have dirty changes", async () => {
+    it("should show dirty indicator on Transforms tab when transforms have dirty changes", async () => {
       setup({
         ...DEFAULT_EE_SETTINGS,
         remoteSyncBranch: "main",
@@ -158,18 +158,15 @@ describe("DataStudioLayout", () => {
         remoteSyncTransforms: true,
       });
 
+      const transformsTab = await screen.findByLabelText("Transforms");
       await waitFor(() => {
-        expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
+        expect(
+          within(transformsTab).getByTestId("remote-sync-status"),
+        ).toBeInTheDocument();
       });
-
-      // Should show the dirty indicator badge on the Exit tab
-      const transformsTab = screen.getByLabelText("Transforms");
-      expect(
-        within(transformsTab).queryByTestId("remote-sync-status"),
-      ).not.toBeInTheDocument();
     });
 
-    it("should not show dirty indicator on Exit tab when no dirty changes", async () => {
+    it("should not show dirty indicator on Transforms tab when no dirty changes", async () => {
       setup({
         ...DEFAULT_EE_SETTINGS,
         remoteSyncBranch: "main",


### PR DESCRIPTION
Closes DEV-1903

Whilst migrating of the entity system, we will often move helpers out of the entity system and into plain hooks that use RTK-query.

This breaks other actions that rely on the entity's state when calling `update` (and particularly `undo`), as the state might be stale if updated through RTK and not through entities system.

This PR makes all fetches in the RTK-query system also update the entities cache, so they stay in sync.

To make components that rely on the entity cache-invalidation work, this PR bridges the RTK-query cache with the entity system cache. 

See https://github.com/metabase/metabase/pull/73460 for a PR where this was necessary. This PR just streamlines it into one PR of related changes.

This code will be removed once we remove the entity system. 
