### PR TITLE
Translate schedule type when deleting subscription

### DIFF
--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -324,6 +324,29 @@ describe("scenarios > dashboard > subscriptions", () => {
         });
     });
 
+    it("should localize schedule type in the delete-confirmation modal", () => {
+      createEmailSubscription();
+      H.sidebar().findByText("Emailed hourly").should("be.visible");
+
+      cy.request("GET", "/api/user/current").then(({ body: user }) => {
+        cy.request("PUT", `/api/user/${user.id}`, { locale: "en-ZZ" });
+      });
+      cy.reload();
+
+      H.dashboardHeader()
+        .findByLabelText("[zz] Move, trash, and more…")
+        .click();
+      H.popover().findByText("[zz] Subscriptions").click();
+      H.sidebar()
+        .findByText(/\[zz\] hourly/)
+        .click();
+      H.sidebar().findByText("[zz] Delete this subscription").click();
+
+      cy.findByTestId("delete-confirmation-modal-pulse")
+        .findByText("[zz] hourly")
+        .should("be.visible");
+    });
+
     it("should send only attachments without email content when 'Send only attachments' is enabled", () => {
       assignRecipient();
 

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/DeleteSubscriptionAction.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/DeleteSubscriptionAction.tsx
@@ -4,14 +4,20 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { jt, msgid, ngettext, t } from "ttag";
 
+import { getScheduleStrings } from "metabase/common/components/Schedule/strings";
 import CS from "metabase/css/core/index.css";
 import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { Button, Checkbox, Flex, Modal } from "metabase/ui";
 import type { Channel } from "metabase-types/api";
 
 function getConfirmItems(pulse: DraftDashboardSubscription): ReactNode[] {
-  return pulse.channels.map((c: Channel, index: number) =>
-    c.channel_type === "email" ? (
+  const { scheduleOptionNames } = getScheduleStrings();
+  return pulse.channels.map((c: Channel, index: number) => {
+    const scheduleTypeLabel = c.schedule_type
+      ? scheduleOptionNames[c.schedule_type]
+      : "";
+
+    return c.channel_type === "email" ? (
       <span key={index}>
         {jt`This dashboard will no longer be emailed to ${(
           <strong key="msg">
@@ -19,7 +25,7 @@ function getConfirmItems(pulse: DraftDashboardSubscription): ReactNode[] {
               c.recipients?.length || 0,
             )}
           </strong>
-        )} ${<strong key="type">{c.schedule_type}</strong>}`}
+        )} ${<strong key="type">{scheduleTypeLabel}</strong>}`}
         .
       </span>
     ) : c.channel_type === "slack" ? (
@@ -27,7 +33,7 @@ function getConfirmItems(pulse: DraftDashboardSubscription): ReactNode[] {
         {jt`Slack channel ${(
           <strong key="msg">{c.details && c.details.channel}</strong>
         )} will no longer get this dashboard ${(
-          <strong key="type">{c.schedule_type}</strong>
+          <strong key="type">{scheduleTypeLabel}</strong>
         )}`}
         .
       </span>
@@ -36,12 +42,12 @@ function getConfirmItems(pulse: DraftDashboardSubscription): ReactNode[] {
         {jt`Channel ${(
           <strong key="msg">{c.channel_type}</strong>
         )} will no longer receive this dashboard ${(
-          <strong key="type">{c.schedule_type}</strong>
+          <strong key="type">{scheduleTypeLabel}</strong>
         )}`}
         .
       </span>
-    ),
-  );
+    );
+  });
 }
 
 interface DeleteSubscriptionActionProps {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59667
Closes https://linear.app/metabase/issue/GDGT-539/incomplete-translation-on-delete-subscription-confirmation-modal

### How to verify

1. Create subscription
2. Switch language to something non-english
3. Try deleting subscription
4. Observe text in modal being properly translated

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
