### PR TITLE
Move `setPinned` from entity object actions to an RTK hook

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -453,7 +453,7 @@ export interface UpdateCardRequest {
   collection_id?: CollectionId | null;
   dashboard_id?: DashboardId | null;
   document_id?: DocumentId | null;
-  collection_position?: number;
+  collection_position?: number | null;
   result_metadata?: Field[] | null;
   cache_ttl?: number;
   collection_preview?: boolean;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -139,7 +139,6 @@ export interface CollectionItem {
   effective_location?: string;
   authority_level?: CollectionAuthorityLevel;
   dashboard_count?: number | null;
-  setPinned?: (isPinned: number | boolean) => void;
   setCollection?: (
     collection: Pick<Collection, "id"> | Pick<Dashboard, "id">,
   ) => void;

--- a/frontend/src/metabase-types/api/document.ts
+++ b/frontend/src/metabase-types/api/document.ts
@@ -14,6 +14,7 @@ export type Document = {
   name: string;
   version: number;
   collection_id: CollectionId | null;
+  collection_position?: number | null;
   collection?: Collection | null;
   created_at: string;
   updated_at: string;

--- a/frontend/src/metabase-types/entities/common.ts
+++ b/frontend/src/metabase-types/entities/common.ts
@@ -3,5 +3,4 @@ import type { Collection } from "metabase-types/api";
 export type WrappedEntity<Entity> = {
   getCollection: () => Collection;
   setCollection: (collection: Collection) => void;
-  setPinned: (isPinned: boolean) => void;
 } & Entity;

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -22,7 +22,6 @@ import {
 } from "metabase/collections/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { EntityItem } from "metabase/common/components/EntityItem";
-import { useSetCollectionPreview } from "metabase/common/hooks/use-set-collection-preview";
 import {
   type ArchivableItem,
   canPinItem,
@@ -30,6 +29,7 @@ import {
   useSetArchive,
   useSetPinned,
 } from "metabase/common/hooks";
+import { useSetCollectionPreview } from "metabase/common/hooks/use-set-collection-preview";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { bookmarks as BookmarkEntity } from "metabase/entities";
 import { entityForObject } from "metabase/entities/utils";

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -25,8 +25,8 @@ import { EntityItem } from "metabase/common/components/EntityItem";
 import { useSetCollectionPreview } from "metabase/common/hooks/use-set-collection-preview";
 import {
   type ArchivableItem,
-  type PinnableItem,
   canPinItem,
+  isPinnable,
   useSetArchive,
   useSetPinned,
 } from "metabase/common/hooks";
@@ -109,7 +109,9 @@ function ActionMenu({
   const canCopy = onCopy && canCopyItem(item);
 
   const handlePin = useCallback(() => {
-    setPinned(item as PinnableItem, !isItemPinned(item));
+    if (isPinnable(item)) {
+      setPinned(item, !isItemPinned(item));
+    }
   }, [item, setPinned]);
 
   const handleCopy = useCallback(() => {

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -16,15 +16,20 @@ import {
   canBookmarkItem,
   canCopyItem,
   canMoveItem,
-  canPinItem,
   canPreviewItem,
   isItemPinned,
   isPreviewEnabled,
 } from "metabase/collections/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { EntityItem } from "metabase/common/components/EntityItem";
-import { type ArchivableItem, useSetArchive } from "metabase/common/hooks";
 import { useSetCollectionPreview } from "metabase/common/hooks/use-set-collection-preview";
+import {
+  type ArchivableItem,
+  type PinnableItem,
+  canPinItem,
+  useSetArchive,
+  useSetPinned,
+} from "metabase/common/hooks";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { bookmarks as BookmarkEntity } from "metabase/entities";
 import { entityForObject } from "metabase/entities/utils";
@@ -89,6 +94,7 @@ function ActionMenu({
 }: ActionMenuProps & ActionMenuStateProps) {
   const dispatch = useDispatch();
   const archive = useSetArchive();
+  const setPinned = useSetPinned();
   const [sendToast] = useToast();
   const setCollectionPreview = useSetCollectionPreview();
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure();
@@ -103,8 +109,8 @@ function ActionMenu({
   const canCopy = onCopy && canCopyItem(item);
 
   const handlePin = useCallback(() => {
-    item.setPinned?.(!isItemPinned(item));
-  }, [item]);
+    setPinned(item as PinnableItem, !isItemPinned(item));
+  }, [item, setPinned]);
 
   const handleCopy = useCallback(() => {
     onCopy?.([item]);

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -38,7 +38,6 @@ export const Question = {
       model: "card",
       name: "Question",
       description: "This is a description of the question",
-      setPinned: action("setPinned"),
       copy: true,
       setCollection: action("setCollection"),
       archived: false,
@@ -62,7 +61,6 @@ export const Dashboard = {
       description: Array(20)
         .fill("This is a description of the dashboard.")
         .join(" "),
-      setPinned: action("setPinned"),
       archived: false,
     },
     onCopy,
@@ -82,7 +80,6 @@ export const Model = {
       collection_id: null,
       name: "Model",
       description: "This is a description of the model",
-      setPinned: action("setPinned"),
       archived: false,
     },
     onCopy,

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
@@ -48,7 +48,6 @@ const getCollectionItem = ({
   name = "My Item",
   description = "description foo foo foo",
   collection_position = 1,
-  setPinned = jest.fn(),
   ...rest
 }: {
   id?: number;
@@ -56,7 +55,6 @@ const getCollectionItem = ({
   name?: string;
   description?: string;
   collection_position?: number;
-  setPinned?: (isPinned: boolean | number) => void;
 } = {}): CollectionItem & { description: string } => {
   return createMockCollectionItem({
     ...rest,
@@ -65,7 +63,6 @@ const getCollectionItem = ({
     name,
     description,
     collection_position,
-    setPinned,
   }) as CollectionItem & { description: string };
 };
 

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.unit.spec.tsx
@@ -21,7 +21,6 @@ const dashboardItem1: CollectionItem = {
   collection_id: null,
   name: "Dashboard Foo",
   description: "description foo",
-  setPinned: jest.fn(),
   archived: false,
 };
 
@@ -32,7 +31,6 @@ const dashboardItem2: CollectionItem = {
   collection_id: null,
   name: "Dashboard Bar",
   description: "description foo",
-  setPinned: jest.fn(),
   archived: false,
 };
 

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -224,10 +224,6 @@ export function canBookmarkItem({ model, type, archived }: CollectionItem) {
   }
 }
 
-export function canPinItem(item: CollectionItem, collection?: Collection) {
-  return collection?.can_write && item.setPinned != null && !item.archived;
-}
-
 export function canPreviewItem(item: CollectionItem, collection?: Collection) {
   return (
     collection?.can_write &&

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
@@ -12,6 +12,7 @@ import { getErrorMessage } from "metabase/api/utils";
 import { isRootTrashCollection } from "metabase/collections/utils";
 import {
   type PinnableItem,
+  isPinnable,
   useSetPinned,
   useToast,
 } from "metabase/common/hooks";
@@ -102,7 +103,7 @@ const DragSourceComponent = DragSource(
             );
           } else if (pinIndex !== undefined) {
             await Promise.all(
-              items.map((i) => setPinned(i as PinnableItem, pinIndex)),
+              items.filter(isPinnable).map((i) => setPinned(i, pinIndex)),
             );
           }
 

--- a/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
+++ b/frontend/src/metabase/common/components/dnd/ItemDragSource.tsx
@@ -10,7 +10,11 @@ import { getEmptyImage } from "react-dnd-html5-backend";
 
 import { getErrorMessage } from "metabase/api/utils";
 import { isRootTrashCollection } from "metabase/collections/utils";
-import { useToast } from "metabase/common/hooks";
+import {
+  type PinnableItem,
+  useSetPinned,
+  useToast,
+} from "metabase/common/hooks";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
 import { dragTypeForItem } from ".";
@@ -53,6 +57,7 @@ interface DragSourceOwnProps {
   collection?: Collection;
   onDrop?: () => void;
   onMoveError?: (error: unknown) => void;
+  setPinned: (item: PinnableItem, pinned: boolean | number) => void;
   children?: ReactNode | ((props: Record<string, unknown>) => ReactNode);
 }
 
@@ -77,7 +82,7 @@ const DragSourceComponent = DragSource(
       return { item: props.item };
     },
     async endDrag(
-      { selected, onDrop, onMoveError }: DragSourceOwnProps,
+      { selected, onDrop, onMoveError, setPinned }: DragSourceOwnProps,
       monitor: DragSourceMonitor,
     ) {
       if (!monitor.didDrop()) {
@@ -97,7 +102,7 @@ const DragSourceComponent = DragSource(
             );
           } else if (pinIndex !== undefined) {
             await Promise.all(
-              items.map((i) => i.setPinned && i.setPinned(pinIndex)),
+              items.map((i) => setPinned(i as PinnableItem, pinIndex)),
             );
           }
 
@@ -127,11 +132,18 @@ interface ItemDragSourceProps {
 
 export function ItemDragSource(props: ItemDragSourceProps) {
   const [sendToast] = useToast();
+  const setPinned = useSetPinned();
   const onMoveError = (error: unknown) =>
     sendToast({
       message: getErrorMessage(error),
       icon: "warning_triangle_filled",
       iconColor: "warning",
     });
-  return <DragSourceComponent {...props} onMoveError={onMoveError} />;
+  return (
+    <DragSourceComponent
+      {...props}
+      onMoveError={onMoveError}
+      setPinned={setPinned}
+    />
+  );
 }

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -16,5 +16,6 @@ export { useStoreUrl } from "./use-store-url/use-store-url";
 export * from "./use-capture-event";
 export * from "./use-progressive-loader";
 export * from "./use-set-archive";
+export * from "./use-set-pinned";
 export * from "./use-snapshot-selector";
 export * from "./use-subscriber";

--- a/frontend/src/metabase/common/hooks/use-set-pinned.ts
+++ b/frontend/src/metabase/common/hooks/use-set-pinned.ts
@@ -6,7 +6,13 @@ import {
   useUpdateDashboardMutation,
   useUpdateDocumentMutation,
 } from "metabase/api";
-import type { Card, Dashboard, Document } from "metabase-types/api";
+import type {
+  Card,
+  Collection,
+  CollectionItem,
+  Dashboard,
+  Document,
+} from "metabase-types/api";
 
 type Pinnable<M extends string, T extends { id: unknown }> = {
   model: M;
@@ -22,7 +28,7 @@ export type PinnableItem =
 
 export type PinnableModel = PinnableItem["model"];
 
-const PINNABLE_MODELS = new Set<string>([
+const PINNABLE_MODELS = new Set<PinnableModel>([
   "card",
   "dataset",
   "metric",
@@ -31,7 +37,11 @@ const PINNABLE_MODELS = new Set<string>([
 ]);
 
 export function isPinnable(item: { model: string }): item is PinnableItem {
-  return PINNABLE_MODELS.has(item.model);
+  return PINNABLE_MODELS.has(item.model as PinnableModel);
+}
+
+export function canPinItem(item: CollectionItem, collection?: Collection) {
+  return !!collection?.can_write && isPinnable(item) && !item.archived;
 }
 
 function toCollectionPosition(pinned: boolean | number): number | null {
@@ -40,6 +50,7 @@ function toCollectionPosition(pinned: boolean | number): number | null {
   }
   return pinned ? 1 : null;
 }
+
 export function useSetPinned() {
   const [updateCard] = useUpdateCardMutation();
   const [updateDashboard] = useUpdateDashboardMutation();

--- a/frontend/src/metabase/common/hooks/use-set-pinned.ts
+++ b/frontend/src/metabase/common/hooks/use-set-pinned.ts
@@ -36,7 +36,9 @@ const PINNABLE_MODELS = new Set<PinnableModel>([
   "document",
 ]);
 
-export function isPinnable(item: { model: string }): item is PinnableItem {
+export function isPinnable<T extends { model: string }>(
+  item: T,
+): item is T & { model: PinnableModel } {
   return PINNABLE_MODELS.has(item.model as PinnableModel);
 }
 

--- a/frontend/src/metabase/common/hooks/use-set-pinned.ts
+++ b/frontend/src/metabase/common/hooks/use-set-pinned.ts
@@ -1,0 +1,68 @@
+import { useCallback } from "react";
+import { match } from "ts-pattern";
+
+import {
+  useUpdateCardMutation,
+  useUpdateDashboardMutation,
+  useUpdateDocumentMutation,
+} from "metabase/api";
+import type { Card, Dashboard, Document } from "metabase-types/api";
+
+type Pinnable<M extends string, T extends { id: unknown }> = {
+  model: M;
+  id: T["id"];
+};
+
+export type PinnableItem =
+  | Pinnable<"card", Card>
+  | Pinnable<"dataset", Card>
+  | Pinnable<"metric", Card>
+  | Pinnable<"dashboard", Dashboard>
+  | Pinnable<"document", Document>;
+
+export type PinnableModel = PinnableItem["model"];
+
+const PINNABLE_MODELS = new Set<string>([
+  "card",
+  "dataset",
+  "metric",
+  "dashboard",
+  "document",
+]);
+
+export function isPinnable(item: { model: string }): item is PinnableItem {
+  return PINNABLE_MODELS.has(item.model);
+}
+
+function toCollectionPosition(pinned: boolean | number): number | null {
+  if (typeof pinned === "number") {
+    return pinned;
+  }
+  return pinned ? 1 : null;
+}
+export function useSetPinned() {
+  const [updateCard] = useUpdateCardMutation();
+  const [updateDashboard] = useUpdateDashboardMutation();
+  const [updateDocument] = useUpdateDocumentMutation();
+
+  return useCallback(
+    (item: PinnableItem, pinned: boolean | number) => {
+      const collection_position = toCollectionPosition(pinned);
+      return match(item)
+        .with(
+          { model: "card" },
+          { model: "dataset" },
+          { model: "metric" },
+          ({ id }) => updateCard({ id, collection_position }),
+        )
+        .with({ model: "dashboard" }, ({ id }) =>
+          updateDashboard({ id, collection_position }),
+        )
+        .with({ model: "document" }, ({ id }) =>
+          updateDocument({ id, collection_position }),
+        )
+        .exhaustive();
+    },
+    [updateCard, updateDashboard, updateDocument],
+  );
+}

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -101,16 +101,6 @@ export const Dashboards = createEntity({
         undo(opts, "dashboard", "moved"),
       ),
 
-    setPinned: ({ id }, pinned, opts) =>
-      Dashboards.actions.update(
-        { id },
-        {
-          collection_position:
-            typeof pinned === "number" ? pinned : pinned ? 1 : null,
-        },
-        opts,
-      ),
-
     // TODO move into more common area as copy is implemented for more entities
     copy: compose(
       withAction(COPY_ACTION),

--- a/frontend/src/metabase/entities/documents.ts
+++ b/frontend/src/metabase/entities/documents.ts
@@ -83,14 +83,6 @@ export const Documents = createEntity({
         undo({}, t`document`, t`moved`),
       ),
 
-    setPinned: ({ id }: Document, pinned: number | boolean) =>
-      Documents.actions.update(
-        { id },
-        {
-          collection_position:
-            typeof pinned === "number" ? pinned : pinned ? 1 : null,
-        },
-      ),
     copy:
       ({ id }: Document, overrides: Omit<CopyDocumentRequest, "id">) =>
       async (dispatch: Dispatch) => {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -123,16 +123,6 @@ export const Questions = createEntity({
         return result;
       };
     },
-
-    setPinned: ({ id }, pinned, opts) =>
-      Questions.actions.update(
-        { id },
-        {
-          collection_position:
-            typeof pinned === "number" ? pinned : pinned ? 1 : null,
-        },
-        opts,
-      ),
   },
 
   selectors: {


### PR DESCRIPTION
Closes DEV-1904

Moves the `setPinned` object action to an RTK-based hook.