### PR TITLE
Move entities `setTimeline` object action to RTK -based hooks

### DIFF
--- a/frontend/src/metabase/entities/timeline-events.js
+++ b/frontend/src/metabase/entities/timeline-events.js
@@ -1,9 +1,7 @@
-import { t } from "ttag";
-
 import { timelineEventApi, useGetTimelineEventQuery } from "metabase/api";
 import { TimelineEventSchema } from "metabase/schema";
 
-import { createEntity, entityCompatibleQuery, undo } from "./utils";
+import { createEntity, entityCompatibleQuery } from "./utils";
 
 /**
  * @deprecated use "metabase/api" instead
@@ -48,16 +46,6 @@ export const TimelineEvents = createEntity({
         dispatch,
         timelineEventApi.endpoints.deleteTimelineEvent,
       ),
-  },
-
-  objectActions: {
-    setTimeline: ({ id }, timeline, opts) => {
-      return TimelineEvents.actions.update(
-        { id },
-        { timeline_id: timeline.id },
-        undo(opts, t`event`, t`moved`),
-      );
-    },
   },
 });
 

--- a/frontend/src/metabase/timelines/collections/containers/MoveEventModal/MoveEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/MoveEventModal/MoveEventModal.tsx
@@ -4,16 +4,19 @@ import _ from "underscore";
 import { Collections } from "metabase/entities/collections";
 import { TimelineEvents } from "metabase/entities/timeline-events";
 import { Timelines } from "metabase/entities/timelines";
-import { connect } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import MoveEventModal from "metabase/timelines/common/components/MoveEventModal";
+import MoveEventModal, {
+  type MoveEventModalProps,
+} from "metabase/timelines/common/components/MoveEventModal";
+import { useSetTimeline } from "metabase/timelines/common/hooks";
 import * as Urls from "metabase/urls";
 import type { Timeline, TimelineEvent } from "metabase-types/api";
 
 import LoadingAndErrorWrapper from "../../components/LoadingAndErrorWrapper";
 import type { ModalParams } from "../../types";
 
-interface MoveEventModalProps {
+interface OwnProps {
   params: ModalParams;
 }
 
@@ -23,33 +26,39 @@ const timelinesProps = {
 };
 
 const timelineEventProps = {
-  id: (state: State, props: MoveEventModalProps) =>
+  id: (state: State, props: OwnProps) =>
     Urls.extractEntityId(props.params.timelineEventId),
   entityAlias: "event",
   LoadingAndErrorWrapper,
 };
 
 const collectionProps = {
-  id: (state: State, props: MoveEventModalProps) =>
+  id: (state: State, props: OwnProps) =>
     Urls.extractCollectionId(props.params.slug),
   LoadingAndErrorWrapper,
 };
 
-const mapDispatchToProps = (dispatch: any) => ({
-  onSubmit: async (
+function MoveEventModalContainer(props: Omit<MoveEventModalProps, "onSubmit">) {
+  const setTimeline = useSetTimeline();
+  const dispatch = useDispatch();
+  const handleSubmit = async (
     event: TimelineEvent,
-    newTimeline: Timeline,
-    oldTimeline: Timeline,
+    newTimeline?: Timeline,
+    oldTimeline?: Timeline,
   ) => {
-    await dispatch(TimelineEvents.actions.setTimeline(event, newTimeline));
-    dispatch(push(Urls.timelineInCollection(oldTimeline)));
-  },
-});
+    if (newTimeline) {
+      await setTimeline(event, newTimeline);
+    }
+    if (oldTimeline) {
+      dispatch(push(Urls.timelineInCollection(oldTimeline)));
+    }
+  };
+  return <MoveEventModal {...props} onSubmit={handleSubmit} />;
+}
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default _.compose(
   Timelines.loadList(timelinesProps),
   TimelineEvents.load(timelineEventProps),
   Collections.load(collectionProps),
-  connect(null, mapDispatchToProps),
-)(MoveEventModal);
+)(MoveEventModalContainer);

--- a/frontend/src/metabase/timelines/common/components/MoveEventModal/index.ts
+++ b/frontend/src/metabase/timelines/common/components/MoveEventModal/index.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./MoveEventModal";
+export type { MoveEventModalProps } from "./MoveEventModal";

--- a/frontend/src/metabase/timelines/common/hooks/index.ts
+++ b/frontend/src/metabase/timelines/common/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-set-timeline";

--- a/frontend/src/metabase/timelines/common/hooks/use-set-timeline.ts
+++ b/frontend/src/metabase/timelines/common/hooks/use-set-timeline.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { useUpdateTimelineEventMutation } from "metabase/api";
+import { useDispatch } from "metabase/redux";
+import { addUndo } from "metabase/redux/undo";
+import type { Timeline, TimelineEvent } from "metabase-types/api";
+
+export function useSetTimeline() {
+  const dispatch = useDispatch();
+  const [updateTimelineEvent] = useUpdateTimelineEventMutation();
+
+  return useCallback(
+    async (
+      event: Pick<TimelineEvent, "id" | "timeline_id">,
+      timeline: Pick<Timeline, "id">,
+    ) => {
+      const previousTimelineId = event.timeline_id;
+      await updateTimelineEvent({
+        id: event.id,
+        timeline_id: timeline.id,
+      }).unwrap();
+
+      dispatch(
+        addUndo({
+          subject: t`event`,
+          verb: t`moved`,
+          actions: [
+            () =>
+              updateTimelineEvent({
+                id: event.id,
+                timeline_id: previousTimelineId,
+              }),
+          ],
+        }),
+      );
+    },
+    [dispatch, updateTimelineEvent],
+  );
+}

--- a/frontend/src/metabase/timelines/questions/containers/MoveEventModal/MoveEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/containers/MoveEventModal/MoveEventModal.tsx
@@ -3,12 +3,14 @@ import _ from "underscore";
 import { Collections, ROOT_COLLECTION } from "metabase/entities/collections";
 import { TimelineEvents } from "metabase/entities/timeline-events";
 import { Timelines } from "metabase/entities/timelines";
-import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import MoveEventModal from "metabase/timelines/common/components/MoveEventModal";
+import MoveEventModal, {
+  type MoveEventModalProps,
+} from "metabase/timelines/common/components/MoveEventModal";
+import { useSetTimeline } from "metabase/timelines/common/hooks";
 import type { Timeline, TimelineEvent } from "metabase-types/api";
 
-interface MoveEventModalProps {
+interface OwnProps {
   eventId: number;
   collectionId?: number;
   onClose?: () => void;
@@ -19,37 +21,37 @@ const timelinesProps = {
 };
 
 const timelineEventProps = {
-  id: (state: State, props: MoveEventModalProps) => props.eventId,
+  id: (state: State, props: OwnProps) => props.eventId,
   entityAlias: "event",
 };
 
 const collectionProps = {
-  id: (state: State, props: MoveEventModalProps) => {
+  id: (state: State, props: OwnProps) => {
     return props.collectionId ?? ROOT_COLLECTION.id;
   },
 };
 
-const mapStateToProps = (state: State, { onClose }: MoveEventModalProps) => ({
-  onSubmitSuccess: onClose,
-  onCancel: onClose,
-});
+type ContainerProps = Omit<MoveEventModalProps, "onSubmit" | "onSubmitSuccess">;
 
-const mapDispatchToProps = (dispatch: any) => ({
-  onSubmit: async (
-    event: TimelineEvent,
-    newTimeline: Timeline,
-    oldTimeline: Timeline,
-    onClose?: () => void,
-  ) => {
-    await dispatch(TimelineEvents.actions.setTimeline(event, newTimeline));
-    onClose?.();
-  },
-});
+function MoveEventModalContainer(props: ContainerProps) {
+  const setTimeline = useSetTimeline();
+  const handleSubmit = async (event: TimelineEvent, newTimeline?: Timeline) => {
+    if (newTimeline) {
+      await setTimeline(event, newTimeline);
+    }
+  };
+  return (
+    <MoveEventModal
+      {...props}
+      onSubmit={handleSubmit}
+      onSubmitSuccess={props.onClose}
+    />
+  );
+}
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default _.compose(
   Timelines.loadList(timelinesProps),
   TimelineEvents.load(timelineEventProps),
   Collections.load(collectionProps),
-  connect(mapStateToProps, mapDispatchToProps),
-)(MoveEventModal);
+)(MoveEventModalContainer);


### PR DESCRIPTION
Closes DEV-1906

Move entities `setTimeline` object action to RTK -based hooks