### PR TITLE
Move `{create|delete}PublicLink` to RTK-based hooks

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -13,8 +13,7 @@ import { FormField } from "metabase/common/components/FormField";
 import { SidebarContent } from "metabase/common/components/SidebarContent";
 import { TextArea } from "metabase/common/components/TextArea";
 import { useUniqueId } from "metabase/common/hooks/use-unique-id";
-import { connect } from "metabase/redux";
-import type { State } from "metabase/redux/store";
+import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Switch, Tooltip } from "metabase/ui";
@@ -28,22 +27,14 @@ import {
   CopyWidgetContainer,
 } from "./InlineActionSettings.styled";
 
-interface OwnProps {
+type InlineActionSettingsProps = {
   action?: Partial<WritebackAction>;
   formSettings: ActionFormSettings;
   isEditable: boolean;
   onChangeFormSettings: (formSettings: ActionFormSettings) => void;
   onClose?: () => void;
   onBack?: () => void;
-}
-
-interface StateProps {
-  siteUrl: string;
-  isAdmin: boolean;
-  isPublicSharingEnabled: boolean;
-}
-
-type ActionSettingsInlineProps = OwnProps & StateProps;
+};
 
 export const ActionSettingsTriggerButton = ({
   onClick,
@@ -61,23 +52,19 @@ export const ActionSettingsTriggerButton = ({
   </Tooltip>
 );
 
-const mapStateToProps = (state: State): StateProps => ({
-  siteUrl: getSetting(state, "site-url"),
-  isAdmin: getUserIsAdmin(state),
-  isPublicSharingEnabled: getSetting(state, "enable-public-sharing"),
-});
-
 const InlineActionSettings = ({
   action,
   formSettings,
   isEditable,
-  siteUrl,
-  isAdmin,
-  isPublicSharingEnabled,
   onChangeFormSettings,
   onClose,
   onBack,
-}: ActionSettingsInlineProps) => {
+}: InlineActionSettingsProps) => {
+  const siteUrl = useSelector((state) => getSetting(state, "site-url"));
+  const isAdmin = useSelector((state) => getUserIsAdmin(state));
+  const isPublicSharingEnabled = useSelector((state) =>
+    getSetting(state, "enable-public-sharing"),
+  );
   const id = useUniqueId();
   const [modalOpened, { open: openModal, close: closeModal }] =
     useDisclosure(false);
@@ -173,6 +160,4 @@ const InlineActionSettings = ({
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect<StateProps, unknown, OwnProps, State>(mapStateToProps)(
-  InlineActionSettings,
-);
+export default InlineActionSettings;

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -2,6 +2,10 @@ import { useDisclosure } from "@mantine/hooks";
 import type { ChangeEvent, ChangeEventHandler } from "react";
 import { t } from "ttag";
 
+import {
+  useCreateActionPublicLinkMutation,
+  useDeleteActionPublicLinkMutation,
+} from "metabase/api";
 import { Button } from "metabase/common/components/Button";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { CopyWidget } from "metabase/common/components/CopyWidget";
@@ -9,18 +13,13 @@ import { FormField } from "metabase/common/components/FormField";
 import { SidebarContent } from "metabase/common/components/SidebarContent";
 import { TextArea } from "metabase/common/components/TextArea";
 import { useUniqueId } from "metabase/common/hooks/use-unique-id";
-import { Actions } from "metabase/entities/actions/actions";
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Switch, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
-import type {
-  ActionFormSettings,
-  WritebackAction,
-  WritebackActionId,
-} from "metabase-types/api";
+import type { ActionFormSettings, WritebackAction } from "metabase-types/api";
 
 import { isActionPublic, isSavedAction } from "../../utils";
 
@@ -44,12 +43,7 @@ interface StateProps {
   isPublicSharingEnabled: boolean;
 }
 
-interface DispatchProps {
-  onCreatePublicLink: ({ id }: { id: WritebackActionId }) => void;
-  onDeletePublicLink: ({ id }: { id: WritebackActionId }) => void;
-}
-
-type ActionSettingsInlineProps = OwnProps & StateProps & DispatchProps;
+type ActionSettingsInlineProps = OwnProps & StateProps;
 
 export const ActionSettingsTriggerButton = ({
   onClick,
@@ -73,11 +67,6 @@ const mapStateToProps = (state: State): StateProps => ({
   isPublicSharingEnabled: getSetting(state, "enable-public-sharing"),
 });
 
-const mapDispatchToProps: DispatchProps = {
-  onCreatePublicLink: Actions.actions.createPublicLink,
-  onDeletePublicLink: Actions.actions.deletePublicLink,
-};
-
 const InlineActionSettings = ({
   action,
   formSettings,
@@ -86,8 +75,6 @@ const InlineActionSettings = ({
   isAdmin,
   isPublicSharingEnabled,
   onChangeFormSettings,
-  onCreatePublicLink,
-  onDeletePublicLink,
   onClose,
   onBack,
 }: ActionSettingsInlineProps) => {
@@ -95,13 +82,15 @@ const InlineActionSettings = ({
   const [modalOpened, { open: openModal, close: closeModal }] =
     useDisclosure(false);
   const hasSharingPermission = isAdmin && isPublicSharingEnabled;
+  const [createPublicLink] = useCreateActionPublicLinkMutation();
+  const [deletePublicLink] = useDeleteActionPublicLinkMutation();
 
   const handleTogglePublic: ChangeEventHandler<HTMLInputElement> = (event) => {
     const isPublic = event.target.checked;
 
     if (isPublic) {
       if (isSavedAction(action)) {
-        onCreatePublicLink({ id: action.id });
+        createPublicLink({ id: action.id });
       }
     } else {
       openModal();
@@ -110,7 +99,7 @@ const InlineActionSettings = ({
 
   const handleDisablePublicLink = () => {
     if (isSavedAction(action)) {
-      onDeletePublicLink({ id: action.id });
+      deletePublicLink({ id: action.id });
     }
     closeModal();
   };
@@ -184,7 +173,6 @@ const InlineActionSettings = ({
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect<StateProps, DispatchProps, OwnProps, State>(
-  mapStateToProps,
-  mapDispatchToProps,
-)(InlineActionSettings);
+export default connect<StateProps, unknown, OwnProps, State>(mapStateToProps)(
+  InlineActionSettings,
+);

--- a/frontend/src/metabase/api/action.ts
+++ b/frontend/src/metabase/api/action.ts
@@ -113,6 +113,7 @@ export const {
   useListActionsQuery,
   useListPublicActionsQuery,
   useUpdateActionMutation,
+  useCreateActionPublicLinkMutation,
   useDeleteActionPublicLinkMutation,
   endpoints: {
     listPublicActions,

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -1,4 +1,3 @@
-import { updateIn } from "icepick";
 import { t } from "ttag";
 
 import {
@@ -6,7 +5,6 @@ import {
   useGetActionQuery,
   useListActionsQuery,
 } from "metabase/api";
-import { createThunkAction } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
 import { ActionSchema } from "metabase/schema";
 import type {
@@ -105,9 +103,6 @@ const enableImplicitActionsForModel =
     dispatch(Actions.actions.invalidateLists());
   };
 
-const CREATE_PUBLIC_LINK = "metabase/entities/actions/CREATE_PUBLIC_LINK";
-const DELETE_PUBLIC_LINK = "metabase/entities/actions/DELETE_PUBLIC_LINK";
-
 /**
  * @deprecated use "metabase/api" instead
  */
@@ -169,51 +164,4 @@ export const Actions = createEntity({
     "visualization_settings",
     "archived",
   ],
-  objectActions: {
-    createPublicLink: createThunkAction(
-      CREATE_PUBLIC_LINK,
-      ({ id }: { id: WritebackActionId }) =>
-        async (dispatch: Dispatch) => {
-          const data = await entityCompatibleQuery(
-            { id },
-            dispatch,
-            actionApi.endpoints.createActionPublicLink,
-          );
-
-          return { id, uuid: data.uuid };
-        },
-    ),
-    deletePublicLink: createThunkAction(
-      DELETE_PUBLIC_LINK,
-      ({ id }: { id: WritebackActionId }) =>
-        async (dispatch: Dispatch) => {
-          await entityCompatibleQuery(
-            { id },
-            dispatch,
-            actionApi.endpoints.deleteActionPublicLink,
-          );
-
-          return { id };
-        },
-    ),
-  },
-  reducer: (state, { type, payload }: { type: string; payload: any }) => {
-    switch (type) {
-      case CREATE_PUBLIC_LINK: {
-        const { id, uuid } = payload;
-        return updateIn(state, [id], (action) => {
-          return { ...action, public_uuid: uuid };
-        });
-      }
-      case DELETE_PUBLIC_LINK: {
-        const { id } = payload;
-        return updateIn(state, [id], (action) => {
-          return { ...action, public_uuid: null };
-        });
-      }
-      default: {
-        return state;
-      }
-    }
-  },
 });


### PR DESCRIPTION
Closes DEV-1907

Moves `createPublicLink` and `deletePublicLink` from object actions to use the RTK-based api hooks directly.