### PR TITLE
Check Mysql connection params for unsafe options

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -210,14 +210,15 @@
                                "All Metabase features may not work properly when using an unsupported version."
                                "\n********************************************************************************\n"))))))))
 
-(def ^:private disallowed-additional-opts #"(allowLoadLocalInfile|allowLoadLocalInfileInPath|allowUrlInLocalInfile|autoDeserialize|serverRSAPublicKeyFile)")
+(def ^:private disallowed-additional-opts #"(?:allowLoadLocalInfile|allowLoadLocalInfileInPath|allowUrlInLocalInfile|autoDeserialize|serverRSAPublicKeyFile)")
 
 (defmethod driver/can-connect? :mysql
   [driver details]
   ;; delegate to parent method to check whether we can connect; if so, check if it's an unsupported version and issue
   ;; a warning if it is
-  (when (re-find disallowed-additional-opts (:additional-options details ""))
-    (throw (ex-info "Potentially dangerous keys in additional options" {:details details})))
+  (let [match (re-find disallowed-additional-opts (:additional-options details ""))]
+    (when match
+      (throw (ex-info "Potentially dangerous keys in additional options" {:disallowed-key match}))))
   (when ((get-method driver/can-connect? :sql-jdbc) driver details)
     (warn-on-unsupported-versions driver details)
     true))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -210,10 +210,14 @@
                                "All Metabase features may not work properly when using an unsupported version."
                                "\n********************************************************************************\n"))))))))
 
+(def ^:private malicious-pattern #"(allowLoadLocalInfile|allowLoadLocalInfileInPath|allowUrlInLocalInfile|autoDeserialize|serverRSAPublicKeyFile)")
+
 (defmethod driver/can-connect? :mysql
   [driver details]
   ;; delegate to parent method to check whether we can connect; if so, check if it's an unsupported version and issue
   ;; a warning if it is
+  (when (re-find malicious-pattern (:additional-options details ""))
+    (throw (ex-info "Malicious keys detected" {:details details})))
   (when ((get-method driver/can-connect? :sql-jdbc) driver details)
     (warn-on-unsupported-versions driver details)
     true))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -210,14 +210,14 @@
                                "All Metabase features may not work properly when using an unsupported version."
                                "\n********************************************************************************\n"))))))))
 
-(def ^:private malicious-pattern #"(allowLoadLocalInfile|allowLoadLocalInfileInPath|allowUrlInLocalInfile|autoDeserialize|serverRSAPublicKeyFile)")
+(def ^:private disallowed-additional-opts #"(allowLoadLocalInfile|allowLoadLocalInfileInPath|allowUrlInLocalInfile|autoDeserialize|serverRSAPublicKeyFile)")
 
 (defmethod driver/can-connect? :mysql
   [driver details]
   ;; delegate to parent method to check whether we can connect; if so, check if it's an unsupported version and issue
   ;; a warning if it is
-  (when (re-find malicious-pattern (:additional-options details ""))
-    (throw (ex-info "Malicious keys detected" {:details details})))
+  (when (re-find disallowed-additional-opts (:additional-options details ""))
+    (throw (ex-info "Potentially dangerous keys in additional options" {:details details})))
   (when ((get-method driver/can-connect? :sql-jdbc) driver details)
     (warn-on-unsupported-versions driver details)
     true))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1049,5 +1049,5 @@
                       ::did-not-throw
                       (catch Exception e e))]
       (is (instance? clojure.lang.ExceptionInfo result))
-      (is (partial= {:cause "Malicious keys detected"}
+      (is (partial= {:cause "Potentially dangerous keys in additional options"}
                     (Throwable->map result))))))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1039,3 +1039,15 @@
               ;; Clean up: Reset partial_revokes to OFF before exiting
               (jdbc/execute! spec "SET GLOBAL partial_revokes = OFF;")
               (jdbc/execute! spec "DROP USER IF EXISTS 'partial_revokes_test_user';"))))))))
+
+(deftest ^:parallel only-connect-when-non-malicious-properties
+  (testing "Reject connection strings with malicious properties"
+    (let [details (assoc (tx/dbdef->connection-details :mysql :db
+                                                       {:database-name "argent"})
+                         :additional-options "allowLoadLocalInfile=true")
+          result (try (driver/can-connect? :mysql details)
+                      ::did-not-throw
+                      (catch Exception e e))]
+      (is (instance? clojure.lang.ExceptionInfo result))
+      (is (partial= {:cause "Malicious keys detected"}
+                    (Throwable->map result))))))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1042,12 +1042,17 @@
 
 (deftest ^:parallel only-connect-when-non-malicious-properties
   (testing "Reject connection strings with malicious properties"
-    (let [details (assoc (tx/dbdef->connection-details :mysql :db
-                                                       {:database-name "argent"})
-                         :additional-options "allowLoadLocalInfile=true")
-          result (try (driver/can-connect? :mysql details)
-                      ::did-not-throw
-                      (catch Exception e e))]
-      (is (instance? clojure.lang.ExceptionInfo result))
-      (is (partial= {:cause "Potentially dangerous keys in additional options"}
-                    (Throwable->map result))))))
+    (are [bad-option] (let [details (assoc (tx/dbdef->connection-details :mysql :db
+                                                                         {:database-name "argent"})
+                                           :additional-options bad-option)
+                            result (try (driver/can-connect? :mysql details)
+                                        ::did-not-throw
+                                        (catch Exception e e))]
+                        (is (instance? clojure.lang.ExceptionInfo result))
+                        (is (partial= {:cause "Potentially dangerous keys in additional options"}
+                                      (Throwable->map result))))
+      "allowLoadLocalInfile=true"
+      "allowLoadLocalInfileInPath=1"
+      "allowUrlInLocalInfile=1"
+      "autoDeserialize=1"
+      "serverRSAPublicKeyFile=/path/to/file")))


### PR DESCRIPTION
Addresses [SEC-101](https://linear.app/metabase/issue/SEC-101/security-vulnerability-report-authenticated-jdbc-connection-property)

### Description

Copy of @technomancy's original PR: https://github.com/metabase/metabase-private/pull/356

<details> 

<summary>screenshot</summary>

<img width="909" height="793" alt="Screenshot 2026-05-01 at 1 20 19 PM" src="https://github.com/user-attachments/assets/42ba606f-4634-4130-8aa4-42aa6cc63304" />

</details>

### How to verify

1. Try to connect to a MySQL DB with one of the disallowed additional JDBC options
2. You should get an error and not be able to add the DB

Need some help with this one.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
