### PR TITLE
db-tables as multimethod in sync.interface to enable driver implementation 

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -8,6 +8,9 @@ title: Driver interface changelog
 
 - `driver/field-reference-mlv2`, deprecated in 0.57.0, has now been removed.
 
+- `metabase.driver.sql-jdbc.sync.interface/db-tables` is now a multimethod for retrieving JDBC metadata
+  tables. SQL JDBC drivers can override this method to customize which database objects are discovered during sync.
+
 ## Metabase 0.60.0
 
 - Added `validate-impersonated-query` multimethod. This is used for drivers to perform validation on impersonated native queries.

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -149,9 +149,9 @@
                            remarks))
           :type        ttype})))))
 
-(defn db-tables
-  "Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given
-  schema. Returns a reducible sequence of results."
+(defmethod sql-jdbc.sync.interface/db-tables :sql-jdbc
+  ;; Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given
+  ;; schema. Returns a reducible sequence of results.
   [driver ^DatabaseMetaData metadata ^String schema-or-nil ^String db-name-or-nil]
   ;; seems like some JDBC drivers like Snowflake are dumb and still narrow the search results by the current session
   ;; schema if you pass in `nil` for `schema-or-nil`, which means not to narrow results at all... For Snowflake, I fixed
@@ -161,6 +161,11 @@
   (jdbc-get-tables driver metadata db-name-or-nil schema-or-nil "%"
                    ["TABLE" "PARTITIONED TABLE" "VIEW" "FOREIGN TABLE" "MATERIALIZED VIEW"
                     "EXTERNAL TABLE" "DYNAMIC_TABLE"]))
+
+(defn db-tables
+  "Compatibility wrapper for drivers calling `sql-jdbc.describe-database/db-tables` directly."
+  [driver ^DatabaseMetaData metadata ^String schema-or-nil ^String db-name-or-nil]
+  (sql-jdbc.sync.interface/db-tables driver metadata schema-or-nil db-name-or-nil))
 
 (defn- build-privilege-map
   "Build a nested map of schema -> table -> set of permissions from current user table privileges.
@@ -264,7 +269,7 @@
                                       (-> table
                                           (dissoc :type)
                                           (assoc :is_writable (privilege-fn table :write))))))
-                         (db-tables driver metadata schema db-name-or-nil))))
+                         (sql-jdbc.sync.interface/db-tables driver metadata schema db-name-or-nil))))
               syncable-schemas)))
 
 (defmethod sql-jdbc.sync.interface/active-tables :sql-jdbc
@@ -288,7 +293,7 @@
              (-> table
                  (dissoc :type)
                  (assoc :is_writable (privilege-fn table :write))))))
-     (db-tables driver (.getMetaData conn) nil db-name-or-nil))))
+     (sql-jdbc.sync.interface/db-tables driver (.getMetaData conn) nil db-name-or-nil))))
 
 (defn db-or-id-or-spec->database
   "Get database instance from `db-or-id-or-spec`."

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -148,6 +148,13 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
+(defmulti db-tables
+  "Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given
+    schema. Returns a reducible sequence of results."
+  {:arglists '([driver metadata schema-or-nil db-name-or-nil])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
 ;; used for compatibility with drivers only implementing alter-columns-sql
 ;; remove when alter-columns-sql is deleted (v0.57+)
 #_{:clj-kondo/ignore [:deprecated-var]}


### PR DESCRIPTION
Issue https://github.com/metabase/metabase/issues/69995

### Description

This add db-tables as multimethod to enable driver implementation for other types of JDBC objects

### How to verify

Sync database schema for a standard driver to see if the standard implementation is picked
Sync database schema with a driver implementing is own version of db-tables
implemented in db 2 for i driver :
https://github.com/damienchambe/metabase-ibmi-driver/commit/883e7a943b74c1a8ce41302cbfdf567887bcee3b


### Checklist

Tested with default postgres driver , the default implementation is called
tested with a custom implementation 
https://github.com/damienchambe/metabase-ibmi-driver/commit/883e7a943b74c1a8ce41302cbfdf567887bcee3b
