### PR TITLE
Move `copy` out of entities and into RTK-based hooks

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -186,12 +186,11 @@ describe("ActionMenu", () => {
         model: "collection",
         can_write: true,
         personal_owner_id: 1,
-        copy: true,
       });
 
       setup({ item });
 
-      await userEvent.click(getIcon("ellipsis"));
+      expect(queryIcon("ellipsis")).not.toBeInTheDocument();
       expect(screen.queryByText("Move")).not.toBeInTheDocument();
       expect(screen.queryByText("Move to trash")).not.toBeInTheDocument();
     });
@@ -201,12 +200,11 @@ describe("ActionMenu", () => {
         name: "My Read Only collection",
         model: "collection",
         can_write: false,
-        copy: true,
       });
 
       setup({ item });
 
-      await userEvent.click(getIcon("ellipsis"));
+      expect(queryIcon("ellipsis")).not.toBeInTheDocument();
       expect(screen.queryByText("Move")).not.toBeInTheDocument();
       expect(screen.queryByText("Move to trash")).not.toBeInTheDocument();
     });

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.tsx
@@ -2,6 +2,10 @@ import { dissoc } from "icepick";
 import { useState } from "react";
 import { t } from "ttag";
 
+import {
+  useCopyDashboardMutation,
+  useCopyDocumentMutation,
+} from "metabase/api";
 import { useInitialCollectionId } from "metabase/collections/hooks";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 import { entityTypeForObject } from "metabase/entities/utils";
@@ -25,6 +29,8 @@ function CollectionCopyEntityModal({
   onClose: () => void;
   onSaved: (newEntityObject: any) => void;
 }) {
+  const [copyDashboard] = useCopyDashboardMutation();
+  const [copyDocument] = useCopyDocumentMutation();
   const initialCollectionId = useInitialCollectionId({
     collectionId: entityObject.collection_id,
   });
@@ -35,8 +41,26 @@ function CollectionCopyEntityModal({
     setIsShallowCopy(is_shallow_copy);
   };
 
-  const handleSaved = (newEntityObject: any) => {
-    onSaved(newEntityObject);
+  const handleCopy = async (values: Record<string, any>) => {
+    const overrides = dissoc(values, "id");
+
+    if (entityObject.model === "dashboard") {
+      const { is_shallow_copy, ...rest } = overrides;
+      return copyDashboard({
+        id: entityObject.id,
+        ...rest,
+        is_deep_copy: !is_shallow_copy,
+      }).unwrap();
+    }
+
+    if (entityObject.model === "document") {
+      return copyDocument({
+        id: entityObject.id,
+        ...overrides,
+      }).unwrap();
+    }
+
+    throw new Error(`Cannot duplicate entity of type "${entityObject.model}"`);
   };
 
   return (
@@ -48,11 +72,9 @@ function CollectionCopyEntityModal({
         collection_id: initialCollectionId,
       }}
       title={title}
-      copy={async (values) => {
-        return entityObject.copy(dissoc(values, "id"));
-      }}
+      copy={handleCopy}
       onClose={onClose}
-      onSaved={handleSaved}
+      onSaved={onSaved}
       onValuesChange={handleValuesChange}
     />
   );

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -267,7 +267,9 @@ export function canArchiveItem(item: CollectionItem, collection?: Collection) {
 }
 
 export function canCopyItem(item: CollectionItem) {
-  return item.model === "dashboard" && !item.archived;
+  return (
+    (item.model === "dashboard" || item.model === "document") && !item.archived
+  );
 }
 
 export function canPlaceEntityInCollection(

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -267,7 +267,7 @@ export function canArchiveItem(item: CollectionItem, collection?: Collection) {
 }
 
 export function canCopyItem(item: CollectionItem) {
-  return item.copy && !item.archived;
+  return item.model === "dashboard" && !item.archived;
 }
 
 export function canPlaceEntityInCollection(

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
@@ -3,30 +3,20 @@ import { useState } from "react";
 import { type WithRouterProps, withRouter } from "react-router";
 import { replace } from "react-router-redux";
 import { t } from "ttag";
-import _ from "underscore";
 
+import { useCopyDashboardMutation } from "metabase/api";
 import { useInitialCollectionId } from "metabase/collections/hooks";
 import type { CopyDashboardFormProperties } from "metabase/dashboard/containers/CopyDashboardForm";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
-import { Dashboards } from "metabase/entities/dashboards";
-import { connect, useSelector } from "metabase/redux";
+import { useDispatch, useSelector } from "metabase/redux";
 import * as Urls from "metabase/urls";
 import type { Dashboard } from "metabase-types/api";
 
 import { getDashboardComplete } from "../selectors";
 
-type OwnProps = {
+type DashboardCopyModalProps = {
   onClose: () => void;
-};
-
-const mapDispatchToProps = {
-  copyDashboard: Dashboards.actions.copy,
-  onReplaceLocation: replace,
-};
-
-type DispatchProps = typeof mapDispatchToProps;
-
-type DashboardCopyModalProps = OwnProps & DispatchProps & WithRouterProps;
+} & WithRouterProps;
 
 const getTitle = (
   dashboard: Dashboard | null,
@@ -43,11 +33,11 @@ const getTitle = (
 
 const DashboardCopyModal = ({
   onClose,
-  onReplaceLocation,
-  copyDashboard,
   params,
   location,
 }: DashboardCopyModalProps) => {
+  const dispatch = useDispatch();
+  const [copyDashboard] = useCopyDashboardMutation();
   const dashboard = useSelector(getDashboardComplete);
   const initialCollectionId = useInitialCollectionId({
     collectionId: dashboard?.collection_id,
@@ -77,19 +67,21 @@ const DashboardCopyModal = ({
       }}
       title={title}
       overwriteOnInitialValuesChange
-      copy={async (object) =>
-        await copyDashboard({ id: dashboardIdFromSlug }, dissoc(object, "id"))
-      }
+      copy={async (object) => {
+        const { is_shallow_copy, ...overrides } = dissoc(object, "id");
+        return await copyDashboard({
+          id: dashboardIdFromSlug,
+          ...overrides,
+          is_deep_copy: !is_shallow_copy,
+        }).unwrap();
+      }}
       onClose={onClose}
       onSaved={(savedDashboard: Dashboard) =>
-        onReplaceLocation(Urls.dashboard(savedDashboard))
+        dispatch(replace(Urls.dashboard(savedDashboard)))
       }
       onValuesChange={handleValuesChange}
     />
   );
 };
 
-export const DashboardCopyModalConnected = _.compose(
-  withRouter,
-  connect(null, mapDispatchToProps),
-)(DashboardCopyModal);
+export const DashboardCopyModalConnected = withRouter(DashboardCopyModal);

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -12,7 +12,6 @@ import {
   DASHBOARD_DESCRIPTION_MAX_LENGTH,
   DASHBOARD_NAME_MAX_LENGTH,
 } from "metabase/common/utils/dashboard";
-import { Dashboards } from "metabase/entities/dashboards";
 import {
   Form,
   FormCheckbox,
@@ -82,8 +81,7 @@ function CopyDashboardForm({
 
   const handleSubmit = useCallback(
     async (values: CopyDashboardFormProperties) => {
-      const result = await onSubmit?.(values);
-      const dashboard = Dashboards.HACK_getObjectFromAction(result);
+      const dashboard = await onSubmit?.(values);
       onSaved?.(dashboard);
     },
     [onSubmit, onSaved],

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -6,12 +6,8 @@ import {
   useListDashboardsQuery,
 } from "metabase/api/dashboard";
 import { getCollectionType } from "metabase/entities/collections/utils";
-import { compose, withAction } from "metabase/redux";
-import { addUndo } from "metabase/redux/undo";
 
-import { createEntity, entityCompatibleQuery, withRequestState } from "./utils";
-
-const COPY_ACTION = `metabase/entities/dashboards/COPY`;
+import { createEntity, entityCompatibleQuery } from "./utils";
 
 /**
  * @deprecated use "metabase/api" instead
@@ -70,46 +66,6 @@ export const Dashboards = createEntity({
         dispatch,
         dashboardApi.endpoints.saveDashboard,
       ),
-    copy: (entityQuery, dispatch) =>
-      entityCompatibleQuery(
-        entityQuery,
-        dispatch,
-        dashboardApi.endpoints.copyDashboard,
-      ),
-  },
-
-  objectActions: {
-    // TODO move into more common area as copy is implemented for more entities
-    copy: compose(
-      withAction(COPY_ACTION),
-      // NOTE: unfortunately we can't use Dashboard.withRequestState, etc because the entity isn't defined yet
-      withRequestState((dashboard) => [
-        "entities",
-        "dashboard",
-        dashboard.id,
-        "copy",
-      ]),
-    )(
-      (entityObject, overrides, { notify } = {}) =>
-        async (dispatch, getState) => {
-          const result = Dashboards.normalize(
-            await entityCompatibleQuery(
-              {
-                id: entityObject.id,
-                ...overrides,
-                is_deep_copy: !overrides.is_shallow_copy,
-              },
-              dispatch,
-              dashboardApi.endpoints.copyDashboard,
-            ),
-          );
-          if (notify) {
-            dispatch(addUndo(notify));
-          }
-          dispatch({ type: Dashboards.actionTypes.INVALIDATE_LISTS_ACTION });
-          return result;
-        },
-    ),
   },
 
   actions: {
@@ -125,13 +81,6 @@ export const Dashboards = createEntity({
         payload: savedDashboard,
       };
     },
-  },
-
-  reducer: (state = {}, { type, payload, error }) => {
-    if (type === COPY_ACTION && !error && state[""]) {
-      return { ...state, "": state[""].concat([payload.result]) };
-    }
-    return state;
   },
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/documents.ts
+++ b/frontend/src/metabase/entities/documents.ts
@@ -4,10 +4,8 @@ import { documentApi, useGetDocumentQuery } from "metabase/api";
 import type { Dispatch } from "metabase/redux/store";
 import { DocumentSchema } from "metabase/schema";
 import type {
-  CopyDocumentRequest,
   CreateDocumentRequest,
   DeleteDocumentRequest,
-  Document,
   GetDocumentRequest,
   UpdateDocumentRequest,
 } from "metabase-types/api";
@@ -62,16 +60,5 @@ export const Documents = createEntity({
         dispatch,
         documentApi.endpoints.deleteDocument,
       ),
-  },
-
-  objectActions: {
-    copy:
-      ({ id }: Document, overrides: Omit<CopyDocumentRequest, "id">) =>
-      async (dispatch: Dispatch) => {
-        const result = await dispatch(
-          documentApi.endpoints.copyDocument.initiate({ id, ...overrides }),
-        );
-        return (result as { data: Document }).data;
-      },
   },
 });


### PR DESCRIPTION
Closes DEV-1909

- Removes unused `documents.objectActions.copy`
- Removes `dashboards.objectActions.copy` and use `useCopyDashboardMutation` instead.