### PR TITLE
[GDGT-2079] add observability to transform timeout system

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -535,6 +535,15 @@
    (prometheus/counter :metabase-transforms/python-api-calls-total
                        {:description "Total number of Python runner API calls."
                         :labels [:status]})
+   (prometheus/counter :metabase-transforms/timeouts-total
+                       {:description "Number of transform runs and job runs marked timed out (per-run timeout handler or sweeper)."
+                        :labels [:type]})
+   (prometheus/histogram :metabase-transforms/timeout-detection-latency-ms
+                         {:description "Time in ms between a transform run/job exceeding its timeout and the sweeper detecting it."
+                          :labels [:type]
+                          ;; Sweepers run every 10 minutes, so detection latency is bounded by sweep cadence.
+                          ;; 0s -> 30 minutes covers normal case + tail when a sweep is delayed.
+                          :buckets [0 1000 10000 30000 60000 120000 300000 600000 900000 1200000 1800000]})
    (prometheus/counter :metabase-transforms/inspector-discovery
                        {:description "Transform Inspector lens discovery calls."
                         :labels [:status]})

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -328,6 +328,7 @@
 (derive :event/update-transform ::transform-event)
 (derive :event/transform-delete ::transform-event)
 (derive :event/transform-run-start ::transform-event)
+(derive :event/transform-run-timeout ::transform-event)
 (derive :event/transform-inspect-discover ::transform-event)
 (derive :event/transform-inspect-lens ::transform-event)
 

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -286,6 +286,8 @@
   []
   (let [timed-out (transforms.job-run/timeout-old-runs!
                    (transforms.settings/transform-timeout) :minute)]
+    (when (seq timed-out)
+      (log/infof "Timed out %d transform job run(s)." (count timed-out)))
     (doseq [{:keys [job_id run_method message]} timed-out
             :when (= run_method :cron)]
       (try
@@ -296,7 +298,8 @@
 (task/defjob  ^{:doc "Times out transform jobs when necessary."
                 org.quartz.DisallowConcurrentExecution true}
   TimeoutOldRuns [_ctx]
-  (timeout-and-notify-old-runs!))
+  (tracing/with-span :tasks "task.transform.timeout-check" {:transform.timeout/type "job"}
+    (timeout-and-notify-old-runs!)))
 
 (defn- start-job! []
   (when (not (task/job-exists? job-key))

--- a/src/metabase/transforms/models/job_run.clj
+++ b/src/metabase/transforms/models/job_run.clj
@@ -80,44 +80,15 @@
                      {:status :failed
                       :is_active nil})))
 
-(defn- timeout-rows!
-  "Atomic select-then-update of stale active job runs older than `cutoff`. Returns the pre-update
-  rows the UPDATE transitioned. See [[timeout-old-runs!]] for atomicity rationale."
-  [cutoff]
-  ;; Alternative considered: `UPDATE … RETURNING *` to avoid an explicit transaction. Rejected —
-  ;; `RETURNING` on UPDATE is portable on Postgres but not on H2 or MySQL/MariaDB, and
-  ;; Metabase's app DB supports all three. The transaction here holds row locks only across a
-  ;; SELECT and one UPDATE-by-id, well within the 10-minute sweep cadence.
-  (t2/with-transaction [_conn]
-    (let [stale (t2/select :model/TransformJobRun
-                           {:where [:and
-                                    [:= :is_active true]
-                                    [:< :updated_at cutoff]]
-                            :for   :update})]
-      (when (seq stale)
-        (t2/update! :model/TransformJobRun
-                    :id        [:in (mapv :id stale)]
-                    :is_active true
-                    {:status :timeout
-                     :end_time :%now
-                     :is_active nil
-                     :message "Timed out by metabase"}))
-      stale)))
-
 (defn timeout-old-runs!
   "Time out all active job runs older than the specified age. Returns the rows that
   were timed out so callers can take follow-up action (e.g. sending notifications).
-
-  Atomicity: the select-and-update is wrapped in a transaction with `SELECT … FOR UPDATE`,
-  so the rows we report on (counter, histogram) are exactly the rows the UPDATE transitions
-  to `:timeout`. Without the lock a concurrent activity update between SELECT and UPDATE
-  could leave the row non-active by UPDATE time — the UPDATE would skip it (its filter matches
-  `:is_active true`), but we'd already have counted it, overstating the timeout rate."
+  See [[metabase.transforms.models.timeout-util/timeout-rows!]] for atomicity rationale."
   [age unit]
   (let [cutoff      (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)
         timeout-dur (timeout-util/unit->duration age unit)
         detected-at (Instant/now)
-        timed-out   (timeout-rows! cutoff)]
+        timed-out   (timeout-util/timeout-rows! :model/TransformJobRun :updated_at cutoff)]
     (when (seq timed-out)
       (analytics/inc! :metabase-transforms/timeouts-total
                       {:type "job"}

--- a/src/metabase/transforms/models/job_run.clj
+++ b/src/metabase/transforms/models/job_run.clj
@@ -1,11 +1,15 @@
 (ns metabase.transforms.models.job-run
   (:require
+   [metabase.analytics-interface.core :as analytics]
    [metabase.app-db.core :as mdb]
    [metabase.models.interface :as mi]
+   [metabase.transforms.models.timeout-util :as timeout-util]
    [metabase.util.honey-sql-2 :as h2x]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.realize :as t2.realize]))
+   [toucan2.realize :as t2.realize])
+  (:import
+   (java.time Instant)))
 
 (set! *warn-on-reflection* true)
 
@@ -76,22 +80,55 @@
                      {:status :failed
                       :is_active nil})))
 
-(defn timeout-old-runs!
-  "Time out all active runs older than the specified age.
+(defn- timeout-rows!
+  "Atomic select-then-update of stale active job runs older than `cutoff`. Returns the pre-update
+  rows the UPDATE transitioned. See [[timeout-old-runs!]] for atomicity rationale."
+  [cutoff]
+  ;; Alternative considered: `UPDATE … RETURNING *` to avoid an explicit transaction. Rejected —
+  ;; `RETURNING` on UPDATE is portable on Postgres but not on H2 or MySQL/MariaDB, and
+  ;; Metabase's app DB supports all three. The transaction here holds row locks only across a
+  ;; SELECT and one UPDATE-by-id, well within the 10-minute sweep cadence.
+  (t2/with-transaction [_conn]
+    (let [stale (t2/select :model/TransformJobRun
+                           {:where [:and
+                                    [:= :is_active true]
+                                    [:< :updated_at cutoff]]
+                            :for   :update})]
+      (when (seq stale)
+        (t2/update! :model/TransformJobRun
+                    :id        [:in (mapv :id stale)]
+                    :is_active true
+                    {:status :timeout
+                     :end_time :%now
+                     :is_active nil
+                     :message "Timed out by metabase"}))
+      stale)))
 
-  Returns the rows that were timed out so callers can take follow-up action
-  (e.g. sending notifications)."
+(defn timeout-old-runs!
+  "Time out all active job runs older than the specified age. Returns the rows that
+  were timed out so callers can take follow-up action (e.g. sending notifications).
+
+  Atomicity: the select-and-update is wrapped in a transaction with `SELECT … FOR UPDATE`,
+  so the rows we report on (counter, histogram) are exactly the rows the UPDATE transitions
+  to `:timeout`. Without the lock a concurrent activity update between SELECT and UPDATE
+  could leave the row non-active by UPDATE time — the UPDATE would skip it (its filter matches
+  `:is_active true`), but we'd already have counted it, overstating the timeout rate."
   [age unit]
-  (let [pks (t2/update-returning-pks!
-             :model/TransformJobRun
-             :is_active true
-             :updated_at [:< (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)]
-             {:status :timeout
-              :end_time :%now
-              :is_active nil
-              :message "Timed out by metabase"})]
-    (when (seq pks)
-      (t2/select :model/TransformJobRun :id [:in pks]))))
+  (let [cutoff      (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)
+        timeout-dur (timeout-util/unit->duration age unit)
+        detected-at (Instant/now)
+        timed-out   (timeout-rows! cutoff)]
+    (when (seq timed-out)
+      (analytics/inc! :metabase-transforms/timeouts-total
+                      {:type "job"}
+                      (count timed-out))
+      (run! (fn [run]
+              (when-let [updated-at (:updated_at run)]
+                (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
+                                    {:type "job"}
+                                    (timeout-util/detection-latency-ms updated-at timeout-dur detected-at))))
+            timed-out))
+    timed-out))
 
 (defn running-run-for-job-id
   "Return a single active job run or nil."

--- a/src/metabase/transforms/models/job_run.clj
+++ b/src/metabase/transforms/models/job_run.clj
@@ -93,12 +93,11 @@
       (analytics/inc! :metabase-transforms/timeouts-total
                       {:type "job"}
                       (count timed-out))
-      (run! (fn [run]
-              (when-let [updated-at (:updated_at run)]
-                (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
-                                    {:type "job"}
-                                    (timeout-util/detection-latency-ms updated-at timeout-dur detected-at))))
-            timed-out))
+      (doseq [run timed-out]
+        (when-let [updated-at (:updated_at run)]
+          (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
+                              {:type "job"}
+                              (timeout-util/detection-latency-ms updated-at timeout-dur detected-at)))))
     timed-out))
 
 (defn running-run-for-job-id

--- a/src/metabase/transforms/models/timeout_util.clj
+++ b/src/metabase/transforms/models/timeout_util.clj
@@ -1,5 +1,7 @@
 (ns metabase.transforms.models.timeout-util
-  "Pure helpers shared by the transform-run and job-run timeout sweepers."
+  "Helpers shared by the transform-run and job-run timeout sweepers."
+  (:require
+   [toucan2.core :as t2])
   (:import
    (java.time Duration Instant OffsetDateTime)
    (java.time.temporal ChronoUnit)))
@@ -19,3 +21,25 @@
   [^OffsetDateTime reference-ts ^Duration timeout-duration ^Instant detected-at]
   (max 0 (.toMillis (.minus (Duration/between (.toInstant reference-ts) detected-at)
                             timeout-duration))))
+
+(defn timeout-rows!
+  "Atomically time out active rows of `model` whose `age-column` predates `cutoff`; returns the pre-update rows.
+  Runs SELECT FOR UPDATE + UPDATE in one transaction so the rows callers report on match those the UPDATE
+  transitions — without the lock, a concurrent `:is_active` flip between SELECT and UPDATE would leave callers
+  counting a timeout that didn't happen. `UPDATE … RETURNING *` would be simpler but isn't portable to H2/MySQL."
+  [model age-column cutoff]
+  (t2/with-transaction [_conn]
+    (let [stale (t2/select model
+                           {:where [:and
+                                    [:= :is_active true]
+                                    [:< age-column cutoff]]
+                            :for   :update})]
+      (when (seq stale)
+        (t2/update! model
+                    :id        [:in (mapv :id stale)]
+                    :is_active true
+                    {:status    :timeout
+                     :end_time  :%now
+                     :is_active nil
+                     :message   "Timed out by metabase"}))
+      stale)))

--- a/src/metabase/transforms/models/timeout_util.clj
+++ b/src/metabase/transforms/models/timeout_util.clj
@@ -1,0 +1,21 @@
+(ns metabase.transforms.models.timeout-util
+  "Pure helpers shared by the transform-run and job-run timeout sweepers."
+  (:import
+   (java.time Duration Instant OffsetDateTime)
+   (java.time.temporal ChronoUnit)))
+
+(set! *warn-on-reflection* true)
+
+(defn unit->duration
+  "Convert `age` of `unit` (`:second`, `:minute`, or `:hour`) to an exact `java.time.Duration`."
+  ^Duration [age unit]
+  (Duration/of age (case unit
+                     :minute ChronoUnit/MINUTES
+                     :second ChronoUnit/SECONDS
+                     :hour   ChronoUnit/HOURS)))
+
+(defn detection-latency-ms
+  "Milliseconds elapsed past `(reference-ts + timeout-duration)` at the time of detection. Clamped at zero."
+  [^OffsetDateTime reference-ts ^Duration timeout-duration ^Instant detected-at]
+  (max 0 (.toMillis (.minus (Duration/between (.toInstant reference-ts) detected-at)
+                            timeout-duration))))

--- a/src/metabase/transforms/models/timeout_util.clj
+++ b/src/metabase/transforms/models/timeout_util.clj
@@ -23,23 +23,23 @@
                             timeout-duration))))
 
 (defn timeout-rows!
-  "Atomically time out active rows of `model` whose `age-column` predates `cutoff`; returns the pre-update rows.
+  "Atomically time out active rows of `model` whose `age-column` predates `cutoff`; returns the pre-update rows,
+  or `nil` if none were stale.
   Runs SELECT FOR UPDATE + UPDATE in one transaction so the rows callers report on match those the UPDATE
   transitions — without the lock, a concurrent `:is_active` flip between SELECT and UPDATE would leave callers
   counting a timeout that didn't happen. `UPDATE … RETURNING *` would be simpler but isn't portable to H2/MySQL."
   [model age-column cutoff]
   (t2/with-transaction [_conn]
-    (let [stale (t2/select model
-                           {:where [:and
-                                    [:= :is_active true]
-                                    [:< age-column cutoff]]
-                            :for   :update})]
-      (when (seq stale)
-        (t2/update! model
-                    :id        [:in (mapv :id stale)]
-                    :is_active true
-                    {:status    :timeout
-                     :end_time  :%now
-                     :is_active nil
-                     :message   "Timed out by metabase"}))
+    (when-let [stale (not-empty (t2/select model
+                                           {:where [:and
+                                                    [:= :is_active true]
+                                                    [:< age-column cutoff]]
+                                            :for   :update}))]
+      (t2/update! model
+                  :id        [:in (mapv :id stale)]
+                  :is_active true
+                  {:status    :timeout
+                   :end_time  :%now
+                   :is_active nil
+                   :message   "Timed out by metabase"})
       stale)))

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -154,44 +154,15 @@
        (when-let [run (t2/select-one :model/TransformRun :id run-id)]
          (publish-timeout-event! run))))))
 
-(defn- timeout-rows!
-  "Atomic select-then-update of stale active runs older than `cutoff`. Returns the pre-update rows
-  the UPDATE transitioned. See [[timeout-old-runs!]] for atomicity rationale."
-  [cutoff]
-  ;; Alternative considered: `UPDATE … RETURNING *` to avoid an explicit transaction. Rejected —
-  ;; `RETURNING` on UPDATE is portable on Postgres but not on H2 or MySQL/MariaDB, and
-  ;; Metabase's app DB supports all three. The transaction here holds row locks only across a
-  ;; SELECT and one UPDATE-by-id, well within the 10-minute sweep cadence.
-  (t2/with-transaction [_conn]
-    (let [stale (t2/select :model/TransformRun
-                           {:where [:and
-                                    [:= :is_active true]
-                                    [:< :start_time cutoff]]
-                            :for   :update})]
-      (when (seq stale)
-        (t2/update! :model/TransformRun
-                    :id        [:in (mapv :id stale)]
-                    :is_active true
-                    {:status    :timeout
-                     :end_time  :%now
-                     :is_active nil
-                     :message   "Timed out by metabase"}))
-      stale)))
-
 (defn timeout-old-runs!
   "Time out all active runs older than the specified age. Returns the number of runs timed out.
-
-  Atomicity: the select-and-update is wrapped in a transaction with `SELECT … FOR UPDATE`,
-  so the rows we report on (counter, histogram, audit event) are exactly the rows the UPDATE
-  transitions to `:timeout`. Without the lock a concurrent run completion between SELECT and
-  UPDATE could leave the row non-active by UPDATE time — the UPDATE would skip it (its filter
-  matches `:is_active true`), but we'd already have counted it, overstating the timeout rate."
+  See [[metabase.transforms.models.timeout-util/timeout-rows!]] for atomicity rationale."
   [age unit]
   (let [cutoff      (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)
         timeout-dur (timeout-util/unit->duration age unit)
         detected-at (Instant/now)
         end-time    (OffsetDateTime/ofInstant detected-at ZoneOffset/UTC)
-        timed-out   (timeout-rows! cutoff)]
+        timed-out   (timeout-util/timeout-rows! :model/TransformRun :start_time cutoff)]
     (when (seq timed-out)
       (analytics/inc! :metabase-transforms/timeouts-total
                       {:type "transform"}

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -167,17 +167,16 @@
       (analytics/inc! :metabase-transforms/timeouts-total
                       {:type "transform"}
                       (count timed-out))
-      (run! (fn [run]
-              (when-let [start (:start_time run)]
-                (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
-                                    {:type "transform"}
-                                    (timeout-util/detection-latency-ms start timeout-dur detected-at)))
-              (publish-timeout-event! (assoc run
-                                             :status    :timeout
-                                             :is_active nil
-                                             :end_time  end-time
-                                             :message   "Timed out by metabase")))
-            timed-out))
+      (doseq [run timed-out]
+        (when-let [start (:start_time run)]
+          (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
+                              {:type "transform"}
+                              (timeout-util/detection-latency-ms start timeout-dur detected-at)))
+        (publish-timeout-event! (assoc run
+                                       :status    :timeout
+                                       :is_active nil
+                                       :end_time  end-time
+                                       :message   "Timed out by metabase"))))
     (cancel/delete-old-canceling-runs!)
     timed-out))
 

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -155,7 +155,7 @@
          (publish-timeout-event! run))))))
 
 (defn timeout-old-runs!
-  "Time out all active runs older than the specified age. Returns the number of runs timed out.
+  "Time out all active runs older than the specified age. Returns the rows that were timed out.
   See [[metabase.transforms.models.timeout-util/timeout-rows!]] for atomicity rationale."
   [age unit]
   (let [cutoff      (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)
@@ -179,7 +179,7 @@
                                              :message   "Timed out by metabase")))
             timed-out))
     (cancel/delete-old-canceling-runs!)
-    (count timed-out)))
+    timed-out))
 
 (defn cancel-old-canceling-runs!
   "Cancel all canceling runs older than the specified age."

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -1,20 +1,25 @@
 (ns metabase.transforms.models.transform-run
   (:require
    [medley.core :as m]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.parameters.dates :as params.dates]
+   [metabase.transforms.models.timeout-util :as timeout-util]
    [metabase.transforms.models.transform-run-cancelation :as cancel]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.realize :as t2.realize]))
+   [toucan2.realize :as t2.realize])
+  (:import
+   (java.time Instant OffsetDateTime ZoneOffset)))
 
 (set! *warn-on-reflection* true)
 
@@ -119,6 +124,17 @@
                                 :is_active nil}))
      (cancel/delete-cancelation! run-id))))
 
+(defn- publish-timeout-event!
+  "Publish `:event/transform-run-timeout` for `run`. Wrapped so that audit-log handler
+  failures don't bubble into the caller's timeout flow."
+  [run]
+  (try
+    (events/publish-event! :event/transform-run-timeout
+                           (cond-> {:object run}
+                             (:user_id run) (assoc :user-id (:user_id run))))
+    (catch Throwable t
+      (log/warnf t "Failed to publish transform-run-timeout event for run %s" (pr-str (:id run))))))
+
 (defn timeout-run!
   "Mark a started run as timed out."
   ([run-id]
@@ -132,19 +148,67 @@
                                 :message   "Timed out"
                                 :status    :timeout
                                 :is_active nil}))
-     (cancel/delete-cancelation! run-id))))
+     (cancel/delete-cancelation! run-id)
+     (when (pos? <>)
+       (analytics/inc! :metabase-transforms/timeouts-total {:type "transform"})
+       (when-let [run (t2/select-one :model/TransformRun :id run-id)]
+         (publish-timeout-event! run))))))
+
+(defn- timeout-rows!
+  "Atomic select-then-update of stale active runs older than `cutoff`. Returns the pre-update rows
+  the UPDATE transitioned. See [[timeout-old-runs!]] for atomicity rationale."
+  [cutoff]
+  ;; Alternative considered: `UPDATE … RETURNING *` to avoid an explicit transaction. Rejected —
+  ;; `RETURNING` on UPDATE is portable on Postgres but not on H2 or MySQL/MariaDB, and
+  ;; Metabase's app DB supports all three. The transaction here holds row locks only across a
+  ;; SELECT and one UPDATE-by-id, well within the 10-minute sweep cadence.
+  (t2/with-transaction [_conn]
+    (let [stale (t2/select :model/TransformRun
+                           {:where [:and
+                                    [:= :is_active true]
+                                    [:< :start_time cutoff]]
+                            :for   :update})]
+      (when (seq stale)
+        (t2/update! :model/TransformRun
+                    :id        [:in (mapv :id stale)]
+                    :is_active true
+                    {:status    :timeout
+                     :end_time  :%now
+                     :is_active nil
+                     :message   "Timed out by metabase"}))
+      stale)))
 
 (defn timeout-old-runs!
-  "Time out all active runs older than the specified age."
+  "Time out all active runs older than the specified age. Returns the number of runs timed out.
+
+  Atomicity: the select-and-update is wrapped in a transaction with `SELECT … FOR UPDATE`,
+  so the rows we report on (counter, histogram, audit event) are exactly the rows the UPDATE
+  transitions to `:timeout`. Without the lock a concurrent run completion between SELECT and
+  UPDATE could leave the row non-active by UPDATE time — the UPDATE would skip it (its filter
+  matches `:is_active true`), but we'd already have counted it, overstating the timeout rate."
   [age unit]
-  (u/prog1 (t2/update! :model/TransformRun
-                       :is_active true
-                       :start_time [:< (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)]
-                       {:status    :timeout
-                        :end_time  :%now
-                        :is_active nil
-                        :message   "Timed out by metabase"})
-    (cancel/delete-old-canceling-runs!)))
+  (let [cutoff      (h2x/add-interval-honeysql-form (mdb/db-type) :%now (- age) unit)
+        timeout-dur (timeout-util/unit->duration age unit)
+        detected-at (Instant/now)
+        end-time    (OffsetDateTime/ofInstant detected-at ZoneOffset/UTC)
+        timed-out   (timeout-rows! cutoff)]
+    (when (seq timed-out)
+      (analytics/inc! :metabase-transforms/timeouts-total
+                      {:type "transform"}
+                      (count timed-out))
+      (run! (fn [run]
+              (when-let [start (:start_time run)]
+                (analytics/observe! :metabase-transforms/timeout-detection-latency-ms
+                                    {:type "transform"}
+                                    (timeout-util/detection-latency-ms start timeout-dur detected-at)))
+              (publish-timeout-event! (assoc run
+                                             :status    :timeout
+                                             :is_active nil
+                                             :end_time  end-time
+                                             :message   "Timed out by metabase")))
+            timed-out))
+    (cancel/delete-old-canceling-runs!)
+    (count timed-out)))
 
 (defn cancel-old-canceling-runs!
   "Cancel all canceling runs older than the specified age."

--- a/src/metabase/transforms/timeout.clj
+++ b/src/metabase/transforms/timeout.clj
@@ -4,6 +4,7 @@
    [clojurewerkz.quartzite.schedule.calendar-interval :as calendar-interval]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.task.core :as task]
+   [metabase.tracing.core :as tracing]
    [metabase.transforms.models.transform-run :as transform-run]
    [metabase.transforms.settings :as transforms.settings]
    [metabase.util.log :as log]))
@@ -13,11 +14,10 @@
 (def ^:private job-key "metabase.transforms.timeout")
 
 (defn- timeout-transform-runs! [_ctx]
-  (log/trace "Timing out old runs.")
-  (try
-    (transform-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute)
-    (catch Throwable t
-      (log/error t "Error timing out old runs."))))
+  (tracing/with-span :tasks "task.transform.timeout-check" {:transform.timeout/type "transform"}
+    (let [timed-out (transform-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute)]
+      (when (pos? timed-out)
+        (log/infof "Timed out %d transform run(s)." timed-out)))))
 
 (task/defjob  ^{:doc "Timeout long-running tasks that have been lost by a worker."
                 org.quartz.DisallowConcurrentExecution true}

--- a/src/metabase/transforms/timeout.clj
+++ b/src/metabase/transforms/timeout.clj
@@ -15,9 +15,8 @@
 
 (defn- timeout-transform-runs! [_ctx]
   (tracing/with-span :tasks "task.transform.timeout-check" {:transform.timeout/type "transform"}
-    (let [timed-out (transform-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute)]
-      (when (seq timed-out)
-        (log/infof "Timed out %d transform run(s)." (count timed-out))))))
+    (when-let [timed-out (not-empty (transform-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute))]
+      (log/infof "Timed out %d transform run(s)." (count timed-out)))))
 
 (task/defjob  ^{:doc "Timeout long-running tasks that have been lost by a worker."
                 org.quartz.DisallowConcurrentExecution true}

--- a/src/metabase/transforms/timeout.clj
+++ b/src/metabase/transforms/timeout.clj
@@ -16,8 +16,8 @@
 (defn- timeout-transform-runs! [_ctx]
   (tracing/with-span :tasks "task.transform.timeout-check" {:transform.timeout/type "transform"}
     (let [timed-out (transform-run/timeout-old-runs! (transforms.settings/transform-timeout) :minute)]
-      (when (pos? timed-out)
-        (log/infof "Timed out %d transform run(s)." timed-out)))))
+      (when (seq timed-out)
+        (log/infof "Timed out %d transform run(s)." (count timed-out))))))
 
 (task/defjob  ^{:doc "Timeout long-running tasks that have been lost by a worker."
                 org.quartz.DisallowConcurrentExecution true}

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -344,6 +344,7 @@
     (mt/with-model-cleanup [:model/Notification
                             :model/TransformJobRun]
       (mt/with-fake-inbox
+        (mt/fetch-user :crowberto)
         (notification.seed/seed-notification!)
         (mt/with-temp [:model/TransformJob job {:name "stalled-cron-job"
                                                 :schedule "0 0 * * * ? *"}]
@@ -370,6 +371,7 @@
     (mt/with-model-cleanup [:model/Notification
                             :model/TransformJobRun]
       (mt/with-fake-inbox
+        (mt/fetch-user :crowberto)
         (notification.seed/seed-notification!)
         (mt/with-temp [:model/TransformJob job {:name "stalled-manual-job"
                                                 :schedule "0 0 * * * ? *"}]

--- a/test/metabase/transforms/models/timeout_util_test.clj
+++ b/test/metabase/transforms/models/timeout_util_test.clj
@@ -1,0 +1,28 @@
+(ns metabase.transforms.models.timeout-util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.transforms.models.timeout-util :as timeout-util])
+  (:import
+   (java.time Duration OffsetDateTime ZoneOffset)))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:parallel unit->duration-test
+  (testing "produces an exact Duration for each supported unit"
+    (is (= (Duration/ofSeconds 30) (timeout-util/unit->duration 30 :second)))
+    (is (= (Duration/ofMinutes 5)  (timeout-util/unit->duration 5  :minute)))
+    (is (= (Duration/ofHours 2)    (timeout-util/unit->duration 2  :hour))))
+  (testing "unknown unit throws"
+    (is (thrown? IllegalArgumentException (timeout-util/unit->duration 1 :day)))))
+
+(deftest ^:parallel detection-latency-ms-test
+  (let [^OffsetDateTime reference-ts (OffsetDateTime/of 2026 1 1 0 0 0 0 ZoneOffset/UTC)
+        timeout-dur                  (Duration/ofMinutes 10)
+        deadline                     (.plus (.toInstant reference-ts) timeout-dur)]
+    (testing "zero at the deadline"
+      (is (zero? (timeout-util/detection-latency-ms reference-ts timeout-dur deadline))))
+    (testing "clamped to zero before the deadline"
+      (is (zero? (timeout-util/detection-latency-ms reference-ts timeout-dur (.minusMillis deadline 5000)))))
+    (testing "milliseconds past the deadline"
+      (is (= 7500
+             (timeout-util/detection-latency-ms reference-ts timeout-dur (.plusMillis deadline 7500)))))))

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -5,7 +5,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.analytics.prometheus :as prometheus]
-   [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.transforms.models.job-run :as transforms.job-run]
@@ -46,10 +45,9 @@
               (is (= :started (t2/select-one-fn :status :model/TransformRun :id fresh-run-id)))))
 
           (testing "counter bumps {type=transform} once for the stale run"
-            (is (prometheus-test/approx= 1
-                                         (mt/metric-value system
-                                                          :metabase-transforms/timeouts-total
-                                                          {:type "transform"}))))
+            (is (== 1 (mt/metric-value system
+                                       :metabase-transforms/timeouts-total
+                                       {:type "transform"}))))
 
           (testing "histogram observes one positive sample for the stale run"
             (let [hist (mt/metric-value system
@@ -77,10 +75,9 @@
                                               :run_method   :manual
                                               :start_time   (minutes-ago 1)}]
           (is (= 0 (transform-run/timeout-old-runs! 5 :minute)))
-          (is (prometheus-test/approx= 0
-                                       (mt/metric-value system
-                                                        :metabase-transforms/timeouts-total
-                                                        {:type "transform"})))
+          (is (== 0 (mt/metric-value system
+                                     :metabase-transforms/timeouts-total
+                                     {:type "transform"})))
           (is (zero? (long (:count (mt/metric-value system
                                                     :metabase-transforms/timeout-detection-latency-ms
                                                     {:type "transform"})))))))
@@ -95,10 +92,9 @@
                                                                :start_time   (minutes-ago 1)}]
           (transform-run/timeout-run! run-id)
           (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id run-id)))
-          (is (prometheus-test/approx= 1
-                                       (mt/metric-value system
-                                                        :metabase-transforms/timeouts-total
-                                                        {:type "transform"})))
+          (is (== 1 (mt/metric-value system
+                                     :metabase-transforms/timeouts-total
+                                     {:type "transform"})))
           (let [entry (mt/latest-audit-log-entry :transform-run-timeout run-id)]
             (is (some? entry))
             (is (= run-id (:model_id entry)))
@@ -123,10 +119,9 @@
             (is (= 1 (count timed-out)))
             (is (= :timeout (t2/select-one-fn :status :model/TransformJobRun :id old-run-id)))
             (is (= :started (t2/select-one-fn :status :model/TransformJobRun :id fresh-run-id))))
-          (is (prometheus-test/approx= 1
-                                       (mt/metric-value system
-                                                        :metabase-transforms/timeouts-total
-                                                        {:type "job"})))
+          (is (== 1 (mt/metric-value system
+                                     :metabase-transforms/timeouts-total
+                                     {:type "job"})))
           (let [hist (mt/metric-value system
                                       :metabase-transforms/timeout-detection-latency-ms
                                       {:type "job"})]

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -1,0 +1,134 @@
+(ns metabase.transforms.timeout-test
+  "Tests for observability of the transform timeout sweepers
+  ([[metabase.transforms.models.transform-run/timeout-old-runs!]] and
+  [[metabase.transforms.models.job-run/timeout-old-runs!]])."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.transforms.models.job-run :as transforms.job-run]
+   [metabase.transforms.models.transform-run :as transform-run]
+   [toucan2.core :as t2])
+  (:import
+   (java.time OffsetDateTime ZoneOffset)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(defn- minutes-ago ^OffsetDateTime [^long n]
+  (.minusMinutes (OffsetDateTime/now ZoneOffset/UTC) n))
+
+(deftest timeout-observability-test
+  (mt/with-premium-features #{:transforms-basic :audit-app}
+    (mt/with-prometheus-system! [_ system]
+      (testing "transform-run sweeper bumps counter, observes histogram, and publishes audit event per timed-out run"
+        (prometheus/clear! :metabase-transforms/timeouts-total)
+        (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)
+        (mt/with-temp [:model/Transform    {old-transform-id :id}   {}
+                       :model/Transform    {fresh-transform-id :id} {}
+                       :model/TransformRun {old-run-id :id}         {:transform_id old-transform-id
+                                                                     :status       :started
+                                                                     :is_active    true
+                                                                     :run_method   :manual
+                                                                     :start_time   (minutes-ago 30)}
+                       :model/TransformRun {fresh-run-id :id}       {:transform_id fresh-transform-id
+                                                                     :status       :started
+                                                                     :is_active    true
+                                                                     :run_method   :manual
+                                                                     :start_time   (minutes-ago 1)}]
+          (let [n-timed-out (transform-run/timeout-old-runs! 5 :minute)]
+            (testing "only the stale run is timed out"
+              (is (= 1 n-timed-out))
+              (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id old-run-id)))
+              (is (= :started (t2/select-one-fn :status :model/TransformRun :id fresh-run-id)))))
+
+          (testing "counter bumps {type=transform} once for the stale run"
+            (is (prometheus-test/approx= 1
+                                         (mt/metric-value system
+                                                          :metabase-transforms/timeouts-total
+                                                          {:type "transform"}))))
+
+          (testing "histogram observes one positive sample for the stale run"
+            (let [hist (mt/metric-value system
+                                        :metabase-transforms/timeout-detection-latency-ms
+                                        {:type "transform"})]
+              (is (= 1 (long (:count hist))))
+              (is (pos? (:sum hist)))))
+
+          (testing "audit event is published with topic transform-run-timeout"
+            (let [entry (mt/latest-audit-log-entry :transform-run-timeout old-run-id)]
+              (is (some? entry))
+              (is (= :transform-run-timeout (some-> entry :topic keyword)))
+              (is (= "TransformRun" (:model entry)))
+              (is (= old-run-id (:model_id entry)))
+              (testing "payload reflects the post-update :timeout status (parity with single-run path)"
+                (is (= "timeout" (some-> entry :details :status))))))))
+
+      (testing "no metric activity when there are no stale runs"
+        (prometheus/clear! :metabase-transforms/timeouts-total)
+        (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)
+        (mt/with-temp [:model/Transform    {transform-id :id} {}
+                       :model/TransformRun _ {:transform_id transform-id
+                                              :status       :started
+                                              :is_active    true
+                                              :run_method   :manual
+                                              :start_time   (minutes-ago 1)}]
+          (is (= 0 (transform-run/timeout-old-runs! 5 :minute)))
+          (is (prometheus-test/approx= 0
+                                       (mt/metric-value system
+                                                        :metabase-transforms/timeouts-total
+                                                        {:type "transform"})))
+          (is (zero? (long (:count (mt/metric-value system
+                                                    :metabase-transforms/timeout-detection-latency-ms
+                                                    {:type "transform"})))))))
+
+      (testing "single-run timeout-run! bumps counter and publishes audit event"
+        (prometheus/clear! :metabase-transforms/timeouts-total)
+        (mt/with-temp [:model/Transform    {transform-id :id} {}
+                       :model/TransformRun {run-id :id}       {:transform_id transform-id
+                                                               :status       :started
+                                                               :is_active    true
+                                                               :run_method   :manual
+                                                               :start_time   (minutes-ago 1)}]
+          (transform-run/timeout-run! run-id)
+          (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id run-id)))
+          (is (prometheus-test/approx= 1
+                                       (mt/metric-value system
+                                                        :metabase-transforms/timeouts-total
+                                                        {:type "transform"})))
+          (let [entry (mt/latest-audit-log-entry :transform-run-timeout run-id)]
+            (is (some? entry))
+            (is (= run-id (:model_id entry)))
+            (is (= "timeout" (some-> entry :details :status))))))
+
+      (testing "job-run sweeper bumps {type=job} counter and observes histogram per timed-out job run"
+        (prometheus/clear! :metabase-transforms/timeouts-total)
+        (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)
+        (mt/with-temp [:model/TransformJob    {job-id :id}        {:name     "timeout-test-job"
+                                                                   :schedule "0 0 * * * ? *"}
+                       :model/TransformJobRun {old-run-id :id}    {:job_id     job-id
+                                                                   :status     :started
+                                                                   :is_active  true
+                                                                   :run_method :manual
+                                                                   :updated_at (minutes-ago 30)}
+                       :model/TransformJobRun {fresh-run-id :id}  {:job_id     job-id
+                                                                   :status     :started
+                                                                   :is_active  true
+                                                                   :run_method :manual
+                                                                   :updated_at (minutes-ago 1)}]
+          (let [timed-out (transforms.job-run/timeout-old-runs! 5 :minute)]
+            (is (= 1 (count timed-out)))
+            (is (= :timeout (t2/select-one-fn :status :model/TransformJobRun :id old-run-id)))
+            (is (= :started (t2/select-one-fn :status :model/TransformJobRun :id fresh-run-id))))
+          (is (prometheus-test/approx= 1
+                                       (mt/metric-value system
+                                                        :metabase-transforms/timeouts-total
+                                                        {:type "job"})))
+          (let [hist (mt/metric-value system
+                                      :metabase-transforms/timeout-detection-latency-ms
+                                      {:type "job"})]
+            (is (= 1 (long (:count hist))))
+            (is (pos? (:sum hist)))))))))

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -38,9 +38,9 @@
                                                                      :is_active    true
                                                                      :run_method   :manual
                                                                      :start_time   (minutes-ago 1)}]
-          (let [n-timed-out (transform-run/timeout-old-runs! 5 :minute)]
+          (let [timed-out (transform-run/timeout-old-runs! 5 :minute)]
             (testing "only the stale run is timed out"
-              (is (= 1 n-timed-out))
+              (is (= 1 (count timed-out)))
               (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id old-run-id)))
               (is (= :started (t2/select-one-fn :status :model/TransformRun :id fresh-run-id)))))
 
@@ -74,7 +74,7 @@
                                               :is_active    true
                                               :run_method   :manual
                                               :start_time   (minutes-ago 1)}]
-          (is (= 0 (transform-run/timeout-old-runs! 5 :minute)))
+          (is (empty? (transform-run/timeout-old-runs! 5 :minute)))
           (is (== 0 (mt/metric-value system
                                      :metabase-transforms/timeouts-total
                                      {:type "transform"})))

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -4,6 +4,7 @@
   [[metabase.transforms.models.job-run/timeout-old-runs!]])."
   (:require
    [clojure.test :refer :all]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.prometheus :as prometheus]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -66,21 +67,21 @@
                 (is (= "timeout" (some-> entry :details :status))))))))
 
       (testing "no metric activity when there are no stale runs"
-        (prometheus/clear! :metabase-transforms/timeouts-total)
-        (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)
-        (mt/with-temp [:model/Transform    {transform-id :id} {}
-                       :model/TransformRun _ {:transform_id transform-id
-                                              :status       :started
-                                              :is_active    true
-                                              :run_method   :manual
-                                              :start_time   (minutes-ago 1)}]
-          (is (empty? (transform-run/timeout-old-runs! 5 :minute)))
-          (is (== 0 (mt/metric-value system
-                                     :metabase-transforms/timeouts-total
-                                     {:type "transform"})))
-          (is (zero? (long (:count (mt/metric-value system
-                                                    :metabase-transforms/timeout-detection-latency-ms
-                                                    {:type "transform"})))))))
+        (let [inc-calls     (atom [])
+              observe-calls (atom [])]
+          (mt/with-dynamic-fn-redefs [analytics/inc!     (fn [metric & _] (swap! inc-calls conj metric))
+                                      analytics/observe! (fn [metric & _] (swap! observe-calls conj metric))]
+            (mt/with-temp [:model/Transform    {transform-id :id} {}
+                           :model/TransformRun _ {:transform_id transform-id
+                                                  :status       :started
+                                                  :is_active    true
+                                                  :run_method   :manual
+                                                  :start_time   (minutes-ago 1)}]
+              (is (empty? (transform-run/timeout-old-runs! 5 :minute)))
+              (is (not-any? #{:metabase-transforms/timeouts-total} @inc-calls)
+                  "sweeper did not increment :metabase-transforms/timeouts-total")
+              (is (not-any? #{:metabase-transforms/timeout-detection-latency-ms} @observe-calls)
+                  "sweeper did not observe :metabase-transforms/timeout-detection-latency-ms")))))
 
       (testing "single-run timeout-run! bumps counter and publishes audit event"
         (prometheus/clear! :metabase-transforms/timeouts-total)


### PR DESCRIPTION
### Description

Add Prometheus instrumentation and an audit event for transform-run and job-run timeouts, and replace the existing non-atomic sweep with a transaction so the emitted metrics can't drift from the rows actually transitioned to `:timeout`.

Changes:
- **Counter** `:metabase-transforms/timeouts-total {type}` - incremented per timed-out run; `type` is `"transform"` or `"job"`.
- **Histogram** `:metabase-transforms/timeout-detection-latency-ms {type}` - how late the sweeper detected each timeout. Bounded by the 10-min sweep interval
- **Audit event** `:event/transform-run-timeout` - fires for both the single-run `timeout-run!` path and the sweeper path. Payload reflects the post-update `:timeout` row state.
- **Tracing span** `task.transform.timeout-check {transform.timeout/type}` on both Quartz jobs.

### Cardinality

Single label `:type` on both new metrics. Values are hardcoded at the two emission sites (`"transform"` from `transform_run.clj`, `"job"` from `job_run.clj`) — no user input, no clamping needed.

**Counter `metabase_transforms_timeouts_total{type}`:**

```
type: 2 values ("transform", "job"), all from a closed enum at emission

Per-instance: 2 combos × 1 series = 2 series
```

**Histogram `metabase_transforms_timeout_detection_latency_ms{type}`:**

```
type: 2 values
Buckets: 11 explicit upper bounds + +Inf = 12 _bucket series per label combo
Plus auto-appended _sum and _count = 14 series per label combo

Per-instance: 2 combos × 14 series = 28 series
```


### Behavior changes worth noting

* The transform-side sweeper previously caught and logged all exceptions inside `timeout-transform-runs!` (`log/error` from this namespace, then swallow). This wrapper is removed, as a wrapper inside `tracing/with-span` would have hidden - clj-otel's internal `add-exception!` only fires if the throw reaches it.
  *  Recovery semantics are unchanged - Quartz catches the throw at the job-execution boundary, logs it at WARN with a `JobExecutionException` stack trace, and the next 10-minute trigger fires normally. The only functional change is observability: the failure now also populates the `task.transform.timeout-check` span with `status=error`.
* The job-side sweeper previously used non-atomic `UPDATE … RETURNING pks` + post-`SELECT`. The new path is one transaction with `SELECT … FOR UPDATE` + `UPDATE` -> this is portable across H2/MySQL/Postgres.

* Also fixed a test-isolation bug in `metabase.transforms.jobs-test/timeout-old-runs-{notifies,does-not-notify}-*-test` - the tests assumed `:crowberto` was already inserted by suite ordering, so they failed when run alone with `:only`. Tests now explicitly `(mt/fetch-user :crowberto)`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
