### PR TITLE
Fix content translation for multi-line markdown cards (EMB-1654)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -153,21 +153,19 @@
 
 (defn- maybe-read
   [reader]
-  (let [lines (line-seq reader)]
-    (import-translations!
-     (for [[i line] (map-indexed vector lines)]
-       (try
-         (first (csv/read-csv (java.io.StringReader. line)))
-         (catch Exception e
-           (let [error-message (.getMessage ^Exception e)
-                 ;; report line number 1 indexed
-                 line-no (inc i)
-                 error-message (tru "Error Parsing CSV at Row {0}: {1}" line-no error-message)]
-             (throw (ex-info error-message
-                             {:status-code http-status-unprocessable
-                              :errors [error-message]
-                              :line line-no}
-                             e)))))))))
+  (let [rows (try
+               ;; Read the whole CSV at once so quoted fields can span multiple
+               ;; physical lines per RFC 4180. Forcing the lazy seq with `vec`
+               ;; ensures parse errors surface inside this try, while the reader
+               ;; is still open.
+               (vec (csv/read-csv reader))
+               (catch Exception e
+                 (let [error-message (tru "Error parsing CSV: {0}" (.getMessage ^Exception e))]
+                   (throw (ex-info error-message
+                                   {:status-code http-status-unprocessable
+                                    :errors [error-message]}
+                                   e)))))]
+    (import-translations! rows)))
 
 (defn read-and-import-csv!
   "Read CSV and catch error if the CSV is invalid."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -153,19 +153,26 @@
 
 (defn- maybe-read
   [reader]
-  (let [rows (try
-               ;; Read the whole CSV at once so quoted fields can span multiple
-               ;; physical lines per RFC 4180. Forcing the lazy seq with `vec`
-               ;; ensures parse errors surface inside this try, while the reader
-               ;; is still open.
-               (vec (csv/read-csv reader))
-               (catch Exception e
-                 (let [error-message (tru "Error parsing CSV: {0}" (.getMessage ^Exception e))]
-                   (throw (ex-info error-message
-                                   {:status-code http-status-unprocessable
-                                    :errors [error-message]}
-                                   e)))))]
-    (import-translations! rows)))
+  ;; Consume the lazy seq one row at a time and count successfully-parsed rows
+  ;; so a parse error can name the failing row. Reading via `csv/read-csv`
+  ;; (rather than line-by-line) lets quoted fields span multiple physical
+  ;; lines per RFC 4180; the reported row number is the logical row, which is
+  ;; what the user authored.
+  (let [rows (volatile! [])]
+    (try
+      (doseq [row (csv/read-csv reader)]
+        (vswap! rows conj row))
+      (catch Exception e
+        (let [row-no (inc (count @rows))
+              error-message (tru "Error parsing CSV at row {0}: {1}"
+                                 row-no
+                                 (.getMessage ^Exception e))]
+          (throw (ex-info error-message
+                          {:status-code http-status-unprocessable
+                           :errors [error-message]
+                           :row row-no}
+                          e)))))
+    (import-translations! @rows)))
 
 (defn read-and-import-csv!
   "Read CSV and catch error if the CSV is invalid."

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -112,7 +112,7 @@
     (testing "Reads CSV with invalid header row and throws informative error"
       (let [file (.getBytes "Language,String,\"Translation\"X")] ; character outside quotation marks
         (is (thrown-with-msg?
-             Exception #"Error parsing CSV.*unexpected character.*X"
+             Exception #"Error parsing CSV at row 1.*unexpected character.*X"
              (dictionary/read-and-import-csv! file)))))
     (testing "Reads CSV with invalid header name and throws informative error"
       (let [file (.getBytes "Loca,String,Translation\nes-mx,hello,hola")] ; bad header
@@ -122,7 +122,13 @@
     (testing "Reads CSV with invalid data row and throws informative error"
       (let [file (.getBytes "Language,String,Translation\nde,Title,Titel\nde,Vendor,\"Anbieter\"X")] ; character outside quotation marks
         (is (thrown-with-msg?
-             Exception #"Error parsing CSV.*unexpected character.*X"
+             Exception #"Error parsing CSV at row 3.*unexpected character.*X"
+             (dictionary/read-and-import-csv! file)))))
+    (testing "Parse-error row number counts logical rows, not physical lines (a quoted multi-line row counts as 1)"
+      ;; Header (row 1) + a 2-physical-line quoted row (row 2) + a broken row (row 3) → error should name row 3.
+      (let [file (.getBytes "Language,String,Translation\nde,\"line one\nline two\",Titel\nde,Vendor,\"Anbieter\"X")]
+        (is (thrown-with-msg?
+             Exception #"Error parsing CSV at row 3.*unexpected character.*X"
              (dictionary/read-and-import-csv! file)))))))
 
 (deftest read-and-import-csv-with-and-without-header-test

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -112,7 +112,7 @@
     (testing "Reads CSV with invalid header row and throws informative error"
       (let [file (.getBytes "Language,String,\"Translation\"X")] ; character outside quotation marks
         (is (thrown-with-msg?
-             Exception #"Row 1.*CSV error.*unexpected character.*X"
+             Exception #"Error parsing CSV.*unexpected character.*X"
              (dictionary/read-and-import-csv! file)))))
     (testing "Reads CSV with invalid header name and throws informative error"
       (let [file (.getBytes "Loca,String,Translation\nes-mx,hello,hola")] ; bad header
@@ -122,7 +122,7 @@
     (testing "Reads CSV with invalid data row and throws informative error"
       (let [file (.getBytes "Language,String,Translation\nde,Title,Titel\nde,Vendor,\"Anbieter\"X")] ; character outside quotation marks
         (is (thrown-with-msg?
-             Exception #"Row 3.*CSV error.*unexpected character.*X"
+             Exception #"Error parsing CSV.*unexpected character.*X"
              (dictionary/read-and-import-csv! file)))))))
 
 (deftest read-and-import-csv-with-and-without-header-test
@@ -156,6 +156,25 @@
           (let [translations (get-translations)]
             (is (some #(and (= (:locale %) "es") (= (:msgid %) "Hello") (= (:msgstr %) "Hola")) translations))
             (is (some #(and (= (:locale %) "fr") (= (:msgid %) "Goodbye") (= (:msgstr %) "Au revoir")) translations))))))))
+
+(deftest read-and-import-csv-multiline-fields-test
+  (ct-utils/with-clean-translations!
+    (testing "CSV with newlines inside quoted fields is imported with the newlines preserved (EMB-1654)"
+      (mt/with-premium-features #{:content-translation}
+        ;; The msgid mirrors the shape of a multi-line markdown text card: a heading followed by
+        ;; an image link, separated by a real newline. Before the fix, the file-level reader split
+        ;; on every physical newline and each half failed to parse as its own CSV row.
+        (let [msgid "##### in partnership with ▸\n[![Logo](https://example.com/logo.png)](https://example.com)"
+              msgstr "##### en partenariat avec ▸\n[![Logo](https://example.com/logo.png)](https://example.com)"
+              csv (str "Language,String,Translation\n"
+                       "fr,\"" msgid "\",\"" msgstr "\"")
+              file (.getBytes csv)]
+          (dictionary/read-and-import-csv! file)
+          (is (= 1 (count-translations)))
+          (let [translation (first (get-translations))]
+            (is (= "fr" (:locale translation)))
+            (is (= msgid (:msgid translation)))
+            (is (= msgstr (:msgstr translation)))))))))
 
 (deftest read-and-import-csv-different-locale-headers-test
   (ct-utils/with-clean-translations!

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -97,7 +97,7 @@
     (testing "admin sees useful error when uploaded file has invalid csv"
       (ct-utils/with-clean-translations!
         (mt/with-premium-features #{:content-translation}
-          (is (=? {:errors ["Error Parsing CSV at Row 4: CSV error (unexpected character: !)"]}
+          (is (=? {:errors ["Error parsing CSV: CSV error (unexpected character: !)"]}
                   (mt/user-http-request :crowberto :post 422 "ee/content-translation/upload-dictionary"
                                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                         {:file invalid-csv}))))))

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -97,7 +97,7 @@
     (testing "admin sees useful error when uploaded file has invalid csv"
       (ct-utils/with-clean-translations!
         (mt/with-premium-features #{:content-translation}
-          (is (=? {:errors ["Error parsing CSV: CSV error (unexpected character: !)"]}
+          (is (=? {:errors ["Error parsing CSV at row 4: CSV error (unexpected character: !)"]}
                   (mt/user-http-request :crowberto :post 422 "ee/content-translation/upload-dictionary"
                                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                         {:file invalid-csv}))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73305
[EMB-1654: Content translation does not work for multi-line markdown cards](https://linear.app/metabase/issue/EMB-1654/content-translation-does-not-work-for-multi-line-markdown-cards)

### Description

The CSV upload reader split the file with `line-seq` and parsed each physical line as its own CSV row, so RFC 4180 quoted fields containing newlines (e.g. a multi-line markdown text card) were torn in half and rejected as malformed. Switched to a single `csv/read-csv` over the whole reader, which natively handles multi-line quoted fields. The lazy seq is forced with `vec` inside the try so parse errors still surface while the reader is open.

Side effect: parse errors no longer carry a "Row N" prefix, because one logical row can now span multiple physical lines and the row-to-line mapping is no longer 1:1. The underlying CSV library message is preserved.

### How to verify

1. On an EE instance with the `content_translation` premium feature, open a dashboard and add a markdown text card whose content spans more than one line, e.g.:

   ```
   ##### in partnership with ▸
   [![Logo](https://example.com/logo.png)](https://example.com)
   ```

2. Embed it as a guest embed with a non-English locale (e.g. `fr`).

3. Upload a translation dictionary CSV containing the full card content as one quoted multi-line field:

   ```
   Locale Code,String,Translation
   fr,"##### in partnership with ▸
   [![Logo](https://example.com/logo.png)](https://example.com)","##### en partenariat avec ▸
   [![Logo](https://example.com/logo.png)](https://example.com)"
   ```

   - **Before this PR:** the upload fails with a CSV parse error.
   - **With this PR:** the upload succeeds, the dictionary stores the multi-line msgid with the embedded newline, and the embedded dashboard renders the French translation.

4. Sanity check: re-upload an invalid CSV (e.g. `Language,String,"Translation"X`) and confirm the error message is `Error parsing CSV: CSV error (unexpected character: X)`.

### Demo

_n/a_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)