### PR TITLE
Fix content translation when embed locale is en (EMB-1683)

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.ts
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbedRaw } from "embedding-sdk-bundle/store/selectors";
 import type { SdkEntityToken } from "embedding-sdk-bundle/types";
-import { useLocale } from "metabase/common/hooks";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 
 export const useSetupContentTranslations = ({
@@ -11,18 +10,16 @@ export const useSetupContentTranslations = ({
 }: {
   token: SdkEntityToken | null;
 }) => {
-  const { locale } = useLocale();
   const isGuestEmbedRaw = useSdkSelector(getIsGuestEmbedRaw);
 
   useEffect(() => {
-    if (locale !== "en" && isGuestEmbedRaw === true && token) {
+    if (isGuestEmbedRaw === true && token) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForStaticEmbedding(token);
     }
-  }, [isGuestEmbedRaw, locale, token]);
+  }, [isGuestEmbedRaw, token]);
 };
 
 export const useSetupAuthContentTranslations = () => {
-  const { locale } = useLocale();
   // Use the raw selector so we can distinguish "not yet known" (null) from
   // "known to be auth embed" (false). ComponentProvider dispatches
   // setIsGuestEmbed in a useEffect, so on the first render isGuestEmbed is
@@ -31,8 +28,8 @@ export const useSetupAuthContentTranslations = () => {
   const isGuestEmbed = useSdkSelector(getIsGuestEmbedRaw);
 
   useEffect(() => {
-    if (locale !== "en" && isGuestEmbed === false) {
+    if (isGuestEmbed === false) {
       PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding();
     }
-  }, [locale, isGuestEmbed]);
+  }, [isGuestEmbed]);
 };

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-setup-content-translations.unit.spec.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from "@testing-library/react";
 
 import { useSdkSelector } from "embedding-sdk-bundle/store";
-import { useLocale } from "metabase/common/hooks";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 
 import {
@@ -13,10 +12,6 @@ jest.mock("embedding-sdk-bundle/store", () => ({
   useSdkSelector: jest.fn(),
 }));
 
-jest.mock("metabase/common/hooks", () => ({
-  useLocale: jest.fn(),
-}));
-
 jest.mock("metabase/plugins", () => ({
   PLUGIN_CONTENT_TRANSLATION: {
     setEndpointsForAuthEmbedding: jest.fn(),
@@ -25,7 +20,6 @@ jest.mock("metabase/plugins", () => ({
 }));
 
 const mockUseSdkSelector = useSdkSelector as unknown as jest.Mock;
-const mockUseLocale = useLocale as jest.Mock;
 const mockSetEndpointsForAuthEmbedding =
   PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding as jest.Mock;
 const mockSetEndpointsForStaticEmbedding =
@@ -37,7 +31,6 @@ describe("useSetupAuthContentTranslations", () => {
   });
 
   it("does not call setEndpointsForAuthEmbedding while isGuestEmbed is null (not yet known)", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(null);
 
     renderHook(() => useSetupAuthContentTranslations());
@@ -45,8 +38,7 @@ describe("useSetupAuthContentTranslations", () => {
     expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
   });
 
-  it("calls setEndpointsForAuthEmbedding when isGuestEmbed is explicitly false and locale is non-English", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
+  it("calls setEndpointsForAuthEmbedding when isGuestEmbed is explicitly false", () => {
     mockUseSdkSelector.mockReturnValue(false);
 
     renderHook(() => useSetupAuthContentTranslations());
@@ -55,7 +47,6 @@ describe("useSetupAuthContentTranslations", () => {
   });
 
   it("does not call setEndpointsForAuthEmbedding when isGuestEmbed is true (guest embed)", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(true);
 
     renderHook(() => useSetupAuthContentTranslations());
@@ -63,17 +54,7 @@ describe("useSetupAuthContentTranslations", () => {
     expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
   });
 
-  it("does not call setEndpointsForAuthEmbedding when locale is English", () => {
-    mockUseLocale.mockReturnValue({ locale: "en" });
-    mockUseSdkSelector.mockReturnValue(false);
-
-    renderHook(() => useSetupAuthContentTranslations());
-
-    expect(mockSetEndpointsForAuthEmbedding).not.toHaveBeenCalled();
-  });
-
   it("calls setEndpointsForAuthEmbedding only after isGuestEmbed transitions from null to false", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(null);
 
     const { rerender } = renderHook(() => useSetupAuthContentTranslations());
@@ -87,7 +68,6 @@ describe("useSetupAuthContentTranslations", () => {
   });
 
   it("never calls setEndpointsForAuthEmbedding when isGuestEmbed transitions from null to true (guest embed race)", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(null);
 
     const { rerender } = renderHook(() => useSetupAuthContentTranslations());
@@ -109,7 +89,6 @@ describe("useSetupContentTranslations", () => {
   });
 
   it("does not call setEndpointsForStaticEmbedding while isGuestEmbed is null (not yet known)", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(null);
 
     renderHook(() => useSetupContentTranslations({ token }));
@@ -117,8 +96,7 @@ describe("useSetupContentTranslations", () => {
     expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
   });
 
-  it("calls setEndpointsForStaticEmbedding with the token when isGuestEmbed is true and locale is non-English", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
+  it("calls setEndpointsForStaticEmbedding with the token when isGuestEmbed is true", () => {
     mockUseSdkSelector.mockReturnValue(true);
 
     renderHook(() => useSetupContentTranslations({ token }));
@@ -127,7 +105,6 @@ describe("useSetupContentTranslations", () => {
   });
 
   it("does not call setEndpointsForStaticEmbedding when token is null", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(true);
 
     renderHook(() => useSetupContentTranslations({ token: null }));
@@ -135,17 +112,7 @@ describe("useSetupContentTranslations", () => {
     expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
   });
 
-  it("does not call setEndpointsForStaticEmbedding when locale is English", () => {
-    mockUseLocale.mockReturnValue({ locale: "en" });
-    mockUseSdkSelector.mockReturnValue(true);
-
-    renderHook(() => useSetupContentTranslations({ token }));
-
-    expect(mockSetEndpointsForStaticEmbedding).not.toHaveBeenCalled();
-  });
-
   it("does not call setEndpointsForStaticEmbedding when isGuestEmbed is false (auth embed)", () => {
-    mockUseLocale.mockReturnValue({ locale: "fr" });
     mockUseSdkSelector.mockReturnValue(false);
 
     renderHook(() => useSetupContentTranslations({ token }));


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73540
[EMB-1683: Content translation never runs when embed locale is `en`](https://linear.app/metabase/issue/EMB-1683/content-translation-never-runs-when-embed-locale-is-en)

### Description

`useSetupContentTranslations` and `useSetupAuthContentTranslations` gated the dictionary endpoint setup on `locale !== "en"`, so the content-translation dictionary was never fetched when the embed locale was English. The implicit assumption was "source content is English, so English viewers need no translation" — wrong for any customer whose source content is in another language and whose users view embeds in English (e.g. a French dashboard that should display English translations to en-locale viewers).

The gate was introduced in [#67730](https://github.com/metabase/metabase/pull/67730) under an "Extract locale setup to a hook" commit; the two original call sites had no such check.

Removed the `locale !== "en"` condition from both hooks. The endpoint setup now fires whenever the embed flow is identified (guest or auth), regardless of locale. Each backend endpoint still filters by locale, so locales without dictionary entries get an empty response and `useTranslateContent` falls back to the no-op path. The EMB-1478 race-condition guard (`isGuestEmbed === false` strict check) is preserved.

### How to verify

1. On an EE instance with the `content_translation` premium feature, create a dashboard with a text card whose content is in a non-English language, e.g. `bonjour`.
2. Upload a translation dictionary entry that translates the source string into English:

   ```
   Locale Code,String,Translation
   en,bonjour,hello
   ```

3. Render the dashboard via Modular embedding (web component or SDK) with `locale: "en"`:

   ```html
   <script defer src="http://localhost:3000/app/embed.js"></script>
   <script>
     window.metabaseConfig = {
       isGuest: true,
       instanceUrl: "http://localhost:3000",
       locale: "en",
     };
   </script>
   <metabase-dashboard dashboard-id="<id>"></metabase-dashboard>
   ```

4. Open DevTools → Network → filter `dictionary`.
   - **Before this PR:** no request to `/api/ee/content-translation/dictionary*` is sent. The card displays `bonjour`.
   - **With this PR:** the request fires (`/dictionary/{token}?locale=en` for guest embeds, `/dictionary?locale=en` for auth embeds) and the card renders `hello`.

5. Sanity check: the existing non-English flow (e.g. `locale: "fr"` with a `fr,Hello,Bonjour` dictionary entry) keeps working as before.

### Demo

_n/a_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)