### PR TITLE
Fix guest embed question downloads ignoring editable filters

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
@@ -1,5 +1,8 @@
+import type { Interception } from "cypress/types/net-stubbing";
+
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  createNativeQuestion,
   createQuestion,
   downloadAndAssert,
   getSignedJwtForResource,
@@ -7,9 +10,10 @@ import {
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountGuestEmbedQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndSetupGuestEmbedding } from "e2e/support/helpers/embedding-sdk-testing";
-import type { Card } from "metabase-types/api";
+import type { Card, TemplateTags } from "metabase-types/api";
+import { createMockParameter } from "metabase-types/api/mocks";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
   const setup = ({ display }: { display?: Card["display"] } = {}) => {
@@ -83,6 +87,95 @@ describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
       getSdkRoot().within(() => {
         cy.findByText("Product ID").should("be.visible");
         cy.findByText("Max of Quantity").should("be.visible");
+      });
+    });
+  });
+
+  it("should include the active editable filter in native question downloads (EMB-1549)", () => {
+    signInAsAdminAndSetupGuestEmbedding({ token: "pro-cloud" });
+
+    const TEMPLATE_TAGS: TemplateTags = {
+      category: {
+        id: "category",
+        name: "category",
+        "display-name": "Category",
+        type: "dimension",
+        "widget-type": "string/=",
+        dimension: ["field", PRODUCTS.CATEGORY, null],
+      },
+    };
+
+    const PARAMETERS = [
+      createMockParameter({
+        id: "category",
+        name: "Category",
+        slug: "category",
+        type: "string/=",
+        target: ["dimension", ["template-tag", "category"]],
+      }),
+    ];
+
+    createNativeQuestion(
+      {
+        name: "EMB-1549 native question with editable filter",
+        native: {
+          query: "SELECT * FROM PRODUCTS WHERE {{category}}",
+          "template-tags": TEMPLATE_TAGS,
+        },
+        parameters: PARAMETERS,
+        enable_embedding: true,
+        embedding_params: {
+          category: "enabled",
+        },
+      },
+      { wrapId: true },
+    );
+
+    cy.signOut();
+
+    cy.get("@questionId").then(async (questionId) => {
+      const token = await getSignedJwtForResource({
+        resourceId: questionId as unknown as number,
+        resourceType: "question",
+      });
+
+      mountGuestEmbedQuestion(
+        { token, withDownloads: true },
+        { shouldAssertCardQuery: false },
+      );
+
+      getSdkRoot()
+        .findAllByTestId("parameter-widget")
+        .filter(':contains("Category")')
+        .click();
+
+      cy.findByTestId("parameter-value-dropdown").within(() => {
+        cy.findByText("Widget").click();
+        cy.findByText("Add filter").click();
+      });
+
+      getSdkRoot()
+        .findAllByTestId("parameter-widget")
+        .filter(':contains("Category")')
+        .should("contain.text", "Widget");
+
+      downloadAndAssert({
+        isDashboard: false,
+        isEmbed: true,
+        enableFormatting: true,
+        assertStatusCode: 200,
+        waitForDismiss: false,
+        fileType: "csv",
+        downloadUrl: "/api/embed/card/*/query/csv*",
+        downloadMethod: "GET",
+      });
+
+      cy.get<Interception>("@fileDownload").then((interception) => {
+        const url = new URL(interception.request.url);
+        const parameters = JSON.parse(
+          url.searchParams.get("parameters") ?? "{}",
+        );
+        expect(parameters).to.deep.equal({ category: ["Widget"] });
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
@@ -15,6 +15,8 @@ import { createMockParameter } from "metabase-types/api/mocks";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
+const { H } = cy;
+
 describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
   const setup = ({ display }: { display?: Card["display"] } = {}) => {
     signInAsAdminAndSetupGuestEmbedding({
@@ -146,17 +148,17 @@ describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
 
       getSdkRoot()
         .findAllByTestId("parameter-widget")
-        .filter(':contains("Category")')
+        .button("Category")
         .click();
 
-      cy.findByTestId("parameter-value-dropdown").within(() => {
+      H.popover().within(() => {
         cy.findByText("Widget").click();
         cy.findByText("Add filter").click();
       });
 
       getSdkRoot()
         .findAllByTestId("parameter-widget")
-        .filter(':contains("Category")')
+        .button("Category")
         .should("contain.text", "Widget");
 
       downloadAndAssert({

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { getGuestEmbedFilteredParameters } from "embedding-sdk-bundle/lib/get-guest-embed-filtered-parameters";
 import {
   QuestionDownloadWidget,
   type UseDownloadDataParams,
@@ -24,7 +25,7 @@ const DownloadWidgetInner = ({
   ...rest
 }: DownloadWidgetProps &
   Pick<UseDownloadDataParams, "question" | "result">) => {
-  const { withDownloads } = useSdkQuestionContext();
+  const { withDownloads, parameterValues } = useSdkQuestionContext();
   const { token } = useEmbeddingEntityContext();
 
   const visualizationSettings = useMemo(
@@ -35,10 +36,19 @@ const DownloadWidgetInner = ({
     [question, result],
   );
 
+  // For Guest Embeds, downloads must honor the active editable filter state
+  // (EMB-1549). The `params` slug-keyed map mirrors what `runQuestionQuerySdk`
+  // sends for live results.
+  const params = useMemo(
+    () => getGuestEmbedFilteredParameters(question, parameterValues),
+    [question, parameterValues],
+  );
+
   const [, handleDownload] = useDownloadData({
     question,
     result,
     token,
+    params,
     visualizationSettings,
   });
 

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -324,40 +324,42 @@ const getEmbedDashcardParams = (
   }),
 });
 
+const convertSearchParamsToObject = (params: URLSearchParams) => {
+  const object: Record<string, string | string[]> = {};
+  for (const [key, value] of params.entries()) {
+    if (object[key]) {
+      object[key] = ([] as string[]).concat(
+        object[key] as string | string[],
+        value,
+      );
+    } else {
+      object[key] = value;
+    }
+  }
+
+  return object;
+};
+
 const getEmbedQuestionParams = (
   token: EntityToken,
   type: string,
+  params: Record<string, unknown>,
   exportParams: ExportParams,
 ): DownloadQueryResultsParams => {
-  const params = isEmbeddingSdk()
-    ? // For SDK/EmbedJS we must not read params from location search as in both cases
-      // additional params are not supported by a public endpoint
-      null
-    : new URLSearchParams(window.location.search);
-
-  const convertSearchParamsToObject = (params: URLSearchParams) => {
-    const object: Record<string, string | string[]> = {};
-    for (const [key, value] of params.entries()) {
-      if (object[key]) {
-        object[key] = ([] as string[]).concat(
-          object[key] as string | string[],
-          value,
-        );
-      } else {
-        object[key] = value;
-      }
-    }
-
-    return object;
-  };
+  // Guest Embed / SDK iframe embeds receive parameter values via postMessage
+  // from the host page, so window.location.search does not reflect the active
+  // editable filter state. Fall back to the params provided by the caller.
+  // Static embed iframes encode filter values in the iframe URL, so read them
+  // from window.location.search.
+  const downloadParameters = isEmbeddingSdk()
+    ? params
+    : convertSearchParamsToObject(new URLSearchParams(window.location.search));
 
   return {
     method: "GET",
     url: Urls.embedCard(token, type),
     params: new URLSearchParams({
-      ...(params && {
-        parameters: JSON.stringify(convertSearchParamsToObject(params)),
-      }),
+      parameters: JSON.stringify(downloadParameters),
       ..._.mapObject(exportParams, (value) => String(value)),
     }),
   };
@@ -423,7 +425,7 @@ const getAdHocQuestionParams = (
   },
 });
 
-const getDatasetParams = ({
+export const getDatasetParams = ({
   type,
   question,
   dashboardId,
@@ -494,7 +496,7 @@ const getDatasetParams = ({
       );
     }
     if (resourceType === "question" && token) {
-      return getEmbedQuestionParams(token, type, exportParams);
+      return getEmbedQuestionParams(token, type, params, exportParams);
     }
   }
 

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -346,7 +346,7 @@ const getEmbedQuestionParams = (
   params: Record<string, unknown>,
   exportParams: ExportParams,
 ): DownloadQueryResultsParams => {
-  // Guest Embed / SDK iframe embeds receive parameter values via postMessage
+  // Guest Embed / Modular embedding SDK embeds receive parameter values via postMessage
   // from the host page, so window.location.search does not reflect the active
   // editable filter state. Fall back to the params provided by the caller.
   // Static embed iframes encode filter values in the iframe URL, so read them

--- a/frontend/src/metabase/redux/downloads.unit.spec.ts
+++ b/frontend/src/metabase/redux/downloads.unit.spec.ts
@@ -1,8 +1,14 @@
+import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
 import api from "metabase/utils/api";
 import Question from "metabase-lib/v1/Question";
-import { createMockCard } from "metabase-types/api/mocks";
+import type { EntityToken } from "metabase-types/api/entity";
+import { createMockCard, createMockDataset } from "metabase-types/api/mocks";
 
-import { getChartFileName, getDatasetDownloadUrl } from "./downloads";
+import {
+  getChartFileName,
+  getDatasetDownloadUrl,
+  getDatasetParams,
+} from "./downloads";
 
 describe("getDatasetResponse", () => {
   describe("normal deployment", () => {
@@ -52,6 +58,74 @@ describe("getDatasetResponse", () => {
 
       expect(getDatasetDownloadUrl(url)).toBe(`/embed/question/123.xlsx`);
     });
+  });
+});
+
+describe("getDatasetParams - embed question (token-based)", () => {
+  const TOKEN = "fake.jwt.token" as EntityToken;
+  const question = new Question(createMockCard({ id: 1 }), undefined);
+  const result = createMockDataset();
+
+  const setLocationSearch = (search: string) => {
+    window.history.replaceState({}, "", `/${search}`);
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setLocationSearch("");
+  });
+
+  it("uses caller-provided params for guest embeds (EMB-1549)", async () => {
+    await mockIsEmbeddingSdk(true);
+    setLocationSearch("?stale_param=stale");
+
+    const downloadParams = getDatasetParams({
+      type: "csv",
+      question,
+      result,
+      token: TOKEN,
+      params: { country: "Brazil", quarter: "Q1" },
+    });
+
+    const url = new URLSearchParams(downloadParams.params);
+    expect(JSON.parse(url.get("parameters") ?? "")).toEqual({
+      country: "Brazil",
+      quarter: "Q1",
+    });
+  });
+
+  it("falls back to window.location.search for static embed iframes", async () => {
+    await mockIsEmbeddingSdk(false);
+    setLocationSearch("?country=Brazil&quarter=Q1");
+
+    const downloadParams = getDatasetParams({
+      type: "csv",
+      question,
+      result,
+      token: TOKEN,
+      params: {},
+    });
+
+    const url = new URLSearchParams(downloadParams.params);
+    expect(JSON.parse(url.get("parameters") ?? "")).toEqual({
+      country: "Brazil",
+      quarter: "Q1",
+    });
+  });
+
+  it("sends an empty parameters object for guest embeds when no filter is set", async () => {
+    await mockIsEmbeddingSdk(true);
+
+    const downloadParams = getDatasetParams({
+      type: "csv",
+      question,
+      result,
+      token: TOKEN,
+      params: {},
+    });
+
+    const url = new URLSearchParams(downloadParams.params);
+    expect(JSON.parse(url.get("parameters") ?? "")).toEqual({});
   });
 });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72090
Closes [EMB-1549: Guest-embedded native SQL question downloads do not honor editable filter state](https://linear.app/metabase/issue/EMB-1549/guest-embedded-native-sql-question-downloads-do-not-honor-editable)

### Description

For guest embeds (Embedded analytics JS), downloads of native SQL questions did not include the active editable filter values, so the exported file did not match what the user saw on screen. Locked params kept working because they live in the JWT, not the query string.

`getEmbedQuestionParams` in `frontend/src/metabase/redux/downloads.ts` deliberately set `params = null` whenever `isEmbeddingSdk()` was true, which covers both Guest Embeds and the SDK iframe. As a result, the embed download URL was missing the `parameters` query string entirely.

This PR threads the active parameter values through to the download endpoint:

- `getEmbedQuestionParams` now takes a caller-provided `params` map and uses it for SDK/Guest Embed contexts. Static embed iframes still read `window.location.search` since the host encodes filter values directly in the iframe URL.
- The SDK `DownloadWidget` pulls `parameterValues` from the SdkQuestion context and converts them to a slug-keyed map via the existing `getGuestEmbedFilteredParameters` helper, mirroring what `runQuestionQuerySdk` already does for live results.

Dashcard downloads were not affected — they already pass parameters via `getParameterValuesBySlugMap` in `PublicOrEmbeddedDashCardMenu` / `DashCardMenu`.

### How to verify

1. Admin → Settings → Embedding → enable **Embedded analytics JS** (and **Static embedding** for the secret key).
2. Create a native SQL question: `SELECT * FROM PRODUCTS WHERE {{category}}` with `category` as a Field Filter on `Products.Category`. Save.
3. Sharing → Embed → choose **Embedded analytics JS**. Set `category` to **Editable**, toggle **Downloads** on.
4. In the wizard preview, change the `Category` filter to e.g. `Widget`. The table updates.
5. Click the download icon → `.csv`.
6. The downloaded file should contain only `Widget` rows. Inspect the request in DevTools → Network: the URL should contain `parameters=%7B%22category%22%3A%5B%22Widget%22%5D%7D` (i.e. `{"category":["Widget"]}`).

Same flow works from a host page that mounts the generated `<metabase-question>` snippet.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR