### PR TITLE
Replace flaky e2e repro no. 55637 with predicate unit test

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1465,27 +1465,6 @@ describe("issue 55673", () => {
   });
 });
 
-describe("issue 55637", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should not show column metadata popovers when header cell is clicked (metabase#55637)", () => {
-    H.openOrdersTable();
-    H.tableHeaderColumn("ID").realHover();
-    cy.findByTestId("column-info").should("exist");
-
-    H.tableHeaderColumn("ID").click();
-
-    H.tableHeaderColumn("ID").realHover();
-    cy.findByTestId("column-info").should("not.exist");
-
-    H.tableHeaderColumn("Tax").realHover();
-    cy.findByTestId("column-info").should("not.exist");
-  });
-});
-
 describe("issue 63745", () => {
   beforeEach(() => {
     H.restore();

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -79,6 +79,7 @@ import {
 import { MiniBarCell } from "./cells/MiniBarCell";
 import { useObjectDetail } from "./hooks/use-object-detail";
 import { useResetWidthsOnColumnsChange } from "./hooks/use-reset-widths-on-columns-change";
+import { getInfoPopoversDisabled } from "./utils/get-info-popovers-disabled";
 import { tableThemeToDataGridTheme } from "./utils/table-theme-to-data-grid-theme";
 
 const shouldWrap = (
@@ -744,11 +745,12 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     enableSelection: true,
   });
   const { getCenterColumns, scrollTo, columnsReordering } = tableProps;
-  const infoPopoversDisabled =
-    clicked !== null ||
-    !hasMetadataPopovers ||
-    isDashboard ||
-    columnsReordering.isDragging;
+  const infoPopoversDisabled = getInfoPopoversDisabled({
+    clicked,
+    hasMetadataPopovers,
+    isDashboard,
+    isReorderingColumns: columnsReordering.isDragging,
+  });
   const tableInteractiveContextValue = useMemo(
     () => ({ infoPopoversDisabled }),
     [infoPopoversDisabled],

--- a/frontend/src/metabase/visualizations/components/TableInteractive/utils/get-info-popovers-disabled.ts
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/utils/get-info-popovers-disabled.ts
@@ -1,0 +1,22 @@
+import type { ClickObject } from "metabase-lib";
+
+type Args = {
+  clicked: ClickObject | null | undefined;
+  hasMetadataPopovers: boolean;
+  isDashboard: boolean;
+  isReorderingColumns: boolean;
+};
+
+export function getInfoPopoversDisabled({
+  clicked,
+  hasMetadataPopovers,
+  isDashboard,
+  isReorderingColumns,
+}: Args) {
+  return (
+    clicked !== null ||
+    !hasMetadataPopovers ||
+    isDashboard ||
+    isReorderingColumns
+  );
+}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/utils/get-info-popovers-disabled.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/utils/get-info-popovers-disabled.unit.spec.ts
@@ -1,0 +1,41 @@
+import type { ClickObject } from "metabase-lib";
+
+import { getInfoPopoversDisabled } from "./get-info-popovers-disabled";
+
+const baseArgs = {
+  clicked: null,
+  hasMetadataPopovers: true,
+  isDashboard: false,
+  isReorderingColumns: false,
+};
+
+describe("getInfoPopoversDisabled", () => {
+  it("returns false when nothing is suppressing the popovers", () => {
+    expect(getInfoPopoversDisabled(baseArgs)).toBe(false);
+  });
+
+  // metabase#55637: clicking a header cell sets `clicked` and the
+  // header-info popover must stop appearing on subsequent hovers.
+  it("returns true when a click action is open", () => {
+    const clicked = { element: document.createElement("div") } as ClickObject;
+    expect(getInfoPopoversDisabled({ ...baseArgs, clicked })).toBe(true);
+  });
+
+  it("returns true when the caller has opted out of metadata popovers", () => {
+    expect(
+      getInfoPopoversDisabled({ ...baseArgs, hasMetadataPopovers: false }),
+    ).toBe(true);
+  });
+
+  it("returns true when rendered inside a dashboard", () => {
+    expect(getInfoPopoversDisabled({ ...baseArgs, isDashboard: true })).toBe(
+      true,
+    );
+  });
+
+  it("returns true while a column drag-reorder is in progress", () => {
+    expect(
+      getInfoPopoversDisabled({ ...baseArgs, isReorderingColumns: true }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

- Extract the `infoPopoversDisabled` predicate from `TableInteractive` into a pure helper.
- Add a 5-case unit test pinning each clause, including `clicked !== null` (the #55637 fix you can see in #59510).
- Delete the e2e repro at `visualizations-tabular-reproductions.cy.spec.js` — Trunk flagged it and put it in the auto-quarantine. See it [here](https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/e8bb3bc3-416d-5d1e-9e56-b8b418282031).

## Why

- The bug was P3 (cosmetic); the e2e cost (flake noise) outweighed its value.
- Codecov line view shows that the only `TableInteractive` callsites that produce a non-null `clicked` are never exercised in unit tests. The `clicked !== null` branch of the predicate is therefore not covered through any click flow. The new helper test pins that branch directly.

## Gaps I'm not closing

- **Context propagation isn't tested.** The original fix used `useLatest`; current code uses `useMemo` + Context. A regression that re-introduces stale-value-at-render-time wouldn't be caught by either layer.
- **Consumer side** (`HeaderCellWithColumnInfo` rendering with/without the popover wrapper) is a 4-line conditional, covered only transitively by every test that mounts a table. I tried a dedicated unit test for it and threw it away — the setup cost dwarfed the assertion.

> [!IMPORTANT]
> This PR is a trade, not an equivalence. Open to pushback if peers think the e2e should stay. Keep in mind we're exercising "clicking" and "hovering" of the header cell in numerous other e2e tests. This specific one was _just_ testing one specific combination.
