### PR TITLE
Use restore task for cypress e2e to avoid unexpected /api/testing/restore failures

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -20,6 +20,7 @@ import {
   startMockLlmServer,
   stopMockLlmServer,
 } from "./helpers/e2e-mock-llm-tasks";
+import { restoreTasks } from "./helpers/e2e-restore-task";
 
 const createBundler = require("@bahmutov/cypress-esbuild-preprocessor"); // This function is called when a project is opened or re-opened (e.g. due to the project's config changing)
 const {
@@ -136,6 +137,7 @@ const defaultConfig = {
       ...dbTasks,
       ...ciTasks,
       ...verifyDownloadTasks,
+      ...restoreTasks,
       readDirectory,
       copyDirectory,
       removeDirectory,

--- a/e2e/support/helpers/e2e-restore-task.ts
+++ b/e2e/support/helpers/e2e-restore-task.ts
@@ -1,0 +1,74 @@
+import http from "node:http";
+
+import {
+  BACKEND_HOST,
+  BACKEND_PORT,
+} from "../../runner/constants/backend-port";
+
+type RestoreSnapshotArgs = {
+  name: string;
+  timeoutMs?: number;
+  retries?: number;
+};
+
+type RestoreSnapshotResult = {
+  ok: true;
+  attempts: number;
+  totalMs: number;
+};
+
+function attempt(name: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: "POST",
+        hostname: BACKEND_HOST,
+        port: BACKEND_PORT,
+        path: `/api/testing/restore/${encodeURIComponent(name)}`,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve();
+          } else {
+            reject(new Error(`restore returned status ${res.statusCode}`));
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error(`restore timed out after ${timeoutMs}ms`));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+export async function restoreSnapshot(
+  args: RestoreSnapshotArgs,
+): Promise<RestoreSnapshotResult> {
+  const { name, timeoutMs = 90_000, retries = 1 } = args;
+  const started = Date.now();
+  let lastErr: unknown;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      await attempt(name, timeoutMs);
+      return { ok: true, attempts: i + 1, totalMs: Date.now() - started };
+    } catch (e) {
+      lastErr = e;
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[restoreSnapshot] attempt ${i + 1} failed: ${msg}`);
+    }
+  }
+  throw new Error(
+    `restoreSnapshot(${name}) failed after ${retries + 1} attempts: ${
+      lastErr instanceof Error ? lastErr.message : String(lastErr)
+    }`,
+  );
+}
+
+export const restoreTasks = {
+  restoreSnapshot,
+};

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -1,5 +1,8 @@
 import { resetWritableDb } from "./e2e-qa-databases-helpers";
 
+const RESTORE_TIMEOUT_MS = 90_000;
+const RESTORE_RETRIES = 1;
+
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
@@ -48,7 +51,11 @@ export function restore(name = "default") {
     resetWritableDb({ type: dbType });
   }
 
-  return cy.request("POST", `/api/testing/restore/${name}`);
+  return cy.task(
+    "restoreSnapshot",
+    { name, timeoutMs: RESTORE_TIMEOUT_MS, retries: RESTORE_RETRIES },
+    { timeout: RESTORE_TIMEOUT_MS * (RESTORE_RETRIES + 1) + 5_000 },
+  );
 }
 
 /**


### PR DESCRIPTION
Use restore task for cypress e2e to avoid unexpected /api/testing/restore failures



This is the attempt to avoid failures with `/api/testing/restore`.