### PR TITLE
Fix issue with closed filesystem for python sources

### DIFF
--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -121,9 +121,9 @@
 
 ;;; -------------------------------------------------- Python path delay --------------------------------------------------
 
-(defn- ^FileSystem read-only-polyglot-fs
+(defn- read-only-polyglot-fs
   "Wrap an NIO `java.nio.file.FileSystem` as a read-only polyglot FileSystem suitable for GraalPy."
-  [^java.nio.file.FileSystem nio-fs]
+  ^FileSystem [^java.nio.file.FileSystem nio-fs]
   (-> nio-fs FileSystem/newFileSystem FileSystem/newReadOnlyFileSystem))
 
 (defonce ^:private

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -17,9 +17,8 @@
     Pool
     Pools)
    (java.io Closeable File)
-   (java.nio.file FileSystems Path)
+   (java.nio.file FileSystems)
    (java.time Duration)
-   (java.util Collections)
    (java.util.concurrent TimeUnit TimeoutException)
    (org.graalvm.polyglot Context HostAccess)
    (org.graalvm.polyglot.io FileSystem IOAccess)))
@@ -122,6 +121,11 @@
 
 ;;; -------------------------------------------------- Python path delay --------------------------------------------------
 
+(defn- ^FileSystem read-only-polyglot-fs
+  "Wrap an NIO `java.nio.file.FileSystem` as a read-only polyglot FileSystem suitable for GraalPy."
+  [^java.nio.file.FileSystem nio-fs]
+  (-> nio-fs FileSystem/newFileSystem FileSystem/newReadOnlyFileSystem))
+
 (defonce ^:private
   ^{:doc "A read-only polyglot FileSystem and the PythonPath within it.
           In dev: wraps the default filesystem, path is resources/python-sources.
@@ -131,29 +135,16 @@
   (delay
     (if (jar-resource? python-sources-resource)
       ;; In the jar: use the jar's zip filesystem directly. Python sources and GraalPy's stdlib are both inside the
-      ;; jar, so nothing is extracted to disk and there's nothing to tamper with.
-      ;;
-      ;; IMPORTANT: We must use the Path-based FileSystems/newFileSystem overload here, NOT the URI-based one. NIO
-      ;; maintains a global cache of zip filesystems keyed by URI. The URI-based overload registers in that cache, and
-      ;; other code (e.g. u.files/with-open-path-to-resource, u.files/find-in-current-jar) can obtain a reference to
-      ;; the same cached instance via FileSystems/getFileSystem and then close it inside a with-open block. That kills
-      ;; *our* filesystem and every subsequent GraalPy context creation fails with: PolyglotException:
-      ;; jdk.nio.zipfs.ZipFileSystem.ensureOpen The Path-based overload bypasses the cache entirely, giving us an
-      ;; independent instance whose lifecycle we fully control. This filesystem lives for the duration of the process
-      ;; (via defonce + delay) and is shared by all pooled Python contexts.
-      (let [jar-path (u.files/get-jar-path)
-            nio-fs   (FileSystems/newFileSystem (Path/of jar-path (into-array String []))
-                                                Collections/EMPTY_MAP)]
-        {:fs          (-> (FileSystem/newFileSystem nio-fs)
-                          FileSystem/newReadOnlyFileSystem)
-         :python-path "/python-sources"
-         :std-lib-home "/META-INF/resources/libpython"
-         :core-home "/META-INF/resources/libgraalpy"})
+      ;; jar, so nothing is extracted to disk and there's nothing to tamper with. The filesystem lives for the
+      ;; duration of the process (via defonce + delay) and is shared by all pooled Python contexts.
+      {:fs           (-> (u.files/get-jar-path) u.files/nio-fs read-only-polyglot-fs)
+       :python-path  "/python-sources"
+       :std-lib-home "/META-INF/resources/libpython"
+       :core-home    "/META-INF/resources/libgraalpy"}
       ;; In dev: use the real filesystem (read-only wrapper). sqlglot is installed locally.
       (do
         (ensure-sqlglot-installed!)
-        {:fs          (-> (FileSystem/newFileSystem (FileSystems/getDefault))
-                          FileSystem/newReadOnlyFileSystem)
+        {:fs          (read-only-polyglot-fs (FileSystems/getDefault))
          :python-path dev-python-sources-dir}))))
 
 ;;; -------------------------------------------- Context Wrappers ----------------------------------------------------

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -17,7 +17,7 @@
     Pool
     Pools)
    (java.io Closeable File)
-   (java.nio.file FileSystems)
+   (java.nio.file FileSystems Path)
    (java.time Duration)
    (java.util Collections)
    (java.util.concurrent TimeUnit TimeoutException)
@@ -130,11 +130,20 @@
   python-fs-and-path
   (delay
     (if (jar-resource? python-sources-resource)
-      ;; In the jar: use the jar's zip filesystem directly. Python sources and GraalPy's stdlib
-      ;; are both inside the jar, so nothing is extracted to disk and there's nothing to tamper with.
+      ;; In the jar: use the jar's zip filesystem directly. Python sources and GraalPy's stdlib are both inside the
+      ;; jar, so nothing is extracted to disk and there's nothing to tamper with.
+      ;;
+      ;; IMPORTANT: We must use the Path-based FileSystems/newFileSystem overload here, NOT the URI-based one. NIO
+      ;; maintains a global cache of zip filesystems keyed by URI. The URI-based overload registers in that cache, and
+      ;; other code (e.g. u.files/with-open-path-to-resource, u.files/find-in-current-jar) can obtain a reference to
+      ;; the same cached instance via FileSystems/getFileSystem and then close it inside a with-open block. That kills
+      ;; *our* filesystem and every subsequent GraalPy context creation fails with: PolyglotException:
+      ;; jdk.nio.zipfs.ZipFileSystem.ensureOpen The Path-based overload bypasses the cache entirely, giving us an
+      ;; independent instance whose lifecycle we fully control. This filesystem lives for the duration of the process
+      ;; (via defonce + delay) and is shared by all pooled Python contexts.
       (let [jar-path (u.files/get-jar-path)
-            jar-uri  (java.net.URI. (str "jar:file:" jar-path))
-            nio-fs   (FileSystems/newFileSystem jar-uri Collections/EMPTY_MAP)]
+            nio-fs   (FileSystems/newFileSystem (Path/of jar-path (into-array String []))
+                                                Collections/EMPTY_MAP)]
         {:fs          (-> (FileSystem/newFileSystem nio-fs)
                           FileSystem/newReadOnlyFileSystem)
          :python-path "/python-sources"

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -117,6 +117,18 @@
         (log/info "File system at" uri "already exists")
         (FileSystems/getFileSystem uri)))))
 
+(defn nio-fs
+  "Open a fresh NIO zip filesystem for the file at `path`."
+  ^FileSystem [^String path]
+  ;; Use the Path-based FileSystems/newFileSystem overload, NOT the URI-based one (see jar-file-system-from-url above
+  ;; for the URI-based pattern). NIO maintains a global cache of zip filesystems keyed by URI; the URI-based overload
+  ;; registers in that cache, so other code (e.g. with-open-path-to-resource, find-in-current-jar) can obtain the
+  ;; cached instance via FileSystems/getFileSystem and close it inside a with-open block, killing the original
+  ;; filesystem and breaking any long-lived consumer (e.g. GraalPy contexts pinned to that filesystem). The Path-based
+  ;; overload bypasses the cache, giving an independent instance whose lifecycle the caller fully controls.
+  (-> (Path/of path (u/varargs String))
+      (FileSystems/newFileSystem Collections/EMPTY_MAP)))
+
 (defn do-with-open-path-to-resource
   "Impl for `with-open-path-to-resource`."
   [resource f]

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -46,4 +46,8 @@
         ;; Closing fs1 must not affect fs2.
         (.close fs1)
         (is (thrown? ClosedFileSystemException (read-hello fs1)))
-        (is (= "hi" (read-hello fs2)))))))
+        (is (= "hi" (read-hello fs2))))
+      ;; Subsequent opens still work after the previous instances close — documents that nothing was left in a
+      ;; permanently-broken state.
+      (with-open [fs (u.files/nio-fs zip-path)]
+        (is (= "hi" (read-hello fs)))))))

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -9,6 +9,8 @@
    (java.nio.file ClosedFileSystemException FileSystem Files)
    (java.util.zip ZipEntry ZipOutputStream)))
 
+(set! *warn-on-reflection* true)
+
 (deftest is-regular-file-test
   (mt/with-temp-file [file "temp-file"]
     (testing (format "file = %s" (pr-str file))
@@ -18,7 +20,7 @@
     (testing (format "dir = %s" (pr-str dir)))
     (let [file-in-dir (str (u.files/get-path dir "file"))]
       (testing (format "file = %s" (pr-str file-in-dir))
-        (spit file-in-dir "abc") ; create a file in the dir to make sure it exists
+        (spit file-in-dir "abc")        ; create a file in the dir to make sure it exists
         (is (u.files/regular-file? (u.files/get-path file-in-dir)))))
     (is (not (u.files/regular-file? (u.files/get-path dir))))))
 

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -6,7 +6,7 @@
    [metabase.util.files :as u.files])
   (:import
    (java.io FileOutputStream)
-   (java.nio.file FileSystem Files)
+   (java.nio.file ClosedFileSystemException FileSystem Files)
    (java.util.zip ZipEntry ZipOutputStream)))
 
 (deftest is-regular-file-test
@@ -34,17 +34,16 @@
   (Files/readString (.getPath fs "/hello.txt" (u/varargs String))))
 
 (deftest nio-fs-bypasses-uri-cache-test
-  (testing "nio-fs can open multiple independent filesystems for the same zip simultaneously"
+  (testing "nio-fs returns independent filesystems for the same zip — closing one cannot kill another"
     (mt/with-temp-file [zip-path]
       (write-test-zip! zip-path)
-      ;; Two simultaneous with-open bindings — the URI-based FileSystems/newFileSystem overload would throw
-      ;; FileSystemAlreadyExistsException on the second open since the cache entry is still live. The Path-based
-      ;; overload returns independent instances that can both read the zip contents.
       (with-open [fs1 (u.files/nio-fs zip-path)
                   fs2 (u.files/nio-fs zip-path)]
+        ;; Both filesystems read the entry — distinguishes Path-based (works) from URI-based (would throw
+        ;; FileSystemAlreadyExistsException on the second open since the cache entry would still be live).
         (is (= "hi" (read-hello fs1)))
-        (is (= "hi" (read-hello fs2))))
-      ;; A follow-up open succeeds — closing the previous instances didn't leave the helper in a permanently closed
-      ;; state.
-      (with-open [fs (u.files/nio-fs zip-path)]
-        (is (= "hi" (read-hello fs)))))))
+        (is (= "hi" (read-hello fs2)))
+        ;; Closing fs1 must not affect fs2.
+        (.close fs1)
+        (is (thrown? ClosedFileSystemException (read-hello fs1)))
+        (is (= "hi" (read-hello fs2)))))))

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -2,9 +2,11 @@
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [metabase.util.files :as u.files])
   (:import
    (java.io FileOutputStream)
+   (java.nio.file FileSystem Files)
    (java.util.zip ZipEntry ZipOutputStream)))
 
 (deftest is-regular-file-test
@@ -21,25 +23,28 @@
     (is (not (u.files/regular-file? (u.files/get-path dir))))))
 
 (defn- write-test-zip!
-  "Write a minimal zip file at `path` containing a single entry."
+  "Write a minimal zip file at `path` containing a single `hello.txt` entry with content `hi`."
   [^String path]
   (with-open [zos (ZipOutputStream. (FileOutputStream. path))]
     (.putNextEntry zos (ZipEntry. "hello.txt"))
     (.write zos (.getBytes "hi"))
     (.closeEntry zos)))
 
+(defn- read-hello [^FileSystem fs]
+  (Files/readString (.getPath fs "/hello.txt" (u/varargs String))))
+
 (deftest nio-fs-bypasses-uri-cache-test
   (testing "nio-fs can open multiple independent filesystems for the same zip simultaneously"
-    (mt/with-temp-file [path "u-files-nio-fs.jar"]
-      (write-test-zip! path)
+    (mt/with-temp-file [zip-path]
+      (write-test-zip! zip-path)
       ;; Two simultaneous with-open bindings — the URI-based FileSystems/newFileSystem overload would throw
       ;; FileSystemAlreadyExistsException on the second open since the cache entry is still live. The Path-based
-      ;; overload returns independent instances and both stay open through the body.
-      (with-open [fs1 (u.files/nio-fs path)
-                  fs2 (u.files/nio-fs path)]
-        (is (.isOpen fs1))
-        (is (.isOpen fs2)))
+      ;; overload returns independent instances that can both read the zip contents.
+      (with-open [fs1 (u.files/nio-fs zip-path)
+                  fs2 (u.files/nio-fs zip-path)]
+        (is (= "hi" (read-hello fs1)))
+        (is (= "hi" (read-hello fs2))))
       ;; A follow-up open succeeds — closing the previous instances didn't leave the helper in a permanently closed
       ;; state.
-      (with-open [fs (u.files/nio-fs path)]
-        (is (.isOpen fs))))))
+      (with-open [fs (u.files/nio-fs zip-path)]
+        (is (= "hi" (read-hello fs)))))))

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -47,7 +47,6 @@
         (.close fs1)
         (is (thrown? ClosedFileSystemException (read-hello fs1)))
         (is (= "hi" (read-hello fs2))))
-      ;; Subsequent opens still work after the previous instances close — documents that nothing was left in a
-      ;; permanently-broken state.
+      ;; Subsequent opens still work after previous instance closes — not in a permanently-broken state.
       (with-open [fs (u.files/nio-fs zip-path)]
         (is (= "hi" (read-hello fs)))))))

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -2,7 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]
-   [metabase.util.files :as u.files]))
+   [metabase.util.files :as u.files])
+  (:import
+   (java.io FileOutputStream)
+   (java.util.zip ZipEntry ZipOutputStream)))
 
 (deftest is-regular-file-test
   (mt/with-temp-file [file "temp-file"]
@@ -16,3 +19,27 @@
         (spit file-in-dir "abc") ; create a file in the dir to make sure it exists
         (is (u.files/regular-file? (u.files/get-path file-in-dir)))))
     (is (not (u.files/regular-file? (u.files/get-path dir))))))
+
+(defn- write-test-zip!
+  "Write a minimal zip file at `path` containing a single entry."
+  [^String path]
+  (with-open [zos (ZipOutputStream. (FileOutputStream. path))]
+    (.putNextEntry zos (ZipEntry. "hello.txt"))
+    (.write zos (.getBytes "hi"))
+    (.closeEntry zos)))
+
+(deftest nio-fs-bypasses-uri-cache-test
+  (testing "nio-fs can open multiple independent filesystems for the same zip simultaneously"
+    (mt/with-temp-file [path "u-files-nio-fs.jar"]
+      (write-test-zip! path)
+      ;; Two simultaneous with-open bindings — the URI-based FileSystems/newFileSystem overload would throw
+      ;; FileSystemAlreadyExistsException on the second open since the cache entry is still live. The Path-based
+      ;; overload returns independent instances and both stay open through the body.
+      (with-open [fs1 (u.files/nio-fs path)
+                  fs2 (u.files/nio-fs path)]
+        (is (.isOpen fs1))
+        (is (.isOpen fs2)))
+      ;; A follow-up open succeeds — closing the previous instances didn't leave the helper in a permanently closed
+      ;; state.
+      (with-open [fs (u.files/nio-fs path)]
+        (is (.isOpen fs))))))


### PR DESCRIPTION
Python works out of the box, but there is an issue with the way we give it it's filesystem. When using URI based filesystems, if it already exists it throws an error. Note this here:

```clojure
;; from metabase.util.files which loads fonts, audit app, types for the user key/value system, and xray yaml files.
(defn- jar-file-system-from-url ^FileSystem [^URL url]
  (let [uri (.toURI url)]
    (try
      (FileSystems/newFileSystem uri Collections/EMPTY_MAP)
      (catch FileSystemAlreadyExistsException _
        (log/info "File system at" uri "already exists")
        (FileSystems/getFileSystem uri)))))
```

It tries to create the new one, and if it already exists it just returns the existing one got from `getFileSystem`.

So mentally: understand that we just got the existing one and returned it, which means IT IS A SHARED RESOURCE. But this code gets passed to

```clojure
(with-open [fs (jar-file-system-from-url url)]
  (f (get-path-in-filesystem fs "/" resource)))
```

Which will close a filesystem that we did not create. Fundamentally a bad call here.

And that's the ballgame. We just closed a filesystem that someone else created. And now python can no longer find its sources.

The fix is to use a Path based filesystem. Now they are no longer shared and we keep this open for the duration of the process. Each python context will use this.

So the race is if python parsing is kicked off early in a task, then fonts are loaded, xray yaml files, types for the user key/value, the shared jar filesystem will be closed after the font is loaded, leaving the python contexts permanently without their source