### PR TITLE
Provide an ApplicationName when running Athena queries

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -64,16 +64,17 @@
 (defmethod sql-jdbc.conn/connection-details->spec :athena
   [_driver {:keys [region access_key secret_key s3_staging_dir workgroup catalog dbname hostname], :as details}]
   (-> (merge
-       {:classname      "com.amazon.athena.jdbc.AthenaDriver"
-        :subprotocol    "athena"
-        :subname       (if (str/blank? hostname)
-                         (endpoint-for-region region)
-                         (str "//" hostname ":443"))
-        :User           access_key
-        :Password       secret_key
-        :OutputLocation s3_staging_dir
-        :WorkGroup      workgroup
-        :Region      region}
+       {:classname       "com.amazon.athena.jdbc.AthenaDriver"
+        :subprotocol     "athena"
+        :subname         (if (str/blank? hostname)
+                           (endpoint-for-region region)
+                           (str "//" hostname ":443"))
+        :User            access_key
+        :Password        secret_key
+        :OutputLocation  s3_staging_dir
+        :WorkGroup       workgroup
+        :Region          region
+        :ApplicationName driver-api/mb-app-id-string}
        (when dbname
          {:database dbname})
        (when (and (not (driver-api/is-hosted?)) (str/blank? access_key))

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.driver-api.core :as driver-api]
    [metabase.driver.athena :as athena]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -75,6 +76,11 @@
       "us-west-2"      "//athena.us-west-2.amazonaws.com:443"
       "cn-north-1"     "//athena.cn-north-1.amazonaws.com.cn:443"
       "cn-northwest-1" "//athena.cn-northwest-1.amazonaws.com.cn:443")))
+
+(deftest ^:parallel connection-spec-application-name-test
+  (testing "connection spec includes ApplicationName"
+    (is (= driver-api/mb-app-id-string
+           (:ApplicationName (sql-jdbc.conn/connection-details->spec :athena {:region "us-east-1"}))))))
 
 (deftest ^:parallel athena-subname-uses-hostname-test
   (mt/test-driver :athena


### PR DESCRIPTION
### Description

I'm a member of the Amazon Athena team. This change adds the JDBC `ApplicationName` parameter when connecting to Athena. This will provide a way for us to include Metabase when breaking down usage by source.

I saw that other drivers were using `config/mb-version-and-process-identifier` as `ApplicationName`, but opted to use only the first part of that string, `config/mb-app-id-string`, since the second part is a UUID unique to the local process. This keeps the telemetry anonymous, with only "Metabase" and the version string being sent.

### How to verify

Tests provided

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
