### PR TITLE
put non-aot drivers into jar

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -152,14 +152,7 @@
       (u/step (format "Copy resources from %s" path)
         (b/copy-dir {:target-dir class-dir
                      :src-dirs   [path]
-                     :ignores    resource-ignore-patterns})))
-    ;; Drivers excluded from AOT need their source files in the jar so they can be compiled lazily at runtime.
-    (doseq [driver drivers-excluded-from-aot]
-      (let [src-dir (u/filename u/project-root-directory "modules" "drivers" driver "src")]
-        (when (.isDirectory (io/file src-dir))
-          (u/step (format "Copy source for non-AOT driver %s" driver)
-            (b/copy-dir {:target-dir class-dir
-                         :src-dirs   [src-dir]})))))))
+                     :ignores    resource-ignore-patterns})))))
 
 (def ^:private dependency-ignore-patterns
   "Files to ignore when copying resources from our dependencies."
@@ -200,6 +193,25 @@
   (.write (manifest) os)
   (.flush os))
 
+(defn- add-non-aot-driver-sources!
+  "Inject source files for drivers excluded from AOT directly into the uberjar.
+  These drivers can't be AOT-compiled (their ns forms reference JDBC classes not bundled due to licensing), so they
+  ship as source and are compiled lazily at runtime. We add them after b/uber because uber strips all .clj files from
+  class-dir."
+  []
+  (u/step "Add non-AOT driver sources to uberjar"
+    (u/with-open-jar-file-system [fs uberjar-filename]
+      (doseq [driver drivers-excluded-from-aot
+              :let [src-dir (io/file (u/filename u/project-root-directory "modules" "drivers" driver "src"))]
+              :when (.isDirectory src-dir)]
+        (u/step (format "Add source for %s" driver)
+          (doseq [^File f (file-seq src-dir)
+                  :when (.isFile f)]
+            (let [rel-path (.toString (.relativize (.toPath src-dir) (.toPath f)))
+                  target   (u/get-path-in-filesystem fs rel-path)]
+              (Files/createDirectories (.getParent target) (into-array java.nio.file.attribute.FileAttribute []))
+              (Files/copy (.toPath f) target (into-array java.nio.file.CopyOption [])))))))))
+
 (defn update-manifest!
   "Start a build step that updates the manifest.
   The customizations we need to make are not currently supported by tools.build -- see
@@ -226,5 +238,6 @@
         (compile-sources! basis)
         (copy-resources! basis)
         (create-uberjar! basis)
+        (add-non-aot-driver-sources!)
         (update-manifest!))
       (u/announce "Built %s in %.1f seconds." uberjar-filename (/ duration-ms 1000.0)))))


### PR DESCRIPTION
before we would build jars and load them at runtime. then we put everything into the normal jar so we can not have our own first party drivers have to go through these hoops. We have postgres, h2, mysql on the classpath.

We strip our clojure source files and this was removing the non-aot'd versions. We had two options to get them back in:

1. update the "remove" regex we use to strip these out
2. patch the jar after being built

the first was getting kinda gnarly with negative lookaheads. The uber task we use treats these as an "OR", so if any regex matches it is excluded from the jar. I would have favored this perhaps if we didn't already patch up the jar, but we do.

We patch up the jar to include the version information, so it felt natural to also patch it up to include all files in the excluded directories for the drivers. Oracle and vertica are just simple namespaces so they aren't complicated, but something like mongo that has it's own query processor would have all files brought along