### PR TITLE
Keep oracle/vertica .clj source in uberjar (#73560)

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -1,6 +1,7 @@
 (ns build.uberjar
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [clojure.tools.build.util.zip :as build.zip]
    [clojure.tools.namespace.dependency :as ns.deps]
@@ -162,8 +163,12 @@
                          :src-dirs   [src-dir]})))))))
 
 (def ^:private dependency-ignore-patterns
-  "Files to ignore when copying resources from our dependencies."
-  [#".*metabase.*\.clj[c|s]?$"
+  "Files to ignore when copying resources from our dependencies.
+
+  NB: `b/uber` applies these to `class-dir` too, hence the [[drivers-excluded-from-aot]] carve-out (#73560)."
+  [(re-pattern
+    (format "(?!metabase/driver/(?:%s)(?:/.*)?\\.clj[cs]?$).*metabase.*\\.clj[c|s]?$"
+            (str/join "|" drivers-excluded-from-aot)))
    ;; ignore module-info files inside META-INF because we don't have a modular JAR and they can break tools like `jar
    ;; tf` -- see Slacc thread
    ;; https://metaboat.slack.com/archives/C5XHN8GLW/p1731633690703149?thread_ts=1731504670.951389&cid=C5XHN8GLW

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -1,7 +1,7 @@
 (ns build.uberjar-test
   (:require
    [build.uberjar]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [are deftest testing]]))
 
 (set! *warn-on-reflection* true)
 
@@ -10,14 +10,13 @@
     (boolean (some #(re-matches % path) patterns))))
 
 (deftest dependency-ignore-patterns-test
-  (testing "drivers excluded from AOT keep their .clj source in the uberjar (#73560)"
-    (is (not (excluded? "metabase/driver/oracle.clj")))
-    (is (not (excluded? "metabase/driver/vertica.clj")))
-    (is (not (excluded? "metabase/driver/oracle.cljc")))
-    (is (not (excluded? "metabase/driver/oracle/util.clj"))
-        "future helper namespaces under the carved-out drivers must also be kept"))
-  (testing "metabase clj source from AOT-compiled drivers and core is still excluded"
-    (is (excluded? "metabase/driver/h2.clj"))
-    (is (excluded? "metabase/util.clj"))
-    (is (excluded? "metabase/driver/oracleish.clj"))
-    (is (excluded? "metabase/util/oracle.clj"))))
+  (testing "carve-out for drivers excluded from AOT keeps their .clj source (#73560)"
+    (are [path excluded] (= excluded (excluded? path))
+      "metabase/driver/oracle.clj"      false
+      "metabase/driver/vertica.clj"     false
+      "metabase/driver/oracle.cljc"     false
+      "metabase/driver/oracle/util.clj" false ; future helper namespaces under the carved-out drivers
+      "metabase/driver/h2.clj"          true
+      "metabase/util.clj"               true
+      "metabase/driver/oracleish.clj"   true
+      "metabase/util/oracle.clj"        true)))

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -5,18 +5,15 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- excluded? [path]
-  (let [patterns @#'build.uberjar/dependency-ignore-patterns]
-    (boolean (some #(re-matches % path) patterns))))
-
 (deftest dependency-ignore-patterns-test
   (testing "carve-out for drivers excluded from AOT keeps their .clj source (#73560)"
-    (are [path excluded] (= excluded (excluded? path))
-      "metabase/driver/oracle.clj"      false
-      "metabase/driver/vertica.clj"     false
-      "metabase/driver/oracle.cljc"     false
-      "metabase/driver/oracle/util.clj" false ; future helper namespaces under the carved-out drivers
-      "metabase/driver/h2.clj"          true
-      "metabase/util.clj"               true
-      "metabase/driver/oracleish.clj"   true
-      "metabase/util/oracle.clj"        true)))
+    (let [patterns @#'build.uberjar/dependency-ignore-patterns]
+      (are [path excluded] (= excluded (boolean (some #(re-matches % path) patterns)))
+        "metabase/driver/oracle.clj"      false
+        "metabase/driver/vertica.clj"     false
+        "metabase/driver/oracle.cljc"     false
+        "metabase/driver/oracle/util.clj" false ; future helper namespaces under the carved-out drivers
+        "metabase/driver/h2.clj"          true
+        "metabase/util.clj"               true
+        "metabase/driver/oracleish.clj"   true
+        "metabase/util/oracle.clj"        true))))

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -1,0 +1,23 @@
+(ns build.uberjar-test
+  (:require
+   [build.uberjar]
+   [clojure.test :refer [deftest is testing]]))
+
+(set! *warn-on-reflection* true)
+
+(defn- excluded? [path]
+  (let [patterns @#'build.uberjar/dependency-ignore-patterns]
+    (boolean (some #(re-matches % path) patterns))))
+
+(deftest dependency-ignore-patterns-test
+  (testing "drivers excluded from AOT keep their .clj source in the uberjar (#73560)"
+    (is (not (excluded? "metabase/driver/oracle.clj")))
+    (is (not (excluded? "metabase/driver/vertica.clj")))
+    (is (not (excluded? "metabase/driver/oracle.cljc")))
+    (is (not (excluded? "metabase/driver/oracle/util.clj"))
+        "future helper namespaces under the carved-out drivers must also be kept"))
+  (testing "metabase clj source from AOT-compiled drivers and core is still excluded"
+    (is (excluded? "metabase/driver/h2.clj"))
+    (is (excluded? "metabase/util.clj"))
+    (is (excluded? "metabase/driver/oracleish.clj"))
+    (is (excluded? "metabase/util/oracle.clj"))))


### PR DESCRIPTION
## Summary
- Fix #73560 — Oracle/Vertica drivers fail to load on a fresh uberjar with `No method in multimethod 'connection-details->spec' for dispatch value: :oracle`. The classpath-flatten change in #73519 left these drivers' `.clj` source out of the jar.
- The `dependency-ignore-patterns` regex `.*metabase.*\.clj[c|s]?$` was applied to every source `b/uber` packaged — including `class-dir` and the `:local/root` driver paths — so the `oracle.clj`/`vertica.clj` source files that `copy-resources!` staged for runtime compilation were stripped right back out.
- Carve out `drivers-excluded-from-aot` via a negative lookahead derived from the same set, so adding/removing a non-AOT driver updates both behaviors in one place.

## Test plan
- [x] `clojure -X:dev:drivers:build:build-dev:build-test :only '["bin/build/test/build/uberjar_test.clj"]'` — new `dependency-ignore-patterns-test` covers both halves: oracle/vertica `.clj` kept; AOT-driver and core metabase `.clj` still excluded (8 assertions).
- [x] Build an EE uberjar locally and confirm `metabase/driver/oracle.clj` / `metabase/driver/vertica.clj` are present (`unzip -l target/uberjar/metabase.jar | grep -E 'driver/(oracle|vertica)\.clj'`).
- [ ] Smoke-test against an Oracle DB on the resulting jar.