### PR TITLE
Bump jackson-core/databind 2.21.2 -> 2.21.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,8 +32,8 @@
   com.clojure-goes-fast/jvm-hiccup-meter    {:mvn/version "0.1.1"}              ; Monitor GC pauses and other system-induced pauses.
   com.draines/postal                        {:mvn/version "2.0.5"               ; SMTP library
                                              :exclusions [com.sun.mail/jakarta.mail]}
-  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.2"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
-  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.2"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
+  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.3"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
+  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.3"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.1"}              ; trans dep of commons-codec
                                                                                 ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -30,4 +30,4 @@
   io.netty/netty-common                  {:mvn/version "4.2.12.Final"}
   io.netty/netty-buffer                  {:mvn/version "4.2.12.Final"}
   ;; pinned: google-cloud-bigquery pulls 2.18.2 which has resource exhaustion vulns
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.3"}}}

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -11,5 +11,5 @@
   org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}
   ;; pinned: databricks-jdbc-thin pulls older transitive versions
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.3"}
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.3.5"}}}

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -8,4 +8,4 @@
  {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.2.5"}
   com.amazonaws/aws-java-sdk-core     {:mvn/version "1.12.792"}
   ;; pinned: aws-java-sdk-core pulls jackson-core 2.17.2 which has resource exhaustion vulns
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.3"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -16,4 +16,4 @@
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.84"}
   ;; pinned: snowflake-jdbc-thin 4.1.0 pulls jackson-core 2.18.4.1 which has resource exhaustion vulns
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.3"}}}


### PR DESCRIPTION
## Summary

Bumps `jackson-core` and `jackson-databind` 2.21.2 -> 2.21.3 across the top-level `/deps.edn` and the snowflake, bigquery, databricks, and redshift driver `deps.edn` files.

2.21.3 was released 2026-04-28; 2.21.2 was the previous patch release. No behavioural changes for us — purely a low-risk patch bump.

## Why split from #73567

Stacked on top of #73567 ("bump snowflake-jdbc-thin 4.0.1 -> 4.1.0") to keep that PR as a single one-line driver bump and address the version-skew concern Copilot raised separately.

## Test plan

- [ ] CI green