### PR TITLE
Tighten spacing below Group limits heading (UXW-3956)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsSettingsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsSettingsSection.tsx
@@ -104,7 +104,7 @@ export function GroupLimitsSettingsSection() {
 
   if (!isUsingTenants) {
     return (
-      <SettingsSection title={t`Group limits`}>
+      <SettingsSection title={t`Group limits`} stackProps={{ gap: 0 }}>
         <GroupLimitsTab
           data-testid="user-group-limits-tab"
           {...commonLimitPeriodProps}


### PR DESCRIPTION
### Description

Fixes [UXW-3956](https://linear.app/metabase/issue/UXW-3956/too-much-space-in-between-group-limits-heading-and-description).

The 32px between the "Group limits" heading and its description was the sum of `SettingsSection`'s outer `Stack gap="lg"` (24px) plus the title block's `mb="sm"` (8px). Zeroing the Stack gap on the no-tabs branch leaves only the 8px the design calls for.

### How to verify

- [ ] Visit `/admin/metabot/1/usage-controls/ai-usage-limits` with `use-tenants` off → 8px between "Group limits" heading and description.

<img width="1059" height="297" alt="image" src="https://github.com/user-attachments/assets/f5b7f1a9-3445-4a76-8968-513d6fd52739" />


