### PR TITLE
[GDGT-2385] block transform runs when trial quotas run out based on token check sync

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -415,3 +415,62 @@
           (testing "transform in root collection has root collection hydrated"
             (is (= "Transforms"
                    (get-in (runs-by-id run-in-root-id) [:transform :collection :name])))))))))
+
+(deftest run-transform-locked-meter-returns-402-test
+  (testing "POST /api/transform/:id/run returns 402 with the structured lock error when the meter is locked.
+            Asserted at the API layer — execution is never reached, so no driver setup is needed."
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/dataset transforms-dataset/transforms-test
+          (mt/with-temp [:model/Transform {transform-id :id} (query-transform-payload
+                                                              (str "locked_" (u/generate-nano-id)))]
+            (testing "basic-bucket lock returns metabase_transforms_locked 402"
+              (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+                (let [response (mt/user-http-request :crowberto :post 402
+                                                     (format "transform/%d/run" transform-id))]
+                  (is (= "metabase_transforms_locked" (:error-code response)))
+                  (is (string? (:message response)))
+                  (is (re-find #"locked" (:message response))))))
+            (testing "advanced-bucket lock — same generic error code (no bucket-specific code)"
+              ;; Add :writable-connection so the basic-mbql transform routes to advanced bucket.
+              (mt/with-premium-features #{:hosting :transforms-basic :writable-connection}
+                (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+                  (let [response (mt/user-http-request :crowberto :post 402
+                                                       (format "transform/%d/run" transform-id))]
+                    (is (= "metabase_transforms_locked" (:error-code response)))))))))))))
+
+(deftest get-transform-settings-test
+  (testing "GET /api/transform/settings returns the aggregate enabled+is_locked shape the FE consumes"
+    (testing "OSS / no premium features → enabled=false, is_locked=false"
+      (mt/with-premium-features #{}
+        (mt/with-temporary-setting-values [locked-meters {}]
+          ;; OSS gets query transforms when self-hosted, so :enabled is true; assert shape
+          (let [response (mt/user-http-request :crowberto :get 200 "transform/settings")]
+            (is (false? (:is_locked response)))
+            (is (contains? response :enabled))
+            (is (= #{:enabled :is_locked} (set (keys response))))))))
+    (testing "hosted basic, no locks → enabled=true, is_locked=false"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {}]
+          (is (= {:enabled true :is_locked false}
+                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
+    (testing "basic-bucket lock → is_locked=true"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+          (is (= {:enabled true :is_locked true}
+                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
+    (testing "advanced-bucket lock → is_locked=true"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+          (is (= {:enabled true :is_locked true}
+                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
+    (testing "non-transform meter (e.g. AI tokens) does not show up as transform lock"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
+          (is (= {:enabled true :is_locked false}
+                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
+    (testing "data-analyst (non-admin) can read the endpoint"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+          (is (= {:enabled true :is_locked true}
+                 (mt/user-http-request :rasta :get 200 "transform/settings"))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -440,35 +440,31 @@
                     (is (= "metabase_transforms_locked" (:error-code response)))))))))))))
 
 (deftest get-transform-settings-test
-  (testing "GET /api/transform/settings returns the aggregate enabled+is_locked shape the FE consumes"
-    (testing "OSS / no premium features → enabled=false, is_locked=false"
-      (mt/with-premium-features #{}
-        (mt/with-temporary-setting-values [locked-meters {}]
-          ;; OSS gets query transforms when self-hosted, so :enabled is true; assert shape
-          (let [response (mt/user-http-request :crowberto :get 200 "transform/settings")]
-            (is (false? (:is_locked response)))
-            (is (contains? response :enabled))
-            (is (= #{:enabled :is_locked} (set (keys response))))))))
-    (testing "hosted basic, no locks → enabled=true, is_locked=false"
+  (testing "GET /api/transform/settings — integration coverage for the endpoint.
+            Lock-state matrix is owned by metabase.transforms.feature-gating-test/transforms-meter-locked?-test;
+            this test focuses on the API surface: response shape, :enabled gating, auth, and round-trip wiring."
+    (testing "response shape and :enabled gating"
+      (testing "OSS, self-hosted, no features → :enabled true (OSS gets query transforms), :is_locked false"
+        (mt/with-premium-features #{}
+          (mt/with-temporary-setting-values [locked-meters {}]
+            (let [response (mt/user-http-request :crowberto :get 200 "transform/settings")]
+              (is (= #{:enabled :is_locked} (set (keys response))) "schema is closed")
+              (is (false? (:is_locked response)))))))
+      (testing "hosted, no premium → :enabled false (no transforms-basic and is-hosted)"
+        (mt/with-premium-features #{:hosting}
+          (mt/with-temporary-setting-values [locked-meters {}]
+            (is (= {:enabled false :is_locked false}
+                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))))
+    (testing "wiring: lock state from setting is reflected in :is_locked"
       (mt/with-premium-features #{:hosting :transforms-basic}
-        (mt/with-temporary-setting-values [locked-meters {}]
-          (is (= {:enabled true :is_locked false}
-                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
-    (testing "basic-bucket lock → is_locked=true"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-          (is (= {:enabled true :is_locked true}
-                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
-    (testing "advanced-bucket lock → is_locked=true"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-          (is (= {:enabled true :is_locked true}
-                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
-    (testing "non-transform meter (e.g. AI tokens) does not show up as transform lock"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
-          (is (= {:enabled true :is_locked false}
-                 (mt/user-http-request :crowberto :get 200 "transform/settings"))))))
+        (testing "unlocked → false"
+          (mt/with-temporary-setting-values [locked-meters {}]
+            (is (= {:enabled true :is_locked false}
+                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))
+        (testing "locked → true"
+          (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+            (is (= {:enabled true :is_locked true}
+                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))))
     (testing "data-analyst (non-admin) can read the endpoint"
       (mt/with-premium-features #{:hosting :transforms-basic}
         (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -6,6 +6,7 @@
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.premium-features.core :as premium-features]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.transforms.test-dataset :as transforms-dataset]
@@ -437,7 +438,20 @@
                 (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
                   (let [response (mt/user-http-request :crowberto :post 402
                                                        (format "transform/%d/run" transform-id))]
-                    (is (= "metabase_transforms_locked" (:error-code response)))))))))))))
+                    (is (= "metabase_transforms_locked" (:error-code response)))))))
+            (testing "non-metered transform (transform-metered-as → nil) → no 402 even with locks set"
+              ;; Realistic scenario: self-hosted EE with only :transforms-basic (no :writable-connection,
+              ;; no :transforms-python). check-feature-enabled! passes (the customer has :transforms-basic),
+              ;; but transform-metered-as returns nil for native/mbql because is-hosted? is false. The
+              ;; fail-open contract requires that lock state is irrelevant for non-metered transforms — even
+              ;; if harbormaster somehow sends lock state for such a customer, or the setting gets tampered.
+              ;; (Note: pure OSS doesn't reach this branch because check-feature-enabled! 402s earlier on
+              ;; missing premium features.)
+              (with-redefs [premium-features/transform-metered-as (constantly nil)]
+                (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
+                                                                  :transform-advanced-runs true}]
+                  (mt/user-http-request :crowberto :post 202
+                                        (format "transform/%d/run" transform-id)))))))))))
 
 (deftest get-transform-settings-test
   (testing "GET /api/transform/settings — integration coverage for the endpoint.

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -452,35 +452,3 @@
                                                                   :transform-advanced-runs true}]
                   (mt/user-http-request :crowberto :post 202
                                         (format "transform/%d/run" transform-id)))))))))))
-
-(deftest get-transform-settings-test
-  (testing "GET /api/transform/settings — integration coverage for the endpoint.
-            Lock-state matrix is owned by metabase.transforms.feature-gating-test/transforms-meter-locked?-test;
-            this test focuses on the API surface: response shape, :enabled gating, auth, and round-trip wiring."
-    (testing "response shape and :enabled gating"
-      (testing "OSS, self-hosted, no features → :enabled true (OSS gets query transforms), :is_locked false"
-        (mt/with-premium-features #{}
-          (mt/with-temporary-setting-values [locked-meters {}]
-            (let [response (mt/user-http-request :crowberto :get 200 "transform/settings")]
-              (is (= #{:enabled :is_locked} (set (keys response))) "schema is closed")
-              (is (false? (:is_locked response)))))))
-      (testing "hosted, no premium → :enabled false (no transforms-basic and is-hosted)"
-        (mt/with-premium-features #{:hosting}
-          (mt/with-temporary-setting-values [locked-meters {}]
-            (is (= {:enabled false :is_locked false}
-                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))))
-    (testing "wiring: lock state from setting is reflected in :is_locked"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (testing "unlocked → false"
-          (mt/with-temporary-setting-values [locked-meters {}]
-            (is (= {:enabled true :is_locked false}
-                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))
-        (testing "locked → true"
-          (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-            (is (= {:enabled true :is_locked true}
-                   (mt/user-http-request :crowberto :get 200 "transform/settings")))))))
-    (testing "data-analyst (non-admin) can read the endpoint"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-          (is (= {:enabled true :is_locked true}
-                 (mt/user-http-request :rasta :get 200 "transform/settings"))))))))

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -91,6 +91,7 @@
   has-attached-dwh?
   hide-embed-branding?
   is-hosted?
+  locked-meters
   premium-embedding-token
   security-center-enabled?
   site-uuid-for-premium-features-token-checks

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -44,6 +44,7 @@
   :type       :json
   :visibility :internal
   :audit      :never
+  :export?    false
   :default    {}
   :doc        false)
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -38,6 +38,15 @@
   :getter     (fn []
                 ((requiring-resolve 'metabase.premium-features.token-check/-token-status))))
 
+(defsetting locked-meters
+  (deferred-tru "Locally-mirrored is-locked state per meter, refreshed on each successful token-check.")
+  :encryption :no
+  :type       :json
+  :visibility :internal
+  :audit      :never
+  :default    {}
+  :doc        false)
+
 ;;; TODO - rename this to premium-features-token?
 (defsetting premium-embedding-token
   (deferred-tru "Token for premium features. Go to the MetaStore to get yours!")

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -392,6 +392,23 @@
   []
   (t2/delete! :model/PremiumFeaturesCache))
 
+(defn- extract-locks
+  "Project a `:meters` map to `{meter-keyword -> boolean}` of `:is-locked` values.
+   Meters without an `:is-locked` field are dropped."
+  [meters]
+  (into {} (keep (fn [[k v]] (when (some? (:is-locked v)) [k (:is-locked v)]))) meters))
+
+(defn- update-locked-meters!
+  "Mirror the `:is-locked` flag for each meter in `result` to the local `:locked-meters`
+   setting, when `:meters` is present in a successful token-check response. Best-effort:
+   failures are logged but never propagated to the refresh path."
+  [result]
+  (when (contains? result :meters)
+    (try
+      (premium-features.settings/locked-meters! (extract-locks (:meters result)))
+      (catch Throwable t
+        (log/warn t "Failed to mirror :locked-meters from token-check response")))))
+
 (def ^:dynamic *testing-only-call-after-refresh*
   "When non-nil, a zero-arg function called after async background refresh completes.
    For testing only — do not use in production."
@@ -416,6 +433,7 @@
                     result-hash (hash-token-status result)
                     now         (t/instant)]
                 (write-cache-to-db! token-hash result-hash)
+                (update-locked-meters! result)
                 (swap! local-cache assoc token-hash {:result      result
                                                      :result-hash result-hash
                                                      :updated-at  now})

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -396,7 +396,7 @@
   "Project a `:meters` map to `{meter-keyword -> boolean}` of `:is-locked` values.
    Meters without an `:is-locked` field are dropped."
   [meters]
-  (into {} (keep (fn [[k v]] (when (some? (:is-locked v)) [k (:is-locked v)]))) meters))
+  (into {} (keep (fn [[k v]] (when-some [locked (:is-locked v)] [k locked]))) meters))
 
 (defn- update-locked-meters!
   "Mirror the `:is-locked` flag for each meter in `result` to the local `:locked-meters`

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -19,7 +19,8 @@
 
 (p/import-vars
  [metabase.transforms.settings
-  transform-timeout]
+  transform-timeout
+  transforms-meter-locked]
  [metabase.transforms-base.util
   native-query-transform?
   output-table

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -50,8 +50,8 @@
    `:transform-advanced-runs`) is currently locked. Per harbormaster's
    mutual-exclusivity constraint, at most one of these is populated for a
    given customer, so this aggregate reduces to 'is the customer's active
-   transforms meter, if any, locked?'. Used by the `/api/transform/settings`
-   endpoint to expose a single instance-wide lock flag to the frontend."
+   transforms meter, if any, locked?'. Backs the [[metabase.transforms.settings/transforms-meter-locked]]
+   setting, which the frontend reads via `useSetting`."
   []
   (let [meters (premium-features/locked-meters)]
     (boolean (or (:transform-basic-runs meters)

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -26,3 +26,33 @@
   "Whether any transforms are enabled."
   []
   (or (query-transforms-enabled?) (python-transforms-enabled?)))
+
+(def ^:private metered-as->meter-key
+  "Map the bucket strings returned by `premium-features/transform-metered-as` to their
+   corresponding `:meters` keys in the harbormaster token-check response."
+  {"transform-basic"    :transform-basic-runs
+   "transform-advanced" :transform-advanced-runs})
+
+(defn- transform-source-type
+  "Return the source-type keyword (:python / :native / :mbql) for a transform map.
+   Prefers the `:source_type` column (set by the model's before-insert/before-update).
+   Falls back to a minimal derivation from `:source` for un-normalized test fixtures —
+   we only need to distinguish python from query here, since native and mbql route to
+   the same meter bucket via `transform-metered-as`."
+  [transform]
+  (or (some-> (:source_type transform) keyword)
+      (case (some-> (get-in transform [:source :type]) keyword)
+        :python :python
+        :query  :native
+        nil)))
+
+(defn transform-locked?
+  "True if the meter that would be charged for running this transform is locked.
+   Returns false for non-metered transforms (OSS, self-hosted basic-only) and when
+   no `:locked-meters` mirror has been written yet (cold cache, airgap)."
+  [transform]
+  (boolean
+   (when-let [meter-key (some-> (transform-source-type transform)
+                                premium-features/transform-metered-as
+                                metered-as->meter-key)]
+     (true? (get (premium-features/locked-meters) meter-key)))))

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -28,7 +28,7 @@
   (or (query-transforms-enabled?) (python-transforms-enabled?)))
 
 (def ^:private metered-as->meter-key
-  "Map the bucket strings returned by `premium-features/transform-metered-as` to their
+  "Map the bucket strings returned by [[premium-features/transform-metered-as]] to their
    corresponding `:meters` keys in the harbormaster token-check response."
   {"transform-basic"    :transform-basic-runs
    "transform-advanced" :transform-advanced-runs})
@@ -38,7 +38,7 @@
    Prefers the `:source_type` column (set by the model's before-insert/before-update).
    Falls back to a minimal derivation from `:source` for un-normalized test fixtures —
    we only need to distinguish python from query here, since native and mbql route to
-   the same meter bucket via `transform-metered-as`."
+   the same meter bucket via [[premium-features/transform-metered-as]]."
   [transform]
   (or (some-> (:source_type transform) keyword)
       (case (some-> (get-in transform [:source :type]) keyword)

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -33,29 +33,17 @@
   {"transform-basic"    :transform-basic-runs
    "transform-advanced" :transform-advanced-runs})
 
-(defn- transform-source-type
-  "Return the source-type keyword (:python / :native / :mbql) for a transform map.
-   Prefers the `:source_type` column (set by the model's before-insert/before-update).
-   Falls back to a minimal derivation from `:source` for un-normalized test fixtures —
-   we only need to distinguish python from query here, since native and mbql route to
-   the same meter bucket via [[premium-features/transform-metered-as]]."
-  [transform]
-  (or (some-> (:source_type transform) keyword)
-      (case (some-> (get-in transform [:source :type]) keyword)
-        :python :python
-        :query  :native
-        nil)))
-
 (defn transform-locked?
   "True if the meter that would be charged for running this transform is locked.
    Returns false for non-metered transforms (OSS, self-hosted basic-only) and when
    no `:locked-meters` mirror has been written yet (cold cache, airgap)."
   [transform]
   (boolean
-   (when-let [meter-key (some-> (transform-source-type transform)
+   (when-let [meter-key (some-> ((requiring-resolve 'metabase.transforms-base.util/transform-source-type)
+                                 (:source transform))
                                 premium-features/transform-metered-as
                                 metered-as->meter-key)]
-     (true? (get (premium-features/locked-meters) meter-key)))))
+     (get (premium-features/locked-meters) meter-key))))
 
 (defn transforms-meter-locked?
   "True if either of the two transforms meters (`:transform-basic-runs` or
@@ -66,5 +54,5 @@
    endpoint to expose a single instance-wide lock flag to the frontend."
   []
   (let [meters (premium-features/locked-meters)]
-    (boolean (or (true? (:transform-basic-runs meters))
-                 (true? (:transform-advanced-runs meters))))))
+    (boolean (or (:transform-basic-runs meters)
+                 (:transform-advanced-runs meters)))))

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -56,3 +56,15 @@
                                 premium-features/transform-metered-as
                                 metered-as->meter-key)]
      (true? (get (premium-features/locked-meters) meter-key)))))
+
+(defn transforms-meter-locked?
+  "True if either of the two transforms meters (`:transform-basic-runs` or
+   `:transform-advanced-runs`) is currently locked. Per harbormaster's
+   mutual-exclusivity constraint, at most one of these is populated for a
+   given customer, so this aggregate reduces to 'is the customer's active
+   transforms meter, if any, locked?'. Used by the `/api/transform/settings`
+   endpoint to expose a single instance-wide lock flag to the frontend."
+  []
+  (let [meters (premium-features/locked-meters)]
+    (boolean (or (true? (:transform-basic-runs meters))
+                 (true? (:transform-advanced-runs meters))))))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -12,6 +12,7 @@
    [metabase.tracing.core :as tracing]
    [metabase.transforms-base.ordering :as transforms-base.ordering]
    [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.feature-gating :as transforms.gating]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
@@ -81,8 +82,14 @@
       (Thread/sleep 2000))))
 
 (defn- run-transform! [run-id run-method user-id {transform-id :id :as transform}]
-  (if-not (transforms.u/check-feature-enabled transform)
+  (cond
+    (not (transforms.u/check-feature-enabled transform))
     (log/warnf "Skip running transform %d due to lacking premium features" transform-id)
+
+    (transforms.gating/transform-locked? transform)
+    (log/warnf "Skip running transform %d due to locked meter (trial quota exhausted)" transform-id)
+
+    :else
     (tracing/with-span :tasks "task.transform.execute" {:transform/id   transform-id
                                                         :transform/name (:name transform)}
       (block-until-not-already-running transform-id)

--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -1,6 +1,7 @@
 (ns metabase.transforms.settings
   (:require
    [metabase.settings.core :as setting]
+   [metabase.transforms.feature-gating :as transforms.gating]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (set! *warn-on-reflection* true)
@@ -24,3 +25,14 @@
   :default    false
   :export?    false
   :audit      :getter)
+
+(setting/defsetting transforms-meter-locked
+  (deferred-tru "True when the customer''s active transforms meter is locked (trial quota exhausted).")
+  :type       :boolean
+  :visibility :authenticated
+  :setter     :none
+  :audit      :never
+  :export?    false
+  :default    false
+  :doc        false
+  :getter     transforms.gating/transforms-meter-locked?)

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -148,15 +148,6 @@
     [:database-id {:optional true} [:maybe ms/PositiveInt]]]]
   (transforms.core/get-transforms query-params))
 
-(api.macros/defendpoint :get "/settings" :- [:map {:closed true}
-                                             [:enabled :boolean]
-                                             [:is_locked [:maybe :boolean]]]
-  "Get instance-wide transform feature settings: whether transforms are enabled,
-   and whether the customer's active transforms meter is locked (trial quota exhausted)."
-  []
-  {:enabled   (transforms.gating/any-transforms-enabled?)
-   :is_locked (transforms.gating/transforms-meter-locked?)})
-
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -154,8 +154,7 @@
   "Get instance-wide transform feature settings: whether transforms are enabled,
    and whether the customer's active transforms meter is locked (trial quota exhausted)."
   []
-  {:enabled   (or (transforms.gating/query-transforms-enabled?)
-                  (transforms.gating/python-transforms-enabled?))
+  {:enabled   (transforms.gating/any-transforms-enabled?)
    :is_locked (transforms.gating/transforms-meter-locked?)})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -4,11 +4,13 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
+   [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms-rest.api.transform-job]
    [metabase.transforms-rest.api.transform-tag]
    [metabase.transforms.core :as transforms.core]
+   [metabase.transforms.feature-gating :as transforms.gating]
    [metabase.transforms.schema :as transforms.schema]
    [metabase.transforms.util :as transforms.u]
    [metabase.util.i18n :refer [deferred-tru]]
@@ -147,6 +149,21 @@
     [:database-id {:optional true} [:maybe ms/PositiveInt]]]]
   (transforms.core/get-transforms query-params))
 
+(api.macros/defendpoint :get "/settings" :- [:map {:closed true}
+                                             [:enabled :boolean]
+                                             [:is_locked [:maybe :boolean]]]
+  "Get instance-wide transform feature settings: whether transforms are enabled,
+   and whether the customer's active transforms meter is locked (trial quota exhausted).
+   Per harbormaster's mutual-exclusivity constraint, at most one of `:transform-basic-runs`
+   or `:transform-advanced-runs` is present, so the OR aggregate reduces to the single
+   active meter (if any)."
+  []
+  (let [meters (premium-features/locked-meters)]
+    {:enabled   (or (transforms.gating/query-transforms-enabled?)
+                    (transforms.gating/python-transforms-enabled?))
+     :is_locked (boolean (or (true? (:transform-basic-runs meters))
+                             (true? (:transform-advanced-runs meters))))}))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -281,6 +298,9 @@
    The transform must already be fetched and validated."
   [transform]
   (transforms.core/check-feature-enabled! transform)
+  (api/check (not (transforms.gating/transform-locked? transform))
+             [402 {:message    (deferred-tru "Transforms are temporarily locked because the trial quota has been reached.")
+                   :error-code "metabase_transforms_locked"}])
   (let [start-promise (promise)]
     (u.jvm/in-virtual-thread*
      (transforms.core/execute! transform {:start-promise start-promise

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -4,7 +4,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
-   [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms-rest.api.transform-job]
@@ -153,16 +152,11 @@
                                              [:enabled :boolean]
                                              [:is_locked [:maybe :boolean]]]
   "Get instance-wide transform feature settings: whether transforms are enabled,
-   and whether the customer's active transforms meter is locked (trial quota exhausted).
-   Per harbormaster's mutual-exclusivity constraint, at most one of `:transform-basic-runs`
-   or `:transform-advanced-runs` is present, so the OR aggregate reduces to the single
-   active meter (if any)."
+   and whether the customer's active transforms meter is locked (trial quota exhausted)."
   []
-  (let [meters (premium-features/locked-meters)]
-    {:enabled   (or (transforms.gating/query-transforms-enabled?)
-                    (transforms.gating/python-transforms-enabled?))
-     :is_locked (boolean (or (true? (:transform-basic-runs meters))
-                             (true? (:transform-advanced-runs meters))))}))
+  {:enabled   (or (transforms.gating/query-transforms-enabled?)
+                  (transforms.gating/python-transforms-enabled?))
+   :is_locked (transforms.gating/transforms-meter-locked?)})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -219,7 +219,7 @@
         (finally
           (token-check/-clear-cache! checker))))))
 
-(deftest extract-locks-test
+(deftest ^:parallel extract-locks-test
   (testing "empty :meters map yields empty result"
     (is (= {} (#'token-check/extract-locks {}))))
   (testing "meters without :is-locked are filtered out"

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -219,6 +219,88 @@
         (finally
           (token-check/-clear-cache! checker))))))
 
+(deftest extract-locks-test
+  (testing "empty :meters map yields empty result"
+    (is (= {} (#'token-check/extract-locks {}))))
+  (testing "meters without :is-locked are filtered out"
+    (is (= {:transform-basic-runs true}
+           (#'token-check/extract-locks {:transform-basic-runs    {:is-locked    true
+                                                                   :meter-value  10}
+                                         :transform-advanced-runs {:meter-value  5}}))))
+  (testing "false :is-locked is preserved (only nil/missing is dropped)"
+    (is (= {:transform-basic-runs    false
+            :transform-advanced-runs true}
+           (#'token-check/extract-locks {:transform-basic-runs    {:is-locked false}
+                                         :transform-advanced-runs {:is-locked true}}))))
+  (testing "non-transform meter keys pass through (e.g. :metabase-ai-tokens)"
+    (is (= {:transform-basic-runs true
+            :metabase-ai-tokens    false}
+           (#'token-check/extract-locks {:transform-basic-runs {:is-locked true}
+                                         :metabase-ai-tokens   {:is-locked false}})))))
+
+(deftest do-refresh-writes-locked-meters-test
+  (testing "do-refresh! mirrors :meters → :locked-meters setting on every successful refresh"
+    (mt/with-temporary-setting-values [locked-meters {}]
+      (let [token       (tu/random-token)
+            response    (atom {:valid true :status "ok" :canonical? true})
+            local-cache (atom {})
+            checker     (binding [token-check/*customize-checker* true]
+                          (token-check/make-checker {:local-ttl           (t/millis 50)
+                                                     :soft-ttl            (t/hours 12)
+                                                     :hard-ttl            (t/hours 36)
+                                                     :db-hash-local-cache local-cache}))]
+        (try
+          (with-redefs [token-check/http-fetch
+                        (fn [& _] {:status 200 :body (json/encode @response)})]
+            (testing "successful response with :meters writes through"
+              (reset! response {:valid true :status "ok"
+                                :meters {:transform-basic-runs    {:is-locked true}
+                                         :transform-advanced-runs {:is-locked false}}})
+              (token-check/check-token checker token)
+              (is (= {:transform-basic-runs    true
+                      :transform-advanced-runs false}
+                     (premium-features/locked-meters))))
+
+            (testing "successful response WITHOUT :meters leaves the setting untouched"
+              (reset! response {:valid true :status "ok"})
+              (token-check/-clear-cache! checker)
+              (reset! local-cache {})
+              (token-check/check-token checker token)
+              (is (= {:transform-basic-runs    true
+                      :transform-advanced-runs false}
+                     (premium-features/locked-meters))
+                  "Setting should retain previous value when response omits :meters"))
+
+            (testing "successful response with empty :meters {} writes empty map (legitimate unlock)"
+              (reset! response {:valid true :status "ok" :meters {}})
+              (token-check/-clear-cache! checker)
+              (reset! local-cache {})
+              (token-check/check-token checker token)
+              (is (= {} (premium-features/locked-meters)))))
+          (finally
+            (token-check/-clear-cache! checker)))))))
+
+(deftest do-refresh-failure-leaves-locked-meters-untouched-test
+  (testing "Outage / 5xx / circuit breaker open → :locked-meters survives unchanged.
+            (Critical correctness property: a network blip MUST NOT accidentally unlock.)"
+    (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+      (let [token       (tu/random-token)
+            local-cache (atom {})
+            checker     (binding [token-check/*customize-checker* true]
+                          (token-check/make-checker {:local-ttl           (t/millis 50)
+                                                     :soft-ttl            (t/hours 12)
+                                                     :hard-ttl            (t/hours 36)
+                                                     :db-hash-local-cache local-cache}))]
+        (try
+          (with-redefs [token-check/http-fetch
+                        (fn [& _] (throw (ex-info "network failure!" {})))]
+            (token-check/check-token checker token)
+            (is (= {:transform-basic-runs true}
+                   (premium-features/locked-meters))
+                "Failed refresh must not touch :locked-meters"))
+          (finally
+            (token-check/-clear-cache! checker)))))))
+
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
             from the store.metabase.com endpoint for that token."

--- a/test/metabase/transforms/feature_gating_test.clj
+++ b/test/metabase/transforms/feature_gating_test.clj
@@ -21,7 +21,7 @@
                                                       :transform-advanced-runs true}]
       (with-mocked-routing! nil
         #(is (false? (transforms.gating/transform-locked?
-                      {:source_type :native})))))))
+                      {:source {:type "query"}})))))))
 
 (deftest transform-locked?-basic-bucket-test
   (testing "basic-bucket transform follows :transform-basic-runs"
@@ -29,16 +29,16 @@
       (fn []
         (testing "locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-            (is (true? (transforms.gating/transform-locked? {:source_type :native})))))
+            (is (true? (transforms.gating/transform-locked? {:source {:type "query"}})))))
         (testing "unlocked"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
-            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))
+            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))
         (testing "missing → unlocked"
           (mt/with-temporary-setting-values [locked-meters {}]
-            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))
+            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))
         (testing "advanced-bucket lock does not bleed into basic"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))))))
+            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))))))
 
 (deftest transform-locked?-advanced-bucket-test
   (testing "advanced-bucket transform follows :transform-advanced-runs"
@@ -46,35 +46,19 @@
       (fn []
         (testing "python locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-            (is (true? (transforms.gating/transform-locked? {:source_type :python})))))
+            (is (true? (transforms.gating/transform-locked? {:source {:type "python"}})))))
         (testing "python unlocked"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs false}]
-            (is (false? (transforms.gating/transform-locked? {:source_type :python})))))
+            (is (false? (transforms.gating/transform-locked? {:source {:type "python"}})))))
         (testing "basic-bucket lock does not bleed into advanced"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-            (is (false? (transforms.gating/transform-locked? {:source_type :python})))))))))
+            (is (false? (transforms.gating/transform-locked? {:source {:type "python"}})))))))))
 
 (deftest transform-locked?-non-transform-meter-ignored-test
   (testing "locks on non-transform meters (e.g. :metabase-ai-tokens) do not affect transforms"
     (with-mocked-routing! "transform-basic"
       #(mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
-         (is (false? (transforms.gating/transform-locked? {:source_type :native})))))))
-
-(deftest transform-locked?-source-fallback-test
-  (testing "source-derivation fallback: transform without :source_type uses :source.type"
-    (with-mocked-routing! "transform-basic"
-      #(mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-         (is (true? (transforms.gating/transform-locked?
-                     {:source {:type "query"}})))))
-    (with-mocked-routing! "transform-advanced"
-      #(mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-         (is (true? (transforms.gating/transform-locked?
-                     {:source {:type "python"}})))))))
-
-(deftest transform-locked?-cold-cache-test
-  (testing "cold cache (default empty :locked-meters) → unlocked"
-    (with-mocked-routing! "transform-basic"
-      #(is (false? (transforms.gating/transform-locked? {:source_type :native}))))))
+         (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))))
 
 (deftest transforms-meter-locked?-test
   (testing "FE-facing aggregate: locked iff either transforms meter is locked"

--- a/test/metabase/transforms/feature_gating_test.clj
+++ b/test/metabase/transforms/feature_gating_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
+   [metabase.transforms.core :as transforms]
    [metabase.transforms.feature-gating :as transforms.gating]))
 
 (set! *warn-on-reflection* true)
@@ -82,3 +83,13 @@
       (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    false
                                                         :transform-advanced-runs false}]
         (is (false? (transforms.gating/transforms-meter-locked?)))))))
+
+(deftest transforms-meter-locked-setting-test
+  (testing "the :transforms-meter-locked setting reflects the underlying transforms-meter-locked? predicate.
+            Smoke test only — exhaustive matrix lives on transforms-meter-locked?-test above."
+    (testing "unlocked"
+      (mt/with-temporary-setting-values [locked-meters {}]
+        (is (false? (transforms/transforms-meter-locked)))))
+    (testing "locked"
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+        (is (true? (transforms/transforms-meter-locked)))))))

--- a/test/metabase/transforms/feature_gating_test.clj
+++ b/test/metabase/transforms/feature_gating_test.clj
@@ -8,7 +8,8 @@
 (set! *warn-on-reflection* true)
 
 (defn- with-mocked-routing!
-  "Run `body` with `transform-metered-as` returning the given fixed bucket string."
+  "Call zero-arg `f` with [[premium-features/transform-metered-as]] redefined to return
+   the given fixed `bucket` string."
   [bucket f]
   (with-redefs [premium-features/transform-metered-as (constantly bucket)]
     (f)))

--- a/test/metabase/transforms/feature_gating_test.clj
+++ b/test/metabase/transforms/feature_gating_test.clj
@@ -1,0 +1,76 @@
+(ns metabase.transforms.feature-gating-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]
+   [metabase.transforms.feature-gating :as transforms.gating]))
+
+(set! *warn-on-reflection* true)
+
+(defn- with-mocked-routing
+  "Run `body` with `transform-metered-as` returning the given fixed bucket string."
+  [bucket f]
+  (with-redefs [premium-features/transform-metered-as (constantly bucket)]
+    (f)))
+
+(deftest transform-locked?-no-bucket-test
+  (testing "non-metered transform (transform-metered-as → nil) is never locked,
+            even when other meters are locked"
+    (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
+                                                      :transform-advanced-runs true}]
+      (with-mocked-routing nil
+        #(is (false? (transforms.gating/transform-locked?
+                      {:source_type :native})))))))
+
+(deftest transform-locked?-basic-bucket-test
+  (testing "basic-bucket transform follows :transform-basic-runs"
+    (with-mocked-routing "transform-basic"
+      (fn []
+        (testing "locked"
+          (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+            (is (true? (transforms.gating/transform-locked? {:source_type :native})))))
+        (testing "unlocked"
+          (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
+            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))
+        (testing "missing → unlocked"
+          (mt/with-temporary-setting-values [locked-meters {}]
+            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))
+        (testing "advanced-bucket lock does not bleed into basic"
+          (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+            (is (false? (transforms.gating/transform-locked? {:source_type :native})))))))))
+
+(deftest transform-locked?-advanced-bucket-test
+  (testing "advanced-bucket transform follows :transform-advanced-runs"
+    (with-mocked-routing "transform-advanced"
+      (fn []
+        (testing "python locked"
+          (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+            (is (true? (transforms.gating/transform-locked? {:source_type :python})))))
+        (testing "python unlocked"
+          (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs false}]
+            (is (false? (transforms.gating/transform-locked? {:source_type :python})))))
+        (testing "basic-bucket lock does not bleed into advanced"
+          (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+            (is (false? (transforms.gating/transform-locked? {:source_type :python})))))))))
+
+(deftest transform-locked?-non-transform-meter-ignored-test
+  (testing "locks on non-transform meters (e.g. :metabase-ai-tokens) do not affect transforms"
+    (with-mocked-routing "transform-basic"
+      #(mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
+         (is (false? (transforms.gating/transform-locked? {:source_type :native})))))))
+
+(deftest transform-locked?-source-fallback-test
+  (testing "source-derivation fallback: transform without :source_type uses :source.type"
+    (with-mocked-routing "transform-basic"
+      #(mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+         (is (true? (transforms.gating/transform-locked?
+                     {:source {:type "query"}})))))
+    (with-mocked-routing "transform-advanced"
+      #(mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+         (is (true? (transforms.gating/transform-locked?
+                     {:source {:type "python"}})))))))
+
+(deftest transform-locked?-cold-cache-test
+  (testing "cold cache (default empty :locked-meters) → unlocked"
+    (with-mocked-routing "transform-basic"
+      #(is (false? (transforms.gating/transform-locked? {:source_type :native}))))))

--- a/test/metabase/transforms/feature_gating_test.clj
+++ b/test/metabase/transforms/feature_gating_test.clj
@@ -7,7 +7,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- with-mocked-routing
+(defn- with-mocked-routing!
   "Run `body` with `transform-metered-as` returning the given fixed bucket string."
   [bucket f]
   (with-redefs [premium-features/transform-metered-as (constantly bucket)]
@@ -18,13 +18,13 @@
             even when other meters are locked"
     (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
                                                       :transform-advanced-runs true}]
-      (with-mocked-routing nil
+      (with-mocked-routing! nil
         #(is (false? (transforms.gating/transform-locked?
                       {:source_type :native})))))))
 
 (deftest transform-locked?-basic-bucket-test
   (testing "basic-bucket transform follows :transform-basic-runs"
-    (with-mocked-routing "transform-basic"
+    (with-mocked-routing! "transform-basic"
       (fn []
         (testing "locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
@@ -41,7 +41,7 @@
 
 (deftest transform-locked?-advanced-bucket-test
   (testing "advanced-bucket transform follows :transform-advanced-runs"
-    (with-mocked-routing "transform-advanced"
+    (with-mocked-routing! "transform-advanced"
       (fn []
         (testing "python locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
@@ -55,22 +55,45 @@
 
 (deftest transform-locked?-non-transform-meter-ignored-test
   (testing "locks on non-transform meters (e.g. :metabase-ai-tokens) do not affect transforms"
-    (with-mocked-routing "transform-basic"
+    (with-mocked-routing! "transform-basic"
       #(mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
          (is (false? (transforms.gating/transform-locked? {:source_type :native})))))))
 
 (deftest transform-locked?-source-fallback-test
   (testing "source-derivation fallback: transform without :source_type uses :source.type"
-    (with-mocked-routing "transform-basic"
+    (with-mocked-routing! "transform-basic"
       #(mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
          (is (true? (transforms.gating/transform-locked?
                      {:source {:type "query"}})))))
-    (with-mocked-routing "transform-advanced"
+    (with-mocked-routing! "transform-advanced"
       #(mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
          (is (true? (transforms.gating/transform-locked?
                      {:source {:type "python"}})))))))
 
 (deftest transform-locked?-cold-cache-test
   (testing "cold cache (default empty :locked-meters) → unlocked"
-    (with-mocked-routing "transform-basic"
+    (with-mocked-routing! "transform-basic"
       #(is (false? (transforms.gating/transform-locked? {:source_type :native}))))))
+
+(deftest transforms-meter-locked?-test
+  (testing "FE-facing aggregate: locked iff either transforms meter is locked"
+    (testing "no locks → false"
+      (mt/with-temporary-setting-values [locked-meters {}]
+        (is (false? (transforms.gating/transforms-meter-locked?)))))
+    (testing "basic-bucket locked → true"
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+        (is (true? (transforms.gating/transforms-meter-locked?)))))
+    (testing "advanced-bucket locked → true"
+      (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
+        (is (true? (transforms.gating/transforms-meter-locked?)))))
+    (testing "both locked (defense-in-depth — harbormaster mutex says this can't happen) → still true"
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
+                                                        :transform-advanced-runs true}]
+        (is (true? (transforms.gating/transforms-meter-locked?)))))
+    (testing "non-transform meter (e.g. :metabase-ai-tokens) does NOT affect transforms aggregate"
+      (mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
+        (is (false? (transforms.gating/transforms-meter-locked?)))))
+    (testing "false values do not count as locked"
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    false
+                                                        :transform-advanced-runs false}]
+        (is (false? (transforms.gating/transforms-meter-locked?)))))))

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -9,6 +9,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.notification.seed :as notification.seed]
+   [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [metabase.test.util.thread-local :as tu.thread-local]
@@ -188,49 +189,59 @@
               "Should call run-mbql-transform! when feature is enabled"))))))
 
 (deftest run-transform-locked-meter-test
-  (testing "scheduled run-transform! is skipped (with warn log) when the meter is locked"
-    (mt/with-premium-features #{:hosting :transforms-basic}
-      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-        (let [transform       {:id          7
-                               :source_type :native
-                               :source      query-source
-                               :name        "Locked Transform"}
-              logged          (atom [])
-              run-called?     (atom false)]
-          (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
-                                                 (swap! logged conj {:level level :message message}))
-                                      transform-run/running-run-for-transform-id (constantly nil)
-                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
-                                      transforms.job-run/add-run-activity! (constantly nil)]
-            (#'jobs/run-transform! 200 :scheduled nil transform)
-            (is (false? @run-called?)
-                "execute! must not be called when the meter is locked")
-            (is (some #(re-matches #".*Skip running transform 7 due to locked meter.*"
-                                   (:message %))
-                      @logged)
-                "Should log warning naming the locked-meter reason"))))))
-  (testing "scheduled run-transform! runs normally when the meter is not locked"
-    (mt/with-premium-features #{:hosting :transforms-basic}
-      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
-        (let [transform   {:id 8 :source_type :native :source query-source :name "Unlocked"}
-              run-called? (atom false)]
-          (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
-                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
-                                      transforms.job-run/add-run-activity! (constantly nil)]
-            (#'jobs/run-transform! 201 :scheduled nil transform)
-            (is (true? @run-called?)))))))
-  (testing "non-metered transform (self-hosted basic-only) is never blocked by lock state"
-    (mt/with-premium-features #{:transforms-basic}    ;; no :hosting → not metered
-      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
-                                                        :transform-advanced-runs true}]
-        (let [transform   {:id 9 :source_type :native :source query-source :name "Self-hosted basic"}
-              run-called? (atom false)]
-          (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
-                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
-                                      transforms.job-run/add-run-activity! (constantly nil)]
-            (#'jobs/run-transform! 202 :scheduled nil transform)
-            (is (true? @run-called?)
-                "Self-hosted basic-only transforms are not metered, so no lock applies")))))))
+  ;; `transform-metered-as` is `defenterprise`; the OSS impl returns nil for everything,
+  ;; which makes `transform-locked?` short-circuit to false regardless of `:locked-meters`.
+  ;; Mock the routing so the test exercises the lock-check branch under any classpath.
+  (with-redefs [premium-features/transform-metered-as (fn [source-type]
+                                                        (case (keyword source-type)
+                                                          :native "transform-basic"
+                                                          :mbql   "transform-basic"
+                                                          :python "transform-advanced"
+                                                          nil))]
+    (testing "scheduled run-transform! is skipped (with warn log) when the meter is locked"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+          (let [transform       {:id          7
+                                 :source_type :native
+                                 :source      query-source
+                                 :name        "Locked Transform"}
+                logged          (atom [])
+                run-called?     (atom false)]
+            (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
+                                                   (swap! logged conj {:level level :message message}))
+                                        transform-run/running-run-for-transform-id (constantly nil)
+                                        transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                        transforms.job-run/add-run-activity! (constantly nil)]
+              (#'jobs/run-transform! 200 :scheduled nil transform)
+              (is (false? @run-called?)
+                  "execute! must not be called when the meter is locked")
+              (is (some #(re-matches #".*Skip running transform 7 due to locked meter.*"
+                                     (:message %))
+                        @logged)
+                  "Should log warning naming the locked-meter reason"))))))
+    (testing "scheduled run-transform! runs normally when the meter is not locked"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
+          (let [transform   {:id 8 :source_type :native :source query-source :name "Unlocked"}
+                run-called? (atom false)]
+            (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
+                                        transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                        transforms.job-run/add-run-activity! (constantly nil)]
+              (#'jobs/run-transform! 201 :scheduled nil transform)
+              (is (true? @run-called?)))))))
+    (testing "non-metered transform (transform-metered-as → nil) is never blocked by lock state"
+      ;; Override the outer mock with one that returns nil for every source-type.
+      (with-redefs [premium-features/transform-metered-as (constantly nil)]
+        (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
+                                                          :transform-advanced-runs true}]
+          (let [transform   {:id 9 :source_type :native :source query-source :name "Non-metered"}
+                run-called? (atom false)]
+            (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
+                                        transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                        transforms.job-run/add-run-activity! (constantly nil)]
+              (#'jobs/run-transform! 202 :scheduled nil transform)
+              (is (true? @run-called?)
+                  "Non-metered transforms are not gated by lock state"))))))))
 
 (deftest job-run-boom-test
   (mt/with-premium-features #{:transforms-basic}

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -187,6 +187,51 @@
           (is @run-called?
               "Should call run-mbql-transform! when feature is enabled"))))))
 
+(deftest run-transform-locked-meter-test
+  (testing "scheduled run-transform! is skipped (with warn log) when the meter is locked"
+    (mt/with-premium-features #{:hosting :transforms-basic}
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
+        (let [transform       {:id          7
+                               :source_type :native
+                               :source      query-source
+                               :name        "Locked Transform"}
+              logged          (atom [])
+              run-called?     (atom false)]
+          (mt/with-dynamic-fn-redefs [log/log* (fn [_ level _ message]
+                                                 (swap! logged conj {:level level :message message}))
+                                      transform-run/running-run-for-transform-id (constantly nil)
+                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                      transforms.job-run/add-run-activity! (constantly nil)]
+            (#'jobs/run-transform! 200 :scheduled nil transform)
+            (is (false? @run-called?)
+                "execute! must not be called when the meter is locked")
+            (is (some #(re-matches #".*Skip running transform 7 due to locked meter.*"
+                                   (:message %))
+                      @logged)
+                "Should log warning naming the locked-meter reason"))))))
+  (testing "scheduled run-transform! runs normally when the meter is not locked"
+    (mt/with-premium-features #{:hosting :transforms-basic}
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
+        (let [transform   {:id 8 :source_type :native :source query-source :name "Unlocked"}
+              run-called? (atom false)]
+          (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
+                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                      transforms.job-run/add-run-activity! (constantly nil)]
+            (#'jobs/run-transform! 201 :scheduled nil transform)
+            (is (true? @run-called?)))))))
+  (testing "non-metered transform (self-hosted basic-only) is never blocked by lock state"
+    (mt/with-premium-features #{:transforms-basic}    ;; no :hosting → not metered
+      (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
+                                                        :transform-advanced-runs true}]
+        (let [transform   {:id 9 :source_type :native :source query-source :name "Self-hosted basic"}
+              run-called? (atom false)]
+          (mt/with-dynamic-fn-redefs [transform-run/running-run-for-transform-id (constantly nil)
+                                      transforms.execute/execute! (fn [_ _] (reset! run-called? true))
+                                      transforms.job-run/add-run-activity! (constantly nil)]
+            (#'jobs/run-transform! 202 :scheduled nil transform)
+            (is (true? @run-called?)
+                "Self-hosted basic-only transforms are not metered, so no lock applies")))))))
+
 (deftest job-run-boom-test
   (mt/with-premium-features #{:transforms-basic}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)


### PR DESCRIPTION
### Description

Related to https://github.com/metabase/metabase/pull/73517

When a customer exceeds their free transforms quota during a trial, this flips the `is-locked` attribute in the token-check call.  This PR mirrors that is-locked attribute into the Metabase's instance's DB as a setting row, and adds a lock check alongside the existing feature check at the two transform-execution sites (scheduled job runner and manual-run API endpoint). We also expose the lock state through a new `GET /api/transform/settings` endpoint.


#### Technical considerations
1. Lock state is mirrored from the token-check response into a json setting. We defensively prevent API writes to this `:visibility :internal` because this is billing-relevant logic. 
2. The new `update-locked-meters!` that syncs the lock state is called from inside `do-refresh!`, which all refresh token paths converge on. Two key points:
  - **Writer fires only when `meters` is present in a successful response.** If the fetch throws / times out / the circuit breaker is open, the setting is left untouched. We do not want to accidentally **change** lock state on an intermittent failure.
  - **Empty `:meters {}` is a legitimate "nothing locked" signal** and is written through. This is also the default value, so it's backwards-compatible with existing customers.
 

### Demo
_Done with local harbormaster / metabase instance_


00:00 - 00:17: Baseline behaviour (transforms unlocked)
00:18 - 00:48: Transforms locked - banner appears on transforms list / runs list / jobs list, "Disabled" badges per row in jobs list, gold "Disabled" badge in job header, "Run now" button disabled with LockedTransformsHoverCard revealed on hover.

With lock state served from API endpoint:

[transforms-locked-demo-DSN-380.webm](https://github.com/user-attachments/assets/f9c07d53-4b9b-4e74-83cd-1aa734253f8b)

With lock state served from setting:

[transforms-locked-demo-DSN-380-setting-based.webm](https://github.com/user-attachments/assets/08ce11ab-be1d-494c-827a-5b703a2f5458)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
