### PR TITLE
fix: show query bar even when only one data point remains

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpQueryBar.tsx
@@ -41,12 +41,7 @@ export function McpQueryBar({ app, instanceUrl }: McpQueryBarProps) {
     handleDateFilterClear,
   } = useDateFilter(question, updateQuestion, rawTemporalColumn);
 
-  if (
-    !question ||
-    !queryResults ||
-    sensibleChartTypes.length === 0 ||
-    hasOnlyTable
-  ) {
+  if (!question || !queryResults || hasOnlyTable) {
     return null;
   }
 
@@ -71,6 +66,13 @@ export function McpQueryBar({ app, instanceUrl }: McpQueryBarProps) {
           onChange: handleBucketChange,
         }
       : undefined;
+
+  const hasControls =
+    sensibleChartTypes.length > 0 || timeRange || timeGranularity || app;
+
+  if (!hasControls) {
+    return null;
+  }
 
   async function handleExploreClicked() {
     if (!instanceUrl || !question || !app) {

--- a/frontend/src/metabase/embedding/mcp/McpQueryBar.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpQueryBar.unit.spec.tsx
@@ -1,0 +1,119 @@
+import {
+  setupAlertsEndpoints,
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+  setupCardQueryMetadataEndpoint,
+  setupDatabaseEndpoints,
+} from "__support__/server-mocks";
+import { screen } from "__support__/ui";
+import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion";
+import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
+import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
+import {
+  createMockCard,
+  createMockCardQueryMetadata,
+  createMockDataset,
+  createMockDatasetData,
+  createMockNumericColumn,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import {
+  ORDERS,
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import { McpQueryBar } from "./McpQueryBar";
+
+const TEST_USER = createMockUser();
+const TEST_DATABASE = createSampleDatabase();
+const TEST_CARD = createMockCard({
+  display: "line",
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "quarter" }]],
+      filter: [
+        "between",
+        ["field", ORDERS.CREATED_AT, null],
+        "2024-01-01",
+        "2024-12-31",
+      ],
+    },
+  },
+});
+
+const ONE_POINT_RESULT = createMockDataset({
+  data: createMockDatasetData({
+    cols: [
+      createMockNumericColumn({
+        name: "count",
+        display_name: "Count",
+        source: "aggregation",
+      }),
+    ],
+    rows: [[26000]],
+  }),
+});
+
+function setup() {
+  const { state } = setupSdkState({ currentUser: TEST_USER });
+  const app = { openLink: jest.fn() };
+
+  setupCardEndpoints(TEST_CARD);
+  setupCardQueryMetadataEndpoint(
+    TEST_CARD,
+    createMockCardQueryMetadata({ databases: [TEST_DATABASE] }),
+  );
+  setupDatabaseEndpoints(TEST_DATABASE);
+
+  setupAlertsEndpoints(TEST_CARD, []);
+  setupCardQueryEndpoints(TEST_CARD, ONE_POINT_RESULT);
+
+  renderWithSDKProviders(
+    <SdkQuestion
+      questionId={TEST_CARD.id}
+      isSaveEnabled={false}
+      withEditorButton={false}
+      withChartTypeSelector={false}
+    >
+      <McpQueryBar app={app as any} instanceUrl="https://metabase.example" />
+    </SdkQuestion>,
+    {
+      componentProviderProps: {
+        authConfig: createMockSdkConfig(),
+      },
+      storeInitialState: state,
+    },
+  );
+
+  return { app };
+}
+
+describe("McpQueryBar", () => {
+  it("renders remaining query controls when a one-point result has no MCP chart types", async () => {
+    setup();
+
+    expect(await screen.findByTestId("query-explorer-bar")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /explore/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "line" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "bar" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "area" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "table" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.tsx
@@ -24,6 +24,7 @@ export function QueryExplorerBar({
   onExplore,
 }: QueryExplorerBarProps) {
   const hasCenterControls = timeRange || timeGranularity;
+  const hasChartTypes = chartTypes.length > 0;
 
   return (
     <Flex
@@ -34,13 +35,15 @@ export function QueryExplorerBar({
       gap={{ base: "sm", xs: "xs" }}
       data-testid="query-explorer-bar"
     >
-      <Flex align="center" gap="xs">
-        <ChartTypePicker
-          chartTypes={chartTypes}
-          value={currentChartType}
-          onChange={onChartTypeChange}
-        />
-      </Flex>
+      {hasChartTypes && (
+        <Flex align="center" gap="xs">
+          <ChartTypePicker
+            chartTypes={chartTypes}
+            value={currentChartType}
+            onChange={onChartTypeChange}
+          />
+        </Flex>
+      )}
 
       {hasCenterControls && (
         <Flex

--- a/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/mcp/QueryExplorerBar/QueryExplorerBar.unit.spec.tsx
@@ -161,4 +161,40 @@ describe("QueryExplorerBar", () => {
       screen.queryByRole("button", { name: /explore/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("renders remaining controls when chart type controls are empty", () => {
+    renderWithProviders(
+      <QueryExplorerBar
+        chartTypes={[]}
+        currentChartType=""
+        onChartTypeChange={jest.fn()}
+        timeRange={{
+          label: "2024 only",
+          value: undefined,
+          availableUnits: [],
+          hasActiveFilter: true,
+          onChange: jest.fn(),
+          onClear: jest.fn(),
+        }}
+        onExplore={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("query-explorer-bar")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "2024 only" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /explore/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "line" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "bar" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "area" }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes EMB-1668

### Description

Keeps the MCP query bar visible after filtering drills reduce a chart to only **one data point**. When no MCP chart-type buttons are available, the bar still renders the remaining controls, excluding the visualization type selector (as no sensible visualization remains for _one_ data point), instead of rendering nothing.

### Demos

We still render the query bar, without the chart type selector, in this case of one data point.

<img width="1596" height="1210" alt="image" src="https://github.com/user-attachments/assets/e2ef4ad4-2c0f-470f-b564-cd245706fc80" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing as you will run into the https://github.com/anthropics/claude-ai-mcp/issues/40 bug, where Claude Desktop strips all HTTP domains (e.g. `localhost:3000`) and nothing will load.

You cannot use the PR environment with Claude Connector either, as it is behind Tailscale and Claude cannot talk to it. You must use `mcp-remote` to test with PR environment.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73628.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case.

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73268.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  },
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. Ask it to "visualize orders in metabase, group by ordered at, bin by quarter, filter by only year 2025"

4. You should see only ONE data point

5. Important: **MCP Query Bar should be visible**.

### How to verify

1. Render an MCP `visualize_query` chart with filter/granularity controls.
2. Drill/filter until only one data point remains.
3. Confirm the MCP query bar remains visible.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit tests
