### PR TITLE
Show authentication and CORS errors for MCP Apps

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -1,10 +1,9 @@
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useEffect, useMemo } from "react";
 
+import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError";
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion";
 import { getSdkStore } from "embedding-sdk-bundle/store";
-import { refreshSiteSettings } from "metabase/redux/settings";
-import { refreshCurrentUser } from "metabase/redux/user";
 import { Box, Flex } from "metabase/ui";
 import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 import { b64_to_utf8 } from "metabase/utils/encoding";
@@ -14,6 +13,7 @@ import { McpQueryBar } from "./McpQueryBar";
 import { McpQuestionTitle } from "./McpQuestionTitle";
 import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
+import { useMcpUserAndSettingsFetch } from "./hooks/useMcpUserAndSettingsFetch";
 import { buildMcpAppsTheme } from "./utils/buildMcpAppsTheme";
 
 const store = getSdkStore();
@@ -30,11 +30,13 @@ const SimpleLoader = () => (
 export function McpUiAppRoute() {
   const { query, hostContext, app } = useMcpApp();
 
-  const [isSettingsReady, setIsSettingsReady] = useState(false);
-
   const handleDrillThrough = useHandleMcpDrillThrough(app);
 
-  const { instanceUrl } = window.metabaseConfig ?? { instanceUrl: "" };
+  const { instanceUrl = "", sessionToken = "" } =
+    (window.metabaseConfig as {
+      instanceUrl: string;
+      sessionToken: string;
+    }) ?? {};
 
   const scheme: ResolvedColorScheme =
     hostContext?.theme === "dark" ? "dark" : "light";
@@ -67,15 +69,12 @@ export function McpUiAppRoute() {
     [hostCssVariables, scheme],
   );
 
-  // The OSS no-op initAuth never loads user or settings. Do it ourselves so
-  // selectors like getTokenFeature has populated settings.
-  // We also no-op the EE auth flow (auth.ts) when in MCP Apps route.
-  useEffect(() => {
-    Promise.all([
-      store.dispatch(refreshCurrentUser()),
-      store.dispatch(refreshSiteSettings()),
-    ]).then(() => setIsSettingsReady(true));
-  }, []);
+  const { isSettingsReady, userAndSettingsFetchError } =
+    useMcpUserAndSettingsFetch({
+      instanceUrl,
+      sessionToken,
+      store,
+    });
 
   const isReady = !!(
     instanceUrl &&
@@ -85,11 +84,12 @@ export function McpUiAppRoute() {
   );
 
   useEffect(() => {
-    // Remove the loading indicator on the HTML page once the app is ready
-    if (isReady) {
+    // Remove the loading indicator on the HTML page once the app is ready or
+    // when initialization fails and the route can render its own error.
+    if (isReady || userAndSettingsFetchError) {
       document.getElementById("mcp-loading")?.remove();
     }
-  }, [isReady]);
+  }, [isReady, userAndSettingsFetchError]);
 
   const height = "500px";
   const visualizationHeight = `calc(${height} - 8.5rem)`;
@@ -101,9 +101,46 @@ export function McpUiAppRoute() {
     background: theme.colors?.background,
   };
 
-  if (!isReady) {
-    return null;
-  }
+  const renderContent = () => {
+    if (userAndSettingsFetchError) {
+      return <SdkError message={userAndSettingsFetchError} />;
+    }
+
+    if (!isReady) {
+      return null;
+    }
+
+    return (
+      <SdkQuestion
+        deserializedCard={deserializedCard}
+        isSaveEnabled={false}
+        // we should never show query builder in chat interfaces
+        withEditorButton={false}
+        withChartTypeSelector={false}
+        onDrillThrough={handleDrillThrough}
+      >
+        <Flex
+          direction="column"
+          justify="space-between"
+          h="100%"
+          py="lg"
+          gap="sm"
+        >
+          <Box px="lg" style={{ flexShrink: 0 }}>
+            <McpQuestionTitle />
+          </Box>
+
+          <Flex px="xs" flex={1} style={{ overflow: "hidden" }}>
+            <SdkQuestion.QuestionVisualization height={visualizationHeight} />
+          </Flex>
+
+          <Flex px="lg">
+            <McpQueryBar app={app} instanceUrl={instanceUrl} />
+          </Flex>
+        </Flex>
+      </SdkQuestion>
+    );
+  };
 
   return (
     <ComponentProvider
@@ -112,36 +149,7 @@ export function McpUiAppRoute() {
       reduxStore={store}
       loaderComponent={SimpleLoader}
     >
-      <div style={containerStyle}>
-        <SdkQuestion
-          deserializedCard={deserializedCard}
-          isSaveEnabled={false}
-          // we should never show query builder in chat interfaces
-          withEditorButton={false}
-          withChartTypeSelector={false}
-          onDrillThrough={handleDrillThrough}
-        >
-          <Flex
-            direction="column"
-            justify="space-between"
-            h="100%"
-            py="lg"
-            gap="sm"
-          >
-            <Box px="lg" style={{ flexShrink: 0 }}>
-              <McpQuestionTitle />
-            </Box>
-
-            <Flex px="xs" flex={1} style={{ overflow: "hidden" }}>
-              <SdkQuestion.QuestionVisualization height={visualizationHeight} />
-            </Flex>
-
-            <Flex px="lg">
-              <McpQueryBar app={app} instanceUrl={instanceUrl} />
-            </Flex>
-          </Flex>
-        </SdkQuestion>
-      </div>
+      <div style={containerStyle}>{renderContent()}</div>
     </ComponentProvider>
   );
 }

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpUserAndSettingsFetch.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpUserAndSettingsFetch.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+import type { SdkStore } from "embedding-sdk-bundle/store/types";
+import { refreshSiteSettings } from "metabase/redux/settings";
+import { userUpdated } from "metabase/redux/user";
+import { UserApi } from "metabase/services";
+
+import {
+  type McpAppsUserAndSettingsFetchErrorType,
+  getMcpAppsUserAndSettingsFetchErrorMessage,
+  getMcpAppsUserAndSettingsFetchErrorType,
+} from "../utils/getMcpAppsUserAndSettingsFetchError";
+
+interface UseMcpUserAndSettingsFetchOptions {
+  instanceUrl: string;
+  sessionToken: string;
+  store: SdkStore;
+}
+
+interface UseMcpUserAndSettingsFetchResult {
+  isSettingsReady: boolean;
+  userAndSettingsFetchError: string | null;
+}
+
+export function useMcpUserAndSettingsFetch({
+  instanceUrl,
+  sessionToken,
+  store,
+}: UseMcpUserAndSettingsFetchOptions): UseMcpUserAndSettingsFetchResult {
+  const [isSettingsReady, setIsSettingsReady] = useState(false);
+
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  // The OSS no-op initAuth never loads user or settings. Do it ourselves so
+  // selectors like getTokenFeature has populated settings.
+  // We also no-op the EE auth flow (auth.ts) when in MCP Apps route.
+  useEffect(() => {
+    let isMounted = true;
+
+    const setErrorByType = (type: McpAppsUserAndSettingsFetchErrorType) =>
+      setFetchError(getMcpAppsUserAndSettingsFetchErrorMessage(type));
+
+    async function fetchUserAndSettings() {
+      try {
+        setIsSettingsReady(false);
+        setFetchError(null);
+
+        if (!sessionToken) {
+          setErrorByType("auth");
+          return;
+        }
+
+        if (!instanceUrl) {
+          setErrorByType("network");
+          return;
+        }
+
+        const [currentUser] = await Promise.all([
+          UserApi.current(),
+          store.dispatch(refreshSiteSettings()),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        store.dispatch(userUpdated(currentUser));
+        setIsSettingsReady(true);
+      } catch (error) {
+        console.error("Error initializing MCP app", error);
+
+        if (isMounted) {
+          setErrorByType(getMcpAppsUserAndSettingsFetchErrorType(error));
+        }
+      }
+    }
+
+    fetchUserAndSettings();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [instanceUrl, sessionToken, store]);
+
+  return { isSettingsReady, userAndSettingsFetchError: fetchError };
+}

--- a/frontend/src/metabase/embedding/mcp/utils/getMcpAppsUserAndSettingsFetchError.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/getMcpAppsUserAndSettingsFetchError.ts
@@ -1,0 +1,36 @@
+/* eslint-disable metabase/no-literal-metabase-strings */
+
+import { match } from "ts-pattern";
+import { t } from "ttag";
+
+export type McpAppsUserAndSettingsFetchErrorType = "auth" | "network";
+
+export function getMcpAppsUserAndSettingsFetchErrorType(
+  error: unknown,
+): McpAppsUserAndSettingsFetchErrorType {
+  if (!error || typeof error !== "object") {
+    return "network";
+  }
+
+  if ("status" in error && error.status === 401) {
+    return "auth";
+  }
+
+  return "network";
+}
+
+export const getMcpAppsUserAndSettingsFetchErrorMessage = (
+  type: McpAppsUserAndSettingsFetchErrorType,
+): string =>
+  match(type)
+    .with(
+      "auth",
+      () =>
+        t`Authentication failed. Try signing out and signing back in, then ask your MCP client to show this again.`,
+    )
+    .with(
+      "network",
+      () =>
+        t`Could not connect to Metabase. Make sure this MCP client is enabled in AI settings and that Metabase is reachable.`,
+    )
+    .exhaustive();

--- a/frontend/src/metabase/embedding/mcp/utils/getMcpAppsUserAndSettingsFetchError.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/getMcpAppsUserAndSettingsFetchError.unit.spec.ts
@@ -1,0 +1,27 @@
+import { getMcpAppsUserAndSettingsFetchErrorType } from "./getMcpAppsUserAndSettingsFetchError";
+
+describe("getMcpAppsUserAndSettingsFetchErrorType", () => {
+  it("returns auth for unauthorized current user or settings API errors", () => {
+    expect(
+      getMcpAppsUserAndSettingsFetchErrorType({
+        status: 401,
+        data: "Unauthenticated",
+      }),
+    ).toBe("auth");
+  });
+
+  it("returns network for non-auth current user or settings API errors", () => {
+    expect(
+      getMcpAppsUserAndSettingsFetchErrorType({
+        status: 500,
+        data: "Internal server error",
+      }),
+    ).toBe("network");
+  });
+
+  it("returns network for unreadable CORS or network failures", () => {
+    expect(
+      getMcpAppsUserAndSettingsFetchErrorType(new TypeError("Failed to fetch")),
+    ).toBe("network");
+  });
+});


### PR DESCRIPTION
Closes EMB-1629
Closes EMB-1633

### Description

Shows a real MCP Apps error instead of leaving the static iframe spinner up when the app cannot fetch the current user or instance settings.

This covers both unreadable CORS/network failures, such as Claude not being enabled in AI settings, and readable authentication failures, such as an expired MCP app session.

### Demos

<img width="1384" height="1110" alt="CleanShot 2569-05-05 at 15 51 19@2x" src="https://github.com/user-attachments/assets/6f4d3466-ab23-40b7-980b-1dd759266ebd" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing because Claude Desktop strips HTTP domains such as `localhost:3000`, so nothing will load.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config:

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any:

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73633.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case. Note that if you change the AI settings, it would change it for everyone though!

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73633.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting:

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. With Claude enabled in AI settings, ask Claude to visualize a query and confirm the MCP App renders normally.
4. Important: **Disable Claude in AI settings** (in admin settings), reload, and ask Claude to visualize a query again.

<img width="1700" height="1278" alt="CleanShot 2569-05-05 at 15 52 42@2x" src="https://github.com/user-attachments/assets/78e54973-6d28-4a82-b22c-bb7297b77d64" />

6. Confirm the MCP App shows an error instead of loading forever. See above screenshot.
7. (Optional) Sign out or invalidate the MCP app session, then confirm auth failures show an authentication error instead of "Question not found". I did this by deleting the MCP session in the AppDB database.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit tests
