### PR TITLE
Security center improvements

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -132,26 +132,24 @@
    (evaluate-advisory! advisory (parse-version (:tag config/mb-version-info))))
   ([advisory instance-version]
    (let [in-range? (affected-by-version? instance-version (:affected_versions advisory))]
-     (when-not (and (not in-range?) (#{:resolved :not_affected} (:match_status advisory)))
+     (when (or in-range? (not (#{:resolved :not_affected} (:match_status advisory))))
        (let [match-status (evaluate-advisory in-range? (execute-matching-query! (:matching_query advisory)))]
          (t2/update! :model/SecurityAdvisory (:id advisory)
                      {:match_status      match-status
                       :last_evaluated_at (mi/now)}))))))
 
 (defn evaluate-all-advisories!
-  "Re-evaluate all non-acknowledged advisories, plus any acknowledged advisories
-   that are still active or in error state."
+  "Re-evaluate every advisory, including acknowledged ones — an acked
+   advisory may apply again if appdb state changes."
   []
-  (let [instance-version (parse-version (:tag config/mb-version-info))
-        advisories       (t2/select :model/SecurityAdvisory
-                                    {:where [:or
-                                             [:= :acknowledged_at nil]
-                                             [:in :match_status ["active" "error"]]]})]
-    (doseq [advisory advisories]
-      (try
-        (evaluate-advisory! advisory instance-version)
-        (catch Exception e
-          (log/warnf e "Error evaluating advisory %s" (:advisory_id advisory))
-          (t2/update! :model/SecurityAdvisory (:id advisory)
-                      {:match_status      :error
-                       :last_evaluated_at (mi/now)}))))))
+  (let [instance-version (parse-version (:tag config/mb-version-info))]
+    (->>
+     (t2/reducible-select :model/SecurityAdvisory)
+     (run! (fn [advisory]
+             (try
+               (evaluate-advisory! advisory instance-version)
+               (catch Exception e
+                 (log/warnf e "Error evaluating advisory %s" (:advisory_id advisory))
+                 (t2/update! :model/SecurityAdvisory (:id advisory)
+                             {:match_status      :error
+                              :last_evaluated_at (mi/now)}))))))))

--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -127,16 +127,27 @@
    in batch.
 
    Short-circuits entirely (no query, no DB update) when the version is outside
-   every affected range and the advisory is already in a terminal state."
+   every affected range and the advisory is already in a terminal state.
+
+   Reactivation: when an acked advisory previously deemed unaffected
+   (`:resolved` / `:not_affected`) transitions to `:active` or `:error` — the
+   appdb evidence now contradicts the prior ack — the acknowledgement is
+   cleared so the next repeat-notification cycle picks it up."
   ([advisory]
    (evaluate-advisory! advisory (parse-version (:tag config/mb-version-info))))
   ([advisory instance-version]
-   (let [in-range? (affected-by-version? instance-version (:affected_versions advisory))]
-     (when (or in-range? (not (#{:resolved :not_affected} (:match_status advisory))))
-       (let [match-status (evaluate-advisory in-range? (execute-matching-query! (:matching_query advisory)))]
+   (let [in-range? (affected-by-version? instance-version (:affected_versions advisory))
+         currently-unaffected (#{:resolved :not_affected} (:match_status advisory))]
+     (when (or in-range? (not currently-unaffected))
+       (let [match-status (evaluate-advisory in-range? (execute-matching-query! (:matching_query advisory)))
+             reactivated? (and (#{:active :error} match-status)
+                               currently-unaffected
+                               (some? (:acknowledged_at advisory)))]
          (t2/update! :model/SecurityAdvisory (:id advisory)
-                     {:match_status      match-status
-                      :last_evaluated_at (mi/now)}))))))
+                     (cond-> {:match_status      match-status
+                              :last_evaluated_at (mi/now)}
+                       reactivated? (assoc :acknowledged_at nil
+                                           :acknowledged_by nil))))))))
 
 (defn evaluate-all-advisories!
   "Re-evaluate every advisory, including acknowledged ones — an acked

--- a/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
@@ -260,6 +260,72 @@
           (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
             (is (not= :active (:match_status reloaded)))))))))
 
+(deftest evaluate-advisory!-reactivation-test
+  (with-redefs [config/mb-version-info {:tag "v1.55.0"}]
+    (let [acked-at #t "2026-04-01T00:00:00Z"
+          notified #t "2026-04-02T00:00:00Z"]
+      (testing "acked unaffected advisory transitioning to :active or :error clears the ack but preserves last_notified_at"
+        (doseq [prior-status        ["resolved" "not_affected"]
+                [label new-status query]
+                [["active" :active {:default {:select [1] :from [:core_user] :limit 1}}]
+                 ["error"  :error  {:default {:select [1] :from [:nonexistent_table] :limit 1}}]]]
+          (testing (str prior-status " -> " label)
+            (mt/with-temp [:model/SecurityAdvisory advisory
+                           {:advisory_id       (str "SC-REACT-" prior-status "-" label)
+                            :severity          "high"
+                            :title             "Test"
+                            :description       "Test"
+                            :remediation       "Upgrade"
+                            :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                            :matching_query    query
+                            :match_status      prior-status
+                            :acknowledged_at   acked-at
+                            :acknowledged_by   (mt/user->id :rasta)
+                            :last_notified_at  notified
+                            :published_at      #t "2026-03-24T00:00:00Z"
+                            :updated_at        #t "2026-03-24T00:00:00Z"}]
+              (matching/evaluate-advisory! advisory)
+              (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+                (is (= new-status (:match_status reloaded)))
+                (is (nil? (:acknowledged_at reloaded)))
+                (is (nil? (:acknowledged_by reloaded)))
+                (is (= (t/instant notified) (t/instant (:last_notified_at reloaded)))))))))
+      (testing "advisory already :active stays acked"
+        (mt/with-temp [:model/SecurityAdvisory advisory
+                       {:advisory_id       "SC-REACT-NOOP"
+                        :severity          "high"
+                        :title             "Test"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                        :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                        :match_status      "active"
+                        :acknowledged_at   acked-at
+                        :acknowledged_by   (mt/user->id :rasta)
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-advisory! advisory)
+          (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+            (is (= :active (:match_status reloaded)))
+            (is (= (t/instant acked-at) (t/instant (:acknowledged_at reloaded))))
+            (is (= (mt/user->id :rasta) (:acknowledged_by reloaded))))))
+      (testing "unacked advisory transitioning to :active is unaffected by reactivation logic"
+        (mt/with-temp [:model/SecurityAdvisory advisory
+                       {:advisory_id       "SC-REACT-UNACKED"
+                        :severity          "high"
+                        :title             "Test"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                        :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                        :match_status      "not_affected"
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-advisory! advisory)
+          (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+            (is (= :active (:match_status reloaded)))
+            (is (nil? (:acknowledged_at reloaded)))))))))
+
 (deftest evaluate-all-advisories!-test
   (with-redefs [config/mb-version-info {:tag "v1.55.0"}]
     (mt/with-temp [:model/SecurityAdvisory _active

--- a/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
@@ -315,16 +315,52 @@
                        :last_evaluated_at past})
           (matching/evaluate-all-advisories!)
           (is (not= past (:last_evaluated_at (fetch "SC-EVAL-001")))))
-        (testing "acknowledged + not_affected advisories are skipped"
+        (testing "acknowledged + not_affected + in-range advisories are still re-evaluated"
           (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-002"}
                       {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
                        :last_evaluated_at past})
           (matching/evaluate-all-advisories!)
-          (is (= (t/instant past)
-                 (t/instant (:last_evaluated_at (fetch "SC-EVAL-002"))))))
+          (is (not= past (:last_evaluated_at (fetch "SC-EVAL-002")))))
         (testing "acknowledged + error advisories are still re-evaluated"
           (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-003"}
                       {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
                        :last_evaluated_at past})
           (matching/evaluate-all-advisories!)
-          (is (not= past (:last_evaluated_at (fetch "SC-EVAL-003")))))))))
+          (is (not= past (:last_evaluated_at (fetch "SC-EVAL-003")))))))
+    (testing "acknowledged + terminal + out-of-range advisories are skipped (version-range opt)"
+      (let [past #t "2020-01-01T00:00:00Z"]
+        (mt/with-temp [:model/SecurityAdvisory _resolved
+                       {:advisory_id       "SC-EVAL-OOR-001"
+                        :severity          "high"
+                        :title             "Out-of-range resolved"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.0.1" :fixed "0.0.2"}]
+                        ;; would error if executed — proves the short-circuit avoids the query
+                        :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
+                        :match_status      "resolved"
+                        :acknowledged_at   (mi/now)
+                        :acknowledged_by   (mt/user->id :rasta)
+                        :last_evaluated_at past
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}
+                       :model/SecurityAdvisory _not-affected
+                       {:advisory_id       "SC-EVAL-OOR-002"
+                        :severity          "low"
+                        :title             "Out-of-range not_affected"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.0.1" :fixed "0.0.2"}]
+                        :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
+                        :match_status      "not_affected"
+                        :acknowledged_at   (mi/now)
+                        :acknowledged_by   (mt/user->id :rasta)
+                        :last_evaluated_at past
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-all-advisories!)
+          (let [fetch (fn [id] (t2/select-one :model/SecurityAdvisory :advisory_id id))]
+            (is (= (t/instant past) (t/instant (:last_evaluated_at (fetch "SC-EVAL-OOR-001")))))
+            (is (= :resolved (:match_status (fetch "SC-EVAL-OOR-001"))))
+            (is (= (t/instant past) (t/instant (:last_evaluated_at (fetch "SC-EVAL-OOR-002")))))
+            (is (= :not_affected (:match_status (fetch "SC-EVAL-OOR-002"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/settings_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
+   [metabase.premium-features.settings :as premium-features.settings]
    [metabase.premium-features.token-check :as token-check]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -21,6 +22,10 @@
   (testing "disabled on trial even with the feature flag"
     (mt/with-premium-features #{:admin-security-center}
       (mt/with-dynamic-fn-redefs [token-check/is-trial? (constantly true)]
+        (is (false? (premium-features/security-center-enabled?))))))
+  (testing "disabled when MB_SECURITY_CENTER_DISABLED escape hatch is set"
+    (mt/with-premium-features #{:admin-security-center}
+      (mt/with-dynamic-fn-redefs [premium-features.settings/security-center-disabled (constantly true)]
         (is (false? (premium-features/security-center-enabled?)))))))
 
 (deftest security-center-email-recipients-test

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -92,6 +92,7 @@
   hide-embed-branding?
   is-hosted?
   premium-embedding-token
+  security-center-disabled
   security-center-enabled?
   site-uuid-for-premium-features-token-checks
   table-data-editing?

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -293,14 +293,26 @@
   "Should we enable the Library?"
   :library)
 
+(defsetting security-center-disabled
+  (deferred-tru "Globally disable Security Center as a customer-controlled escape hatch.")
+  :type             :boolean
+  :feature          :admin-security-center
+  :default          false
+  :visibility       :internal
+  :include-in-list? false
+  :audit            :never
+  :setter           :none
+  :export?          false)
+
 (define-premium-feature security-center-enabled?
   "True if the current instance has Security Center access.
    Requires the `:admin-security-center` feature flag, a non-trial subscription,
-   and a self-hosted instance."
+   a self-hosted instance, and the `security-center-disabled` setting to be unset."
   :admin-security-center
   :getter (fn []
             (and (has-feature? :admin-security-center)
                  (not (is-hosted?))
+                 (not (security-center-disabled))
                  (not ((requiring-resolve 'metabase.premium-features.token-check/is-trial?)))
                  (or config/is-test? config/is-e2e?
                      (not= (mdb/db-type) :h2)))))


### PR DESCRIPTION
Closes [GDGT-2395: Re-check acknowledged advisories after config changes](https://linear.app/metabase/issue/GDGT-2395/re-check-acknowledged-advisories-after-config-changes)

Recheck all advisories in matching version ranges, even if they've been acknowledged
If a previously acked advisory is reactivated, clear the ack

Also closes https://linear.app/metabase/issue/GDGT-2396/add-env-var-to-disable-security-center

Adds an env variable to disable the security center