### PR TITLE
Avoid temp files when reading JAR

### DIFF
--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -138,11 +138,10 @@
         (.getPath provider uri))
       (^Path parsePath [_ ^String s]
         (.getPath nio-fs s (into-array String [])))
-      (^void checkAccess [_ ^Path p ^Set modes ^"[Ljava.nio.file.LinkOption;" opts]
-        (if (.isEmpty modes)
-          (when-not (Files/exists p opts)
-            (throw (java.nio.file.NoSuchFileException. (str p))))
-          (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes))))
+      (^void checkAccess [_ ^Path p ^Set modes ^"[Ljava.nio.file.LinkOption;" _opts]
+        ;; FileSystemProvider.checkAccess with an empty mode array does an existence-only check while
+        ;; preserving permission errors as IOException — unlike Files/exists, which collapses them to false.
+        (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes)))
       (^void createDirectory [_ ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs]
         (Files/createDirectory p attrs))
       (^void delete [_ ^Path p]

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -139,6 +139,8 @@
       (^Path parsePath [_ ^String s]
         (.getPath nio-fs s (into-array String [])))
       (^void checkAccess [_ ^Path p ^Set modes ^"[Ljava.nio.file.LinkOption;" _opts]
+        ;; LinkOption opts are dropped: the only value is NOFOLLOW_LINKS, and neither our jar zip FS
+        ;; nor resources/python-sources contains symlinks.
         (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes)))
       (^void createDirectory [_ ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs]
         (Files/createDirectory p attrs))

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -139,8 +139,6 @@
       (^Path parsePath [_ ^String s]
         (.getPath nio-fs s (into-array String [])))
       (^void checkAccess [_ ^Path p ^Set modes ^"[Ljava.nio.file.LinkOption;" _opts]
-        ;; FileSystemProvider.checkAccess with an empty mode array does an existence-only check while
-        ;; preserving permission errors as IOException — unlike Files/exists, which collapses them to false.
         (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes)))
       (^void createDirectory [_ ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs]
         (Files/createDirectory p attrs))

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -17,7 +17,9 @@
     Pool
     Pools)
    (java.io Closeable File)
-   (java.nio.file FileSystems)
+   (java.net URI)
+   (java.nio.file AccessMode DirectoryStream$Filter Files FileSystems LinkOption OpenOption Path)
+   (java.nio.file.attribute FileAttribute)
    (java.time Duration)
    (java.util.concurrent TimeUnit TimeoutException)
    (org.graalvm.polyglot Context HostAccess)
@@ -121,10 +123,40 @@
 
 ;;; -------------------------------------------------- Python path delay --------------------------------------------------
 
+(defn- nio-polyglot-fs
+  "Wrap a NIO `java.nio.file.FileSystem` as a polyglot `FileSystem`, routing reads to
+  `Files/newByteChannel` instead of the provider's `newFileChannel`.
+
+  The stock wrapper triggers ZipFileSystem to extract deflated entries to a temp file beside the jar,
+  which fails when the jar's parent directory isn't writable (e.g. non-root in a Kubernetes pod).
+  See https://github.com/metabase/metabase/issues/73541."
+  ^FileSystem [^java.nio.file.FileSystem nio-fs]
+  (let [provider (.provider nio-fs)]
+    (reify FileSystem
+      (^Path parsePath [_ ^URI uri]    (.getPath provider uri))
+      (^Path parsePath [_ ^String s]   (.getPath nio-fs s (into-array String [])))
+      (checkAccess [_ p modes opts]
+        (if (.isEmpty ^java.util.Set modes)
+          (when-not (Files/exists ^Path p ^"[Ljava.nio.file.LinkOption;" opts)
+            (throw (java.nio.file.NoSuchFileException. (str p))))
+          (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes))))
+      (createDirectory [_ p attrs]   (Files/createDirectory ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
+      (delete [_ p]                  (Files/delete ^Path p))
+      (newByteChannel [_ p opts attrs]
+        (Files/newByteChannel ^Path p
+                              ^java.util.Set opts
+                              ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
+      (newDirectoryStream [_ dir filter]
+        (Files/newDirectoryStream ^Path dir ^DirectoryStream$Filter filter))
+      (toAbsolutePath [_ p]          (.toAbsolutePath ^Path p))
+      (toRealPath [_ p opts]         (.toRealPath ^Path p ^"[Ljava.nio.file.LinkOption;" opts))
+      (readAttributes [_ p attrs opts]
+        (Files/readAttributes ^Path p ^String attrs ^"[Ljava.nio.file.LinkOption;" opts)))))
+
 (defn- read-only-polyglot-fs
   "Wrap an NIO `java.nio.file.FileSystem` as a read-only polyglot FileSystem suitable for GraalPy."
   ^FileSystem [^java.nio.file.FileSystem nio-fs]
-  (-> nio-fs FileSystem/newFileSystem FileSystem/newReadOnlyFileSystem))
+  (-> nio-fs nio-polyglot-fs FileSystem/newReadOnlyFileSystem))
 
 (defonce ^:private
   ^{:doc "A read-only polyglot FileSystem and the PythonPath within it.

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -18,8 +18,10 @@
     Pools)
    (java.io Closeable File)
    (java.net URI)
-   (java.nio.file AccessMode DirectoryStream$Filter Files FileSystems Path)
+   (java.nio.channels SeekableByteChannel)
+   (java.nio.file AccessMode DirectoryStream DirectoryStream$Filter Files FileSystems Path)
    (java.time Duration)
+   (java.util Map Set)
    (java.util.concurrent TimeUnit TimeoutException)
    (org.graalvm.polyglot Context HostAccess)
    (org.graalvm.polyglot.io FileSystem IOAccess)))
@@ -136,27 +138,26 @@
         (.getPath provider uri))
       (^Path parsePath [_ ^String s]
         (.getPath nio-fs s (into-array String [])))
-      (checkAccess [_ p modes opts]
-        (if (.isEmpty ^java.util.Set modes)
-          (when-not (Files/exists ^Path p ^"[Ljava.nio.file.LinkOption;" opts)
+      (^void checkAccess [_ ^Path p ^Set modes ^"[Ljava.nio.file.LinkOption;" opts]
+        (if (.isEmpty modes)
+          (when-not (Files/exists p opts)
             (throw (java.nio.file.NoSuchFileException. (str p))))
           (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes))))
-      (createDirectory [_ p attrs]
-        (Files/createDirectory ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
-      (delete [_ p]
-        (Files/delete ^Path p))
-      (newByteChannel [_ p opts attrs]
-        (Files/newByteChannel ^Path p
-                              ^java.util.Set opts
-                              ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
-      (newDirectoryStream [_ dir filter]
-        (Files/newDirectoryStream ^Path dir ^DirectoryStream$Filter filter))
-      (toAbsolutePath [_ p]
-        (.toAbsolutePath ^Path p))
-      (toRealPath [_ p opts]
-        (.toRealPath ^Path p ^"[Ljava.nio.file.LinkOption;" opts))
-      (readAttributes [_ p attrs opts]
-        (Files/readAttributes ^Path p ^String attrs ^"[Ljava.nio.file.LinkOption;" opts)))))
+      (^void createDirectory [_ ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs]
+        (Files/createDirectory p attrs))
+      (^void delete [_ ^Path p]
+        (Files/delete p))
+      (^SeekableByteChannel newByteChannel
+        [_ ^Path p ^Set opts ^"[Ljava.nio.file.attribute.FileAttribute;" attrs]
+        (Files/newByteChannel p opts attrs))
+      (^DirectoryStream newDirectoryStream [_ ^Path dir ^DirectoryStream$Filter filter]
+        (Files/newDirectoryStream dir filter))
+      (^Path toAbsolutePath [_ ^Path p]
+        (.toAbsolutePath p))
+      (^Path toRealPath [_ ^Path p ^"[Ljava.nio.file.LinkOption;" opts]
+        (.toRealPath p opts))
+      (^Map readAttributes [_ ^Path p ^String attrs ^"[Ljava.nio.file.LinkOption;" opts]
+        (Files/readAttributes p attrs opts)))))
 
 (defn- read-only-polyglot-fs
   "Wrap an NIO `java.nio.file.FileSystem` as a read-only polyglot FileSystem suitable for GraalPy."

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -18,8 +18,7 @@
     Pools)
    (java.io Closeable File)
    (java.net URI)
-   (java.nio.file AccessMode DirectoryStream$Filter Files FileSystems LinkOption OpenOption Path)
-   (java.nio.file.attribute FileAttribute)
+   (java.nio.file AccessMode DirectoryStream$Filter Files FileSystems Path)
    (java.time Duration)
    (java.util.concurrent TimeUnit TimeoutException)
    (org.graalvm.polyglot Context HostAccess)
@@ -133,23 +132,29 @@
   ^FileSystem [^java.nio.file.FileSystem nio-fs]
   (let [provider (.provider nio-fs)]
     (reify FileSystem
-      (^Path parsePath [_ ^URI uri]    (.getPath provider uri))
-      (^Path parsePath [_ ^String s]   (.getPath nio-fs s (into-array String [])))
+      (^Path parsePath [_ ^URI uri]
+        (.getPath provider uri))
+      (^Path parsePath [_ ^String s]
+        (.getPath nio-fs s (into-array String [])))
       (checkAccess [_ p modes opts]
         (if (.isEmpty ^java.util.Set modes)
           (when-not (Files/exists ^Path p ^"[Ljava.nio.file.LinkOption;" opts)
             (throw (java.nio.file.NoSuchFileException. (str p))))
           (.checkAccess provider p ^"[Ljava.nio.file.AccessMode;" (into-array AccessMode modes))))
-      (createDirectory [_ p attrs]   (Files/createDirectory ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
-      (delete [_ p]                  (Files/delete ^Path p))
+      (createDirectory [_ p attrs]
+        (Files/createDirectory ^Path p ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
+      (delete [_ p]
+        (Files/delete ^Path p))
       (newByteChannel [_ p opts attrs]
         (Files/newByteChannel ^Path p
                               ^java.util.Set opts
                               ^"[Ljava.nio.file.attribute.FileAttribute;" attrs))
       (newDirectoryStream [_ dir filter]
         (Files/newDirectoryStream ^Path dir ^DirectoryStream$Filter filter))
-      (toAbsolutePath [_ p]          (.toAbsolutePath ^Path p))
-      (toRealPath [_ p opts]         (.toRealPath ^Path p ^"[Ljava.nio.file.LinkOption;" opts))
+      (toAbsolutePath [_ p]
+        (.toAbsolutePath ^Path p))
+      (toRealPath [_ p opts]
+        (.toRealPath ^Path p ^"[Ljava.nio.file.LinkOption;" opts))
       (readAttributes [_ p attrs opts]
         (Files/readAttributes ^Path p ^String attrs ^"[Ljava.nio.file.LinkOption;" opts)))))
 

--- a/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
+++ b/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
@@ -21,7 +21,7 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest ^:parallel newByteChannel-returns-in-memory-channel-test
+(deftest ^:parallel new-byte-channel-returns-in-memory-channel-test
   (testing "newByteChannel on a compressed zip entry returns an in-memory channel rather than extracting
             to a temp file beside the jar. With the stock GraalVM wrapper, the channel is a `FileChannel`
             backed by temp-file extraction — that path fails when the jar's parent dir isn't writable."

--- a/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
+++ b/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
@@ -20,19 +20,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- write-deflated-zip!
-  "Writes a zip at `path` containing `entries` as DEFLATE-compressed entries (the case that triggered the
-  bug — STORED entries don't need temp extraction)."
-  [^String path entries]
-  (with-open [zos (ZipOutputStream. (FileOutputStream. path))]
-    (.setLevel zos java.util.zip.Deflater/DEFAULT_COMPRESSION)
-    (doseq [[entry-path content] entries]
-      (let [e (ZipEntry. (str entry-path))]
-        (.setMethod e ZipEntry/DEFLATED)
-        (.putNextEntry zos e)
-        (.write zos (.getBytes ^String content "UTF-8"))
-        (.closeEntry zos)))))
-
 (deftest ^:parallel newByteChannel-returns-in-memory-channel-test
   (testing "newByteChannel on a compressed zip entry returns an in-memory ByteArrayChannel rather than
             extracting to a temp file beside the jar.
@@ -40,7 +27,15 @@
             temp-file extraction) — that path fails when the jar's parent dir isn't writable."
     (let [zip-file (Files/createTempFile "metabase-fs-repro" ".zip" (make-array FileAttribute 0))]
       (try
-        (write-deflated-zip! (str zip-file) [["/python-sources/sql_tools.py" "print('hello')\n"]])
+        ;; Write a DEFLATE-compressed zip entry — the case that triggered the bug; STORED entries don't
+        ;; need temp extraction.
+        (with-open [zos (ZipOutputStream. (FileOutputStream. (str zip-file)))]
+          (.setLevel zos java.util.zip.Deflater/DEFAULT_COMPRESSION)
+          (let [entry (ZipEntry. "/python-sources/sql_tools.py")]
+            (.setMethod entry ZipEntry/DEFLATED)
+            (.putNextEntry zos entry)
+            (.write zos (.getBytes "print('hello')\n" "UTF-8"))
+            (.closeEntry zos)))
         (with-open [^java.nio.file.FileSystem nio-fs (u.files/nio-fs (str zip-file))]
           (let [^FileSystem polyfs (#'pool/read-only-polyglot-fs nio-fs)
                 path               (.parsePath polyfs "/python-sources/sql_tools.py")]

--- a/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
+++ b/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
@@ -1,0 +1,53 @@
+(ns metabase.sql-parsing.jar-python-fs-repro-test
+  "Regression for https://github.com/metabase/metabase/issues/73541.
+
+  GraalVM's bundled polyglot `FileSystem` wrapper routes `newByteChannel` through
+  `provider.newFileChannel`, which forces JDK ZipFileSystem to extract deflated entries to a temp file
+  beside the jar — fails when that directory isn't writable (non-root in a Kubernetes pod).
+  The fix in `metabase.sql-parsing.pool/nio-polyglot-fs` overrides `newByteChannel` to call
+  `Files/newByteChannel`, which returns an in-memory `ByteArrayChannel` for compressed entries."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.sql-parsing.pool :as pool]
+   [metabase.util.files :as u.files])
+  (:import
+   (java.io FileOutputStream)
+   (java.nio.file Files StandardOpenOption)
+   (java.nio.file.attribute FileAttribute)
+   (java.util EnumSet)
+   (java.util.zip ZipEntry ZipOutputStream)
+   (org.graalvm.polyglot.io FileSystem)))
+
+(set! *warn-on-reflection* true)
+
+(defn- write-deflated-zip!
+  "Writes a zip at `path` containing `entries` as DEFLATE-compressed entries (the case that triggered the
+  bug — STORED entries don't need temp extraction)."
+  [^String path entries]
+  (with-open [zos (ZipOutputStream. (FileOutputStream. path))]
+    (.setLevel zos java.util.zip.Deflater/DEFAULT_COMPRESSION)
+    (doseq [[entry-path content] entries]
+      (let [e (ZipEntry. (str entry-path))]
+        (.setMethod e ZipEntry/DEFLATED)
+        (.putNextEntry zos e)
+        (.write zos (.getBytes ^String content "UTF-8"))
+        (.closeEntry zos)))))
+
+(deftest ^:parallel newByteChannel-returns-in-memory-channel-test
+  (testing "newByteChannel on a compressed zip entry returns an in-memory ByteArrayChannel rather than
+            extracting to a temp file beside the jar.
+            With the stock GraalVM wrapper, the channel is `ZipFileSystem$1` (FileChannel-backed via
+            temp-file extraction) — that path fails when the jar's parent dir isn't writable."
+    (let [zip-file (Files/createTempFile "metabase-fs-repro" ".zip" (make-array FileAttribute 0))]
+      (try
+        (write-deflated-zip! (str zip-file) [["/python-sources/sql_tools.py" "print('hello')\n"]])
+        (with-open [^java.nio.file.FileSystem nio-fs (u.files/nio-fs (str zip-file))]
+          (let [^FileSystem polyfs (#'pool/read-only-polyglot-fs nio-fs)
+                path               (.parsePath polyfs "/python-sources/sql_tools.py")]
+            (with-open [ch (.newByteChannel polyfs path
+                                            (EnumSet/of StandardOpenOption/READ)
+                                            (make-array FileAttribute 0))]
+              (is (= "jdk.nio.zipfs.ByteArrayChannel" (-> ch class .getName))
+                  "Channel must be the in-memory ByteArrayChannel; a FileChannel implies temp-file extraction."))))
+        (finally
+          (Files/deleteIfExists zip-file))))))

--- a/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
+++ b/test/metabase/sql_parsing/jar_python_fs_repro_test.clj
@@ -12,6 +12,7 @@
    [metabase.util.files :as u.files])
   (:import
    (java.io FileOutputStream)
+   (java.nio.channels FileChannel)
    (java.nio.file Files StandardOpenOption)
    (java.nio.file.attribute FileAttribute)
    (java.util EnumSet)
@@ -21,10 +22,9 @@
 (set! *warn-on-reflection* true)
 
 (deftest ^:parallel newByteChannel-returns-in-memory-channel-test
-  (testing "newByteChannel on a compressed zip entry returns an in-memory ByteArrayChannel rather than
-            extracting to a temp file beside the jar.
-            With the stock GraalVM wrapper, the channel is `ZipFileSystem$1` (FileChannel-backed via
-            temp-file extraction) — that path fails when the jar's parent dir isn't writable."
+  (testing "newByteChannel on a compressed zip entry returns an in-memory channel rather than extracting
+            to a temp file beside the jar. With the stock GraalVM wrapper, the channel is a `FileChannel`
+            backed by temp-file extraction — that path fails when the jar's parent dir isn't writable."
     (let [zip-file (Files/createTempFile "metabase-fs-repro" ".zip" (make-array FileAttribute 0))]
       (try
         ;; Write a DEFLATE-compressed zip entry — the case that triggered the bug; STORED entries don't
@@ -42,7 +42,7 @@
             (with-open [ch (.newByteChannel polyfs path
                                             (EnumSet/of StandardOpenOption/READ)
                                             (make-array FileAttribute 0))]
-              (is (= "jdk.nio.zipfs.ByteArrayChannel" (-> ch class .getName))
-                  "Channel must be the in-memory ByteArrayChannel; a FileChannel implies temp-file extraction."))))
+              (is (not (instance? FileChannel ch))
+                  "Channel must not be a FileChannel — that implies temp-file extraction beside the jar."))))
         (finally
           (Files/deleteIfExists zip-file))))))


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/73541 (likely resolves it, but want customer verification)

## Summary
- GraalVM's bundled polyglot `FileSystem` wrapper routes `newByteChannel` through `provider.newFileChannel`, which forces JDK ZipFileSystem to extract deflated entries to a temp file beside the jar.
- In Metabase Cloud / Kubernetes the pod runs non-root with `/app/metabase.jar` owned by root, so the temp create fails with `AccessDeniedException`. GraalPy surfaces it as `PermissionError: [Errno 13] Permission denied: '/python-sources/sql_tools.py'`.
- Wrap the NIO zip FS with a custom polyglot FileSystem that delegates `newByteChannel` to `Files/newByteChannel` — returns an in-memory `ByteArrayChannel` for compressed entries, no temp file. The polyglot interface only requires `SeekableByteChannel`.

Fixes #73541. The earlier closed-filesystem fix (#73562) was unrelated to this failure mode.

## Test plan
- [x] Unit regression test asserts the channel type is `jdk.nio.zipfs.ByteArrayChannel` (the stock wrapper returns `jdk.nio.zipfs.ZipFileSystem$1`, which would fail the assertion)
- [x] Local verification: real production code path (`metabase.sql-parsing.core/is-single-select-stmt?`) executed in a non-root Linux container against a patched 1.60.3.8 uberjar — fails on iter 0 without the fix (exact customer error), passes 5/5 with it
- [ ] CI green