### PR TITLE
Show plain-text 4xx body in guest embed visualization

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -51,6 +51,13 @@ async function handleQueryApiError(apiPromise) {
       error.status < 500 &&
       error.data
     ) {
+      // The QP returns a structured `{ error, error_type, ... }` body, but
+      // plainer endpoints (e.g. `/api/embed/*` API-level checks) return a
+      // plain-text body. Normalize so callers can rely on a `{ error, ... }`
+      // shape and don't fall through to the empty state (EMB-1659).
+      if (typeof error.data === "string") {
+        return { error: error.data, status: error.status };
+      }
       return error.data;
     }
     // For 5xx and other errors, re-throw

--- a/frontend/src/metabase/services.unit.spec.ts
+++ b/frontend/src/metabase/services.unit.spec.ts
@@ -259,5 +259,26 @@ describe("metabase/services > runQuestionQuery", () => {
         status: 500,
       });
     });
+
+    it("normalizes plain-text 4xx error bodies into a structured error result (EMB-1659)", async () => {
+      // Embed API checks (e.g. `/api/embed/card/:token/query`) reject with a
+      // plain-text body when a locked param is missing from the JWT. Without
+      // normalization the result reaches the visualization as a bare string,
+      // so `result?.error` is undefined and the UI falls through to an empty
+      // state instead of showing the message.
+      const question = createMockSavedQuestion();
+      const errorMessage = "You must specify a value for category in the JWT.";
+
+      fetchMock.post(getQueryEndpointPath(question), {
+        status: 400,
+        body: errorMessage,
+      });
+
+      const result = await runQuestionQuery(question, {
+        cancelDeferred: defer(),
+      });
+
+      expect(result).toEqual([{ error: errorMessage, status: 400 }]);
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73360
[EMB-1659: Guest embed shows unhelpful error for invalid param](https://linear.app/metabase/issue/EMB-1659/guest-embed-shows-unhelpful-error-for-invalid-param)

### Description

When a guest embed query hits an `/api/embed/*` API-level check (e.g. a required locked param missing from the JWT), the backend rejects with a plain-text body like `"You must specify a value for category in the JWT."`. `handleQueryApiError` in `services.js` was returning that body verbatim, so `queryResults[0]` reached the visualization as a bare string. `QueryVisualization` looks at `result?.error` and `result?.data` — strings have neither — so the question fell through to the empty-state placeholder ("To run your code, click on the Run button…") instead of showing the actual error.

The QP returns a structured `{ error, error_type, ... }` body, so this only manifests for the plainer embed-API endpoints. The fix wraps plain-text 4xx bodies as `{ error, status }` so the existing `result?.error` branch in `QueryVisualization` triggers `<VisualizationError>`. Object bodies flow through unchanged.

### How to verify

1. Create a SQL question `SELECT * FROM products WHERE category = {{category}}` with the `category` template tag marked **Required**.
2. Enable embedding for the question and mark `category` as **Locked** in the embedding params; set `embedding_type: "guest-embed"` on the card.
3. Sign a guest-embed JWT for the question with empty `params` (i.e. omit `category`).
4. In a host page, configure the embed:
   ```html
   <script src="http://localhost:3000/app/embed.js"></script>
   <script>
     metabaseConfig.set({
       instanceUrl: "http://localhost:3000",
       isGuest: true,
       guestEmbedProviderUri: "<your-jwt-endpoint>",
     });
   </script>
   <metabase-question question-id="<id>"></metabase-question>
   ```
5. Load the page.
   - Before: empty native-editor placeholder ("To run your code, click on the Run button or type ⌘ + return / Here's where your results will appear").
   - After: `<VisualizationError>` showing *"An error occurred in your query / You must specify a value for category in the JWT."*
6. Sign a JWT that includes `params: {category: "Gizmo"}` and reload — the question runs normally.

### Demo

_n/a_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)