### PR TITLE
docs: make MCP snippet copyable

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -17,7 +17,11 @@ If your admin has turned on [your Metabase's MCP server](./settings.md#enable-mc
 https://{your-metabase.example.com}/api/mcp
 ```
 
-In Claude Code, for example, you can run `/mcp add metabase https://{your-metabase.example.com}/api/mcp --transport streamable-http` and Claude will handle the OAuth flow for you.
+In Claude Code, for example, you can run the following snippet, and Claude will handle the OAuth flow for you:
+
+```
+/mcp add metabase https://{your-metabase.example.com}/api/mcp --transport streamable-http
+```
 
 For Claude Desktop, you can create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp) by just giving it that URL to your Metabase's mcp endpoint.
 


### PR DESCRIPTION
I'm lazy and i want to click a button