### PR TITLE
feat: confirmation modal when disconnecting AI provider

### DIFF
--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -25,6 +25,7 @@ import {
   useAdminSetting,
   useAdminSettings,
 } from "metabase/api/utils";
+import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { PLUGIN_METABOT } from "metabase/plugins";
@@ -217,7 +218,7 @@ export function MetabotSetupInner({
     "llm-openrouter-api-key",
   ] as const);
 
-  const handleDisconnect = useCallback(async () => {
+  const disconnectProvider = useCallback(async () => {
     if (!connectedProvider) {
       return;
     }
@@ -286,8 +287,9 @@ export function MetabotSetupInner({
 
   const connectHandlerRef = useRef<(() => Promise<void>) | null>(null);
 
-  const [isConnecting, setIsConnecting] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [isDisconnectConfirmOpen, setIsDisconnectConfirmOpen] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
   const handleConnect = async () => {
     if (!connectHandlerRef.current) {
       return;
@@ -302,6 +304,20 @@ export function MetabotSetupInner({
 
   const resetProvider = () => {
     setProvider(undefined);
+  };
+
+  const handleDisconnect = useCallback(() => {
+    setIsDisconnectConfirmOpen(true);
+  }, []);
+
+  const handleConfirmDisconnect = async () => {
+    setIsDisconnecting(true);
+    try {
+      await disconnectProvider();
+      setIsDisconnectConfirmOpen(false);
+    } finally {
+      setIsDisconnecting(false);
+    }
   };
 
   const isLoading =
@@ -392,14 +408,7 @@ export function MetabotSetupInner({
                   c="danger"
                   loading={isLoading}
                   disabled={isLoading}
-                  onClick={async () => {
-                    setIsDisconnecting(true);
-                    try {
-                      await handleDisconnect();
-                    } finally {
-                      setIsDisconnecting(false);
-                    }
-                  }}
+                  onClick={handleDisconnect}
                 >
                   {t`Disconnect`}
                 </Button>
@@ -421,6 +430,14 @@ export function MetabotSetupInner({
             )
             .exhaustive()}
         </Flex>
+        <ConfirmModal
+          opened={isDisconnectConfirmOpen}
+          onClose={() => setIsDisconnectConfirmOpen(false)}
+          title={t`Disconnect AI provider?`}
+          message={t`This will disconnect your AI provider and disable AI features across your instance until you connect a provider again.`}
+          confirmButtonText={t`Disconnect provider`}
+          onConfirm={handleConfirmDisconnect}
+        />
       </Stack>
     </MetabotSetupContext.Provider>
   );

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -414,6 +414,19 @@ async function selectProvider(name: string) {
   await userEvent.click(await screen.findByRole("option", { name }));
 }
 
+async function openDisconnectProviderModal() {
+  await userEvent.click(
+    await screen.findByRole("button", { name: "Disconnect" }),
+  );
+}
+
+async function confirmDisconnectProvider() {
+  await openDisconnectProviderModal();
+  await userEvent.click(
+    await screen.findByRole("button", { name: "Disconnect provider" }),
+  );
+}
+
 describe("MetabotSetup", () => {
   afterEach(() => {
     reinitialize();
@@ -1062,6 +1075,17 @@ describe("MetabotSetup", () => {
       screen.getByRole("button", { name: "Use a different AI provider" }),
     );
 
+    expect(
+      await screen.findByText("Disconnect AI provider?"),
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls("path:/api/setting", { method: "PUT" }),
+    ).toHaveLength(0);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Disconnect provider" }),
+    );
+
     await waitFor(() => {
       expect(fetchMock.callHistory.called("path:/api/setting")).toBe(true);
     });
@@ -1167,8 +1191,22 @@ describe("MetabotSetup", () => {
     await setup();
 
     await screen.findByLabelText("API key");
+    await openDisconnectProviderModal();
+
+    expect(
+      await screen.findByText("Disconnect AI provider?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will disconnect your AI provider and disable AI features across your instance until you connect a provider again.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls("path:/api/setting", { method: "PUT" }),
+    ).toHaveLength(0);
+
     await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
+      screen.getByRole("button", { name: "Disconnect provider" }),
     );
 
     await waitFor(() => {
@@ -1203,9 +1241,7 @@ describe("MetabotSetup", () => {
     });
 
     await screen.findByText("Connected to Metabase");
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
-    );
+    await confirmDisconnectProvider();
 
     expect(
       fetchMock.callHistory.called(
@@ -1258,9 +1294,7 @@ describe("MetabotSetup", () => {
     });
 
     await screen.findByText("Connected to Metabase");
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
-    );
+    await confirmDisconnectProvider();
 
     expect(
       fetchMock.callHistory.called(
@@ -1315,9 +1349,7 @@ describe("MetabotSetup", () => {
 
     await screen.findByText("Connected to Metabase");
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
-    );
+    await confirmDisconnectProvider();
 
     expect(
       fetchMock.callHistory.called(
@@ -1356,9 +1388,7 @@ describe("MetabotSetup", () => {
     });
 
     await screen.findByText("Current billing cycle");
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
-    );
+    await confirmDisconnectProvider();
 
     await waitFor(() => {
       expect(
@@ -1379,9 +1409,7 @@ describe("MetabotSetup", () => {
   it("shows an error toast when disconnect fails", async () => {
     const { store } = await setup({ settingUpdateResponse: { status: 500 } });
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Disconnect" }),
-    );
+    await confirmDisconnectProvider();
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73298
Closes [BOT-1404: No confirmation to disconnect AI provider](https://linear.app/metabase/issue/BOT-1404/no-confirmation-to-disconnect-ai-provider)

### Description

Adds confirmation modal when disconnecting AI provider.

### How to verify

1. Connect to AI provider
2. Try clicking disconnect

### Demo


https://github.com/user-attachments/assets/9422730b-55f9-4653-869b-7d01b10ef481


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
