### PR TITLE
Remove x and y labels from ad-hoc charts for MCP Apps

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -6,11 +6,10 @@ import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion"
 import { getSdkStore } from "embedding-sdk-bundle/store";
 import { Box, Flex } from "metabase/ui";
 import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
-import { b64_to_utf8 } from "metabase/utils/encoding";
-import type { Card } from "metabase-types/api";
 
 import { McpQueryBar } from "./McpQueryBar";
 import { McpQuestionTitle } from "./McpQuestionTitle";
+import { getMcpDeserializedCard } from "./McpUiAppRoute.utils";
 import { useHandleMcpDrillThrough } from "./hooks/useHandleMcpDrillThrough";
 import { useMcpApp } from "./hooks/useMcpApp";
 import { useMcpUserAndSettingsFetch } from "./hooks/useMcpUserAndSettingsFetch";
@@ -53,15 +52,7 @@ export function McpUiAppRoute() {
       return null;
     }
 
-    try {
-      return {
-        display: "table",
-        dataset_query: JSON.parse(b64_to_utf8(query)),
-        visualization_settings: {},
-      } as Card;
-    } catch {
-      return null;
-    }
+    return getMcpDeserializedCard(query);
   }, [query]);
 
   const theme = useMemo(

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.utils.ts
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.utils.ts
@@ -1,0 +1,19 @@
+import { b64_to_utf8 } from "metabase/utils/encoding";
+import type { Card, VisualizationSettings } from "metabase-types/api";
+
+export const MCP_APP_VISUALIZATION_SETTINGS: VisualizationSettings = {
+  "graph.x_axis.labels_enabled": false,
+  "graph.y_axis.labels_enabled": false,
+};
+
+export function getMcpDeserializedCard(query: string): Card | null {
+  try {
+    return {
+      display: "table",
+      dataset_query: JSON.parse(b64_to_utf8(query)),
+      visualization_settings: MCP_APP_VISUALIZATION_SETTINGS,
+    } as Card;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.utils.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.utils.unit.spec.ts
@@ -1,0 +1,25 @@
+import { utf8_to_b64 } from "metabase/utils/encoding";
+
+import { getMcpDeserializedCard } from "./McpUiAppRoute.utils";
+
+describe("getMcpDeserializedCard", () => {
+  it("hides axis labels for MCP App ad-hoc charts", () => {
+    const datasetQuery = { database: 1, type: "query", query: {} };
+    const query = utf8_to_b64(JSON.stringify(datasetQuery));
+
+    expect(getMcpDeserializedCard(query)).toEqual(
+      expect.objectContaining({
+        display: "table",
+        dataset_query: datasetQuery,
+        visualization_settings: {
+          "graph.x_axis.labels_enabled": false,
+          "graph.y_axis.labels_enabled": false,
+        },
+      }),
+    );
+  });
+
+  it("returns null for invalid query params", () => {
+    expect(getMcpDeserializedCard("not-json")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes EMB-1675

### Description

Removes the x-axis and y-axis labels from MCP Apps ad-hoc charts.

Those labels repeat the generated question title, so the chart has less duplicate text while keeping the title visible above the visualization.

### Demo

X axis and Y axis labels are hidden:

<img width="1456" height="1266" alt="CleanShot 2569-05-05 at 23 38 25@2x" src="https://github.com/user-attachments/assets/9bc998af-dfe1-47c0-8f2e-531d6b9a81ce" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing because Claude Desktop strips HTTP domains such as `localhost:3000`, so nothing will load.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config:

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any:

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73663.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case. Note that if you change the AI settings, it would change it for everyone though!

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73663.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting:

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. With Claude enabled in AI settings, ask Claude to visualize a query with both a breakout and a metric, e.g. `Show count of orders by created month`.

4. Confirm that the **the chart does not show the x-axis or y-axis label**

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit tests
