### PR TITLE
Adjusting other-sso-enabled? setting to not include metabot slack connection

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.sso.api.interface
   (:require
    [metabase-enterprise.sso.settings :as ee-sso-settings]
-   [metabase.sso.settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]))
 
 (defn- select-sso-backend
@@ -24,8 +23,7 @@
   [req]
   (let [enabled-count (count (filter identity
                                      [(ee-sso-settings/saml-enabled)
-                                      (ee-sso-settings/jwt-enabled-and-configured)
-                                      (sso-settings/slack-connect-enabled)]))]
+                                      (ee-sso-settings/jwt-enabled-and-configured)]))]
     (cond
       ;; Multiple SSO methods enabled - use preferred_method or selection logic
       (> enabled-count 1) (select-sso-backend req)
@@ -33,7 +31,6 @@
       ;; Single SSO method enabled
       (ee-sso-settings/saml-enabled) :saml
       (ee-sso-settings/jwt-enabled-and-configured)  :jwt
-      (sso-settings/slack-connect-enabled)  :slack-connect
 
       ;; No SSO method enabled
       :else nil)))

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -7,7 +7,6 @@
    [metabase-enterprise.scim.core :as scim]
    [metabase.appearance.core :as appearance]
    [metabase.settings.core :as setting :refer [define-multi-setting-impl defsetting]]
-   [metabase.sso.settings :as sso-settings]
    [metabase.system.core :as system]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
@@ -431,7 +430,7 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
 
 (defsetting other-sso-enabled?
   "Are we using an SSO integration other than LDAP or Google Auth or OIDC? These integrations use the `/auth/sso` endpoint
-  (SAML/JWT) or `/auth/sso/slack-connect` (Slack Connect) for authorization rather than the normal login form or Google Auth button."
+  (SAML/JWT) for authorization rather than the normal login form or Google Auth button."
   :visibility :public
   :setter     :none
-  :getter     (fn [] (or (saml-enabled) (jwt-enabled-and-configured) (sso-settings/slack-connect-enabled))))
+  :getter     (fn [] (or (saml-enabled) (jwt-enabled-and-configured))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
@@ -6,7 +6,8 @@
    [metabase.sso.integrations.slack-connect-test :as slack-connect-test]
    [metabase.sso.test-helpers :as sso.test-helpers]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.http-client :as client]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,3 +28,17 @@
                                                         :redirect slack-connect-test/default-redirect-uri)
                   redirect-url (get-in result [:headers "Location"])]
               (is (str/starts-with? redirect-url "http://example.com/slack")))))))))
+
+(deftest auth-sso-does-not-dispatch-to-slack-connect-test
+  (testing "with only Slack Connect enabled, GET /auth/sso returns 400 (UXW-3940)"
+    ;; Slack Connect uses /auth/sso/slack-connect, not /auth/sso. The /auth/sso multimethod
+    ;; only handles SAML and JWT, so it must surface "not enabled" rather than dispatching
+    ;; to a non-existent :slack-connect implementation.
+    (mt/with-additional-premium-features #{:sso-saml :sso-jwt}
+      (sso.test-helpers/with-slack-default-setup!
+        (is (partial=
+             {:cause   "SSO has not been enabled and/or configured"
+              :data    {:status "error-sso-disabled" :status-code 400}
+              :message "SSO has not been enabled and/or configured"
+              :status  "error-sso-disabled"}
+             (client/client :get 400 "/auth/sso")))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.session.core :as session]
    [metabase.sso.settings :as sso.settings]
+   [metabase.sso.test-helpers :as sso.test-helpers]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]))
@@ -277,3 +278,27 @@
 (deftest sso-source-enabled?-unknown-test
   (testing "sso-source-enabled? returns false for unknown sources"
     (is (false? (sso.settings/sso-source-enabled? :unknown-provider)))))
+
+(deftest other-sso-enabled?-test
+  (testing "other-sso-enabled? gates the `/auth/sso` login button (SAML/JWT only)"
+    (testing "false when nothing is enabled"
+      (mt/with-premium-features #{:sso-saml :sso-jwt}
+        (is (false? (sso-settings/other-sso-enabled?)))))
+    (testing "true when SAML is enabled and configured"
+      (mt/with-premium-features #{:sso-saml}
+        (tu/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
+                                           saml-identity-provider-certificate default-idp-cert
+                                           saml-enabled                       true]
+          (is (true? (sso-settings/other-sso-enabled?))))))
+    (testing "true when JWT is enabled and configured"
+      (mt/with-premium-features #{:sso-jwt}
+        (tu/with-temporary-setting-values [jwt-identity-provider-uri default-idp-uri
+                                           jwt-shared-secret         "01234"
+                                           jwt-enabled               true]
+          (is (true? (sso-settings/other-sso-enabled?))))))
+    (testing "false when only Slack Connect is enabled (UXW-3940 regression)"
+      ;; Slack Connect uses /auth/sso/slack-connect, not /auth/sso, so it must
+      ;; not flip on the SAML/JWT login button. See UXW-3940.
+      (sso.test-helpers/with-slack-default-setup!
+        (is (true? (sso.settings/slack-connect-enabled)))
+        (is (false? (sso-settings/other-sso-enabled?)))))))


### PR DESCRIPTION
### Description
Remoes `slack-connect-enabled` from  the calculation of `other-sso-enabled?` setting, which is causing the login via SSO button to be rendered on the login page when Metabot is connected to slack

### How to verify
1. Ensure that you have an instance with metabot setup, a slack connection, and metabot installed on the slack workspace
2. Also ensure that email and password is the only auth method available
3. Log out
4. You should no longer see a Sign in with SSO button

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
