### PR TITLE
collapse view permissions when apropriate

### DIFF
--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -191,6 +191,21 @@
         [:int {:title "table-id" :min 0}]
         ::permissions.schema/data-permission-value]]]]]])
 
+(defn- collapse-uniform-view-data
+  "If every table-level `:perms/view-data` value across every schema for a given (group, db) is the same
+   scalar, collapse the schema/table map to that scalar at the db level. Without this, a newly-added DB
+   whose tables are all uniformly `:blocked` (e.g. via the going-granular path during sync) is reported
+   as a `{schema {table-id :blocked}}` map, which the frontend interprets as `granular`. Only applied to
+   `:perms/view-data`; other granular perm types intentionally retain their map shape."
+  [perm-type->value]
+  (let [view-data-val (get perm-type->value :perms/view-data)]
+    (if (map? view-data-val)
+      (let [leaf-vals (into #{} (mapcat vals) (vals view-data-val))]
+        (if (= 1 (count leaf-vals))
+          (assoc perm-type->value :perms/view-data (first leaf-vals))
+          perm-type->value))
+      perm-type->value)))
+
 (mu/defn data-permissions-graph :- ::graph
   "Returns a tree representation of all data permissions. Can be optionally filtered by group ID, database ID,
   and/or permission type. This is intended to power the permissions editor in the admin panel, and should not be used
@@ -211,21 +226,19 @@
                                        (when-not audit? [:not= :db_id audit/audit-db-id])
                                        [:not-in :db_id {:select [:id]
                                                         :from   [:metabase_database]
-                                                        :where  [:not= :router_database_id nil]}]]})]
-    (reduce
-     (fn [graph {group-id  :group-id
-                 perm-type :type
-                 value     :value
-                 db-id     :db-id
-                 schema    :schema
-                 table-id  :table-id}]
-       (let [schema (or schema "")
-             path   (if table-id
-                      [group-id db-id perm-type schema table-id]
-                      [group-id db-id perm-type])]
-         (assoc-in graph path value)))
-     {}
-     data-perms)))
+                                                        :where  [:not= :router_database_id nil]}]]})
+        raw-graph  (reduce
+                    (fn [graph {:keys [group-id value db-id schema table-id]
+                                perm-type :type}]
+                      (let [schema (or schema "")
+                            path   (if table-id
+                                     [group-id db-id perm-type schema table-id]
+                                     [group-id db-id perm-type])]
+                        (assoc-in graph path value)))
+                    {}
+                    data-perms)]
+    (update-vals raw-graph (fn [db-id->perms]
+                             (update-vals db-id->perms collapse-uniform-view-data)))))
 
 (mu/defn api-graph :- ::permissions-rest.schema/data-permissions-graph
   "Converts the backend representation of the data permissions graph to the representation we send over the API. Mainly

--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -198,13 +198,12 @@
    as a `{schema {table-id :blocked}}` map, which the frontend interprets as `granular`. Only applied to
    `:perms/view-data`; other granular perm types intentionally retain their map shape."
   [perm-type->value]
-  (let [view-data-val (get perm-type->value :perms/view-data)]
-    (if (map? view-data-val)
-      (let [leaf-vals (into #{} (mapcat vals) (vals view-data-val))]
-        (if (= 1 (count leaf-vals))
-          (assoc perm-type->value :perms/view-data (first leaf-vals))
-          perm-type->value))
-      perm-type->value)))
+  (let [view-data-val (:perms/view-data perm-type->value)
+        leaf-vals     (when (map? view-data-val)
+                        (into #{} (mapcat vals) (vals view-data-val)))]
+    (cond-> perm-type->value
+      (= 1 (count leaf-vals))
+      (assoc :perms/view-data (first leaf-vals)))))
 
 (mu/defn data-permissions-graph :- ::graph
   "Returns a tree representation of all data permissions. Can be optionally filtered by group ID, database ID,

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -372,14 +372,10 @@
                                {table-id-1 :unrestricted
                                 table-id-2 :legacy-no-self-service}}
                               :perms/create-queries :query-builder-and-native}
-               database-id-2 {:perms/view-data
-                              {""
-                               {table-id-3 :unrestricted}}
+               database-id-2 {:perms/view-data :unrestricted
                               :perms/create-queries :no}}
               group-id-2
-              {database-id-1 {:perms/view-data
-                              {"PUBLIC"
-                               {table-id-1 :legacy-no-self-service}}}}}
+              {database-id-1 {:perms/view-data :legacy-no-self-service}}}
              (data-perms.graph/data-permissions-graph))))
 
       (testing "Additional data permissions are included when set"
@@ -407,9 +403,7 @@
                                 :perms/manage-table-metadata
                                 {"PUBLIC"
                                  {table-id-1 :yes}}}
-                 database-id-2 {:perms/view-data
-                                {""
-                                 {table-id-3 :unrestricted}}
+                 database-id-2 {:perms/view-data :unrestricted
                                 :perms/download-results
                                 {""
                                  {table-id-3 :one-million-rows}}

--- a/test/metabase/permissions_rest/data_permissions/graph_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph_test.clj
@@ -98,7 +98,7 @@
           {group-id-1
            {database-id-1
             {:perms/create-queries {"PUBLIC" {table-id-1 :query-builder}}
-             :perms/view-data {"PUBLIC" {table-id-1 :unrestricted}}}}}
+             :perms/view-data :unrestricted}}}
 
           {group-id-1
            {database-id-1
@@ -113,7 +113,7 @@
           {group-id-1
            {database-id-1
             {:perms/create-queries {"PUBLIC" {table-id-1 :query-builder}}
-             :perms/view-data {"PUBLIC" {table-id-1 :unrestricted}}}}}
+             :perms/view-data :unrestricted}}}
 
           {group-id-1
            {database-id-1
@@ -353,6 +353,46 @@
          {database-id-1
           {:perms/manage-database :no}}}))))
 
+(deftest data-permissions-graph-view-data-collapse-test
+  (testing "data-permissions-graph collapses uniform table-level :perms/view-data values to a db-level scalar (#73520)"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/Database         {db-id :id}    {}
+                     :model/Table            {t1 :id}       {:db_id db-id :schema "PUBLIC"}
+                     :model/Table            {t2 :id}       {:db_id db-id :schema "PUBLIC"}
+                     :model/Table            {t3 :id}       {:db_id db-id :schema "OTHER"}]
+        (t2/delete! :model/DataPermissions :group_id group-id)
+        (testing "all tables uniformly :blocked across one schema collapses to scalar"
+          (data-perms/set-table-permissions! group-id :perms/view-data {t1 :blocked t2 :blocked})
+          (is (= :blocked
+                 (get-in (data-perms.graph/data-permissions-graph :group-id group-id)
+                         [group-id db-id :perms/view-data]))))
+        (testing "all tables uniformly :blocked across multiple schemas collapses to scalar"
+          (data-perms/set-table-permissions! group-id :perms/view-data {t3 :blocked})
+          (is (= :blocked
+                 (get-in (data-perms.graph/data-permissions-graph :group-id group-id)
+                         [group-id db-id :perms/view-data]))))
+        (testing "mixed values within a schema do not collapse"
+          (data-perms/set-table-permissions! group-id :perms/view-data {t2 :unrestricted})
+          (is (= {"PUBLIC" {t1 :blocked t2 :unrestricted}
+                  "OTHER" {t3 :blocked}}
+                 (get-in (data-perms.graph/data-permissions-graph :group-id group-id)
+                         [group-id db-id :perms/view-data]))))
+        (testing "uniform within each schema but different across schemas does not collapse"
+          (data-perms/set-table-permissions! group-id :perms/view-data {t2 :blocked})
+          (data-perms/set-table-permissions! group-id :perms/view-data {t3 :unrestricted})
+          (is (= {"PUBLIC" {t1 :blocked t2 :blocked}
+                  "OTHER" {t3 :unrestricted}}
+                 (get-in (data-perms.graph/data-permissions-graph :group-id group-id)
+                         [group-id db-id :perms/view-data]))))
+        (testing "other granular perm types are not collapsed"
+          (t2/delete! :model/DataPermissions :group_id group-id)
+          (data-perms/set-table-permissions! group-id :perms/create-queries {t1 :no t2 :no t3 :no})
+          (is (= {"PUBLIC" {t1 :no t2 :no}
+                  "OTHER" {t3 :no}}
+                 (get-in (data-perms.graph/data-permissions-graph :group-id group-id)
+                         [group-id db-id :perms/create-queries]))))))))
+
 ;; ------------------------------ API Graph Tests ------------------------------
 
 (deftest ellide?-test
@@ -436,6 +476,21 @@
         (data-perms/set-table-permission! group (mt/id :categories) :perms/create-queries :query-builder)
         (is (= {(mt/id :categories) :query-builder, (mt/id :venues) :query-builder}
                (test-query-graph group)))))))
+
+(deftest api-graph-uniform-blocked-not-granular-test
+  (testing "api-graph elides :view-data when all tables are uniformly :blocked, instead of returning a map (#73520)"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/Database         {db-id :id}    {}
+                     :model/Table            {t1 :id}       {:db_id db-id :schema "PUBLIC"}
+                     :model/Table            {t2 :id}       {:db_id db-id :schema "PUBLIC"}
+                     :model/Table            {t3 :id}       {:db_id db-id :schema "OTHER"}]
+        (t2/delete! :model/DataPermissions :group_id group-id)
+        (data-perms/set-table-permissions! group-id :perms/view-data {t1 :blocked t2 :blocked t3 :blocked})
+        (let [api-perms (get-in (data-perms.graph/api-graph :group-id group-id :db-id db-id)
+                                [:groups group-id db-id])]
+          (testing ":view-data is elided (the FE infers :blocked from absence) — not surfaced as a granular map"
+            (is (not (contains? api-perms :view-data)))))))))
 
 (deftest graph-set-blocked-permissions-for-table-test
   (let [view-data (fn view-data [group]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73520
### Description

When a new database connection is added, it's possible that the permissions graph will be updated with `block` permissions for certain groups (based on if they are blocked on any other DB / Schemas). This was causing a map with `{[schema]: "blocked"}` to be returned by the API, and the FE was incorrectly parsing that as granular permissions.

This PR adds a new function called `collapse-uniform-view-data` to flatten the data-permission-graph when requested by the API, which should catch the case described above and pass the FE what it's actually expecting

### How to verify
1. Ensure you have at least one group on the instance that is restricted on at least 1 DB
2. Add a new database connection
3. Go to permissions and click on your restricted group
4. The new DB connection should be showing as "blocked", not "granular"


### Checklist

- [x] Tests have been added/updated to cover changes in this PR