### PR TITLE
Test that the underlying-records drill properly handles timezones

### DIFF
--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -785,6 +785,51 @@
                (map #(:long-display-name (lib/display-info query' %))
                     (lib/filters query'))))))))
 
+(deftest ^:parallel underlying-records-month-breakout-with-tz-offset-test
+  (testing "drilling on a `month`-bucketed cell whose value carries a non-UTC offset filters the right month (#71147)"
+    ;; The bug: a pivot cell for February stamped as Berlin local time ("2024-02-01T00:00:00+01:00") was
+    ;; being shifted to UTC (2024-01-31T23:00Z) before truncation, so the resulting filter spanned January.
+    (doseq [[unit value start end]
+            [[:month   "2024-02-01T00:00:00+01:00" "2024-02-01" "2024-02-29"]
+             [:quarter "2024-04-01T00:00:00+02:00" "2024-04-01" "2024-06-30"]
+             [:year    "2024-01-01T00:00:00+02:00" "2024-01-01" "2024-12-31"]]]
+      (testing (str unit " bucket, value " value)
+        (let [query     (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                            (lib/aggregate (lib/count))
+                            (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                              (lib/with-temporal-bucket unit)))
+                            (lib/breakout (meta/field-metadata :orders :product-id)))
+              cols      (lib/returned-columns query)
+              created   (lib.tu.notebook/find-col-with-spec
+                         query cols {} {:display-name (str "Created At: "
+                                                           (case unit
+                                                             :month   "Month"
+                                                             :quarter "Quarter"
+                                                             :year    "Year"))})
+              product   (lib.tu.notebook/find-col-with-spec
+                         query cols {} {:display-name "Product ID"})
+              count-col (lib.tu.notebook/find-col-with-spec
+                         query cols {} {:display-name "Count"})
+              context   {:column     count-col
+                         :column-ref (lib/ref count-col)
+                         :value      77
+                         :row        [{:column created,   :column-ref (lib/ref created),   :value value}
+                                      {:column product,   :column-ref (lib/ref product),   :value 14}
+                                      {:column count-col, :column-ref (lib/ref count-col), :value 77}]
+                         :dimensions [{:column created,   :column-ref (lib/ref created),   :value value}
+                                      {:column product,   :column-ref (lib/ref product),   :value 14}]}
+              drill     (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                      (lib/available-drill-thrus query context))]
+          (is (some? drill))
+          (is (=? {:stages [{:filters [[:between {}
+                                        [:field {:temporal-unit unit} (meta/id :orders :created-at)]
+                                        start
+                                        end]
+                                       [:= {}
+                                        [:field {} (meta/id :orders :product-id)]
+                                        14]]}]}
+                  (lib/drill-thru query drill))))))))
+
 (deftest ^:parallel double-summarize-then-drill-twice-test
   (testing "drilling twice on a double-summarize query keeps the correct date filter (#72937)"
     (let [;; First summarize: max(subtotal) by day(created-at), product-id.


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71147
Closes QUE2-440

### Description

#71147 is yet another manifestation of the FE/CLJS timezone handling issue fixed with #73466. This PR adds a regression test to demonstrate that it has been fixed.

### How to verify

See the test. The repro steps of #71147 should produce the expected data.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
