### PR TITLE
Drop cljs from timezone tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -116,8 +116,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
       - name: Run frontend timezones tests
         run: bun run test-timezones
 

--- a/package.json
+++ b/package.json
@@ -526,7 +526,7 @@
     "test-cypress-host-sample-apps": "tsx ./e2e/runner/run_cypress_host_sample_apps.ts",
     "test-debug": "bun run build:cljs && node --inspect-brk node_modules/.bin/jest --runInBand --detectOpenHandles",
     "test-timezones": "bun install && ./frontend/test/__runner__/run_timezone_tests",
-    "test-timezones-unit": "bun run build:cljs && jest --silent --maxWorkers=4 --config jest.tz.unit.conf.js",
+    "test-timezones-unit": "jest --silent --maxWorkers=4 --config jest.tz.unit.conf.js",
     "test-unit": "bun run build:cljs && jest --maxWorkers=4",
     "test-unit-keep-cljs": "jest --maxWorkers=4",
     "test-unit-watch": "bun run test-unit --watch",


### PR DESCRIPTION
Resolves DEV-1918

## Summary 

Tests need a second to finish, and yet... the whole job takes more than three minutes in CI! Since these tests are being run using a loop, each timezone was building its own cljs. But the best part is that these tests do not even need cljs to run. I have confirmed this by running them locally.