### PR TITLE
[perms] Refactor graph updates to remove costly N+1 query

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/permissions/published_tables.clj
@@ -13,13 +13,15 @@
   "Returns :query-builder permission if table is published and user has collection access.
   Tables published into the root collection (collection_id=nil) are accessible to all users."
   :feature :library
-  [perm-type table-id]
+  [user-id perm-type table-id]
   (when (and (= perm-type :perms/create-queries)
              (t2/exists? :model/Table
                          {:where [:and
                                   [:= :id table-id]
                                   [:= :is_published true]
-                                  (collection/visible-collection-filter-clause :collection_id)]}))
+                                  (collection/visible-collection-filter-clause
+                                   :collection_id {} {:current-user-id user-id
+                                                      :is-superuser?   (perms/is-superuser? user-id)})]}))
     :query-builder))
 
 (defenterprise user-has-any-published-table-permission?

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -38,11 +38,14 @@
 (p/import-vars
  [metabase.permissions.models.data-permissions
   at-least-as-permissive?
+  batch-delete-permissions!
+  batch-insert-permissions!
   disable-perms-cache
   download-perms-level
   full-db-permission-for-user
   full-schema-permission-for-user
   groups-have-permission-for-table?
+  index-database-permissions
   is-superuser?
   is-data-analyst?
   most-permissive-database-permission-for-user

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -402,7 +402,7 @@
       (or (when-not (= table-perm (least-permissive-value perm-type))
             table-perm)
           (when (pos-int? table-id)
-            (published-tables/user-published-table-permission perm-type table-id))
+            (published-tables/user-published-table-permission user-id perm-type table-id))
           (least-permissive-value perm-type)))))
 
 (mu/defn user-has-permission-for-table? :- :boolean
@@ -690,33 +690,31 @@
   Returns a map with keys:
   - :to-delete - sequence of DataPermissions models to delete
   - :to-insert - sequence of DataPermissions models to insert "
-  [group-or-id :- TheIdable
+  [perms
+   group-or-id :- TheIdable
    db-or-id    :- TheIdable
    perm-type   :- ::permissions.schema/data-permission-type
    value       :- :keyword]
   (let [group-id (u/the-id group-or-id)
         db-id    (u/the-id db-or-id)
-        existing-perms (t2/select :model/DataPermissions
-                                  :perm_type perm-type
-                                  :group_id group-id
-                                  :db_id db-id)
+        existing-perms (get perms [group-id db-id perm-type])
         new-perm {:perm_type  perm-type
                   :group_id   group-id
                   :perm_value value
                   :db_id      db-id}
         recursive-calls (cond-> []
                           (and (= perm-type :perms/create-queries) (not= value :no))
-                          (conj (build-database-permission group-or-id db-or-id :perms/view-data :unrestricted))
+                          (conj (build-database-permission perms group-or-id db-or-id :perms/view-data :unrestricted))
 
                           (= [:perms/view-data :blocked] [perm-type value])
-                          (into [(build-database-permission group-or-id db-or-id :perms/create-queries :no)
-                                 (build-database-permission group-or-id db-or-id :perms/download-results :no)])
+                          (into [(build-database-permission perms group-or-id db-or-id :perms/create-queries :no)
+                                 (build-database-permission perms group-or-id db-or-id :perms/download-results :no)])
 
                           (and (= perm-type :perms/view-data) (not= value :unrestricted))
-                          (conj (build-database-permission group-or-id db-or-id :perms/transforms :no))
+                          (conj (build-database-permission perms group-or-id db-or-id :perms/transforms :no))
 
                           (and (= perm-type :perms/create-queries) (not= value :query-builder-and-native))
-                          (conj (build-database-permission group-or-id db-or-id :perms/transforms :no)))]
+                          (conj (build-database-permission perms group-or-id db-or-id :perms/transforms :no)))]
     (apply merge-with concat
            {:to-delete existing-perms
             :to-insert [new-perm]}
@@ -724,7 +722,7 @@
 
 (def ^:private permission-batch-size 1000)
 
-(defn- batch-insert-permissions!
+(defn batch-insert-permissions!
   "In certain cases, when updating the permissions for many tables at once, we need to batch the insertions to avoid
   hitting database limits for the number of parameters in a prepared statement. This is only really applicable when a DB
   has more than ~10k tables and we're transitioning from database-level permissions to table-level permissions."
@@ -732,30 +730,61 @@
   (doseq [batched-new-perms (partition-all permission-batch-size new-perms)]
     (t2/insert! :model/DataPermissions batched-new-perms)))
 
-(defn- batch-delete-permissions!
+(defn batch-delete-permissions!
   "Much like on insert, sometimes we have to delete more permission models than the psql limit of MAX 16-bit parameters.
   This batches our deletes into groups of `permission-batch-size`."
   [to-delete-ids]
   (doseq [batched-to-delete-ids (partition-all permission-batch-size to-delete-ids)]
     (t2/delete! :model/DataPermissions :id [:in batched-to-delete-ids])))
 
+(defn index-database-permissions
+  "Given seqs of `group-ids` and `db-ids`, computes an index of all relevant permissions.
+
+  Use this to avoid N+1s in repeated [[set-database-permission!]] calls.
+
+  BEWARE race conditions! This function must be run inside a cluster lock on the relevant DB(s), or you risk working
+  from stale data and generating bad permissions. See
+  [[metabase.permissions.models.data-permissions-test/race-conditions-test]].
+
+  Returns a map of `{[group-id db-id perm-type] [DataPermission ...]}`. Returns nil if either input list is empty."
+  [group-ids db-ids]
+  (when (and (seq group-ids) (seq db-ids))
+    (group-by (juxt :group_id :db_id :perm_type)
+              (t2/select :model/DataPermissions :group_id [:in group-ids] :db_id [:in db-ids]))))
+
 (mu/defn set-database-permission!
-  "Set a single permission to a specified
-  value for a given group and database. If a permission value already exists for the specified group and object,
-  it will be updated to the new value.
+  "Set a single permission to a specified value for a given group and database. If a permission value already exists
+  for the specified group and object, it will be updated to the new value.
+
+  The optional first argument holds an in-memory index of permissions; this exists to avoid N+1 queries in large edits
+  like updating the entire permissions graph. Singular calls to this function can omit it, and an index for just the
+  input group and DB will be created on demand.
 
   Block permissions (i.e. :perms/view-data :blocked) can be set at the table or database-level."
-  [group-or-id :- TheIdable
-   db-or-id    :- TheIdable
-   perm-type   :- ::permissions.schema/data-permission-type
-   value       :- :keyword]
-  (with-cluster-lock {:db-id     (u/the-id db-or-id)
-                      :perm-type (u/qualified-name perm-type)}
-    (let [{:keys [to-insert to-delete]} (build-database-permission group-or-id db-or-id perm-type value)]
-      (when (seq to-delete)
-        (batch-delete-permissions! (map :id to-delete)))
-      (when (seq to-insert)
-        (batch-insert-permissions! to-insert)))))
+  ([group-or-id :- TheIdable
+    db-or-id    :- TheIdable
+    perm-type   :- ::permissions.schema/data-permission-type
+    value       :- :keyword]
+   (let [group-id (u/the-id group-or-id)
+         db-id    (u/the-id db-or-id)]
+     (with-cluster-lock {:db-id     db-id
+                         :perm-type (u/qualified-name perm-type)}
+       (set-database-permission! (index-database-permissions [group-id] [db-id])
+                                 group-or-id db-or-id perm-type value))))
+  ([perms       :- [:map-of
+                    [:tuple pos-int? pos-int? ::permissions.schema/data-permission-type]
+                    [:sequential :any]]
+    group-or-id :- TheIdable
+    db-or-id    :- TheIdable
+    perm-type   :- ::permissions.schema/data-permission-type
+    value       :- :keyword]
+   (with-cluster-lock {:db-id     (u/the-id db-or-id)
+                       :perm-type (u/qualified-name perm-type)}
+     (let [{:keys [to-insert to-delete]} (build-database-permission perms group-or-id db-or-id perm-type value)]
+       (when (seq to-delete)
+         (batch-delete-permissions! (map :id to-delete)))
+       (when (seq to-insert)
+         (batch-insert-permissions! to-insert))))))
 
 (defenterprise new-group-view-data-permission-levels
   "Returns a map of {db-id → permission-level} for multiple databases. On OSS, all are `:unrestricted`."
@@ -855,7 +884,8 @@
              (= values existing-table-values))
       ;; If all tables would have the same permissions after we update these ones, we can replace all of the table
       ;; perms with a DB-level perm instead.
-      (build-database-permission group-id db-id perm-type (first values))
+      (build-database-permission (index-database-permissions [group-id] [db-id])
+                                 group-id db-id perm-type (first values))
       ;; Otherwise, just replace the rows for the individual table perm
       (let [table-perms-to-delete (t2/select :model/DataPermissions
                                              {:where [:and
@@ -866,11 +896,11 @@
          :to-insert new-perms}))))
 
 (mu/defn- build-table-permissions
-  "Builds a sequence of DataPermissions models to delete and insert for setting
+  "Determines which DataPermissions rows must be deleted and inserted to set the permissions for the provided tables.
 
   Returns a map with keys:
-  - :to-delete - sequence of DataPermissions models to delete
-  - :to-insert - sequence of DataPermissions models to insert "
+  - :to-delete - sequence of DataPermissions row IDs to delete
+  - :to-insert - sequence of DataPermissions maps to insert "
   [group-or-id :- TheIdable
    perm-type   :- ::permissions.schema/data-permission-type
    table-perms :- [:map-of TheIdable :keyword]]

--- a/src/metabase/permissions/published_tables.clj
+++ b/src/metabase/permissions/published_tables.clj
@@ -14,7 +14,7 @@
   "Returns `:query-builder` permission if table is published and user has collection access.
   OSS implementation always returns nil - published tables only grant access in EE."
   metabase-enterprise.data-studio.permissions.published-tables
-  [_perm-type _table-id]
+  [_user-id _perm-type _table-id]
   nil)
 
 (defenterprise user-has-any-published-table-permission?

--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -277,160 +277,245 @@
         (str/replace (name perm-type) "-" " "))
    {:status-code 402}))
 
-(defn- update-table-level-metadata-permissions!
-  [group-id db-id schema new-table-perms]
-  (let [new-table-perms
-        (-> new-table-perms
-            (update-vals (fn [table-perm]
-                           (case table-perm
-                             :all  :yes
-                             :none :no)))
-            (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (perms/set-table-permissions! group-id :perms/manage-table-metadata new-table-perms)))
+;; Bulk update implementation ====================================================================================
+;; Instead of iterating over groups x dbs x perm-types x schemas and making individual DB calls,
+;; this implementation:
+;; 1. Pre-fetches all tables and current permissions in bulk (2 queries)
+;; 2. Uses pure functions to compute the desired state
+;; 3. Diffs desired vs current to produce minimal inserts/deletes
+;; 4. Applies changes in bulk (2 queries)
 
-(defn- update-schema-level-metadata-permissions!
-  [group-id db-id schema new-schema-perms]
-  (if (map? new-schema-perms)
-    (update-table-level-metadata-permissions! group-id db-id schema new-schema-perms)
-    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
-      (when (seq tables)
-        (case new-schema-perms
-          :all
-          (perms/set-table-permissions! group-id :perms/manage-table-metadata (zipmap tables (repeat :yes)))
+(def ^:private api-val->db-val
+  {:view-data      {:unrestricted           :unrestricted
+                    :impersonated           :unrestricted
+                    :sandboxed              :unrestricted
+                    :legacy-no-self-service :legacy-no-self-service
+                    :blocked                :blocked}
+   :create-queries {:query-builder-and-native :query-builder-and-native
+                    :query-builder            :query-builder
+                    :no                       :no}
+   :download       {:full    :one-million-rows
+                    :limited :ten-thousand-rows
+                    :none    :no}
+   :data-model     {:all  :yes
+                    :none :no}
+   :details        {:yes :yes :no :no}
+   :transforms     {:yes :yes :no :no}})
 
-          :none
-          (perms/set-table-permissions! group-id :perms/manage-table-metadata (zipmap tables (repeat :no))))))))
+(def ^:private api-key->perm-type
+  {:view-data      :perms/view-data
+   :create-queries :perms/create-queries
+   :download       :perms/download-results
+   :data-model     :perms/manage-table-metadata
+   :details        :perms/manage-database
+   :transforms     :perms/transforms})
 
-(defn- update-db-level-metadata-permissions!
-  [group-id db-id new-db-perms]
-  (when-let [schemas (:schemas new-db-perms)]
-    (if (map? schemas)
-      (doseq [[schema schema-changes] schemas]
-        (update-schema-level-metadata-permissions! group-id db-id schema schema-changes))
-      (case schemas
-        :all
-        (perms/set-database-permission! group-id db-id :perms/manage-table-metadata :yes)
+(defn- resolve-api-value
+  "Translates an API permission value for a single [group-id db-id api-key] into a map of
+   {table-id-or-nil {:perm_value v :schema_name s}}. A nil key means db-level."
+  [api-key api-value db-id tables-by-db-schema]
+  (let [raw-value (if (#{:download :data-model} api-key)
+                    (:schemas api-value)
+                    api-value)]
+    (if (keyword? raw-value)
+      {nil {:perm_value  (get-in api-val->db-val [api-key raw-value])
+            :schema_name nil}}
+      (into {}
+            (mapcat
+             (fn [[schema-str schema-val]]
+               (let [db-schema (not-empty schema-str)]
+                 (if (keyword? schema-val)
+                   (map (fn [{:keys [id schema]}]
+                          [id {:perm_value  (get-in api-val->db-val [api-key schema-val])
+                               :schema_name schema}])
+                        (get tables-by-db-schema [db-id db-schema]))
+                   (map (fn [[table-id table-val]]
+                          [table-id {:perm_value  (get-in api-val->db-val [api-key table-val])
+                                     :schema_name db-schema}])
+                        schema-val)))))
+            raw-value))))
 
-        :none
-        (perms/set-database-permission! group-id db-id :perms/manage-table-metadata :no)))))
+(defn- add-implications:db-level
+  [desired group-id db-id perm-type db-value]
+  (cond-> desired
+    (and (= perm-type :perms/create-queries) (not= db-value :no))
+    (update [group-id db-id :perms/view-data]
+            #(merge % {nil {:perm_value :unrestricted :schema_name nil}}))
 
-(defn- update-table-level-download-permissions!
-  [group-id db-id schema new-table-perms]
-  (let [new-table-perms
-        (-> new-table-perms
-            (update-vals (fn [table-perm]
-                           (case table-perm
-                             :full    :one-million-rows
-                             :limited :ten-thousand-rows
-                             :none    :no)))
-            (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (perms/set-table-permissions! group-id :perms/download-results new-table-perms)))
+    (and (= perm-type :perms/view-data) (= db-value :blocked))
+    (-> (update [group-id db-id :perms/create-queries]
+                #(merge % {nil {:perm_value :no :schema_name nil}}))
+        (update [group-id db-id :perms/download-results]
+                #(merge % {nil {:perm_value :no :schema_name nil}})))
 
-(defn- update-schema-level-download-permissions!
-  [group-id db-id schema new-schema-perms]
-  (if (map? new-schema-perms)
-    (update-table-level-download-permissions! group-id db-id schema new-schema-perms)
-    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
-      (when (seq tables)
-        (case new-schema-perms
-          :full
-          (perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :one-million-rows)))
+    (and (= perm-type :perms/view-data) (not= db-value :unrestricted))
+    (update [group-id db-id :perms/transforms]
+            #(merge % {nil {:perm_value :no :schema_name nil}}))
 
-          :limited
-          (perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :ten-thousand-rows)))
+    (and (= perm-type :perms/create-queries) (not= db-value :query-builder-and-native))
+    (update [group-id db-id :perms/transforms]
+            #(merge % {nil {:perm_value :no :schema_name nil}}))))
 
-          :none
-          (perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :no))))))))
+(defn- add-implications:table-level
+  [desired group-id db-id perm-type table-entries]
+  (cond-> desired
+    (= perm-type :perms/create-queries)
+    (update [group-id db-id :perms/view-data]
+            #(merge %
+                    (into {}
+                          (keep (fn [[tid {:keys [perm_value schema_name]}]]
+                                  (when (not= perm_value :no)
+                                    [tid {:perm_value :unrestricted :schema_name schema_name}])))
+                          table-entries)))
 
-(defn- update-db-level-download-permissions!
-  [group-id db-id new-db-perms]
-  (when-let [schemas (:schemas new-db-perms)]
-    (if (map? schemas)
-      (doseq [[schema schema-changes] schemas]
-        (update-schema-level-download-permissions! group-id db-id schema schema-changes))
-      (case schemas
-        :full
-        (perms/set-database-permission! group-id db-id :perms/download-results :one-million-rows)
+    (= perm-type :perms/view-data)
+    (-> (update [group-id db-id :perms/create-queries]
+                #(merge %
+                        (into {}
+                              (keep (fn [[tid {:keys [perm_value schema_name]}]]
+                                      (when (= perm_value :blocked)
+                                        [tid {:perm_value :no :schema_name schema_name}])))
+                              table-entries)))
+        (update [group-id db-id :perms/download-results]
+                #(merge %
+                        (into {}
+                              (keep (fn [[tid {:keys [perm_value schema_name]}]]
+                                      (when (= perm_value :blocked)
+                                        [tid {:perm_value :no :schema_name schema_name}])))
+                              table-entries))))))
 
-        :limited
-        (perms/set-database-permission! group-id db-id :perms/download-results :ten-thousand-rows)
+(defn- add-implications
+  "Given a desired-state map and entries just added for a perm-type, merges in implied permission changes.
+   Implications from later-processed perm-types override earlier values."
+  [desired group-id db-id perm-type entries]
+  (let [has-db-level? (contains? entries nil)
+        db-value      (get-in entries [nil :perm_value])
+        table-entries (dissoc entries nil)]
+    (cond
+      has-db-level?          (add-implications:db-level desired group-id db-id perm-type db-value)
+      (empty? table-entries) desired
+      :else                  (add-implications:table-level desired group-id db-id perm-type table-entries))))
 
-        :none
-        (perms/set-database-permission! group-id db-id :perms/download-results :no)))))
+(defn- compute-desired-state
+  "Process the API graph changes in dependency order, producing a desired-state map of
+   {[group-id db-id perm-type] {table-id-or-nil {:perm_value v :schema_name s}}}."
+  [graph tables-by-db-schema]
+  (reduce
+   (fn [desired [group-id db-id api-key api-value]]
+     (let [perm-type (api-key->perm-type api-key)
+           entries   (resolve-api-value api-key api-value db-id tables-by-db-schema)]
+       (-> desired
+           (update [group-id db-id perm-type] #(merge % entries))
+           (add-implications group-id db-id perm-type entries))))
+   {}
+   (for [[group-id group-changes] graph
+         [db-id db-changes] group-changes
+         api-key [:details :data-model :download :transforms :create-queries :view-data]
+         :let [api-value (get db-changes api-key)]
+         :when api-value]
+     [group-id db-id api-key api-value])))
 
-(defn- update-details-perms!
-  [group-id db-id value]
-  (perms/set-database-permission! group-id db-id :perms/manage-database value))
+(defn- expand-to-table-level
+  "Expands a db-level permission value to table-level entries for all tables in the db.
+   :query-builder-and-native becomes :query-builder per table since it can only be db-level."
+  [perm-value all-tables]
+  (let [table-value (if (= perm-value :query-builder-and-native) :query-builder perm-value)]
+    (into {}
+          (map (fn [{:keys [id schema]}]
+                 [id {:perm_value table-value :schema_name schema}]))
+          all-tables)))
 
-(defn- update-transforms-perms!
-  [group-id db-id value]
-  (perms/set-database-permission! group-id db-id :perms/transforms value))
+(defn- table-permissions-map [current-rows]
+  (into {}
+        (keep (fn [{:keys [table_id perm_value schema_name] :as _row}]
+                (when table_id
+                  [table_id
+                   {:perm_value  perm_value
+                    :schema_name schema_name}])))
+        current-rows))
 
-(defn- update-table-level-create-queries-permissions!
-  [group-id db-id schema new-table-perms]
-  (let [new-table-perms (update-keys
-                         new-table-perms
-                         (fn [table-id] {:id table-id :db_id db-id :schema schema}))]
-    (perms/set-table-permissions! group-id :perms/create-queries new-table-perms)))
+(defn- perms->base-state [current-rows current-db-row all-tables]
+  (if current-db-row
+    (expand-to-table-level (:perm_value current-db-row) all-tables)
+    (table-permissions-map current-rows)))
 
-(defn- update-schema-level-create-queries-permissions!
-  [group-id db-id schema new-schema-perms]
-  (if (map? new-schema-perms)
-    (update-table-level-create-queries-permissions! group-id db-id schema new-schema-perms)
-    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
-      (when (seq tables)
-        (perms/set-table-permissions! group-id :perms/create-queries (zipmap tables (repeat new-schema-perms)))))))
+(defn- finalize-tuple
+  "For a single [group-id db-id perm-type], compute the final desired DataPermissions rows.
+   Merges desired entries with current state for unmentioned tables, then coalesces if possible.
 
-(defn- update-db-level-create-queries-permissions!
-  [group-id db-id new-db-perms]
-  (if (map? new-db-perms)
-    (doseq [[schema new-schema-perms] new-db-perms]
-      (update-schema-level-create-queries-permissions! group-id db-id schema new-schema-perms))
-    (when new-db-perms
-      (perms/set-database-permission! group-id db-id :perms/create-queries new-db-perms))))
+   Coalescing rules (matching legacy behavior):
+   - Explicit db-level desired (nil key, no table overrides) → always db-level
+   - Mixed (db-level default + table overrides) where all values same → coalesce to db-level
+   - Table-level desired, current was db-level, all values match current → keep db-level (no-op)
+   - Otherwise → table-level rows"
+  [group-id db-id perm-type desired-entries current-rows all-tables]
+  (let [has-db-level?  (contains? desired-entries nil)
+        table-entries  (dissoc desired-entries nil)]
+    (if (and has-db-level? (empty? table-entries))
+      [{:perm_type   perm-type
+        :group_id    group-id
+        :perm_value  (:perm_value (desired-entries nil))
+        :db_id       db-id}]
+      (let [current-db-row (first (filter #(nil? (:table_id %)) current-rows))
+            base-state     (if has-db-level?
+                             (expand-to-table-level (:perm_value (desired-entries nil)) all-tables)
+                             (perms->base-state current-rows current-db-row all-tables))
+            final-state    (merge base-state table-entries)
+            values         (into #{} (map :perm_value) (vals final-state))
+            all-same?      (and (= 1 (count values))
+                                (seq all-tables)
+                                (= (count final-state) (count all-tables)))
+            coalesce?      (and all-same?
+                                (or has-db-level?
+                                    (and current-db-row
+                                         (= (first values) (:perm_value current-db-row)))))]
+        (if coalesce?
+          [{:perm_type   perm-type
+            :group_id    group-id
+            :perm_value  (first values)
+            :db_id       db-id}]
+          (mapv (fn [[table-id {:keys [perm_value schema_name]}]]
+                  {:perm_type   perm-type
+                   :group_id    group-id
+                   :perm_value  perm_value
+                   :db_id       db-id
+                   :table_id    table-id
+                   :schema_name schema_name})
+                final-state))))))
 
-(defn- update-table-level-view-data-permissions!
-  [group-id db-id schema new-table-perms]
-  (let [new-table-perms (->
-                         (update-keys
-                          new-table-perms
-                          (fn [table-id] {:id table-id :db_id db-id :schema schema}))
-                         (update-vals (fn [table-perm]
-                                        (case table-perm
-                                          :unrestricted           :unrestricted
-                                          ;; If the table is sandboxed, we set `view-data` to `unrestricted` since
-                                          ;; sandboxes are stored separately in the `sandboxes` table
-                                          :sandboxed              :unrestricted
-                                          :legacy-no-self-service :legacy-no-self-service
-                                          :blocked                :blocked))))]
-    (perms/set-table-permissions! group-id :perms/view-data new-table-perms)))
+(def ^:private row-signature
+  (juxt :perm_type :perm_value :table_id :schema_name))
 
-(defn- update-schema-level-view-data-permissions!
-  [group-id db-id schema new-schema-perms]
-  (if (map? new-schema-perms)
-    (update-table-level-view-data-permissions! group-id db-id schema new-schema-perms)
-    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
-      (when (seq tables)
-        (perms/set-table-permissions! group-id :perms/view-data (zipmap tables (repeat new-schema-perms)))))))
+(defn- rows-match?
+  "Check if the current rows already represent the desired state (no changes needed)."
+  [current-rows desired-rows]
+  (= (into #{} (map row-signature) current-rows)
+     (into #{} (map row-signature) desired-rows)))
 
-(defn- update-db-level-view-data-permissions!
-  [group-id db-id new-db-perms]
-  (if (map? new-db-perms)
-    (doseq [[schema new-schema-perms] new-db-perms]
-      (update-schema-level-view-data-permissions! group-id db-id schema new-schema-perms))
-    (case new-db-perms
-      (:unrestricted :impersonated)
-      (perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
+(defn- compute-diff
+  "Given the desired state, current permissions index, and tables-by-db,
+   returns {:to-delete [id ...] :to-insert [row-map ...]}."
+  [desired-state current-perms-index tables-by-db]
+  (reduce-kv
+   (fn [acc [group-id db-id perm-type] desired-entries]
+     (let [current-rows (get current-perms-index [group-id db-id perm-type] [])
+           all-tables   (get tables-by-db db-id [])
+           desired-rows (finalize-tuple group-id db-id perm-type desired-entries current-rows all-tables)]
+       (if (rows-match? current-rows desired-rows)
+         acc
+         (-> acc
+             (update :to-delete into (keep :id) current-rows)
+             (update :to-insert into desired-rows)))))
+   {:to-delete [] :to-insert []}
+   desired-state))
 
-      ;; Support setting legacy-no-self-service for testing purposes, though the UI shouldn't allow it normally
-      :legacy-no-self-service
-      (perms/set-database-permission! group-id db-id :perms/view-data :legacy-no-self-service)
-
-      :blocked
-      (do
-        (when-not (premium-features/has-feature? :advanced-permissions)
-          (throw (ee-permissions-exception :blocked)))
-        (perms/set-database-permission! group-id db-id :perms/view-data :blocked)))))
+(defn- validate-blocked-permissions!
+  [graph]
+  (doseq [[_group-id group-changes] graph
+          [_db-id db-changes] group-changes]
+    (when (= (:view-data db-changes) :blocked)
+      (when-not (premium-features/has-feature? :advanced-permissions)
+        (throw (ee-permissions-exception :blocked))))))
 
 (defn- check-data-analyst-locked-permissions
   "Check that we're not modifying data-model permission for the Data Analysts group.
@@ -458,26 +543,31 @@
                       {:status-code 400})))))
 
 (mu/defn update-data-perms-graph!*
-  "Takes an API-style perms graph and sets the permissions in the database accordingly."
+  "Takes an API-style perms graph and sets the permissions in the database accordingly.
+   Uses bulk operations to minimize database round-trips."
   ([graph]
-   (doseq [[group-id group-changes] graph]
-     (doseq [[db-id db-changes] group-changes
-             ;; instead of iterating the provided cb-changes object we need to go in a specific order
-             ;; so backend consistency rules like setting create-queries and download to no when view-data
-             ;; is blocked can happen in the correct order despite what may come in the API request
-             perm-type [:details :data-model :download :transforms :create-queries :view-data]]
-       (when-let [new-perms (perm-type db-changes)]
-         (case perm-type
-           :view-data      (update-db-level-view-data-permissions! group-id db-id new-perms)
-           :create-queries (update-db-level-create-queries-permissions! group-id db-id new-perms)
-           :download       (update-db-level-download-permissions! group-id db-id new-perms)
-           :data-model     (update-db-level-metadata-permissions! group-id db-id new-perms)
-           :details        (update-details-perms! group-id db-id new-perms)
-           :transforms     (update-transforms-perms! group-id db-id new-perms))))))
+   (let [affected-group-ids  (keys graph)
+         affected-db-ids     (into #{} (mapcat keys) (vals graph))
+         all-tables          (when (seq affected-db-ids)
+                               (t2/select [:model/Table :id :db_id :schema]
+                                          :db_id [:in affected-db-ids]))
+         tables-by-db-schema (group-by (juxt :db_id :schema) all-tables)
+         tables-by-db        (group-by :db_id all-tables)
+         current-perms       (or (perms/index-database-permissions affected-group-ids affected-db-ids) {})
+         desired-state       (compute-desired-state graph tables-by-db-schema)
+         {:keys [to-delete to-insert]} (compute-diff desired-state current-perms tables-by-db)]
+     (validate-blocked-permissions! graph)
+     (when (seq to-delete)
+       (perms/batch-delete-permissions! to-delete))
+     (when (seq to-insert)
+       (perms/batch-insert-permissions! to-insert))))
 
   ;; The following arity is provided solely for convenience for tests/REPL usage
   ([ks :- [:vector :any] new-value]
-   (update-data-perms-graph!* (assoc-in (-> api-graph :groups) ks new-value))))
+   (-> (api-graph)
+       :groups
+       (assoc-in ks new-value)
+       update-data-perms-graph!*)))
 
 (mu/defn update-data-perms-graph!
   "Takes an API-style perms graph and sets the permissions in the database accordingly. Additionally ensures
@@ -494,4 +584,6 @@
 
   ;; The following arity is provided solely for convenience for tests/REPL usage
   ([ks :- [:vector :any] new-value]
-   (update-data-perms-graph! (assoc-in (api-graph) (cons :groups ks) new-value))))
+   (-> (api-graph)
+       (assoc-in (cons :groups ks) new-value)
+       update-data-perms-graph!)))

--- a/test/metabase/permissions_rest/data_permissions/graph/bulk_update_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph/bulk_update_test.clj
@@ -1,0 +1,395 @@
+(ns metabase.permissions-rest.data-permissions.graph.bulk-update-test
+  "Unit tests for the pure functions in the bulk permissions graph update implementation."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(def ^:private tables-by-db-schema
+  "A mock table index with two schemas: PUBLIC has tables 1,2 and OTHER has table 3."
+  {[1 "PUBLIC"] [{:id 10 :db_id 1 :schema "PUBLIC"}
+                 {:id 11 :db_id 1 :schema "PUBLIC"}]
+   [1 nil]      [{:id 12 :db_id 1 :schema nil}]})
+
+;;; ================================ resolve-api-value ================================
+
+(deftest resolve-api-value-db-level-test
+  (testing "DB-level keyword values"
+    (is (= {nil {:perm_value :unrestricted :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data :unrestricted 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :blocked :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data :blocked 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :query-builder-and-native :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :create-queries :query-builder-and-native 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :no :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :create-queries :no 1 tables-by-db-schema)))))
+
+(deftest resolve-api-value-download-wrapper-test
+  (testing "Download and data-model unwrap the :schemas key"
+    (is (= {nil {:perm_value :one-million-rows :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :download {:schemas :full} 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :no :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :download {:schemas :none} 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :yes :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :data-model {:schemas :all} 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :no :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :data-model {:schemas :none} 1 tables-by-db-schema)))))
+
+(deftest resolve-api-value-schema-level-test
+  (testing "Schema-level keyword expands to all tables in that schema"
+    (is (= {10 {:perm_value :unrestricted :schema_name "PUBLIC"}
+            11 {:perm_value :unrestricted :schema_name "PUBLIC"}}
+           (#'data-perms.graph/resolve-api-value :view-data {"PUBLIC" :unrestricted} 1 tables-by-db-schema))))
+  (testing "Multiple schemas"
+    (is (= {10 {:perm_value :unrestricted :schema_name "PUBLIC"}
+            11 {:perm_value :unrestricted :schema_name "PUBLIC"}
+            12 {:perm_value :blocked :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data {"PUBLIC" :unrestricted "" :blocked}
+                                                 1 tables-by-db-schema)))))
+
+(deftest resolve-api-value-table-level-test
+  (testing "Table-level values produce per-table entries"
+    (is (= {10 {:perm_value :query-builder :schema_name "PUBLIC"}
+            11 {:perm_value :no :schema_name "PUBLIC"}}
+           (#'data-perms.graph/resolve-api-value :create-queries {"PUBLIC" {10 :query-builder 11 :no}}
+                                                 1 tables-by-db-schema)))))
+
+(deftest resolve-api-value-empty-schema-test
+  (testing "Empty string schema maps to nil (null schema in DB)"
+    (is (= {12 {:perm_value :unrestricted :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data {"" :unrestricted} 1 tables-by-db-schema)))))
+
+(deftest resolve-api-value-translation-test
+  (testing "API values are translated to DB values"
+    (is (= {nil {:perm_value :unrestricted :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data :impersonated 1 tables-by-db-schema)))
+    (is (= {nil {:perm_value :unrestricted :schema_name nil}}
+           (#'data-perms.graph/resolve-api-value :view-data :sandboxed 1 tables-by-db-schema)))
+    (is (= {10 {:perm_value :one-million-rows :schema_name "PUBLIC"}
+            11 {:perm_value :no :schema_name "PUBLIC"}}
+           (#'data-perms.graph/resolve-api-value :download {:schemas {"PUBLIC" {10 :full 11 :none}}}
+                                                 1 tables-by-db-schema)))
+    (is (= {10 {:perm_value :yes :schema_name "PUBLIC"}
+            11 {:perm_value :no :schema_name "PUBLIC"}}
+           (#'data-perms.graph/resolve-api-value :data-model {:schemas {"PUBLIC" {10 :all 11 :none}}}
+                                                 1 tables-by-db-schema)))))
+
+;;; ================================ add-implications ================================
+
+(deftest add-implications-create-queries-db-level-test
+  (testing "create-queries non-:no at db-level implies view-data :unrestricted and transforms :no"
+    (let [desired {}
+          entries {nil {:perm_value :query-builder :schema_name nil}}
+          result  (#'data-perms.graph/add-implications desired 1 1 :perms/create-queries entries)]
+      (is (= {nil {:perm_value :unrestricted :schema_name nil}}
+             (get result [1 1 :perms/view-data])))
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/transforms])))))
+  (testing "create-queries :query-builder-and-native implies view-data but NOT transforms :no"
+    (let [desired {}
+          entries {nil {:perm_value :query-builder-and-native :schema_name nil}}
+          result  (#'data-perms.graph/add-implications desired 1 1 :perms/create-queries entries)]
+      (is (= {nil {:perm_value :unrestricted :schema_name nil}}
+             (get result [1 1 :perms/view-data])))
+      (is (nil? (get result [1 1 :perms/transforms])))))
+  (testing "create-queries :no implies transforms :no but NOT view-data"
+    (let [desired {}
+          entries {nil {:perm_value :no :schema_name nil}}
+          result  (#'data-perms.graph/add-implications desired 1 1 :perms/create-queries entries)]
+      (is (nil? (get result [1 1 :perms/view-data])))
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/transforms]))))))
+
+(deftest add-implications-view-data-db-level-test
+  (testing "view-data :blocked implies create-queries :no, download :no, and transforms :no"
+    (let [result (#'data-perms.graph/add-implications {} 1 1 :perms/view-data
+                                                      {nil {:perm_value :blocked :schema_name nil}})]
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/create-queries])))
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/download-results])))
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/transforms])))))
+  (testing "view-data :unrestricted has no implications"
+    (let [result (#'data-perms.graph/add-implications {} 1 1 :perms/view-data
+                                                      {nil {:perm_value :unrestricted :schema_name nil}})]
+      (is (empty? result)))))
+
+(deftest add-implications-table-level-test
+  (testing "Table-level create-queries non-:no implies view-data for those tables only"
+    (let [entries {10 {:perm_value :query-builder :schema_name "PUBLIC"}
+                   11 {:perm_value :no :schema_name "PUBLIC"}}
+          result  (#'data-perms.graph/add-implications {} 1 1 :perms/create-queries entries)]
+      (is (= {10 {:perm_value :unrestricted :schema_name "PUBLIC"}}
+             (get result [1 1 :perms/view-data])))
+      (is (nil? (get result [1 1 :perms/transforms]))
+          "No transforms implication at table level")))
+  (testing "Table-level view-data :blocked implies create-queries :no and download :no for those tables"
+    (let [entries {10 {:perm_value :blocked :schema_name "PUBLIC"}
+                   11 {:perm_value :unrestricted :schema_name "PUBLIC"}}
+          result  (#'data-perms.graph/add-implications {} 1 1 :perms/view-data entries)]
+      (is (= {10 {:perm_value :no :schema_name "PUBLIC"}}
+             (get result [1 1 :perms/create-queries])))
+      (is (= {10 {:perm_value :no :schema_name "PUBLIC"}}
+             (get result [1 1 :perms/download-results]))))))
+
+(deftest add-implications-override-behavior-test
+  (testing "Implications override existing entries (later perm-type side effects take precedence)"
+    (let [desired {[1 1 :perms/transforms] {nil {:perm_value :yes :schema_name nil}}}
+          entries {nil {:perm_value :query-builder :schema_name nil}}
+          result  (#'data-perms.graph/add-implications desired 1 1 :perms/create-queries entries)]
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get result [1 1 :perms/transforms]))
+          "create-queries :query-builder implies transforms :no, overriding earlier :yes")))
+  (testing "Protection from overriding explicit API values comes from processing order, not add-implications"
+    (let [graph   {1 {1 {:create-queries :query-builder :view-data :blocked}}}
+          desired (#'data-perms.graph/compute-desired-state graph tables-by-db-schema)]
+      (is (= {nil {:perm_value :blocked :schema_name nil}}
+             (get desired [1 1 :perms/view-data]))
+          "Explicit view-data :blocked overrides create-queries's implication because view-data is processed last"))))
+
+;;; ================================ compute-desired-state ================================
+
+(deftest compute-desired-state-ordering-test
+  (testing "Transforms :yes is overridden by create-queries implication of transforms :no"
+    (let [graph   {1 {1 {:transforms :yes :create-queries :query-builder}}}
+          desired (#'data-perms.graph/compute-desired-state graph tables-by-db-schema)]
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get desired [1 1 :perms/transforms])))))
+  (testing "Explicit view-data overrides create-queries implication"
+    (let [graph   {1 {1 {:create-queries :query-builder :view-data :blocked}}}
+          desired (#'data-perms.graph/compute-desired-state graph tables-by-db-schema)]
+      (is (= {nil {:perm_value :blocked :schema_name nil}}
+             (get desired [1 1 :perms/view-data]))))))
+
+(deftest compute-desired-state-details-test
+  (testing "Details and transforms produce db-level entries"
+    (let [desired (#'data-perms.graph/compute-desired-state {1 {1 {:details :yes :transforms :no}}} tables-by-db-schema)]
+      (is (= {nil {:perm_value :yes :schema_name nil}}
+             (get desired [1 1 :perms/manage-database])))
+      (is (= {nil {:perm_value :no :schema_name nil}}
+             (get desired [1 1 :perms/transforms]))))))
+
+;;; ================================ finalize-tuple ================================
+
+(def ^:private all-tables-db1
+  [{:id 10 :db_id 1 :schema "PUBLIC"}
+   {:id 11 :db_id 1 :schema "PUBLIC"}
+   {:id 12 :db_id 1 :schema nil}])
+
+(deftest finalize-tuple-pure-db-level-test
+  (testing "Pure db-level entry produces one db-level row"
+    (let [result (#'data-perms.graph/finalize-tuple 1 1 :perms/view-data
+                                                    {nil {:perm_value :unrestricted :schema_name nil}}
+                                                    [] all-tables-db1)]
+      (is (= [{:perm_type :perms/view-data :group_id 1 :perm_value :unrestricted :db_id 1}]
+             result)))))
+
+(deftest finalize-tuple-table-level-empty-current-test
+  (testing "Table-level entries with no current state produce table-level rows"
+    (let [result (#'data-perms.graph/finalize-tuple 1 1 :perms/create-queries
+                                                    {10 {:perm_value :query-builder :schema_name "PUBLIC"}}
+                                                    [] all-tables-db1)]
+      (is (= [{:perm_type :perms/create-queries :group_id 1 :perm_value :query-builder
+               :db_id 1 :table_id 10 :schema_name "PUBLIC"}]
+             result)))))
+
+(deftest finalize-tuple-noop-when-current-db-level-matches-test
+  (testing "Table-level entries that all match current db-level value coalesce (no-op)"
+    (let [current [{:id 99 :perm_type :perms/view-data :group_id 1 :perm_value :unrestricted
+                    :db_id 1 :table_id nil :schema_name nil}]
+          result  (#'data-perms.graph/finalize-tuple 1 1 :perms/view-data
+                                                     {10 {:perm_value :unrestricted :schema_name "PUBLIC"}}
+                                                     current all-tables-db1)]
+      (is (= [{:perm_type :perms/view-data :group_id 1 :perm_value :unrestricted :db_id 1}]
+             result)))))
+
+(deftest finalize-tuple-expand-db-level-on-change-test
+  (testing "When current is db-level and change differs, expands to table-level"
+    (let [current [{:id 99 :perm_type :perms/view-data :group_id 1 :perm_value :unrestricted
+                    :db_id 1 :table_id nil :schema_name nil}]
+          result  (#'data-perms.graph/finalize-tuple 1 1 :perms/view-data
+                                                     {10 {:perm_value :blocked :schema_name "PUBLIC"}}
+                                                     current all-tables-db1)]
+      (is (= 3 (count result)))
+      (is (every? :table_id result))
+      (is (= :blocked (:perm_value (first (filter #(= 10 (:table_id %)) result)))))
+      (is (= :unrestricted (:perm_value (first (filter #(= 11 (:table_id %)) result)))))
+      (is (= :unrestricted (:perm_value (first (filter #(= 12 (:table_id %)) result))))))))
+
+(deftest finalize-tuple-mixed-level-coalesces-test
+  (testing "Mixed db-level + table overrides coalesces when all values same"
+    (let [result (#'data-perms.graph/finalize-tuple 1 1 :perms/view-data
+                                                    {nil {:perm_value :unrestricted :schema_name nil}
+                                                     10  {:perm_value :unrestricted :schema_name "PUBLIC"}}
+                                                    [] all-tables-db1)]
+      (is (= [{:perm_type :perms/view-data :group_id 1 :perm_value :unrestricted :db_id 1}]
+             result))))
+  (testing "Mixed db-level + table overrides stays table-level when values differ"
+    (let [result (#'data-perms.graph/finalize-tuple 1 1 :perms/view-data
+                                                    {nil {:perm_value :unrestricted :schema_name nil}
+                                                     10  {:perm_value :blocked :schema_name "PUBLIC"}}
+                                                    [] all-tables-db1)]
+      (is (= 3 (count result)))
+      (is (every? :table_id result)))))
+
+(deftest finalize-tuple-query-builder-and-native-expansion-test
+  (testing ":query-builder-and-native becomes :query-builder when expanding to table-level"
+    (let [current [{:id 99 :perm_type :perms/create-queries :group_id 1
+                    :perm_value :query-builder-and-native :db_id 1 :table_id nil :schema_name nil}]
+          result  (#'data-perms.graph/finalize-tuple 1 1 :perms/create-queries
+                                                     {10 {:perm_value :no :schema_name "PUBLIC"}}
+                                                     current all-tables-db1)]
+      (is (= :no (:perm_value (first (filter #(= 10 (:table_id %)) result)))))
+      (is (= :query-builder (:perm_value (first (filter #(= 11 (:table_id %)) result)))))
+      (is (= :query-builder (:perm_value (first (filter #(= 12 (:table_id %)) result))))))))
+
+;;; ================================ rows-match? ================================
+
+(deftest rows-match?-test
+  (testing "Matching rows"
+    (is (#'data-perms.graph/rows-match?
+         [{:perm_type :perms/view-data :perm_value :unrestricted :table_id nil :schema_name nil}]
+         [{:perm_type :perms/view-data :perm_value :unrestricted :table_id nil :schema_name nil}])))
+  (testing "Different values don't match"
+    (is (not (#'data-perms.graph/rows-match?
+              [{:perm_type :perms/view-data :perm_value :unrestricted :table_id nil :schema_name nil}]
+              [{:perm_type :perms/view-data :perm_value :blocked :table_id nil :schema_name nil}]))))
+  (testing "Different formats (db-level vs table-level) don't match"
+    (is (not (#'data-perms.graph/rows-match?
+              [{:perm_type :perms/view-data :perm_value :unrestricted :table_id nil :schema_name nil}]
+              [{:perm_type :perms/view-data :perm_value :unrestricted :table_id 10 :schema_name "PUBLIC"}])))))
+
+;;; ================================ compute-diff ================================
+
+(deftest compute-diff-noop-test
+  (testing "No-op when desired matches current"
+    (let [desired-state {[1 1 :perms/view-data] {nil {:perm_value :unrestricted :schema_name nil}}}
+          current-index {[1 1 :perms/view-data] [{:id 99 :perm_type :perms/view-data :group_id 1
+                                                  :perm_value :unrestricted :db_id 1
+                                                  :table_id nil :schema_name nil}]}
+          tables-by-db  {1 all-tables-db1}
+          result        (#'data-perms.graph/compute-diff desired-state current-index tables-by-db)]
+      (is (empty? (:to-delete result)))
+      (is (empty? (:to-insert result))))))
+
+(deftest compute-diff-change-test
+  (testing "Produces deletes and inserts when state changes"
+    (let [desired-state {[1 1 :perms/view-data] {nil {:perm_value :blocked :schema_name nil}}}
+          current-index {[1 1 :perms/view-data] [{:id 99 :perm_type :perms/view-data :group_id 1
+                                                  :perm_value :unrestricted :db_id 1
+                                                  :table_id nil :schema_name nil}]}
+          tables-by-db  {1 all-tables-db1}
+          result        (#'data-perms.graph/compute-diff desired-state current-index tables-by-db)]
+      (is (= [99] (:to-delete result)))
+      (is (= [{:perm_type :perms/view-data :group_id 1 :perm_value :blocked :db_id 1}]
+             (:to-insert result))))))
+
+(deftest compute-diff-new-perms-test
+  (testing "Inserts without deletes when no current state exists"
+    (let [desired-state {[1 1 :perms/view-data] {nil {:perm_value :unrestricted :schema_name nil}}}
+          result        (#'data-perms.graph/compute-diff desired-state {} {1 all-tables-db1})]
+      (is (empty? (:to-delete result)))
+      (is (= [{:perm_type :perms/view-data :group_id 1 :perm_value :unrestricted :db_id 1}]
+             (:to-insert result))))))
+
+;;; ================================ N+1 regression ================================
+
+(deftest ^:synchronized update-data-perms-graph-query-count-regression-test
+  (testing "update-data-perms-graph!* uses a constant number of queries regardless of input size"
+    ;; 3 groups × 3 databases × 2 schemas each × 3 tables per schema = 18 tables per db
+    ;; Permissions set across multiple perm types at mixed granularity.
+    ;; An N+1 in any dimension (groups, dbs, schemas, perm types, tables) would push
+    ;; the query count well above the threshold.
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup {g1  :id} {}
+                     :model/PermissionsGroup {g2  :id} {}
+                     :model/PermissionsGroup {g3  :id} {}
+                     :model/Database         {db1 :id} {}
+                     :model/Database         {db2 :id} {}
+                     :model/Database         {db3 :id} {}
+                     :model/Table {t1a :id}  {:db_id db1 :schema "s1"}
+                     :model/Table {t1b :id}  {:db_id db1 :schema "s1"}
+                     :model/Table {t1c :id}  {:db_id db1 :schema "s1"}
+                     :model/Table {t1d :id}  {:db_id db1 :schema "s2"}
+                     :model/Table {t1e :id}  {:db_id db1 :schema "s2"}
+                     :model/Table {t1f :id}  {:db_id db1 :schema "s2"}
+                     :model/Table {t2a :id}  {:db_id db2 :schema "s1"}
+                     :model/Table {t2b :id}  {:db_id db2 :schema "s1"}
+                     :model/Table {t2c :id}  {:db_id db2 :schema "s1"}
+                     :model/Table {_t2d :id} {:db_id db2 :schema "s2"}
+                     :model/Table {_t2e :id} {:db_id db2 :schema "s2"}
+                     :model/Table {_t2f :id} {:db_id db2 :schema "s2"}
+                     :model/Table {t3a :id}  {:db_id db3 :schema "s1"}
+                     :model/Table {t3b :id}  {:db_id db3 :schema "s1"}
+                     :model/Table {_t3c :id} {:db_id db3 :schema "s1"}
+                     :model/Table {t3d :id}  {:db_id db3 :schema "s2"}
+                     :model/Table {t3e :id}  {:db_id db3 :schema "s2"}
+                     :model/Table {_t3f :id} {:db_id db3 :schema "s2"}]
+        ;; Clear default perms so we start clean
+        (t2/delete! :model/DataPermissions :group_id [:in [g1 g2 g3]])
+        (let [graph {g1 {db1 {:view-data      :unrestricted
+                              :create-queries :query-builder-and-native
+                              :download       {:schemas :full}
+                              :data-model     {:schemas :all}
+                              :details        :yes
+                              :transforms     :yes}
+                         db2 {:view-data      :blocked}
+                         db3 {:view-data      {"s1" :unrestricted
+                                               "s2" {t3d :blocked}}
+                              :create-queries {"s1" :query-builder
+                                               "s2" :no}}}
+                     g2 {db1 {:view-data      {"s1" {t1a :unrestricted
+                                                     t1b :blocked
+                                                     t1c :unrestricted}
+                                               "s2" :unrestricted}
+                              :download       {:schemas {"s1" :full
+                                                         "s2" {t1d :full t1e :none t1f :limited}}}}
+                         db2 {:view-data      :unrestricted
+                              :create-queries :query-builder
+                              :download       {:schemas {"s1" {t2a :full t2b :none t2c :limited}
+                                                         "s2" :full}}
+                              :data-model     {:schemas {"s1" {t2a :all t2b :none t2c :all}
+                                                         "s2" :none}}}
+                         db3 {:view-data      :unrestricted
+                              :create-queries :query-builder-and-native
+                              :details        :no
+                              :transforms     :yes}}
+                     g3 {db1 {:view-data      :blocked}
+                         db2 {:view-data      :legacy-no-self-service
+                              :create-queries :no}
+                         db3 {:view-data      :unrestricted
+                              :download       {:schemas :full}
+                              :data-model     {:schemas {"s1" {t3a :all t3b :none}
+                                                         "s2" {t3d :all t3e :none}}}}}}
+              ;; Run the update and count queries.
+              ;; Expected: 1 select tables + 1 select current perms + 1 bulk delete + 1 bulk insert = 4
+              ;; If this grows to 5 or 6, that's okay, but more should be very suspicious - it's very likely an N+1
+              ;; query in one of these dimensions!
+              query-count (t2/with-call-count [call-count]
+                            (data-perms.graph/update-data-perms-graph!* graph)
+                            (call-count))]
+          (is (<= query-count 4)
+              (format "Expected constant query count but got %d — possible N+1 regression" query-count)))
+
+        ;; Verify the permissions actually took effect by spot-checking a few values
+        (let [result (data-perms.graph/data-permissions-graph :group-ids [g1 g2 g3])]
+          (testing "g1/db1 db-level perms applied"
+            (is (= :unrestricted             (get-in result [g1 db1 :perms/view-data])))
+            (is (= :query-builder-and-native (get-in result [g1 db1 :perms/create-queries]))))
+          (testing "g1/db2 blocked cascades"
+            (is (= :blocked (get-in result [g1 db2 :perms/view-data])))
+            (is (= :no      (get-in result [g1 db2 :perms/create-queries]))))
+          (testing "g2/db1 table-level view-data and download"
+            (is (= :blocked           (get-in result [g2 db1 :perms/view-data "s1" t1b])))
+            (is (= :no                (get-in result [g2 db1 :perms/download-results "s2" t1e])))
+            (is (= :ten-thousand-rows (get-in result [g2 db1 :perms/download-results "s2" t1f]))))
+          (testing "g2/db2 table-level download and data-model"
+            (is (= :no (get-in result [g2 db2 :perms/download-results "s1" t2b])))
+            (is (= :no (get-in result [g2 db2 :perms/manage-table-metadata "s1" t2b]))))
+          (testing "g3/db3 table-level data-model"
+            (is (= :yes (get-in result [g3 db3 :perms/manage-table-metadata "s1" t3a])))
+            (is (= :no  (get-in result [g3 db3 :perms/manage-table-metadata "s1" t3b])))
+            (is (= :yes (get-in result [g3 db3 :perms/manage-table-metadata "s2" t3d])))
+            (is (= :no  (get-in result [g3 db3 :perms/manage-table-metadata "s2" t3e])))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73249
Fixes UXW-3902.

### Description

The original architecture for updating the permissions resulted in
`O(schemas * groups * perm_types)` `SELECT` queries and similarly for
`DELETE` and `INSERT` queries to update them. This made graph updates
extremely slow, where "slow" means that we have observed them taking 30+
minutes.

The new approach uses 3 or 4 queries no matter how many permissions are
being updated.

### How to verify

Should be no behavioural changes, so check that permissions updates still work as before.

I'm preparing a perf test with the 180 groups touching 60k tables in 10k schemas that the
reporting user has, to make sure it fixes that.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
