### PR TITLE
Disable experiments by default and set visibility to internal.

### DIFF
--- a/src/metabase/util/experiment.cljc
+++ b/src/metabase/util/experiment.cljc
@@ -19,10 +19,10 @@
 
 (defonce ^{:private true
            :doc "Atom holding a zero-arg function that returns whether experiments are enabled.
-   Defaults to (constantly true). On JVM, wired to the setting getter at startup.
+   On JVM, wired to the setting getter at startup.
    On CLJS, wired to read from bootstrap data."}
   experiments-enabled-fn
-  (atom (constantly true)))
+  (atom (constantly false)))
 
 (defn experiments-enabled?
   "Returns true if experiments are globally enabled. Checks the setting on every call."

--- a/src/metabase/util/experiment/settings.clj
+++ b/src/metabase/util/experiment/settings.clj
@@ -9,6 +9,7 @@
   (deferred-tru "Enable or disable all code experiments. When disabled, only the production code path runs.")
   :type       :boolean
   :default    false
+  :doc        false
   :visibility :admin
   :export?    false
   :audit      :getter)

--- a/test/metabase/util/experiment_test.cljc
+++ b/test/metabase/util/experiment_test.cljc
@@ -11,10 +11,16 @@
     [(fn [result] (swap! results conj result))
      results]))
 
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each
   (fn [t]
+    ;; this is safe because we don't have any parallel deftests in this namespace
+    ;; but the linter rule is over-general and assumes we might. could be a problem
+    ;; if a parallel test gets added, maybe.
     (binding [experiment/*sync?* true]
-      (t))))
+      (experiment/set-experiments-enabled-fn! (constantly true))
+      (t)
+      (experiment/set-experiments-enabled-fn! (constantly false)))))
 
 ;;; ------------------------------------------------ Core behavior ------------------------------------------------
 


### PR DESCRIPTION
### Description

In https://github.com/metabase/metabase/pull/72794 we added an "experiments" system. However, the visibility was set to `:admin` where I believe it should have been `:internal`. Also we should set it to disabled by default.
