### PR TITLE
Show "No results" empty state in Metric Viewer 

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -363,9 +363,7 @@ describe("scenarios > metrics > explorer", () => {
       H.MetricsViewer.goToViewer();
       addMetric("Empty Metric");
 
-      H.MetricsViewer.getMetricVisualization()
-        .findByText("No results!")
-        .should("exist");
+      cy.findByText("No results!").should("exist");
     });
   });
 

--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -363,7 +363,7 @@ describe("scenarios > metrics > explorer", () => {
       H.MetricsViewer.goToViewer();
       addMetric("Empty Metric");
 
-      cy.findByText("No results!").should("exist");
+      cy.findByRole("heading", { name: "No results!" }).should("exist");
     });
   });
 

--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -364,7 +364,7 @@ describe("scenarios > metrics > explorer", () => {
       addMetric("Empty Metric");
 
       H.MetricsViewer.getMetricVisualization()
-        .findByText(/No dice/)
+        .findByText("No results!")
         .should("exist");
     });
   });

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
+import { t } from "ttag";
 import { noop } from "underscore";
 
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
+import { ErrorMessage } from "metabase/common/components/ErrorMessage";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { DISPLAY_TYPE_REGISTRY } from "metabase/metrics-viewer/utils";
 import { MetricsViewerClickActionsMode } from "metabase/metrics-viewer/utils/MetricsViewerClickActionsMode";
@@ -9,6 +11,7 @@ import { getGridColumns } from "metabase/metrics-viewer/utils/grid-columns";
 import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
 import { Center, Flex, SimpleGrid, Stack, useElementSize } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
+import { datasetContainsNoResults } from "metabase-lib/v1/queries/utils/dataset";
 import type { CardId, SingleSeries } from "metabase-types/api";
 
 import type {
@@ -88,6 +91,23 @@ export function MetricsViewerVisualization({
 
   if (rawSeries.length === 0) {
     return null;
+  }
+
+  const hasNoResults = rawSeries.every((series) =>
+    datasetContainsNoResults(series.data),
+  );
+
+  if (hasNoResults) {
+    return (
+      <Center h="100%">
+        <ErrorMessage
+          type="noRows"
+          title={t`No results!`}
+          message={t`This may be the answer you're looking for. If not, try removing or changing your filters to make them less specific.`}
+          action={null}
+        />
+      </Center>
+    );
   }
 
   return (

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -877,7 +877,7 @@ class Visualization extends PureComponent<
           )}
           {replacementContent ? (
             replacementContent
-          ) : isDashboard && noResults ? (
+          ) : (isDashboard || isMetricsViewer) && noResults ? (
             <NoResultsView isSmall={small} />
           ) : error && !isRunning ? (
             <ErrorView


### PR DESCRIPTION
### Description

Fixes [UXW-3906](https://linear.app/metabase/issue/UXW-3906/metric-viewer-should-use-existing-no-results-state).

When all series in the Metric Viewer have zero rows (e.g. a filter excludes everything), render the same chill-mode "No results!" empty state used by the question viewer instead of the per-visualization `MinRowsError` warning. The warning was misleading — zero rows from filters isn't a visualization configuration problem.

### How to verify

- [ ] Open a metric whose Created At tab uses a line chart (e.g. *Orders, Count by Created At: Month*).
- [ ] Add a filter that yields zero rows (e.g. `Total >= 999999999`).
- [ ] Confirm the chart pane shows the sailboat "No results!" state with the "try removing or changing your filters" subtitle, not the warning triangle.

### Demo

#### Before
<img width="2476" height="1222" alt="image" src="https://github.com/user-attachments/assets/959f2736-2dbc-48fd-ae35-8bdf57eb22c3" />

#### After
<img width="1684" height="640" alt="image" src="https://github.com/user-attachments/assets/76d9b165-ee91-4bf3-a26d-2ae341b5f439" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)