### PR TITLE
Fix dark event tooltip title in light mode

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.tsx
@@ -22,7 +22,7 @@ const TimelineEventTooltip = (props: TimelineEventTooltipProps) => {
               <Icon name={event.icon as unknown as IconName} />
             </Flex>
             <Stack gap={0}>
-              <Text component="span" fz="md" fw="bold">
+              <Text component="span" c="inherit" fz="md" fw="bold">
                 {event.name}
               </Text>
               <DateTime


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73664

### Description

Fixes [GIT-9964](https://linear.app/metabase/issue/GIT-9964/event-tooltip-text-is-dark-in-light-mode).

Mantine's `Text` defaults to `color="text-primary"`, which overrode the tooltip's white text color. Pass `c="inherit"` so the event title picks up `--mb-color-tooltip-text`.

### How to verify

- [ ] In light mode, hover an event marker on a chart - the title should be white

### Demo

#### Before
<img width="696" height="572" alt="image" src="https://github.com/user-attachments/assets/914c169d-c2e8-421f-a5ad-9d8d872d8786" />

#### After
<img width="374" height="288" alt="image" src="https://github.com/user-attachments/assets/bad7f7c7-7170-4ade-bba9-c5009474a573" />
