### PR TITLE
Send MCP Apps client header from MCP Apps

### DIFF
--- a/frontend/src/metabase/app-embed-mcp.tsx
+++ b/frontend/src/metabase/app-embed-mcp.tsx
@@ -8,10 +8,7 @@ import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 
 EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 EMBEDDING_SDK_CONFIG.isMcpApp = true;
-
-// TODO(EMB-1534): change this header to "embedding-mcp" as we need to
-//                 exclude this from actual embedded analytics
-EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader = "embedding-simple";
+EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader = "mcp-apps";
 EMBEDDING_SDK_CONFIG.tokenFeatureKey = "embedding_simple";
 
 // Load EE plugins (whitelabeling, etc.) - no-op in OSS

--- a/frontend/src/metabase/embedding-sdk/config.ts
+++ b/frontend/src/metabase/embedding-sdk/config.ts
@@ -5,7 +5,10 @@ export const EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID = "metabase-sdk-portal-root";
 type InternalSdkConfig = {
   isEmbeddingSdk: boolean;
   isMcpApp: boolean;
-  metabaseClientRequestHeader: "embedding-sdk-react" | "embedding-simple";
+  metabaseClientRequestHeader:
+    | "embedding-sdk-react"
+    | "embedding-simple"
+    | "mcp-apps";
   enableEmbeddingSettingKey: "enable-embedding-sdk" | "enable-embedding-simple";
   tokenFeatureKey: "embedding_sdk" | "embedding_simple";
 };

--- a/frontend/src/metabase/embedding/mcp/api.ts
+++ b/frontend/src/metabase/embedding/mcp/api.ts
@@ -28,6 +28,7 @@ export async function storeDrillQuery({
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "X-Metabase-Client": "mcp-apps",
       "X-Metabase-Session": sessionToken,
       "Mcp-Session-Id": mcpSessionId,
     },


### PR DESCRIPTION
Closes EMB-1534

### Description

Sends `X-Metabase-Client: mcp-apps` from MCP Apps requests instead of reusing the Embedded Analytics JS `embedding-simple` client header.

This keeps MCP Apps query execution context distinguishable as `mcp-apps`, while avoiding counting MCP Apps traffic as Embedded Analytics.

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing because Claude Desktop strips HTTP domains such as `localhost:3000`, so nothing will load.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config:

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any:

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr73709.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case. Note that if you change the AI settings, it would change it for everyone though!

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr73709.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting:

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. With Claude enabled in AI settings, ask Claude to visualize a query, e.g. `Show count of orders by product category`.
4. In browser DevTools or the MCP App iframe network requests, confirm query/API requests include `X-Metabase-Client: mcp-apps`.
5. Confirm the MCP App still renders the visualization normally.
6. For a drill-through flow, click a chart value and confirm the `/api/embed-mcp/drills` request also includes `X-Metabase-Client: mcp-apps`.