### PR TITLE
Move embedding types into metabase-types

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -1,8 +1,8 @@
 import { P, match } from "ts-pattern";
 
-import type { EmbedResourceDownloadOptions } from "metabase/embedding/types";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
+import type { EmbedResourceDownloadOptions } from "metabase-types/api";
 
 /**
  * Initialize resource downloads plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
@@ -1,7 +1,9 @@
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import type { EmbedResourceDownloadOptions } from "metabase/embedding/types";
-import type { TokenFeatures } from "metabase-types/api";
+import type {
+  EmbedResourceDownloadOptions,
+  TokenFeatures,
+} from "metabase-types/api";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 export interface SetupOpts {

--- a/frontend/src/metabase-types/analytics/embed-flow.ts
+++ b/frontend/src/metabase-types/analytics/embed-flow.ts
@@ -1,4 +1,4 @@
-import type { EmbedResourceDownloadOptions } from "metabase/embedding/types";
+import type { EmbedResourceDownloadOptions } from "metabase-types/api";
 
 type EmbedFlowParams = {
   locked?: number;

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,7 +1,3 @@
-import type {
-  EmbeddingParameters,
-  EmbeddingType,
-} from "metabase/embedding/types";
 import type { CurrencyStyle } from "metabase/utils/formatting";
 import type { IconName } from "metabase-types/api";
 import type { EntityToken, EntityUuid } from "metabase-types/api/entity";
@@ -18,6 +14,7 @@ import type {
 import type { Database, DatabaseId } from "./database";
 import type { RowValue } from "./dataset";
 import type { Document, DocumentId } from "./document";
+import type { EmbeddingParameters, EmbeddingType } from "./embed";
 import type { BaseEntityId } from "./entity-id";
 import type { Field } from "./field";
 import type { ModerationReview } from "./moderation";

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -1,8 +1,4 @@
 import type {
-  EmbeddingParameters,
-  EmbeddingType,
-} from "metabase/embedding/types";
-import type {
   BaseEntityId,
   CardDisplayType,
   ClickBehavior,
@@ -10,6 +6,8 @@ import type {
   CollectionAuthorityLevel,
   CollectionId,
   Database,
+  EmbeddingParameters,
+  EmbeddingType,
   Field,
   FieldId,
   Parameter,

--- a/frontend/src/metabase-types/api/embed.ts
+++ b/frontend/src/metabase-types/api/embed.ts
@@ -1,0 +1,10 @@
+export type EmbeddingType = "static-legacy" | "guest-embed";
+
+export type EmbeddingParameterVisibility = "disabled" | "enabled" | "locked";
+
+export type EmbeddingParameters = Record<string, EmbeddingParameterVisibility>;
+
+export type EmbedResourceDownloadOptions = {
+  pdf?: boolean;
+  results?: boolean;
+};

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -21,6 +21,7 @@ export * from "./dataset";
 export * from "./dependencies";
 export * from "./document";
 export * from "./email";
+export * from "./embed";
 export * from "./embedding-theme";
 export * from "./entity-id";
 export * from "./field";

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/ParameterSettings.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { t } from "ttag";
 
-import type { EmbeddingParameterVisibility } from "metabase/embedding/types";
 import { ParameterValueWidget } from "metabase/parameters/components/ParameterValueWidget";
 import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle";
 import { TemporalUnitSettings } from "metabase/parameters/components/TemporalUnitSettings";

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/ParameterSettings.tsx
@@ -34,6 +34,7 @@ import {
 } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
   DashboardCard,
+  EmbeddingParameterVisibility,
   Parameter,
   TemporalUnit,
   ValuesQueryType,

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -8,7 +8,6 @@ import {
   DASHBOARD_SLOW_TIMEOUT,
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
-import type { EmbeddingParameterVisibility } from "metabase/embedding/types";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import {
   getDashboardQuestions,

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -47,6 +47,7 @@ import type {
   DashboardId,
   DashboardParameterMapping,
   DashboardTabId,
+  EmbeddingParameterVisibility,
   ParameterId,
   VirtualCard,
 } from "metabase-types/api";

--- a/frontend/src/metabase/dashboard/types/display-options.ts
+++ b/frontend/src/metabase/dashboard/types/display-options.ts
@@ -1,4 +1,4 @@
-import type { EmbedResourceDownloadOptions } from "metabase/embedding/types";
+import type { EmbedResourceDownloadOptions } from "metabase-types/api";
 
 export type DashboardFullscreenControls = {
   isFullscreen: boolean;

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -1,8 +1,6 @@
-import type {
-  DisplayTheme,
-  EmbedResourceDownloadOptions,
-} from "metabase/embedding/types";
+import type { DisplayTheme } from "metabase/embedding/types";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
+import type { EmbedResourceDownloadOptions } from "metabase-types/api";
 
 type EmbedBackground = boolean;
 

--- a/frontend/src/metabase/embedding/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/embedding/components/EmbedModal/EmbedModal.tsx
@@ -5,9 +5,9 @@ import { StaticEmbedSetupPane } from "metabase/embedding/components/EmbedModal/S
 import type {
   EmbedResource,
   EmbedResourceParameter,
-  EmbeddingParameters,
   GuestEmbedResourceType,
 } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 import { EmbedModalHeader } from "./EmbedModal.styled";
 

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -8,14 +8,16 @@ import CS from "metabase/css/core/index.css";
 import type {
   EmbedResourceParameter,
   EmbedResourceType,
-  EmbeddingParameterVisibility,
-  EmbeddingParameters,
   EmbeddingParametersValues,
 } from "metabase/embedding/types";
 import { ParameterWidget as StaticParameterWidget } from "metabase/parameters/components/ParameterWidget";
 import { getParameterIconName } from "metabase/parameters/utils/ui";
 import { Box, Divider, Icon, Stack, Text } from "metabase/ui";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
+import type {
+  EmbeddingParameterVisibility,
+  EmbeddingParameters,
+} from "metabase-types/api";
 
 import { StaticEmbedSetupPaneSettingsContentSection } from "./StaticEmbedSetupPaneSettingsContentSection";
 import type { EmbedResourceParameterWithValue } from "./types";

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -15,7 +15,6 @@ import type {
   EmbedResource,
   EmbedResourceParameter,
   EmbeddingDisplayOptions,
-  EmbeddingParameters,
   EmbeddingParametersValues,
   GuestEmbedResourceType,
 } from "metabase/embedding/types";
@@ -23,6 +22,7 @@ import { useSelector } from "metabase/redux";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 import { Paper, Stack, Tabs } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 import { EmbedModalContentStatusBar } from "./EmbedModalContentStatusBar";
 import { LookAndFeelSettings } from "./LookAndFeelSettings";

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-default-embedding-params.ts
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-default-embedding-params.ts
@@ -3,8 +3,8 @@ import _ from "underscore";
 import type {
   EmbedResource,
   EmbedResourceParameter,
-  EmbeddingParameters,
 } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 export function getDefaultEmbeddingParams(
   resource: EmbedResource,

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-has-params-changed.ts
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-has-params-changed.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import type { EmbeddingParameters } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 function getNonDisabledEmbeddingParams(
   embeddingParams: EmbeddingParameters,

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-locked-preview-parameters.ts
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-locked-preview-parameters.ts
@@ -1,7 +1,5 @@
-import type {
-  EmbedResourceParameter,
-  EmbeddingParameters,
-} from "metabase/embedding/types";
+import type { EmbedResourceParameter } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 export function getLockedPreviewParameters(
   resourceParameters: EmbedResourceParameter[],

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-preview-params-by-slug.ts
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-preview-params-by-slug.ts
@@ -1,10 +1,10 @@
 import { getLockedPreviewParameters } from "metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-locked-preview-parameters";
 import type {
   EmbedResourceParameter,
-  EmbeddingParameters,
   EmbeddingParametersValues,
 } from "metabase/embedding/types";
 import { getParameterValue } from "metabase-lib/v1/parameters/utils/parameter-values";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 export function getPreviewParamsBySlug({
   resourceParameters,

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-static-embed-setup-publish-handlers.ts
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-static-embed-setup-publish-handlers.ts
@@ -5,10 +5,8 @@ import {
   trackStaticEmbedUnpublished,
 } from "metabase/embedding/lib/analytics";
 import { countEmbeddingParameterOptions } from "metabase/embedding/lib/count-embedding-parameter-options";
-import type {
-  EmbedResourceParameter,
-  EmbeddingParameters,
-} from "metabase/embedding/types";
+import type { EmbedResourceParameter } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 import { getDefaultEmbeddingParams } from "./get-default-embedding-params";
 

--- a/frontend/src/metabase/embedding/constants.ts
+++ b/frontend/src/metabase/embedding/constants.ts
@@ -1,4 +1,4 @@
-import type { EmbeddingType } from "metabase/embedding/types";
+import type { EmbeddingType } from "metabase-types/api";
 
 export const STATIC_LEGACY_EMBEDDING_TYPE: EmbeddingType = "static-legacy";
 export const GUEST_EMBED_EMBEDDING_TYPE: EmbeddingType = "guest-embed";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/analytics.ts
@@ -8,9 +8,8 @@ import type {
 import { getAuthSubTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-sub-type-for-settings";
 import { getAuthTypeForSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-auth-type-for-settings";
 import { countEmbeddingParameterOptions } from "metabase/embedding/lib/count-embedding-parameter-options";
-import type { EmbeddingParameters } from "metabase/embedding/types";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
-import type { Card, Dashboard } from "metabase-types/api";
+import type { Card, Dashboard, EmbeddingParameters } from "metabase-types/api";
 
 import type {
   SdkIframeEmbedSetupExperience,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/context.ts
@@ -1,11 +1,13 @@
 import { createContext, useContext } from "react";
 
-import type {
-  EmbeddingParameters,
-  EmbeddingParametersValues,
-} from "metabase/embedding/types";
+import type { EmbeddingParametersValues } from "metabase/embedding/types";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
-import type { Card, Dashboard, Parameter } from "metabase-types/api";
+import type {
+  Card,
+  Dashboard,
+  EmbeddingParameters,
+  Parameter,
+} from "metabase-types/api";
 
 import type {
   SdkIframeEmbedSetupExperience,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion.ts
@@ -1,8 +1,7 @@
 import { useCallback } from "react";
 
 import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-iframe-sdk-setup/types";
-import type { EmbeddingParameters } from "metabase/embedding/types";
-import type { Parameter } from "metabase-types/api";
+import type { EmbeddingParameters, Parameter } from "metabase-types/api";
 
 export const useEmbeddingParametersConversion = () => {
   const convertToEmbedSettings = useCallback(

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion.unit.spec.ts
@@ -1,8 +1,7 @@
 import { renderHook } from "@testing-library/react";
 
 import { useEmbeddingParametersConversion } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion";
-import type { EmbeddingParameters } from "metabase/embedding/types";
-import type { Parameter } from "metabase-types/api";
+import type { EmbeddingParameters, Parameter } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 describe("useEmbeddingParametersConversion", () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters.ts
@@ -4,8 +4,12 @@ import { usePrevious } from "react-use";
 import { getDefaultEmbeddingParams } from "metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-default-embedding-params";
 import type { SdkIframeEmbedSetupContextType } from "metabase/embedding/embedding-iframe-sdk-setup/context";
 import { useEmbeddingParametersConversion } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters-conversion";
-import type { EmbeddingParameters } from "metabase/embedding/types";
-import type { Card, Dashboard, Parameter } from "metabase-types/api";
+import type {
+  Card,
+  Dashboard,
+  EmbeddingParameters,
+  Parameter,
+} from "metabase-types/api";
 
 export const useEmbeddingParameters = ({
   settings,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters.unit.spec.ts
@@ -2,8 +2,12 @@ import { renderHook } from "@testing-library/react";
 
 import { useEmbeddingParameters } from "metabase/embedding/embedding-iframe-sdk-setup/hooks/use-embedding-parameters";
 import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-iframe-sdk-setup/types";
-import type { EmbeddingParameters } from "metabase/embedding/types";
-import type { Card, Dashboard, Parameter } from "metabase-types/api";
+import type {
+  Card,
+  Dashboard,
+  EmbeddingParameters,
+  Parameter,
+} from "metabase-types/api";
 import {
   createMockCard,
   createMockDashboard,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-parameters-values.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-parameters-values.ts
@@ -3,8 +3,7 @@ import { useMemo } from "react";
 import { getPreviewParamsBySlug } from "metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-preview-params-by-slug";
 import type { SdkIframeEmbedSetupSettings } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 import { convertParameterValuesBySlugToById } from "metabase/embedding/embedding-iframe-sdk-setup/utils/convert-parameter-values-by-slug-to-by-id";
-import type { EmbeddingParameters } from "metabase/embedding/types";
-import type { Parameter } from "metabase-types/api";
+import type { EmbeddingParameters, Parameter } from "metabase-types/api";
 
 interface UseParametersValuesProps {
   settings: SdkIframeEmbedSetupSettings;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-toggle-resource-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-toggle-resource-embedding.ts
@@ -7,7 +7,7 @@ import {
 import { useSetting } from "metabase/common/hooks";
 import { getStaticEmbedSetupPublishHandlers } from "metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/lib/get-static-embed-setup-publish-handlers";
 import { GUEST_EMBED_EMBEDDING_TYPE } from "metabase/embedding/constants";
-import type { EmbeddingParameters } from "metabase/embedding/types";
+import type { EmbeddingParameters } from "metabase-types/api";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 import { getResourceTypeFromExperience } from "../utils/get-resource-type-from-experience";

--- a/frontend/src/metabase/embedding/lib/analytics.ts
+++ b/frontend/src/metabase/embedding/lib/analytics.ts
@@ -1,13 +1,15 @@
 import { trackSchemaEvent } from "metabase/analytics";
 import type { ExportFormat } from "metabase/common/types/export";
+import type {
+  EmbedResourceDownloadOptions,
+  EmbeddingParameterVisibility,
+} from "metabase-types/api";
 
 import type {
   DisplayTheme,
   EmbedResource,
-  EmbedResourceDownloadOptions,
   EmbedResourceType,
   EmbeddingDisplayOptions,
-  EmbeddingParameterVisibility,
 } from "../types";
 
 const SCHEMA_NAME = "embed_flow";

--- a/frontend/src/metabase/embedding/lib/count-embedding-parameter-options.ts
+++ b/frontend/src/metabase/embedding/lib/count-embedding-parameter-options.ts
@@ -1,7 +1,7 @@
 import type {
   EmbeddingParameterVisibility,
   EmbeddingParameters,
-} from "metabase/embedding/types";
+} from "metabase-types/api";
 
 export const countEmbeddingParameterOptions = (
   embeddingParams: EmbeddingParameters,

--- a/frontend/src/metabase/embedding/types.ts
+++ b/frontend/src/metabase/embedding/types.ts
@@ -2,6 +2,8 @@ import type { CodeLanguage } from "metabase/common/components/CodeEditor";
 import type {
   Card,
   Dashboard,
+  EmbedResourceDownloadOptions,
+  EmbeddingParameters,
   ParameterValueOrArray,
 } from "metabase-types/api";
 
@@ -22,17 +24,6 @@ export type EmbedResourceParameter = {
   required?: boolean;
   default?: ParameterValueOrArray | null;
 };
-
-export type EmbedResourceDownloadOptions = {
-  pdf?: boolean;
-  results?: boolean;
-};
-
-export type EmbeddingType = "static-legacy" | "guest-embed";
-
-export type EmbeddingParameterVisibility = "disabled" | "enabled" | "locked";
-
-export type EmbeddingParameters = Record<string, EmbeddingParameterVisibility>;
 
 export type EmbeddingParametersValues = Record<
   string,

--- a/frontend/src/metabase/plugins/oss/resource-downloads.ts
+++ b/frontend/src/metabase/plugins/oss/resource-downloads.ts
@@ -1,4 +1,4 @@
-import type { EmbedResourceDownloadOptions } from "metabase/embedding/types";
+import type { EmbedResourceDownloadOptions } from "metabase-types/api";
 
 const getDefaultPluginResourceDownloads = () => ({
   areDownloadsEnabled: (_args: {

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -4,10 +4,7 @@ import type { Dispatch, SetStateAction } from "react";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
-import type {
-  DisplayTheme,
-  EmbedResourceDownloadOptions,
-} from "metabase/embedding/types";
+import type { DisplayTheme } from "metabase/embedding/types";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { EmbedFrame } from "metabase/public/components/EmbedFrame";
 import { PublicOrEmbeddedQuestionDownloadPopover } from "metabase/query_builder/components/QuestionDownloadPopover/QuestionDownloadPopover";
@@ -19,6 +16,7 @@ import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Card,
   Dataset,
+  EmbedResourceDownloadOptions,
   ParameterId,
   ParameterValuesMap,
   RawSeries,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -2,7 +2,6 @@ import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import type { EmbeddingParameterVisibility } from "metabase/embedding/types";
 import { TemporalUnitSettings } from "metabase/parameters/components/TemporalUnitSettings";
 import { ValuesSourceSettings } from "metabase/parameters/components/ValuesSourceSettings";
 import { isSingleOrMultiSelectable } from "metabase/parameters/utils/parameter-type";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -25,6 +25,7 @@ import {
 } from "metabase-lib/v1/parameters/utils/template-tag-options";
 import type {
   DimensionReference,
+  EmbeddingParameterVisibility,
   FieldId,
   Parameter,
   ParameterValuesConfig,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -3,13 +3,13 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { SidebarContent } from "metabase/common/components/SidebarContent";
-import type { EmbeddingParameterVisibility } from "metabase/embedding/types";
 import { Box, Tabs } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
   DatabaseId,
+  EmbeddingParameterVisibility,
   NativeDatasetQuery,
   Parameter,
   ParameterId,

--- a/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
@@ -1,6 +1,5 @@
 import { match } from "ts-pattern";
 
-import type { EmbeddingParameterVisibility } from "metabase/embedding/types";
 import { AIQuestionAnalysisSidebar } from "metabase/metabot/components/AIQuestionAnalysisSidebar";
 import { TagEditorSidebar } from "metabase/query_builder/components/template_tags/TagEditorSidebar";
 import { QuestionInfoSidebar } from "metabase/query_builder/components/view/sidebars/QuestionInfoSidebar";

--- a/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.tsx
@@ -13,6 +13,7 @@ import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   DatabaseId,
+  EmbeddingParameterVisibility,
   NativeDatasetQuery,
   RowValue,
   TemplateTag,


### PR DESCRIPTION
Moves the types `EmbeddingType`, `EmbeddingParameterVisibility`, `EmbeddingParameters` and `EmbedResourceDownloadOptions` from metabase/public/lib/types and to metabase-types/api/embed.ts so they can be used from metabase-types/api. 

Fixes boundary violations where metabase-types/api/card.ts, dashboard.ts, and analytics/embed-flow.ts were reaching up into a shared-tier module.