### PR TITLE
fix(sdk-package): use v55+ JWT auth method in CLI Express snippet

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/bin/generate-cli-snippets-for-testing.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/bin/generate-cli-snippets-for-testing.ts
@@ -127,7 +127,6 @@ const generateExpressServerSnippet = ({
   setupOutDir(outDir);
 
   const snippetContent = getExpressServerSnippet({
-    instanceUrl: "https://example.com",
     tenantIdsMap: {},
   });
   const packageJsonContent = JSON.stringify(MOCK_SERVER_PACKAGE_JSON, null, 2);

--- a/enterprise/frontend/src/embedding-sdk-package/cli/constants/mock-server-package-json.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/constants/mock-server-package-json.ts
@@ -11,9 +11,5 @@ export const MOCK_SERVER_PACKAGE_JSON = {
     express: "^4.19.2",
     "express-session": "^1.18.0",
     jsonwebtoken: "^9.0.2",
-    "node-fetch": "^2.7.0",
-  },
-  resolutions: {
-    "whatwg-url": "^14.0.0",
   },
 };

--- a/enterprise/frontend/src/embedding-sdk-package/cli/snippets/express-server-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/snippets/express-server-snippet.ts
@@ -4,12 +4,12 @@ import { HARDCODED_JWT_SHARED_SECRET } from "../constants/config";
 import { HARDCODED_USERS } from "../constants/hardcoded-users";
 import type { CliState } from "../types/cli";
 
-type Options = Pick<CliState, "instanceUrl" | "tenantIdsMap">;
+type Options = Pick<CliState, "tenantIdsMap">;
 
 const DEFAULT_EXPRESS_SERVER_PORT = 4477;
 
 export const getExpressServerSnippet = (options: Options) => {
-  const { tenantIdsMap, instanceUrl } = options;
+  const { tenantIdsMap } = options;
 
   const users = HARDCODED_USERS.map((user, i) => {
     const tenancyAttributes: Record<string, string | number> = {};
@@ -39,14 +39,11 @@ export const getExpressServerSnippet = (options: Options) => {
 
   return `
 const express = require("express");
-const fetch = require("node-fetch");
 const jwt = require("jsonwebtoken");
 const session = require('express-session')
 const cors = require('cors')
 
 const PORT = process.env.PORT || ${DEFAULT_EXPRESS_SERVER_PORT}
-
-const METABASE_INSTANCE_URL = '${instanceUrl}'
 
 const METABASE_JWT_SHARED_SECRET =
   '${HARDCODED_JWT_SHARED_SECRET}'
@@ -78,22 +75,8 @@ ${tenancyAttributeMaps}
     METABASE_JWT_SHARED_SECRET,
   );
 
-  const ssoUrl = \`\${METABASE_INSTANCE_URL}/auth/sso?token=true&jwt=\${token}\`;
-
-  try {
-    const response = await fetch(ssoUrl, { method: "GET" });
-    const token = await response.json();
-
-    return res.status(200).json(token);
-  } catch (error) {
-    if (error instanceof Error) {
-      res.status(401).json({
-        status: "error",
-        message: "authentication failed",
-        error: error.message,
-      });
-    }
-  }
+  // The user backend should return a JSON object with the JWT.
+  return res.status(200).json({ jwt: token });
 }
 
 async function switchUserHandler(req, res) {

--- a/enterprise/frontend/src/embedding-sdk-package/cli/steps/generate-express-server-file.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/steps/generate-express-server-file.ts
@@ -10,14 +10,6 @@ import type { CliStepMethod } from "../types/cli";
 import { printError } from "../utils/print";
 
 export const generateExpressServerFile: CliStepMethod = async (state) => {
-  const { instanceUrl } = state;
-
-  if (!instanceUrl) {
-    const message = "Missing instance URL.";
-
-    return [{ type: "error", message }, state];
-  }
-
   let mockServerDir: string;
 
   while (true) {
@@ -46,7 +38,6 @@ export const generateExpressServerFile: CliStepMethod = async (state) => {
   }
 
   const snippet = getExpressServerSnippet({
-    instanceUrl,
     tenantIdsMap: state.tenantIdsMap,
   });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73500
Closes [EMB-1678: SDK CLI Express snippet uses pre-55 auth method](https://linear.app/metabase/issue/EMB-1678/sdk-cli-express-snippet-uses-pre-55-auth-method)

### Description

The SDK CLI's Express server snippet used the pre-v55 JWT flow: it signed a JWT, called Metabase's `/auth/sso?token=true&jwt=...` endpoint, and returned that response. The v55+ flow expects the customer backend to return `{ jwt: string }` directly — same shape as the canonical example in `docs/embedding/sdk/snippets/authentication/express-server.ts`.

Also dropped the now-unused `node-fetch` dependency, the `whatwg-url` resolution, and the `instanceUrl` parameter that was only needed by the old flow.

### How to verify

1. Generate the snippet: `tsx ./enterprise/frontend/src/embedding-sdk-package/bin/generate-cli-snippets-for-testing.ts`
2. `cd enterprise/frontend/src/embedding-sdk-package/cli-snippets-tmp/express-server && bun install && node server.js`
3. Log in: `curl -c cookies.txt -X POST http://localhost:4477/switch-user -H 'Content-Type: application/json' -d '{"email":"alice@example.com"}'`
4. Fetch the JWT: `curl -b cookies.txt http://localhost:4477/sso/metabase`
5. Response should be `{"jwt":"eyJ..."}` — the v55+ shape.

Type-check: `bash bin/embedding-sdk/type-check-embedding-sdk-cli-snippets.sh` (passes).

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR