### PR TITLE
Fix login redirects when metabot is enabled

### DIFF
--- a/frontend/src/metabase/metabot/hooks/use-user-metabot-permissions.ts
+++ b/frontend/src/metabase/metabot/hooks/use-user-metabot-permissions.ts
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 
 import { useGetUserMetabotPermissionsQuery } from "metabase/api";
+import { useSelector } from "metabase/redux";
+import { getUser } from "metabase/selectors/user";
 
 import { useMetabotEnabledEmbeddingAware } from "./use-metabot-embedding-aware-enabled";
 
@@ -9,9 +11,10 @@ import { useMetabotEnabledEmbeddingAware } from "./use-metabot-embedding-aware-e
  * Returns all false while loading or on error. */
 export const useUserMetabotPermissions = () => {
   const isMetabotEnabled = useMetabotEnabledEmbeddingAware();
+  const isAuthenticated = !!useSelector(getUser);
   const { data, isLoading, isError } = useGetUserMetabotPermissionsQuery(
     undefined,
-    { skip: !isMetabotEnabled },
+    { skip: !isMetabotEnabled || !isAuthenticated },
   );
 
   const perms = data?.permissions;

--- a/frontend/src/metabase/metabot/hooks/use-user-metabot-permissions.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-user-metabot-permissions.unit.spec.tsx
@@ -19,10 +19,12 @@ function TestComponent() {
 
 function setup({
   isMetabotEnabled = true,
+  isAuthenticated = true,
   apiResponse,
   apiStatus = 200,
 }: {
   isMetabotEnabled?: boolean;
+  isAuthenticated?: boolean;
   apiResponse?: UserMetabotPermissionsResponse;
   apiStatus?: number;
 } = {}) {
@@ -43,7 +45,10 @@ function setup({
   setupEnterprisePlugins();
 
   renderWithProviders(<TestComponent />, {
-    storeInitialState: createMockState({ settings }),
+    storeInitialState: createMockState({
+      settings,
+      ...(isAuthenticated ? {} : { currentUser: null }),
+    }),
   });
 }
 
@@ -75,6 +80,17 @@ describe("useUserMetabotPermissions", () => {
     expect(perms.canUseSqlGeneration).toBe(false);
     expect(perms.canUseNlq).toBe(false);
     expect(perms.canUseOtherTools).toBe(false);
+  });
+
+  it("does not call the API when the user is unauthenticated (UXW-3939)", async () => {
+    setup({ isAuthenticated: false });
+    const perms = await getPerms();
+    expect(perms.canUseMetabot).toBe(false);
+    expect(
+      fetchMock.callHistory.calls(
+        "path:/api/metabot/permissions/user-permissions",
+      ),
+    ).toHaveLength(0);
   });
 
   it("returns all false when the API returns an error", async () => {

--- a/frontend/src/metabase/route-guards.unit.spec.tsx
+++ b/frontend/src/metabase/route-guards.unit.spec.tsx
@@ -1,12 +1,17 @@
 import { type Context, createContext } from "react";
+import { Route } from "react-router";
 import { routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { metabaseReduxContext } from "metabase/redux/context";
 import { createMockState } from "metabase/redux/store/mocks";
 
-import { isBackendOnlyPath } from "./route-guards";
+import {
+  IsAuthenticated,
+  IsNotAuthenticated,
+  isBackendOnlyPath,
+} from "./route-guards";
 
 describe("route-guards", () => {
   describe("patched redux-auth-wrapper", () => {
@@ -62,6 +67,47 @@ describe("route-guards", () => {
 
       expect(selectorState.auth.VAL_ONLY_IN_THIS_CTX).toBe(false);
       expect(screen.queryByText(text)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("redirect-after-login flow (UXW-3939)", () => {
+    it("UserIsAuthenticated should preserve original path as ?redirect= when sending logged-out user to /auth/login", async () => {
+      const settings = {
+        "has-user-setup": true,
+      } as any;
+      const state = createMockState({
+        currentUser: undefined,
+        settings: { values: settings } as any,
+      });
+
+      const Dashboard = () => <div>protected dashboard</div>;
+      const LoginPage = () => <div>login page</div>;
+
+      const { history } = renderWithProviders(
+        <>
+          <Route component={IsAuthenticated}>
+            <Route path="/dashboard/:slug" component={Dashboard} />
+          </Route>
+          <Route component={IsNotAuthenticated}>
+            <Route path="/auth/login" component={LoginPage} />
+          </Route>
+        </>,
+        {
+          storeInitialState: state,
+          withRouter: true,
+          initialRoute: "/dashboard/123",
+        },
+      );
+
+      await waitFor(() => {
+        expect(history?.getCurrentLocation().pathname).toBe("/auth/login");
+      });
+
+      const location = history!.getCurrentLocation();
+      expect(location.query).toEqual(
+        expect.objectContaining({ redirect: "/dashboard/123" }),
+      );
+      expect(location.search).toContain("redirect");
     });
   });
 


### PR DESCRIPTION
### Description

This issue came from the unauthenticated -> redirect logic at the API layer, rather than the route guard layer. When metabot is enabled and a user is unauthenticated, the App (and App Bar) are still mounted, causing `use-user-metabot-permissions.ts` to reach out to `/user-permissions` and get a 401. This caused a hard redirect to `/auth/login` without the redirect search param. The fix here is to only make this call if a user is logged in, though this is a class of bug that requires a broader solution to prevent in the future.

### How to verify
1. Set up Metabot and have it enabled on an instance
2. Go to a question and copy that url
3. sign out
4. paste the copied url into the browser and hit enter
5. You should see a redirect param in the url. Log in as usual
6. You should be at the redirect page

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
