### PR TITLE
Move the `delete` object action to RTK-based hook

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
@@ -8,7 +8,12 @@ import {
   BulkActionDangerButton,
 } from "metabase/common/components/BulkActionBar";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
-import { canMoveItem, useSetArchive } from "metabase/common/hooks";
+import {
+  canDelete,
+  canMoveItem,
+  useDeleteItem,
+  useSetArchive,
+} from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
 import type { Collection, CollectionItem } from "metabase-types/api";
@@ -34,6 +39,7 @@ export const ArchivedBulkActions = ({
 }: ArchivedBulkActionsProps) => {
   const dispatch = useDispatch();
   const archive = useSetArchive();
+  const deleteItem = useDeleteItem();
 
   const hasSelectedItems = useMemo(
     () => !!selectedItems && !_.isEmpty(selectedItems),
@@ -66,8 +72,8 @@ export const ArchivedBulkActions = ({
   };
 
   // delete
-  const canDelete = useMemo(() => {
-    return selected.every((item) => item.can_delete);
+  const canDeleteAll = useMemo(() => {
+    return selected.every((item) => canDelete(item));
   }, [selected]);
 
   const handleBulkDeletePermanentlyStart = async () => {
@@ -76,7 +82,7 @@ export const ArchivedBulkActions = ({
   };
 
   const handleBulkDeletePermanently = async () => {
-    const actions = selected.map((item) => item.delete());
+    const actions = selected.filter(canDelete).map((item) => deleteItem(item));
     Promise.all(actions).finally(unselect);
     dispatch(
       addUndo({
@@ -112,7 +118,7 @@ export const ArchivedBulkActions = ({
       </BulkActionButton>
       <BulkActionDangerButton
         onClick={handleBulkDeletePermanentlyStart}
-        disabled={!canDelete}
+        disabled={!canDeleteAll}
       >
         {t`Delete permanently`}
       </BulkActionDangerButton>

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -15,6 +15,7 @@ export * from "./use-url-with-utm";
 export { useStoreUrl } from "./use-store-url/use-store-url";
 export * from "./use-capture-event";
 export * from "./use-progressive-loader";
+export * from "./use-delete-item";
 export * from "./use-set-archive";
 export * from "./use-set-collection";
 export * from "./use-set-pinned";

--- a/frontend/src/metabase/common/hooks/use-delete-item.ts
+++ b/frontend/src/metabase/common/hooks/use-delete-item.ts
@@ -1,0 +1,74 @@
+import { useCallback } from "react";
+import { match } from "ts-pattern";
+
+import {
+  useDeleteCardMutation,
+  useDeleteCollectionMutation,
+  useDeleteDashboardMutation,
+  useDeleteDocumentMutation,
+} from "metabase/api";
+import type {
+  CardId,
+  DashboardId,
+  DocumentId,
+  RegularCollectionId,
+} from "metabase-types/api";
+
+type Deletable<M extends string, Id> = {
+  model: M;
+  id: Id;
+  can_delete?: boolean;
+};
+
+export type DeletableItem =
+  | Deletable<"card", CardId>
+  | Deletable<"dataset", CardId>
+  | Deletable<"metric", CardId>
+  | Deletable<"dashboard", DashboardId>
+  | Deletable<"collection", RegularCollectionId>
+  | Deletable<"document", DocumentId>;
+
+export type DeletableModel = DeletableItem["model"];
+
+const DELETABLE_MODELS = new Set<string>([
+  "card",
+  "dataset",
+  "metric",
+  "dashboard",
+  "collection",
+  "document",
+]);
+
+export function canDelete(item: {
+  model: string;
+  can_delete?: boolean;
+}): item is DeletableItem {
+  return item.can_delete !== false && DELETABLE_MODELS.has(item.model);
+}
+
+export function useDeleteItem() {
+  const [deleteCard] = useDeleteCardMutation();
+  const [deleteDashboard] = useDeleteDashboardMutation();
+  const [deleteCollection] = useDeleteCollectionMutation();
+  const [deleteDocument] = useDeleteDocumentMutation();
+
+  return useCallback(
+    (item: DeletableItem) =>
+      match(item)
+        .with(
+          { model: "card" },
+          { model: "dataset" },
+          { model: "metric" },
+          ({ id }) => deleteCard(id).unwrap(),
+        )
+        .with({ model: "dashboard" }, ({ id }) => deleteDashboard(id).unwrap())
+        .with({ model: "collection" }, ({ id }) =>
+          deleteCollection({ id }).unwrap(),
+        )
+        .with({ model: "document" }, ({ id }) =>
+          deleteDocument({ id }).unwrap(),
+        )
+        .exhaustive(),
+    [deleteCard, deleteDashboard, deleteCollection, deleteDocument],
+  );
+}

--- a/frontend/src/metabase/common/hooks/use-delete-item.ts
+++ b/frontend/src/metabase/common/hooks/use-delete-item.ts
@@ -43,7 +43,7 @@ export function canDelete(item: {
   model: string;
   can_delete?: boolean;
 }): item is DeletableItem {
-  return item.can_delete !== false && DELETABLE_MODELS.has(item.model);
+  return item.can_delete === true && DELETABLE_MODELS.has(item.model);
 }
 
 export function useDeleteItem() {


### PR DESCRIPTION
Closes DEV-1924

This is the last thing standing in the way from removing `wrapEntity` from search
