### PR TITLE
Add server.json configuration for modelcontextprotocol.io registry MCP publishing

### DIFF
--- a/src/metabase/mcp/server.json
+++ b/src/metabase/mcp/server.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.metabase/mcp",
+  "title": "Metabase",
+  "description": "Lets AI clients search, explore, query, and visualize data in a Metabase instance.",
+  "version": "1.0.0",
+  "websiteUrl": "https://www.metabase.com",
+  "icons": [
+    {
+      "src": "https://www.metabase.com/images/logo.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": ["any"]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/metabase/metabase",
+    "source": "github",
+    "subfolder": "src/metabase/mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{metabase_host}/api/mcp",
+      "variables": {
+        "metabase_host": {
+          "description": "Your Metabase hostname, e.g. 'metabase.example.com'.",
+          "isRequired": true
+        }
+      }
+    }
+  ]
+}

--- a/src/metabase/mcp/server.json
+++ b/src/metabase/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.metabase/mcp",
   "title": "Metabase",
   "description": "Lets AI clients search, explore, query, and visualize data in a Metabase instance.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "websiteUrl": "https://www.metabase.com",
   "icons": [
     {

--- a/src/metabase/mcp/server.json
+++ b/src/metabase/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.metabase/mcp",
   "title": "Metabase",
   "description": "Lets AI clients search, explore, query, and visualize data in a Metabase instance.",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "websiteUrl": "https://www.metabase.com",
   "icons": [
     {


### PR DESCRIPTION
This PR prepares the `server.json` manifest file so we can publish.

We will backport this PR to `x.60.x` and do a first publish to the registry from there, but technically as for our case, the `version` field in the file describes the version of the manifest file itself, we can also publish it from the master branch.

The main thing is the `remotes` section - it contains a required variable, so consumers will be asked to fill the value. And because of `remotes`, it will be added as a remote MCP configuration.

Note the `name` field. It has the value for the `Github`-based authentication.