### PR TITLE
Bump request/response timeout for tenant-users-sidecar e2e

### DIFF
--- a/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/tenant-users-sidecar.cy.spec.ts
@@ -47,153 +47,160 @@ const GIZMO_USER: TenantUser = {
 
 // Tests for when a tenant user is given SSO logins to
 // login to the internal Metabase instances, aka sidecar.
-describe("scenarios > sidecar > tenant users", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-    H.activateToken("pro-self-hosted");
+describe(
+  "scenarios > sidecar > tenant users",
+  { requestTimeout: 30000, responseTimeout: 60000 },
+  () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
 
-    cy.request("PUT", "/api/setting", {
-      "jwt-attribute-email": "email",
-      "jwt-attribute-firstname": "first_name",
-      "jwt-attribute-lastname": "last_name",
-      "jwt-enabled": true,
-      "jwt-identity-provider-uri": "localhost:4000",
-      "jwt-shared-secret": JWT_SHARED_SECRET,
-      "jwt-user-provisioning-enabled?": true,
-      "use-tenants": true,
+      cy.request("PUT", "/api/setting", {
+        "jwt-attribute-email": "email",
+        "jwt-attribute-firstname": "first_name",
+        "jwt-attribute-lastname": "last_name",
+        "jwt-enabled": true,
+        "jwt-identity-provider-uri": "localhost:4000",
+        "jwt-shared-secret": JWT_SHARED_SECRET,
+        "jwt-user-provisioning-enabled?": true,
+        "use-tenants": true,
+      });
+
+      cy.request("POST", "/api/ee/tenant", GIZMO_TENANT);
+
+      H.createSharedTenantCollection("Shared tenant collection 1").then(
+        ({ body }) => {
+          cy.wrap(body.id).as("sharedCollection1Id");
+        },
+      );
+      H.createSharedTenantCollection("Shared tenant collection 2").then(
+        ({ body }) => {
+          cy.wrap(body.id).as("sharedCollection2Id");
+        },
+      );
     });
 
-    cy.request("POST", "/api/ee/tenant", GIZMO_TENANT);
+    it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
+      cy.log("log in as tenant user");
+      loginWithJWT(GIZMO_USER, "/question/notebook");
 
-    H.createSharedTenantCollection("Shared tenant collection 1").then(
-      ({ body }) => {
-        cy.wrap(body.id).as("sharedCollection1Id");
-      },
-    );
-    H.createSharedTenantCollection("Shared tenant collection 2").then(
-      ({ body }) => {
-        cy.wrap(body.id).as("sharedCollection2Id");
-      },
-    );
-  });
-
-  it("should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)", () => {
-    cy.log("log in as tenant user");
-    loginWithJWT(GIZMO_USER, "/question/notebook");
-
-    cy.log("embedding data picker is shown");
-    cy.findByTestId("embedding-simple-data-picker-trigger").should(
-      "be.visible",
-    );
-    H.popover().contains("Orders").should("be.visible");
-    H.popover().contains("People").should("be.visible");
-  });
-
-  it("tenant users should see a flatten view of collections", () => {
-    loginWithJWT(GIZMO_USER);
-
-    H.navigationSidebar().within(() => {
-      cy.findByText("Collections").should("be.visible");
-      cy.findByText("Shared tenant collection 1").should("be.visible");
-      cy.findByText("Shared tenant collection 2").should("be.visible");
-      cy.findByText("Our data").should("be.visible");
-
-      // No "internal/external" naming or sections
-      cy.findByText(/External collections/).should("not.exist");
-      cy.findByText(/Internal collections/).should("not.exist");
+      cy.log("embedding data picker is shown");
+      cy.findByTestId("embedding-simple-data-picker-trigger").should(
+        "be.visible",
+      );
+      H.popover().contains("Orders").should("be.visible");
+      H.popover().contains("People").should("be.visible");
     });
-  });
 
-  it("the tenant collection should be called 'Our data' and be read only", () => {
-    /*
-      The "Our data" comes from both on the FE and the BE depending on the place it's used.
-      This test checks a few places to make sure everything is working as expected.
-    */
-    loginWithJWT(GIZMO_USER);
+    it("tenant users should see a flatten view of collections", () => {
+      loginWithJWT(GIZMO_USER);
 
-    H.navigationSidebar().findByText("Our data").should("be.visible").click();
-    cy.url().should("include", "/collection/");
+      H.navigationSidebar().within(() => {
+        cy.findByText("Collections").should("be.visible");
+        cy.findByText("Shared tenant collection 1").should("be.visible");
+        cy.findByText("Shared tenant collection 2").should("be.visible");
+        cy.findByText("Our data").should("be.visible");
 
-    // Check the collection name on the collection page, it should be read only
-    cy.findByTestId("collection-name-heading").should("have.text", "Our data");
-    cy.findByTestId("collection-name-heading").should("be.disabled");
-
-    // Check the save modal
-    H.main().findByText("New").click();
-    H.popover().findByText("Question").click();
-    H.popover().findByText("Orders").click();
-    H.main().findByText("Save").click();
-
-    // Check the entity picker modal
-    H.modal()
-      .findByLabelText(/Where do you want to save this/)
-      .should("have.text", "Our data")
-      .click();
-
-    H.entityPickerModal().findByText("Our data").should("be.visible");
-  });
-
-  it("tenant users should not see the synced collection icons", () => {
-    cy.signInAsAdmin();
-
-    // Setup git sync
-    H.setupGitSync();
-    H.copySyncedCollectionFixture();
-    H.commitToRepo();
-
-    // Make shared tenant collections synced
-    cy.get<number>("@sharedCollection1Id").then((id1) => {
-      cy.get<number>("@sharedCollection2Id").then((id2) => {
-        const collectionsConfig = {
-          [id1]: true,
-          [id2]: true,
-        };
-
-        cy.request("PUT", "/api/ee/remote-sync/settings", {
-          collections: collectionsConfig,
-          "remote-sync-branch": "main",
-          "remote-sync-type": "read-write",
-          "remote-sync-url": H.LOCAL_GIT_PATH + "/.git",
-          "remote-sync-enabled": true,
-        });
+        // No "internal/external" naming or sections
+        cy.findByText(/External collections/).should("not.exist");
+        cy.findByText(/Internal collections/).should("not.exist");
       });
     });
 
-    cy.signOut();
+    it("the tenant collection should be called 'Our data' and be read only", () => {
+      /*
+      The "Our data" comes from both on the FE and the BE depending on the place it's used.
+      This test checks a few places to make sure everything is working as expected.
+    */
+      loginWithJWT(GIZMO_USER);
 
-    loginWithJWT(GIZMO_USER);
+      H.navigationSidebar().findByText("Our data").should("be.visible").click();
+      cy.url().should("include", "/collection/");
 
-    // Check sidebar
-    H.navigationSidebar().within(() => {
-      // Synced collections should show a regular folder icon for tenant users
-      cy.findByText("Shared tenant collection 1")
-        .closest("li")
-        .icon("folder")
-        .should("be.visible");
+      // Check the collection name on the collection page, it should be read only
+      cy.findByTestId("collection-name-heading").should(
+        "have.text",
+        "Our data",
+      );
+      cy.findByTestId("collection-name-heading").should("be.disabled");
 
-      cy.findByText("Shared tenant collection 1")
-        .closest("li")
-        .icon("synced_collection")
-        .should("not.exist");
+      // Check the save modal
+      H.main().findByText("New").click();
+      H.popover().findByText("Question").click();
+      H.popover().findByText("Orders").click();
+      H.main().findByText("Save").click();
+
+      // Check the entity picker modal
+      H.modal()
+        .findByLabelText(/Where do you want to save this/)
+        .should("have.text", "Our data")
+        .click();
+
+      H.entityPickerModal().findByText("Our data").should("be.visible");
     });
 
-    // Check picker
-    H.newButton().click();
-    H.popover().findByText("Question").click();
-    H.popover().findByText("Orders").click();
-    H.main().findByText("Save").click();
-    H.modal()
-      .findByLabelText(/Where do you want to save this/)
-      .click();
+    it("tenant users should not see the synced collection icons", () => {
+      cy.signInAsAdmin();
 
-    H.entityPickerModal().within(() => {
-      cy.findByText("Shared collections").click();
+      // Setup git sync
+      H.setupGitSync();
+      H.copySyncedCollectionFixture();
+      H.commitToRepo();
 
-      cy.findByText("Shared tenant collection 1")
-        .closest("a")
-        .icon("folder")
-        .should("be.visible");
+      // Make shared tenant collections synced
+      cy.get<number>("@sharedCollection1Id").then((id1) => {
+        cy.get<number>("@sharedCollection2Id").then((id2) => {
+          const collectionsConfig = {
+            [id1]: true,
+            [id2]: true,
+          };
+
+          cy.request("PUT", "/api/ee/remote-sync/settings", {
+            collections: collectionsConfig,
+            "remote-sync-branch": "main",
+            "remote-sync-type": "read-write",
+            "remote-sync-url": H.LOCAL_GIT_PATH + "/.git",
+            "remote-sync-enabled": true,
+          });
+        });
+      });
+
+      cy.signOut();
+
+      loginWithJWT(GIZMO_USER);
+
+      // Check sidebar
+      H.navigationSidebar().within(() => {
+        // Synced collections should show a regular folder icon for tenant users
+        cy.findByText("Shared tenant collection 1")
+          .closest("li")
+          .icon("folder")
+          .should("be.visible");
+
+        cy.findByText("Shared tenant collection 1")
+          .closest("li")
+          .icon("synced_collection")
+          .should("not.exist");
+      });
+
+      // Check picker
+      H.newButton().click();
+      H.popover().findByText("Question").click();
+      H.popover().findByText("Orders").click();
+      H.main().findByText("Save").click();
+      H.modal()
+        .findByLabelText(/Where do you want to save this/)
+        .click();
+
+      H.entityPickerModal().within(() => {
+        cy.findByText("Shared collections").click();
+
+        cy.findByText("Shared tenant collection 1")
+          .closest("a")
+          .icon("folder")
+          .should("be.visible");
+      });
     });
-  });
-});
+  },
+);


### PR DESCRIPTION
Closes [EMB-1682: \[Broken Test\] \[e2e-tests\] scenarios > sidecar > tenant users scenarios > sidecar > tenant users "before each" hook for "should show the embedding data picker when logged in as a tenant user (metabase#EMB-1144)"](https://linear.app/metabase/issue/EMB-1682/broken-test-e2e-tests-scenarios-sidecar-tenant-users-scenarios-sidecar)

### Description

`scenarios > sidecar > tenant users` was failing intermittently because the `PUT /api/setting` call in `beforeEach` could exceed Cypress's default 30s `responseTimeout`. The setting bulk-update validates each setting's `:feature` flag, which goes through `has-feature?` → `*token-features*` → synchronous HTTP call to `token-check.staging.metabase.com` (10s circuit- breaker timeout, serialized through a global `(locking lock)`). Combined with `H.restore()` invalidating the persistent token cache and `H.activateToken("pro-self-hosted")` doing its own token check, the cumulative wall time can occasionally blow past 30s.

This bumps `requestTimeout` to 30s and `responseTimeout` to 60s for this describe block to absorb that variance.

### How to verify

[Stress test PR with 100 burns](https://github.com/metabase/metabase/actions/runs/25428694139): ✅ 
[Stress test master with 100 burns](https://github.com/metabase/metabase/actions/runs/25479901983)