### PR TITLE
Remove e2e test failure list on pull requests

### DIFF
--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -124,19 +124,6 @@ if (isCI) {
     );
   });
 
-  // Fast failure notifications
-  afterEach(() => {
-    const testInfo = Cypress.mocha.getRunner().suite.ctx.currentTest;
-    const isLastRetry = testInfo.currentRetry() === testInfo.retries();
-
-    if (testInfo.state === "failed" && isLastRetry) {
-      cy.task("reportCIFailure", {
-        spec: Cypress.spec,
-        test: Cypress.currentTest,
-      });
-    }
-  });
-
   const options = {
     collectTypes: [
       "cons:log",


### PR DESCRIPTION
Since we have a significant number of quarantined tests, this became useless noise.

Leaving the called code in there because I want to make it more useful in the future.