### PR TITLE
fix: cannot create a chart using metabot in a document

### DIFF
--- a/e2e/support/helpers/e2e-mock-llm-tasks.ts
+++ b/e2e/support/helpers/e2e-mock-llm-tasks.ts
@@ -2,6 +2,23 @@ import http from "node:http";
 
 let server: http.Server | null = null;
 
+type MockLlmToolCall = {
+  name: string;
+  input: Record<string, unknown>;
+};
+
+type MockLlmServerOptions =
+  | {
+      port: number;
+      responseText: string;
+      toolCall?: never;
+    }
+  | {
+      port: number;
+      responseText?: never;
+      toolCall: MockLlmToolCall;
+    };
+
 /**
  * Build a raw Anthropic SSE response that streams the given text as a single
  * content_block_delta and then closes the message cleanly.
@@ -33,26 +50,52 @@ function buildAnthropicSSE(text: string): string {
   return lines.join("\n");
 }
 
+function buildAnthropicToolUseSSE({ name, input }: MockLlmToolCall): string {
+  const lines = [
+    "event: message_start",
+    `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_mock", type: "message", role: "assistant", content: [], model: "claude-haiku-4-5", stop_reason: null, usage: { input_tokens: 10, output_tokens: 0 } } })}`,
+    "",
+    "event: content_block_start",
+    `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_mock", name, input: {} } })}`,
+    "",
+    "event: content_block_delta",
+    `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: JSON.stringify(input) } })}`,
+    "",
+    "event: content_block_stop",
+    `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    "",
+    "event: message_delta",
+    `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 8 } })}`,
+    "",
+    "event: message_stop",
+    `data: ${JSON.stringify({ type: "message_stop" })}`,
+    "",
+  ];
+  return lines.join("\n");
+}
+
 /**
  * Start a mock server that impersonates the Anthropic Messages API.
  *
  * Every POST to /v1/messages responds with a valid SSE stream containing
- * the given `responseText`.  The server listens on `port`.
+ * either the given `responseText` or a tool-use call. The server listens on `port`.
  *
  * Call `stopMockLlmServer` to tear it down.
  */
-export function startMockLlmServer({
-  port,
-  responseText,
-}: {
-  port: number;
-  responseText: string;
-}): Promise<null> {
+export function startMockLlmServer(
+  options: MockLlmServerOptions,
+): Promise<null> {
+  const { port } = options;
+
   return new Promise((resolve, reject) => {
     if (server) {
       server.close();
       server = null;
     }
+
+    const response = options.toolCall
+      ? buildAnthropicToolUseSSE(options.toolCall)
+      : buildAnthropicSSE(options.responseText);
 
     server = http.createServer((_req, res) => {
       res.writeHead(200, {
@@ -60,7 +103,7 @@ export function startMockLlmServer({
         "cache-control": "no-cache",
         connection: "keep-alive",
       });
-      res.end(buildAnthropicSSE(responseText));
+      res.end(response);
     });
 
     server.on("error", reject);

--- a/e2e/test/scenarios/documents/document-metabot.cy.spec.ts
+++ b/e2e/test/scenarios/documents/document-metabot.cy.spec.ts
@@ -1,0 +1,70 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+
+const { H } = cy;
+
+const GENERATED_CARD_NAME = "Feature requests mentioned twice";
+const MOCK_LLM_PORT = 6124;
+
+describe("documents > metabot (#73690)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.task("startMockLlmServer", {
+      port: MOCK_LLM_PORT,
+      toolCall: {
+        name: "document_construct_sql_chart",
+        input: {
+          database_id: SAMPLE_DB_ID,
+          name: GENERATED_CARD_NAME,
+          description: "Feature requests mentioned at least twice.",
+          analysis: "Count orders for a deterministic e2e chart.",
+          approach: "Use a simple aggregate query against the sample database.",
+          sql: "SELECT COUNT(*) AS count FROM ORDERS",
+          viz_settings: { chart_type: "bar" },
+        },
+      },
+    });
+    H.updateSetting("llm-anthropic-api-key", "sk-ant-test-key");
+    H.updateSetting(
+      "llm-anthropic-api-base-url",
+      `http://localhost:${MOCK_LLM_PORT}`,
+    );
+  });
+
+  afterEach(() => {
+    cy.task("stopMockLlmServer");
+  });
+
+  it("should create a chart from a document Metabot block", () => {
+    H.createDocument({
+      name: "Document Metabot Chart",
+      document: {
+        content: [
+          {
+            type: "metabot",
+            content: [
+              {
+                type: "text",
+                text: "create a chart using issue customer mention",
+              },
+            ],
+          },
+        ],
+        type: "doc",
+      },
+      collection_id: null,
+      idAlias: "documentId",
+    });
+
+    H.visitDocument("@documentId");
+
+    cy.findByRole("button", { name: "Run" }).click();
+
+    H.getDocumentCard(GENERATED_CARD_NAME).should("be.visible");
+    H.documentContent().should(
+      "contain.text",
+      "Feature requests mentioned at least twice.",
+    );
+    H.documentContent().should("contain.text", "Created with Metabot");
+  });
+});

--- a/frontend/src/metabase/api/metabot.ts
+++ b/frontend/src/metabase/api/metabot.ts
@@ -112,7 +112,7 @@ export const metabotApi = Api.injectEndpoints({
     >({
       query: (params) => ({
         method: "POST",
-        url: "/api/metabot/document/native-generate-content",
+        url: "/api/metabot/document/generate-content",
         body: params,
       }),
     }),

--- a/src/metabase/metabot/api/document.clj
+++ b/src/metabase/metabot/api/document.clj
@@ -91,31 +91,33 @@
    _query-params
 
    {:keys [instructions references]} :- generate-content-body-schema]
-  (metabot.config/check-metabot-enabled!)
-  (metabot.usage/check-metabase-managed-free-limit!)
-  (let [context      (assoc
-                      (metabot.context/create-context {:capabilities #{"permission:write_sql_queries"}})
-                      :references references)
-        parts        (into [] (metabot.agent/run-agent-loop
-                               {:messages      [{:role    :user
-                                                 :content instructions}]
-                                :profile-id    :document-generate-content
-                                :state         {}
-                                :context       context
-                                :tracking-opts {:source "document_generate_content"}}))
-        chart-output (latest-chart-structured-output parts)
-        draft-card   (draft-card-from-chart-output chart-output)
-        description  (or (:description chart-output)
-                         (:name chart-output)
-                         (:name draft-card))]
-    (if draft-card
-      {:draft_card  draft-card
-       :description description
-       :error       nil}
-      {:draft_card  nil
-       :description nil
-       :error       (or (last-agent-message parts)
-                        "Unable to generate chart content.")})))
+  (let [metabot-id (metabot.config/resolve-dynamic-metabot-id nil)]
+    (metabot.config/check-metabot-enabled! metabot-id)
+    (metabot.usage/check-metabase-managed-free-limit!)
+    (let [context      (assoc
+                        (metabot.context/create-context {:capabilities #{"permission:write_sql_queries"}})
+                        :references references)
+          parts        (into [] (metabot.agent/run-agent-loop
+                                 {:messages      [{:role    :user
+                                                   :content instructions}]
+                                  :metabot-id    metabot-id
+                                  :profile-id    :document-generate-content
+                                  :state         {}
+                                  :context       context
+                                  :tracking-opts {:source "document_generate_content"}}))
+          chart-output (latest-chart-structured-output parts)
+          draft-card   (draft-card-from-chart-output chart-output)
+          description  (or (:description chart-output)
+                           (:name chart-output)
+                           (:name draft-card))]
+      (if draft-card
+        {:draft_card  draft-card
+         :description description
+         :error       nil}
+        {:draft_card  nil
+         :description nil
+         :error       (or (last-agent-message parts)
+                          "Unable to generate chart content.")}))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/metabot/document` routes."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73690
Closes [BOT-1448: Cannot create a chart using Metabot in a document](https://linear.app/metabase/issue/BOT-1448/cannot-create-a-chart-using-metabot-in-a-document)

### Description

Endpoint was wrong for the document generation, fixed it.

### How to verify

1. New document
2. Type `/metabot`
3. Type something into metabot box

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
