### PR TITLE
Improve searchable <Select /> default behavior

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
@@ -57,6 +57,7 @@ export const FontWidget = () => {
             value={fontValue}
             name="application-font"
             inputType="select"
+            searchable
             onChange={(newValue) => handleChange(newValue as string)}
             options={fontOptions}
           />

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -107,6 +107,7 @@ const UserProfileForm = ({
                 name="locale"
                 label={t`Language`}
                 data={localeOptions}
+                searchable
                 description={
                   <CommunityLocalizationNotice isAdminView={false} />
                 }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/LocalizationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/LocalizationSettingsPage.tsx
@@ -25,6 +25,7 @@ export function LocalizationSettingsPage() {
         <AdminSettingInput
           name="site-locale"
           title={t`Instance language`}
+          searchable
           options={_.sortBy(availableLocales || [], ([, label]) => label).map(
             ([code, label]) => ({ label, value: code }),
           )}

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -184,6 +184,7 @@ export function FormattingWidget() {
               label={t`Unit of currency`}
               value={currency}
               inputType="select"
+              searchable
               options={currencyOptions}
               onChange={(newValue) =>
                 handleChange({
@@ -225,6 +226,7 @@ function FormattingInput({
   onChange,
   options,
   inputType,
+  searchable,
 }: {
   id: string;
   label: string;
@@ -232,6 +234,7 @@ function FormattingInput({
   onChange: (newValue: string | boolean | number) => void;
   options?: { label: string; value: string }[];
   inputType: "boolean" | "select" | "radio";
+  searchable?: boolean;
 }) {
   const [localValue, setLocalValue] = useState(value);
 
@@ -255,6 +258,7 @@ function FormattingInput({
           value={localValue}
           onChange={handleChange}
           data={options ?? []}
+          searchable={searchable}
         />
       )}
       {inputType === "boolean" && (

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
@@ -17,7 +17,7 @@
   position: relative;
 
   &::after {
-    content: attr(data-placeholder);
+    content: attr(data-label);
     color: var(--mb-color-text-primary);
     font-weight: 700;
     position: absolute;

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
@@ -2,11 +2,7 @@
   text-align: center;
   border-radius: var(--mantine-radius-sm);
   cursor: pointer;
-
-  &::placeholder {
-    color: var(--mb-color-text-primary);
-    font-weight: 700;
-  }
+  color: transparent;
 
   &:hover {
     background-color: var(--mb-color-background-hover);
@@ -14,6 +10,21 @@
     &::placeholder {
       color: var(--mb-color-brand);
     }
+  }
+}
+
+.CollapsedMoveParameterMenuInputWrapper {
+  position: relative;
+
+  &::after {
+    content: attr(data-placeholder);
+    color: var(--mb-color-text-primary);
+    font-weight: 700;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
   }
 }
 

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
@@ -95,12 +95,10 @@ export function MoveParameterMenu({ parameterId }: MoveParameterMenuProps) {
     [dashcardMap],
   );
 
-  const value = useMemo(() => {
-    if (!isOpen) {
-      return;
-    }
-    return parameterDashcard ? String(parameterDashcard?.id) : TOP_NAV_VALUE;
-  }, [isOpen, parameterDashcard]);
+  const value = useMemo(
+    () => (parameterDashcard ? String(parameterDashcard?.id) : TOP_NAV_VALUE),
+    [parameterDashcard],
+  );
 
   const options = useMemo(() => {
     const rootGroup = {
@@ -139,6 +137,12 @@ export function MoveParameterMenu({ parameterId }: MoveParameterMenuProps) {
 
         // Hides the chevron-down icon on the right to make it look like a button
         section: !isOpen ? CS.hidden : undefined,
+      }}
+      wrapperProps={{
+        className: !isOpen
+          ? S.CollapsedMoveParameterMenuInputWrapper
+          : undefined,
+        "data-placeholder": t`Move filter`,
       }}
       placeholder={t`Move filter`}
       data={options}

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
@@ -142,7 +142,7 @@ export function MoveParameterMenu({ parameterId }: MoveParameterMenuProps) {
         className: !isOpen
           ? S.CollapsedMoveParameterMenuInputWrapper
           : undefined,
-        "data-placeholder": t`Move filter`,
+        "data-label": t`Move filter`,
       }}
       placeholder={t`Move filter`}
       data={options}

--- a/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
+++ b/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
@@ -1,4 +1,3 @@
-import type { FocusEvent } from "react";
 import { t } from "ttag";
 
 import {
@@ -26,14 +25,8 @@ export const CurrencyPicker = ({
   comboboxProps,
   value,
   onChange,
-  onFocus,
   ...props
 }: Props) => {
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
-  };
-
   return (
     <Select
       comboboxProps={{
@@ -83,7 +76,6 @@ export const CurrencyPicker = ({
       searchable
       value={value}
       onChange={(value) => onChange(value)}
-      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/EntityTypeInput.tsx
+++ b/frontend/src/metabase/metadata/components/EntityTypeInput.tsx
@@ -1,4 +1,3 @@
-import type { FocusEvent } from "react";
 import { t } from "ttag";
 
 import { getEntityIcon } from "metabase/detail-view/utils";
@@ -14,14 +13,8 @@ export const EntityTypeInput = ({
   comboboxProps,
   value,
   onChange,
-  onFocus,
   ...props
 }: Props) => {
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
-  };
-
   const entities = [
     { value: "entity/GenericTable", label: t`Generic` },
     { value: "entity/UserTable", label: t`Person` },
@@ -62,7 +55,6 @@ export const EntityTypeInput = ({
       placeholder={t`Select entity type`}
       value={value}
       onChange={(value) => onChange(value)}
-      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -1,4 +1,4 @@
-import { type FocusEvent, useMemo } from "react";
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import {
@@ -32,7 +32,6 @@ export const FkTargetPicker = ({
   idFields,
   value,
   onChange,
-  onFocus,
   ...props
 }: Props) => {
   const { comparableIdFields, hasIdFields, data, optionsByFieldId } =
@@ -74,11 +73,6 @@ export const FkTargetPicker = ({
       const fieldId = getFieldIdFromValue(value);
       onChange(fieldId);
     }
-  };
-
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
   };
 
   return (
@@ -148,7 +142,6 @@ export const FkTargetPicker = ({
       searchable
       value={stringifyValue(value)}
       onChange={handleChange}
-      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/LayerInput.tsx
+++ b/frontend/src/metabase/metadata/components/LayerInput.tsx
@@ -1,4 +1,3 @@
-import type { FocusEvent } from "react";
 import { t } from "ttag";
 
 import { Group, Icon, Select, SelectItem, type SelectProps } from "metabase/ui";
@@ -15,14 +14,8 @@ export const LayerInput = ({
   comboboxProps,
   value,
   onChange,
-  onFocus,
   ...props
 }: Props) => {
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
-  };
-
   return (
     <Select
       comboboxProps={{
@@ -57,7 +50,6 @@ export const LayerInput = ({
       placeholder={t`Select visibility layer`}
       value={value}
       onChange={(value) => onChange(value)}
-      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
@@ -1,4 +1,4 @@
-import { type FocusEvent, useMemo } from "react";
+import { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -21,7 +21,6 @@ export const SemanticTypePicker = ({
   field,
   value,
   onChange,
-  onFocus,
   ...props
 }: Props) => {
   const data = useMemo(() => getData({ field, value }), [field, value]);
@@ -29,11 +28,6 @@ export const SemanticTypePicker = ({
   const handleChange = (value: string) => {
     const parsedValue = parseValue(value);
     onChange(parsedValue);
-  };
-
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
   };
 
   return (
@@ -54,7 +48,6 @@ export const SemanticTypePicker = ({
       searchable
       value={stringifyValue(value)}
       onChange={handleChange}
-      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/UserInput.tsx
+++ b/frontend/src/metabase/metadata/components/UserInput.tsx
@@ -1,4 +1,4 @@
-import { type FocusEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useListUsersQuery } from "metabase/api";
@@ -19,7 +19,6 @@ export const UserInput = ({
   email,
   userId,
   onEmailChange,
-  onFocus,
   onUserIdChange,
   unknownUserLabel = t`Unspecified`,
   ...props
@@ -39,11 +38,6 @@ export const UserInput = ({
 
     return users.find((user) => user.id === userId)?.common_name;
   }, [users, userId]);
-
-  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-    onFocus?.(event);
-  };
 
   const handleChange = (value: string | null) => {
     if (value == null) {
@@ -111,7 +105,6 @@ export const UserInput = ({
       }}
       value={email ? email : userId ? String(userId) : null}
       onChange={handleChange}
-      onFocus={handleFocus}
       onSearchChange={setSearch}
       {...props}
     />

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
@@ -4,7 +4,8 @@ import type {
   SelectProps as MantineSelectProps,
 } from "@mantine/core";
 import { Select as MantineSelect } from "@mantine/core";
-import { type Ref, forwardRef } from "react";
+import mergeRefs from "merge-refs";
+import { type Ref, forwardRef, useCallback, useMemo, useRef } from "react";
 
 import type { IconName } from "../../icons";
 
@@ -34,18 +35,38 @@ export interface SelectProps<Value extends string | null = string> extends Omit<
   onChange?: (newValue: Value) => void;
 }
 
-function _Select<Value extends string | null>(
+function SelectWrapper<Value extends string | null>(
   props: SelectProps<Value>,
   ref: Ref<HTMLElement>,
 ) {
+  const { onDropdownOpen, searchable } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const combinedRef = useMemo(() => mergeRefs(ref, inputRef), [ref]);
+  const handleDropdownOpen = useCallback(() => {
+    if (searchable) {
+      inputRef.current?.select();
+    }
+    onDropdownOpen?.();
+  }, [searchable, onDropdownOpen]);
+
   return (
-    // @ts-expect-error -- our tighter types are better
-    <MantineSelect {...props} ref={ref} />
+    <MantineSelect
+      {...props}
+      // @ts-expect-error -- our tighter types are better
+      ref={combinedRef}
+      // A bit confusing prop name but it actually means "on change of search input", not Select's value
+      selectFirstOptionOnChange={
+        props.selectFirstOptionOnChange ?? props.searchable
+      }
+      onDropdownOpen={handleDropdownOpen}
+    />
   );
 }
 
 // forwardRef is hard to type with generics
 // see https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref
-export const Select = forwardRef(_Select) as <Value extends string | null>(
+export const Select = forwardRef(SelectWrapper) as <
+  Value extends string | null,
+>(
   props: SelectProps<Value> & { ref?: Ref<HTMLElement> },
 ) => React.ReactNode;

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { render, screen } from "__support__/ui";
-import { Select } from "metabase/ui";
+import { Select, type SelectProps } from "metabase/ui";
 
 const DATA = [
   { value: "apple", label: "Apple" },
@@ -9,13 +9,31 @@ const DATA = [
   { value: "banana", label: "Banana" },
 ];
 
+type SetupOpts = Omit<Partial<SelectProps>, "onChange" | "onDropdownOpen">;
+
+function setup({ data = DATA, ...props }: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onDropdownOpen = jest.fn();
+
+  render(
+    <Select
+      label="Fruit"
+      data={data}
+      onChange={onChange}
+      onDropdownOpen={onDropdownOpen}
+      {...props}
+    />,
+  );
+
+  const input = screen.getByLabelText<HTMLInputElement>("Fruit");
+
+  return { input, onChange, onDropdownOpen };
+}
+
 describe("Select", () => {
   describe("searchable", () => {
     it("should select existing input text when the dropdown opens, so typing replaces it", async () => {
-      render(
-        <Select label="Fruit" searchable data={DATA} defaultValue="apple" />,
-      );
-      const input = screen.getByLabelText<HTMLInputElement>("Fruit");
+      const { input } = setup({ searchable: true, defaultValue: "apple" });
       expect(input).toHaveValue("Apple");
 
       await userEvent.click(input);
@@ -28,11 +46,7 @@ describe("Select", () => {
     });
 
     it("should auto-highlight the first matching option so Enter selects it", async () => {
-      const onChange = jest.fn();
-      render(
-        <Select label="Fruit" searchable data={DATA} onChange={onChange} />,
-      );
-      const input = screen.getByLabelText("Fruit");
+      const { input, onChange } = setup({ searchable: true });
 
       await userEvent.click(input);
       await userEvent.keyboard("ap");
@@ -42,33 +56,18 @@ describe("Select", () => {
     });
 
     it("should still call a user-provided onDropdownOpen handler", async () => {
-      const onDropdownOpen = jest.fn();
-      render(
-        <Select
-          label="Fruit"
-          searchable
-          data={DATA}
-          onDropdownOpen={onDropdownOpen}
-        />,
-      );
+      const { input, onDropdownOpen } = setup({ searchable: true });
 
-      await userEvent.click(screen.getByLabelText("Fruit"));
+      await userEvent.click(input);
 
       expect(onDropdownOpen).toHaveBeenCalledTimes(1);
     });
 
     it("should respect an explicit selectFirstOptionOnChange={false} override", async () => {
-      const onChange = jest.fn();
-      render(
-        <Select
-          label="Fruit"
-          searchable
-          selectFirstOptionOnChange={false}
-          data={DATA}
-          onChange={onChange}
-        />,
-      );
-      const input = screen.getByLabelText("Fruit");
+      const { input, onChange } = setup({
+        searchable: true,
+        selectFirstOptionOnChange: false,
+      });
 
       await userEvent.click(input);
       await userEvent.keyboard("ap");
@@ -80,8 +79,7 @@ describe("Select", () => {
 
   describe("non-searchable", () => {
     it("should not pre-select input text on open and should still open the dropdown", async () => {
-      render(<Select label="Fruit" data={DATA} defaultValue="apple" />);
-      const input = screen.getByLabelText<HTMLInputElement>("Fruit");
+      const { input } = setup({ defaultValue: "apple" });
 
       await userEvent.click(input);
 

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
@@ -1,0 +1,94 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+import { Select } from "metabase/ui";
+
+const DATA = [
+  { value: "apple", label: "Apple" },
+  { value: "apricot", label: "Apricot" },
+  { value: "banana", label: "Banana" },
+];
+
+describe("Select", () => {
+  describe("searchable", () => {
+    it("should select existing input text when the dropdown opens, so typing replaces it", async () => {
+      render(
+        <Select label="Fruit" searchable data={DATA} defaultValue="apple" />,
+      );
+      const input = screen.getByLabelText<HTMLInputElement>("Fruit");
+      expect(input).toHaveValue("Apple");
+
+      await userEvent.click(input);
+
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe("Apple".length);
+
+      await userEvent.keyboard("ban");
+      expect(input).toHaveValue("ban");
+    });
+
+    it("should auto-highlight the first matching option so Enter selects it", async () => {
+      const onChange = jest.fn();
+      render(
+        <Select label="Fruit" searchable data={DATA} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText("Fruit");
+
+      await userEvent.click(input);
+      await userEvent.keyboard("ap");
+      await userEvent.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith("apple", expect.anything());
+    });
+
+    it("should still call a user-provided onDropdownOpen handler", async () => {
+      const onDropdownOpen = jest.fn();
+      render(
+        <Select
+          label="Fruit"
+          searchable
+          data={DATA}
+          onDropdownOpen={onDropdownOpen}
+        />,
+      );
+
+      await userEvent.click(screen.getByLabelText("Fruit"));
+
+      expect(onDropdownOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it("should respect an explicit selectFirstOptionOnChange={false} override", async () => {
+      const onChange = jest.fn();
+      render(
+        <Select
+          label="Fruit"
+          searchable
+          selectFirstOptionOnChange={false}
+          data={DATA}
+          onChange={onChange}
+        />,
+      );
+      const input = screen.getByLabelText("Fruit");
+
+      await userEvent.click(input);
+      await userEvent.keyboard("ap");
+      await userEvent.keyboard("{Enter}");
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-searchable", () => {
+    it("should not pre-select input text on open and should still open the dropdown", async () => {
+      render(<Select label="Fruit" data={DATA} defaultValue="apple" />);
+      const input = screen.getByLabelText<HTMLInputElement>("Fruit");
+
+      await userEvent.click(input);
+
+      expect(
+        screen.getByRole("option", { name: "Banana" }),
+      ).toBeInTheDocument();
+      expect(input.selectionStart).toBe(input.selectionEnd);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73546

### Description

As mentioned in original issue's comment, Mantine doesn't support usual typeahead on `<Select />`. Instead recommended approach is to use `searchable` property. This PR does two related changes
1. It slightly improves default behavior of searchable select
   1. Opening dropdown (either by click/focus or arrow down when already focused) will autoselect text in search input. With this, if user starts to type (to search for something), it will remove existing text in search input. I think this behavior better matches user intent and I _feel_ (because I don't have specific links to prove it) is quite common pattern.
   1. Typing in search input automatically highlights first match, so user can confirm selection by just pressing Enter (previously you had to press arrow down and only then Enter to confirm selection)
   
2. Makes selects in admin portal that have too many options searchable

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to Admin > Localization
2. Click on language select
3. Try typing language name
4. Press Enter
5. See first matched language option being selected

### Checklist

- [x] Tests have been added/updated to cover changes in this PR