### PR TITLE
Pin gson dep for bigquery 

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -30,4 +30,7 @@
   io.netty/netty-common                  {:mvn/version "4.2.12.Final"}
   io.netty/netty-buffer                  {:mvn/version "4.2.12.Final"}
   ;; pinned: google-cloud-bigquery pulls 2.18.2 which has resource exhaustion vulns
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}
+  ;; Need gson ≥ 2.9.0 for JsonWriter.value(float) used in
+  ;; BigQueryRetryAlgorithm error handling (#73736).
+  com.google.code.gson/gson {:mvn/version "2.12.1"}}}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73736

### Description

Pins gson dep to avoid older version in uberjar being used. 

I couldn't actually reproduce this but I'm fairly confident this is the issue based on the stacktrace.

### How to verify

Use `clojure -Stree` from `modules/drivers/biquery-cloud-sdk/` and compare the results before and after this change. Note that the gson will be pinned to the top level with this change.

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
