### PR TITLE
Remove explicit escape spec from postgres LIKE filters

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -17,7 +17,6 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.driver.sql.query-processor.like-escape-char-built-in :as-alias like-escape-char-built-in]
    [metabase.driver.sync :as driver.s]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
@@ -37,8 +36,9 @@
 
 (set! *warn-on-reflection* true)
 
-(driver/register! :redshift, :parent #{:postgres
-                                       ::like-escape-char-built-in/like-escape-char-built-in})
+;; `::like-escape-char-built-in/like-escape-char-built-in` is inherited transitively via
+;; `:postgres` (see `metabase.driver.postgres`).
+(driver/register! :redshift, :parent :postgres)
 
 (doseq [[feature supported?] {:atomic-renames                   true
                               :connection-impersonation         true

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -25,6 +25,7 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.sql.query-processor.like-escape-char-built-in :as like-escape-char-built-in]
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
@@ -55,7 +56,11 @@
   postgres.ddl/keep-me
   sql.pg-ops/keep-me)
 
-(driver/register! :postgres, :parent :sql-jdbc)
+;; Inherit from `::like-escape-char-built-in/like-escape-char-built-in` because Postgres's
+;; default `LIKE` escape character is already `\`, so an explicit `ESCAPE '\'` clause is
+;; redundant *and* the literal `'\'` is unparseable by the PG JDBC driver when the server has
+;; `standard_conforming_strings = off` (#73721).
+(driver/register! :postgres, :parent #{:sql-jdbc ::like-escape-char-built-in/like-escape-char-built-in})
 
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -546,6 +546,42 @@
                   "  1048575"]
                  (str/split-lines (driver/prettify-native-form :postgres (:query nested))))))))))
 
+;;; Postgres `:contains`/`:starts-with`/`:ends-with` must produce SQL that the PostgreSQL JDBC
+;;; driver can prepare regardless of the server's `standard_conforming_strings` setting. With
+;;; that setting off, PGJDBC's parser treats `\` as an escape inside string literals, so the
+;;; `'\'` in `LIKE ? ESCAPE '\'` is parsed as an unterminated literal and the query crashes with
+;;; `Unterminated string literal started at position N` before the SQL ever reaches the server
+;;; (#73721).
+(deftest contains-filter-jdbc-parser-test
+  (mt/test-driver :postgres
+    (testing "PGJDBC parses :contains/:starts-with/:ends-with SQL regardless of standard_conforming_strings (#73721)"
+      (let [mp       (mt/metadata-provider)
+            venues   (lib.metadata/table mp (mt/id :venues))
+            name-col (lib.metadata/field mp (mt/id :venues :name))]
+        (doseq [scs ["on" "off"]]
+          (testing (str "standard_conforming_strings = " scs)
+            ;; Fresh non-pooled connection per setting (the pool is bypassed because we pass a
+            ;; raw JDBC spec rather than a Database ID), so:
+            ;; - the session-scoped `SET` can't contaminate the shared pool, and
+            ;; - PGJDBC's per-connection parsed-query cache starts empty, so each
+            ;;   `prepareStatement` actually exercises the parser.
+            (sql-jdbc.execute/do-with-connection-with-options
+             :postgres
+             (sql-jdbc.conn/connection-details->spec :postgres (:details (mt/db)))
+             nil
+             (fn [^Connection conn]
+               (with-open [stmt (.createStatement conn)]
+                 (.execute stmt (str "SET standard_conforming_strings TO " scs)))
+               (doseq [[op-name op-fn] {:contains    lib/contains
+                                        :starts-with lib/starts-with
+                                        :ends-with   lib/ends-with}]
+                 (testing op-name
+                   (let [query (-> (lib/query mp venues)
+                                   (lib/filter (op-fn name-col "Foo")))
+                         {sql :query} (qp.compile/compile query)]
+                     (is (some? (with-open [pstmt (.prepareStatement conn sql)] pstmt))
+                         (str "PGJDBC should prepare the SQL; got SQL: " sql)))))))))))))
+
 (deftest describe-nested-field-columns-identifier-test
   (mt/test-driver :postgres
     (testing "sync goes and runs with identifier if there is a schema other than default public one"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73721
Closes QUE2-555

### Description

Postgres's default is already '\' and explicitly setting it breaks when the `standard_conforming_strings` setting is turned off.

### How to verify

See  the new test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
