### PR TITLE
Save Metabot system prompts on blur instead of debounced keystroke

### DIFF
--- a/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
@@ -269,7 +269,8 @@ describe("AI Controls > Metabot access and customization", () => {
       cy.findByRole("textbox", { name: /AI chat prompt instructions/ })
         .should("be.visible")
         .click()
-        .type("Be concise and helpful.");
+        .type("Be concise and helpful.")
+        .blur();
 
       cy.wait("@savePrompt").its("response.statusCode").should("eq", 204);
 
@@ -297,7 +298,8 @@ describe("AI Controls > Metabot access and customization", () => {
       })
         .should("be.visible")
         .click()
-        .type("Always use uppercase SQL keywords.");
+        .type("Always use uppercase SQL keywords.")
+        .blur();
 
       cy.wait("@saveSqlPrompt").its("response.statusCode").should("eq", 204);
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useAdminSettingWithBlurInput } from "./useAdminSettingWithBlurInput";
 export { useAdminSettingWithDebouncedInput } from "./useAdminSettingWithDebouncedInput";

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
@@ -4,7 +4,7 @@ import { useAdminSetting } from "metabase/api/utils";
 import { useBeforeUnload } from "metabase/common/hooks/use-before-unload";
 import type {
   EnterpriseSettingKey,
-  EnterpriseSettingValue,
+  EnterpriseSettings,
 } from "metabase-types/api";
 
 /**
@@ -12,20 +12,21 @@ import type {
  * For text settings whose saves shouldn't be debounced (e.g. Metabot system
  * prompts, where each save changes LLM behavior and the audit log).
  *
- * Dirty check uses `===`, so `T` should be a primitive.
+ * Dirty check uses `===` - safe for primitive setting values only.
  */
-export function useAdminSettingWithBlurInput<T>(
-  settingName: EnterpriseSettingKey,
+export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
+  settingName: K,
 ) {
   const { value: settingValue, updateSetting } = useAdminSetting(settingName);
-  const [inputValue, setInputValue] = useState<T>(settingValue as T);
-  const lastSavedRef = useRef<T | undefined>(undefined);
+  const [inputValue, setInputValue] =
+    useState<EnterpriseSettings[K]>(settingValue);
+  const lastSavedRef = useRef<EnterpriseSettings[K] | undefined>(undefined);
 
   // `lastSavedRef.current === undefined` is the "not yet initialized" sentinel.
   useEffect(() => {
     if (lastSavedRef.current === undefined && settingValue !== undefined) {
-      setInputValue(settingValue as T);
-      lastSavedRef.current = settingValue as T;
+      setInputValue(settingValue);
+      lastSavedRef.current = settingValue;
     }
   }, [settingValue]);
 
@@ -38,7 +39,7 @@ export function useAdminSettingWithBlurInput<T>(
     lastSavedRef.current = inputValue;
     updateSetting({
       key: settingName,
-      value: inputValue as EnterpriseSettingValue<typeof settingName>,
+      value: inputValue,
     });
   }, [isDirty, inputValue, settingName, updateSetting]);
 
@@ -51,10 +52,6 @@ export function useAdminSettingWithBlurInput<T>(
 
   // Browsers won't wait for async saves during unload, so prompt the user.
   useBeforeUnload(isDirty);
-
-  const handleInputChange = useCallback((newValue: T) => {
-    setInputValue(newValue);
-  }, []);
 
   const handleBlur = useCallback(() => {
     saveRef.current();
@@ -69,7 +66,7 @@ export function useAdminSettingWithBlurInput<T>(
 
   return {
     inputValue,
-    handleInputChange,
+    handleInputChange: setInputValue,
     handleBlur,
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAdminSetting } from "metabase/api/utils";
+import { useBeforeUnload } from "metabase/common/hooks/use-before-unload";
+import type {
+  EnterpriseSettingKey,
+  EnterpriseSettingValue,
+} from "metabase-types/api";
+
+/**
+ * Persists a setting on blur and on unmount instead of on every keystroke.
+ * For text settings whose saves shouldn't be debounced (e.g. Metabot system
+ * prompts, where each save changes LLM behavior and the audit log).
+ *
+ * Dirty check uses `===`, so `T` should be a primitive.
+ */
+export function useAdminSettingWithBlurInput<T>(
+  settingName: EnterpriseSettingKey,
+) {
+  const { value: settingValue, updateSetting } = useAdminSetting(settingName);
+  const [inputValue, setInputValue] = useState<T>(settingValue as T);
+  const lastSavedRef = useRef<T | undefined>(undefined);
+
+  // `lastSavedRef.current === undefined` is the "not yet initialized" sentinel.
+  useEffect(() => {
+    if (lastSavedRef.current === undefined && settingValue !== undefined) {
+      setInputValue(settingValue as T);
+      lastSavedRef.current = settingValue as T;
+    }
+  }, [settingValue]);
+
+  const isDirty = inputValue !== lastSavedRef.current;
+
+  const save = useCallback(() => {
+    if (!isDirty) {
+      return;
+    }
+    lastSavedRef.current = inputValue;
+    updateSetting({
+      key: settingName,
+      value: inputValue as EnterpriseSettingValue<typeof settingName>,
+    });
+  }, [isDirty, inputValue, settingName, updateSetting]);
+
+  // Mirror `save` so blur / unmount can read the latest closure without
+  // re-binding handlers on every keystroke.
+  const saveRef = useRef(save);
+  useEffect(() => {
+    saveRef.current = save;
+  }, [save]);
+
+  // Browsers won't wait for async saves during unload, so prompt the user.
+  useBeforeUnload(isDirty);
+
+  const handleInputChange = useCallback((newValue: T) => {
+    setInputValue(newValue);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    saveRef.current();
+  }, []);
+
+  // Persist a pending edit on SPA navigation away.
+  useEffect(() => {
+    return () => {
+      saveRef.current();
+    };
+  }, []);
+
+  return {
+    inputValue,
+    handleInputChange,
+    handleBlur,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -46,16 +46,25 @@ function SystemPromptPage(props: SystemPromptPageProps) {
   );
 }
 
-const getPlaceholder = () =>
-  t`# Here's a section
-1. Do this
-2. And this
-3. And lastly, this
-
-# Here's another section
-1. Do this
-2. And this
-3. And lastly, this`;
+const getPlaceholder = () => {
+  return (
+    t`# Here's a section` +
+    "\n" +
+    t`1. Do this` +
+    "\n" +
+    t`2. And this` +
+    "\n" +
+    t`3. And lastly, this` +
+    "\n\n" +
+    t`# Here's another section` +
+    "\n" +
+    t`1. Do this` +
+    "\n" +
+    t`2. And this` +
+    "\n" +
+    t`3. And lastly, this`
+  );
+};
 
 export function MetabotChatPromptPage() {
   const applicationName = useSelector(getApplicationName);

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -7,7 +7,7 @@ import {
 import { useSelector } from "metabase/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Text, Textarea } from "metabase/ui";
-import { useAdminSettingWithDebouncedInput } from "metabase-enterprise/ai-controls/hooks";
+import { useAdminSettingWithBlurInput } from "metabase-enterprise/ai-controls/hooks";
 
 import S from "./MetabotSystemPromptsPage.module.css";
 
@@ -24,9 +24,8 @@ type SystemPromptPageProps = {
 
 function SystemPromptPage(props: SystemPromptPageProps) {
   const { title, description, settingKey } = props;
-  const { handleInputChange, inputValue } = useAdminSettingWithDebouncedInput<
-    string | null
-  >(settingKey);
+  const { handleInputChange, handleBlur, inputValue } =
+    useAdminSettingWithBlurInput<string | null>(settingKey);
 
   return (
     <SettingsPageWrapper title={title} mt="sm">
@@ -38,6 +37,7 @@ function SystemPromptPage(props: SystemPromptPageProps) {
           aria-label={title}
           className={S.textareaWrapper}
           onChange={(e) => handleInputChange(e.target.value)}
+          onBlur={handleBlur}
           placeholder={getPlaceholder()}
           value={inputValue || ""}
         />
@@ -46,25 +46,16 @@ function SystemPromptPage(props: SystemPromptPageProps) {
   );
 }
 
-const getPlaceholder = () => {
-  return (
-    t`# Here's a section` +
-    "\n" +
-    t`1. Do this` +
-    "\n" +
-    t`2. And this` +
-    "\n" +
-    t`3. And lastly, this` +
-    "\n\n" +
-    t`# Here's another section` +
-    "\n" +
-    t`1. Do this` +
-    "\n" +
-    t`2. And this` +
-    "\n" +
-    t`3. And lastly, this`
-  );
-};
+const getPlaceholder = () =>
+  t`# Here's a section
+1. Do this
+2. And this
+3. And lastly, this
+
+# Here's another section
+1. Do this
+2. And this
+3. And lastly, this`;
 
 export function MetabotChatPromptPage() {
   const applicationName = useSelector(getApplicationName);

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -25,7 +25,7 @@ type SystemPromptPageProps = {
 function SystemPromptPage(props: SystemPromptPageProps) {
   const { title, description, settingKey } = props;
   const { handleInputChange, handleBlur, inputValue } =
-    useAdminSettingWithBlurInput<string | null>(settingKey);
+    useAdminSettingWithBlurInput(settingKey);
 
   return (
     <SettingsPageWrapper title={title} mt="sm">

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -1,11 +1,18 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import {
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import { UndoListing } from "metabase/common/components/UndoListing";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 import {
@@ -34,7 +41,18 @@ function setup({
   setupSettingsEndpoints([]);
   setupUpdateSettingEndpoint();
 
-  renderWithProviders(<Component />);
+  return renderWithProviders(
+    <>
+      <Component />
+      <UndoListing />
+    </>,
+  );
+}
+
+function getUpdateCallsFor(settingKey: string) {
+  return fetchMock.callHistory.calls(`path:/api/setting/${settingKey}`, {
+    method: "PUT",
+  });
 }
 
 describe("MetabotSystemPromptsPage", () => {
@@ -79,6 +97,132 @@ describe("MetabotSystemPromptsPage", () => {
 
       await waitFor(() => {
         expect(textarea).toHaveValue("New instructions");
+      });
+    });
+
+    it("does not save while the user is typing", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await userEvent.type(textarea, "Some prompt");
+
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
+    it("saves on blur and shows a 'Changes saved' toast", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await userEvent.type(textarea, "Be concise");
+      fireEvent.blur(textarea);
+
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
+      });
+
+      const [call] = getUpdateCallsFor("metabot-chat-system-prompt");
+      expect(await call?.request?.json()).toEqual({ value: "Be concise" });
+
+      expect(await screen.findByText("Changes saved")).toBeInTheDocument();
+    });
+
+    it("does not re-save on blur if the value did not change", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: "Existing prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await waitFor(() => {
+        expect(textarea).toHaveValue("Existing prompt");
+      });
+
+      fireEvent.focus(textarea);
+      fireEvent.blur(textarea);
+
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
+    it("saves each distinct value across consecutive edit cycles", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+
+      await userEvent.type(textarea, "First");
+      fireEvent.blur(textarea);
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
+      });
+
+      await userEvent.type(textarea, " edit");
+      fireEvent.blur(textarea);
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(2);
+      });
+
+      const calls = getUpdateCallsFor("metabot-chat-system-prompt");
+      expect(await calls[0]?.request?.json()).toEqual({ value: "First" });
+      expect(await calls[1]?.request?.json()).toEqual({ value: "First edit" });
+    });
+
+    it("warns about unsaved edits via beforeunload, but stops once saved", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await userEvent.type(textarea, "Pending");
+
+      const dirtyEvent = new Event("beforeunload", { cancelable: true });
+      window.dispatchEvent(dirtyEvent);
+      expect(dirtyEvent.defaultPrevented).toBe(true);
+
+      fireEvent.blur(textarea);
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
+      });
+
+      const cleanEvent = new Event("beforeunload", { cancelable: true });
+      window.dispatchEvent(cleanEvent);
+      expect(cleanEvent.defaultPrevented).toBe(false);
+    });
+
+    it("saves a pending edit when the page unmounts", async () => {
+      const { unmount } = setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await userEvent.type(textarea, "Half-typed");
+      // No blur - simulate navigating away mid-edit.
+      unmount();
+
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
       });
     });
   });


### PR DESCRIPTION
### Description

Fixes [UXW-3954](https://linear.app/metabase/issue/UXW-3954/save-edits-to-custom-system-prompts-on-blur-rather-than-on-key-up).

Metabot system-prompt textareas now persist on blur (and on SPA unmount) instead of debouncing every keystroke, so each edit produces a single audited save with a "Changes saved" toast for feedback.

- Page refresh / tab close while dirty triggers the standard "You have unsaved changes" prompt rather than silently losing the edit; we don't try to save during unload because browsers won't wait for async fetches.
- Scoped to the three system-prompt textareas (chat / NLQ / SQL); the customization name field and usage-limit selects intentionally keep their existing debounced-save behavior.

### How to verify

- [ ] Go to AI → System prompts → AI chat. Type without losing focus — confirm no `PUT /api/setting/metabot-chat-system-prompt` fires while typing.
- [ ] Click outside the textarea. Confirm exactly one `PUT` fires and the "Changes saved" toast appears.
- [ ] Type something new without blurring, then hit browser refresh — confirm the "Leave site?" dialog appears.
- [ ] Blur the textarea, then refresh — confirm no dialog.
- [ ] Type something, then click another sidebar item (SPA nav). Confirm the value was saved by reloading the page.

### Demo

https://github.com/user-attachments/assets/5c3811fd-1198-4d05-b2c8-30587a550527

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)