### PR TITLE
Redirect Metabot admin sub-pages to the index until AI is configured

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.tsx
@@ -1,0 +1,29 @@
+import { useLayoutEffect } from "react";
+import { replace } from "react-router-redux";
+
+import { useSetting } from "metabase/common/hooks";
+import { useDispatch } from "metabase/redux";
+
+const FALLBACK_PATH = "/admin/metabot/";
+
+/** Redirects Metabot admin sub-pages to the index until AI is configured. */
+export const RequireMetabotConfigured = ({
+  children,
+}: {
+  children?: React.ReactNode;
+}) => {
+  const isConfigured = useSetting("llm-metabot-configured?");
+  const dispatch = useDispatch();
+
+  useLayoutEffect(() => {
+    if (!isConfigured) {
+      dispatch(replace(FALLBACK_PATH));
+    }
+  }, [isConfigured, dispatch]);
+
+  if (!isConfigured) {
+    return null;
+  }
+
+  return <>{children}</>;
+};

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/components/RequireMetabotConfigured.unit.spec.tsx
@@ -1,0 +1,48 @@
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettingsState } from "metabase/redux/store/mocks";
+
+import { RequireMetabotConfigured } from "./RequireMetabotConfigured";
+
+const SUB_PAGE_PATH = "/admin/metabot/1/usage-controls/ai-usage-limits";
+const INDEX_PATH = "/admin/metabot/";
+
+function setup({ configured }: { configured: boolean }) {
+  return renderWithProviders(
+    <>
+      <Route component={RequireMetabotConfigured}>
+        <Route
+          path={SUB_PAGE_PATH}
+          component={() => <div>SUB PAGE CONTENT</div>}
+        />
+      </Route>
+      <Route path={INDEX_PATH} component={() => <div>METABOT INDEX</div>} />
+    </>,
+    {
+      withRouter: true,
+      initialRoute: SUB_PAGE_PATH,
+      storeInitialState: {
+        settings: createMockSettingsState({
+          "llm-metabot-configured?": configured,
+        }),
+      },
+    },
+  );
+}
+
+describe("RequireMetabotConfigured", () => {
+  it("redirects to the AI settings index when AI is not configured", async () => {
+    const { history } = setup({ configured: false });
+
+    expect(await screen.findByText("METABOT INDEX")).toBeInTheDocument();
+    expect(history?.getCurrentLocation().pathname).toBe(INDEX_PATH);
+  });
+
+  it("renders the requested sub-page when AI is configured", async () => {
+    const { history } = setup({ configured: true });
+
+    expect(await screen.findByText("SUB PAGE CONTENT")).toBeInTheDocument();
+    expect(history?.getCurrentLocation().pathname).toBe(SUB_PAGE_PATH);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -1,5 +1,6 @@
 import { Route } from "react-router";
 
+import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured";
 import {
   MetabotCustomizationPage,
   MetabotCustomizationUpsellPage,
@@ -18,7 +19,7 @@ import { MetabotUsageLimitsPage } from "./pages/MetabotUsageLimitsPage";
 
 export function getAiControlsRoutes() {
   return (
-    <>
+    <Route component={RequireMetabotConfigured}>
       <Route
         key="ai-feature-access"
         path=":metabotId/usage-controls/ai-feature-access"
@@ -49,7 +50,7 @@ export function getAiControlsRoutes() {
         path=":metabotId/system-prompts/sql-generation"
         component={SqlGenerationPromptPage}
       />
-    </>
+    </Route>
   );
 }
 


### PR DESCRIPTION
### Description

Fixes [UXW-3990](https://linear.app/metabase/issue/UXW-3990/block-direct-url-access-to-metabot-admin-sub-pages-when-ai-is-not).

The Metabot admin sub-pages (Access, Limits, Customization, all three System prompts) were hidden in the navigation when AI hadn't been configured but were still reachable by direct URL. Wrapped them in a route-level guard that reads `llm-metabot-configured?` and `replace`s to `/admin/metabot/` until a provider is set up. Index pages remain accessible since that's where you go to actually configure the provider.

### How to verify

- [ ] On a fresh instance with no AI provider configured, paste `/admin/metabot/1/usage-controls/ai-usage-limits` into the URL bar - confirm you land on `/admin/metabot/` instead.
- [ ] Repeat for `/admin/metabot/1/customization` and `/admin/metabot/1/system-prompts/metabot-chat`.
- [ ] Configure an AI provider, then visit a sub-page directly - confirm it loads as before.
- [ ] `/admin/metabot/` and `/admin/metabot/1` (the AI Settings index) remain accessible at all times.

### Demo

https://github.com/user-attachments/assets/e4b9a660-84fc-4d51-ada3-353fd3e326fa


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)