### PR TITLE
Handle UUID field filters

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -691,11 +691,14 @@
     (condp #(isa? %2 %1) (or effective-type base-type)
       ;; When we are dealing with a uuid type we should try to convert to a real UUID
       ;; If that fails,, we will add a fallback cast to "text"
-      :type/UUID (when (not= "" value) ; support is-empty/non-empty checks
-                   (try
-                     (UUID/fromString value)
-                     (catch IllegalArgumentException _
-                       (h2x/with-type-info value {:database-type "varchar"}))))
+      :type/UUID (cond
+                   (instance? UUID value) value
+                   (= "" value)           nil ; support is-empty/non-empty checks
+                   (string? value)        (try
+                                            (UUID/fromString value)
+                                            (catch IllegalArgumentException _
+                                              (h2x/with-type-info value {:database-type "varchar"})))
+                   :else                  value)
       (->honeysql driver value))))
 
 (defn- literal-text-value?

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -15,6 +15,7 @@
    [metabase.dashboards-rest.api :as api.dashboard]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.dashboards.models.dashboard-test :as dashboard-test]
+   [metabase.driver :as driver]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -44,6 +45,7 @@
    [metabase.test.http-client :as client]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.malli :as mu]
    [metabase.warehouse-schema.models.field-values :as field-values]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]
@@ -3657,6 +3659,48 @@
                                                                 "_text_"
                                                               ;; a0 is part of first 2 rows of queried table
                                                                 "a0")))))))))
+
+(deftest field-filter-uuid-operator-dashboard-test
+  (testing "Dashboard ID filter with operator parameter type on a UUID native field filter (#73758)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :uuid-type
+                                                     :test/uuids-in-create-table-statements)
+      (mt/dataset uuid-dogs
+        (let [uuid-value "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]
+          (doseq [param-type ["string/=" "number/="]]
+            (testing (str "param type " (pr-str param-type))
+              (mt/with-temp
+                [:model/Card {card-id :id}
+                 {:dataset_query {:database (mt/id)
+                                  :type     :native
+                                  :native   (assoc (mt/count-with-field-filter-query
+                                                    driver/*driver* :people :id uuid-value)
+                                                   :template-tags
+                                                   {"id" {:name         "id"
+                                                          :display-name "id"
+                                                          :type         :dimension
+                                                          :widget-type  :id
+                                                          :dimension    [:field (mt/id :people :id) nil]}})}}
+                 :model/Dashboard {dashboard-id :id}
+                 {:parameters [{:name "id" :slug "id" :id "_id_" :type param-type}]}
+                 :model/DashboardCard {dashcard-id :id}
+                 {:dashboard_id       dashboard-id
+                  :card_id            card-id
+                  :parameter_mappings [{:parameter_id "_id_"
+                                        :card_id      card-id
+                                        :target       [:dimension [:template-tag "id"]]}]}]
+                ;; In production, malli checks are switched off (see metabase.util.malli.fn/instrument-ns?), and
+                ;; this code path produces a non-final intermediate value that doesn't satisfy the legacy
+                ;; ::mbql.s/Filter schema. We disable enforcement here to match production runtime.
+                (mu/disable-enforcement
+                  (is (=? {:row_count 1
+                           :data      {:rows [[1]]}}
+                          (mt/user-http-request :rasta :post 202
+                                                (format "dashboard/%d/dashcard/%d/card/%d/query"
+                                                        dashboard-id dashcard-id card-id)
+                                                {:parameters [{:id    "_id_"
+                                                               :type  param-type
+                                                               :target [:dimension [:template-tag "id"]]
+                                                               :value [uuid-value]}]}))))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                             POST /api/dashboard/:dashboard-id/card/:card-id/query                              |

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1385,6 +1385,15 @@
               (sql.qp/coerce-integer :sql
                                      (h2x/with-database-type-info value type))))))))
 
+(deftest ^:parallel uuid-value-honeysql-test
+  (testing "->honeysql for [:value <UUID> {:base_type :type/UUID}] handles UUID instances without throwing (#73758)"
+    (doseq [driver (mt/normal-drivers-with-feature :uuid-type)]
+      (testing driver
+        (let [uuid #uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
+          (is (= uuid
+                 (sql.qp/->honeysql driver
+                                    [:value uuid {:base_type :type/UUID :effective_type :type/UUID}]))))))))
+
 (deftest ^:parallel multiple-counts-test
   (testing "Count of count grouping works (#15074)"
     (let [query (lib.tu.macros/mbql-query checkins


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73758
Closes QUE2-561

### Description

The problem was that in v60 we started using `:string/=` instead of the `:id` types and, as a result, parsing UUID strings before it reached the value clause handler. That then tried  to parse the value once more but ran into a ClassCastException that wasn't caught.

This PR skips parsing values that are already UUIDs.

### How to verify

See the tests. The repro steps should not lead to an error after a fix.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
