### PR TITLE
Fix Metabase command syntax in mcp.md

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -17,13 +17,13 @@ If your admin has turned on [your Metabase's MCP server](./settings.md#enable-mc
 https://{your-metabase.example.com}/api/mcp
 ```
 
-In Claude Code, for example, you can run the following snippet, and Claude will handle the OAuth flow for you:
+In the terminal, for example, you can run the following command.
 
 ```
 claude mcp add --transport sse metabase https://{your-metabase-url}/api/mcp
 ```
 
-Replacing {your-metabase-url} with your Metabase address.
+Replacing {your-metabase-url} with your Metabase address.  Once added, Claude Code will handle the OAuth flow for you:
 
 For Claude Desktop, you can create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp) by just giving it that URL to your Metabase's mcp endpoint.
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -20,10 +20,10 @@ https://{your-metabase.example.com}/api/mcp
 In the terminal, for example, you can run the following command.
 
 ```
-claude mcp add --transport sse metabase https://{your-metabase-url}/api/mcp
+claude mcp add --transport http metabase https://{your-metabase-url}/api/mcp
 ```
 
-Replacing {your-metabase-url} with your Metabase address.  Once added, Claude Code will handle the OAuth flow for you:
+Replacing {your-metabase-url} with your Metabase address. Once added, Claude Code will handle the OAuth flow for you:
 
 For Claude Desktop, you can create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp) by just giving it that URL to your Metabase's mcp endpoint.
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -20,7 +20,7 @@ https://{your-metabase.example.com}/api/mcp
 In Claude Code, for example, you can run the following snippet, and Claude will handle the OAuth flow for you:
 
 ```
-claude add --transport sse metabase https://{your-metabase-url}/api/mcp
+claude mcp add --transport sse metabase https://{your-metabase-url}/api/mcp
 ```
 
 Replacing {your-metabase-url} with your Metabase address.

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -20,8 +20,10 @@ https://{your-metabase.example.com}/api/mcp
 In Claude Code, for example, you can run the following snippet, and Claude will handle the OAuth flow for you:
 
 ```
-/mcp add metabase https://{your-metabase.example.com}/api/mcp --transport streamable-http
+claude add --transport sse metabase https://{your-metabase-url}/api/mcp
 ```
+
+Replacing {your-metabase-url} with your Metabase address.
 
 For Claude Desktop, you can create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp) by just giving it that URL to your Metabase's mcp endpoint.
 


### PR DESCRIPTION
Updated the command syntax for adding Metabase in Claude Code and clarified the URL placeholder.

