### PR TITLE
Port sankey repro no. 65317 to Jest 

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
@@ -1,4 +1,3 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {
   DashboardDetails,
@@ -289,53 +288,5 @@ describe("issue 65908 (UXW-2293)", () => {
         expect($main[0].scrollHeight).to.be.lessThan(1000);
       });
     });
-  });
-});
-
-describe("issue 65317", () => {
-  const SANKEY_QUERY = `
-SELECT 'A' AS source, 'B' AS target, 100 AS value
-UNION ALL
-SELECT 'B', 'C', 80
-UNION ALL
-SELECT 'C', 'D', 60
-`;
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should not show 'Visualize another way' button for Sankey charts (metabase#65317)", () => {
-    H.createDashboard({
-      name: "Dashboard with Sankey",
-    }).then(({ body: dashboard }) => {
-      H.createNativeQuestion({
-        name: "Sankey Question",
-        native: {
-          query: SANKEY_QUERY,
-        },
-        display: "sankey",
-        database: SAMPLE_DB_ID,
-      }).then(({ body: card }) => {
-        H.addOrUpdateDashboardCard({
-          card_id: card.id,
-          dashboard_id: dashboard.id,
-          card: {
-            size_x: 12,
-            size_y: 8,
-          },
-        });
-
-        H.visitDashboard(dashboard.id);
-      });
-    });
-
-    H.editDashboard();
-
-    H.getDashboardCard(0).realHover({ scrollBehavior: "bottom" });
-
-    cy.findByTestId("dashboardcard-actions-panel").should("be.visible");
-    cy.findByLabelText("Visualize another way").should("not.exist");
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -442,6 +442,32 @@ describe("DashCard", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("should not show 'Visualize another way' for sankey cards (metabase#65317)", () => {
+      const dashcard = createMockDashboardCard({
+        card: createMockCard({
+          name: "My Card",
+          display: "sankey",
+        }),
+      });
+
+      setup({
+        dashboard: {
+          ...testDashboard,
+          dashcards: [dashcard],
+        },
+        dashcard,
+        isEditing: true,
+      });
+
+      // Anchor: prove sankey is routed as a non-visualizer type.
+      expect(
+        screen.getByLabelText("Show visualization options"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Visualize another way"),
+      ).not.toBeInTheDocument();
+    });
+
     it.each([
       ["heading", createMockHeadingDashboardCard()],
       ["text", createMockTextDashboardCard()],


### PR DESCRIPTION
Replaces the e2e repro with a unit test alongside the existing visualizer-button assertions in Dashcard.unit.spec.tsx. Anchors on 'Show visualization options' so a layout regression that drops the actions panel cannot mask the negative assertion.

- [x] Tests have been added/updated to cover changes in this PR

### e2e test review

This is original Claude's test review using e2e-test-review skill
https://files.slack.com/files-pri/T078VCLCR-F0B0MUVRDL2/65317.md