### PR TITLE
Use correct workflow for auto minor release

### DIFF
--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -79,7 +79,7 @@ jobs:
                 await github.rest.actions.createWorkflowDispatch({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  workflow_id: 'build-for-release.yml',
+                  workflow_id: 'tag-for-release.yml',
                   ref: 'refs/heads/master',
                   inputs: {
                     commit: releaseCommit,


### PR DESCRIPTION
We want to use "tag-for-release" not "build-for-release". Tag for release takes an existing jar and tags it with a version number. 

"build-for-release" builds a fresh jar and is much slower, and is really just a fallback.

In this case, the "build-for-release" job didn't send the jars to the correct bucket for deploying to cloud