### PR TITLE
Handle query stages that have both `:limit` and `:page`

### DIFF
--- a/src/metabase/lib/page.cljc
+++ b/src/metabase/lib/page.cljc
@@ -22,4 +22,9 @@
   ([query        :- ::lib.schema/query
     stage-number :- :int
     page         :- [:maybe ::lib.schema/page]]
-   (lib.util/update-query-stage query stage-number u/assoc-dissoc :page page)))
+   (lib.util/update-query-stage query stage-number (fn [stage]
+                                                     (if page
+                                                       (-> stage
+                                                           (dissoc :limit) ; drop `:limit` if present since it conflicts with `:page`
+                                                           (assoc :page page))
+                                                       (dissoc stage :page))))))

--- a/src/metabase/lib/page.cljc
+++ b/src/metabase/lib/page.cljc
@@ -2,7 +2,6 @@
   (:require
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util :as lib.util]
-   [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
 (mu/defn current-page :- [:maybe ::lib.schema/page]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -272,6 +272,16 @@
       ;; reliable way to differentiate them since it gets populated by the QP.
       (merge (select-keys stage [:qp/stage-is-from-source-card :qp/stage-had-source-card]))))
 
+(mr/def ::stage.page-and-limit-are-mutually-exclusive
+  "If an MBQL query stage specifies `:page`, it should not also specify `:limit`"
+  [:fn
+   {:error/message    "A query stage should not specify both :page and :limit since they conflict"
+    ;; if both are specified, ignore `:limit` and prefer `:page`
+    :decode/normalize (fn [stage]
+                        (cond-> stage
+                          ((every-pred :page :limit) stage) (dissoc :limit)))}
+   (complement (every-pred :page :limit))])
+
 (mr/def ::stage.mbql
   [:and
    [:merge
@@ -295,6 +305,7 @@
     {:error/message "A query must have exactly one of :source-table or :source-card"}
     (complement (comp #(= (count %) 1) #{:source-table :source-card}))]
    [:ref ::stage.valid-refs]
+   [:ref ::stage.page-and-limit-are-mutually-exclusive]
    (common/disallowed-keys
     {:native             ":native is not allowed in an MBQL stage."
      :aggregation-idents ":aggregation-idents is deprecated and should not be used"

--- a/test/metabase/lib/limit_test.cljc
+++ b/test/metabase/lib/limit_test.cljc
@@ -114,8 +114,8 @@
       10)))
 
 (deftest ^:parallel max-rows-limit-test-6
-  (testing "if both `:limit` and `:page` are set (not sure makes sense), return the smaller of the two"
-    (are [query expected] (= expected (lib/max-rows-limit query))
+  (testing "if both `:limit` and `:page` are set page should be preferred over limit"
+    (are [query expected] (= expected (lib/max-rows-limit (lib/normalize query)))
       {:database     1
        :lib/type     :mbql/query
        :lib/metadata meta/metadata-provider
@@ -132,7 +132,7 @@
                        :source-table 1
                        :limit        5
                        :page         {:page 1, :items 10}}]}
-      5)))
+      10)))
 
 (deftest ^:parallel max-rows-limit-test-7
   (testing "if nothing is set return `nil`"

--- a/test/metabase/lib/page_test.cljc
+++ b/test/metabase/lib/page_test.cljc
@@ -1,10 +1,13 @@
 (ns metabase.lib.page-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.page :as lib.page]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel current-page-test
   (let [query (lib.tu/venues-query)]

--- a/test/metabase/lib/page_test.cljc
+++ b/test/metabase/lib/page_test.cljc
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.page :as lib.page]
+   [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]))
 
 (deftest ^:parallel current-page-test
@@ -75,3 +76,13 @@
       ;; 2-arity should set page on the last stage (stage 1), not the first (stage 0)
       (is (nil? (get-in result [:stages 0 :page])))
       (is (= page (get-in result [:stages 1 :page]))))))
+
+(deftest ^:parallel with-page-drops-limit-test
+  (testing "`with-page` should drop `:limit` since the two conflict"
+    (let [mp    meta/metadata-provider
+          query (-> (lib/query mp (meta/table-metadata :venues))
+                    (lib/limit 10)
+                    (lib/with-page {:page 1, :items 15}))]
+      (is (=? {:stages [{:page  {:page 1, :items 15}
+                         :limit (symbol "nil #_\"key is not present.\"")}]}
+              query)))))

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.schema.util-test :as lib.schema.util-test]
+   [metabase.lib.test-metadata :as meta]
    [metabase.util.malli.registry :as mr]))
 
 (comment
@@ -418,3 +419,13 @@
                                     basic-external-query))))
   (is (not (me/humanize (mr/explain ::lib.schema/external-query
                                     native-external-query)))))
+
+(deftest ^:parallel normalize-query-drop-limit-in-stage-with-page-test
+  (testing "If a query has `:page` we should drop `:limit` since the two conflict during normalization"
+    (let [stage {:lib/type     :mbql.stage/mbql
+                 :source-table (:id (meta/table-metadata :venues))
+                 :page         {:page 1, :items 15}
+                 :limit        20}]
+      (is (=? {:page  {:page 1, :items 15}
+               :limit (symbol "nil #_\"key is not present.\"")}
+              (lib/normalize ::lib.schema/stage stage))))))

--- a/test/metabase/query_processor/page_test.clj
+++ b/test/metabase/query_processor/page_test.clj
@@ -2,8 +2,11 @@
   "Tests for the `:page` clause."
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.test :as qp]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.malli :as mu]))
 
 (defn- page-is [expected page-num]
   (let [query (mt/mbql-query categories
@@ -36,3 +39,21 @@
                   [9 "Breakfast / Brunch"]
                   [10 "Brewery"]]
                  2)))))
+
+(deftest ^:parallel page-combined-with-limit-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "If both `:limit` and `:page` are specified in an MBQL stage the query should still compile correctly (prefer `:page` to `:limit`) (#73483)"
+      (let [mp    (mt/metadata-provider)
+            query (mu/disable-enforcement ; disable schema constraint that we cannot have `:page` and `:limit` together
+                    (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                        (lib/order-by (lib.metadata/field mp (mt/id :venues :id)))
+                        (lib/with-fields [(lib.metadata/field mp (mt/id :venues :id))
+                                          (lib.metadata/field mp (mt/id :venues :name))])
+                        (lib/with-page {:page 1, :items 5})
+                        (lib/limit 10)))]
+        (is (= [[1 "Red Medicine"]
+                [2 "Stout Burgers & Beers"]
+                [3 "The Apple Pan"]
+                [4 "Wurstküche"]
+                [5 "Brite Spot Family Restaurant"]]
+               (mt/formatted-rows [int str] (qp/process-query query))))))))


### PR DESCRIPTION
Apparently MetaBot is generating MBQL queries with both `:limit` and `:page`, which doesn't **really** make sense since `:page` is a superset of `:limit`... fix this by dropping `:limit` during normalization if both are present.

Fixes #73483
Fixes QUE2-543