### PR TITLE
Work around sqlglot #>> operator priority bug

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -730,13 +730,22 @@
   ```clj
   [::json-query [::h2x/identifier :field [\"boop\" \"bleh\"]] \"bigint\" [\"meh\"]]
   =>
-  [\"(boop.bleh#>> array[?]::text[])::bigint\" \"meh\"]
-  ```"
+  [\"(boop.bleh#>> (array[?]::text[]))::bigint\" \"meh\"]
+  ```
+
+  The path argument is wrapped in an extra pair of parentheses so the `::text[]`
+  cast is unambiguously bound to `array[...]` rather than to the result of `#>>`.
+  Postgres' grammar gives `::` higher precedence than `#>>` so the parens are
+  redundant for Postgres itself, but `sqlglot` (used by
+  [[metabase.driver.sql/validate-impersonated-query*]] to canonicalize impersonated
+  native SQL) parses `parent #>> array[?]::text[]` as `(parent #>> array[?])::text[]`
+  and re-emits it with the cast wrapping the wrong expression — which then makes
+  Postgres reject the query at execution. See #73776."
   [_fn [parent-identifier field-type names]]
   (let [names-text-array                 (into [::text-array] names)
         [parent-id-sql & parent-id-args] (sql/format-expr parent-identifier {:nested true})
         [path-sql & path-args]           (sql/format-expr names-text-array {:nested true})]
-    (into [(format "(%s#>> %s)::%s" parent-id-sql path-sql field-type)]
+    (into [(format "(%s#>> (%s))::%s" parent-id-sql path-sql field-type)]
           cat
           [parent-id-args path-args])))
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -16,6 +16,7 @@
    [metabase.driver.postgres :as postgres]
    [metabase.driver.postgres.actions :as postgres.actions]
    [metabase.driver.settings :as driver.settings]
+   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc :as driver.sql-jdbc]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
    [metabase.driver.sql-jdbc.actions-test :as sql-jdbc.actions-test]
@@ -392,20 +393,38 @@
                 "decimal"
                 [:meh]]
                (#'sql.qp/json-query :postgres boop-identifier boop-field)))
-        (is (= ["(boop.bleh#>> array[?]::text[])::decimal" "meh"]
+        (is (= ["(boop.bleh#>> (array[?]::text[]))::decimal" "meh"]
                (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boop-field))))))
     (testing "What if types are weird and we have lists"
       (let [weird-field {:nfc-path [:bleh "meh" :foobar 1234] :database-type "bigint"}]
-        (is (= ["(boop.bleh#>> array[?, ?, 1234]::text[])::bigint" "meh" "foobar"]
+        (is (= ["(boop.bleh#>> (array[?, ?, 1234]::text[]))::bigint" "meh" "foobar"]
                (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier weird-field))))))
     (testing "Give us a boolean cast when the field is boolean"
       (let [boolean-boop-field {:database-type "boolean" :nfc-path [:bleh "boop" :foobar 1234]}]
-        (is (= ["(boop.bleh#>> array[?, ?, 1234]::text[])::boolean" "boop" "foobar"]
+        (is (= ["(boop.bleh#>> (array[?, ?, 1234]::text[]))::boolean" "boop" "foobar"]
                (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boolean-boop-field))))))
     (testing "Give us a bigint cast when the field is bigint (#22732)"
       (let [boolean-boop-field {:database-type "bigint" :nfc-path [:bleh "boop" :foobar 1234]}]
-        (is (= ["(boop.bleh#>> array[?, ?, 1234]::text[])::bigint" "boop" "foobar"]
+        (is (= ["(boop.bleh#>> (array[?, ?, 1234]::text[]))::bigint" "boop" "foobar"]
                (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boolean-boop-field))))))))
+
+(deftest ^:parallel json-query-survives-impersonation-validation-test
+  (testing "JSON-extracted field SQL still extracts the same value after `validate-impersonated-query*` re-emits it (#73776)"
+    ;; `validate-impersonated-query*` runs the native SQL through sqlglot's parse-and-emit
+    ;; canonicalization. We need its reconstruction of our `(parent #>> path)::field-type`
+    ;; expression to keep the inner `::text[]` cast on the path argument — not on the result
+    ;; of `#>>`, which would tell Postgres to read text values as array literals and fail.
+    (let [parent     (h2x/identifier :field "public" "test_table" "data")
+          nfc-field  {:nfc-path ["data" "key"] :database-type "text"}
+          [json-sql] (sql/format-expr (#'sql.qp/json-query :postgres parent nfc-field))
+          stage      {:lib/type :mbql.stage/native :native (str "SELECT " json-sql " AS k FROM t")}
+          out-sql    (-> (driver.sql/validate-impersonated-query* :postgres {:stages [stage]})
+                         :stages first :native)]
+      ;; The broken reconstruction looks like `CAST(parent #>> array[?] AS TEXT[])` — i.e.
+      ;; the cast wraps the entire `#>>` expression instead of just the path argument.
+      (is (not (re-find #"(?i)#>>\s+array\s*\[\?\]\s+AS\s+TEXT\s*\[\s*\]" out-sql))
+          (str "validate-impersonated-query* placed the TEXT[] cast on the result of #>> "
+               "rather than on the array path argument:\n  " out-sql)))))
 
 (deftest ^:parallel json-field-test
   (mt/test-driver :postgres
@@ -428,7 +447,7 @@
                                        :min-value 0.75
                                        :max-value 54.0
                                        :bin-width 0.75}}]]
-          (is (= ["((FLOOR((((complicated_identifiers.jsons#>> array[?, ?]::text[])::integer - 0.75) / 0.75)) * 0.75) + 0.75)"
+          (is (= ["((FLOOR((((complicated_identifiers.jsons#>> (array[?, ?]::text[]))::integer - 0.75) / 0.75)) * 0.75) + 0.75)"
                   "values" "qty"]
                  (sql/format-expr (sql.qp/->honeysql :postgres field-clause) {:nested true}))))))))
 
@@ -471,7 +490,7 @@
                   "  DATE_TRUNC("
                   "    'month',"
                   "    CAST("
-                  "      (\"json_alias_test\".\"bob\" #>> array [ ?, ? ] :: text [ ]) :: VARCHAR AS timestamp"
+                  "      (\"json_alias_test\".\"bob\" #>> (array [ ?, ? ] :: text [ ])) :: VARCHAR AS timestamp"
                   "    )"
                   "  ) AS \"json_alias_test\","
                   "  COUNT(*) AS \"count\""
@@ -497,7 +516,7 @@
                                :query    {:source-table 1
                                           :order-by     [[:asc field-ordinary]]}})]
           (is (= ["SELECT"
-                  "  (\"json_alias_test\".\"bob\" #>> array [ ?, ? ] :: text [ ]) :: VARCHAR AS \"json_alias_test\""
+                  "  (\"json_alias_test\".\"bob\" #>> (array [ ?, ? ] :: text [ ])) :: VARCHAR AS \"json_alias_test\""
                   "FROM"
                   "  \"json_alias_test\""
                   "ORDER BY"
@@ -533,7 +552,7 @@
                   "FROM"
                   "  ("
                   "    SELECT"
-                  "      (\"json_alias_test\".\"bob\" #>> array [ ?, ? ] :: text [ ]) :: VARCHAR AS \"json_alias_test\","
+                  "      (\"json_alias_test\".\"bob\" #>> (array [ ?, ? ] :: text [ ])) :: VARCHAR AS \"json_alias_test\","
                   "      COUNT(*) AS \"count\""
                   "    FROM"
                   "      \"json_alias_test\""


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73776
Closes QUE2-562

### Description

`format-json-query` in `src/metabase/driver/postgres.clj` emits `(parent #>> array[?]::text[])::<field-type>`.

Postgres' grammar binds `::` tighter than `#>>`, so `::text[]` correctly applies to `array[?]` only. But the impersonation pipeline runs the SQL through `validate-impersonated-query*`, which round-trips through sqlglot for safety — and sqlglot treats `::` and `#>>` as equal-precedence column operators. It re-emits as `CAST((CAST(parent #>> array[?] AS TEXT[])) AS TEXT)`, putting the cast around the result of `#>>` instead of the path. Postgres then tries to read the JSON text value as an array literal and fails with malformed array literal: `"value"`.

The bug should be fixed in sqlglot, which I will try later. this PR implements a work-around: we parenthesize the path with the cast to make sure sqlglot doesn't have to know about operator priorities.

### How to verify

See the new test. The repro steps from #73776 should not lead to an error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
