### PR TITLE
deps: upgrade postgres to 42.7.11

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -176,7 +176,7 @@
   org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now
   {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.7.8"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.7.11"}            ; Postgres driver
   org.semver4j/semver4j                     {:mvn/version "6.0.0"}              ; Semantic versioning parsing & comparison
   org.slf4j/slf4j-api                       {:mvn/version "2.0.17"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath


### PR DESCRIPTION
Bump postgres JDBC from `42.7.8` → `42.7.11`. Patch release on the same `42.7.x` line; no API changes.

closes https://github.com/metabase/metabase/security/code-scanning/719
closes https://linear.app/metabase/issue/SEC-102/code-scanning-alerts-high-severity-allocation-of-resources-without