### PR TITLE
deps: bump netty to 4.2.13.Final in hive-like driver

### DIFF
--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -245,11 +245,11 @@
 
   ;; Netty — pinned explicitly at safe versions for security scanning.
   ;; Driver JARs are scanned individually so these must be declared directly.
-  io.netty/netty-common                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-handler                             {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport                           {:mvn/version "4.2.12.Final"}
-  io.netty/netty-buffer                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-codec                               {:mvn/version "4.2.12.Final"}
-  io.netty/netty-resolver                            {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.12.Final"}}}
+  io.netty/netty-common                              {:mvn/version "4.2.13.Final"}
+  io.netty/netty-handler                             {:mvn/version "4.2.13.Final"}
+  io.netty/netty-transport                           {:mvn/version "4.2.13.Final"}
+  io.netty/netty-buffer                              {:mvn/version "4.2.13.Final"}
+  io.netty/netty-codec                               {:mvn/version "4.2.13.Final"}
+  io.netty/netty-resolver                            {:mvn/version "4.2.13.Final"}
+  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.13.Final"}
+  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.13.Final"}}}


### PR DESCRIPTION
Bump the 8 Netty modules pinned in the hive-like driver from `4.2.12.Final` → `4.2.13.Final`. Patch release on the same `4.2.x` line; per-driver pin convention from #72787.

closes https://github.com/metabase/metabase/security/code-scanning/730
closes https://github.com/metabase/metabase/security/code-scanning/735
closes https://github.com/metabase/metabase/security/code-scanning/734
closes https://github.com/metabase/metabase/security/code-scanning/733