### PR TITLE
deps: bump netty to 4.1.133.Final in athena driver

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -16,14 +16,14 @@
 
   ;; Netty — pinned at latest 4.1.x patched release. The Athena JDBC driver's
   ;; async AWS SDK path requires the 4.1 API; 4.2.x is not binary-compatible
-  ;; with classes the driver calls. 4.1.132 patches CVE-2026-33870 et al.
-  io.netty/netty-common                       {:mvn/version "4.1.132.Final"}
-  io.netty/netty-handler                      {:mvn/version "4.1.132.Final"}
-  io.netty/netty-transport                    {:mvn/version "4.1.132.Final"}
-  io.netty/netty-buffer                       {:mvn/version "4.1.132.Final"}
-  io.netty/netty-codec                        {:mvn/version "4.1.132.Final"}
-  io.netty/netty-codec-http                   {:mvn/version "4.1.132.Final"}
-  io.netty/netty-codec-http2                  {:mvn/version "4.1.132.Final"}
-  io.netty/netty-resolver                     {:mvn/version "4.1.132.Final"}
-  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.132.Final"}
-  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.132.Final"}}}
+  ;; with classes the driver calls. 4.1.133 patches CVE-2026-33870 et al.
+  io.netty/netty-common                       {:mvn/version "4.1.133.Final"}
+  io.netty/netty-handler                      {:mvn/version "4.1.133.Final"}
+  io.netty/netty-transport                    {:mvn/version "4.1.133.Final"}
+  io.netty/netty-buffer                       {:mvn/version "4.1.133.Final"}
+  io.netty/netty-codec                        {:mvn/version "4.1.133.Final"}
+  io.netty/netty-codec-http                   {:mvn/version "4.1.133.Final"}
+  io.netty/netty-codec-http2                  {:mvn/version "4.1.133.Final"}
+  io.netty/netty-resolver                     {:mvn/version "4.1.133.Final"}
+  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.133.Final"}
+  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.133.Final"}}}


### PR DESCRIPTION
Bump the 10 Netty modules pinned in the athena driver from `4.1.132.Final` → `4.1.133.Final`. Athena's async AWS SDK path requires the 4.1 API; 4.2.x is not binary-compatible (see existing comment in `deps.edn`).

closes https://github.com/metabase/metabase/security/code-scanning/732
closes https://github.com/metabase/metabase/security/code-scanning/728