### PR TITLE
deps: upgrade dompurify to 3.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -418,7 +418,7 @@
     "cross-spawn": "^7.0.5",
     "d3-color": "^3.1.0",
     "debug": "^4.3.4",
-    "dompurify": "^3.3.2",
+    "dompurify": "^3.4.0",
     "elliptic": "^6.6.1",
     "follow-redirects": "^1.16.0",
     "lodash": "^4.18.1",
@@ -2865,7 +2865,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
+    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/package.json
+++ b/package.json
@@ -421,7 +421,7 @@
     "cross-spawn": "^7.0.5",
     "d3-color": "^3.1.0",
     "debug": "^4.3.4",
-    "dompurify": "^3.3.2",
+    "dompurify": "^3.4.0",
     "elliptic": "^6.6.1",
     "follow-redirects": "^1.16.0",
     "lodash-es": "^4.18.1",


### PR DESCRIPTION
Bump the dompurify resolution from `^3.3.2` → `^3.4.0` (resolves to `3.4.2`). Pulled transitively by `jspdf` for HTML-to-PDF rendering; we don't call dompurify directly. Refreshes `bun.lock`.

closes https://github.com/metabase/metabase/security/code-scanning/704
closes https://github.com/metabase/metabase/security/code-scanning/705