### PR TITLE
deps: exclude azure-core-http-netty from snowflake driver

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -9,7 +9,12 @@
                                                    ;; exclusion here will (hopefully?) prevent code scanning alerts
                                                    ;; from complaining about it as well.
                                                    io.netty/netty-codec-http
-                                                   io.netty/netty-codec-http2]}
+                                                   io.netty/netty-codec-http2
+                                                   ;; Azure SDK's Netty HTTP transport is only used for PUT/GET to
+                                                   ;; Azure-backed Snowflake stages, which Metabase never does
+                                                   ;; (read-only SQL driver). Excluding the Netty transport removes
+                                                   ;; the entire reactor-netty + transitive Netty 4.1.x chain.
+                                                   com.azure/azure-core-http-netty]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version


### PR DESCRIPTION
The Snowflake JDBC driver pulls Azure SDK transitively (`azure-storage-blob → azure-core-http-netty → reactor-netty → ~13 netty modules at 4.1.127.Final`). Azure SDK's Netty HTTP transport is only exercised when Snowflake uses Azure-backed stages for `PUT`/`GET` — which Metabase's read-only SQL driver never does.

Excluding `com.azure/azure-core-http-netty` removes the entire reactor-netty and transitive Netty 4.1.x chain from the classpath in one line.

closes https://github.com/metabase/metabase/security/code-scanning/737
closes https://github.com/metabase/metabase/security/code-scanning/731
closes https://github.com/metabase/metabase/security/code-scanning/726
closes https://github.com/metabase/metabase/security/code-scanning/736