### PR TITLE
remove custom react settings widget support

### DIFF
--- a/enterprise/frontend/src/custom-viz/src/templates/README.md
+++ b/enterprise/frontend/src/custom-viz/src/templates/README.md
@@ -180,7 +180,7 @@ settings: {
 | `group`                        | Sub-heading within a section for grouping related settings.                          |
 | `index`                        | Display order within a group.                                                        |
 | `inline`                       | When `true`, renders the widget on the same line as `title` (useful for `"toggle"`). |
-| `widget`                       | Built-in widget name or a custom React component.                                    |
+| `widget`                       | Built-in widget name (see below).                                                    |
 | `getDefault(series, settings)` | Computes the default value when none is stored.                                      |
 | `getValue(series, settings)`   | Always-computed value — overrides stored value on every render.                      |
 | `getProps(series, settings)`   | Returns widget-specific props.                                                       |
@@ -204,8 +204,6 @@ settings: {
 | `"multiselect"`      | `{ options: { label, value }[], placeholder?, placeholderNoOptions? }`     | Multi-select dropdown    |
 | `"field"`            | `{ columns, options: { name, value }[], showColumnSetting? }`              | Single column picker     |
 | `"fields"`           | `{ columns, options: { name, value }[], addAnother?, showColumnSetting? }` | Multi-column picker      |
-
-You can also pass a **custom React component** as `widget`. Its props (minus the base props injected by Metabase) are returned by `getProps`.
 
 ---
 

--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -1,7 +1,7 @@
-import type { ComponentType, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import type { Column, Series } from "./data";
-import type { BaseWidgetProps, ClickBehavior } from "./viz";
+import type { ClickBehavior } from "./viz";
 
 export type WidgetName = keyof Widgets;
 
@@ -88,18 +88,7 @@ export type MultiselectProps = {
   placeholderNoOptions?: string;
 };
 
-type OmitBaseWidgetProps<P> = keyof BaseWidgetProps<
-  unknown,
-  Record<string, unknown>
-> extends keyof P
-  ? Omit<P, keyof BaseWidgetProps<unknown, Record<string, unknown>>>
-  : P;
-
-type PropsFromWidget<W> = W extends WidgetName
-  ? Widgets[W]
-  : W extends ComponentType<infer P>
-    ? OmitBaseWidgetProps<P>
-    : never;
+type PropsFromWidget<W extends WidgetName> = Widgets[W];
 
 type CommonVisualizationSettings = {
   "card.title"?: string | undefined | null;
@@ -113,10 +102,7 @@ export type CustomVisualizationSettings<
 > = TSettings & CommonVisualizationSettings;
 
 export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
-  () => <
-    W extends WidgetName | ComponentType<any>,
-    Key extends keyof TSettings,
-  >(settingDefinition: {
+  () => <W extends WidgetName, Key extends keyof TSettings>(settingDefinition: {
     /**
      * Unique key that identifies this setting. Must match the key used in your
      * `CustomVisualizationSettings` type and in the `settings` map passed to
@@ -202,11 +188,10 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
     eraseDependencies?: string[];
 
     /**
-     * Widget to render for this setting: either a built-in widget name (`WidgetName`)
-     * or a custom React component (`React.ComponentType<P>`).
-     *
-     * When using a custom component, `getProps` should return only the non-base props;
-     * base widget props are provided by the settings renderer.
+     * Widget to render for this setting. Must be one of the built-in widget
+     * names (see `WidgetName`). Custom React components are not supported:
+     * plugin code must run inside the sandbox, and a custom widget would be
+     * rendered host-side, bypassing it.
      */
     widget: W;
 
@@ -256,9 +241,7 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
      * dropdown's `options` list from the available columns.
      *
      * The return type is inferred from the `widget` value: props of the named
-     * built-in widget when `widget` is a `WidgetName`, or the component's own
-     * props (minus the base props the engine injects) when `widget` is a custom
-     * React component. Omit `getProps` entirely when the widget has no
+     * built-in widget. Omit `getProps` entirely when the widget has no
      * configurable props (`ToggleProps` is `never`).
      *
      * @param series - The current query result (rows + column metadata).

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -95,18 +95,6 @@ export type CustomVisualization<TSettings extends Record<string, unknown>> = {
   VisualizationComponent: ComponentType<CustomVisualizationProps<TSettings>>;
 };
 
-export type BaseWidgetProps<
-  TValue,
-  TSettings extends Record<string, unknown>,
-> = {
-  id: string;
-  value: TValue | undefined;
-  onChange: (value?: TValue | null) => void;
-  onChangeSettings: (
-    settings: Partial<CustomVisualizationSettings<TSettings>>,
-  ) => void;
-};
-
 export type VisualizationGridSize = {
   /**
    * Number of grid columns in a Metabase dashboard.

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.tsx
@@ -6,6 +6,7 @@ import type {
   CustomVisualizationSettingDefinition,
   ClickObject as CustomVizClickObject,
   HoverObject as CustomVizHoverObject,
+  Widgets,
 } from "custom-viz";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useUnmount } from "react-use";
@@ -324,6 +325,8 @@ export async function loadCustomVizPlugin(
       );
     }
 
+    assertValidSettingWidgets(vizDef.settings);
+
     // Build a Metabase-compatible identifier, prefixed to avoid collisions
     const identifier = getCustomPluginIdentifier(plugin);
 
@@ -402,6 +405,38 @@ type GenericVizMountHandle =
 
 function isValidVizDefinition(value: unknown): value is GenericVizDefinition {
   return isObject(value) && typeof value.mount === "function";
+}
+
+const ALLOWED_WIDGET_NAMES: Array<keyof Widgets> = [
+  "input",
+  "number",
+  "radio",
+  "select",
+  "toggle",
+  "segmentedControl",
+  "field",
+  "fields",
+  "color",
+  "multiselect",
+] as const;
+
+function assertValidSettingWidgets(
+  settings: GenericVizDefinition["settings"] | undefined,
+): void {
+  if (!settings) {
+    return;
+  }
+  for (const [settingId, def] of Object.entries(settings)) {
+    const widget = (def as { widget?: unknown }).widget;
+    if (
+      typeof widget !== "string" ||
+      !ALLOWED_WIDGET_NAMES.some((w) => w === widget)
+    ) {
+      throw new Error(
+        t`Setting "${settingId}" has unsupported widget. Use one of: ${ALLOWED_WIDGET_NAMES.join(", ")}.`,
+      );
+    }
+  }
 }
 
 function createCustomVizWrapper(


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2406/remove-temporarily-custom-react-settings-widget-support

### Description

Remove support for custom React widget in custom viz.

### How to verify


### Demo

<img width="2096" height="214" alt="image" src="https://github.com/user-attachments/assets/f5719a48-cb28-49b5-bf57-71d689eb5119" />


<img width="934" height="460" alt="image" src="https://github.com/user-attachments/assets/a3958c57-395e-40d9-94b8-ed950431f6d6" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
