### PR TITLE
[GDGT-2403] chore: split out transforms.usage from transforms.feature-gating

### DIFF
--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -14,6 +14,7 @@
    [metabase.transforms.models.transform-tag]
    [metabase.transforms.schedule]
    [metabase.transforms.settings]
+   [metabase.transforms.usage]
    [metabase.transforms.util]
    [potemkin :as p]))
 
@@ -21,6 +22,9 @@
  [metabase.transforms.settings
   transform-timeout
   transforms-meter-locked]
+ [metabase.transforms.usage
+  transform-locked?
+  transforms-meter-locked?]
  [metabase.transforms-base.util
   native-query-transform?
   output-table

--- a/src/metabase/transforms/feature_gating.clj
+++ b/src/metabase/transforms/feature_gating.clj
@@ -26,33 +26,3 @@
   "Whether any transforms are enabled."
   []
   (or (query-transforms-enabled?) (python-transforms-enabled?)))
-
-(def ^:private metered-as->meter-key
-  "Map the bucket strings returned by [[premium-features/transform-metered-as]] to their
-   corresponding `:meters` keys in the harbormaster token-check response."
-  {"transform-basic"    :transform-basic-runs
-   "transform-advanced" :transform-advanced-runs})
-
-(defn transform-locked?
-  "True if the meter that would be charged for running this transform is locked.
-   Returns false for non-metered transforms (OSS, self-hosted basic-only) and when
-   no `:locked-meters` mirror has been written yet (cold cache, airgap)."
-  [transform]
-  (boolean
-   (when-let [meter-key (some-> ((requiring-resolve 'metabase.transforms-base.util/transform-source-type)
-                                 (:source transform))
-                                premium-features/transform-metered-as
-                                metered-as->meter-key)]
-     (get (premium-features/locked-meters) meter-key))))
-
-(defn transforms-meter-locked?
-  "True if either of the two transforms meters (`:transform-basic-runs` or
-   `:transform-advanced-runs`) is currently locked. Per harbormaster's
-   mutual-exclusivity constraint, at most one of these is populated for a
-   given customer, so this aggregate reduces to 'is the customer's active
-   transforms meter, if any, locked?'. Backs the [[metabase.transforms.settings/transforms-meter-locked]]
-   setting, which the frontend reads via `useSetting`."
-  []
-  (let [meters (premium-features/locked-meters)]
-    (boolean (or (:transform-basic-runs meters)
-                 (:transform-advanced-runs meters)))))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -12,11 +12,11 @@
    [metabase.tracing.core :as tracing]
    [metabase.transforms-base.ordering :as transforms-base.ordering]
    [metabase.transforms.execute :as transforms.execute]
-   [metabase.transforms.feature-gating :as transforms.gating]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
    [metabase.transforms.settings :as transforms.settings]
+   [metabase.transforms.usage :as transforms.usage]
    [metabase.transforms.util :as transforms.u]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -86,7 +86,7 @@
     (not (transforms.u/check-feature-enabled transform))
     (log/warnf "Skip running transform %d due to lacking premium features" transform-id)
 
-    (transforms.gating/transform-locked? transform)
+    (transforms.usage/transform-locked? transform)
     (log/warnf "Skip running transform %d due to locked meter (trial quota exhausted)" transform-id)
 
     :else

--- a/src/metabase/transforms/settings.clj
+++ b/src/metabase/transforms/settings.clj
@@ -1,7 +1,7 @@
 (ns metabase.transforms.settings
   (:require
    [metabase.settings.core :as setting]
-   [metabase.transforms.feature-gating :as transforms.gating]
+   [metabase.transforms.usage :as transforms.usage]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (set! *warn-on-reflection* true)
@@ -35,4 +35,4 @@
   :export?    false
   :default    false
   :doc        false
-  :getter     transforms.gating/transforms-meter-locked?)
+  :getter     transforms.usage/transforms-meter-locked?)

--- a/src/metabase/transforms/usage.clj
+++ b/src/metabase/transforms/usage.clj
@@ -1,0 +1,35 @@
+(ns metabase.transforms.usage
+  "Meter-related limit checking for transforms"
+  (:require
+   [metabase.premium-features.core :as premium-features]
+   [metabase.transforms-base.util :as transforms-base.u]))
+
+(def ^:private metered-as->meter-key
+  "Map the bucket strings returned by [[premium-features/transform-metered-as]] to their
+   corresponding `:meters` keys in the harbormaster token-check response."
+  {"transform-basic"    :transform-basic-runs
+   "transform-advanced" :transform-advanced-runs})
+
+(defn transform-locked?
+  "True if the meter that would be charged for running this transform is locked.
+   Returns false for non-metered transforms (OSS, self-hosted basic-only) and when
+   no `:locked-meters` mirror has been written yet (cold cache, airgap)."
+  [transform]
+  (boolean
+   (when-let [meter-key (some-> (:source transform)
+                                transforms-base.u/transform-source-type
+                                premium-features/transform-metered-as
+                                metered-as->meter-key)]
+     (get (premium-features/locked-meters) meter-key))))
+
+(defn transforms-meter-locked?
+  "True if either of the two transforms meters (`:transform-basic-runs` or
+   `:transform-advanced-runs`) is currently locked. Per harbormaster's
+   mutual-exclusivity constraint, at most one of these is populated for a
+   given customer, so this aggregate reduces to 'is the customer's active
+   transforms meter, if any, locked?'. Backs the [[metabase.transforms.settings/transforms-meter-locked]]
+   setting, which the frontend reads via `useSetting`."
+  []
+  (let [meters (premium-features/locked-meters)]
+    (boolean (or (:transform-basic-runs meters)
+                 (:transform-advanced-runs meters)))))

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -9,7 +9,6 @@
    [metabase.transforms-rest.api.transform-job]
    [metabase.transforms-rest.api.transform-tag]
    [metabase.transforms.core :as transforms.core]
-   [metabase.transforms.feature-gating :as transforms.gating]
    [metabase.transforms.schema :as transforms.schema]
    [metabase.transforms.util :as transforms.u]
    [metabase.util.i18n :refer [deferred-tru]]
@@ -282,7 +281,7 @@
    The transform must already be fetched and validated."
   [transform]
   (transforms.core/check-feature-enabled! transform)
-  (api/check (not (transforms.gating/transform-locked? transform))
+  (api/check (not (transforms.core/transform-locked? transform))
              [402 {:message    (deferred-tru "Transforms are temporarily locked because the trial quota has been reached.")
                    :error-code "metabase_transforms_locked"}])
   (let [start-promise (promise)]

--- a/test/metabase/transforms/usage_test.clj
+++ b/test/metabase/transforms/usage_test.clj
@@ -1,10 +1,10 @@
-(ns metabase.transforms.feature-gating-test
+(ns metabase.transforms.usage-test
   (:require
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.transforms.core :as transforms]
-   [metabase.transforms.feature-gating :as transforms.gating]))
+   [metabase.transforms.usage :as transforms.usage]))
 
 (set! *warn-on-reflection* true)
 
@@ -21,7 +21,7 @@
     (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
                                                       :transform-advanced-runs true}]
       (with-mocked-routing! nil
-        #(is (false? (transforms.gating/transform-locked?
+        #(is (false? (transforms.usage/transform-locked?
                       {:source {:type "query"}})))))))
 
 (deftest transform-locked?-basic-bucket-test
@@ -30,16 +30,16 @@
       (fn []
         (testing "locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-            (is (true? (transforms.gating/transform-locked? {:source {:type "query"}})))))
+            (is (true? (transforms.usage/transform-locked? {:source {:type "query"}})))))
         (testing "unlocked"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs false}]
-            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))
+            (is (false? (transforms.usage/transform-locked? {:source {:type "query"}})))))
         (testing "missing → unlocked"
           (mt/with-temporary-setting-values [locked-meters {}]
-            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))
+            (is (false? (transforms.usage/transform-locked? {:source {:type "query"}})))))
         (testing "advanced-bucket lock does not bleed into basic"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-            (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))))))
+            (is (false? (transforms.usage/transform-locked? {:source {:type "query"}})))))))))
 
 (deftest transform-locked?-advanced-bucket-test
   (testing "advanced-bucket transform follows :transform-advanced-runs"
@@ -47,42 +47,42 @@
       (fn []
         (testing "python locked"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-            (is (true? (transforms.gating/transform-locked? {:source {:type "python"}})))))
+            (is (true? (transforms.usage/transform-locked? {:source {:type "python"}})))))
         (testing "python unlocked"
           (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs false}]
-            (is (false? (transforms.gating/transform-locked? {:source {:type "python"}})))))
+            (is (false? (transforms.usage/transform-locked? {:source {:type "python"}})))))
         (testing "basic-bucket lock does not bleed into advanced"
           (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-            (is (false? (transforms.gating/transform-locked? {:source {:type "python"}})))))))))
+            (is (false? (transforms.usage/transform-locked? {:source {:type "python"}})))))))))
 
 (deftest transform-locked?-non-transform-meter-ignored-test
   (testing "locks on non-transform meters (e.g. :metabase-ai-tokens) do not affect transforms"
     (with-mocked-routing! "transform-basic"
       #(mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
-         (is (false? (transforms.gating/transform-locked? {:source {:type "query"}})))))))
+         (is (false? (transforms.usage/transform-locked? {:source {:type "query"}})))))))
 
 (deftest transforms-meter-locked?-test
   (testing "FE-facing aggregate: locked iff either transforms meter is locked"
     (testing "no locks → false"
       (mt/with-temporary-setting-values [locked-meters {}]
-        (is (false? (transforms.gating/transforms-meter-locked?)))))
+        (is (false? (transforms.usage/transforms-meter-locked?)))))
     (testing "basic-bucket locked → true"
       (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs true}]
-        (is (true? (transforms.gating/transforms-meter-locked?)))))
+        (is (true? (transforms.usage/transforms-meter-locked?)))))
     (testing "advanced-bucket locked → true"
       (mt/with-temporary-setting-values [locked-meters {:transform-advanced-runs true}]
-        (is (true? (transforms.gating/transforms-meter-locked?)))))
+        (is (true? (transforms.usage/transforms-meter-locked?)))))
     (testing "both locked (defense-in-depth — harbormaster mutex says this can't happen) → still true"
       (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    true
                                                         :transform-advanced-runs true}]
-        (is (true? (transforms.gating/transforms-meter-locked?)))))
+        (is (true? (transforms.usage/transforms-meter-locked?)))))
     (testing "non-transform meter (e.g. :metabase-ai-tokens) does NOT affect transforms aggregate"
       (mt/with-temporary-setting-values [locked-meters {:metabase-ai-tokens true}]
-        (is (false? (transforms.gating/transforms-meter-locked?)))))
+        (is (false? (transforms.usage/transforms-meter-locked?)))))
     (testing "false values do not count as locked"
       (mt/with-temporary-setting-values [locked-meters {:transform-basic-runs    false
                                                         :transform-advanced-runs false}]
-        (is (false? (transforms.gating/transforms-meter-locked?)))))))
+        (is (false? (transforms.usage/transforms-meter-locked?)))))))
 
 (deftest transforms-meter-locked-setting-test
   (testing "the :transforms-meter-locked setting reflects the underlying transforms-meter-locked? predicate.


### PR DESCRIPTION
### Description

Follow up to https://github.com/metabase/metabase/pull/73622

A cycle got introduced into `transforms.feature-gating` from the above PR. This splits out the methods to a separate module focussed more on functionality related to meter usage, similar to `metabot.usage`.

For reviewers:
Is this naming appropriate (taking from the established naming in metabot)? Alternatives I was considering were `metering` or `meter-gating` (if we preferred more closely scoping this module to _only_ locking/disabling based on meter usage. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
