### PR TITLE
bump the version, new sdk

### DIFF
--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/custom-viz",
-  "version": "0.0.1-canary.16",
+  "version": "0.0.1-canary.17",
   "description": "Creating custom visualizations for Metabase",
   "type": "module",
   "bin": {

--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/custom-viz",
-  "version": "0.0.1-canary.17",
+  "version": "0.0.1-canary.18",
   "description": "Creating custom visualizations for Metabase",
   "type": "module",
   "bin": {

--- a/enterprise/frontend/src/custom-viz/tsconfig.lib.json
+++ b/enterprise/frontend/src/custom-viz/tsconfig.lib.json
@@ -1,5 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/index.ts", "src/column-types.ts", "src/format.ts", "src/measure-text.ts", "src/lib/**/*.ts", "src/types/**/*.ts", "src/vite-env.d.ts"],
+  "include": [
+    "src/index.ts",
+    "src/column-types.ts",
+    "src/define-config.tsx",
+    "src/format.ts",
+    "src/measure-text.ts",
+    "src/types/**/*.ts",
+    "src/vite-env.d.ts"
+  ],
   "exclude": ["node_modules", "dist", "src/types/_example*"]
 }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2407/custom-viz-plugins-fail-to-load-with-jsxruntime-error

### Description

### How to verify

### Demo


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
