### PR TITLE
test: add e2e regression for EMB-332 (#57028) multi-value contains chain filter

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -3,7 +3,8 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { questionAsPinMapWithTiles } from "e2e/test/scenarios/embedding/shared/embedding-questions";
 import { defer } from "metabase/utils/promise";
-const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID, FEEDBACK, FEEDBACK_ID } =
+  SAMPLE_DATABASE;
 
 describe("issue 15860", { tags: "@skip" }, () => {
   const q1IdFilter = {
@@ -1557,6 +1558,89 @@ describe("issue 63687", () => {
 
     cy.wait("@getTiles").then(({ response: tileResponse }) => {
       expect(tileResponse?.statusCode).to.equal(200);
+    });
+  });
+});
+
+describe("issue 57028", () => {
+  const lockedContainsBodyFilter = {
+    name: "locked_contains_body",
+    slug: "locked_contains_body",
+    id: "e6588080",
+    type: "string/contains",
+    sectionId: "string",
+    isMultiSelect: true,
+    values_query_type: "none",
+  };
+
+  const emailFilter = {
+    name: "Email",
+    slug: "email",
+    id: "d31e550f",
+    type: "string/=",
+    sectionId: "string",
+    values_query_type: "list",
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("static embedded editable filter should load dropdown values when a string/contains locked param has multiple values (metabase#57028)", () => {
+    H.createQuestionAndDashboard({
+      questionDetails: {
+        name: "Feedback",
+        query: { "source-table": FEEDBACK_ID },
+      },
+      dashboardDetails: {
+        parameters: [lockedContainsBodyFilter, emailFilter],
+        enable_embedding: true,
+        embedding_params: {
+          [lockedContainsBodyFilter.slug]: "locked",
+          [emailFilter.slug]: "enabled",
+        },
+      },
+    }).then(({ body: { card_id, dashboard_id } }) => {
+      H.addOrUpdateDashboardCard({
+        dashboard_id,
+        card_id,
+        card: {
+          parameter_mappings: [
+            {
+              card_id,
+              parameter_id: lockedContainsBodyFilter.id,
+              target: ["dimension", ["field", FEEDBACK.BODY, null]],
+            },
+            {
+              card_id,
+              parameter_id: emailFilter.id,
+              target: ["dimension", ["field", FEEDBACK.EMAIL, null]],
+            },
+          ],
+        },
+      });
+
+      cy.intercept(
+        "GET",
+        `/api/embed/dashboard/*/params/${emailFilter.id}/values`,
+      ).as("emailValues");
+
+      H.visitEmbeddedPage({
+        resource: { dashboard: dashboard_id },
+        params: {
+          [lockedContainsBodyFilter.slug]: ["March", "damp", "somewhat"],
+        },
+      });
+    });
+
+    H.filterWidget().contains("Email").click();
+
+    cy.wait("@emailValues").its("response.statusCode").should("eq", 200);
+
+    H.popover().within(() => {
+      cy.findByPlaceholderText("Search the list").should("be.visible");
+      cy.findAllByRole("checkbox").its("length").should("be.greaterThan", 0);
     });
   });
 });


### PR DESCRIPTION
closes EMB-332
Closes https://github.com/metabase/metabase/issues/57028

Since the actual fix was already there since 54, I just backport the test so we have it in the current release. I don't think we need to backport this more than that.

### Description

The bug was fixed by #58646 and released in 0.53.18. This PR adds the
repro to prevent future regressions.

The test follows [the instructions in this comment](https://github.com/metabase/metabase/issues/57028#issuecomment-3589848563). The test was verified to fail on `release-x.53.x` at commit [9b79cacf26f](https://github.com/metabase/metabase/commit/9b79cacf26f)
(parent of the backport), and passes on master.

### How to verify

- `bun run test-cypress`
- Suite: `embedding > issue 57028` in `e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js`
- Test should pass.

### Demo

#### Test on master
<img width="2585" height="1522" alt="Screenshot 2026-05-07 at 6 49 01 PM" src="https://github.com/user-attachments/assets/8511ca18-15bc-423f-b73d-1012cd45d1e7" />


#### Test at 9b79cacf26f

<img width="2585" height="1522" alt="Screenshot 2026-05-07 at 4 51 06 PM" src="https://github.com/user-attachments/assets/4f91027a-bb27-4f6c-af82-5e884b93858d" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)