### PR TITLE
Handle nil additional options in mysql can-connect?

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -218,7 +218,7 @@
   [driver details]
   ;; delegate to parent method to check whether we can connect; if so, check if it's an unsupported version and issue
   ;; a warning if it is
-  (let [match (re-find disallowed-additional-opts (:additional-options details ""))]
+  (let [match (some->> (:additional-options details) (re-find disallowed-additional-opts))]
     (when match
       (throw (ex-info "Potentially dangerous keys in additional options" {:disallowed-key match}))))
   (when ((get-method driver/can-connect? :sql-jdbc) driver details)

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1042,21 +1042,26 @@
               (jdbc/execute! spec "DROP USER IF EXISTS 'partial_revokes_test_user';"))))))))
 
 (deftest ^:parallel only-connect-when-non-malicious-properties
-  (testing "Reject connection strings with malicious properties"
-    (are [bad-option] (let [details (assoc (tx/dbdef->connection-details :mysql :db
-                                                                         {:database-name "argent"})
-                                           :additional-options bad-option)
-                            result (try (driver/can-connect? :mysql details)
-                                        ::did-not-throw
-                                        (catch Exception e e))]
-                        (is (instance? clojure.lang.ExceptionInfo result))
-                        (is (partial= {:cause "Potentially dangerous keys in additional options"}
-                                      (Throwable->map result))))
-      "allowLoadLocalInfile=true"
-      "allowLoadLocalInfileInPath=1"
-      "allowUrlInLocalInfile=1"
-      "autoDeserialize=1"
-      "serverRSAPublicKeyFile=/path/to/file")))
+  (mt/test-driver :mysql
+    (let [details (:details (mt/db))]
+      (testing "Reject connection strings with malicious properties"
+        (are [bad-option] (let [details (assoc details :additional-options bad-option)]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Potentially dangerous keys in additional options"
+                                                  (driver/can-connect? :mysql details))))
+          "allowLoadLocalInfile=true"
+          "allowLoadLocalInfileInPath=1"
+          "allowUrlInLocalInfile=1"
+          "autoDeserialize=1"
+          "serverRSAPublicKeyFile=/path/to/file"))
+      (testing "Allow connection strings with non-malicious properties"
+        (are [ok-option] (let [details (assoc details :additional-options ok-option)]
+                           (is (true? (driver/can-connect? :mysql details))))
+          nil
+          ""
+          " "
+          "tinyInt1isBit=1")
+        (is (true? (driver/can-connect? :mysql details)))))))
 
 (deftest ^:parallel set-role-statement-escape-quotes-test
   (mt/test-driver :mysql


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73804

### Description

The issue was introduced by https://github.com/metabase/metabase/pull/73510

Handles `nil` additional options to avoid calling the disallowed keys regex on `nil`. 

### How to verify

1. Set the DB details additional options field to `null` in your app DB.
2. Try to connect
3. See it failed before but succeeds now

### Demo

[loom](https://www.loom.com/share/31840dc78a0549b99ab237258a96c735)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
