### PR TITLE
Add batch_id to data complexity events

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -390,6 +390,7 @@
   Returns false when tracking is disabled or any emission failed."
   [{:keys [library universe metabot meta]}]
   (let [base   {:event           :data_complexity_scoring
+                :batch_id        (str (random-uuid))
                 :formula_version (:formula-version meta)
                 :parameters      (parameters-map meta)}
         events (for [[catalog result] [[:library library] [:universe universe] [:metabot metabot]]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -656,6 +656,12 @@
 
 (defn- snake [k] (-> k name (str/replace "-" "_")))
 
+(defn- uuid-string?
+  [s]
+  (try
+    (some? (java.util.UUID/fromString s))
+    (catch Exception _ false)))
+
 (defn- expected-keys-for-catalog
   "For a catalog result, return `#{[key score], ...}` matching what emit-snowplow! should emit:
    grand `total`, one `<group>.total` per group, and one `<group>.<leaf>` per sub-component."
@@ -793,9 +799,6 @@
           (is (every? #(= expected-model (get-in % ["parameters" "embedding_model"])) events))
           (is (every? #(= "names_split"  (get-in % ["parameters" "text_variant"])) events)))))))
 
-(def ^:private uuid-pattern
-  #"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-
 (deftest ^:sequential emit-snowplow-batch-id-test
   (testing "scoring stamps every event with a UUID batch_id, constant within a pass and fresh between passes"
     (snowplow-test/with-fake-snowplow-collector
@@ -813,7 +816,7 @@
                     (is (= {"library" 8 "universe" 8 "metabot" 8} catalogs))
                     (is (= (count events) (count event-keys)))
                     (is (= 1 (count batch-ids)))
-                    (is (every? #(re-matches uuid-pattern %) batch-ids))
+                    (is (every? uuid-string? batch-ids))
                     (first batch-ids)))]
           (complexity/complexity-scores :embedder nil)
           (let [batch-1 (drain-and-check-pass!)]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -656,12 +656,6 @@
 
 (defn- snake [k] (-> k name (str/replace "-" "_")))
 
-(defn- uuid-string?
-  [s]
-  (try
-    (some? (java.util.UUID/fromString s))
-    (catch Exception _ false)))
-
 (defn- expected-keys-for-catalog
   "For a catalog result, return `#{[key score], ...}` matching what emit-snowplow! should emit:
    grand `total`, one `<group>.total` per group, and one `<group>.<leaf>` per sub-component."
@@ -816,7 +810,7 @@
                     (is (= {"library" 8 "universe" 8 "metabot" 8} catalogs))
                     (is (= (count events) (count event-keys)))
                     (is (= 1 (count batch-ids)))
-                    (is (every? uuid-string? batch-ids))
+                    (is (every? parse-uuid batch-ids))
                     (first batch-ids)))]
           (complexity/complexity-scores :embedder nil)
           (let [batch-1 (drain-and-check-pass!)]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -793,6 +793,34 @@
           (is (every? #(= expected-model (get-in % ["parameters" "embedding_model"])) events))
           (is (every? #(= "names_split"  (get-in % ["parameters" "text_variant"])) events)))))))
 
+(def ^:private uuid-pattern
+  #"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+(deftest ^:sequential emit-snowplow-batch-id-test
+  (testing "scoring stamps every event with a UUID batch_id, constant within a pass and fresh between passes"
+    (snowplow-test/with-fake-snowplow-collector
+      (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs
+                                  (constantly {:library  [(entity :name "orders")]
+                                               :universe [(entity :name "orders")]
+                                               :metabot  [(entity :name "orders")]})]
+        (snowplow-test/pop-event-data-and-user-id!)
+        (letfn [(drain-and-check-pass! []
+                  (let [events     (complexity-events!)
+                        batch-ids  (set (map #(get % "batch_id") events))
+                        catalogs   (frequencies (map #(get % "catalog") events))
+                        event-keys (set (map (juxt #(get % "catalog") #(get % "key")) events))]
+                    ;; 1 grand total + 2 group totals + 5 leaves = 8 events per catalog.
+                    (is (= {"library" 8 "universe" 8 "metabot" 8} catalogs))
+                    (is (= (count events) (count event-keys)))
+                    (is (= 1 (count batch-ids)))
+                    (is (every? #(re-matches uuid-pattern %) batch-ids))
+                    (first batch-ids)))]
+          (complexity/complexity-scores :embedder nil)
+          (let [batch-1 (drain-and-check-pass!)]
+            (complexity/complexity-scores :embedder nil)
+            (let [batch-2 (drain-and-check-pass!)]
+              (is (not= batch-1 batch-2)))))))))
+
 (deftest ^:sequential emit-snowplow-failure-is-swallowed-test
   (testing "emission failure is caught; complexity-scores still returns the score and logs a warning"
     (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
@@ -27,7 +27,10 @@
         },
         "batch_id": {
             "description": "Unique identifier for the scoring run that emitted this event; consumers use it to group events from the same run.",
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "format": "uuid",
             "maxLength": 36
         },

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
@@ -11,6 +11,7 @@
     "additionalProperties": false,
     "required": [
         "event",
+        "batch_id",
         "catalog",
         "key",
         "formula_version",
@@ -27,10 +28,7 @@
         },
         "batch_id": {
             "description": "Unique identifier for the scoring run that emitted this event; consumers use it to group events from the same run.",
-            "type": [
-                "string",
-                "null"
-            ],
+            "type": "string",
             "format": "uuid",
             "maxLength": 36
         },

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
@@ -11,7 +11,6 @@
     "additionalProperties": false,
     "required": [
         "event",
-        "batch_id",
         "catalog",
         "key",
         "formula_version",
@@ -27,7 +26,7 @@
             "maxLength": 64
         },
         "batch_id": {
-            "description": "UUID identifying the scoring run that emitted this event.",
+            "description": "Unique identifier for the scoring run that emitted this event; consumers use it to group events from the same run.",
             "type": "string",
             "format": "uuid",
             "maxLength": 36

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
@@ -11,6 +11,7 @@
     "additionalProperties": false,
     "required": [
         "event",
+        "batch_id",
         "catalog",
         "key",
         "formula_version",
@@ -24,6 +25,12 @@
                 "data_complexity_scoring"
             ],
             "maxLength": 64
+        },
+        "batch_id": {
+            "description": "UUID identifying the scoring run that emitted this event.",
+            "type": "string",
+            "format": "uuid",
+            "maxLength": 36
         },
         "catalog": {
             "description": "Which catalog of the data layer was scored.",


### PR DESCRIPTION
I realized that we'll want an easy way to distinguish separate runs. Typically there will only be one run per day per fingerprint, but it can be triggered manually, and grouping by date is treachorous.

It's safe to update the schema in place because it's still in draft in Snowcatcloud.
