### PR TITLE
fix(sdk-bundle): Fix New question breadcrumb dead-end after Visualize in metabase-browser

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/metabase-browser.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/metabase-browser.cy.spec.ts
@@ -178,7 +178,41 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
       cy.findByTestId("sdk-breadcrumbs").findByText("New question").click();
 
       cy.findByText("Pick your starting data").should("be.visible");
-      cy.findByText("Orders").should("not.exist");
+      cy.findByTestId("data-step-cell").should("not.have.text", "Orders");
+    });
+  });
+
+  it("should reset `New question` editor state when clicking 'New question' breadcrumb after Visualize", () => {
+    H.prepareSdkIframeEmbedTest({
+      withToken: "bleeding-edge",
+      signOut: false,
+    });
+
+    setupEmbed(`
+        <metabase-browser
+          initial-collection="root"
+          read-only="false"
+        />
+      `);
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("New question").click();
+
+      cy.findByText("Pick your starting data").should("be.visible");
+
+      cy.intercept("POST", "/api/dataset/query_metadata").as("datasetMetadata");
+      cy.findByText("Orders").click();
+      cy.wait("@datasetMetadata");
+      cy.findByTestId("data-step-cell").should("have.text", "Orders");
+
+      cy.button("Visualize").click();
+      cy.findByTestId("visualization-root").should("be.visible");
+
+      cy.findByTestId("sdk-breadcrumbs").findByText("New question").click();
+
+      // Expected: editor reopens fresh, prior table cleared.
+      cy.findByText("Pick your starting data").should("be.visible");
+      cy.findByTestId("data-step-cell").should("not.have.text", "Orders");
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -120,29 +120,18 @@ export const SdkQuestionDefaultView = ({
     question && shouldRunCardQuery({ question, isGuestEmbed }) && !queryResults;
 
   useEffect(() => {
-    const isNewQuestion = originalId === "new" || originalId === "new-native";
-    const isExistingQuestion =
-      question &&
+    if (
       !isQuestionLoading &&
       question?.isSaved() &&
-      !isNewQuestion &&
-      queryResults;
-
-    const onNavigate = onNavigateBack ?? onReset ?? undefined;
-
-    if (isNewQuestion) {
-      reportLocation({
-        type: "question",
-        id: originalId,
-        name: "New question",
-        onNavigate,
-      });
-    } else if (isExistingQuestion) {
+      originalId !== "new" &&
+      originalId !== "new-native" &&
+      queryResults
+    ) {
       reportLocation({
         type: "question",
         id: question.id(),
         name: question.displayName() || "Question",
-        onNavigate,
+        onNavigate: onNavigateBack ?? onReset ?? undefined,
       });
     }
   }, [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -52,6 +52,8 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
     id: initialCollection,
   });
 
+  const [newQuestionKey, setNewQuestionKey] = useState(0);
+
   useMount(() => {
     if (navigationContext.stack.length === 0) {
       // Populate the initial entry of the stack when this is the root/starting point
@@ -84,6 +86,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
         .with({ type: "new-question" }, () => (
           <Box px="xl" h="100%">
             <InteractiveQuestion
+              key={newQuestionKey}
               questionId="new"
               height="100%"
               withDownloads
@@ -200,6 +203,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
 
   const handleNewQuestion = () => {
     setCurrentView({ type: "new-question" });
+    reportLocation({ type: "question", id: "new", name: "New question" });
   };
 
   // Only show "New question" button if user has write access and it's enabled
@@ -237,6 +241,12 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
                   for (let i = 0; i < count; i++) {
                     navigationContext.pop();
                   }
+                } else if (item.type === "question" && item.id === "new") {
+                  // EMB-1118 / EMB-1610: bump key to remount
+                  // InteractiveQuestion so the editor reopens fresh after
+                  // Visualize, with no stale queryResults.
+                  setNewQuestionKey((previousKey) => previousKey + 1);
+                  setCurrentView({ type: "new-question" });
                 }
               }}
             />


### PR DESCRIPTION
closes EMB-1610
Closes https://github.com/metabase/metabase/issues/72918

### Description

In the `<metabase-browser>` embed, clicking the **New question** breadcrumb after **Visualize** landed the user on a stale visualization / "execute your code" empty-state dead-end.

EMB-1118 / PR #67523 fixed the same dead-end for the pre-Visualize case (click the breadcrumb after picking a table but before visualizing). Post-Visualize was still broken.

This PR handles both cases at the wrapper layer: `MetabaseBrowser` now force-remounts `<InteractiveQuestion>` when the user clicks the **New question** breadcrumb, so the editor reopens fresh every time. Since the new approach also covers the pre-Visualize case, the old wiring from EMB-1118 is no longer needed and is reverted. The restricted-collection pieces from EMB-1118 stay.

#### Behavior change for the pre-Visualize flow

Previously, clicking the **New question** breadcrumb after picking a table cleared the data step but left the data picker closed. With the remount, the data picker now auto-opens — same starting state the user sees on the very first **New question** click. This is consistent with how the query builder is shown to everyone else in the product, so it actually feels more natural.

### How to verify

1. Embed `<metabase-browser initial-collection="root" read-only="false" />`.
2. Click **New question** → editor opens, "Pick your starting data" shown.
3. Pick **Orders** → click **Visualize** → results render.
4. Click the **New question** breadcrumb badge.
5. Editor reopens fresh; previous `Orders` selection cleared.
6. Repeat without **Visualize** (pre-Visualize path) — same reset behavior. Covered by e2e test `should reset 'New question' editor state when clicking 'New question' breadcrumb after selecting a filter` in `metabase-browser.cy.spec.ts`.

### Demo
#### After fix
<img width="1144" height="432" alt="Screenshot 2026-05-07 at 8 31 07 PM" src="https://github.com/user-attachments/assets/0047222c-4ca7-47aa-a065-cb33259109f8" />

#### Before fix (captured from the original reported Loom)
<img width="865" height="382" alt="image" src="https://github.com/user-attachments/assets/cbf4041f-6829-4ab4-891b-bc66602e28ce" /> 


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)