### PR TITLE
Add aliases to common actions in command palette

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -120,7 +120,7 @@ describe("command palette", () => {
 
       // When entering a query, if there are results that come before search results, highlight
       // the first action, otherwise, highlight the first search result
-      H.commandPaletteInput().clear().type("For");
+      H.commandPaletteInput().clear().type("Form");
       cy.findByRole("option", { name: "Performance" }).should(
         "have.attr",
         "aria-selected",
@@ -212,7 +212,7 @@ describe("command palette", () => {
 
         cy.findAllByRole("option")
           // filter out unrelated items, keep only options with data
-          .invoke("slice", 1, -2)
+          .invoke("slice", 3, -2)
           .should("have.length", results.length)
           .each(($option, index) => {
             cy.wrap($option).should("contain", results[index].name);

--- a/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
@@ -88,6 +88,41 @@ describe("command palette", () => {
     });
   });
 
+  it("should match the action with alias when typing original name", async () => {
+    setup();
+    await userEvent.keyboard("[ControlLeft>]k");
+    await screen.findByTestId("command-palette");
+    const input = await screen.findByPlaceholderText(/search for anything/i);
+
+    // Original shortcut name is "Create a question" but when registering action
+    // we rename it to "New question"
+    await userEvent.type(input, "create q");
+
+    expect(await screen.findByText("New question")).toBeInTheDocument();
+  });
+
+  it("should match actions via verb-swap aliases", async () => {
+    setup();
+    await userEvent.keyboard("[ControlLeft>]k");
+    await screen.findByTestId("command-palette");
+    const input = await screen.findByPlaceholderText(/search for anything/i);
+
+    await userEvent.type(input, "add dashboard");
+
+    expect(await screen.findByText("New dashboard")).toBeInTheDocument();
+  });
+
+  it("should tolerate small typos in the search query", async () => {
+    setup();
+    await userEvent.keyboard("[ControlLeft>]k");
+    await screen.findByTestId("command-palette");
+    const input = await screen.findByPlaceholderText(/search for anything/i);
+
+    await userEvent.type(input, "creat q");
+
+    expect(await screen.findByText("New question")).toBeInTheDocument();
+  });
+
   it("should preserve user navigation selection when search results load", async () => {
     const getSelectedOption = () =>
       screen

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -248,6 +248,8 @@ export const useCommandPaletteBasicActions = ({
     actions.push(
       {
         id: "navigate-user-settings",
+        section: "basic",
+        icon: "person",
         perform: () => dispatch(push("/account/profile")),
       },
       {
@@ -256,6 +258,8 @@ export const useCommandPaletteBasicActions = ({
       },
       {
         id: "navigate-home",
+        section: "basic",
+        icon: "home",
         perform: () => dispatch(push("/")),
       },
     );
@@ -263,6 +267,8 @@ export const useCommandPaletteBasicActions = ({
     if (hasDataStudioAccess) {
       actions.push({
         id: "navigate-data-studio",
+        section: "basic",
+        icon: "table",
         perform: () => dispatch(push("/data-studio")),
       });
     }

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -318,6 +318,7 @@ export const useCommandPaletteBasicActions = ({
     openActionModal.push({
       id: "create-action",
       name: t`New action`,
+      keywords: t`add action, create action`,
       section: "basic",
       icon: "bolt",
       perform: () => {

--- a/frontend/src/metabase/palette/hooks/useRegisterShortcut.tsx
+++ b/frontend/src/metabase/palette/hooks/useRegisterShortcut.tsx
@@ -11,6 +11,29 @@ export type RegisterShortcutProps = {
   perform: (action: ActionImpl, event?: KeyboardEvent) => void;
 } & Partial<ShortcutAction>;
 
+/**
+ * Combines `keywords` from the shortcut definition and the registration site,
+ * and — when the registration overrides `name` — also includes the original
+ * shortcut def name.
+ */
+export const composeKeywords = (
+  shortcutDef: { name?: string; keywords?: string } | undefined,
+  rest: { name?: string; keywords?: string },
+): string => {
+  const isNameOverridden =
+    shortcutDef?.name !== undefined &&
+    rest.name !== undefined &&
+    rest.name !== shortcutDef.name;
+
+  return [
+    shortcutDef?.keywords,
+    rest.keywords,
+    isNameOverridden ? shortcutDef?.name : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+};
+
 export const useRegisterShortcut = (
   shortcutsToRegister: RegisterShortcutProps[],
   deps: DependencyList = [],
@@ -31,6 +54,8 @@ export const useRegisterShortcut = (
           throw Error(`Unrecognized shortcut id ${id}`);
         }
 
+        const keywords = composeKeywords(shortcutDef, rest);
+
         return {
           ...shortcutDef,
           id,
@@ -41,6 +66,7 @@ export const useRegisterShortcut = (
             }
           },
           ...rest,
+          ...(keywords ? { keywords } : {}),
         };
       })
     : [];

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -132,18 +132,12 @@ export const globalShortcuts = {
     get name() {
       return t`Open trash`;
     },
-    get keywords() {
-      return t`go to trash, view trash`;
-    },
     shortcut: ["g t"],
     shortcutGroup: "global" as const,
   },
   "navigate-personal-collection": {
     get name() {
       return t`Open personal collection`;
-    },
-    get keywords() {
-      return t`go to personal collection, view personal collection`;
     },
     shortcut: ["g p"],
     shortcutGroup: "global" as const,
@@ -159,9 +153,6 @@ export const globalShortcuts = {
   "navigate-admin-settings": {
     get name() {
       return t`Go to admin`;
-    },
-    get keywords() {
-      return t`open admin, view admin, admin settings`;
     },
     shortcut: ["g a"],
     shortcutGroup: "global" as const,

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -5,12 +5,18 @@ export const globalShortcuts = {
     get name() {
       return t`Create a question`;
     },
+    get keywords() {
+      return t`add question`;
+    },
     shortcut: ["c q"],
     shortcutGroup: "global" as const,
   },
   "create-new-native-query": {
     get name() {
       return t`Create a native query`;
+    },
+    get keywords() {
+      return t`add native query, add SQL, create SQL, new SQL`;
     },
     shortcut: ["c n"],
     shortcutGroup: "global" as const,
@@ -19,12 +25,18 @@ export const globalShortcuts = {
     get name() {
       return t`Create a dashboard`;
     },
+    get keywords() {
+      return t`add dashboard`;
+    },
     shortcut: ["c d"],
     shortcutGroup: "global" as const,
   },
   "create-new-document": {
     get name() {
       return t`Create a document`;
+    },
+    get keywords() {
+      return t`add document`;
     },
     shortcut: ["c t"],
     shortcutGroup: "global" as const,
@@ -33,12 +45,18 @@ export const globalShortcuts = {
     get name() {
       return t`Create a collection`;
     },
+    get keywords() {
+      return t`add collection`;
+    },
     shortcut: ["c f"],
     shortcutGroup: "global" as const,
   },
   "create-new-model": {
     get name() {
       return t`Create a model`;
+    },
+    get keywords() {
+      return t`add model`;
     },
     shortcut: ["c m"],
     shortcutGroup: "global" as const,
@@ -47,12 +65,18 @@ export const globalShortcuts = {
     get name() {
       return t`Create a metric`;
     },
+    get keywords() {
+      return t`add metric`;
+    },
     shortcut: ["c k"],
     shortcutGroup: "global" as const,
   },
   "navigate-browse-database": {
     get name() {
       return t`Browse databases`;
+    },
+    get keywords() {
+      return t`go to databases, view databases, open databases`;
     },
     shortcut: ["g d"],
     shortcutGroup: "global" as const,
@@ -61,6 +85,9 @@ export const globalShortcuts = {
     get name() {
       return t`Browse models`;
     },
+    get keywords() {
+      return t`go to models, view models, open models`;
+    },
     shortcut: ["g m"],
     shortcutGroup: "global" as const,
   },
@@ -68,12 +95,18 @@ export const globalShortcuts = {
     get name() {
       return t`Browse metrics`;
     },
+    get keywords() {
+      return t`go to metrics, view metrics, open metrics`;
+    },
     shortcut: ["g k"],
     shortcutGroup: "global" as const,
   },
   "navigate-data-studio": {
     get name() {
       return t`Go to Data Studio`;
+    },
+    get keywords() {
+      return t`open data studio, view data studio`;
     },
     shortcut: ["g s"],
     shortcutGroup: "global" as const,
@@ -99,12 +132,18 @@ export const globalShortcuts = {
     get name() {
       return t`Open trash`;
     },
+    get keywords() {
+      return t`go to trash, view trash`;
+    },
     shortcut: ["g t"],
     shortcutGroup: "global" as const,
   },
   "navigate-personal-collection": {
     get name() {
       return t`Open personal collection`;
+    },
+    get keywords() {
+      return t`go to personal collection, view personal collection`;
     },
     shortcut: ["g p"],
     shortcutGroup: "global" as const,
@@ -121,6 +160,9 @@ export const globalShortcuts = {
     get name() {
       return t`Go to admin`;
     },
+    get keywords() {
+      return t`open admin, view admin, admin settings`;
+    },
     shortcut: ["g a"],
     shortcutGroup: "global" as const,
   },
@@ -129,6 +171,9 @@ export const globalShortcuts = {
     get name() {
       return t`Go to user settings`;
     },
+    get keywords() {
+      return t`open user settings, view user settings, account settings`;
+    },
     shortcut: ["g u"],
     shortcutGroup: "global" as const,
   },
@@ -136,6 +181,9 @@ export const globalShortcuts = {
   "navigate-home": {
     get name() {
       return t`Go to home`;
+    },
+    get keywords() {
+      return t`open home, view home`;
     },
     shortcut: ["g h"],
     shortcutGroup: "global" as const,

--- a/patches/kbar+0.1.0-beta.45.patch
+++ b/patches/kbar+0.1.0-beta.45.patch
@@ -715,6 +715,15 @@ index 0d3b4e7..0571622 100644
  }) : (function(o, m, k, k2) {
      if (k2 === undefined) k2 = k;
      o[k2] = m[k];
+@@ -51,7 +55,7 @@ var fuseOptions = {
+     ignoreLocation: true,
+     includeScore: true,
+     includeMatches: true,
+-    threshold: 0.2,
++    threshold: 0.35,
+     minMatchCharLength: 1,
+ };
+ function order(a, b) {
 @@ -195,7 +199,7 @@ function useInternalMatches(filtered, search, fuse) {
          matches = searchResults.map(function (_a) {
              var action = _a.item, score = _a.score;

--- a/patches/kbar+0.1.0-beta.45.patch
+++ b/patches/kbar+0.1.0-beta.45.patch
@@ -720,7 +720,7 @@ index 0d3b4e7..0571622 100644
      includeScore: true,
      includeMatches: true,
 -    threshold: 0.2,
-+    threshold: 0.35,
++    threshold: 0.3,
      minMatchCharLength: 1,
  };
  function order(a, b) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73550

### Description

* Adds keywords to common actions so they are more discoverable (i.e. "create question" query will now match "New question" action)
* Slightly relax matching threshold. After some testing I noticed that current setup isn't very forgiving to typos. E.g. "creat q" (missing 'e') won't match "Create a question" keyword. Unfortunately, kbar doesn't expose this as API, so I had to update our patch file. 

### How to verify

Describe the steps to verify that the changes are working as expected.

* Try typing "create question" in command palette -> see "New question" action matched
* Try typing "creat q" in command palette -> see "New question" action matched

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
