### PR TITLE
Do not run e2e tests when uberjar build fails

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,19 @@ jobs:
 
   e2e-tests:
     needs: [files-changed, uberjar]
-    if: always() && !cancelled() && needs.files-changed.result == 'success'
+    # Skip e2e tests when the uberjar build failed or was cancelled — the
+    # downstream tests can't fetch a missing artifact, and we don't want to
+    # mask the uberjar failure with a wave of misleading e2e errors. We still
+    # enter the workflow when uberjar is `skipped` (docs-only PRs), because
+    # the inner `skip` input handles that path and reports the required
+    # `e2e-tests-result` check as success. When the uberjar genuinely failed,
+    # this whole job is skipped, the inner required checks never report, and
+    # branch protection blocks the merge as pending.
+    if: |
+      always() && !cancelled() &&
+      needs.files-changed.result == 'success' &&
+      needs.uberjar.result != 'failure' &&
+      needs.uberjar.result != 'cancelled'
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,12 +51,8 @@ jobs:
   uberjar:
     needs: [files-changed]
     if: ${{ !cancelled() && !(needs.files-changed.outputs.documentation == 'true' && needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.frontend_all == 'false' && needs.files-changed.outputs.e2e_all == 'false') }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    steps:
-      - name: Force uberjar failure (DEV-1928 verification, REVERT BEFORE MERGE)
-        run: |
-          echo "Forcing uberjar failure to verify e2e skip behavior"
-          exit 1
+    uses: ./.github/workflows/uberjar.yml
+    secrets: inherit
 
   backend-tests:
     if: ${{ !cancelled() && needs.files-changed.result == 'success' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,8 +51,12 @@ jobs:
   uberjar:
     needs: [files-changed]
     if: ${{ !cancelled() && !(needs.files-changed.outputs.documentation == 'true' && needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.frontend_all == 'false' && needs.files-changed.outputs.e2e_all == 'false') }}
-    uses: ./.github/workflows/uberjar.yml
-    secrets: inherit
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    steps:
+      - name: Force uberjar failure (DEV-1928 verification, REVERT BEFORE MERGE)
+        run: |
+          echo "Forcing uberjar failure to verify e2e skip behavior"
+          exit 1
 
   backend-tests:
     if: ${{ !cancelled() && needs.files-changed.result == 'success' }}


### PR DESCRIPTION
Resolves DEV-1928

Behavior by uberjar.result:
  - success → e2e runs (unchanged)
  - skipped (docs-only) → e2e runs with skip=true, green stub fires (unchanged)
  - failure / cancelled → entire e2e-tests job skipped; inner required checks never
  report → branch protection holds them pending → merge blocked

Why negations, and not `== 'success'`? Preserves docs-only PRs — they need the innerstub to fire green so required checks pass.


## Test (temporary commit)
<img width="1195" height="577" alt="image" src="https://github.com/user-attachments/assets/5ba1cd3d-dae8-4a2f-9a63-e860cdc5b58d" />
