### PR TITLE
Fix price displayed for advanced transforms in upsell modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PurchaseAdvancedTransforms.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PurchaseAdvancedTransforms.unit.spec.tsx
@@ -11,7 +11,7 @@ import {
   createMockSettings,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
-import { mockAdvancedTransformsAddOn } from "metabase-types/api/mocks/add-ons";
+import { mockAdvancedTransformsCloudAddOn } from "metabase-types/api/mocks/add-ons";
 
 import { PurchaseAdvancedTransforms } from "./PurchaseAdvancedTransforms";
 
@@ -36,7 +36,7 @@ const setup = () => {
   renderWithProviders(
     <PurchaseAdvancedTransforms
       handleModalClose={handleModalClose}
-      addOn={mockAdvancedTransformsAddOn}
+      addOn={mockAdvancedTransformsCloudAddOn}
       freeUnitsIncluded
     />,
     {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/hooks/useTransformsBilling.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/hooks/useTransformsBilling.ts
@@ -36,14 +36,22 @@ export function useTransformsBilling() {
         product_type === "transforms-advanced-metered" && self_service,
     ) ?? false;
 
+  const instanceDeployment = isHosted ? "hosting" : "selfhosted";
+
   const basicTransformsAddOn = addOns?.find(
-    ({ active, product_type, self_service }) =>
-      active && self_service && product_type === "transforms-basic-metered",
+    ({ active, product_type, self_service, deployment }) =>
+      active &&
+      self_service &&
+      product_type === "transforms-basic-metered" &&
+      deployment === instanceDeployment,
   );
 
   const advancedTransformsAddOn = addOns?.find(
-    ({ active, product_type, self_service }) =>
-      active && self_service && product_type === "transforms-advanced-metered",
+    ({ active, product_type, self_service, deployment }) =>
+      active &&
+      self_service &&
+      product_type === "transforms-advanced-metered" &&
+      deployment === instanceDeployment,
   );
 
   return {

--- a/frontend/src/metabase-types/api/mocks/add-ons.ts
+++ b/frontend/src/metabase-types/api/mocks/add-ons.ts
@@ -1,6 +1,28 @@
 import type { ICloudAddOnProduct } from "metabase-types/api";
 
-export const mockAdvancedTransformsAddOn: ICloudAddOnProduct = {
+export const mockAdvancedTransformsSelfHostedAddOn: ICloudAddOnProduct = {
+  description: "Advanced Transforms Add-on (self-hosted) (Monthly)-  metered",
+  name: "Advanced Transforms Add-on (self-hosted) metered",
+  self_service: true,
+  trial_days: 0,
+  short_name: "Advanced Transforms (self-hosted) - metered",
+  is_metered: true,
+  product_type: "transforms-advanced-metered",
+  default_total_units: 1,
+  free_units: 1000,
+  billing_period_months: 1,
+  default_base_fee: 0,
+  active: true,
+  id: 110,
+  deployment: "selfhosted",
+  token_features: ["transforms-python", "transforms-basic"],
+  default_included_units: 0,
+  default_price_per_unit: 0.01,
+  product_tiers: [],
+  default_prepaid_units: 1,
+};
+
+export const mockAdvancedTransformsCloudAddOn: ICloudAddOnProduct = {
   active: true,
   billing_period_months: 1,
   default_base_fee: 0,
@@ -125,7 +147,11 @@ export function createMockCloudAddOns(
 
     // transforms
     {
-      ...mockAdvancedTransformsAddOn,
+      ...mockAdvancedTransformsSelfHostedAddOn,
+      billing_period_months,
+    },
+    {
+      ...mockAdvancedTransformsCloudAddOn,
       billing_period_months,
     },
   ];

--- a/frontend/test/__support__/server-mocks/store.ts
+++ b/frontend/test/__support__/server-mocks/store.ts
@@ -3,7 +3,7 @@ import { match } from "ts-pattern";
 
 import {
   createMockCloudAddOns,
-  mockAdvancedTransformsAddOn,
+  mockAdvancedTransformsCloudAddOn,
 } from "metabase-types/api/mocks/add-ons";
 import type { AddOnProductType } from "metabase-types/api/store";
 
@@ -52,7 +52,7 @@ export function setupBillingEndpoints({
     ...(hasAdvancedTransformsAddOn
       ? [
           {
-            ...mockAdvancedTransformsAddOn,
+            ...mockAdvancedTransformsCloudAddOn,
             billing_period_months: billingPeriodMonths,
           },
         ]


### PR DESCRIPTION
### Description

Fix issue where self-hosted advanced transforms price is displayed on cloud instances.

The logic was: we display the price for the first "transforms-advanced-metered" add-on we find. When the self-hosted version of the advanced transforms add-on comes before cloud one, we'd show that price, even on a cloud instance.

The order of the add-ons is different on cloud compared to `hma-mb` which is probably why we missed this.

### How to verify

1. Locally change the add-ons data so it matches that from a staging instance
2. Verify the basic transforms upsell still shows the correct per-run price (1c)
3. Navigate to the cloud advanced transforms upsell modal
4. Verify the per-run price for advanced transforms is correct (2c)

We don't show transforms prices for self-hosted. We just take people to the store.

<details>
<summary>
This is what /add-ons returns on a cloud staging instance
</summary>

```
[
    {
        "description": null,
        "trialup_to_product_id": null,
        "name": "Metabase ETL Connections (Monthly)",
        "hosting_features": [
            "etl-connections",
            "metabase-api-key"
        ],
        "self_service": true,
        "trial_days": null,
        "invoiceable_counterpart": null,
        "short_name": "ETL Connections (Monthly)",
        "is_metered": null,
        "product_type": "etl-connections",
        "default_total_units": 1,
        "alias": "etl-connections",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 55,
        "deployment": "all",
        "token_features": [
            "etl-connections"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": null,
        "trialup_to_product_id": null,
        "name": "Metabase ETL Connections (Yearly)",
        "hosting_features": [
            "etl-connections",
            "metabase-api-key"
        ],
        "self_service": true,
        "trial_days": null,
        "invoiceable_counterpart": null,
        "short_name": "ETL Connections (Yearly)",
        "is_metered": null,
        "product_type": "etl-connections",
        "default_total_units": 1,
        "alias": "etl-connections-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 0,
        "active": true,
        "id": 56,
        "deployment": "all",
        "token_features": [
            "etl-connections"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": null,
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Selfhosted Add-on (Yearly) (Free)",
        "hosting_features": [
            "advanced-transforms"
        ],
        "self_service": true,
        "trial_days": 0,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms Selfhosted (Yearly) (Free)",
        "is_metered": false,
        "product_type": "transforms-advanced-free",
        "default_total_units": 99999999999,
        "alias": "advanced-transforms-self-hosted-yearly-free",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 0,
        "active": true,
        "id": 168,
        "deployment": "selfhosted",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 99999999999,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 0
    },
    {
        "description": "Advanced Transforms Add-on (self-hosted) (Monthly)-  metered",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on (self-hosted) metered",
        "hosting_features": [
            "transforms",
            "advanced-transforms"
        ],
        "self_service": true,
        "trial_days": 0,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms (self-hosted) - metered",
        "is_metered": true,
        "product_type": "transforms-advanced-metered",
        "default_total_units": 1,
        "alias": "transforms-advanced-metered-self-hosted",
        "free_units": 1000,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 110,
        "deployment": "selfhosted",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.01,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "basic Transforms Add-on (Monthly)-  metered",
        "trialup_to_product_id": null,
        "name": "Basic Transforms Add-on metered",
        "hosting_features": [
            "transforms-basic"
        ],
        "self_service": true,
        "trial_days": 0,
        "invoiceable_counterpart": null,
        "short_name": "Basic Transforms - metered",
        "is_metered": true,
        "product_type": "transforms-basic-metered",
        "default_total_units": 1,
        "alias": "transforms-basic-metered",
        "free_units": 1000,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 106,
        "deployment": "hosting",
        "token_features": [
            "transforms-basic"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.01,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "basic Transforms Add-on (Monthly)",
        "trialup_to_product_id": null,
        "name": "Basic Transforms Add-on",
        "hosting_features": [
            "transforms-basic"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Basic Transforms",
        "is_metered": false,
        "product_type": "transforms-basic",
        "default_total_units": 1,
        "alias": "transforms-basic",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 100,
        "active": true,
        "id": 100,
        "deployment": "hosting",
        "token_features": [
            "transforms-basic"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "basic Transforms Add-on (Yearly)",
        "trialup_to_product_id": null,
        "name": "Basic Transforms Add-on Yearly",
        "hosting_features": [
            "transforms-basic"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Basic Transforms",
        "is_metered": false,
        "product_type": "transforms-basic",
        "default_total_units": 1,
        "alias": "transforms-basic-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 1080,
        "active": true,
        "id": 101,
        "deployment": "hosting",
        "token_features": [
            "transforms-basic"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "Advanced Transforms Add-on (Monthly)",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on",
        "hosting_features": [
            "transforms",
            "python-runner",
            "transforms-advanced"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms",
        "is_metered": false,
        "product_type": "transforms-advanced",
        "default_total_units": 1,
        "alias": "transforms-advanced",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 250,
        "active": true,
        "id": 102,
        "deployment": "hosting",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "Metabase Cloud Storage Add-on",
        "trialup_to_product_id": null,
        "name": "Metabase Cloud Storage Add-on",
        "hosting_features": [
            "clickhouse-dwh",
            "metabase-api-key"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Cloud Storage",
        "is_metered": null,
        "product_type": "dwh",
        "default_total_units": 500000,
        "alias": "dwh",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 53,
        "deployment": "hosting",
        "token_features": [
            "attached-dwh",
            "upload-management"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.00008,
        "product_tiers": [],
        "default_prepaid_units": 500000
    },
    {
        "description": "Metabase Cloud Storage Add-on",
        "trialup_to_product_id": null,
        "name": "Metabase Cloud Storage Add-on",
        "hosting_features": [
            "clickhouse-dwh",
            "metabase-api-key"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Cloud Storage",
        "is_metered": null,
        "product_type": "dwh",
        "default_total_units": 500000,
        "alias": "dwh-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 0,
        "active": true,
        "id": 54,
        "deployment": "hosting",
        "token_features": [
            "attached-dwh",
            "upload-management"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.000864,
        "product_tiers": [],
        "default_prepaid_units": 500000
    },
    {
        "description": "Advanced Transforms Add-on (self-hosted) (Monthly)",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on (self-hosted)",
        "hosting_features": [
            "transforms",
            "advanced-transforms"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms (self-hosted)",
        "is_metered": false,
        "product_type": "transforms-advanced",
        "default_total_units": 1,
        "alias": "advanced-transforms-self-hosted",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 100,
        "active": true,
        "id": 104,
        "deployment": "selfhosted",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "Advanced Transforms Add-on (self-hosted) (Yearly)",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on (self-hosted)",
        "hosting_features": [
            "transforms",
            "advanced-transforms"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms (self-hosted)",
        "is_metered": false,
        "product_type": "transforms-advanced",
        "default_total_units": 1,
        "alias": "advanced-transforms-self-hosted-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 1080,
        "active": true,
        "id": 105,
        "deployment": "selfhosted",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "Metabase AI Managed Add-on",
        "trialup_to_product_id": null,
        "name": "Metabase AI Managed",
        "hosting_features": [
            "metabase-ai-managed"
        ],
        "self_service": true,
        "trial_days": 0,
        "invoiceable_counterpart": null,
        "short_name": "Metabase AI Managed",
        "is_metered": true,
        "product_type": "metabase-ai-managed",
        "default_total_units": 1,
        "alias": "metabase-ai-managed",
        "free_units": 1000000,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 133,
        "deployment": "hosting",
        "token_features": [
            "semantic-search",
            "ai-sql-generation",
            "metabase-ai-managed",
            "ai-sql-fixer",
            "ai-entity-analysis",
            "sso-slack",
            "metabot-v3"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.00000375,
        "product_tiers": [],
        "default_prepaid_units": 0
    },
    {
        "description": "Metabase AI Add-on (tiered)",
        "trialup_to_product_id": null,
        "name": "Metabase AI (tiered)",
        "hosting_features": [
            "metabase-ai",
            "semantic-search-db"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Metabase AI (tiered)",
        "is_metered": false,
        "product_type": "metabase-ai-tiered",
        "default_total_units": 500,
        "alias": "metabase-ai-tiered",
        "free_units": null,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 65,
        "deployment": "all",
        "token_features": [
            "semantic-search",
            "ai-sql-generation",
            "ai-sql-fixer",
            "ai-entity-analysis",
            "sso-slack",
            "metabot-v3"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.2,
        "product_tiers": [
            {
                "id": 1,
                "is_default": true,
                "name": "Small",
                "price": 100,
                "quantity": 500
            },
            {
                "id": 2,
                "is_default": false,
                "name": "Medium",
                "price": 300,
                "quantity": 1500
            },
            {
                "id": 3,
                "is_default": false,
                "name": "Large",
                "price": 500,
                "quantity": 2500
            }
        ],
        "default_prepaid_units": 500
    },
    {
        "description": "Metabase AI Add-on (tiered)",
        "trialup_to_product_id": null,
        "name": "Metabase AI (tiered)",
        "hosting_features": [
            "metabase-ai",
            "semantic-search-db"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Metabase AI (tiered)",
        "is_metered": false,
        "product_type": "metabase-ai-tiered",
        "default_total_units": 6000,
        "alias": "metabase-ai-tiered-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 0,
        "active": true,
        "id": 66,
        "deployment": "all",
        "token_features": [
            "semantic-search",
            "ai-sql-generation",
            "ai-sql-fixer",
            "ai-entity-analysis",
            "sso-slack",
            "metabot-v3"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.18,
        "product_tiers": [
            {
                "id": 4,
                "is_default": true,
                "name": "Small",
                "price": 1080,
                "quantity": 6000
            },
            {
                "id": 5,
                "is_default": false,
                "name": "Medium",
                "price": 3240,
                "quantity": 18000
            },
            {
                "id": 6,
                "is_default": false,
                "name": "Large",
                "price": 5400,
                "quantity": 30000
            }
        ],
        "default_prepaid_units": 6000
    },
    {
        "description": "Advanced Transforms Add-on (Yearly)",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on",
        "hosting_features": [
            "transforms",
            "python-runner",
            "transforms-advanced"
        ],
        "self_service": true,
        "trial_days": 14,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms",
        "is_metered": false,
        "product_type": "transforms-advanced",
        "default_total_units": 1,
        "alias": "transforms-advanced-yearly",
        "free_units": null,
        "billing_period_months": 12,
        "default_base_fee": 2700,
        "active": true,
        "id": 103,
        "deployment": "hosting",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0,
        "product_tiers": [],
        "default_prepaid_units": 1
    },
    {
        "description": "Advanced Transforms Add-on (Monthly)-  metered",
        "trialup_to_product_id": null,
        "name": "Advanced Transforms Add-on metered",
        "hosting_features": [
            "transforms",
            "python-runner",
            "transforms-advanced"
        ],
        "self_service": true,
        "trial_days": 0,
        "invoiceable_counterpart": null,
        "short_name": "Advanced Transforms - metered",
        "is_metered": true,
        "product_type": "transforms-advanced-metered",
        "default_total_units": 1,
        "alias": "transforms-advanced-metered",
        "free_units": 1000,
        "billing_period_months": 1,
        "default_base_fee": 0,
        "active": true,
        "id": 108,
        "deployment": "hosting",
        "token_features": [
            "transforms-python",
            "transforms-basic",
            "writable-connection"
        ],
        "default_included_units": 0,
        "default_price_per_unit": 0.02,
        "product_tiers": [],
        "default_prepaid_units": 1
    }
]
```
</details>

### Demo

**BEFORE (incorrectly showing 1c for advanced)**
<img width="955" height="521" alt="CleanShot 2026-05-07 at 08 42 44" src="https://github.com/user-attachments/assets/97d0f5eb-b25c-4dcd-9bca-038d78b62abc" />

**AFTER (basic, right price - 1c)**
<img width="1312" height="736" alt="Screenshot 2026-05-07 at 12 27 44 PM" src="https://github.com/user-attachments/assets/b89c3118-2c29-4e8d-b9ef-bc2a5649197c" />

**AFTER (advanced, right price - 2c)**
<img width="1312" height="736" alt="Screenshot 2026-05-07 at 12 27 53 PM" src="https://github.com/user-attachments/assets/6b47274b-5f6d-404e-b6cf-8ac3a4d00e41" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [na] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
