### PR TITLE
Fix the release-log workflow

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -40,10 +40,14 @@ jobs:
         with:
           ref: master # this only works on master
           fetch-depth: 0 # we want all branches and tags
-      - name: Install Dependencies
-        run: yarn --cwd release --frozen-lockfile && npm i -g tsx
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.7"
+          token: ${{ github.token }}
       - name: Build release scripts
-        run: yarn --cwd release build
+        run: cd ${{ github.workspace }}/release && bun install --frozen-lockfile && bun run build
+      - name: Install tsx
+        run: npm i -g tsx
       - name: Get version number
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Resolves DEV-1932

## Test

Temporary commit shows that both bun and tsx install properly.
https://github.com/metabase/metabase/actions/runs/25506921441/job/74854992596