### PR TITLE
Allow impersonated set operations like union, intersect, and except

### DIFF
--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1615,7 +1615,8 @@ def is_single_stmt_of_type(sql: str, stmt_type: str = "read", dialect: str = Non
     result = {"is_single_stmt?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)
-        allowed_types = (exp.Select,) if stmt_type == "read" else (exp.Update, exp.Insert, exp.Delete)
+        allowed_types = (exp.Select, exp.SetOperation)
+        if stmt_type != "read": allowed_types = (exp.Update, exp.Insert, exp.Delete)
         if len(stmts) == 1 and isinstance(stmts[0], allowed_types):
             result["is_single_stmt?"] = True
             result["sql"] = stmts[0].sql(dialect=dialect) if dialect else stmts[0].sql()

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -215,4 +215,18 @@
         "UPDATE table SET column = 1; SELECT 1"
         "DELETE FROM table WHERE id = 1; SELECT 1"
         "SET ROLE NONE; INSERT INTO table VALUES (1)"
-        "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1"))))
+        "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1"))
+    (testing "A single set operation statement returns true and the reconstructed SQL"
+      (doseq [op ["UNION" "INTERSECT" "EXCEPT" "UNION ALL" "INTERSECT ALL" "EXCEPT ALL"]
+              ts [["foo" "bar"] ["foo" "bar" "baz"]]
+              :let [sql (str/join (str " " op " ") (map #(str "SELECT * FROM " %) ts))]]
+        (is (=? {:is-single-stmt? true, :sql string?}
+                (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))))
+      (are [sql] (=? {:is-single-stmt? true, :sql string?}
+                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
+        "SELECT * FROM foo UNION SELECT * FROM bar INTERSECT SELECT * FROM baz"
+        "SELECT * FROM foo UNION SELECT * FROM bar EXCEPT SELECT * FROM baz"
+        "SELECT * FROM foo INTERSECT SELECT * FROM bar UNION SELECT * FROM baz"
+        "SELECT * FROM foo INTERSECT SELECT * FROM bar EXCEPT SELECT * FROM baz"
+        "SELECT * FROM foo EXCEPT SELECT * FROM bar UNION SELECT * FROM baz"
+        "SELECT * FROM foo EXCEPT SELECT * FROM bar INTERSECT SELECT * FROM baz"))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -217,16 +217,16 @@
         "SET ROLE NONE; INSERT INTO table VALUES (1)"
         "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1"))
     (testing "A single set operation statement returns true and the reconstructed SQL"
-      (doseq [op ["UNION" "INTERSECT" "EXCEPT" "UNION ALL" "INTERSECT ALL" "EXCEPT ALL"]
+      (doseq [op ["UNION ALL" "INTERSECT ALL" "EXCEPT ALL"]
               ts [["foo" "bar"] ["foo" "bar" "baz"]]
               :let [sql (str/join (str " " op " ") (map #(str "SELECT * FROM " %) ts))]]
         (is (=? {:is-single-stmt? true, :sql string?}
                 (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))))
       (are [sql] (=? {:is-single-stmt? true, :sql string?}
                      (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
-        "SELECT * FROM foo UNION SELECT * FROM bar INTERSECT SELECT * FROM baz"
-        "SELECT * FROM foo UNION SELECT * FROM bar EXCEPT SELECT * FROM baz"
-        "SELECT * FROM foo INTERSECT SELECT * FROM bar UNION SELECT * FROM baz"
-        "SELECT * FROM foo INTERSECT SELECT * FROM bar EXCEPT SELECT * FROM baz"
-        "SELECT * FROM foo EXCEPT SELECT * FROM bar UNION SELECT * FROM baz"
-        "SELECT * FROM foo EXCEPT SELECT * FROM bar INTERSECT SELECT * FROM baz"))))
+        "SELECT * FROM foo UNION ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"
+        "SELECT * FROM foo UNION ALL SELECT * FROM bar EXCEPT ALL SELECT * FROM baz"
+        "SELECT * FROM foo INTERSECT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
+        "SELECT * FROM foo INTERSECT ALL SELECT * FROM bar EXCEPT ALL SELECT * FROM baz"
+        "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
+        "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))


### PR DESCRIPTION
Closes [QUE2-567](https://linear.app/metabase/issue/QUE2-567/dbs-with-impersonation-cannot-execute-set-operation-queries)

### Description

We were being too restrictive with the impersonated queries we allowed. Queries with top level set operations like union, intersect and except were being rejected. The fix is to allow these set operations in impersonated queries. 

### How to verify

1. Set up impersonation
2. Try to execute a query with a union
3. Before it was rejected, now it is allowed

### Demo

[loom](https://www.loom.com/share/6947e105a527473bb8d983b05c1e2121)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
