### PR TITLE
[UXW-3795] Setting visualization options on dashboard cards breaks error messages

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -279,10 +279,12 @@ export function DashCardVisualization({
   );
 
   const visualizerErrMsg = useMemo(() => {
-    // If the dashcard couldn't be loaded (e.g. permission denied), skip the
+    // If the user can't view the underlying card (permission denied), skip the
     // missing-columns check. Every column would look "missing" when there is
-    // no data, and that would mask the real error message.
-    if (error != null) {
+    // no data, and that would mask the real "no permission" message. Other
+    // errors (e.g. SQL failures in one of several sources) still get the
+    // missing-columns hint, since the visualizer can partially render.
+    if (error?.icon === "key") {
       return;
     }
     if (

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -290,11 +290,8 @@ export function DashCardVisualization({
     ) {
       return;
     }
-    // If the user can't view the underlying card (permission denied), skip the
-    // missing-columns check. Every column would look "missing" when there is
-    // no data, and that would mask the real "no permission" message. Other
-    // errors (e.g. SQL failures in one of several sources) still get the
-    // missing-columns hint, since the visualizer can partially render.
+    // Skip when access is denied; the permission message would otherwise be
+    // masked by "Some columns are missing".
     if (isDashcardAccessRestricted(rawSeries)) {
       return;
     }
@@ -363,11 +360,7 @@ export function DashCardVisualization({
     );
 
     if (!everyDatasetLoaded) {
-      // Return a series without a `data` payload so the parent <Visualization>
-      // renders its `error` prop (e.g. permission-denied) or its loading view.
-      // Don't substitute an empty `{ cols: [], rows: [] }` here — that would
-      // flip `isLoading` to false and render <NoResultsView> for the
-      // genuinely-loading case where no error is set yet.
+      // No `data` so the parent <Visualization> picks its error or loading view.
       return [{ card }] as RawSeries;
     }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -16,7 +16,10 @@ import {
   getDashCardInlineValuePopulatedParameters,
   getDashcardData,
 } from "metabase/dashboard/selectors";
-import { getVirtualCardType } from "metabase/dashboard/utils";
+import {
+  getVirtualCardType,
+  isDashcardAccessRestricted,
+} from "metabase/dashboard/utils";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
@@ -279,20 +282,20 @@ export function DashCardVisualization({
   );
 
   const visualizerErrMsg = useMemo(() => {
-    // If the user can't view the underlying card (permission denied), skip the
-    // missing-columns check. Every column would look "missing" when there is
-    // no data, and that would mask the real "no permission" message. Other
-    // errors (e.g. SQL failures in one of several sources) still get the
-    // missing-columns hint, since the visualizer can partially render.
-    if (error?.icon === "key") {
-      return;
-    }
     if (
       !dashcard ||
       !rawSeries ||
       rawSeries.length === 0 ||
       !isVisualizerDashboardCard(dashcard)
     ) {
+      return;
+    }
+    // If the user can't view the underlying card (permission denied), skip the
+    // missing-columns check. Every column would look "missing" when there is
+    // no data, and that would mask the real "no permission" message. Other
+    // errors (e.g. SQL failures in one of several sources) still get the
+    // missing-columns hint, since the visualizer can partially render.
+    if (isDashcardAccessRestricted(rawSeries)) {
       return;
     }
 
@@ -304,7 +307,7 @@ export function DashCardVisualization({
     if (missingCols.flat().length > 0) {
       return t`Some columns are missing, this card might not render correctly.`;
     }
-  }, [dashcard, rawSeries, error]);
+  }, [dashcard, rawSeries]);
 
   const untranslatedSeries = useMemo(() => {
     if (

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -279,6 +279,12 @@ export function DashCardVisualization({
   );
 
   const visualizerErrMsg = useMemo(() => {
+    // If the dashcard couldn't be loaded (e.g. permission denied), skip the
+    // missing-columns check. Every column would look "missing" when there is
+    // no data, and that would mask the real error message.
+    if (error != null) {
+      return;
+    }
     if (
       !dashcard ||
       !rawSeries ||
@@ -296,7 +302,7 @@ export function DashCardVisualization({
     if (missingCols.flat().length > 0) {
       return t`Some columns are missing, this card might not render correctly.`;
     }
-  }, [dashcard, rawSeries]);
+  }, [dashcard, rawSeries, error]);
 
   const untranslatedSeries = useMemo(() => {
     if (
@@ -330,9 +336,10 @@ export function DashCardVisualization({
       ]),
     );
 
-    const didEveryDatasetLoad = dataSources.every(
-      (dataSource) => dataSourceDatasets[dataSource.id] != null,
-    );
+    const everyDatasetLoaded = dataSources.every((dataSource) => {
+      const dataset = dataSourceDatasets[dataSource.id];
+      return dataset != null && dataset.error == null;
+    });
 
     const columns = getVisualizationColumns(
       visualizerEntity,
@@ -350,7 +357,12 @@ export function DashCardVisualization({
       _.omit(dashcard.visualization_settings, "visualization"),
     );
 
-    if (!didEveryDatasetLoad) {
+    if (!everyDatasetLoaded) {
+      // Return a series without a `data` payload so the parent <Visualization>
+      // renders its `error` prop (e.g. permission-denied) or its loading view.
+      // Don't substitute an empty `{ cols: [], rows: [] }` here — that would
+      // flip `isLoading` to false and render <NoResultsView> for the
+      // genuinely-loading case where no error is set yet.
       return [{ card }] as RawSeries;
     }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -21,6 +21,7 @@ import {
   createMockDashboardState,
   createMockState,
 } from "metabase/redux/store/mocks";
+import { SERVER_ERROR_TYPES } from "metabase/utils/errors";
 import registerVisualizations from "metabase/visualizations/register";
 import type { DashCardDataMap } from "metabase-types/api";
 import {
@@ -305,7 +306,7 @@ describe("DashCard", () => {
 
   const permissionDeniedDataset = createMockDataset({
     error: { status: 403 },
-    error_type: "missing-required-permissions",
+    error_type: SERVER_ERROR_TYPES.missingPermissions,
   });
 
   it("should show the permission-denied message on a visualizer dashcard the user cannot read", () => {
@@ -363,7 +364,6 @@ describe("DashCard", () => {
         name: "Public Source",
         display: "table",
       }),
-      // Second underlying source — the user CAN see this one
       series: [
         createMockCard({
           id: deniedSourceCardId,

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -303,6 +303,115 @@ describe("DashCard", () => {
     expect(screen.queryByLabelText("Replace")).not.toBeInTheDocument();
   });
 
+  const permissionDeniedDataset = createMockDataset({
+    error: { status: 403 },
+    error_type: "missing-required-permissions",
+  });
+
+  it("should show the permission-denied message on a visualizer dashcard the user cannot read", () => {
+    const visualizerDashcard = createMockDashboardCard({
+      card: createMockCard({
+        name: "Private Card",
+        display: "table",
+      }),
+      visualization_settings: {
+        visualization: {
+          display: "table",
+          columns: [],
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: `card:${tableDashcard.card.id}`,
+                originalName: "SUBTOTAL",
+                name: "COLUMN_1",
+              },
+            ],
+          },
+          settings: {},
+        },
+      },
+    });
+    const permissionDeniedData: DashCardDataMap = {
+      [visualizerDashcard.id]: {
+        [visualizerDashcard.card.id]: permissionDeniedDataset,
+      },
+    };
+
+    setup({
+      dashboard: {
+        ...testDashboard,
+        dashcards: [visualizerDashcard],
+      },
+      dashcard: visualizerDashcard,
+      dashcardData: permissionDeniedData,
+    });
+
+    expect(
+      screen.getByText("Sorry, you don't have permission to see this card."),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/Some columns are missing/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the permission-denied message on a multi-source visualizer dashcard when any source is denied", () => {
+    const allowedSourceCardId = 9000;
+    const deniedSourceCardId = 9001;
+    const visualizerDashcard = createMockDashboardCard({
+      card: createMockCard({
+        id: allowedSourceCardId,
+        name: "Public Source",
+        display: "table",
+      }),
+      // Second underlying source — the user CAN see this one
+      series: [
+        createMockCard({
+          id: deniedSourceCardId,
+          name: "Private Source",
+          display: "table",
+        }),
+      ],
+      visualization_settings: {
+        visualization: {
+          display: "table",
+          columns: [],
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: `card:${deniedSourceCardId}`,
+                originalName: "SUBTOTAL",
+                name: "COLUMN_1",
+              },
+            ],
+          },
+          settings: {},
+        },
+      },
+    });
+    const mixedAccessData: DashCardDataMap = {
+      [visualizerDashcard.id]: {
+        [allowedSourceCardId]: createMockDataset(),
+        [deniedSourceCardId]: permissionDeniedDataset,
+      },
+    };
+
+    setup({
+      dashboard: {
+        ...testDashboard,
+        dashcards: [visualizerDashcard],
+      },
+      dashcard: visualizerDashcard,
+      dashcardData: mixedAccessData,
+    });
+
+    expect(
+      screen.getByText("Sorry, you don't have permission to see this card."),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/Some columns are missing/),
+    ).not.toBeInTheDocument();
+  });
+
   describe("edit mode", () => {
     it("should not show the info icon", () => {
       setup({ isEditing: true });

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -259,17 +259,30 @@ export function isDashcardLoading(
   return cardData.length === 0 || cardData.some((data) => data == null);
 }
 
-export function getDashcardResultsError(
-  datasets: Dataset[],
-  isGuestEmbed: boolean,
+/**
+ * True when any dataset in the list represents a permission failure
+ * (`missing-required-permissions` error_type or HTTP 403). The "Sorry, you
+ * don't have permission to see this card." UX is gated on this signal.
+ *
+ * Takes the structural minimum so it accepts both `Dataset[]` (used internally
+ * by `getDashcardResultsError`) and `Series` (where each item carries the
+ * dataset fields spread alongside the card).
+ */
+export function isDashcardAccessRestricted(
+  datasets: ReadonlyArray<Pick<Dataset, "error" | "error_type">>,
 ) {
-  const isAccessRestricted = datasets.some(
+  return datasets.some(
     (s) =>
       s.error_type === SERVER_ERROR_TYPES.missingPermissions ||
       (typeof s.error === "object" && s.error?.status === 403),
   );
+}
 
-  if (isAccessRestricted) {
+export function getDashcardResultsError(
+  datasets: Dataset[],
+  isGuestEmbed: boolean,
+) {
+  if (isDashcardAccessRestricted(datasets)) {
     return {
       message: getPermissionErrorMessage(),
       icon: "key" as const,

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -259,7 +259,6 @@ export function isDashcardLoading(
   return cardData.length === 0 || cardData.some((data) => data == null);
 }
 
-/** True if any dataset failed because of permissions (403 or `missing-required-permissions`). */
 export function isDashcardAccessRestricted(
   datasets: ReadonlyArray<Pick<Dataset, "error" | "error_type">>,
 ) {

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -259,15 +259,7 @@ export function isDashcardLoading(
   return cardData.length === 0 || cardData.some((data) => data == null);
 }
 
-/**
- * True when any dataset in the list represents a permission failure
- * (`missing-required-permissions` error_type or HTTP 403). The "Sorry, you
- * don't have permission to see this card." UX is gated on this signal.
- *
- * Takes the structural minimum so it accepts both `Dataset[]` (used internally
- * by `getDashcardResultsError`) and `Series` (where each item carries the
- * dataset fields spread alongside the card).
- */
+/** True if any dataset failed because of permissions (403 or `missing-required-permissions`). */
 export function isDashcardAccessRestricted(
   datasets: ReadonlyArray<Pick<Dataset, "error" | "error_type">>,
 ) {

--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -51,7 +51,9 @@ export function mergeVisualizerData({
   const insights: Insight[] = [];
   referencedColumns.forEach((ref) => {
     const dataset = datasets[ref.sourceId];
-    if (!dataset) {
+    // Skip datasets that aren't loaded or that errored out (e.g. permission
+    // denied). An errored dataset may not carry a usable `data` payload.
+    if (!dataset || dataset.error != null) {
       return;
     }
     const columnIndex = dataset.data.cols.findIndex(

--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -51,8 +51,7 @@ export function mergeVisualizerData({
   const insights: Insight[] = [];
   referencedColumns.forEach((ref) => {
     const dataset = datasets[ref.sourceId];
-    // Skip datasets that aren't loaded or that errored out (e.g. permission
-    // denied). An errored dataset may not carry a usable `data` payload.
+    // Errored datasets (e.g. permission denied) may not carry `data`.
     if (!dataset || dataset.error != null) {
       return;
     }

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -1,4 +1,5 @@
 import { NumberColumn, StringColumn } from "__support__/visualizations";
+import { SERVER_ERROR_TYPES } from "metabase/utils/errors";
 import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
 
 import { mergeVisualizerData } from "./merge-data";
@@ -126,7 +127,7 @@ describe("mergeVisualizerData", () => {
       label: "errored (e.g. permission denied)",
       dataset: createMockDataset({
         error: { status: 403 },
-        error_type: "missing-required-permissions",
+        error_type: SERVER_ERROR_TYPES.missingPermissions,
       }),
     },
   ])(

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -118,4 +118,41 @@ describe("mergeVisualizerData", () => {
       "COLUMN_3",
     ]);
   });
+
+  it.each([
+    { label: "undefined", dataset: undefined },
+    { label: "null", dataset: null },
+    {
+      label: "errored (e.g. permission denied)",
+      dataset: createMockDataset({
+        error: { status: 403 },
+        error_type: "missing-required-permissions",
+      }),
+    },
+  ])(
+    "should return an empty merge when a referenced dataset is $label",
+    ({ dataset }) => {
+      const column = createMockColumn(StringColumn({ name: "COLUMN_1" }));
+      const result = mergeVisualizerData({
+        columns: [column],
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              originalName: "CREATED_AT",
+              name: "COLUMN_1",
+            },
+          ],
+        },
+        datasets: { "card:1": dataset },
+        dataSources: [
+          { id: "card:1", sourceId: 1, type: "card", name: "Chart 1" },
+        ],
+      });
+
+      expect(result.cols).toEqual([column]);
+      expect(result.rows).toEqual([]);
+      expect(result.insights).toEqual([]);
+    },
+  );
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72984
### Description

Fixes [UXW-3795](https://linear.app/metabase/issue/UXW-3795/setting-visualization-options-on-dashboard-cards-breaks-error-messages).

**Cause:** for visualizer-style dashcards (those with `visualization_settings.visualization` set), `mergeVisualizerData` dereferenced `.data.cols` on permission-denied datasets that carry no `data` payload, so the throw escaped to the outer ErrorBoundary and rendered the generic "Oops" warning instead of the proper permission message.

**Fix:** treat datasets with `error` set as not-loaded, both at the call site and inside `mergeVisualizerData`. Also short-circuit the visualizer's "Some columns are missing…" check when the dashcard already has an error, so it doesn't mask the permission message.

### How to verify

- [ ] As an admin, add a card from a private collection to a dashboard another user can read; on the dashcard, use "Edit visualization" to change anything and save.
- [ ] As the other user, open the dashboard: see "Sorry, you don't have permission to see this card." with the key icon (not a warning triangle).

### Demo

<img width="2302" height="1096" alt="image" src="https://github.com/user-attachments/assets/499feb31-43ed-4f85-b138-6679b2b5a301" />

### Checklist

- [x ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)