### PR TITLE
fix: document the anthropic api key setting

### DIFF
--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -69,6 +69,7 @@ config:
   settings:
     admin-email: null
     aggregated-query-row-limit: null
+    ai-features-enabled: true
     allowed-iframe-hosts: |-
       youtube.com,
       youtu.be,
@@ -137,6 +138,7 @@ config:
     email-smtp-security-override: ssl
     email-smtp-username: null
     email-smtp-username-override: null
+    embedded-metabot-enabled: true
     embedding-app-origins-interactive: null
     embedding-app-origins-sdk: ''
     embedding-homepage: hidden
@@ -199,6 +201,8 @@ config:
     ldap-user-filter: (&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))
     ldap-user-provisioning-enabled: true
     license-token-missing-banner-dismissal-timestamp: []
+    llm-anthropic-api-key: null
+    llm-metabot-provider: anthropic/claude-sonnet-4-6
     load-analytics-content: true
     loading-message: doing-science
     login-page-illustration: default
@@ -206,6 +210,7 @@ config:
     map-tile-server-url: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
     mcp-apps-cors-custom-origins: ''
     mcp-apps-cors-enabled-clients: []
+    metabot-enabled: true
     metabot-slack-signing-secret: null
     native-query-autocomplete-match-style: substring
     nested-field-columns-value-length-limit: 50000

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -71,6 +71,15 @@ Maximum number of rows to return for aggregated queries via the API.
 
 Must be less than 1048575. See also MB_UNAGGREGATED_QUERY_ROW_LIMIT.
 
+### `MB_AI_FEATURES_ENABLED`
+
+- Type: boolean
+- Default: `true`
+- [Exported as](../installation-and-operation/serialization.md): `ai-features-enabled`.
+- [Configuration file name](./config-file.md): `ai-features-enabled`
+
+Whether AI features are enabled.
+
 ### `MB_ALLOWED_IFRAME_HOSTS`
 
 - Type: string
@@ -573,6 +582,15 @@ SMTP username.
 - [Configuration file name](./config-file.md): `email-smtp-username-override`
 
 Custom SMTP server username.
+
+### `MB_EMBEDDED_METABOT_ENABLED`
+
+- Type: boolean
+- Default: `true`
+- [Exported as](../installation-and-operation/serialization.md): `embedded-metabot-enabled`.
+- [Configuration file name](./config-file.md): `embedded-metabot-enabled`
+
+Whether Metabot is enabled for embedding.
 
 ### `MB_EMBEDDING_APP_ORIGIN [DEPRECATED]`
 
@@ -1161,6 +1179,22 @@ When set to `true`, users who log in via LDAP will automatically get a Metabase 
 
 The array of last two ISO8601 dates when an admin dismissed the license token missing banner.
 
+### `MB_LLM_ANTHROPIC_API_KEY`
+
+- Type: string
+- Default: `null`
+- [Configuration file name](./config-file.md): `llm-anthropic-api-key`
+
+The Anthropic API Key.
+
+### `MB_LLM_METABOT_PROVIDER`
+
+- Type: string
+- Default: `anthropic/claude-sonnet-4-6`
+- [Configuration file name](./config-file.md): `llm-metabot-provider`
+
+The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini`, `openrouter/anthropic/claude-haiku-4-5`.
+
 ### `MB_LOAD_ANALYTICS_CONTENT`
 
 - Type: boolean
@@ -1227,6 +1261,15 @@ Custom CORS origins for self-hosted MCP clients, space-separated.
 - [Configuration file name](./config-file.md): `mcp-apps-cors-enabled-clients`
 
 Popular MCP clients enabled for CORS, stored as CSV client keys (e.g. claude, vscode).
+
+### `MB_METABOT_ENABLED`
+
+- Type: boolean
+- Default: `true`
+- [Exported as](../installation-and-operation/serialization.md): `metabot-enabled`.
+- [Configuration file name](./config-file.md): `metabot-enabled`
+
+Whether Metabot is enabled for regular usage.
 
 ### `MB_METABOT_SLACK_SIGNING_SECRET`
 

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -29,8 +29,7 @@
   :setter           (partial set-prefixed-api-key!
                              :llm-anthropic-api-key
                              "sk-ant-"
-                             (deferred-tru "Invalid Anthropic API key format. Key must start with ''sk-ant-''."))
-  :doc false)
+                             (deferred-tru "Invalid Anthropic API key format. Key must start with ''sk-ant-''.")))
 
 (defsetting llm-anthropic-api-key-configured?
   "Whether an Anthropic API key has been configured."
@@ -159,8 +158,7 @@
   :type       :boolean
   :visibility :public
   :default    true
-  :export?    true
-  :doc        false)
+  :export?    true)
 
 (defsetting llm-max-tokens
   (deferred-tru "Maximum tokens for LLM responses.")

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -21,8 +21,7 @@
   :default    true
   :getter     #(and (llm.settings/ai-features-enabled?)
                     (setting/get-value-of-type :boolean :metabot-enabled?))
-  :export?    true
-  :doc        false)
+  :export?    true)
 
 (defsetting metabot-name
   (deferred-tru "The display name for Metabot.")
@@ -91,8 +90,7 @@
   :default    true
   :getter     #(and (llm.settings/ai-features-enabled?)
                     (setting/get-value-of-type :boolean :embedded-metabot-enabled?))
-  :export?    true
-  :doc        false)
+  :export?    true)
 
 ;;; ------------------------------------------------- LLM Provider ------------------------------------------------
 
@@ -217,7 +215,6 @@
   :visibility       :settings-manager
   :export?          false
   :deprecated-name  :ee-ai-metabot-provider
-  :doc              false
   :setter           (fn [new-value]
                       (when new-value
                         (validate-metabot-provider! new-value))


### PR DESCRIPTION
Closes [BOT-1119: Document the Anthropic API key setting](https://linear.app/metabase/issue/BOT-1119/document-the-anthropic-api-key-setting)

### Description

Documents the anthropic API key setting and some more (`llm-metabot-provider`, `embedded-metabot-enabled`, `ai-features-enabled`, `metabot-enabled`
