### PR TITLE
Fix document default selected entity picker collection on save

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -341,6 +341,38 @@ describe("documents", () => {
       .should("have.attr", "contenteditable", "false");
   });
 
+  it("should default the save modal to a selectable collection when Library is enabled (#73538)", () => {
+    H.activateToken("pro-self-hosted");
+    H.createLibrary();
+    cy.intercept("POST", "/api/document").as("createDocument");
+
+    cy.visit("/");
+
+    H.newButton("Document").click();
+    cy.findByRole("textbox", { name: "Document Title" }).type(
+      "Document in default collection",
+    );
+    H.documentContent().type(
+      "This document should save without changing folders",
+    );
+
+    cy.findByRole("button", { name: "Save" }).click();
+
+    H.entityPickerModal().within(() => {
+      cy.findByTestId("entity-picker-select-button").should("be.enabled");
+    });
+    cy.findByTestId("entity-picker-select-button").click();
+
+    cy.wait("@createDocument").then(({ request }) => {
+      expect(request.body).not.to.have.property("collection_id");
+    });
+    cy.location("pathname").should("match", /^\/document\/\d+/);
+    cy.findByRole("textbox", { name: "Document Title" }).should(
+      "have.value",
+      "Document in default collection",
+    );
+  });
+
   it("should focus the start of the document body when pressing Enter on the title input", () => {
     cy.visit("/document/new");
 

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -527,6 +527,10 @@ export const DocumentPage = ({
             title={t`Where should we save this document?`}
             onClose={() => setCollectionPickerMode(null)}
             entityType="document"
+            value={{
+              id: documentData?.collection_id ?? "root",
+              model: "collection",
+            }}
             onChange={(collection) => {
               if (collectionPickerMode === "save") {
                 handleSave(canonicalCollectionId(collection.id));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73538

### Description

Defaults the new-document save picker to the current/root collection instead of the Library branch, so the destination is immediately selectable when Library is enabled.

### How to verify

1. Enable Library.
2. Create a new document and click Save.
3. The save modal should open with Select enabled and saving should create the document outside Library.

### Demo
Before:
<img width="2230" height="1108" alt="image" src="https://github.com/user-attachments/assets/bb1d3b69-e7a5-41f1-92e4-9a6ea4cdf6f3" />

After:
<img width="1869" height="1115" alt="image" src="https://github.com/user-attachments/assets/19a71dac-4001-4506-a94d-767b8954fbe0" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)