### PR TITLE
[UXW-3769] Fix Tooltip for total bar in waterfall charts shows transformed value

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -114,7 +114,7 @@ export const getWaterfallDataset = (
 
 export const extendOriginalDatasetWithTotalDatum = (
   dataset: ChartDataset,
-  waterfallDatasetTotalDatum: Datum,
+  totalValue: RowValue,
   seriesDataKey: DataKey,
   settings: ComputedVisualizationSettings,
 ) => {
@@ -123,7 +123,7 @@ export const extendOriginalDatasetWithTotalDatum = (
   }
 
   const totalDatum: Datum = {
-    [seriesDataKey]: waterfallDatasetTotalDatum[WATERFALL_TOTAL_KEY],
+    [seriesDataKey]: totalValue,
     [X_AXIS_DATA_KEY]: t`Total`,
     [IS_WATERFALL_TOTAL_DATA_KEY]: true,
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.unit.spec.ts
@@ -1,4 +1,7 @@
-import { IS_WATERFALL_TOTAL_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import {
+  IS_WATERFALL_TOTAL_DATA_KEY,
+  X_AXIS_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { ChartDataset } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { createMockVisualizationSettings } from "metabase-types/api/mocks";
@@ -15,7 +18,10 @@ const settings = (
 
 describe("extendOriginalDatasetWithTotalDatum", () => {
   const seriesKey = "count";
-  const dataset: ChartDataset = [{ [seriesKey]: 100 }, { [seriesKey]: 200 }];
+  const dataset: ChartDataset = [
+    { [X_AXIS_DATA_KEY]: "a", [seriesKey]: 100 },
+    { [X_AXIS_DATA_KEY]: "b", [seriesKey]: 200 },
+  ];
 
   it("appends a total datum with the raw value it was given", () => {
     const result = extendOriginalDatasetWithTotalDatum(

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.unit.spec.ts
@@ -1,0 +1,51 @@
+import { IS_WATERFALL_TOTAL_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import type { ChartDataset } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import { createMockVisualizationSettings } from "metabase-types/api/mocks";
+
+import { extendOriginalDatasetWithTotalDatum } from "./dataset";
+
+const settings = (
+  overrides: Partial<ComputedVisualizationSettings> = {},
+): ComputedVisualizationSettings =>
+  createMockVisualizationSettings({
+    "waterfall.show_total": true,
+    ...overrides,
+  });
+
+describe("extendOriginalDatasetWithTotalDatum", () => {
+  const seriesKey = "count";
+  const dataset: ChartDataset = [{ [seriesKey]: 100 }, { [seriesKey]: 200 }];
+
+  it("appends a total datum with the raw value it was given", () => {
+    const result = extendOriginalDatasetWithTotalDatum(
+      dataset,
+      300,
+      seriesKey,
+      settings(),
+    );
+
+    expect(result).toHaveLength(3);
+    expect(result[2][seriesKey]).toBe(300);
+    expect(result[2][IS_WATERFALL_TOTAL_DATA_KEY]).toBe(true);
+  });
+
+  it("returns the dataset unchanged when waterfall.show_total is off", () => {
+    const result = extendOriginalDatasetWithTotalDatum(
+      dataset,
+      300,
+      seriesKey,
+      settings({ "waterfall.show_total": false }),
+    );
+
+    expect(result).toBe(dataset);
+  });
+
+  it("returns the dataset unchanged when it is empty", () => {
+    const empty: ChartDataset = [];
+
+    expect(
+      extendOriginalDatasetWithTotalDatum(empty, 0, seriesKey, settings()),
+    ).toBe(empty);
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -15,6 +15,7 @@ import {
 import type { WaterfallChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { ShowWarning } from "metabase/visualizations/echarts/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import { getNumberOr } from "metabase/visualizations/lib/settings/row-values";
 import type {
   ComputedVisualizationSettings,
   RenderingContext,
@@ -117,10 +118,16 @@ export const getWaterfallChartModel = (
     },
   );
 
-  // Extending the original dataset with total datum for tooltips
+  // Extending the original dataset with total datum for tooltips. Sum from the
+  // untransformed scaledDataset so the tooltip shows the raw total, not the
+  // y-axis-transformed value (e.g. with log/power scale).
+  const untransformedTotal = scaledDataset.reduce(
+    (sum, datum) => sum + getNumberOr(datum[seriesModel.dataKey], 0),
+    0,
+  );
   const originalDatasetWithTotal = extendOriginalDatasetWithTotalDatum(
     scaledDataset,
-    transformedDataset[transformedDataset.length - 1],
+    untransformedTotal,
     seriesModel.dataKey,
     settings,
   );

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.unit.spec.ts
@@ -1,0 +1,96 @@
+import { IS_WATERFALL_TOTAL_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { RawSeries } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+
+import { getWaterfallChartModel } from "./index";
+
+describe("getWaterfallChartModel", () => {
+  const dimensionColumn = createMockColumn({
+    name: "bucket",
+    display_name: "Bucket",
+    base_type: "type/Text",
+    semantic_type: "type/Category",
+  });
+  const metricColumn = createMockColumn({
+    name: "count",
+    display_name: "Count",
+    base_type: "type/Integer",
+    semantic_type: "type/Quantity",
+  });
+
+  // Includes a negative value so the running total is not monotonic; this
+  // prevents accidentally testing the "last end happens to equal the sum" case.
+  const rows: [string, number][] = [
+    ["a", 100],
+    ["b", 200],
+    ["c", -50],
+    ["d", 300],
+  ];
+  const expectedRawTotal = 550;
+
+  const rawSeries: RawSeries = [
+    {
+      card: createMockCard({ id: 1, name: "Waterfall", display: "waterfall" }),
+      data: createMockDatasetData({
+        rows,
+        cols: [dimensionColumn, metricColumn],
+      }),
+    },
+  ];
+
+  const renderingContext: RenderingContext = {
+    getColor: () => "#000000",
+    measureText: () => 10,
+    measureTextHeight: () => 10,
+    fontFamily: "Arial",
+    theme: { cartesian: { label: { fontSize: 12 } } } as any,
+  };
+
+  const buildModel = (
+    yAxisScale: "linear" | "log" | "pow",
+    extraSettings: Partial<ComputedVisualizationSettings> = {},
+  ) =>
+    getWaterfallChartModel(
+      rawSeries,
+      createMockVisualizationSettings({
+        "graph.dimensions": [dimensionColumn.name],
+        "graph.metrics": [metricColumn.name],
+        "graph.x_axis.scale": "ordinal",
+        "graph.y_axis.scale": yAxisScale,
+        "waterfall.show_total": true,
+        ...extraSettings,
+      }),
+      [],
+      renderingContext,
+    );
+
+  it.each(["linear", "log", "pow"] as const)(
+    "puts the raw total (not the y-axis-transformed value) into the dataset's Total row on %s scale",
+    (scale) => {
+      const { dataset, seriesModels } = buildModel(scale);
+      const seriesDataKey = seriesModels[0].dataKey;
+
+      const totalDatum = dataset[dataset.length - 1];
+      expect(totalDatum[IS_WATERFALL_TOTAL_DATA_KEY]).toBe(true);
+      expect(totalDatum[seriesDataKey]).toBe(expectedRawTotal);
+    },
+  );
+
+  it("omits the Total row when waterfall.show_total is disabled", () => {
+    const { dataset } = buildModel("log", { "waterfall.show_total": false });
+
+    expect(dataset).toHaveLength(rows.length);
+    expect(
+      dataset.some((datum) => datum[IS_WATERFALL_TOTAL_DATA_KEY] === true),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72696
### Description

Fixes [UXW-3769](https://linear.app/metabase/issue/UXW-3769/tooltip-for-total-bar-in-waterfall-charts-shows-transformed-value).

**Cause:** the Total entry appended to the original (untransformed) dataset used for tooltips was sourced from the post-y-axis-transform waterfall dataset, so on log / power scale the tooltip rendered the transformed value (e.g. `5.27` instead of `186,602`).

**Fix:** compute the Total by summing raw series values from `scaledDataset` and pass that scalar in directly.

### How to verify

- [ ] Build a Waterfall question with `Show total` enabled.
- [ ] Set Y-axis scale to `Log`, hover the Total bar, confirm the tooltip shows the raw sum (matches the bar's visible magnitude), not a tiny transformed number.
- [ ] Repeat for `Power` scale.
- [ ] Switch back to `Linear` and confirm the Total tooltip is unchanged.

### Demo

<img width="1968" height="1032" alt="image" src="https://github.com/user-attachments/assets/4b8645bc-3afe-42b8-a10c-9263ebf060fb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)