### PR TITLE
Test to prove #33878 is fixed :wrench:

### DIFF
--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -11,6 +11,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.premium-features.core :as premium-features]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.date-time-zone-functions-test :as qp-test.date-time-zone-functions-test]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -504,3 +505,28 @@
                             {:name "t", :schema "db_router_data", :description nil}
                             {:name "times", :schema "diff_time_zones_athena_cases", :description nil}}}
                  filtered-tables)))))))
+
+(deftest ^:parallel regex-text-parameters-in-native-template-tags-test
+  (testing "Text parameters should be compiled inline (#33878)"
+    (driver/with-driver :athena
+      (letfn [(query-with-param [parameter-value]
+                {:lib/type     :mbql/query
+                 :lib/metadata meta/metadata-provider
+                 :database     (meta/id)
+                 :stages       [{:lib/type      :mbql.stage/native
+                                 :template-tags {"category_name" {:name         "category_name"
+                                                                  :display-name "Category name"
+                                                                  :type         :text
+                                                                  :required     true}}
+                                 :native        "SELECT * FROM categories WHERE regexp_like(name, {{category_name}})"}]
+                 :parameters   [{:type   :text
+                                 :target [:variable [:template-tag "category_name"]]
+                                 :value  parameter-value}]})]
+        (are [parameter-value expected] (=? {:query expected}
+                                            (qp.compile/compile (query-with-param parameter-value)))
+          "^(?!.*\btrial_text\b).*$"
+          "SELECT * FROM categories WHERE regexp_like(name, '^(?!.*\btrial_text\b).*$')"
+
+          ;; should escape single quotes
+          "'); OR 1 = 1 --"
+          "SELECT * FROM categories WHERE regexp_like(name, '''); OR 1 = 1 --')")))))


### PR DESCRIPTION
The SQL we generated for string literals in Athena had issues in the past, but as best as I can tell #45008 fixed those issues which means #33878 has been fixed since then. Add a test to prove the SQL is compiled as we'd expect

Fixes #33878 
Fixes QUE2-226