### PR TITLE
Fix scatterplot visualization without color distinction

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -163,6 +163,23 @@ export const getEventDimensions = (
     });
   }
 
+  // Include any other breakout column whose value is present at this data point but isn't yet
+  // captured as a dimension — e.g. a scatterplot whose categorical breakout is not bound to the
+  // series/color in viz settings would otherwise drop that filter from "See these records" (#73803).
+  const alreadyAddedColumns = new Set(dimensions.map((d) => d.column));
+  for (const dataKey of sameCardDataKeys) {
+    const column = chartModel.columnByDataKey[dataKey];
+    if (
+      column != null &&
+      column.source === "breakout" &&
+      !alreadyAddedColumns.has(column) &&
+      dataKey in datum
+    ) {
+      dimensions.push({ column, value: datum[dataKey] });
+      alreadyAddedColumns.add(column);
+    }
+  }
+
   return dimensions.filter(
     (dimension) => dimension.column.source !== "query-transform",
   );

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -166,7 +166,9 @@ export const getEventDimensions = (
   // Include any other breakout column whose value is present at this data point but isn't yet
   // captured as a dimension — e.g. a scatterplot whose categorical breakout is not bound to the
   // series/color in viz settings would otherwise drop that filter from "See these records" (#73803).
-  const alreadyAddedColumns = new Set(dimensions.map((d) => d.column));
+  const alreadyAddedColumns = new Set(
+    dimensions.map((dimension) => dimension.column),
+  );
   for (const dataKey of sameCardDataKeys) {
     const column = chartModel.columnByDataKey[dataKey];
     if (

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
@@ -1,0 +1,219 @@
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import type {
+  BaseCartesianChartModel,
+  BreakoutSeriesModel,
+  Datum,
+  DimensionModel,
+  ScatterSeriesModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
+import type { DatasetColumn } from "metabase-types/api";
+
+import { getEventDimensions } from "./events";
+
+const CARD_ID = 107;
+
+const createdAtColumn = {
+  name: "CREATED_AT",
+  display_name: "Created At: Month",
+  source: "breakout",
+  base_type: "type/DateTime",
+  effective_type: "type/DateTime",
+  semantic_type: "type/CreationTimestamp",
+} as DatasetColumn;
+
+const sourceColumn = {
+  name: "SOURCE",
+  display_name: "User → Source",
+  source: "breakout",
+  base_type: "type/Text",
+  effective_type: "type/Text",
+  semantic_type: "type/Source",
+} as DatasetColumn;
+
+const sumColumn = {
+  name: "sum",
+  display_name: "Sum of Total",
+  source: "aggregation",
+  base_type: "type/Float",
+  effective_type: "type/Float",
+} as DatasetColumn;
+
+const dimensionModel: DimensionModel = {
+  column: createdAtColumn,
+  columnIndex: 0,
+  columnByCardId: { [CARD_ID]: createdAtColumn },
+};
+
+describe("getEventDimensions", () => {
+  // Reproduces issue #73803: a scatterplot with two breakouts (a temporal X-axis and a categorical
+  // breakout) must surface ALL breakout dimensions on the click context, even when the categorical
+  // breakout isn't bound to series/color in viz settings. Previously only the X-axis dimension was
+  // included, so "See these records" dropped the categorical filter from the drill-thru query. (#73803)
+  it("includes all breakout columns when a scatterplot's categorical breakout is not bound to series/color (#73803)", () => {
+    const createdAtKey = `${CARD_ID}:CREATED_AT`;
+    const sourceKey = `${CARD_ID}:SOURCE`;
+    const sumKey = `${CARD_ID}:sum`;
+
+    const datum: Datum = {
+      [X_AXIS_DATA_KEY]: "2027-10-01T00:00:00Z",
+      [createdAtKey]: "2027-10-01T00:00:00Z",
+      [sourceKey]: "Affiliate",
+      [sumKey]: 6720.6432478784345,
+    };
+
+    const chartModel = {
+      columnByDataKey: {
+        [createdAtKey]: createdAtColumn,
+        [sourceKey]: sourceColumn,
+        [sumKey]: sumColumn,
+      },
+    } as unknown as BaseCartesianChartModel;
+
+    // Scatter series model without `breakoutColumn`: this is what happens when graph.dimensions
+    // has only the X-axis column even though the underlying query has a second breakout.
+    const seriesModel = {
+      name: "Sum of Total",
+      color: "#509EE3",
+      dataKey: sumKey,
+      visible: true,
+      column: sumColumn,
+      columnIndex: 2,
+      cardId: CARD_ID,
+      vizSettingsKey: "sum",
+      legacySeriesSettingsObjectKey: { vizSettingsKey: "sum" },
+      tooltipName: "Sum of Total",
+    } as unknown as ScatterSeriesModel;
+
+    const dimensions = getEventDimensions(
+      chartModel,
+      datum,
+      dimensionModel,
+      seriesModel,
+    );
+
+    expect(dimensions).toEqual([
+      { column: createdAtColumn, value: "2027-10-01T00:00:00" },
+      { column: sourceColumn, value: "Affiliate" },
+    ]);
+  });
+
+  // The same field can be broken out twice with different temporal units (e.g. CREATED_AT bucketed
+  // by month AND year). The result columns are deduplicated to "CREATED_AT" and "CREATED_AT_2",
+  // each becoming a separate DatasetColumn — so both should land in dimensions, even though they
+  // point at the same underlying field.
+  it("includes both breakouts when the same field is broken out twice with different temporal units", () => {
+    const monthColumn = {
+      ...createdAtColumn,
+      name: "CREATED_AT",
+      display_name: "Created At: Month",
+      unit: "month",
+    } as DatasetColumn;
+
+    const yearColumn = {
+      ...createdAtColumn,
+      name: "CREATED_AT_2",
+      display_name: "Created At: Year",
+      unit: "year",
+    } as DatasetColumn;
+
+    const monthKey = `${CARD_ID}:CREATED_AT`;
+    const yearKey = `${CARD_ID}:CREATED_AT_2`;
+    const sumKey = `${CARD_ID}:sum`;
+
+    const datum: Datum = {
+      [X_AXIS_DATA_KEY]: "2027-10-01T00:00:00Z",
+      [monthKey]: "2027-10-01T00:00:00Z",
+      [yearKey]: "2027-01-01T00:00:00Z",
+      [sumKey]: 6720.6432478784345,
+    };
+
+    const chartModel = {
+      columnByDataKey: {
+        [monthKey]: monthColumn,
+        [yearKey]: yearColumn,
+        [sumKey]: sumColumn,
+      },
+    } as unknown as BaseCartesianChartModel;
+
+    const dimensionModelMonthAxis: DimensionModel = {
+      column: monthColumn,
+      columnIndex: 0,
+      columnByCardId: { [CARD_ID]: monthColumn },
+    };
+
+    const seriesModel = {
+      name: "Sum of Total",
+      color: "#509EE3",
+      dataKey: sumKey,
+      visible: true,
+      column: sumColumn,
+      columnIndex: 2,
+      cardId: CARD_ID,
+      vizSettingsKey: "sum",
+      legacySeriesSettingsObjectKey: { vizSettingsKey: "sum" },
+      tooltipName: "Sum of Total",
+    } as unknown as ScatterSeriesModel;
+
+    const dimensions = getEventDimensions(
+      chartModel,
+      datum,
+      dimensionModelMonthAxis,
+      seriesModel,
+    );
+
+    expect(dimensions).toEqual([
+      { column: monthColumn, value: "2027-10-01T00:00:00" },
+      { column: yearColumn, value: "2027-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("does not duplicate the breakout column already provided by seriesModel.breakoutColumn", () => {
+    const createdAtKey = `${CARD_ID}:CREATED_AT:Affiliate`;
+    const sourceKey = `${CARD_ID}:SOURCE:Affiliate`;
+    const sumKey = `${CARD_ID}:sum:Affiliate`;
+
+    const datum: Datum = {
+      [X_AXIS_DATA_KEY]: "2027-10-01T00:00:00Z",
+      [createdAtKey]: "2027-10-01T00:00:00Z",
+      [sourceKey]: "Affiliate",
+      [sumKey]: 6720.6432478784345,
+    };
+
+    const chartModel = {
+      columnByDataKey: {
+        [createdAtKey]: createdAtColumn,
+        [sourceKey]: sourceColumn,
+        [sumKey]: sumColumn,
+      },
+    } as unknown as BaseCartesianChartModel;
+
+    // Scatter series model WITH breakoutColumn (the working case where series/color is set).
+    const seriesModel = {
+      name: "Affiliate",
+      color: "#509EE3",
+      dataKey: sumKey,
+      visible: true,
+      column: sumColumn,
+      columnIndex: 2,
+      cardId: CARD_ID,
+      vizSettingsKey: "Affiliate",
+      legacySeriesSettingsObjectKey: { vizSettingsKey: "Affiliate" },
+      tooltipName: "Sum of Total",
+      breakoutColumn: sourceColumn,
+      breakoutColumnIndex: 1,
+      breakoutValue: "Affiliate",
+    } as unknown as BreakoutSeriesModel;
+
+    const dimensions = getEventDimensions(
+      chartModel,
+      datum,
+      dimensionModel,
+      seriesModel,
+    );
+
+    expect(dimensions).toEqual([
+      { column: createdAtColumn, value: "2027-10-01T00:00:00" },
+      { column: sourceColumn, value: "Affiliate" },
+    ]);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
@@ -1,42 +1,45 @@
+import {
+  createMockBreakoutSeriesModel,
+  createMockCartesianChartModel,
+  createMockSeriesModel,
+} from "__support__/echarts";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
-  BaseCartesianChartModel,
-  BreakoutSeriesModel,
   Datum,
   DimensionModel,
-  ScatterSeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
-import type { DatasetColumn } from "metabase-types/api";
+import {
+  createMockColumn,
+  createMockDatetimeColumn,
+} from "metabase-types/api/mocks";
 
 import { getEventDimensions } from "./events";
 
 const CARD_ID = 107;
 
-const createdAtColumn = {
+const createdAtColumn = createMockDatetimeColumn({
   name: "CREATED_AT",
   display_name: "Created At: Month",
   source: "breakout",
-  base_type: "type/DateTime",
-  effective_type: "type/DateTime",
   semantic_type: "type/CreationTimestamp",
-} as DatasetColumn;
+});
 
-const sourceColumn = {
+const sourceColumn = createMockColumn({
   name: "SOURCE",
   display_name: "User → Source",
   source: "breakout",
   base_type: "type/Text",
   effective_type: "type/Text",
   semantic_type: "type/Source",
-} as DatasetColumn;
+});
 
-const sumColumn = {
+const sumColumn = createMockColumn({
   name: "sum",
   display_name: "Sum of Total",
   source: "aggregation",
   base_type: "type/Float",
   effective_type: "type/Float",
-} as DatasetColumn;
+});
 
 const dimensionModel: DimensionModel = {
   column: createdAtColumn,
@@ -61,28 +64,23 @@ describe("getEventDimensions", () => {
       [sumKey]: 6720.6432478784345,
     };
 
-    const chartModel = {
+    const chartModel = createMockCartesianChartModel({
       columnByDataKey: {
         [createdAtKey]: createdAtColumn,
         [sourceKey]: sourceColumn,
         [sumKey]: sumColumn,
       },
-    } as unknown as BaseCartesianChartModel;
+    });
 
     // Scatter series model without `breakoutColumn`: this is what happens when graph.dimensions
     // has only the X-axis column even though the underlying query has a second breakout.
-    const seriesModel = {
-      name: "Sum of Total",
-      color: "#509EE3",
+    const seriesModel = createMockSeriesModel({
       dataKey: sumKey,
-      visible: true,
       column: sumColumn,
       columnIndex: 2,
       cardId: CARD_ID,
       vizSettingsKey: "sum",
-      legacySeriesSettingsObjectKey: { vizSettingsKey: "sum" },
-      tooltipName: "Sum of Total",
-    } as unknown as ScatterSeriesModel;
+    });
 
     const dimensions = getEventDimensions(
       chartModel,
@@ -102,19 +100,21 @@ describe("getEventDimensions", () => {
   // each becoming a separate DatasetColumn — so both should land in dimensions, even though they
   // point at the same underlying field.
   it("includes both breakouts when the same field is broken out twice with different temporal units", () => {
-    const monthColumn = {
-      ...createdAtColumn,
+    const monthColumn = createMockDatetimeColumn({
       name: "CREATED_AT",
       display_name: "Created At: Month",
+      source: "breakout",
+      semantic_type: "type/CreationTimestamp",
       unit: "month",
-    } as DatasetColumn;
+    });
 
-    const yearColumn = {
-      ...createdAtColumn,
+    const yearColumn = createMockDatetimeColumn({
       name: "CREATED_AT_2",
       display_name: "Created At: Year",
+      source: "breakout",
+      semantic_type: "type/CreationTimestamp",
       unit: "year",
-    } as DatasetColumn;
+    });
 
     const monthKey = `${CARD_ID}:CREATED_AT`;
     const yearKey = `${CARD_ID}:CREATED_AT_2`;
@@ -127,13 +127,13 @@ describe("getEventDimensions", () => {
       [sumKey]: 6720.6432478784345,
     };
 
-    const chartModel = {
+    const chartModel = createMockCartesianChartModel({
       columnByDataKey: {
         [monthKey]: monthColumn,
         [yearKey]: yearColumn,
         [sumKey]: sumColumn,
       },
-    } as unknown as BaseCartesianChartModel;
+    });
 
     const dimensionModelMonthAxis: DimensionModel = {
       column: monthColumn,
@@ -141,18 +141,13 @@ describe("getEventDimensions", () => {
       columnByCardId: { [CARD_ID]: monthColumn },
     };
 
-    const seriesModel = {
-      name: "Sum of Total",
-      color: "#509EE3",
+    const seriesModel = createMockSeriesModel({
       dataKey: sumKey,
-      visible: true,
       column: sumColumn,
       columnIndex: 2,
       cardId: CARD_ID,
       vizSettingsKey: "sum",
-      legacySeriesSettingsObjectKey: { vizSettingsKey: "sum" },
-      tooltipName: "Sum of Total",
-    } as unknown as ScatterSeriesModel;
+    });
 
     const dimensions = getEventDimensions(
       chartModel,
@@ -179,30 +174,25 @@ describe("getEventDimensions", () => {
       [sumKey]: 6720.6432478784345,
     };
 
-    const chartModel = {
+    const chartModel = createMockCartesianChartModel({
       columnByDataKey: {
         [createdAtKey]: createdAtColumn,
         [sourceKey]: sourceColumn,
         [sumKey]: sumColumn,
       },
-    } as unknown as BaseCartesianChartModel;
+    });
 
-    // Scatter series model WITH breakoutColumn (the working case where series/color is set).
-    const seriesModel = {
-      name: "Affiliate",
-      color: "#509EE3",
+    // Series model WITH breakoutColumn (the working case where series/color is set).
+    const seriesModel = createMockBreakoutSeriesModel({
       dataKey: sumKey,
-      visible: true,
       column: sumColumn,
       columnIndex: 2,
       cardId: CARD_ID,
       vizSettingsKey: "Affiliate",
-      legacySeriesSettingsObjectKey: { vizSettingsKey: "Affiliate" },
-      tooltipName: "Sum of Total",
       breakoutColumn: sourceColumn,
       breakoutColumnIndex: 1,
       breakoutValue: "Affiliate",
-    } as unknown as BreakoutSeriesModel;
+    });
 
     const dimensions = getEventDimensions(
       chartModel,

--- a/frontend/test/__support__/echarts.ts
+++ b/frontend/test/__support__/echarts.ts
@@ -1,4 +1,5 @@
 import type {
+  BaseCartesianChartModel,
   BreakoutSeriesModel,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -32,3 +33,35 @@ export const createMockBreakoutSeriesModel = (
   breakoutValue: "foo",
   ...createMockSeriesModel(opts),
 });
+
+export const createMockCartesianChartModel = (
+  opts?: Partial<BaseCartesianChartModel>,
+): BaseCartesianChartModel => {
+  const column = createMockColumn();
+  return {
+    dimensionModel: {
+      column,
+      columnIndex: 0,
+      columnByCardId: {},
+    },
+    seriesModels: [],
+    dataset: [],
+    transformedDataset: [],
+    yAxisScaleTransforms: {
+      toEChartsAxisValue: (value) => (typeof value === "number" ? value : null),
+      fromEChartsAxisValue: (value) => value,
+    },
+    stackModels: [],
+    leftAxisModel: null,
+    rightAxisModel: null,
+    xAxisModel: {
+      axisType: "category",
+      isHistogram: false,
+      formatter: String,
+      valuesCount: 0,
+    },
+    columnByDataKey: {},
+    seriesLabelsFormatters: {},
+    ...opts,
+  };
+};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73803
Closes QUE2-566

### Description

`getEventDimensions` only added a breakout dimension when `seriesModel.breakoutColumn` was set. For scatter plots, `breakoutColumn` is set only when the categorical column is bound to series/color in viz settings. When the user removed the color mapping, the column still existed in the underlying query as a breakout, so MLv2 would have applied the filter — but the FE never sent it.

The fix: after the existing X-axis/breakout-series logic, walk `sameCardDataKeys`, find any breakout columns not already in `dimensions`, and push it with the value at the clicked datum. 

### How to verify

See the unit tests. The repro steps from #73803 should not lose any filters.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
