### PR TITLE
Make metabot system prompt textareas fill the viewport

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
@@ -7,17 +7,23 @@ import type {
   EnterpriseSettings,
 } from "metabase-types/api";
 
+type StringSettingKey = {
+  [K in EnterpriseSettingKey]: EnterpriseSettings[K] extends
+    | string
+    | null
+    | undefined
+    ? K
+    : never;
+}[EnterpriseSettingKey];
+
 /**
  * Persists a text setting on blur and on unmount. Suited for settings whose
  * saves shouldn't be debounced (e.g. Metabot system prompts).
  */
-export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
-  settingName: K,
-) {
+export function useAdminSettingWithBlurInput(settingName: StringSettingKey) {
   const { value: settingValue, updateSetting } = useAdminSetting(settingName);
-  const [inputValue, setInputValue] =
-    useState<EnterpriseSettings[K]>(settingValue);
-  const lastSavedRef = useRef<EnterpriseSettings[K] | undefined>(settingValue);
+  const [inputValue, setInputValue] = useState(settingValue);
+  const lastSavedRef = useRef(settingValue);
 
   useEffect(() => {
     if (lastSavedRef.current === undefined && settingValue !== undefined) {
@@ -26,7 +32,9 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
     }
   }, [settingValue]);
 
-  const isDirty = (inputValue || "") !== (lastSavedRef.current || "");
+  const trimmedInput = (inputValue ?? "").trim();
+  const trimmedSaved = (lastSavedRef.current ?? "").trim();
+  const isDirty = trimmedInput !== trimmedSaved;
 
   useBeforeUnload(isDirty);
 
@@ -34,12 +42,9 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
     if (!isDirty) {
       return;
     }
-    lastSavedRef.current = inputValue;
-    updateSetting({
-      key: settingName,
-      value: inputValue,
-    });
-  }, [isDirty, inputValue, settingName, updateSetting]);
+    lastSavedRef.current = trimmedInput;
+    updateSetting({ key: settingName, value: trimmedInput });
+  }, [isDirty, trimmedInput, settingName, updateSetting]);
 
   // Track the latest `save` so the unmount cleanup can fire it. Browser back
   // doesn't fire blur on the focused textarea, so the cleanup is what saves.

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
@@ -21,6 +21,7 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
   const [inputValue, setInputValue] =
     useState<EnterpriseSettings[K]>(settingValue);
   const lastSavedRef = useRef<EnterpriseSettings[K] | undefined>(undefined);
+  const isFocusedRef = useRef(false);
 
   // `lastSavedRef.current === undefined` is the "not yet initialized" sentinel.
   useEffect(() => {
@@ -30,10 +31,16 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
     }
   }, [settingValue]);
 
-  const isDirty = inputValue !== lastSavedRef.current;
+  // Treat null/undefined/"" as equivalent so a stray onChange event (e.g.
+  // Mantine syncing a controlled input with `value={null}`) doesn't mark the
+  // setting dirty when the user hasn't actually changed anything.
+  const isDirty = (inputValue ?? "") !== (lastSavedRef.current ?? "");
 
   const save = useCallback(() => {
-    if (!isDirty) {
+    // Only save while the field is part of an active focus session: real user
+    // input always happens between focus and blur. Outside that window (unmount
+    // long after blur, stray onChange events), skip the save.
+    if (!isFocusedRef.current || !isDirty) {
       return;
     }
     lastSavedRef.current = inputValue;
@@ -53,8 +60,15 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
   // Browsers won't wait for async saves during unload, so prompt the user.
   useBeforeUnload(isDirty);
 
+  const handleFocus = useCallback(() => {
+    isFocusedRef.current = true;
+  }, []);
+
   const handleBlur = useCallback(() => {
+    // Run save while still considered focused, then clear the flag so a later
+    // unmount won't save again.
     saveRef.current();
+    isFocusedRef.current = false;
   }, []);
 
   // Persist a pending edit on SPA navigation away.
@@ -67,6 +81,7 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
   return {
     inputValue,
     handleInputChange: setInputValue,
+    handleFocus,
     handleBlur,
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/hooks/useAdminSettingWithBlurInput.ts
@@ -8,11 +8,8 @@ import type {
 } from "metabase-types/api";
 
 /**
- * Persists a setting on blur and on unmount instead of on every keystroke.
- * For text settings whose saves shouldn't be debounced (e.g. Metabot system
- * prompts, where each save changes LLM behavior and the audit log).
- *
- * Dirty check uses `===` - safe for primitive setting values only.
+ * Persists a text setting on blur and on unmount. Suited for settings whose
+ * saves shouldn't be debounced (e.g. Metabot system prompts).
  */
 export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
   settingName: K,
@@ -20,10 +17,8 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
   const { value: settingValue, updateSetting } = useAdminSetting(settingName);
   const [inputValue, setInputValue] =
     useState<EnterpriseSettings[K]>(settingValue);
-  const lastSavedRef = useRef<EnterpriseSettings[K] | undefined>(undefined);
-  const isFocusedRef = useRef(false);
+  const lastSavedRef = useRef<EnterpriseSettings[K] | undefined>(settingValue);
 
-  // `lastSavedRef.current === undefined` is the "not yet initialized" sentinel.
   useEffect(() => {
     if (lastSavedRef.current === undefined && settingValue !== undefined) {
       setInputValue(settingValue);
@@ -31,16 +26,12 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
     }
   }, [settingValue]);
 
-  // Treat null/undefined/"" as equivalent so a stray onChange event (e.g.
-  // Mantine syncing a controlled input with `value={null}`) doesn't mark the
-  // setting dirty when the user hasn't actually changed anything.
-  const isDirty = (inputValue ?? "") !== (lastSavedRef.current ?? "");
+  const isDirty = (inputValue || "") !== (lastSavedRef.current || "");
+
+  useBeforeUnload(isDirty);
 
   const save = useCallback(() => {
-    // Only save while the field is part of an active focus session: real user
-    // input always happens between focus and blur. Outside that window (unmount
-    // long after blur, stray onChange events), skip the save.
-    if (!isFocusedRef.current || !isDirty) {
+    if (!isDirty) {
       return;
     }
     lastSavedRef.current = inputValue;
@@ -50,38 +41,17 @@ export function useAdminSettingWithBlurInput<K extends EnterpriseSettingKey>(
     });
   }, [isDirty, inputValue, settingName, updateSetting]);
 
-  // Mirror `save` so blur / unmount can read the latest closure without
-  // re-binding handlers on every keystroke.
+  // Track the latest `save` so the unmount cleanup can fire it. Browser back
+  // doesn't fire blur on the focused textarea, so the cleanup is what saves.
   const saveRef = useRef(save);
-  useEffect(() => {
-    saveRef.current = save;
-  }, [save]);
-
-  // Browsers won't wait for async saves during unload, so prompt the user.
-  useBeforeUnload(isDirty);
-
-  const handleFocus = useCallback(() => {
-    isFocusedRef.current = true;
-  }, []);
-
-  const handleBlur = useCallback(() => {
-    // Run save while still considered focused, then clear the flag so a later
-    // unmount won't save again.
-    saveRef.current();
-    isFocusedRef.current = false;
-  }, []);
+  saveRef.current = save;
 
   // Persist a pending edit on SPA navigation away.
-  useEffect(() => {
-    return () => {
-      saveRef.current();
-    };
-  }, []);
+  useEffect(() => () => saveRef.current(), []);
 
   return {
     inputValue,
     handleInputChange: setInputValue,
-    handleFocus,
-    handleBlur,
+    handleBlur: save,
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.module.css
@@ -1,6 +1,15 @@
+.textareaRoot {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
 .textareaWrapper {
-  textarea {
-    line-height: 1.25rem;
-    min-height: 400px;
-  }
+  flex: 1;
+  display: flex;
+}
+
+.textareaInput {
+  height: 100%;
+  line-height: 1.25rem;
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.module.css
@@ -1,3 +1,13 @@
+/*
+ * 8rem accounts for the admin layout chrome above this wrapper (nav header +
+ * page top padding) plus a small gap below so the content doesn't touch the
+ * viewport edge.
+ */
+.wrapper {
+  height: calc(100dvh - 8rem);
+  overflow: hidden;
+}
+
 .textareaRoot {
   flex: 1;
   min-height: 0;

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -21,7 +21,7 @@ type SystemPromptPageProps = {
 
 function SystemPromptPage(props: SystemPromptPageProps) {
   const { title, description, settingKey } = props;
-  const { handleInputChange, handleBlur, inputValue } =
+  const { handleInputChange, handleFocus, handleBlur, inputValue } =
     useAdminSettingWithBlurInput(settingKey);
 
   return (
@@ -40,6 +40,7 @@ function SystemPromptPage(props: SystemPromptPageProps) {
         }}
         onBlur={handleBlur}
         onChange={(e) => handleInputChange(e.target.value)}
+        onFocus={handleFocus}
         placeholder={getPlaceholder()}
         value={inputValue || ""}
       />
@@ -50,14 +51,6 @@ function SystemPromptPage(props: SystemPromptPageProps) {
 const getPlaceholder = () => {
   return (
     t`# Here's a section` +
-    "\n" +
-    t`1. Do this` +
-    "\n" +
-    t`2. And this` +
-    "\n" +
-    t`3. And lastly, this` +
-    "\n\n" +
-    t`# Here's another section` +
     "\n" +
     t`1. Do this` +
     "\n" +

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -1,12 +1,9 @@
 import { t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { useSelector } from "metabase/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Text, Textarea } from "metabase/ui";
+import { Textarea } from "metabase/ui";
 import { useAdminSettingWithBlurInput } from "metabase-enterprise/ai-controls/hooks";
 
 import S from "./MetabotSystemPromptsPage.module.css";
@@ -30,28 +27,22 @@ function SystemPromptPage(props: SystemPromptPageProps) {
   return (
     <SettingsPageWrapper
       title={title}
-      mt="sm"
-      h="calc(100dvh - 8rem)"
-      style={{ overflow: "hidden" }}
+      description={description}
+      className={S.wrapper}
     >
-      <SettingsSection h="100%" mih={0} stackProps={{ h: "100%" }}>
-        <Text c="text-secondary" size="md">
-          {description}
-        </Text>
-        <Textarea
-          aria-label={title}
-          autosize={false}
-          classNames={{
-            root: S.textareaRoot,
-            wrapper: S.textareaWrapper,
-            input: S.textareaInput,
-          }}
-          onChange={(e) => handleInputChange(e.target.value)}
-          onBlur={handleBlur}
-          placeholder={getPlaceholder()}
-          value={inputValue || ""}
-        />
-      </SettingsSection>
+      <Textarea
+        aria-label={title}
+        autosize={false}
+        classNames={{
+          root: S.textareaRoot,
+          wrapper: S.textareaWrapper,
+          input: S.textareaInput,
+        }}
+        onBlur={handleBlur}
+        onChange={(e) => handleInputChange(e.target.value)}
+        placeholder={getPlaceholder()}
+        value={inputValue || ""}
+      />
     </SettingsPageWrapper>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -28,14 +28,24 @@ function SystemPromptPage(props: SystemPromptPageProps) {
     useAdminSettingWithBlurInput(settingKey);
 
   return (
-    <SettingsPageWrapper title={title} mt="sm">
-      <SettingsSection>
-        <Text c="text-secondary" size="md" mb="lg">
+    <SettingsPageWrapper
+      title={title}
+      mt="sm"
+      h="calc(100dvh - 8rem)"
+      style={{ overflow: "hidden" }}
+    >
+      <SettingsSection h="100%" mih={0} stackProps={{ h: "100%" }}>
+        <Text c="text-secondary" size="md">
           {description}
         </Text>
         <Textarea
           aria-label={title}
-          className={S.textareaWrapper}
+          autosize={false}
+          classNames={{
+            root: S.textareaRoot,
+            wrapper: S.textareaWrapper,
+            input: S.textareaInput,
+          }}
           onChange={(e) => handleInputChange(e.target.value)}
           onBlur={handleBlur}
           placeholder={getPlaceholder()}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.tsx
@@ -21,7 +21,7 @@ type SystemPromptPageProps = {
 
 function SystemPromptPage(props: SystemPromptPageProps) {
   const { title, description, settingKey } = props;
-  const { handleInputChange, handleFocus, handleBlur, inputValue } =
+  const { handleInputChange, handleBlur, inputValue } =
     useAdminSettingWithBlurInput(settingKey);
 
   return (
@@ -40,7 +40,6 @@ function SystemPromptPage(props: SystemPromptPageProps) {
         }}
         onBlur={handleBlur}
         onChange={(e) => handleInputChange(e.target.value)}
-        onFocus={handleFocus}
         placeholder={getPlaceholder()}
         value={inputValue || ""}
       />

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -156,6 +156,97 @@ describe("MetabotSystemPromptsPage", () => {
       expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
     });
 
+    it("does not save on focus+blur when the setting starts as null and the user did not type", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: null,
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+
+      await userEvent.click(textarea);
+      fireEvent.blur(textarea);
+
+      // Wait a tick for any async save to flush.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
+    it("does not save if the user types and reverts to the initial value before blurring", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: "Existing prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await waitFor(() => {
+        expect(textarea).toHaveValue("Existing prompt");
+      });
+
+      await userEvent.click(textarea);
+      await userEvent.type(textarea, "x{Backspace}");
+      fireEvent.blur(textarea);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
+    it("does not save on unmount after blur, even if the value drifts later", async () => {
+      const { unmount } = setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: "Existing prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await waitFor(() => {
+        expect(textarea).toHaveValue("Existing prompt");
+      });
+
+      // Focus + blur with no real change.
+      fireEvent.focus(textarea);
+      fireEvent.blur(textarea);
+
+      // After blur, a stray change should not be persisted on unmount.
+      fireEvent.change(textarea, { target: { value: "Drifted" } });
+      unmount();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
+    it("does not save when onChange fires without a prior focus event", async () => {
+      const { unmount } = setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: "Existing prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await waitFor(() => {
+        expect(textarea).toHaveValue("Existing prompt");
+      });
+
+      // Simulate a stray onChange event (e.g. controlled-input sync) without
+      // the field ever being focused by the user.
+      fireEvent.change(textarea, { target: { value: "Drifted value" } });
+      fireEvent.blur(textarea);
+      unmount();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
     it("saves each distinct value across consecutive edit cycles", async () => {
       setup({
         Component: MetabotChatPromptPage,
@@ -166,12 +257,14 @@ describe("MetabotSystemPromptsPage", () => {
         name: "AI chat prompt instructions",
       });
 
+      fireEvent.focus(textarea);
       await userEvent.type(textarea, "First");
       fireEvent.blur(textarea);
       await waitFor(() => {
         expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
       });
 
+      fireEvent.focus(textarea);
       await userEvent.type(textarea, " edit");
       fireEvent.blur(textarea);
       await waitFor(() => {

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -136,7 +136,7 @@ describe("MetabotSystemPromptsPage", () => {
       expect(await screen.findByText("Changes saved")).toBeInTheDocument();
     });
 
-    it("does not re-save on blur if the value did not change", async () => {
+    it("does not save on blur if the value did not change", async () => {
       setup({
         Component: MetabotChatPromptPage,
         settingKey: "metabot-chat-system-prompt",
@@ -150,13 +150,13 @@ describe("MetabotSystemPromptsPage", () => {
         expect(textarea).toHaveValue("Existing prompt");
       });
 
-      fireEvent.focus(textarea);
+      await userEvent.click(textarea);
       fireEvent.blur(textarea);
 
       expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
     });
 
-    it("does not save on focus+blur when the setting starts as null and the user did not type", async () => {
+    it("does not save on blur when the setting starts as null and the user did not type", async () => {
       setup({
         Component: MetabotChatPromptPage,
         settingKey: "metabot-chat-system-prompt",
@@ -170,8 +170,6 @@ describe("MetabotSystemPromptsPage", () => {
       await userEvent.click(textarea);
       fireEvent.blur(textarea);
 
-      // Wait a tick for any async save to flush.
-      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
     });
 
@@ -193,57 +191,6 @@ describe("MetabotSystemPromptsPage", () => {
       await userEvent.type(textarea, "x{Backspace}");
       fireEvent.blur(textarea);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
-    });
-
-    it("does not save on unmount after blur, even if the value drifts later", async () => {
-      const { unmount } = setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: "Existing prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Existing prompt");
-      });
-
-      // Focus + blur with no real change.
-      fireEvent.focus(textarea);
-      fireEvent.blur(textarea);
-
-      // After blur, a stray change should not be persisted on unmount.
-      fireEvent.change(textarea, { target: { value: "Drifted" } });
-      unmount();
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
-    });
-
-    it("does not save when onChange fires without a prior focus event", async () => {
-      const { unmount } = setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: "Existing prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Existing prompt");
-      });
-
-      // Simulate a stray onChange event (e.g. controlled-input sync) without
-      // the field ever being focused by the user.
-      fireEvent.change(textarea, { target: { value: "Drifted value" } });
-      fireEvent.blur(textarea);
-      unmount();
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
     });
 
@@ -257,14 +204,12 @@ describe("MetabotSystemPromptsPage", () => {
         name: "AI chat prompt instructions",
       });
 
-      fireEvent.focus(textarea);
       await userEvent.type(textarea, "First");
       fireEvent.blur(textarea);
       await waitFor(() => {
         expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
       });
 
-      fireEvent.focus(textarea);
       await userEvent.type(textarea, " edit");
       fireEvent.blur(textarea);
       await waitFor(() => {
@@ -301,7 +246,7 @@ describe("MetabotSystemPromptsPage", () => {
       expect(cleanEvent.defaultPrevented).toBe(false);
     });
 
-    it("saves a pending edit when the page unmounts", async () => {
+    it("saves a pending edit when the page unmounts (browser back, etc.)", async () => {
       const { unmount } = setup({
         Component: MetabotChatPromptPage,
         settingKey: "metabot-chat-system-prompt",

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -21,16 +21,38 @@ import {
   SqlGenerationPromptPage,
 } from "./MetabotSystemPromptsPage";
 
-function setup({
+type SystemPromptSettingKey =
+  | "metabot-chat-system-prompt"
+  | "metabot-nlq-system-prompt"
+  | "metabot-sql-system-prompt";
+
+const PAGES = [
+  {
+    Component: MetabotChatPromptPage,
+    settingKey: "metabot-chat-system-prompt" as const,
+    title: "AI chat prompt instructions",
+  },
+  {
+    Component: NaturalLanguagePromptPage,
+    settingKey: "metabot-nlq-system-prompt" as const,
+    title: "Natural language query prompt instructions",
+  },
+  {
+    Component: SqlGenerationPromptPage,
+    settingKey: "metabot-sql-system-prompt" as const,
+    title: "SQL generation prompt instructions",
+  },
+];
+
+async function setup({
   Component,
   settingKey,
+  title,
   settingValue = "",
 }: {
   Component: React.ComponentType;
-  settingKey:
-    | "metabot-chat-system-prompt"
-    | "metabot-nlq-system-prompt"
-    | "metabot-sql-system-prompt";
+  settingKey: SystemPromptSettingKey;
+  title: string;
   settingValue?: string | null;
 }) {
   setupPropertiesEndpoints(
@@ -41,233 +63,108 @@ function setup({
   setupSettingsEndpoints([]);
   setupUpdateSettingEndpoint();
 
-  return renderWithProviders(
+  const view = renderWithProviders(
     <>
       <Component />
       <UndoListing />
     </>,
   );
+  const textarea = await screen.findByRole("textbox", { name: title });
+  // Wait for the hook to hydrate inputValue from the loaded setting.
+  await waitFor(() => expect(textarea).toHaveValue(settingValue ?? ""));
+  return { ...view, textarea };
 }
 
-function getUpdateCallsFor(settingKey: string) {
+function getUpdateCallsFor(settingKey: SystemPromptSettingKey) {
   return fetchMock.callHistory.calls(`path:/api/setting/${settingKey}`, {
     method: "PUT",
   });
 }
 
 describe("MetabotSystemPromptsPage", () => {
-  describe("MetabotChatPromptPage", () => {
-    it("renders with the correct title", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
+  describe.each(PAGES)("$title", ({ Component, settingKey, title }) => {
+    it("renders the page with the existing prompt value", async () => {
+      const { textarea } = await setup({
+        Component,
+        settingKey,
+        title,
+        settingValue: "Existing value",
       });
 
-      expect(
-        await screen.findByText("AI chat prompt instructions"),
-      ).toBeInTheDocument();
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(textarea).toHaveValue("Existing value");
     });
+  });
 
-    it("renders the textarea with existing prompt value", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: "Be concise and helpful",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Be concise and helpful");
-      });
-    });
-
-    it("updates the textarea value when user types", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await userEvent.type(textarea, "New instructions");
-
-      await waitFor(() => {
-        expect(textarea).toHaveValue("New instructions");
-      });
-    });
-
-    it("does not save while the user is typing", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await userEvent.type(textarea, "Some prompt");
-
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
-    });
+  describe("MetabotChatPromptPage save behavior", () => {
+    const chatPage = PAGES[0];
+    const getChatSaves = () => getUpdateCallsFor(chatPage.settingKey);
 
     it("saves on blur and shows a 'Changes saved' toast", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
+      const { textarea } = await setup(chatPage);
 
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
       await userEvent.type(textarea, "Be concise");
       fireEvent.blur(textarea);
 
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
-      });
-
-      const [call] = getUpdateCallsFor("metabot-chat-system-prompt");
+      await waitFor(() => expect(getChatSaves()).toHaveLength(1));
+      const [call] = getChatSaves();
       expect(await call?.request?.json()).toEqual({ value: "Be concise" });
-
       expect(await screen.findByText("Changes saved")).toBeInTheDocument();
     });
 
-    it("does not save on blur if the value did not change", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
+    it("does not save if the user types and reverts before blurring", async () => {
+      const { textarea } = await setup({
+        ...chatPage,
         settingValue: "Existing prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Existing prompt");
-      });
-
-      await userEvent.click(textarea);
-      fireEvent.blur(textarea);
-
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
-    });
-
-    it("does not save on blur when the setting starts as null and the user did not type", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: null,
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-
-      await userEvent.click(textarea);
-      fireEvent.blur(textarea);
-
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
-    });
-
-    it("does not save if the user types and reverts to the initial value before blurring", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: "Existing prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Existing prompt");
       });
 
       await userEvent.click(textarea);
       await userEvent.type(textarea, "x{Backspace}");
       fireEvent.blur(textarea);
 
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+      expect(getChatSaves()).toHaveLength(0);
     });
 
-    it("saves each distinct value across consecutive edit cycles", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-
-      await userEvent.type(textarea, "First");
-      fireEvent.blur(textarea);
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
-      });
-
-      await userEvent.type(textarea, " edit");
-      fireEvent.blur(textarea);
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(2);
-      });
-
-      const calls = getUpdateCallsFor("metabot-chat-system-prompt");
-      expect(await calls[0]?.request?.json()).toEqual({ value: "First" });
-      expect(await calls[1]?.request?.json()).toEqual({ value: "First edit" });
-    });
-
-    it("trims leading and trailing whitespace before saving", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await userEvent.type(textarea, "  hello world  ");
-      fireEvent.blur(textarea);
-
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
-      });
-      const [call] = getUpdateCallsFor("metabot-chat-system-prompt");
-      expect(await call?.request?.json()).toEqual({ value: "hello world" });
-    });
-
-    it("does not save when only whitespace changes (trimmed value unchanged)", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-        settingValue: "hello",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
-      await waitFor(() => expect(textarea).toHaveValue("hello"));
+    it("does not save if only the leading/trailing whitespace changes", async () => {
+      const { textarea } = await setup({ ...chatPage, settingValue: "hello" });
 
       await userEvent.click(textarea);
       await userEvent.type(textarea, "   ");
       fireEvent.blur(textarea);
 
-      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+      expect(getChatSaves()).toHaveLength(0);
     });
 
-    it("warns about unsaved edits via beforeunload, but stops once saved", async () => {
-      setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
+    it("trims leading and trailing whitespace before saving", async () => {
+      const { textarea } = await setup(chatPage);
 
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
+      await userEvent.type(textarea, "  hello world  ");
+      fireEvent.blur(textarea);
+
+      await waitFor(() => expect(getChatSaves()).toHaveLength(1));
+      const [call] = getChatSaves();
+      expect(await call?.request?.json()).toEqual({ value: "hello world" });
+    });
+
+    it("saves each distinct value across consecutive edit cycles", async () => {
+      const { textarea } = await setup(chatPage);
+
+      await userEvent.type(textarea, "First");
+      fireEvent.blur(textarea);
+      await waitFor(() => expect(getChatSaves()).toHaveLength(1));
+
+      await userEvent.type(textarea, " edit");
+      fireEvent.blur(textarea);
+      await waitFor(() => expect(getChatSaves()).toHaveLength(2));
+
+      const calls = getChatSaves();
+      expect(await calls[0]?.request?.json()).toEqual({ value: "First" });
+      expect(await calls[1]?.request?.json()).toEqual({ value: "First edit" });
+    });
+
+    it("toggles the beforeunload guard with the dirty state", async () => {
+      const { textarea } = await setup(chatPage);
+
       await userEvent.type(textarea, "Pending");
 
       const dirtyEvent = new Event("beforeunload", { cancelable: true });
@@ -275,87 +172,22 @@ describe("MetabotSystemPromptsPage", () => {
       expect(dirtyEvent.defaultPrevented).toBe(true);
 
       fireEvent.blur(textarea);
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
-      });
+      await waitFor(() => expect(getChatSaves()).toHaveLength(1));
 
       const cleanEvent = new Event("beforeunload", { cancelable: true });
       window.dispatchEvent(cleanEvent);
       expect(cleanEvent.defaultPrevented).toBe(false);
     });
 
-    it("saves a pending edit when the page unmounts (browser back, etc.)", async () => {
-      const { unmount } = setup({
-        Component: MetabotChatPromptPage,
-        settingKey: "metabot-chat-system-prompt",
-      });
+    it("saves a pending edit when the page unmounts", async () => {
+      // Covers SPA navigation away mid-edit (e.g. browser back), where blur
+      // never fires on the focused textarea.
+      const { textarea, unmount } = await setup(chatPage);
 
-      const textarea = await screen.findByRole("textbox", {
-        name: "AI chat prompt instructions",
-      });
       await userEvent.type(textarea, "Half-typed");
-      // No blur - simulate navigating away mid-edit.
       unmount();
 
-      await waitFor(() => {
-        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
-      });
-    });
-  });
-
-  describe("NaturalLanguagePromptPage", () => {
-    it("renders with the correct title", async () => {
-      setup({
-        Component: NaturalLanguagePromptPage,
-        settingKey: "metabot-nlq-system-prompt",
-      });
-
-      expect(
-        await screen.findByText("Natural language query prompt instructions"),
-      ).toBeInTheDocument();
-    });
-
-    it("renders the textarea with existing prompt value", async () => {
-      setup({
-        Component: NaturalLanguagePromptPage,
-        settingKey: "metabot-nlq-system-prompt",
-        settingValue: "Prefer bar charts",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "Natural language query prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Prefer bar charts");
-      });
-    });
-  });
-
-  describe("SqlGenerationPromptPage", () => {
-    it("renders with the correct title", async () => {
-      setup({
-        Component: SqlGenerationPromptPage,
-        settingKey: "metabot-sql-system-prompt",
-      });
-
-      expect(
-        await screen.findByText("SQL generation prompt instructions"),
-      ).toBeInTheDocument();
-    });
-
-    it("renders the textarea with existing prompt value", async () => {
-      setup({
-        Component: SqlGenerationPromptPage,
-        settingKey: "metabot-sql-system-prompt",
-        settingValue: "Use uppercase SQL keywords",
-      });
-
-      const textarea = await screen.findByRole("textbox", {
-        name: "SQL generation prompt instructions",
-      });
-      await waitFor(() => {
-        expect(textarea).toHaveValue("Use uppercase SQL keywords");
-      });
+      await waitFor(() => expect(getChatSaves()).toHaveLength(1));
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotSystemPromptsPage/MetabotSystemPromptsPage.unit.spec.tsx
@@ -221,6 +221,44 @@ describe("MetabotSystemPromptsPage", () => {
       expect(await calls[1]?.request?.json()).toEqual({ value: "First edit" });
     });
 
+    it("trims leading and trailing whitespace before saving", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await userEvent.type(textarea, "  hello world  ");
+      fireEvent.blur(textarea);
+
+      await waitFor(() => {
+        expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(1);
+      });
+      const [call] = getUpdateCallsFor("metabot-chat-system-prompt");
+      expect(await call?.request?.json()).toEqual({ value: "hello world" });
+    });
+
+    it("does not save when only whitespace changes (trimmed value unchanged)", async () => {
+      setup({
+        Component: MetabotChatPromptPage,
+        settingKey: "metabot-chat-system-prompt",
+        settingValue: "hello",
+      });
+
+      const textarea = await screen.findByRole("textbox", {
+        name: "AI chat prompt instructions",
+      });
+      await waitFor(() => expect(textarea).toHaveValue("hello"));
+
+      await userEvent.click(textarea);
+      await userEvent.type(textarea, "   ");
+      fireEvent.blur(textarea);
+
+      expect(getUpdateCallsFor("metabot-chat-system-prompt")).toHaveLength(0);
+    });
+
     it("warns about unsaved edits via beforeunload, but stops once saved", async () => {
       setup({
         Component: MetabotChatPromptPage,


### PR DESCRIPTION
### Description

Fixes [UXW-3923](https://linear.app/metabase/issue/UXW-3923/system-prompt-text-areas-in-adminmetabotsystem-prompts-should-be-the).
Fixes [UXW-3953](https://linear.app/metabase/issue/UXW-3953/simplify-layout-for-custom-system-prompts)

The textareas on `/admin/metabot/system-prompts/*` now grow to fill the viewport with breathing room below, and the layout drops the surrounding card so the description sits directly under the heading.

- Mantine `Textarea` autosize is enabled globally, so the height-driven layout requires `autosize={false}` to take effect.
- The wrapper height (`calc(100dvh - 8rem)`) and `overflow: hidden` live in the CSS module with a comment explaining where `8rem` comes from.

Layout changes:
- Removed the surrounding card (`SettingsSection`) around the textarea — the textarea is now a direct child of the page wrapper.

### How to verify

- [ ] Visit `/admin/metabot/1/system-prompts/sql-generation` (and the other two tabs) on a tall viewport: the textarea fills the viewport with a small gap below.
- [ ] Resize the window short: the textarea shrinks gracefully without overflowing.

### Demo

https://github.com/user-attachments/assets/c88464ca-cfb2-4bea-a556-00ab9d122810
<img width="880" height="830" alt="image" src="https://github.com/user-attachments/assets/90483274-3ecb-4ad9-9c61-d4355acd3b4c" />

