### PR TITLE
Fix created questions missing from recents

### DIFF
--- a/src/metabase/activity_feed/events/recent_views.clj
+++ b/src/metabase/activity_feed/events/recent_views.clj
@@ -56,6 +56,17 @@
     (catch Throwable e
       (log/warnf e "Failed to process recent_views event: %s" topic))))
 
+(derive ::card-create-with-result-metadata :metabase/event)
+(derive :event/card-create-with-result-metadata ::card-create-with-result-metadata)
+
+(m/defmethod events/publish-event! ::card-create-with-result-metadata
+  "Handle recent-view processing for created cards with result metadata."
+  [topic {:keys [card-id user-id]}]
+  (try
+    (recent-views/update-users-recent-views! (or user-id api/*current-user-id*) :model/Card card-id :view)
+    (catch Throwable e
+      (log/warnf e "Failed to process recent_views event: %s" topic))))
+
 (derive ::legacy-card-event :metabase/event)
 ;; in practice, updating or creating a card will immediately trigger a card-read
 (derive :event/card-read ::legacy-card-event)

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -568,9 +568,15 @@
       (lib/check-card-overwrite ::no-id query)
       (catch clojure.lang.ExceptionInfo e
         (throw (ex-info (ex-message e) (assoc (ex-data e) :status-code 400)))))
-    (-> (queries/create-card! card @api/*current-user*)
-        hydrate-card-details
-        (assoc :last-edit-info (revisions/edit-information-for-user @api/*current-user*)))))
+    (let [created-card (queries/create-card! card @api/*current-user*)]
+      (when (and (some? (:result_metadata card))
+                 (= (name (:type created-card)) "question"))
+        (events/publish-event! :event/card-create-with-result-metadata
+                               {:card-id (:id created-card)
+                                :user-id api/*current-user-id*}))
+      (-> created-card
+          hydrate-card-details
+          (assoc :last-edit-info (revisions/edit-information-for-user @api/*current-user*))))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -781,6 +781,27 @@
                                                               (update :id boolean)
                                                               (update :timestamp boolean)))))))))))))))))
 
+(deftest create-a-card-with-result-metadata-updates-recents-test
+  (testing "POST /api/card adds user-created questions to recents (UXW-3171)"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-model-cleanup [:model/Card]
+        (t2/delete! :model/RecentViews :user_id (mt/user->id :rasta))
+        (let [card    (assoc (card-with-name-and-query) :result_metadata [])
+              card-id (:id (mt/user-http-request :rasta :post 200 "card" card))]
+          (is (= {:user_id  (mt/user->id :rasta)
+                  :model    "card"
+                  :model_id card-id}
+                 (t2/select-one [:model/RecentViews :user_id :model :model_id]
+                                :user_id  (mt/user->id :rasta)
+                                :model_id card-id
+                                :model    "card"))))
+        (testing "Cards saved without result metadata are not treated as viewed"
+          (let [card-id (:id (mt/user-http-request :rasta :post 200 "card" (card-with-name-and-query)))]
+            (is (nil? (t2/select-one :model/RecentViews
+                                     :user_id  (mt/user->id :rasta)
+                                     :model_id card-id
+                                     :model    "card")))))))))
+
 (deftest ^:parallel create-card-validation-test
   (testing "POST /api/card"
     (is (=? {:errors {:name                   "value must be a non-blank string."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70014
### Description

Adds newly created cards to the creator's recent views via the existing card-create event flow, while keeping document cards out of question recents.

### How to verify

- Create a new question and navigate elsewhere.
- Confirm it appears in Recents when you click the search input.

### Demo
https://github.com/user-attachments/assets/690ef480-7c0a-4ac6-94c2-b2dd0ec382ac


### Checklist

- [x] Tests have been added/updated to cover changes in this PR