### PR TITLE
Toggle Collect User Data input based on audit_app feature

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -307,6 +307,27 @@ describe("scenarios > admin > settings (EE)", () => {
       .findByLabelText("store icon")
       .should("not.exist");
   });
+
+  it("should show the usage analytics PII toggle only when the audit_app feature is enabled", () => {
+    cy.visit("/admin/settings/general");
+
+    cy.log("With the pro-self-hosted token, audit_app is enabled");
+    cy.findByTestId("admin-layout-content").within(() => {
+      cy.contains("Usage tracking");
+      cy.contains("Collect user data to display in usage analytics");
+    });
+
+    cy.log("Without a token, audit_app is gone and the toggle is hidden");
+    H.deleteToken();
+    cy.reload();
+
+    cy.findByTestId("admin-layout-content").within(() => {
+      cy.contains("Send anonymous tracking data to Metabase");
+      cy.contains("Collect user data to display in usage analytics").should(
+        "not.exist",
+      );
+    });
+  });
 });
 
 describe("Cloud settings section", () => {

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -307,27 +307,6 @@ describe("scenarios > admin > settings (EE)", () => {
       .findByLabelText("store icon")
       .should("not.exist");
   });
-
-  it("should show the usage analytics PII toggle only when the audit_app feature is enabled", () => {
-    cy.visit("/admin/settings/general");
-
-    cy.log("With the pro-self-hosted token, audit_app is enabled");
-    cy.findByTestId("admin-layout-content").within(() => {
-      cy.contains("Usage tracking");
-      cy.contains("Collect user data to display in usage analytics");
-    });
-
-    cy.log("Without a token, audit_app is gone and the toggle is hidden");
-    H.deleteToken();
-    cy.reload();
-
-    cy.findByTestId("admin-layout-content").within(() => {
-      cy.contains("Send anonymous tracking data to Metabase");
-      cy.contains("Collect user data to display in usage analytics").should(
-        "not.exist",
-      );
-    });
-  });
 });
 
 describe("Cloud settings section", () => {

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -22,6 +22,7 @@ export function GeneralSettingsPage() {
     anchor: "allowed-domains-for-iframes-in-dashboards",
   });
   const hasHostingFeature = useHasTokenFeature("hosting");
+  const hasAuditAppFeature = useHasTokenFeature("audit_app");
   const enableAnonymousTracking = !hasHostingFeature;
 
   return (
@@ -89,7 +90,7 @@ export function GeneralSettingsPage() {
       <SettingsSection title={t`Usage tracking`}>
         {enableAnonymousTracking && <AnonymousTrackingInput />}
 
-        <CollectUserDataInput />
+        {hasAuditAppFeature && <CollectUserDataInput />}
       </SettingsSection>
 
       <UpsellDevInstances location="settings-general" />

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
@@ -37,13 +37,15 @@ const generalSettings = {
   "search-engine": "appdb",
 } as const;
 
-const setup = async (
-  { isCloudPlan }: { isCloudPlan: boolean } = { isCloudPlan: false },
-) => {
+const setup = async ({
+  isCloudPlan,
+  hasAuditApp,
+}: { isCloudPlan?: boolean; hasAuditApp?: boolean } = {}) => {
   const settings = createMockSettings({
     ...generalSettings,
     "token-features": createMockTokenFeatures({
-      hosting: isCloudPlan,
+      hosting: isCloudPlan ?? false,
+      audit_app: hasAuditApp ?? true,
     }),
   });
 
@@ -179,6 +181,22 @@ describe("GeneralSettingsPage", () => {
 
     expect(
       screen.queryByText("Send anonymous tracking data to Metabase"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show Collect User Data input when the audit_app token feature is enabled", async () => {
+    await setup({ hasAuditApp: true });
+
+    expect(
+      screen.getByText("Collect user data to display in usage analytics"),
+    ).toBeInTheDocument();
+  });
+
+  it("should not show Collect User Data input when the audit_app token feature is disabled", async () => {
+    await setup({ hasAuditApp: false });
+
+    expect(
+      screen.queryByText("Collect user data to display in usage analytics"),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/metabase/analytics/settings.clj
+++ b/src/metabase/analytics/settings.clj
@@ -98,4 +98,5 @@
   :type       :boolean
   :default    false
   :visibility :admin
-  :export?    true)
+  :export?    true
+  :feature    :audit-app)

--- a/test/metabase/analytics/settings_test.clj
+++ b/test/metabase/analytics/settings_test.clj
@@ -28,3 +28,18 @@
       (finally
         (when original-value
           (t2/update! :model/Setting {:key "instance-creation"} {:value original-value}))))))
+
+(deftest analytics-pii-retention-enabled-feature-gate-test
+  (testing "analytics-pii-retention-enabled is gated behind the :audit-app premium feature"
+    (testing "with :audit-app, the setting can be read and written"
+      (mt/with-premium-features #{:audit-app}
+        (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+          (analytics.settings/analytics-pii-retention-enabled! true)
+          (is (true? (analytics.settings/analytics-pii-retention-enabled))))))
+    (testing "without :audit-app, reads return the default and writes throw"
+      (mt/with-premium-features #{}
+        (is (false? (analytics.settings/analytics-pii-retention-enabled)))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Setting analytics-pii-retention-enabled is not enabled because feature :audit-app is not available"
+             (analytics.settings/analytics-pii-retention-enabled! true)))))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -949,24 +949,25 @@
           info-with-ip (fn [ip] {:origin nil :referer nil :user-agent nil :ip-address ip})]
       (with-redefs [metabot.config/check-metabot-enabled! (constantly nil)
                     api/native-agent-streaming-request    (constantly nil)]
-        (mt/with-test-user :rasta
-          (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-            (testing "first writer wins: initial call captures the IP, later calls do not overwrite it"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id) (info-with-ip "1.2.3.4"))
-                (is (= "1.2.3.4" (ip-for conversation-id)))
-                (api/streaming-request (request-body conversation-id) (info-with-ip "5.6.7.8"))
-                (is (= "1.2.3.4" (ip-for conversation-id)))))
-            (testing "null IP on pre-feature rows is backfilled on next call"
-              (let [conversation-id (str (random-uuid))]
-                (t2/insert! :model/MetabotConversation {:id conversation-id :user_id (mt/user->id :rasta)})
-                (api/streaming-request (request-body conversation-id) (info-with-ip "9.9.9.9"))
-                (is (= "9.9.9.9" (ip-for conversation-id))))))
-          (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-            (testing "ip_address is NOT recorded when analytics-pii-retention-enabled is off"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id) (info-with-ip "1.2.3.4"))
-                (is (nil? (ip-for conversation-id)))))))))))
+        (mt/with-premium-features #{:audit-app}
+          (mt/with-test-user :rasta
+            (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+              (testing "first writer wins: initial call captures the IP, later calls do not overwrite it"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id) (info-with-ip "1.2.3.4"))
+                  (is (= "1.2.3.4" (ip-for conversation-id)))
+                  (api/streaming-request (request-body conversation-id) (info-with-ip "5.6.7.8"))
+                  (is (= "1.2.3.4" (ip-for conversation-id)))))
+              (testing "null IP on pre-feature rows is backfilled on next call"
+                (let [conversation-id (str (random-uuid))]
+                  (t2/insert! :model/MetabotConversation {:id conversation-id :user_id (mt/user->id :rasta)})
+                  (api/streaming-request (request-body conversation-id) (info-with-ip "9.9.9.9"))
+                  (is (= "9.9.9.9" (ip-for conversation-id))))))
+            (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+              (testing "ip_address is NOT recorded when analytics-pii-retention-enabled is off"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id) (info-with-ip "1.2.3.4"))
+                  (is (nil? (ip-for conversation-id))))))))))))
 
 (deftest streaming-request-embedding-fields-test
   (mt/with-model-cleanup [:model/MetabotMessage
@@ -989,117 +990,119 @@
                          (t2/select-one :model/MetabotConversation :id conversation-id))]
       (with-redefs [metabot.config/check-metabot-enabled! (constantly nil)
                     api/native-agent-streaming-request    (constantly nil)]
-        (mt/with-test-user :rasta
-          (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-            (testing "flag on: hostname AND path are recorded"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id)
-                                       (info-with "https://customer.example.com/dashboard"))
-                (let [convo (convo-for conversation-id)]
-                  (is (= "customer.example.com" (:embedding_hostname convo)))
-                  (is (= "/dashboard"           (:embedding_path     convo))))))
-            (testing "first writer wins: hostname is not overwritten on later calls"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id)
-                                       (info-with "https://host.example.com/page"))
-                (api/streaming-request (request-body conversation-id)
-                                       (info-with "https://other.example.com/other"))
-                (let [convo (convo-for conversation-id)]
-                  (is (= "host.example.com" (:embedding_hostname convo)))
-                  (is (= "/page"            (:embedding_path     convo))))))
-            (testing "missing embed referrer leaves both columns null"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id) (info-with nil))
-                (let [convo (convo-for conversation-id)]
-                  (is (nil? (:embedding_hostname convo)))
-                  (is (nil? (:embedding_path     convo)))))))
-          (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-            (testing "flag off: hostname IS still recorded (ungated), path is NOT"
-              (let [conversation-id (str (random-uuid))]
-                (api/streaming-request (request-body conversation-id)
-                                       (info-with "https://customer.example.com/dashboard"))
-                (let [convo (convo-for conversation-id)]
-                  (is (= "customer.example.com" (:embedding_hostname convo)))
-                  (is (nil?                     (:embedding_path     convo))))))))))))
+        (mt/with-premium-features #{:audit-app}
+          (mt/with-test-user :rasta
+            (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+              (testing "flag on: hostname AND path are recorded"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id)
+                                         (info-with "https://customer.example.com/dashboard"))
+                  (let [convo (convo-for conversation-id)]
+                    (is (= "customer.example.com" (:embedding_hostname convo)))
+                    (is (= "/dashboard"           (:embedding_path     convo))))))
+              (testing "first writer wins: hostname is not overwritten on later calls"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id)
+                                         (info-with "https://host.example.com/page"))
+                  (api/streaming-request (request-body conversation-id)
+                                         (info-with "https://other.example.com/other"))
+                  (let [convo (convo-for conversation-id)]
+                    (is (= "host.example.com" (:embedding_hostname convo)))
+                    (is (= "/page"            (:embedding_path     convo))))))
+              (testing "missing embed referrer leaves both columns null"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id) (info-with nil))
+                  (let [convo (convo-for conversation-id)]
+                    (is (nil? (:embedding_hostname convo)))
+                    (is (nil? (:embedding_path     convo)))))))
+            (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+              (testing "flag off: hostname IS still recorded (ungated), path is NOT"
+                (let [conversation-id (str (random-uuid))]
+                  (api/streaming-request (request-body conversation-id)
+                                         (info-with "https://customer.example.com/dashboard"))
+                  (let [convo (convo-for conversation-id)]
+                    (is (= "customer.example.com" (:embedding_hostname convo)))
+                    (is (nil?                     (:embedding_path     convo)))))))))))))
 
 (deftest agent-streaming-endpoint-captures-embed-referrer-test
   (testing "POST /metabot/agent-streaming captures x-metabase-embed-referrer as embedding_hostname/embedding_path"
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]
-      (binding [scope/*current-user-metabot-permissions* scope/all-yes-permissions]
-        (with-redefs [openrouter/openrouter (fn [_]
-                                              (mut/mock-llm-response
-                                               [{:type :start :id "msg-1"}
-                                                {:type :text :text "hi"}
-                                                {:type  :usage       :usage {:promptTokens 1 :completionTokens 1}
-                                                 :model "test-model" :id    "msg-1"}]))]
-          (mt/with-model-cleanup [:model/MetabotMessage
-                                  [:model/MetabotConversation :created_at]]
-            (testing "flag on: hostname AND path are recorded"
-              (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-                (let [conversation-id (str (random-uuid))
-                      embed-referrer  "https://customer.example.com/dashboard"]
-                  (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                                        {:request-options {:headers {"x-metabase-embed-referrer" embed-referrer}}}
-                                        {:message         "hello"
-                                         :context         {}
-                                         :conversation_id conversation-id
-                                         :history         []
-                                         :state           {}})
-                  (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
-                    (is (= "customer.example.com" (:embedding_hostname convo)))
-                    (is (= "/dashboard"           (:embedding_path     convo)))))))
-            (testing "flag off: hostname recorded (ungated), path NOT recorded"
-              (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-                (let [conversation-id (str (random-uuid))
-                      embed-referrer  "https://customer.example.com/dashboard"]
-                  (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                                        {:request-options {:headers {"x-metabase-embed-referrer" embed-referrer}}}
-                                        {:message         "hello"
-                                         :context         {}
-                                         :conversation_id conversation-id
-                                         :history         []
-                                         :state           {}})
-                  (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
-                    (is (= "customer.example.com" (:embedding_hostname convo)))
-                    (is (nil?                     (:embedding_path     convo)))))))
-            (testing "standard Referer header (no x-metabase-embed-referrer) leaves both columns null"
-              (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-                (let [conversation-id (str (random-uuid))]
-                  (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                                        {:request-options {:headers {"referer" "https://customer.example.com/dashboard"}}}
-                                        {:message         "hello"
-                                         :context         {}
-                                         :conversation_id conversation-id
-                                         :history         []
-                                         :state           {}})
-                  (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
-                    (is (nil? (:embedding_hostname convo)))
-                    (is (nil? (:embedding_path     convo)))))))
-            (testing "user-agent recorded only when flag is on"
-              (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-                (let [conversation-id (str (random-uuid))]
-                  (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                                        {:request-options {:headers {"user-agent" "Mozilla/5.0 (TestAgent)"}}}
-                                        {:message         "hello"
-                                         :context         {}
-                                         :conversation_id conversation-id
-                                         :history         []
-                                         :state           {}})
-                  (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
-                    (is (= "Mozilla/5.0 (TestAgent)" (:user_agent convo)))
-                    (is (some? (:sanitized_user_agent convo))))))
-              (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-                (let [conversation-id (str (random-uuid))]
-                  (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                                        {:request-options {:headers {"user-agent" "Mozilla/5.0 (TestAgent)"}}}
-                                        {:message         "hello"
-                                         :context         {}
-                                         :conversation_id conversation-id
-                                         :history         []
-                                         :state           {}})
-                  (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
-                    (is (nil? (:user_agent           convo)))
-                    (is (nil? (:sanitized_user_agent convo)))))))))))))
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]
+        (binding [scope/*current-user-metabot-permissions* scope/all-yes-permissions]
+          (with-redefs [openrouter/openrouter (fn [_]
+                                                (mut/mock-llm-response
+                                                 [{:type :start :id "msg-1"}
+                                                  {:type :text :text "hi"}
+                                                  {:type  :usage       :usage {:promptTokens 1 :completionTokens 1}
+                                                   :model "test-model" :id    "msg-1"}]))]
+            (mt/with-model-cleanup [:model/MetabotMessage
+                                    [:model/MetabotConversation :created_at]]
+              (testing "flag on: hostname AND path are recorded"
+                (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+                  (let [conversation-id (str (random-uuid))
+                        embed-referrer  "https://customer.example.com/dashboard"]
+                    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                          {:request-options {:headers {"x-metabase-embed-referrer" embed-referrer}}}
+                                          {:message         "hello"
+                                           :context         {}
+                                           :conversation_id conversation-id
+                                           :history         []
+                                           :state           {}})
+                    (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
+                      (is (= "customer.example.com" (:embedding_hostname convo)))
+                      (is (= "/dashboard"           (:embedding_path     convo)))))))
+              (testing "flag off: hostname recorded (ungated), path NOT recorded"
+                (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+                  (let [conversation-id (str (random-uuid))
+                        embed-referrer  "https://customer.example.com/dashboard"]
+                    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                          {:request-options {:headers {"x-metabase-embed-referrer" embed-referrer}}}
+                                          {:message         "hello"
+                                           :context         {}
+                                           :conversation_id conversation-id
+                                           :history         []
+                                           :state           {}})
+                    (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
+                      (is (= "customer.example.com" (:embedding_hostname convo)))
+                      (is (nil?                     (:embedding_path     convo)))))))
+              (testing "standard Referer header (no x-metabase-embed-referrer) leaves both columns null"
+                (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+                  (let [conversation-id (str (random-uuid))]
+                    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                          {:request-options {:headers {"referer" "https://customer.example.com/dashboard"}}}
+                                          {:message         "hello"
+                                           :context         {}
+                                           :conversation_id conversation-id
+                                           :history         []
+                                           :state           {}})
+                    (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
+                      (is (nil? (:embedding_hostname convo)))
+                      (is (nil? (:embedding_path     convo)))))))
+              (testing "user-agent recorded only when flag is on"
+                (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+                  (let [conversation-id (str (random-uuid))]
+                    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                          {:request-options {:headers {"user-agent" "Mozilla/5.0 (TestAgent)"}}}
+                                          {:message         "hello"
+                                           :context         {}
+                                           :conversation_id conversation-id
+                                           :history         []
+                                           :state           {}})
+                    (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
+                      (is (= "Mozilla/5.0 (TestAgent)" (:user_agent convo)))
+                      (is (some? (:sanitized_user_agent convo))))))
+                (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+                  (let [conversation-id (str (random-uuid))]
+                    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                          {:request-options {:headers {"user-agent" "Mozilla/5.0 (TestAgent)"}}}
+                                          {:message         "hello"
+                                           :context         {}
+                                           :conversation_id conversation-id
+                                           :history         []
+                                           :state           {}})
+                    (let [convo (t2/select-one :model/MetabotConversation :id conversation-id)]
+                      (is (nil? (:user_agent           convo)))
+                      (is (nil? (:sanitized_user_agent convo))))))))))))))
 
 (deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -171,20 +171,21 @@
                                  :type   :category
                                  :target $price
                                  :value  "4"}]})]
-      (testing "PII retention enabled -> parameters populated"
-        (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-          (with-query-execution! [qe query]
-            (process-userland-query query)
-            (is (=? {:parameterized true
-                     :parameters    some?}
-                    (qe))))))
-      (testing "PII retention disabled -> parameters nil, parameterized still set"
-        (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-          (with-query-execution! [qe query]
-            (process-userland-query query)
-            (is (=? {:parameterized true
-                     :parameters    nil}
-                    (qe)))))))))
+      (mt/with-premium-features #{:audit-app}
+        (testing "PII retention enabled -> parameters populated"
+          (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+            (with-query-execution! [qe query]
+              (process-userland-query query)
+              (is (=? {:parameterized true
+                       :parameters    some?}
+                      (qe))))))
+        (testing "PII retention disabled -> parameters nil, parameterized still set"
+          (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+            (with-query-execution! [qe query]
+              (process-userland-query query)
+              (is (=? {:parameterized true
+                       :parameters    nil}
+                      (qe))))))))))
 
 (def ^:private ^:dynamic *viewlog-call-count* nil)
 

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -306,33 +306,34 @@
                     (ring.mock/header "x-metabase-embed-referrer" "https://app.example.com/dashboard/1?x=y")
                     (ring.mock/header "user-agent" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                     (assoc :remote-addr "10.0.0.1"))]
-    (testing "PII fields populated when setting enabled and request bound"
-      (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-        (request.current/with-current-request request
+    (mt/with-premium-features #{:audit-app}
+      (testing "PII fields populated when setting enabled and request bound"
+        (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+          (request.current/with-current-request request
+            (let [result (sdk/include-sdk-info {})]
+              (is (= "app.example.com"  (:embedding_hostname result)))
+              (is (= "/dashboard/1"     (:embedding_path result)))
+              (is (= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                     (:user_agent result)))
+              (is (= "Browser (Chrome/OS X)" (:sanitized_user_agent result)))
+              (is (= "10.0.0.1"         (:ip_address result)))))))
+      (testing "PII fields nil when setting disabled, but hostname still populated"
+        (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+          (request.current/with-current-request request
+            (let [result (sdk/include-sdk-info {})]
+              (is (= "app.example.com" (:embedding_hostname result)))
+              (is (nil? (:embedding_path result)))
+              (is (nil? (:user_agent result)))
+              (is (nil? (:sanitized_user_agent result)))
+              (is (nil? (:ip_address result)))))))
+      (testing "PII fields nil when no request bound"
+        (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
           (let [result (sdk/include-sdk-info {})]
-            (is (= "app.example.com"  (:embedding_hostname result)))
-            (is (= "/dashboard/1"     (:embedding_path result)))
-            (is (= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-                   (:user_agent result)))
-            (is (= "Browser (Chrome/OS X)" (:sanitized_user_agent result)))
-            (is (= "10.0.0.1"         (:ip_address result)))))))
-    (testing "PII fields nil when setting disabled, but hostname still populated"
-      (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-        (request.current/with-current-request request
-          (let [result (sdk/include-sdk-info {})]
-            (is (= "app.example.com" (:embedding_hostname result)))
+            (is (nil? (:embedding_hostname result)))
             (is (nil? (:embedding_path result)))
             (is (nil? (:user_agent result)))
             (is (nil? (:sanitized_user_agent result)))
-            (is (nil? (:ip_address result)))))))
-    (testing "PII fields nil when no request bound"
-      (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-        (let [result (sdk/include-sdk-info {})]
-          (is (nil? (:embedding_hostname result)))
-          (is (nil? (:embedding_path result)))
-          (is (nil? (:user_agent result)))
-          (is (nil? (:sanitized_user_agent result)))
-          (is (nil? (:ip_address result))))))))
+            (is (nil? (:ip_address result)))))))))
 
 (deftest embed-referrer-header-precedence-test
   (let [request (-> (ring.mock/request :get "/api/embed/card/1")
@@ -340,10 +341,11 @@
                     (ring.mock/header "origin" "https://fallback-origin.example.com")
                     (ring.mock/header "referer" "https://fallback-referer.example.com/other/path")
                     (assoc :remote-addr "10.0.0.1"))]
-    (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-      (request.current/with-current-request request
-        (let [result (sdk/include-sdk-info {})]
-          (testing "hostname comes from embed-referrer header, not origin"
-            (is (= "embed.example.com" (:embedding_hostname result))))
-          (testing "path comes from embed-referrer header, not referer"
-            (is (= "/analytics/dash" (:embedding_path result)))))))))
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+        (request.current/with-current-request request
+          (let [result (sdk/include-sdk-info {})]
+            (testing "hostname comes from embed-referrer header, not origin"
+              (is (= "embed.example.com" (:embedding_hostname result))))
+            (testing "path comes from embed-referrer header, not referer"
+              (is (= "/analytics/dash" (:embedding_path result))))))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -233,29 +233,30 @@
 
 (deftest slackbot-streaming-never-writes-pii-columns-test
   (testing "Slack-originated rows leave ip_address/embedding_*/user_agent NULL regardless of analytics-pii-retention-enabled"
-    (tu/with-slackbot-setup
-      (let [event-body tu/base-dm-event]
-        (doseq [flag-on? [true false]]
-          (testing (str "with analytics-pii-retention-enabled=" flag-on?)
-            (let [store-opts (atom [])]
-              (tu/with-slackbot-mocks
-                {:ai-text "Hello!"}
-                (fn [{:keys [stop-stream-calls]}]
-                  (mt/with-temporary-setting-values [analytics-pii-retention-enabled flag-on?]
-                    (with-redefs [metabot.persistence/store-native-parts!
-                                  (fn [_conv-id _profile-id _parts & {:as opts}]
-                                    (swap! store-opts conj opts)
-                                    nil)]
-                      (mt/client :post 200 "metabot/slack/events"
-                                 (tu/slack-request-options event-body)
-                                 event-body)
-                      (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
-                               :done?      true?
-                               :timeout-ms 5000})))
-                  (testing "store-native-parts! never received :hostname or :pii-info from the slackbot path"
-                    (doseq [opts @store-opts]
-                      (is (not (contains? opts :hostname)))
-                      (is (not (contains? opts :pii-info))))))))))))))
+    (mt/with-premium-features #{:audit-app}
+      (tu/with-slackbot-setup
+        (let [event-body tu/base-dm-event]
+          (doseq [flag-on? [true false]]
+            (testing (str "with analytics-pii-retention-enabled=" flag-on?)
+              (let [store-opts (atom [])]
+                (tu/with-slackbot-mocks
+                  {:ai-text "Hello!"}
+                  (fn [{:keys [stop-stream-calls]}]
+                    (mt/with-temporary-setting-values [analytics-pii-retention-enabled flag-on?]
+                      (with-redefs [metabot.persistence/store-native-parts!
+                                    (fn [_conv-id _profile-id _parts & {:as opts}]
+                                      (swap! store-opts conj opts)
+                                      nil)]
+                        (mt/client :post 200 "metabot/slack/events"
+                                   (tu/slack-request-options event-body)
+                                   event-body)
+                        (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
+                                 :done?      true?
+                                 :timeout-ms 5000})))
+                    (testing "store-native-parts! never received :hostname or :pii-info from the slackbot path"
+                      (doseq [opts @store-opts]
+                        (is (not (contains? opts :hostname)))
+                        (is (not (contains? opts :pii-info)))))))))))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
   (testing "user + assistant persists receive ai-proxy? = false for direct BYOK provider"

--- a/test/metabase/view_log/events/view_log_test.clj
+++ b/test/metabase/view_log/events/view_log_test.clj
@@ -386,22 +386,23 @@
 ;; `metabase-enterprise.database-routing.query-execution-test`.
 
 (deftest query-execution-parameters-test
-  (testing "parameters is JSON-encoded when PII retention enabled"
-    (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
-      (let [params [{:type "text/single" :value "foo"}]
-            ei     (#'process-userland-query/query-execution-info
-                    (make-test-query :parameters params))]
-        (is (string? (:parameters ei)))
-        (is (= params (json/decode+kw (:parameters ei)))))))
-  (testing "parameters is nil when PII retention disabled"
-    (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
-      (let [params [{:type "text/single" :value "foo"}]
-            ei     (#'process-userland-query/query-execution-info
-                    (make-test-query :parameters params))]
-        (is (= nil (:parameters ei))))))
-  (testing "parameters is nil when absent"
-    (let [ei (#'process-userland-query/query-execution-info (make-test-query))]
-      (is (= nil (:parameters ei))))))
+  (mt/with-premium-features #{:audit-app}
+    (testing "parameters is JSON-encoded when PII retention enabled"
+      (mt/with-temporary-setting-values [analytics-pii-retention-enabled true]
+        (let [params [{:type "text/single" :value "foo"}]
+              ei     (#'process-userland-query/query-execution-info
+                      (make-test-query :parameters params))]
+          (is (string? (:parameters ei)))
+          (is (= params (json/decode+kw (:parameters ei)))))))
+    (testing "parameters is nil when PII retention disabled"
+      (mt/with-temporary-setting-values [analytics-pii-retention-enabled false]
+        (let [params [{:type "text/single" :value "foo"}]
+              ei     (#'process-userland-query/query-execution-info
+                      (make-test-query :parameters params))]
+          (is (= nil (:parameters ei))))))
+    (testing "parameters is nil when absent"
+      (let [ei (#'process-userland-query/query-execution-info (make-test-query))]
+        (is (= nil (:parameters ei)))))))
 
 ;; `is_impersonated` is now populated from the `*impersonation-role*` dynamic var in
 ;; `enrich-with-execution-context` (see process_userland_query.clj). End-to-end coverage lives in


### PR DESCRIPTION
Toggle Collect User Data input based on audit_app feature

I used `useHasTokenFeature` as the `frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx` already uses similar selector

How to test:
- on OSS version you should not see this
- on EE version you should see it
