### PR TITLE
Refactor command palette to distinguish between live and debounced search queries

### DIFF
--- a/frontend/src/metabase/AppKBarProvider.tsx
+++ b/frontend/src/metabase/AppKBarProvider.tsx
@@ -21,7 +21,7 @@ const AppPaletteActions = () => {
   const { searchQuery } = useKBar((state) => ({
     searchQuery: state.searchQuery,
   }));
-  const hasQuery = searchQuery.length > 0;
+  const hasQuery = searchQuery.trim().length > 0;
 
   const adminActions = useMemo<PaletteAction[]>(() => {
     const adminSubpaths = isAdmin

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -56,10 +56,15 @@ export const PaletteContainer = withRouter(
     disabled: boolean;
     locationQuery: Query;
   }) => {
-    const { query } = useKBar((state) => ({ actions: state.actions }));
+    const { query } = useKBar();
     const ref = useRef(null);
 
-    const { searchRequestId, searchResults, searchTerm } = useCommandPalette({
+    const {
+      searchRequestId,
+      searchResults,
+      liveSearchTerm,
+      appliedRemoteSearchTerm,
+    } = useCommandPalette({
       locationQuery,
       disabled,
     });
@@ -99,7 +104,8 @@ export const PaletteContainer = withRouter(
             locationQuery={locationQuery}
             searchRequestId={searchRequestId}
             searchResults={searchResults}
-            searchTerm={searchTerm}
+            liveSearchTerm={liveSearchTerm}
+            appliedRemoteSearchTerm={appliedRemoteSearchTerm}
           />
         </Stack>
       </Card>

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -63,7 +63,7 @@ export const PaletteContainer = withRouter(
       searchRequestId,
       searchResults,
       liveSearchTerm,
-      appliedRemoteSearchTerm,
+      debouncedSearchTerm,
     } = useCommandPalette({
       locationQuery,
       disabled,
@@ -105,7 +105,7 @@ export const PaletteContainer = withRouter(
             searchRequestId={searchRequestId}
             searchResults={searchResults}
             liveSearchTerm={liveSearchTerm}
-            appliedRemoteSearchTerm={appliedRemoteSearchTerm}
+            debouncedSearchTerm={debouncedSearchTerm}
           />
         </Stack>
       </Card>

--- a/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
@@ -53,6 +53,7 @@ const setupInList = ({ item }: { item: Partial<PaletteActionImpl> }) => {
             items={items.map((item) => mockPaletteActionImpl(item))}
             maxHeight={580}
             minHeight={220}
+            liveSearchTerm=""
             renderItem={({
               item,
               active,

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -33,12 +33,12 @@ const PAGE_SIZE = 4;
 const FullSearchCTA = ({
   locationQuery,
   searchResults,
-  appliedRemoteSearchTerm,
+  debouncedSearchTerm,
   onClick,
 }: {
   locationQuery: Query;
   searchResults: SearchResponse;
-  appliedRemoteSearchTerm: string;
+  debouncedSearchTerm: string;
   onClick: () => void;
 }) => {
   const showOtherUsersCollections = useShowOtherUsersCollections();
@@ -59,7 +59,7 @@ const FullSearchCTA = ({
         pathname: "search",
         query: {
           ...locationQuery,
-          q: appliedRemoteSearchTerm,
+          q: debouncedSearchTerm,
         },
       }}
       className={S.viewAndFilterResults}
@@ -82,7 +82,7 @@ type Props = Omit<StackProps, "children"> & {
   searchRequestId?: string;
   searchResults?: SearchResponse;
   liveSearchTerm: string;
-  appliedRemoteSearchTerm: string;
+  debouncedSearchTerm: string;
 };
 
 export const PaletteResults = ({
@@ -90,7 +90,7 @@ export const PaletteResults = ({
   searchRequestId,
   searchResults,
   liveSearchTerm,
-  appliedRemoteSearchTerm,
+  debouncedSearchTerm,
   ...props
 }: Props) => {
   // Used for finding actions within the list
@@ -171,7 +171,7 @@ export const PaletteResults = ({
                     <FullSearchCTA
                       locationQuery={locationQuery}
                       searchResults={searchResults}
-                      appliedRemoteSearchTerm={appliedRemoteSearchTerm}
+                      debouncedSearchTerm={debouncedSearchTerm}
                       onClick={() => {
                         query.setVisualState(VisualState.hidden);
 
@@ -183,7 +183,7 @@ export const PaletteResults = ({
                           requestId: searchRequestId,
                           entityModel: null,
                           entityId: null,
-                          searchTerm: appliedRemoteSearchTerm,
+                          searchTerm: debouncedSearchTerm,
                         });
                       }}
                     />

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -33,12 +33,12 @@ const PAGE_SIZE = 4;
 const FullSearchCTA = ({
   locationQuery,
   searchResults,
-  searchTerm,
+  appliedRemoteSearchTerm,
   onClick,
 }: {
   locationQuery: Query;
   searchResults: SearchResponse;
-  searchTerm: string;
+  appliedRemoteSearchTerm: string;
   onClick: () => void;
 }) => {
   const showOtherUsersCollections = useShowOtherUsersCollections();
@@ -59,7 +59,7 @@ const FullSearchCTA = ({
         pathname: "search",
         query: {
           ...locationQuery,
-          q: searchTerm,
+          q: appliedRemoteSearchTerm,
         },
       }}
       className={S.viewAndFilterResults}
@@ -81,14 +81,16 @@ type Props = Omit<StackProps, "children"> & {
   locationQuery: Query;
   searchRequestId?: string;
   searchResults?: SearchResponse;
-  searchTerm: string;
+  liveSearchTerm: string;
+  appliedRemoteSearchTerm: string;
 };
 
 export const PaletteResults = ({
   locationQuery,
   searchRequestId,
   searchResults,
-  searchTerm,
+  liveSearchTerm,
+  appliedRemoteSearchTerm,
   ...props
 }: Props) => {
   // Used for finding actions within the list
@@ -97,8 +99,12 @@ export const PaletteResults = ({
   const { results } = useMatches();
 
   const processedResults = useMemo(
-    () => processResults(results as (PaletteActionImpl | string)[], searchTerm),
-    [results, searchTerm],
+    () =>
+      processResults(
+        results as (PaletteActionImpl | string)[],
+        liveSearchTerm.length !== 0,
+      ),
+    [results, liveSearchTerm],
   );
 
   useEffect(() => {
@@ -129,11 +135,11 @@ export const PaletteResults = ({
     );
   });
 
-  if (processedResults.length === 0 && searchTerm.length === 0) {
+  if (processedResults.length === 0 && liveSearchTerm.length === 0) {
     return <PaletteEmptyState />;
   }
 
-  if (processedResults.length === 0 && searchTerm.length > 0) {
+  if (processedResults.length === 0 && liveSearchTerm.length > 0) {
     return <PaletteResultsSkeleton />;
   }
 
@@ -142,7 +148,8 @@ export const PaletteResults = ({
       <PaletteResultList
         items={processedResults} // items needs to be a stable reference, otherwise the activeIndex will constantly be hijacked
         maxHeight={530}
-        minHeight={searchTerm.length === 0 ? 280 : 0}
+        minHeight={liveSearchTerm.length === 0 ? 280 : 0}
+        liveSearchTerm={liveSearchTerm}
         renderItem={({ item, active }) => {
           const isFirst = processedResults[0] === item;
 
@@ -164,7 +171,7 @@ export const PaletteResults = ({
                     <FullSearchCTA
                       locationQuery={locationQuery}
                       searchResults={searchResults}
-                      searchTerm={searchTerm}
+                      appliedRemoteSearchTerm={appliedRemoteSearchTerm}
                       onClick={() => {
                         query.setVisualState(VisualState.hidden);
 
@@ -176,7 +183,7 @@ export const PaletteResults = ({
                           requestId: searchRequestId,
                           entityModel: null,
                           entityId: null,
-                          searchTerm,
+                          searchTerm: appliedRemoteSearchTerm,
                         });
                       }}
                     />

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -31,9 +31,11 @@ interface PaletteResultListProps {
   renderItem: (params: RenderParams) => React.ReactElement;
   maxHeight: number;
   minHeight: number;
+  liveSearchTerm: string;
 }
 
 export const PaletteResultList = (props: PaletteResultListProps) => {
+  const { liveSearchTerm } = props;
   const activeRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -44,9 +46,8 @@ export const PaletteResultList = (props: PaletteResultListProps) => {
 
   const hasUserInteractedRef = useRef(false);
 
-  const { query, search, currentRootActionId, activeIndex, options } = useKBar(
+  const { query, currentRootActionId, activeIndex, options } = useKBar(
     (state) => ({
-      search: state.searchQuery,
       currentRootActionId: state.currentRootActionId,
       activeIndex: state.activeIndex,
     }),
@@ -120,7 +121,7 @@ export const PaletteResultList = (props: PaletteResultListProps) => {
   // Reset interaction tracking when search changes
   useEffect(() => {
     hasUserInteractedRef.current = false;
-  }, [search]);
+  }, [liveSearchTerm]);
 
   useEffect(() => {
     // Only auto-set the active index if the user hasn't interacted yet.
@@ -133,7 +134,7 @@ export const PaletteResultList = (props: PaletteResultListProps) => {
           : START_INDEX,
       );
     }
-  }, [search, currentRootActionId, props.items, query]);
+  }, [liveSearchTerm, currentRootActionId, props.items, query]);
 
   const execute = useCallback(
     (item: RenderParams["item"], e?: MouseEvent) => {

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
@@ -35,11 +35,11 @@ describe("PaletteResults", () => {
   it("should surface static actions before the remote search debounce fires", async () => {
     setup({ query: "new" });
 
-    // Static actions render off the live (non-debounced) search term, so
-    // they must appear well before the 500ms remote-search debounce fires.
-    expect(
-      await screen.findByText("New question", undefined, { timeout: 200 }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("New question")).toBeInTheDocument();
+
+    // useCommandPaletteBasicActions makes one baseline /api/search call; any
+    // additional call means the debounced remote search has already run.
+    expect(fetchMock.callHistory.calls("path:/api/search").length).toBe(1);
   });
 
   //For some reason, New Question isn't showing up without searching. My guess is virtualization weirdness

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
@@ -32,6 +32,16 @@ describe("PaletteResults", () => {
     expect(await screen.findByText("Results")).toBeInTheDocument();
   });
 
+  it("should surface static actions before the remote search debounce fires", async () => {
+    setup({ query: "new" });
+
+    // Static actions render off the live (non-debounced) search term, so
+    // they must appear well before the 500ms remote-search debounce fires.
+    expect(
+      await screen.findByText("New question", undefined, { timeout: 200 }),
+    ).toBeInTheDocument();
+  });
+
   //For some reason, New Question isn't showing up without searching. My guess is virtualization weirdness
   it("should allow you to create a new question", async () => {
     setup({ query: "ques" });

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
@@ -29,7 +29,7 @@ describe("PaletteResults", () => {
     expect(await screen.findByText("New SQL query")).toBeInTheDocument();
     expect(await screen.findByText("New dashboard")).toBeInTheDocument();
 
-    expect(screen.getByText("Results")).toBeInTheDocument();
+    expect(await screen.findByText("Results")).toBeInTheDocument();
   });
 
   //For some reason, New Question isn't showing up without searching. My guess is virtualization weirdness

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -34,7 +34,12 @@ import { PaletteResults } from "../../PaletteResults";
 const TestComponent = withRouter(
   ({ q, ...props }: WithRouterProps & { q?: string; isLoggedIn: boolean }) => {
     useCommandPaletteBasicActions(props);
-    const { searchRequestId, searchResults, searchTerm } = useCommandPalette({
+    const {
+      searchRequestId,
+      searchResults,
+      liveSearchTerm,
+      appliedRemoteSearchTerm,
+    } = useCommandPalette({
       disabled: false,
       locationQuery: props.location.query,
     });
@@ -53,7 +58,8 @@ const TestComponent = withRouter(
         locationQuery={props.location.query}
         searchRequestId={searchRequestId}
         searchResults={searchResults}
-        searchTerm={searchTerm}
+        liveSearchTerm={liveSearchTerm}
+        appliedRemoteSearchTerm={appliedRemoteSearchTerm}
       />
     );
   },

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -38,7 +38,7 @@ const TestComponent = withRouter(
       searchRequestId,
       searchResults,
       liveSearchTerm,
-      appliedRemoteSearchTerm,
+      debouncedSearchTerm,
     } = useCommandPalette({
       disabled: false,
       locationQuery: props.location.query,
@@ -59,7 +59,7 @@ const TestComponent = withRouter(
         searchRequestId={searchRequestId}
         searchResults={searchResults}
         liveSearchTerm={liveSearchTerm}
-        appliedRemoteSearchTerm={appliedRemoteSearchTerm}
+        debouncedSearchTerm={debouncedSearchTerm}
       />
     );
   },

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -311,7 +311,7 @@ export const useCommandPalette = ({
     searchRequestId,
     searchResults,
     liveSearchTerm: trimmedQuery,
-    appliedRemoteSearchTerm: debouncedSearchText,
+    debouncedSearchTerm: debouncedSearchText,
   };
 };
 

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -310,7 +310,8 @@ export const useCommandPalette = ({
   return {
     searchRequestId,
     searchResults,
-    searchTerm: debouncedSearchText,
+    liveSearchTerm: trimmedQuery,
+    appliedRemoteSearchTerm: debouncedSearchText,
   };
 };
 

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -115,7 +115,8 @@ export const useCommandPalette = ({
           ? t`Search documentation for "${debouncedSearchText}"`
           : t`View documentation`,
         section: "docs",
-        keywords: debouncedSearchText, // Always match the debouncedSearchText string
+        // Include original search query in keywords so kbar always shows it
+        keywords: searchQuery,
         icon: "document",
         extra: {
           href: link,
@@ -123,7 +124,7 @@ export const useCommandPalette = ({
       },
     ];
     return ret;
-  }, [debouncedSearchText, docsUrl]);
+  }, [debouncedSearchText, docsUrl, searchQuery]);
 
   const showDocsAction = showMetabaseLinks && hasQuery && !disabled;
 
@@ -150,7 +151,7 @@ export const useCommandPalette = ({
           id: `search-without-typeahead`,
           name: t`View search results for "${debouncedSearchText}"`,
           section: "search",
-          keywords: debouncedSearchText,
+          keywords: searchQuery,
           icon: "link" as const,
           priority: Priority.HIGH,
           extra: {
@@ -189,7 +190,7 @@ export const useCommandPalette = ({
             icon: icon.name,
             iconUrl: icon.iconUrl,
             section: "search",
-            keywords: debouncedSearchText,
+            keywords: searchQuery,
             priority: Priority.NORMAL - index,
             perform: () => {
               trackSearchClick({
@@ -216,7 +217,7 @@ export const useCommandPalette = ({
           {
             id: "no-search-results",
             name: t`No results for “${debouncedSearchText}”`,
-            keywords: debouncedSearchText,
+            keywords: searchQuery,
             section: "search",
             disabled: true,
           },

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -115,8 +115,8 @@ export const useCommandPalette = ({
           ? t`Search documentation for "${debouncedSearchText}"`
           : t`View documentation`,
         section: "docs",
-        // Include original search query in keywords so kbar always shows it
-        keywords: searchQuery,
+        // Include search query in keywords so kbar always shows it
+        keywords: trimmedQuery,
         icon: "document",
         extra: {
           href: link,
@@ -124,7 +124,7 @@ export const useCommandPalette = ({
       },
     ];
     return ret;
-  }, [debouncedSearchText, docsUrl, searchQuery]);
+  }, [debouncedSearchText, docsUrl, trimmedQuery]);
 
   const showDocsAction = showMetabaseLinks && hasQuery && !disabled;
 
@@ -151,7 +151,7 @@ export const useCommandPalette = ({
           id: `search-without-typeahead`,
           name: t`View search results for "${debouncedSearchText}"`,
           section: "search",
-          keywords: searchQuery,
+          keywords: trimmedQuery,
           icon: "link" as const,
           priority: Priority.HIGH,
           extra: {
@@ -164,7 +164,7 @@ export const useCommandPalette = ({
         {
           id: "search-is-loading",
           name: t`Loading...`,
-          keywords: searchQuery,
+          keywords: trimmedQuery,
           section: "search",
           disabled: true,
         },
@@ -190,7 +190,7 @@ export const useCommandPalette = ({
             icon: icon.name,
             iconUrl: icon.iconUrl,
             section: "search",
-            keywords: searchQuery,
+            keywords: trimmedQuery,
             priority: Priority.NORMAL - index,
             perform: () => {
               trackSearchClick({
@@ -217,7 +217,7 @@ export const useCommandPalette = ({
           {
             id: "no-search-results",
             name: t`No results for “${debouncedSearchText}”`,
-            keywords: searchQuery,
+            keywords: trimmedQuery,
             section: "search",
             disabled: true,
           },
@@ -229,7 +229,7 @@ export const useCommandPalette = ({
     disabled,
     dispatch,
     debouncedSearchText,
-    searchQuery,
+    trimmedQuery,
     isSearchLoading,
     searchError,
     searchResults,

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -18,7 +18,7 @@ const BASIC_ACTION_ORDER_BY_NAME = BASIC_ACTION_ORDER.reduce<
 
 export const processResults = (
   results: (string | PaletteActionImpl)[],
-  searchTerm: string,
+  hasSearchTerm: boolean,
 ): (string | PaletteActionImpl)[] => {
   const groupedResults = _.groupBy(
     results.filter((r): r is PaletteActionImpl => !(typeof r === "string")),
@@ -35,7 +35,7 @@ export const processResults = (
   const admin = processSection(t`Admin`, groupedResults["admin"]);
   const docs = processSection(t`Documentation`, groupedResults["docs"]);
 
-  if (searchTerm.trim().length === 0) {
+  if (!hasSearchTerm) {
     return [...recent];
   }
 

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -73,25 +73,25 @@ describe("command palette utils", () => {
     const testDoc = [createMockAction({ name: "doc action", section: "docs" })];
 
     it("should limit to 6 actions including header", () => {
-      const result = processResults(testActions, "xyz");
+      const result = processResults(testActions, true);
       expect(result).toHaveLength(6);
       expect(result[0]).toBe("Actions");
     });
 
     it("should not limit the other action types", () => {
       expect(
-        processResults([...testActions, ...testSearch], "xyz"),
+        processResults([...testActions, ...testSearch], true),
       ).toHaveLength(12);
       expect(
-        processResults([...testActions, ...testRecent], "xyz"),
+        processResults([...testActions, ...testRecent], true),
       ).toHaveLength(12);
       expect(
-        processResults([...testRecent, ...testAdmin, ...testDoc], "xyz"),
+        processResults([...testRecent, ...testAdmin, ...testDoc], true),
       ).toHaveLength(19);
     });
 
     it("should add a header to doc", () => {
-      expect(processResults([...testDoc], "xyz")).toHaveLength(2);
+      expect(processResults([...testDoc], true)).toHaveLength(2);
     });
 
     it("should enforce a specific order", () => {
@@ -103,7 +103,7 @@ describe("command palette utils", () => {
           ...testActions,
           ...testRecent,
         ],
-        "xyz",
+        true,
       );
 
       const actionsIndex = results.findIndex((action) => action === "Actions");
@@ -121,7 +121,7 @@ describe("command palette utils", () => {
     });
 
     it("should not show actions if there is no search query", () => {
-      const result = processResults(testActions, "");
+      const result = processResults(testActions, false);
       expect(result).toHaveLength(0);
     });
 
@@ -151,7 +151,7 @@ describe("command palette utils", () => {
         createMockAction({ id, name: id }),
       );
 
-      const result = processResults(actionsList, "xyz");
+      const result = processResults(actionsList, true);
       expect(result).toEqual([
         "Actions",
         createMockAction({

--- a/patches/kbar+0.1.0-beta.45.patch
+++ b/patches/kbar+0.1.0-beta.45.patch
@@ -724,7 +724,13 @@ index 0d3b4e7..0571622 100644
      minMatchCharLength: 1,
  };
  function order(a, b) {
-@@ -195,7 +199,7 @@ function useInternalMatches(filtered, search, fuse) {
+@@ -190,12 +194,12 @@ function useInternalMatches(filtered, search, fuse) {
+         }
+         var matches = [];
+         // Use Fuse's `search` method to perform the search efficiently
+-        var searchResults = fuse.search(throttledSearch);
++        var searchResults = fuse.search(throttledSearch.trim());
+         // Format the search results to match the existing structure
          matches = searchResults.map(function (_a) {
              var action = _a.item, score = _a.score;
              return ({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73856

### Description

Previously the command palette waited for the 500ms search debounce before rendering anything — including static actions ("New question", admin links, "Search documentation for…") that don't depend on the server-side search at all. They were gated by the debounce only because everything was driven off the single debounced search term.

`useCommandPalette` now returns two values: `liveSearchTerm` (immediate, drives static actions) and `appliedRemoteSearchTerm` (debounced, drives the `/api/search` request). Static actions render instantly; remote results still wait for the debounce.

### How to verify

1. Open the command palette (Cmd+K / Ctrl+K) and type "new q"
2. Static action should appear immediately
3. The "Results" section should still appear after the usual short debounce

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
