### PR TITLE
fix(sdk-bundle): race condition in ContentTranslationsProvider setup

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -4,6 +4,7 @@ import { type JSX, memo, useEffect, useId, useRef } from "react";
 
 import { ContentTranslationsProvider } from "embedding-sdk-bundle/components/private/ContentTranslationsProvider";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
+import { useArePluginsReady } from "embedding-sdk-bundle/hooks/private/use-are-plugins-ready";
 import { useInitDataInternal } from "embedding-sdk-bundle/hooks/private/use-init-data";
 import { useNormalizeComponentProviderProps } from "embedding-sdk-bundle/hooks/private/use-normalize-component-provider-props";
 import { useSdkCustomLoader } from "embedding-sdk-bundle/hooks/private/use-sdk-custom-loader";
@@ -130,6 +131,11 @@ export const ComponentProviderInternal = (
 
   const ensureSingleInstanceId = useId();
 
+  // Defer ContentTranslationsProvider until EE plugins are assigned to
+  // PLUGIN_CONTENT_TRANSLATION; otherwise useSetupAuthContentTranslations
+  // calls the OSS no-op, and its deps don't re-fire when the EE fn lands.
+  const pluginsReady = useArePluginsReady();
+
   return (
     <EmotionCacheProvider>
       <SdkThemeProvider theme={theme}>
@@ -142,7 +148,9 @@ export const ComponentProviderInternal = (
               <LocaleProvider locale={locale || instanceLocale}>
                 {children}
 
-                {isInstanceToRender && <ContentTranslationsProvider />}
+                {isInstanceToRender && pluginsReady && (
+                  <ContentTranslationsProvider />
+                )}
               </LocaleProvider>
 
               {isInstanceToRender && (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73927
Closes EMB-1716

Might be related to EMB-1711

### Description

The race condition is very similar to https://github.com/metabase/metabase/pull/70737

In the SDK auth-embed flow, `ContentTranslationsProvider` mounted before EE plugins finished initializing, so its setup hook called `PLUGIN_CONTENT_TRANSLATION.setEndpointsForAuthEmbedding()` while it was still the OSS no-op. EE assigned the real function ~2 ms later, but the hook's `useEffect` deps `[isGuestEmbed]` did not change, so it never re-fired — the dictionary endpoint stayed unset and content translations silently never applied for the rest of the session.

Fix: defer mounting `<ContentTranslationsProvider />` behind `useArePluginsReady()`, mirroring the existing gate already used by `PublicComponentWrapper`. Once plugins are ready, the provider mounts and its setup hook calls the EE-assigned function on first effect run.

### How to verify

1. Run `e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx`. Was 0% pass before fix; passes consistently after.
    ```sh
    CYPRESS_TESTING_TYPE=component bun run test-cypress
    ```

### Demo

#### After
<img width="504" height="409" alt="image" src="https://github.com/user-attachments/assets/d267d9a6-b5e6-4137-b4b4-5fa9742cd3b7" />

#### Before: it never passes locally for me.
<img width="1333" height="795" alt="image" src="https://github.com/user-attachments/assets/8c38e42b-432d-4f10-8650-60f6ea1cb60d" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (existing test)
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)