### PR TITLE
Fix reflection warning in compress-test

### DIFF
--- a/test/metabase/util/compress_test.clj
+++ b/test/metabase/util/compress_test.clj
@@ -72,7 +72,7 @@
 
 (deftest untgz-max-uncompressed-bytes-test
   (testing "untgz aborts when total uncompressed bytes exceed :max-uncompressed-bytes"
-    (let [content (.getBytes (apply str (repeat 1024 \a)) "UTF-8")
+    (let [content (.getBytes ^String (apply str (repeat 1024 \a)) "UTF-8")
           archive (create-multi-entry-tgz 10 content) ;; 10 KiB total uncompressed
           out     (doto (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))
                     .mkdirs)]


### PR DESCRIPTION
## Summary
- Add `^String` hint to `(apply str ...)` on line 75 of `test/metabase/util/compress_test.clj` so `.getBytes` resolves at compile time instead of via reflection.

## Test plan
- [x] Lint output for `metabase.util.compress-test` no longer reports the reflection warning at line 75. (Eastwood `:reflection` linter on the namespace: `Warnings: 0. Exceptions thrown: 0`.)
- [x] `./bin/test-agent :only '[metabase.util.compress-test]'` still passes. (4 tests, 8 assertions, 0 failures, 0 errors.)