### PR TITLE
Add hover border for default Mantine Input and Select across the app

### DIFF
--- a/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
@@ -36,6 +36,10 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   transition: all 200ms;
   color: ${getColor};
 
+  &:hover {
+    border-color: var(--mb-color-brand);
+  }
+
   &:focus {
     border-color: var(--mb-color-brand);
     outline: 2px solid var(--mb-color-focus);

--- a/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectButton/SelectButton.styled.tsx
@@ -33,7 +33,6 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   border-radius: var(--mantine-spacing-sm);
   font-weight: 700;
   min-width: 104px;
-  transition: all 200ms;
   color: ${getColor};
 
   &:hover {

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
@@ -5,11 +5,8 @@
   color: transparent;
 
   &:hover {
+    border-color: var(--mb-color-border) !important;
     background-color: var(--mb-color-background-hover);
-
-    &::placeholder {
-      color: var(--mb-color-brand);
-    }
   }
 }
 
@@ -25,6 +22,10 @@
     left: 50%;
     transform: translate(-50%, -50%);
     pointer-events: none;
+  }
+
+  &:hover::after {
+    color: var(--mb-color-text-hover);
   }
 }
 

--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
@@ -4,8 +4,8 @@
   cursor: pointer;
   color: transparent;
 
-  &:hover {
-    border-color: var(--mb-color-border) !important;
+  &[data-variant="default"]:hover:not(:disabled) {
+    border-color: var(--mb-color-border);
     background-color: var(--mb-color-background-hover);
   }
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
@@ -107,7 +107,6 @@
   border: 1px solid var(--mb-color-border);
   border-radius: 0.25rem;
   cursor: pointer;
-  transition: border-color 0.3s;
 
   &:hover,
   &.hasValue {

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
@@ -107,7 +107,9 @@
   border: 1px solid var(--mb-color-border);
   border-radius: 0.25rem;
   cursor: pointer;
+  transition: border-color 0.3s;
 
+  &:hover,
   &.hasValue {
     border-color: var(--mb-color-brand);
   }

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
@@ -35,7 +35,7 @@
     border-color: var(--mb-color-border);
     transition: border-color 0.3s;
 
-    &:hover {
+    &:hover:not(:disabled) {
       border-color: var(--mb-color-brand);
     }
 

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
@@ -33,6 +33,11 @@
 
   &[data-variant="default"] {
     border-color: var(--mb-color-border);
+    transition: border-color 0.3s;
+
+    &:hover {
+      border-color: var(--mb-color-brand);
+    }
 
     &:focus {
       border-color: var(--mb-color-brand);

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
@@ -33,7 +33,6 @@
 
   &[data-variant="default"] {
     border-color: var(--mb-color-border);
-    transition: border-color 0.3s;
 
     &:hover:not(:disabled) {
       border-color: var(--mb-color-brand);

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -24,13 +24,4 @@ export const Root = styled.div<{
       justify-content: space-between;
       align-items: center;
     `}
-
-  input {
-    transition: border 0.3s;
-
-    &:hover {
-      transition: border 0.3s;
-      border-color: var(--mb-color-brand);
-    }
-  }
 `;


### PR DESCRIPTION
Closes [GDGT-761](https://linear.app/metabase/issue/GDGT-761)

### Description

Previously, dropdowns in the Metadata and Behavior sections of the field settings had no hover affordance, while the Align dropdown in the Formatting section did. The hover came from a descendant `input { &:hover { border-color: brand } }` rule in `ChartSettingsWidget.styled.tsx` that only applied to chart settings components.

This PR lifts that hover rule into the design-system `Input.module.css` (`data-variant="default"`) so every Mantine `Input` across the app — not only `Select`s — gets a consistent brand-colored hover border, matching the original intent of the `ChartSettingsWidget` rule.

Also adjusted three trigger components so they stay visually consistent with the new behavior:
- `MoveParameterMenu` (collapsed state): stays borderless on hover so it keeps looking like a button.
- `ParameterValueWidget` `TriggerContainer`: added matching brand-colored hover border.
- `SelectButton` (legacy `metabase/common/components`): added matching brand-colored hover border so it stays in sync.

### How to verify

1. Open admin → Table Metadata → pick any table → click a field
2. Hover over the dropdowns in the **Metadata** section (Semantic type) and **Behavior** section (Visibility, Filtering, Display values, Casting). Each closed trigger should show a brand-colored border on hover, matching the **Align** dropdown in the Formatting section

### Checklist

- [x] Tests have been added/updated to cover changes in this PR