### PR TITLE
Run Eastwood against changed tests only

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -75,9 +75,10 @@ jobs:
           git fetch --no-tags --depth=200 origin "$BASE_SHA"
           DIFF_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
           # Test roots we lint: core, EE, and each driver module's test tree.
-          # The :eastwood/test alias declares matching :source-paths so any namespace
-          # we name here is reachable.
-          FILES=$(git diff --name-only --diff-filter=AM "$DIFF_BASE" "$HEAD_SHA" \
+          # :eastwood/test derives matching :source-paths from the classpath, so any
+          # namespace we name here is reachable. Include renames (R) so a test that
+          # was just renamed still gets linted under its new name.
+          FILES=$(git diff --name-only --diff-filter=AMR "$DIFF_BASE" "$HEAD_SHA" \
                     -- 'test/**/*.clj' 'test/**/*.cljc' \
                        'enterprise/backend/test/**/*.clj' 'enterprise/backend/test/**/*.cljc' \
                        'modules/drivers/**/test/**/*.clj' 'modules/drivers/**/test/**/*.cljc')

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -37,7 +37,8 @@ jobs:
         name: Run Eastwood linter
 
   be-linter-eastwood-test:
-    if: ${{ !inputs.skip && github.ref_name == 'master' }}
+    # Master / release safety net: lint every backend test namespace.
+    if: ${{ !inputs.skip && github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release-')) }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     name: Eastwood (tests only)
@@ -47,6 +48,50 @@ jobs:
         uses: ./.github/actions/prepare-backend
       - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test
         name: Run Eastwood linter on our backend tests
+
+  be-linter-eastwood-test-changed:
+    # PR / merge queue: lint only the test namespaces touched by the diff.
+    if: ${{ !inputs.skip && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 15
+    name: Eastwood (changed tests only)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+      - name: Compute changed test namespaces
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ]; then
+            echo "No base SHA available; skipping."
+            echo "namespaces=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Make sure the base commit is reachable for the diff.
+          git fetch --no-tags --depth=200 origin "$BASE_SHA" 2>/dev/null \
+            || git fetch --no-tags origin
+          FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
+                    -- 'test/**/*.clj' 'enterprise/backend/test/**/*.clj' || true)
+          if [ -z "$FILES" ]; then
+            echo "No backend test files changed; skipping lint."
+            echo "namespaces=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NS=$(echo "$FILES" \
+            | sed -E 's#^(test/|enterprise/backend/test/)##; s#\.clj$##; s#/#.#g; s#_#-#g' \
+            | sort -u \
+            | tr '\n' ' ')
+          echo "Changed test namespaces: $NS"
+          echo "namespaces=[$NS]" >> "$GITHUB_OUTPUT"
+      - name: Run Eastwood on changed test namespaces
+        if: steps.changed.outputs.namespaces != ''
+        run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test :namespaces '${{ steps.changed.outputs.namespaces }}'
 
   be-tests:
     if: ${{ !inputs.skip }}
@@ -196,6 +241,7 @@ jobs:
     needs:
       - be-linter-eastwood
       - be-linter-eastwood-test
+      - be-linter-eastwood-test-changed
       - be-linter-clj-kondo
       - be-cljfmt
       - be-check

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Enough history for `git merge-base` to find the divergence point on any reasonable PR.
+          # Enough history for `git merge-base` on a typical PR.
           fetch-depth: 200
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
@@ -69,36 +69,31 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${BASE_SHA:-}" ]; then
-            echo "No base SHA available; skipping."
-            echo "namespaces=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Pull the base commit so we can compute the merge-base; 200 matches the checkout depth.
+
+          # Diff from the merge-base so changes that landed on the base branch after the PR was
+          # last synced don't widen our scope. Falls back to BASE_SHA if older than fetched depth.
           git fetch --no-tags --depth=200 origin "$BASE_SHA"
-          # Diff from the merge-base, not the base ref tip, so unrelated changes that landed on the
-          # base branch after this PR was last synced don't widen our scope. Fall back to BASE_SHA
-          # if the merge-base is outside the fetched window.
           DIFF_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
           FILES=$(git diff --name-only --diff-filter=AM "$DIFF_BASE" "$HEAD_SHA" \
                     -- 'test/**/*.clj' 'test/**/*.cljc' \
                        'enterprise/backend/test/**/*.clj' 'enterprise/backend/test/**/*.cljc')
+
           if [ -z "$FILES" ]; then
             echo "No backend test files changed; skipping lint."
             echo "namespaces=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # File paths flow into a subsequent shell command via the step output. Reject anything
-          # outside the conservative character set we expect from Clojure source paths.
-          if printf '%s\n' "$FILES" | grep -Eqv '^[A-Za-z0-9_./-]+$'; then
-            echo "Refusing to lint: unexpected characters in changed file paths." >&2
-            printf '%s\n' "$FILES" >&2
+
+          # Defence-in-depth: paths flow into a subsequent shell command via $GITHUB_OUTPUT.
+          if grep -Eqv '^[A-Za-z0-9_./-]+$' <<<"$FILES"; then
+            echo "Refusing to lint: unexpected characters in changed file paths:" >&2
+            echo "$FILES" >&2
             exit 1
           fi
-          NS=$(printf '%s\n' "$FILES" \
-            | sed -E 's#^(test/|enterprise/backend/test/)##; s#\.cljc?$##; s#/#.#g; s#_#-#g' \
-            | sort -u \
-            | paste -sd' ' -)
+
+          NS=$(sed -E 's#^(test/|enterprise/backend/test/)##; s#\.cljc?$##; s#/#.#g; s#_#-#g' <<<"$FILES" \
+                 | sort -u \
+                 | paste -sd' ' -)
           echo "Changed test namespaces: $NS"
           echo "namespaces=$NS" >> "$GITHUB_OUTPUT"
       - name: Run Eastwood on changed test namespaces

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,7 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Enough history for `git merge-base` to find the divergence point on any reasonable PR.
+          fetch-depth: 200
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Compute changed test namespaces
@@ -73,25 +74,38 @@ jobs:
             echo "namespaces=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Make sure the base commit is reachable for the diff.
-          git fetch --no-tags --depth=200 origin "$BASE_SHA" 2>/dev/null \
-            || git fetch --no-tags origin
-          FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
-                    -- 'test/**/*.clj' 'enterprise/backend/test/**/*.clj' || true)
+          # Pull the base commit so we can compute the merge-base; 200 matches the checkout depth.
+          git fetch --no-tags --depth=200 origin "$BASE_SHA"
+          # Diff from the merge-base, not the base ref tip, so unrelated changes that landed on the
+          # base branch after this PR was last synced don't widen our scope. Fall back to BASE_SHA
+          # if the merge-base is outside the fetched window.
+          DIFF_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+          FILES=$(git diff --name-only --diff-filter=AM "$DIFF_BASE" "$HEAD_SHA" \
+                    -- 'test/**/*.clj' 'test/**/*.cljc' \
+                       'enterprise/backend/test/**/*.clj' 'enterprise/backend/test/**/*.cljc')
           if [ -z "$FILES" ]; then
             echo "No backend test files changed; skipping lint."
             echo "namespaces=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          NS=$(echo "$FILES" \
-            | sed -E 's#^(test/|enterprise/backend/test/)##; s#\.clj$##; s#/#.#g; s#_#-#g' \
+          # File paths flow into a subsequent shell command via the step output. Reject anything
+          # outside the conservative character set we expect from Clojure source paths.
+          if printf '%s\n' "$FILES" | grep -Eqv '^[A-Za-z0-9_./-]+$'; then
+            echo "Refusing to lint: unexpected characters in changed file paths." >&2
+            printf '%s\n' "$FILES" >&2
+            exit 1
+          fi
+          NS=$(printf '%s\n' "$FILES" \
+            | sed -E 's#^(test/|enterprise/backend/test/)##; s#\.cljc?$##; s#/#.#g; s#_#-#g' \
             | sort -u \
-            | tr '\n' ' ')
+            | paste -sd' ' -)
           echo "Changed test namespaces: $NS"
-          echo "namespaces=[$NS]" >> "$GITHUB_OUTPUT"
+          echo "namespaces=$NS" >> "$GITHUB_OUTPUT"
       - name: Run Eastwood on changed test namespaces
         if: steps.changed.outputs.namespaces != ''
-        run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test :namespaces '${{ steps.changed.outputs.namespaces }}'
+        env:
+          NAMESPACES: ${{ steps.changed.outputs.namespaces }}
+        run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test :namespaces "[$NAMESPACES]"
 
   be-tests:
     if: ${{ !inputs.skip }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -74,9 +74,13 @@ jobs:
           # last synced don't widen our scope. Falls back to BASE_SHA if older than fetched depth.
           git fetch --no-tags --depth=200 origin "$BASE_SHA"
           DIFF_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+          # Test roots we lint: core, EE, and each driver module's test tree.
+          # The :eastwood/test alias declares matching :source-paths so any namespace
+          # we name here is reachable.
           FILES=$(git diff --name-only --diff-filter=AM "$DIFF_BASE" "$HEAD_SHA" \
                     -- 'test/**/*.clj' 'test/**/*.cljc' \
-                       'enterprise/backend/test/**/*.clj' 'enterprise/backend/test/**/*.cljc')
+                       'enterprise/backend/test/**/*.clj' 'enterprise/backend/test/**/*.cljc' \
+                       'modules/drivers/**/test/**/*.clj' 'modules/drivers/**/test/**/*.cljc')
 
           if [ -z "$FILES" ]; then
             echo "No backend test files changed; skipping lint."
@@ -91,7 +95,7 @@ jobs:
             exit 1
           fi
 
-          NS=$(sed -E 's#^(test/|enterprise/backend/test/)##; s#\.cljc?$##; s#/#.#g; s#_#-#g' <<<"$FILES" \
+          NS=$(sed -E 's#^(test/|enterprise/backend/test/|modules/drivers/[^/]+/test/)##; s#\.cljc?$##; s#/#.#g; s#_#-#g' <<<"$FILES" \
                  | sort -u \
                  | paste -sd' ' -)
           echo "Changed test namespaces: $NS"

--- a/deps.edn
+++ b/deps.edn
@@ -57,7 +57,7 @@
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
   {:mvn/version "1.0.1"}              ; Snowplow analytics
   com.sun.mail/jakarta.mail                 ^:antq/exclude                      ; 2+ changes imports from javax.mail to jakarta.mail
-  {:mvn/version "1.6.8"}              ; SMTP lib, required by postal
+                                            {:mvn/version "1.6.8"}              ; SMTP lib, required by postal
   com.taoensso/encore                       {:mvn/version "3.160.1"}            ; Utilities library (used by Nippy)
   com.taoensso/nippy                        {:mvn/version "3.6.2"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.8"}             ; Markdown parsing
@@ -112,7 +112,7 @@
   org.apache.commons/commons-compress           {:mvn/version "1.28.0"}             ; compression utils
   org.apache.commons/commons-lang3              {:mvn/version "3.20.0"}             ; helper methods for working with java.lang stuff
   org.apache.datasketches/datasketches-java     ^:antq/exclude                      ; Sketching algorithms (used for fingerprinting)
-  {:mvn/version "7.0.1"}              ; version is fixed to ensure JDK21 compatibility.
+                                                {:mvn/version "7.0.1"}              ; version is fixed to ensure JDK21 compatibility.
   org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.4.4"}              ; pinned: ClickHouse JDBC 0.9.7 needs httpcore5 5.3.4+; must pair with httpclient5 5.4.x
   org.apache.httpcomponents.core5/httpcore5     {:mvn/version "5.3.5"}              ; pinned: ClickHouse JDBC 0.9.7 requires URIBuilder.optimize() added in 5.3
   org.apache.httpcomponents.core5/httpcore5-h2  {:mvn/version "5.3.5"}              ; pinned: must match httpcore5 version
@@ -665,27 +665,8 @@
   ;;
   ;; clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test
   :eastwood/test
-  {:exec-fn   metabase.linters.eastwood/eastwood
-   :exec-args {:source-paths ["test"
-                              "enterprise/backend/test"
-                              "modules/drivers/athena/test"
-                              "modules/drivers/bigquery-cloud-sdk/test"
-                              "modules/drivers/clickhouse/test"
-                              "modules/drivers/databricks/test"
-                              "modules/drivers/druid/test"
-                              "modules/drivers/druid-jdbc/test"
-                              "modules/drivers/hive-like/test"
-                              "modules/drivers/mongo/test"
-                              "modules/drivers/oracle/test"
-                              "modules/drivers/presto-jdbc/test"
-                              "modules/drivers/redshift/test"
-                              "modules/drivers/snowflake/test"
-                              "modules/drivers/sparksql/test"
-                              "modules/drivers/sqlite/test"
-                              "modules/drivers/sqlserver/test"
-                              "modules/drivers/starburst/test"
-                              "modules/drivers/vertica/test"]
-               :linters      [:reflection]
+  {:exec-fn   metabase.linters.eastwood/eastwood-tests
+   :exec-args {:linters      [:reflection]
                :exclude-namespaces
                [;; byte/1 dispatch value trips up Eastwood's reader
                 metabase.test.http-client

--- a/deps.edn
+++ b/deps.edn
@@ -57,7 +57,7 @@
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
   {:mvn/version "1.0.1"}              ; Snowplow analytics
   com.sun.mail/jakarta.mail                 ^:antq/exclude                      ; 2+ changes imports from javax.mail to jakarta.mail
-                                            {:mvn/version "1.6.8"}              ; SMTP lib, required by postal
+  {:mvn/version "1.6.8"}              ; SMTP lib, required by postal
   com.taoensso/encore                       {:mvn/version "3.160.1"}            ; Utilities library (used by Nippy)
   com.taoensso/nippy                        {:mvn/version "3.6.2"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.8"}             ; Markdown parsing
@@ -112,7 +112,7 @@
   org.apache.commons/commons-compress           {:mvn/version "1.28.0"}             ; compression utils
   org.apache.commons/commons-lang3              {:mvn/version "3.20.0"}             ; helper methods for working with java.lang stuff
   org.apache.datasketches/datasketches-java     ^:antq/exclude                      ; Sketching algorithms (used for fingerprinting)
-                                                {:mvn/version "7.0.1"}              ; version is fixed to ensure JDK21 compatibility.
+  {:mvn/version "7.0.1"}              ; version is fixed to ensure JDK21 compatibility.
   org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.4.4"}              ; pinned: ClickHouse JDBC 0.9.7 needs httpcore5 5.3.4+; must pair with httpclient5 5.4.x
   org.apache.httpcomponents.core5/httpcore5     {:mvn/version "5.3.5"}              ; pinned: ClickHouse JDBC 0.9.7 requires URIBuilder.optimize() added in 5.3
   org.apache.httpcomponents.core5/httpcore5-h2  {:mvn/version "5.3.5"}              ; pinned: must match httpcore5 version
@@ -667,7 +667,24 @@
   :eastwood/test
   {:exec-fn   metabase.linters.eastwood/eastwood
    :exec-args {:source-paths ["test"
-                              "enterprise/backend/test"]
+                              "enterprise/backend/test"
+                              "modules/drivers/athena/test"
+                              "modules/drivers/bigquery-cloud-sdk/test"
+                              "modules/drivers/clickhouse/test"
+                              "modules/drivers/databricks/test"
+                              "modules/drivers/druid/test"
+                              "modules/drivers/druid-jdbc/test"
+                              "modules/drivers/hive-like/test"
+                              "modules/drivers/mongo/test"
+                              "modules/drivers/oracle/test"
+                              "modules/drivers/presto-jdbc/test"
+                              "modules/drivers/redshift/test"
+                              "modules/drivers/snowflake/test"
+                              "modules/drivers/sparksql/test"
+                              "modules/drivers/sqlite/test"
+                              "modules/drivers/sqlserver/test"
+                              "modules/drivers/starburst/test"
+                              "modules/drivers/vertica/test"]
                :linters      [:reflection]
                :exclude-namespaces
                [;; byte/1 dispatch value trips up Eastwood's reader

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -28,7 +28,8 @@
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2])
   (:import
-   (com.google.cloud.bigquery BigQuery TableResult)))
+   (com.google.cloud.bigquery BigQuery TableResult)
+   (com.google.cloud.http HttpTransportOptions)))
 
 (set! *warn-on-reflection* true)
 
@@ -1324,7 +1325,7 @@
     (testing "Read timeout is configured as the query-timeout-ms setting"
       (let [^BigQuery client (#'bigquery/database-details->client (:details (mt/db)))
             options (.getOptions client)
-            transport-options (.getTransportOptions options)]
+            ^HttpTransportOptions transport-options (.getTransportOptions options)]
         (is (= driver.settings/*query-timeout-ms*
                (.getReadTimeout transport-options)))))))
 

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -274,9 +274,9 @@
      [nil nil]]]
    ["maps_test"
     [{:field-name "m", :base-type {:native "Map(String, UInt64)"}}]
-    [[(java.util.HashMap. {"key1" 1, "key2" 10})]
-     [(java.util.HashMap. {"key1" 2, "key2" 20})]
-     [(java.util.HashMap. {"key1" 3, "key2" 30})]]]
+    [[(doto (java.util.HashMap.) (.putAll {"key1" 1, "key2" 10}))]
+     [(doto (java.util.HashMap.) (.putAll {"key1" 2, "key2" 20}))]
+     [(doto (java.util.HashMap.) (.putAll {"key1" 3, "key2" 30}))]]]
    ["datetime_diff_nullable"
     [{:field-name "idx",  :base-type {:native "Int32"}}
      {:field-name "dt64", :base-type {:native "Nullable(DateTime64(3, 'UTC'))"}}

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -8,7 +8,7 @@
    [metabase.test.data.clickhouse :as ctd]
    [metabase.util :as u]
    [schema.core :as s])
-  (:import (java.time LocalDate LocalDateTime)))
+  (:import (java.time Clock LocalDate LocalDateTime)))
 
 (set! *warn-on-reflection* true)
 
@@ -31,7 +31,7 @@
                    :target ["dimension" ["template-tag" "x"]]
                    :id uuid}]}))
 
-(def ^:private clock (t/mock-clock (t/instant "2019-11-30T23:00:00Z") (t/zone-id "UTC")))
+(def ^:private ^Clock clock (t/mock-clock (t/instant "2019-11-30T23:00:00Z") (t/zone-id "UTC")))
 (s/defn ^:private local-date-now      :- LocalDate     [] (LocalDate/now clock))
 (s/defn ^:private local-date-time-now :- LocalDateTime [] (LocalDateTime/now clock))
 

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -366,7 +366,7 @@
        driver/*driver* (mt/id) nil
        (fn [^Connection conn]
          (let [stmt (.prepareStatement conn "select 1" ResultSet/TYPE_FORWARD_ONLY ResultSet/CONCUR_READ_ONLY)
-               prepared-stmt (#'starburst/proxy-optimized-prepared-statement driver/*driver* conn stmt [])]
+               ^PreparedStatement prepared-stmt (#'starburst/proxy-optimized-prepared-statement driver/*driver* conn stmt [])]
            (is (false? (.isClosed prepared-stmt)))
            (.close stmt)
            (is (true? (.isClosed prepared-stmt)))))))))

--- a/test/metabase/linters/eastwood.clj
+++ b/test/metabase/linters/eastwood.clj
@@ -23,6 +23,6 @@
    (merge
     {:source-paths (filterv (fn [^File f]
                               (and (= "test" (.getName f))
-                                   (not (re-find #"(?:^|/)\.clj-kondo/" (.getPath f)))))
+                                   (not= ".clj-kondo" (some-> (.getParentFile f) .getName))))
                             (common/source-paths))}
     options)))

--- a/test/metabase/linters/eastwood.clj
+++ b/test/metabase/linters/eastwood.clj
@@ -1,7 +1,8 @@
 (ns metabase.linters.eastwood
   (:require
    [eastwood.lint :as eastwood]
-   [metabase.linters.common :as common]))
+   [metabase.linters.common :as common])
+  (:import (java.io File)))
 
 (defn eastwood
   "Entrypoint for running Eastwood from the CLI. Adds some programatically-determined config options. See comments in
@@ -10,4 +11,18 @@
   (eastwood/eastwood-from-cmdline
    (merge
     {:source-paths (common/source-paths)}
+    options)))
+
+(defn eastwood-tests
+  "Entry-point for the :eastwood/test alias. Derives :source-paths from classpath directories
+  whose basename is `test` so we don't have to hardcode the per-driver test paths in deps.edn —
+  they're already on the classpath via :drivers-dev's :extra-paths. Excludes `.clj-kondo/test`,
+  which is for clj-kondo hook tests and uses a different toolchain."
+  [options]
+  (eastwood/eastwood-from-cmdline
+   (merge
+    {:source-paths (filterv (fn [^File f]
+                              (and (= "test" (.getName f))
+                                   (not (re-find #"(?:^|/)\.clj-kondo/" (.getPath f)))))
+                            (common/source-paths))}
     options)))

--- a/test/metabase/linters/eastwood.clj
+++ b/test/metabase/linters/eastwood.clj
@@ -4,6 +4,8 @@
    [metabase.linters.common :as common])
   (:import (java.io File)))
 
+(set! *warn-on-reflection* true)
+
 (defn eastwood
   "Entrypoint for running Eastwood from the CLI. Adds some programatically-determined config options. See comments in
   `deps.edn` for usage instructions."

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.util.log-test
+  ;; Trivial touch to exercise CI: Eastwood (changed tests only) — see PR #73951.
   (:require
    [clojure.test :refer :all]
    [metabase.util.log :as log])

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -1,5 +1,4 @@
 (ns metabase.util.log-test
-  ;; Trivial touch to exercise CI: Eastwood (changed tests only) — see PR #73951.
   (:require
    [clojure.test :refer :all]
    [metabase.util.log :as log])


### PR DESCRIPTION
## Summary
The `:reflection` Eastwood lint over `test/` and `enterprise/backend/test/` was gated on `github.ref_name == 'master'` because a full pass is slow. That meant reflection regressions in tests slipped past PR CI and only surfaced post-merge.

This adds a second job, `be-linter-eastwood-test-changed`, that runs on PRs and merge-queue events:

- Diffs `HEAD` against the PR / merge-queue base SHA.
- Filters to `.clj` files under `test/**` and `enterprise/backend/test/**`.
- Maps paths → namespaces (`_` → `-`, `/` → `.`, drop `.clj`, strip the source-path prefix).
- If the set is empty, exits early.
- Otherwise runs `clojure -X:...:eastwood/test :namespaces '[ns1 ns2 ...]'`. The eastwood/test alias's `:exclude-namespaces` still applies.

The full master / release-branch lint (`be-linter-eastwood-test`) stays as the safety net for anything that slips through scoping.

## Test plan
- [x] In this PR, the changed-only job runs (no test files changed → step skips, job passes). Confirmed via [job 75054336711](https://github.com/metabase/metabase/actions/runs/25567417081/job/75054336711) — `Compute changed test namespaces` succeeded, `Run Eastwood on changed test namespaces` was skipped, total 1m28s.
- [x] A reflection regression in a touched test namespace fails the job. Verified locally by removing the `^String` hint from `test/metabase/util/compress_test.clj:75` and running `clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test :namespaces '[metabase.util.compress-test]'` — eastwood reported `Warnings: 1` and exited `1`.
- [ ] Confirm the master safety-net job still runs on the next master push. (Post-merge check; can't be validated on a PR.)
- [x] `be-tests-result` aggregates correctly with one of the two eastwood-test jobs skipped. Confirmed via [job 75056824310](https://github.com/metabase/metabase/actions/runs/25567417081/job/75056824310) — passed in 4s.