### PR TITLE
Fix schema-less databases freezing /browse/databases/{id} page

### DIFF
--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
@@ -47,7 +47,7 @@ const getDatabaseId = (
 };
 
 const getSchemaName = (props: TableBrowserContainerProps): string | undefined =>
-  props.schemaName ?? props.params?.schemaName;
+  props.schemaName || props.params?.schemaName || undefined;
 
 const getReloadInterval = (
   _state: State,

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { TableBrowser } from "./TableBrowser";
 
@@ -45,5 +46,34 @@ describe("TableBrowser", () => {
       { timeout: 3000 },
     );
     await waitForLoaderToBeRemoved();
+  });
+
+  it("loads database metadata for schema-less databases (#73928)", async () => {
+    const table = createMockTable({
+      id: 123,
+      name: "foo",
+      display_name: "foo",
+      initial_sync_status: "complete",
+    });
+    const database = createMockDatabase({
+      id: 1,
+      tables: [table],
+    });
+    fetchMock.get(`path:/api/database/${database.id}`, database);
+    fetchMock.get(`path:/api/database/${database.id}/metadata`, database);
+    fetchMock.get(`path:/api/database/${database.id}/schema/`, [table]);
+
+    renderWithProviders(<TableBrowser dbId={1} schemaName="" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("foo")).toBeInTheDocument();
+    });
+
+    expect(
+      fetchMock.callHistory.calls("path:/api/database/1/metadata"),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.callHistory.calls("path:/api/database/1/schema/"),
+    ).toHaveLength(0);
   });
 });

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -456,7 +456,7 @@ function useListQuery({ dbId, schemaName, ...params } = {}, options) {
 }
 
 function getUseListQueryEndpoint(dbId, schemaName) {
-  if (dbId != null && schemaName != null) {
+  if (dbId != null && schemaName) {
     return "listDatabaseSchemaTables";
   }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73928
Closes https://linear.app/metabase/issue/UXW-4034/browsedatabasesid-freezes-for-schema-less-databases-mongomariadb

### Description

Schema-less databases were causing an infinite re-render cascade, freezing the page (/browse/databases/{id}). Please check the repro bot report for more details.

### How to verify

- Open /browse/databases/{id} for a MySQL, MariaDB or Mongo database (I could repro with MySQL)
- Page shouldn't freeze or become unresponsive.
- Browser console shouldn't show the React warning "Maximum update depth exceeded".

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
