### PR TITLE
Enable data complexity score by default in Staging

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/settings.clj
@@ -1,17 +1,25 @@
 (ns metabase-enterprise.data-complexity-score.settings
   "Settings for the data-complexity-score module."
   (:require
-   [metabase.settings.core :refer [defsetting]]
+   [metabase.config.core :as config]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting :refer [defsetting]]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting data-complexity-scoring-enabled
   (deferred-tru "Run the scheduled Data Complexity Score job (one node per cluster, daily).")
   :encryption :no
   :visibility :admin
-  :default    false
   :type       :boolean
   :export?    false
-  :doc        false)
+  :doc        false
+  :getter     (fn []
+                (u/or-with some?
+                  (setting/get-value-of-type :boolean :data-complexity-scoring-enabled)
+                  ;; Defaults to true on Metabase Cloud staging hosts and false elsewhere.
+                  (boolean (and (premium-features/is-hosted?)
+                                (config/config-bool :mb-store-use-staging))))))
 
 (defsetting data-complexity-scoring-last-fingerprint
   (deferred-tru "Internal bookkeeping: Fingerprint of last successful run, to prevent needless re-calculations.")

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/settings_test.clj
@@ -1,0 +1,27 @@
+(ns metabase-enterprise.data-complexity-score.settings-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.data-complexity-score.settings :as settings]
+   [metabase.premium-features.settings :as premium-features.settings]
+   [metabase.test :as mt]
+   [metabase.test.util :as tu]))
+
+(set! *warn-on-reflection* true)
+
+(deftest data-complexity-scoring-enabled-test
+  (doseq [[label                             hosted? staging-env scoring-env db-value expected]
+          [["pure self-hosted off"           false   "false"     nil         nil      false]
+           ["self-hosted ignores staging"    false   "true"      nil         nil      false]
+           ["prod cloud defaults off"        true    "false"     nil         nil      false]
+           ["cloud staging defaults on"      true    "true"      nil         nil      true]
+           ["env=true forces on self-host"   false   "false"     "true"      nil      true]
+           ["env=false opts staging out"     true    "true"      "false"     nil      false]
+           ["DB=true enables self-host"      false   "false"     nil         "true"   true]
+           ["DB=false beats staging default" true    "true"      nil         "false"  false]
+           ["env beats DB"                   true    "true"      "false"     "true"   false]]]
+    (testing label
+      (tu/with-temporary-raw-setting-values [data-complexity-scoring-enabled db-value]
+        (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly hosted?)]
+          (mt/with-temp-env-var-value! [mb-store-use-staging               staging-env
+                                        mb-data-complexity-scoring-enabled scoring-env]
+            (is (= expected (settings/data-complexity-scoring-enabled)))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/settings_test.clj
@@ -3,8 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.data-complexity-score.settings :as settings]
    [metabase.premium-features.settings :as premium-features.settings]
-   [metabase.test :as mt]
-   [metabase.test.util :as tu]))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -20,7 +19,7 @@
            ["DB=false beats staging default" true    "true"      nil         "false"  false]
            ["env beats DB"                   true    "true"      "false"     "true"   false]]]
     (testing label
-      (tu/with-temporary-raw-setting-values [data-complexity-scoring-enabled db-value]
+      (mt/with-temporary-raw-setting-values [data-complexity-scoring-enabled db-value]
         (mt/with-dynamic-fn-redefs [premium-features.settings/is-hosted? (constantly hosted?)]
           (mt/with-temp-env-var-value! [mb-store-use-staging               staging-env
                                         mb-data-complexity-scoring-enabled scoring-env]


### PR DESCRIPTION
Adds a custom getter so the setting defaults to `true` on Metabase Cloud staging hosts (is-hosted? + `MB_STORE_USE_STAGING`) and `false` elsewhere.

Explicit env var or admin-set DB values still win, so staging instances can opt out via `MB_DATA_COMPLEXITY_SCORING_ENABLED=false`.
