### PR TITLE
Fix clj-kondo errors regarding Nippy

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -260,9 +260,7 @@
     (metabase.driver-api.core/replace-in)
     (metabase.query-processor.middleware.cache-backend.interface/with-cached-results)
     (metabase.util.regex/rx [opt])
-    (metabase.util/prog1 [<>])
-    (taoensso.nippy/extend-freeze)
-    (taoensso.nippy/extend-thaw)]}
+    (metabase.util/prog1 [<>])]}
 
   ;; TODO (Cam 8/22/25) -- what's the point of marking stuff deprecated if we don't have Kondo enforce it? We should
   ;; remove all of these and add individual ignores as needed.
@@ -685,7 +683,9 @@
    metabase.util.malli.registry/def                                                                                          hooks.metabase.util.malli.registry/def
    metabase.util/case-enum                                                                                                   hooks.metabase.util/case-enum
    metabase.util/format-color                                                                                                hooks.metabase.util/format-color
-   metabase.xrays.api.automagic-dashboards-test/with-indexed-model!                                                          hooks.metabase.xrays.api.automagic-dashboards-test/with-indexed-model!}
+   metabase.xrays.api.automagic-dashboards-test/with-indexed-model!                                                          hooks.metabase.xrays.api.automagic-dashboards-test/with-indexed-model!
+   taoensso.nippy/extend-freeze                                                                                              hooks.taoensso.nippy/extend-freeze
+   taoensso.nippy/extend-thaw                                                                                                hooks.taoensso.nippy/extend-thaw}
 
   :macroexpand
   {clojurewerkz.quartzite.jobs/build                                                            macros.quartz/build-job

--- a/.clj-kondo/src/hooks/taoensso/nippy.clj
+++ b/.clj-kondo/src/hooks/taoensso/nippy.clj
@@ -1,0 +1,22 @@
+(ns hooks.taoensso.nippy
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn extend-thaw
+  [{:keys [node]}]
+  (let [[_ _ arglist & body] (:children node)]
+    {:node (with-meta (api/list-node
+                       (list*
+                        (api/token-node 'fn)
+                        arglist
+                        body))
+                      (meta node))}))
+
+(defn extend-freeze
+  [{:keys [node]}]
+  (let [[_ _ _ arglist & body] (:children node)]
+    {:node (with-meta (api/list-node
+                       (list*
+                        (api/token-node 'fn)
+                        arglist
+                        body))
+                      (meta node))}))


### PR DESCRIPTION
For the reason I couldn't identify, Kondo spams the following warnings when linting the project:

```
WARNING: file taoensso/nippy not found while loading hook
WARNING: error while trying to read hook for taoensso.nippy/extend-freeze: Could not find namespace: taoensso.nippy.
WARNING: file taoensso/nippy not found while loading hook
WARNING: error while trying to read hook for taoensso.nippy/extend-thaw: Could not find namespace: taoensso.nippy.
```
As seen, for example, here: https://github.com/metabase/metabase/actions/runs/25640884147/job/75262694517

I'm not sure what tries to locate such a hook (I haven't found any references to those hooks in Metabase codebase itself). So next best thing I thought of doing is to implement the hooks for real. This PR does that. Please, correct me if there is a better way to solve this.