### PR TITLE
Move DashCardLoadingView into visualizations

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -41,6 +41,7 @@ const elements = [
     type: "basic",
     name: "mlv1",
     pattern: "frontend/src/metabase-lib/v1/**",
+    enforceOutgoing: true,
   }),
   createElement({
     type: "lib",
@@ -67,6 +68,7 @@ const elements = [
   createElement({ type: "shared", name: "data-grid", enforceOutgoing: true }),
   createElement({ type: "shared", name: "data-studio", enforceOutgoing: true }),
   createElement({ type: "shared", name: "databases", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "detail-view", enforceOutgoing: true }),
   createElement({ type: "shared", name: "forms", enforceOutgoing: true }),
   createElement({ type: "shared", name: "history", enforceOutgoing: true }),
   createElement({ type: "shared", name: "hoc", enforceOutgoing: true }),
@@ -83,6 +85,7 @@ const elements = [
   createElement({ type: "shared", name: "questions", enforceOutgoing: true }),
   createElement({ type: "shared", name: "router", enforceOutgoing: true }),
   createElement({ type: "shared", name: "search", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "setup", enforceOutgoing: true }),
   createElement({ type: "shared", name: "status", enforceOutgoing: true }),
   createElement({
     type: "shared",
@@ -90,6 +93,8 @@ const elements = [
     enforceOutgoing: true,
   }),
   createElement({ type: "shared", name: "timelines", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "transforms", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "urls", enforceOutgoing: true }),
   createElement({
     type: "shared",
     name: "embedding-sdk-shared",
@@ -106,6 +111,12 @@ const elements = [
     type: "shared",
     name: "types",
     pattern: "frontend/src/types/**",
+    enforceOutgoing: true,
+  }),
+  createElement({
+    type: "shared",
+    name: "custom-viz",
+    pattern: "enterprise/frontend/src/custom-viz/**",
     enforceOutgoing: true,
   }),
   createElement({

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -31,6 +31,7 @@ import { isVirtualDashCard } from "metabase/utils/dashboard";
 import { measureTextWidth } from "metabase/utils/measure-text";
 import { getVisualizationRaw, isCartesianChart } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
+import { DashCardLoadingView } from "metabase/visualizations/components/Visualization/LoadingView/DashCardLoadingView";
 import type { LoadingViewProps } from "metabase/visualizations/components/Visualization/LoadingView/LoadingView";
 import {
   LEGEND_LABEL_FONT_SIZE,
@@ -69,7 +70,6 @@ import type {
 import { CollapsibleDashboardParameterList } from "../CollapsibleDashboardParameterList";
 
 import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay";
-import { DashCardLoadingView } from "./DashCardLoadingView";
 import { DashCardMenu } from "./DashCardMenu/DashCardMenu";
 import { DashCardParameterMapper } from "./DashCardParameterMapper/DashCardParameterMapper";
 import S from "./DashCardVisualization.module.css";

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/DashCardLoadingView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/DashCardLoadingView.tsx
@@ -6,9 +6,10 @@ import { useLearnUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { Box, Button, HoverCard, Icon, Text, Transition } from "metabase/ui";
 import { duration } from "metabase/utils/formatting";
-import type { LoadingViewProps } from "metabase/visualizations/components/Visualization/LoadingView/LoadingView";
 import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
 import type { CardDisplayType } from "metabase-types/api";
+
+import type { LoadingViewProps } from "./LoadingView";
 
 export const DashCardLoadingView = ({
   isSlow,

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -18,7 +18,6 @@ import { SmallGenericError } from "metabase/common/components/ErrorPages";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
-import { DashCardLoadingView } from "metabase/dashboard/components/DashCard/DashCardLoadingView";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
@@ -86,6 +85,7 @@ import { EmptyVizState } from "../EmptyVizState";
 import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
 import { ErrorView } from "./ErrorView";
 import LoadingView, { type LoadingViewProps } from "./LoadingView";
+import { DashCardLoadingView } from "./LoadingView/DashCardLoadingView";
 import NoResultsView from "./NoResultsView";
 import {
   VisualizationActionButtonsContainer,


### PR DESCRIPTION
Fixes a violation because visualizations was importing from dashboard.

Also updates config to enforce more ZeroModules