### PR TITLE
Reset embedding SDK props store state in place on cleanup

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/loading-performance.cy.spec.tsx
@@ -279,9 +279,18 @@ describe(
         cy.log("Unmounting");
         cy.mount(<></>);
 
-        cy.log("Checking METABASE_PROVIDER_PROPS_STORE cleaned up");
+        cy.log("Checking METABASE_PROVIDER_PROPS_STORE state was reset");
+        // cleanup() resets the props store state in place rather than dropping
+        // the singleton (EMB-1684 — dropping the singleton orphaned consumers
+        // that outlive a provider unmount). The store object stays on
+        // `window`, but its state should be back to initial (no props, no
+        // redux store).
         cy.window().should((win) => {
-          expect((win as any).METABASE_PROVIDER_PROPS_STORE).to.be.undefined;
+          const store = (win as any).METABASE_PROVIDER_PROPS_STORE;
+          expect(store, "store singleton persists").to.exist;
+          const state = store.getState();
+          expect(state.props, "props reset").to.be.null;
+          expect(state.internalProps.reduxStore, "reduxStore reset").to.be.null;
         });
       });
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-bundle.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-bundle.cy.spec.tsx
@@ -22,6 +22,19 @@ const sdkBundleCleanup = () => {
   deleteConflictingCljsGlobals();
 };
 
+// After `<MetabaseProvider>` unmounts, the props store's `cleanup()` resets
+// state in place rather than removing the singleton (EMB-1684). Use this
+// helper to assert the post-unmount shape.
+const assertPropsStoreReset = () => {
+  cy.window().should((win) => {
+    const store = (win as any).METABASE_PROVIDER_PROPS_STORE;
+    expect(store, "store singleton persists").to.exist;
+    const state = store.getState();
+    expect(state.props, "props reset").to.be.null;
+    expect(state.internalProps.reduxStore, "reduxStore reset").to.be.null;
+  });
+};
+
 describe(
   "scenarios > embedding-sdk > sdk-bundle",
   {
@@ -79,10 +92,12 @@ describe(
 
           cy.window().its("METABASE_PROVIDER_PROPS_STORE").should("exist");
 
-          // Unmount
+          // Unmount — cleanup() resets the singleton's state in place rather
+          // than dropping it from `window` (EMB-1684 — dropping the singleton
+          // orphaned consumers that outlive a provider unmount).
           cy.mount(<></>);
 
-          cy.window().its("METABASE_PROVIDER_PROPS_STORE").should("not.exist");
+          assertPropsStoreReset();
 
           cy.mount(metabaseProviderElement);
 
@@ -91,7 +106,7 @@ describe(
           // Unmount
           cy.mount(<></>);
 
-          cy.window().its("METABASE_PROVIDER_PROPS_STORE").should("not.exist");
+          assertPropsStoreReset();
         });
 
         it("should properly render global Mantine and Emotion styles once for multiple rendered components", () => {

--- a/frontend/src/embedding-sdk-shared/hooks/use-lazy-selector.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-shared/hooks/use-lazy-selector.unit.spec.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode, useEffect, useState } from "react";
+
+import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
+
+import { ensureMetabaseProviderPropsStore } from "../lib/ensure-metabase-provider-props-store";
+
+import { useLazySelector } from "./use-lazy-selector";
+
+const PROPS_STORE_KEY = "METABASE_PROVIDER_PROPS_STORE" as const;
+
+type FakeState = { sdk: { initStatus: { status: string } } };
+
+const makeStore = (initialStatus: string) => {
+  // Minimal store shim matching the redux API that useLazySelector consumes.
+  const state: FakeState = { sdk: { initStatus: { status: initialStatus } } };
+  const subs = new Set<() => void>();
+  return {
+    getState: () => state,
+    subscribe: (cb: () => void) => {
+      subs.add(cb);
+      return () => {
+        subs.delete(cb);
+      };
+    },
+  };
+};
+
+const getStatus = (state: SdkStoreState) =>
+  (state as unknown as FakeState).sdk?.initStatus?.status ?? null;
+
+const Consumer = () => {
+  const status = useLazySelector(getStatus);
+  return <div data-testid="status">{status === null ? "NULL" : status}</div>;
+};
+
+const Provider = ({ status }: { status: string }) => {
+  // Stand-in for MetabaseProviderInner: install a redux store in the props
+  // store on mount, run the props-store cleanup on unmount.
+  useEffect(() => {
+    const store = makeStore(status);
+    ensureMetabaseProviderPropsStore().updateInternalProps({
+      reduxStore: store as any,
+    });
+    return () => {
+      ensureMetabaseProviderPropsStore().cleanup();
+    };
+  }, [status]);
+  return null;
+};
+
+describe("useLazySelector — provider remount with stale consumer", () => {
+  beforeEach(() => {
+    delete (window as any)[PROPS_STORE_KEY];
+  });
+  afterEach(() => {
+    delete (window as any)[PROPS_STORE_KEY];
+  });
+
+  it("reflects the new redux store after the provider unmounts and remounts", async () => {
+    const App = () => {
+      const [show, setShow] = useState(true);
+      const [status, setStatus] = useState("success");
+      return (
+        <>
+          <Consumer />
+          <button
+            data-testid="remount"
+            type="button"
+            onClick={() => {
+              setShow(false);
+              setTimeout(() => {
+                setStatus("error");
+                setShow(true);
+              }, 0);
+            }}
+          >
+            remount
+          </button>
+          {show && <Provider status={status} />}
+        </>
+      );
+    };
+
+    render(<App />);
+
+    expect(await screen.findByText("success")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("remount"));
+
+    expect(await screen.findByText("error")).toBeInTheDocument();
+  });
+
+  it("works under React.StrictMode (mount → cleanup → mount cycle on first render)", async () => {
+    const App = () => {
+      const [status, setStatus] = useState("success");
+      return (
+        <>
+          <Consumer />
+          <button
+            data-testid="set-error"
+            type="button"
+            onClick={() => setStatus("error")}
+          >
+            set
+          </button>
+          <Provider status={status} />
+        </>
+      );
+    };
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+
+    expect(await screen.findByText("success")).toBeInTheDocument();
+
+    // Now flip the status; the Provider's useEffect re-runs with the new
+    // status, installing a new redux store. The Consumer should pick it up.
+    fireEvent.click(screen.getByTestId("set-error"));
+
+    expect(await screen.findByText("error")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/embedding-sdk-shared/hooks/use-lazy-selector.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-shared/hooks/use-lazy-selector.unit.spec.tsx
@@ -1,3 +1,20 @@
+/**
+ * Regression tests for EMB-1684 covering the `useLazySelector` layer of the
+ * Embedding SDK hook chain.
+ *
+ * `useMetabaseAuthStatus` (and every other public hook in `embedding-sdk-package`)
+ * is implemented on top of `useLazySelector`. `useLazySelector` itself reads
+ * the current redux store from the "props store" singleton on
+ * `window.METABASE_PROVIDER_PROPS_STORE`, then subscribes to that redux store
+ * via `useSyncExternalStore`. When `<MetabaseProvider>` unmounts, it calls
+ * `cleanup()` on the props store; if that cleanup orphans the consumer's
+ * subscription, the hook gets stuck on a stale value and never picks up
+ * updates from the next mount.
+ *
+ * These tests build a minimal stand-in for `<MetabaseProvider>` (which avoids
+ * pulling in the real SDK bundle loading machinery) so we can exercise the
+ * exact unmount → cleanup → remount sequence that triggers the bug.
+ */
 import { fireEvent, render, screen } from "@testing-library/react";
 import { StrictMode, useEffect, useState } from "react";
 
@@ -7,12 +24,32 @@ import { ensureMetabaseProviderPropsStore } from "../lib/ensure-metabase-provide
 
 import { useLazySelector } from "./use-lazy-selector";
 
+/**
+ * The window key that the SDK's props store is keyed under. We delete it
+ * before and after each test to guarantee a clean singleton — otherwise state
+ * from one test would leak into the next via `window`.
+ */
 const PROPS_STORE_KEY = "METABASE_PROVIDER_PROPS_STORE" as const;
 
+/**
+ * Shape of the slice we care about from the real SDK redux state.
+ * `useMetabaseAuthStatus` reads `state.sdk.initStatus` — we mirror just
+ * enough of that shape (using a `status: string` instead of the real status
+ * union) to drive the selector.
+ */
 type FakeState = { sdk: { initStatus: { status: string } } };
 
+/**
+ * Build a minimal object that quacks like a redux store for our purposes:
+ * `getState` + `subscribe`. We don't need `dispatch` because none of the
+ * tests dispatch actions — each test installs a brand-new store with a fixed
+ * initial state and then swaps it for another store with a different fixed
+ * state via the Provider re-running its effect.
+ *
+ * This shim sidesteps the full `configureStore` / sdk reducers wiring; we
+ * only need the *subscription* surface that `useLazySelector` consumes.
+ */
 const makeStore = (initialStatus: string) => {
-  // Minimal store shim matching the redux API that useLazySelector consumes.
   const state: FakeState = { sdk: { initStatus: { status: initialStatus } } };
   const subs = new Set<() => void>();
   return {
@@ -26,17 +63,41 @@ const makeStore = (initialStatus: string) => {
   };
 };
 
+/**
+ * The selector under test — mirrors what `useMetabaseAuthStatus` does:
+ * pluck `state.sdk.initStatus.status` out of redux state. Returns `null`
+ * when the slice is missing so we can distinguish "no store yet" from
+ * "store with a real status".
+ */
 const getStatus = (state: SdkStoreState) =>
   (state as unknown as FakeState).sdk?.initStatus?.status ?? null;
 
+/**
+ * The component whose subscription we want to keep alive across provider
+ * remounts. In real apps this is whichever component calls
+ * `useMetabaseAuthStatus` — placed *above* or *as a sibling of*
+ * `<MetabaseProvider>` so it outlives a provider unmount cycle.
+ *
+ * Renders `"NULL"` when the hook returns `null` so the test can assert on
+ * that transition explicitly.
+ */
 const Consumer = () => {
   const status = useLazySelector(getStatus);
   return <div data-testid="status">{status === null ? "NULL" : status}</div>;
 };
 
+/**
+ * Stand-in for the real `MetabaseProviderInner` component. The only thing we
+ * borrow from the real provider is its effect contract:
+ *   - on mount: install a redux store into the props store
+ *   - on unmount: call `cleanup()` on the props store
+ *
+ * Because the `status` prop is in the effect's deps, changing it triggers
+ * unmount-and-remount of the effect — which mirrors what happens in user
+ * code when `<MetabaseProvider>` is conditionally rendered or its
+ * `authConfig` changes between mounts.
+ */
 const Provider = ({ status }: { status: string }) => {
-  // Stand-in for MetabaseProviderInner: install a redux store in the props
-  // store on mount, run the props-store cleanup on unmount.
   useEffect(() => {
     const store = makeStore(status);
     ensureMetabaseProviderPropsStore().updateInternalProps({
@@ -50,6 +111,7 @@ const Provider = ({ status }: { status: string }) => {
 };
 
 describe("useLazySelector — provider remount with stale consumer", () => {
+  // Clear the window-scoped singleton so each test starts from scratch.
   beforeEach(() => {
     delete (window as any)[PROPS_STORE_KEY];
   });
@@ -58,6 +120,11 @@ describe("useLazySelector — provider remount with stale consumer", () => {
   });
 
   it("reflects the new redux store after the provider unmounts and remounts", async () => {
+    // App scenario: <Consumer> is rendered as a sibling of <Provider>.
+    // Clicking "remount" toggles the provider off and back on with a
+    // *different* status, simulating the user-reported "remount with bad
+    // config" repro from EMB-1684. <Consumer> stays mounted throughout, so
+    // its `useSyncExternalStore` subscription must survive the cleanup.
     const App = () => {
       const [show, setShow] = useState(true);
       const [status, setStatus] = useState("success");
@@ -69,6 +136,9 @@ describe("useLazySelector — provider remount with stale consumer", () => {
             type="button"
             onClick={() => {
               setShow(false);
+              // Defer the remount to the next tick so React commits the
+              // unmount (and runs the props-store cleanup) before the new
+              // mount installs a fresh store.
               setTimeout(() => {
                 setStatus("error");
                 setShow(true);
@@ -84,14 +154,22 @@ describe("useLazySelector — provider remount with stale consumer", () => {
 
     render(<App />);
 
+    // Initial mount: Provider installs a store with status "success".
     expect(await screen.findByText("success")).toBeInTheDocument();
 
+    // Unmount → cleanup → remount with status "error".
     fireEvent.click(screen.getByTestId("remount"));
 
+    // Without the EMB-1684 fix, Consumer stays stuck on "success" because
+    // its subscription was orphaned on the wiped store.
     expect(await screen.findByText("error")).toBeInTheDocument();
   });
 
   it("works under React.StrictMode (mount → cleanup → mount cycle on first render)", async () => {
+    // React.StrictMode synthetically runs mount → unmount → mount on every
+    // effect during development. That means the props store's cleanup fires
+    // mid-mount on the very first render, before any real unmount happens.
+    // This test makes sure the fix survives that simulated cycle too.
     const App = () => {
       const [status, setStatus] = useState("success");
       return (
@@ -117,8 +195,9 @@ describe("useLazySelector — provider remount with stale consumer", () => {
 
     expect(await screen.findByText("success")).toBeInTheDocument();
 
-    // Now flip the status; the Provider's useEffect re-runs with the new
-    // status, installing a new redux store. The Consumer should pick it up.
+    // Flip the status; Provider's useEffect re-runs with the new status,
+    // tearing down the old store (running cleanup) and installing a fresh
+    // one. Consumer must follow the swap.
     fireEvent.click(screen.getByTestId("set-error"));
 
     expect(await screen.findByText("error")).toBeInTheDocument();

--- a/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.ts
+++ b/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.ts
@@ -3,12 +3,10 @@ import { useCallback, useSyncExternalStore } from "react";
 import { ensureMetabaseProviderPropsStore } from "../lib/ensure-metabase-provider-props-store";
 
 export function useMetabaseProviderPropsStore() {
-  // Re-resolve the store from `window` on every subscribe/snapshot call.
-  // `cleanup()` deletes the window key, and the next `ensureMetabaseProviderPropsStore()`
-  // creates a fresh store. Holding a `useRef`'d store across React StrictMode's
-  // simulated unmount/remount cycle would leave the component reading from a
-  // stale store object while writes (via direct `ensureMetabaseProviderPropsStore()`
-  // calls in effects) target the current one.
+  // Re-resolve the store on every subscribe/snapshot call rather than capturing
+  // it in a closure. `cleanup()` resets state in place and reuses the same
+  // singleton, so this is mostly defensive — but it also keeps the hook
+  // resilient if the singleton implementation ever swaps the underlying object.
   const subscribe = useCallback(
     (listener: () => void) =>
       ensureMetabaseProviderPropsStore().subscribe(listener),

--- a/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-shared/hooks/use-metabase-provider-props-store.unit.spec.tsx
@@ -1,5 +1,5 @@
-import { act, render, screen } from "@testing-library/react";
-import { StrictMode, useEffect } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode, useEffect, useState } from "react";
 
 import { ensureMetabaseProviderPropsStore } from "../lib/ensure-metabase-provider-props-store";
 
@@ -33,7 +33,7 @@ const Consumer = () => {
   );
 };
 
-describe("useMetabaseProviderPropsStore under StrictMode", () => {
+describe("useMetabaseProviderPropsStore", () => {
   beforeEach(resetWindow);
   afterEach(resetWindow);
 
@@ -58,6 +58,56 @@ describe("useMetabaseProviderPropsStore under StrictMode", () => {
 
     expect(screen.getByTestId("instance-url")).toHaveTextContent(
       "https://example.com",
+    );
+  });
+
+  it("keeps observing updates when the provider unmounts and remounts while the consumer stays mounted", () => {
+    // Reproduces EMB-1684: a consumer of `useMetabaseAuthStatus`/`useMetabaseProviderPropsStore`
+    // that outlives a `<MetabaseProvider>` mount cycle previously got orphaned
+    // on the wiped store and never saw updates from the next mount.
+    const App = () => {
+      const [showProvider, setShowProvider] = useState(true);
+      return (
+        <>
+          <Consumer />
+          {showProvider && <ParentWithCleanup>{null}</ParentWithCleanup>}
+          <button
+            type="button"
+            data-testid="toggle"
+            onClick={() => setShowProvider((v) => !v)}
+          >
+            toggle
+          </button>
+        </>
+      );
+    };
+
+    render(<App />);
+
+    act(() => {
+      ensureMetabaseProviderPropsStore().setProps({
+        authConfig: { metabaseInstanceUrl: "https://before.com" } as any,
+      });
+    });
+    expect(screen.getByTestId("instance-url")).toHaveTextContent(
+      "https://before.com",
+    );
+
+    // Unmount the provider — its cleanup wipes the props store while the
+    // Consumer is still mounted.
+    fireEvent.click(screen.getByTestId("toggle"));
+
+    // Remount the provider.
+    fireEvent.click(screen.getByTestId("toggle"));
+
+    act(() => {
+      ensureMetabaseProviderPropsStore().setProps({
+        authConfig: { metabaseInstanceUrl: "https://after.com" } as any,
+      });
+    });
+
+    expect(screen.getByTestId("instance-url")).toHaveTextContent(
+      "https://after.com",
     );
   });
 });

--- a/frontend/src/embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts
+++ b/frontend/src/embedding-sdk-shared/lib/ensure-metabase-provider-props-store.ts
@@ -99,8 +99,13 @@ export function ensureMetabaseProviderPropsStore(): MetabaseProviderPropsStore {
       listeners.forEach((callback) => callback());
     },
     cleanup() {
-      listeners.clear();
-      delete win[KEY];
+      // Reset state in place rather than dropping the singleton. Subscribers
+      // (e.g. consumers of `useMetabaseAuthStatus` rendered as siblings of
+      // `<MetabaseProvider>`) keep their useSyncExternalStore subscriptions —
+      // a deleted-singleton cleanup orphans them on the abandoned store and
+      // they never see updates from the next mount cycle.
+      state = getInitialState();
+      listeners.forEach((callback) => callback());
     },
   };
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73608
Closes [EMB-1684: Embedding SDK auth status hook stays null after initial load and only updates after route changes](https://linear.app/metabase/issue/EMB-1684/embedding-sdk-auth-status-hook-stays-null-after-initial-load-and-only)

### Description

`useMetabaseAuthStatus` could get stuck on a stale value when `<MetabaseProvider>` unmounts while a consumer of the hook stays mounted (e.g. consumer above the provider, conditional render, route swap, Fast Refresh).

The props store's `cleanup()` did `listeners.clear()` + `delete win[KEY]`, dropping the singleton. Consumers subscribed via `useSyncExternalStore` kept their listener on the abandoned store and never saw updates from the next mount. The fix resets state in place and notifies listeners, so existing subscriptions stay valid across provider remounts.

### How to verify

Set up a consuming app with this `App` (consumer above the provider so it outlives the provider mount cycle):

```tsx
function AuthStatusDebug() {
  const status = useMetabaseAuthStatus();
  return <pre>{JSON.stringify(status)}</pre>;
}

function App() {
  const [show, setShow] = useState(true);
  const [config, setConfig] = useState(goodConfig);
  return (
    <>
      <AuthStatusDebug />
      <button
        onClick={() => {
          setShow(false);
          setTimeout(() => { setConfig(badConfig); setShow(true); }, 50);
        }}
      >
        remount with bad config
      </button>
      {show && (
        <MetabaseProvider authConfig={config}>
          <InteractiveDashboard dashboardId={1} />
        </MetabaseProvider>
      )}
    </>
  );
}
```

**On master**

1. Load the app → `AuthStatusDebug` shows `{"status":"success"}`.
2. Click "remount with bad config".
3. Dashboard renders `Failed to fetch the user, the session might be invalid.`
4. `AuthStatusDebug` is **still stuck on `{"status":"success"}`** — the bug.

**With this PR**

1. Load the app → `AuthStatusDebug` shows `{"status":"success"}`.
2. Click "remount with bad config".
3. Dashboard renders the same error.
4. `AuthStatusDebug` **transitions to `{"status":"error", ...}`** reflecting the new mount.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR