### PR TITLE
Exclude current day from Task Runs date filters

### DIFF
--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -69,13 +69,13 @@ export type TaskRunEntityType = "database" | "card" | "dashboard";
 export type TaskRunStatus = "started" | "success" | "failed" | "abandoned";
 export type TaskRunDateFilterOption =
   | "thisday"
-  | "past1days~"
-  | "past1weeks~"
-  | "past7days~"
-  | "past30days~"
-  | "past1months~"
-  | "past3months~"
-  | "past12months~";
+  | "past1days"
+  | "past1weeks"
+  | "past7days"
+  | "past30days"
+  | "past1months"
+  | "past3months"
+  | "past12months";
 
 export interface TaskRun {
   id: number;

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -23,13 +23,13 @@ export const TaskRunDatePicker = ({
    */
   const data: SelectData<TaskRunDateFilterOption> = [
     { label: t`Today`, value: "thisday" },
-    { label: t`Yesterday`, value: "past1days~" },
-    { label: t`Previous week`, value: "past1weeks~" },
-    { label: t`Previous 7 days`, value: "past7days~" },
-    { label: t`Previous 30 days`, value: "past30days~" },
-    { label: t`Previous month`, value: "past1months~" },
-    { label: t`Previous 3 months`, value: "past3months~" },
-    { label: t`Previous 12 months`, value: "past12months~" },
+    { label: t`Yesterday`, value: "past1days" },
+    { label: t`Previous week`, value: "past1weeks" },
+    { label: t`Previous 7 days`, value: "past7days" },
+    { label: t`Previous 30 days`, value: "past30days" },
+    { label: t`Previous month`, value: "past1months" },
+    { label: t`Previous 3 months`, value: "past3months" },
+    { label: t`Previous 12 months`, value: "past12months" },
   ];
 
   return (

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -111,12 +111,12 @@ export const guardTaskRunStartedAtRange = (
   (
     [
       "thisday",
-      "past1days~",
-      "past1weeks~",
-      "past7days~",
-      "past30days~",
-      "past1months~",
-      "past3months~",
-      "past12months~",
+      "past1days",
+      "past1weeks",
+      "past7days",
+      "past30days",
+      "past1months",
+      "past3months",
+      "past12months",
     ] satisfies TaskRunDateFilterOption[]
   ).includes(value as TaskRunDateFilterOption);


### PR DESCRIPTION
Closes [GDGT-2033](https://linear.app/metabase/issue/GDGT-2033/filtering-logs-by-start-date-is-not-working)

### Description

Previously, every option in the "Filter by started at" picker on `admin/tools/tasks/runs` was suffixed with `~`, which means "include the current day". Technically the filter was working — but if you had enough task runs today, today's runs would fill the entire first page, so selecting "Yesterday", "Previous week", or "Previous 30 days" all looked identical and gave the impression that the filter was broken (this is what was reported in the ticket).

After [confirming with design](https://metaboat.slack.com/archives/C02H619CJ8K/p1777913621350449?thread_ts=1777884828.406869&cid=C02H619CJ8K), `TaskRunDatePicker` now sends the filter values without the `~` suffix, so today's runs are excluded from every "Previous …" option. "Today" is unaffected.

### How to verify

See the screen recording attached to the [Linear ticket](https://linear.app/metabase/issue/GDGT-2033/filtering-logs-by-start-date-is-not-working) for the original behavior.

1. Go to `admin/tools/tasks/runs` on an instance with a healthy stream of task runs today.
2. Open "Filter by started at" and pick "Yesterday" → results should not include any runs with `started_at` on today's date.
3. Switch to "Previous week", "Previous 7 days", "Previous 30 days", etc. — same expectation: today is excluded.
4. Pick "Today" → only today's runs appear.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR