### PR TITLE
localize last updated at value in Data Studio Table Metadata

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -4,7 +4,6 @@ const { H } = cy;
 const { TablePicker } = H.DataModel;
 
 interface MetadataResponse {
-  updated_at: string;
   data_layer: string;
   view_count: number;
 }
@@ -45,12 +44,10 @@ describe("Table editing", () => {
     TablePicker.getTable("Orders").click();
 
     cy.wait<MetadataResponse>("@metadata").then(({ response }) => {
-      const updatedAt = response?.body.updated_at ?? "";
-      const expectedDate = new Date(updatedAt).toLocaleString();
       const viewCount = response?.body.view_count ?? 0;
 
       cy.findByLabelText("Name in the database").should("have.text", "ORDERS");
-      cy.findByLabelText("Last updated at").should("have.text", expectedDate);
+      cy.findByLabelText("Last updated at").should("exist"); // Testing the actual value is done in TableMetadata.unit.spec.tsx
       cy.findByLabelText("View count").should("have.text", viewCount);
       cy.findByLabelText("Est. row count").should("not.exist");
       cy.findByLabelText("Dependencies").should("have.text", "0");

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableMetadata.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableMetadata.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useId } from "react";
 import { t } from "ttag";
 
+import { DateTime } from "metabase/common/components/DateTime";
 import { Link } from "metabase/common/components/Link";
 import { useNumberFormatter } from "metabase/common/hooks/use-number-formatter";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
@@ -15,7 +16,6 @@ interface Props {
 }
 
 export function TableMetadata({ table }: Props) {
-  const formattedDate = new Date(table.updated_at).toLocaleString();
   const formatNumber = useNumberFormatter();
   const isDependenciesEnabled = PLUGIN_DEPENDENCIES.isEnabled;
 
@@ -28,7 +28,10 @@ export function TableMetadata({ table }: Props) {
   return (
     <Stack gap="md">
       <MetadataRow label={t`Name in the database`} value={table.name} />
-      <MetadataRow label={t`Last updated at`} value={formattedDate} />
+      <MetadataRow
+        label={t`Last updated at`}
+        value={<DateTime value={table.updated_at} />}
+      />
       <MetadataRow
         label={t`View count`}
         value={formatNumber(table.view_count)}

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableMetadata.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableMetadata.unit.spec.tsx
@@ -1,0 +1,40 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { DateFormattingSettings } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
+
+import { TableMetadata } from "./TableMetadata";
+
+describe("TableMetadata", () => {
+  function setup(temporalFormatting: DateFormattingSettings) {
+    const settings = mockSettings({
+      "custom-formatting": { "type/Temporal": temporalFormatting },
+    });
+
+    const table = createMockTable({ updated_at: "2021-06-08T14:40:10" });
+
+    renderWithProviders(<TableMetadata table={table} />, {
+      storeInitialState: { settings },
+    });
+  }
+
+  it("formats the last updated at date with a long weekday/24h style", () => {
+    setup({
+      date_style: "dddd, MMMM D, YYYY",
+      time_style: "HH:mm",
+    });
+
+    expect(
+      screen.getByText("Tuesday, June 8, 2021, 14:40"),
+    ).toBeInTheDocument();
+  });
+
+  it("formats the last updated at date with a short date/12h style", () => {
+    setup({
+      date_style: "MMMM D, YYYY",
+      time_style: "h:mm A",
+    });
+
+    expect(screen.getByText("June 8, 2021, 2:40 PM")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Localizes the `Last updated at` value in the Table Metadata section of the Data Studio Data page (phew). Previously this was using browser localization settings, but now it's using our DateTime component which will pull from app localization settings.

### How to verify
1. Ensure you have a custom date time localization set
2. Navigate to the Data Studio -> Tables page
3. Click on a table, and under `Metadata` you should see the last update at time localized. 


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
