### PR TITLE
[Slackbot] Remove slash command

### DIFF
--- a/src/metabase/slackbot/config.clj
+++ b/src/metabase/slackbot/config.clj
@@ -23,11 +23,7 @@
                            :messages_tab_read_only_enabled false}
                 :bot_user {:display_name bot-name
                            :always_online false}
-                :assistant_view {:assistant_description "Your AI-powered data assistant"}
-                :slash_commands [{:command "/metabot"
-                                  :url (str base-url "/api/metabot/slack/commands")
-                                  :description (str "Issue a " bot-name " command")
-                                  :should_escape false}]}
+                :assistant_view {:assistant_description "Your AI-powered data assistant"}}
      :oauth_config {:redirect_urls [(str base-url "/auth/sso/slack-connect/callback")]
                     :scopes {:bot ["app_mentions:read"
                                    "assistant:write"


### PR DESCRIPTION
For some reason we had registered a `/metabot` slack command but it is not used. This removes it.