### PR TITLE
Reconcile module :team tags with Notion playbook

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1118,7 +1118,7 @@
                     :model/Transform}}
 
   lib-metric
-  {:team "UX West"
+  {:team "Querying Platform"
    :api  #{metabase.lib-metric.core
            metabase.lib-metric.schema}
    :uses #{lib

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2538,7 +2538,7 @@
                     :model/Table}}
 
   warehouses
-  {:team "Graphy"
+  {:team "UX West"
    :api  #{metabase.warehouses.core
            metabase.warehouses.init
            metabase.warehouses.models.database}
@@ -2563,7 +2563,7 @@
                     :model/User}}
 
   warehouses-rest
-  {:team "Graphy"
+  {:team "UX West"
    :api  #{metabase.warehouses-rest.api}
    :uses #{analytics
            api

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1118,7 +1118,7 @@
                     :model/Transform}}
 
   lib-metric
-  {:team "Querying Platform"
+  {:team "UX West"
    :api  #{metabase.lib-metric.core
            metabase.lib-metric.schema}
    :uses #{lib

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1279,7 +1279,7 @@
                     :model/User}}
 
   metrics
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.metrics.api
            metabase.metrics.core}
    :uses #{api
@@ -1428,7 +1428,7 @@
 
   ;; TODO -- too many API namespaces
   parameters
-  {:team "Graphy"
+  {:team "Querying Platform"
    :api  #{metabase.parameters.chain-filter
            metabase.parameters.core
            metabase.parameters.custom-values
@@ -1799,7 +1799,7 @@
                     :model/Table}}
 
   remote-sync
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.remote-sync.core
            metabase.remote-sync.init}
    :uses #{api
@@ -2249,7 +2249,7 @@
            util}}
 
   transforms
-  {:team "Graphy"
+  {:team "Gadget"
    :api  #{metabase.transforms.core
            metabase.transforms.feature-gating
            metabase.transforms.init
@@ -2293,7 +2293,7 @@
                     :model/User}}
 
   transforms-base
-  {:team "Graphy"
+  {:team "Gadget"
    :api  #{metabase.transforms-base.init
            metabase.transforms-base.interface
            metabase.transforms-base.util}
@@ -2472,7 +2472,7 @@
    :model-imports #{:model/Card :model/Dashboard :model/Table}}
 
   warehouse-schema
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.warehouse-schema.field
            metabase.warehouse-schema.metadata-from-qp
            metabase.warehouse-schema.metadata-queries
@@ -2510,7 +2510,7 @@
                     :model/User}}
 
   warehouse-schema-rest
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.warehouse-schema-rest.api}
    :uses #{analytics
            api
@@ -2538,7 +2538,7 @@
                     :model/Table}}
 
   warehouses
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.warehouses.core
            metabase.warehouses.init
            metabase.warehouses.models.database}
@@ -2563,7 +2563,7 @@
                     :model/User}}
 
   warehouses-rest
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase.warehouses-rest.api}
    :uses #{analytics
            api
@@ -2597,7 +2597,7 @@
                     :model/Table}}
 
   xrays
-  {:team "Graphy"
+  {:team "Metabot"
    :api  #{metabase.xrays.api
            metabase.xrays.core
            metabase.xrays.init}
@@ -3042,7 +3042,7 @@
            util}}
 
   enterprise/impersonation
-  {:team "Graphy"
+  {:team "UX West"
    :api  #{metabase-enterprise.impersonation.api}
    :uses #{api
            audit-app
@@ -3128,7 +3128,7 @@
            util}}
 
   enterprise/remote-sync
-  {:team "UX West"
+  {:team "Graphy"
    :api  #{metabase-enterprise.remote-sync.api
            metabase-enterprise.remote-sync.core
            metabase-enterprise.remote-sync.init}
@@ -3395,7 +3395,7 @@
    :model-imports #{:model/Collection :model/User}}
 
   enterprise/transforms
-  {:team "Graphy"
+  {:team "Gadget"
    :api  #{metabase-enterprise.transforms.api}
    :uses #{premium-features
            enterprise/transforms-inspector}}
@@ -3422,7 +3422,7 @@
                     :model/Transform}}
 
   enterprise/transforms-python
-  {:team "Graphy"
+  {:team "Gadget"
    :api  #{metabase-enterprise.transforms-python.api
            metabase-enterprise.transforms-python.core
            metabase-enterprise.transforms-python.init}
@@ -3463,7 +3463,7 @@
    :uses #{premium-features}}
 
   enterprise/writable-connection
-  {:team "Graphy"
+  {:team "Gadget"
    :api  #{}
    :uses #{premium-features}}}
 


### PR DESCRIPTION
## Summary

Aligns `:team` tags in `.clj-kondo/config/modules/config.edn` with the [Eng Team Charters and Product Areas](https://www.notion.so/metabase/Eng-Team-Charters-and-Product-Areas-fd733128936a48aa8c03c7141e849307) page on Notion (canonical source of truth).

These tags drive the new `dev.team-report` tool (per-team module dependency report) — stale tags = wrong reports for everyone.

### Moves out of Graphy (9 modules)

| Module | New owner | Per Notion |
| --- | --- | --- |
| `transforms` | Gadget | Gadget owns "Transforms" |
| `transforms-base` | Gadget | same |
| `enterprise/transforms` | Gadget | same |
| `enterprise/transforms-python` | Gadget | same |
| `enterprise/writable-connection` | Gadget | Transforms-adjacent (write-back) |
| `xrays` | Metabot | "Querying/X-rays (backend)" is Metabot scope |
| `parameters` | Querying Platform | Platform charter: "Parameters, Linked Filters" |
| `enterprise/impersonation` | UX West | Permissions/SSO are UX West |

Note: `transforms-inspector`, `transforms-rest`, and `enterprise/transforms-inspector` were already Gadget — this just brings the rest of the cluster in line.

### Claims for Graphy (7 modules)

| Module | Was | Per Notion |
| --- | --- | --- |
| `warehouse-schema` | UX West | "Administration/Table Metadata" is Graphy |
| `warehouse-schema-rest` | UX West | REST surface for the above |
| `warehouses` | UX West | "Administration/Metadata & Sync" |
| `warehouses-rest` | UX West | REST surface for the above |
| `remote-sync` | UX West | "Remote Sync" explicit in Graphy charter |
| `enterprise/remote-sync` | UX West | same |
| `metrics` | UX West | "Administration/Metrics & Segments" is Graphy |

### Not included — needs discussion

Left as-is until the relevant teams confirm:
- `measures` — Graphy semantic-layer scope or Platform MBQL?
- `model-persistence` — Graphy or Platform (Querying/Cache)?
- `upload` / `enterprise/upload-management` — Platform (CSV Uploads) or Metabot (Organization/Uploads)?
- `enterprise/serialization` — Platform or Metabot (both have "Operation/Serialization")?
- `enterprise/dashboard-subscription-filters` — UX West (Dashboards) or Gadget (Subscriptions)?
- `lib-metric` — follows `metrics`, or stays Platform as `.metabase-lib` infra?
- `enterprise/checker` — confirm it's Dependencies-related

## Test plan

- [x] `metabase.core.modules-test` — 3817 assertions, 0 failures
- [ ] Sanity-check from each receiving EM (Gadget, Metabot, Querying Platform, UX West) that the moves match their understanding