### PR TITLE
Fix password resets for Helping Hand instance access account

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
@@ -310,8 +310,8 @@
                   (is (true? (:success response)) "Reset should succeed")
                   (is (some? (:session_id response)) "Should return session ID"))))))))))
 
-(deftest forgot-password-support-user-disabled-test
-  (testing "POST /api/session/forgot_password - Support Users cannot reset passwords"
+(deftest forgot-password-support-user-no-active-grant-test
+  (testing "POST /api/session/forgot_password - Support user with no active grant gets no email"
     (with-redefs [api.session/forgot-password-impl
                   (let [orig @#'api.session/forgot-password-impl]
                     (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
@@ -320,8 +320,97 @@
                                        :email "support@example.com"}
                      :model/AuthIdentity _ {:user_id (:id user)
                                             :provider "support-access-grant"}]
-        (let [my-url "abcdefghij"]
-          (mt/with-temporary-setting-values [site-url my-url]
-            (mt/with-fake-inbox
-              (mt/user-http-request user :post 204 "session/forgot_password" {:email (:email user)})
-              (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "emailed-secret-password-reset"))))))))))
+        (mt/with-temporary-setting-values [site-url "http://localhost"]
+          (mt/with-fake-inbox
+            (mt/user-http-request user :post 204 "session/forgot_password" {:email (:email user)})
+            (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "emailed-secret-password-reset"))
+                "Should not create a normal password reset token")
+            (is (empty? @mt/inbox)
+                "No email should be sent when the grant has no active credentials")))))))
+
+(deftest forgot-password-support-user-active-grant-test
+  (testing "POST /api/session/forgot_password - Support user with active grant gets a refreshed token"
+    (with-redefs [api.session/forgot-password-impl
+                  (let [orig @#'api.session/forgot-password-impl]
+                    (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
+      (mt/with-temp [:model/User {creator-id :id} {}]
+        (mt/with-model-cleanup [:model/SupportAccessGrantLog :model/AuthIdentity :model/User]
+          (with-redefs [sag.settings/support-access-grant-email (constantly "support-forgot@example.com")
+                        sag.settings/support-access-grant-first-name (constantly "Support")
+                        sag.settings/support-access-grant-last-name (constantly "User")]
+            (let [grant (grants/create-grant! creator-id 60 "TICKET-FORGOT" "Test forgot password")
+                  original-token (:token grant)]
+              (is (some? original-token) "Grant should create a token")
+              (mt/with-temporary-setting-values [site-url "http://test.example.com"]
+                (mt/with-fake-inbox
+                  (mt/client :post 204 "session/forgot_password" {:email "support-forgot@example.com"})
+                  (testing "Email is sent with a valid reset URL"
+                    (let [emails (get @mt/inbox "support-forgot@example.com")]
+                      (is (= 1 (count emails)) "Should send exactly one email")
+                      (is (mt/received-email-body? "support-forgot@example.com"
+                                                   #"http://test.example.com/auth/reset_password/\d+_")
+                          "Email should contain a reset URL")))
+                  (testing "No normal password reset token is created"
+                    (let [support-user (t2/select-one :model/User :email "support-forgot@example.com")]
+                      (is (not (t2/exists? :model/AuthIdentity
+                                           :user_id (:id support-user)
+                                           :provider "emailed-secret-password-reset"))
+                          "Should not create a normal password reset token")))
+                  (testing "The refreshed token is different from the original"
+                    (let [support-user (t2/select-one :model/User :email "support-forgot@example.com")
+                          auth-identity (t2/select-one :model/AuthIdentity
+                                                       :user_id (:id support-user)
+                                                       :provider "support-access-grant")]
+                      (is (nil? (get-in auth-identity [:credentials :consumed_at]))
+                          "Token should not be marked as consumed")
+                      (is (some? (get-in auth-identity [:credentials :grant_ends_at]))
+                          "Grant end time should still be present in credentials"))))))))))))
+
+(deftest forgot-password-then-reset-preserves-support-provider-test
+  (testing "Consuming a refreshed support-access token via reset_password keeps the support-access-grant provider"
+    (with-redefs [api.session/forgot-password-impl
+                  (let [orig @#'api.session/forgot-password-impl]
+                    (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
+      (mt/with-temp [:model/User {creator-id :id} {}]
+        (mt/with-model-cleanup [:model/SupportAccessGrantLog :model/AuthIdentity :model/User]
+          (with-redefs [sag.settings/support-access-grant-email (constantly "support-reset@example.com")
+                        sag.settings/support-access-grant-first-name (constantly "Support")
+                        sag.settings/support-access-grant-last-name (constantly "User")]
+            (let [grant (grants/create-grant! creator-id 60 "TICKET-PROVIDER" "Test provider preservation")]
+              (is (some? (:token grant)) "Grant should create a token")
+              (mt/with-temporary-setting-values [site-url "http://test.example.com"]
+                (mt/with-fake-inbox
+                  ;; Step 1: Request a password reset for the support user.
+                  (mt/client :post 204 "session/forgot_password" {:email "support-reset@example.com"})
+                  ;; Step 2: Extract the refreshed token from the email.
+                  (let [emails          (get @mt/inbox "support-reset@example.com")
+                        _               (is (= 1 (count emails)) "Should send exactly one email")
+                        email-body      (-> emails first :body first :content)
+                        [_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)" email-body)
+                        _               (is (some? reset-token) "Should find reset token in email")
+                        new-password    "ResetViaForgot123!"
+                        support-user    (t2/select-one :model/User :email "support-reset@example.com")]
+                    ;; Step 3: Use the token to reset the password.
+                    (let [response (mt/client :post 200 "session/reset_password"
+                                              {:token reset-token :password new-password})]
+                      (is (true? (:success response)) "Reset should succeed")
+                      (is (some? (:session_id response)) "Should return session ID"))
+                    ;; Step 4: Verify the support-access-grant AuthIdentity is consumed, not replaced.
+                    (testing "support-access-grant AuthIdentity is consumed"
+                      (let [sag-auth (t2/select-one :model/AuthIdentity
+                                                    :user_id (:id support-user)
+                                                    :provider "support-access-grant")]
+                        (is (some? sag-auth) "support-access-grant AuthIdentity should still exist")
+                        (is (some? (get-in sag-auth [:credentials :consumed_at]))
+                            "Token should be marked as consumed")))
+                    (testing "No emailed-secret-password-reset AuthIdentity was created"
+                      (is (not (t2/exists? :model/AuthIdentity
+                                           :user_id (:id support-user)
+                                           :provider "emailed-secret-password-reset"))
+                          "Should not create a normal password reset AuthIdentity"))
+                    (testing "Password AuthIdentity has grant expiration, not unlimited"
+                      (let [pw-auth (t2/select-one :model/AuthIdentity
+                                                   :user_id (:id support-user)
+                                                   :provider "password")]
+                        (is (some? (:expires_at pw-auth))
+                            "Password AuthIdentity should have an expiration from the grant")))))))))))))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -20,6 +20,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.password :as u.password]
    [throttle.core :as throttle]
    [toucan2.core :as t2]))
 
@@ -164,17 +165,30 @@
   {:email      (throttle/make-throttler :email :attempts-threshold 3 :attempt-ttl-ms 1000)
    :ip-address (throttle/make-throttler :email :attempts-threshold 50)})
 
-(defn- password-reset-disabled?
+(defn- sso-password-reset-disabled?
   "Disable password reset for users whose SSO provider is still active — they should use SSO.
    When a provider is no longer available (e.g., after license downgrade), allow password reset
-   so users aren't locked out.
+   so users aren't locked out."
+  [sso-source]
+  (and (some? sso-source)
+       (sso/sso-source-enabled? sso-source)))
 
-   Always disable password reset for support-access users."
-  [user-id sso-source]
-  (cond
-    (t2/exists? :model/AuthIdentity :user_id user-id :provider "support-access-grant") true
-    (some? sso-source) (sso/sso-source-enabled? sso-source)
-    :else false))
+(defn- refresh-support-access-token!
+  "Refresh the reset token on an existing support-access-grant AuthIdentity, preserving the grant
+   binding. Returns the new plaintext token, or nil if the grant has expired."
+  [user-id]
+  (when-let [auth-identity (t2/select-one :model/AuthIdentity
+                                          :user_id user-id
+                                          :provider "support-access-grant")]
+    (let [grant-ends-at (get-in auth-identity [:credentials :grant_ends_at])]
+      (when (and grant-ends-at (t/before? (t/instant) (t/instant grant-ends-at)))
+        (let [token (auth-identity/generate-reset-token user-id)]
+          (t2/update! :model/AuthIdentity (:id auth-identity)
+                      {:credentials {:token_hash   (u.password/hash-bcrypt token)
+                                     :expires_at   (t/plus (t/instant) (t/hours 48))
+                                     :grant_ends_at grant-ends-at
+                                     :consumed_at  nil}})
+          token)))))
 
 (defn- forgot-password-impl
   [email]
@@ -185,9 +199,21 @@
                (t2/select-one [:model/User :id :sso_source :is_active]
                               :%lower.email
                               (u/lower-case-en email))]
-      ;; If user uses any *enabled* SSO method to log in, no need to generate a reset token.
-      (if (password-reset-disabled? user-id sso-source)
+      (cond
+        ;; SSO users should use their SSO provider, not password reset.
+        (sso-password-reset-disabled? sso-source)
         (messages/send-password-reset-email! email sso-source nil is-active?)
+
+        ;; Support-access users get a refreshed token bound to the grant.
+        ;; If the grant has expired, refresh-support-access-token! returns nil and we silently
+        ;; do nothing (same as a nonexistent account).
+        (t2/exists? :model/AuthIdentity :user_id user-id :provider "support-access-grant")
+        (when-let [reset-token (refresh-support-access-token! user-id)]
+          (let [password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
+            (messages/send-password-reset-email! email nil password-reset-url is-active?)))
+
+        ;; Normal password reset.
+        :else
         (let [reset-token        (auth-identity/create-password-reset! user-id)
               password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
           (messages/send-password-reset-email! email nil password-reset-url is-active?)))


### PR DESCRIPTION
Fixes UXW-4037.

### Description

Previously, it was possible to have a grant for Helping Hand access by
the Metabase success team with a much longer validity period than the
token which gets emailed to the success team.

The tokens (like other password reset tokens) are only good for 48h.
However the grants of access default to 96 hours, and can be raised
further. Password resets were previously disabled for these accounts,
so you can end up with a valid grant and no way to access the instance.

That results in extra back and forth with customers to revoke the first
grant and generate a new one, etc.

With this change, it is now possible to request a password reset for the
magic success account, which will generate and email a new 48h token,
provided the underlying grant is still valid.

### How to verify

1. Create a support access grant in the UI
2. Use the REPL to make the password reset token - not the grant itself - expired
3. Try to use the link: get invalid token page
4. Do a password reset; it works and you get a valid email with a new token.
5. Use that new token, it works to set the password.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
