### PR TITLE
Revisions: Show deleted collections as `#123` rather than null

### DIFF
--- a/src/metabase/revisions/models/revision/diff.clj
+++ b/src/metabase/revisions/models/revision/diff.clj
@@ -58,15 +58,18 @@
 
     [:collection_id nil coll-id]
     (deferred-tru "moved {0} to {1}" identifier (if coll-id
-                                                  (t2/select-one-fn :name 'Collection coll-id)
+                                                  (or (t2/select-one-fn :name 'Collection coll-id)
+                                                      (str "#" coll-id))
                                                   (deferred-tru "Our analytics")))
 
     [:collection_id (prev-coll-id :guard int?) coll-id]
     (deferred-tru "moved {0} from {1} to {2}"
                   identifier
-                  (t2/select-one-fn :name 'Collection prev-coll-id)
+                  (or (t2/select-one-fn :name 'Collection prev-coll-id)
+                      (str "#" prev-coll-id))
                   (if coll-id
-                    (t2/select-one-fn :name 'Collection coll-id)
+                    (or (t2/select-one-fn :name 'Collection coll-id)
+                        (str "#" coll-id))
                     (deferred-tru "Our analytics")))
 
     [:visualization_settings _ _]

--- a/test/metabase/revisions/impl/card_test.clj
+++ b/test/metabase/revisions/impl/card_test.clj
@@ -36,6 +36,25 @@
      :description "New description"}
     "added a description and renamed it from \"Diff Test\" to \"Diff Test changed\"."))
 
+;; Regression test for https://github.com/metabase/metabase/issues/73681
+(deftest diff-cards-str-deleted-collection-test
+  (mt/initialize-if-needed! :db)
+  (testing "When a collection referenced in a revision has been deleted, the description should not show 'null'"
+    (let [deleted-coll-id 99999]
+      (are [x y expected] (= expected
+                             (u/build-sentence (revision/diff-strings :model/Card x y)))
+        ;; moved from nil (root) to a now-deleted collection
+        {:name "Apple"}
+        {:name          "Apple"
+         :collection_id deleted-coll-id}
+        (str "moved this Card to #" deleted-coll-id ".")
+
+        ;; moved from a now-deleted collection back to root: should show ID, not "null"
+        {:name          "Apple"
+         :collection_id deleted-coll-id}
+        {:name "Apple"}
+        (str "moved this Card from #" deleted-coll-id " to Our analytics.")))))
+
 (deftest ^:parallel diff-cards-str-update-collection--test
   (mt/with-temp
     [:model/Collection {coll-id-1 :id} {:name "Old collection"}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73681
Fixes UXW-4000.

### Description

When a revision history includes moving something to a now-deleted collection, the collection's name was rendered as `null`. This change renders its ID as `#1234` instead.

### How to verify

Have revision history enabled.

1. Move something into a collection
2. Move it out again
3. The moves in and out render with collection names in the revision history
4. Delete that collection (permanently)
5. The moves now render with the `#1234` IDs, but not `null`

### Demo

<img width="587" height="331" alt="Screenshot 2026-05-11 at 14 04 46" src="https://github.com/user-attachments/assets/f973b399-edd6-4ab3-b9e2-0f360a14ebe7" />
<img width="589" height="306" alt="Screenshot 2026-05-11 at 14 05 44" src="https://github.com/user-attachments/assets/5a0312e8-4cb7-44a1-88dd-d809b2d9733e" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
