### PR TITLE
do not show toggles on library collections in main app

### DIFF
--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.tsx
@@ -9,13 +9,11 @@ import type {
   OnMove,
   OnToggleSelectedWithItem,
 } from "metabase/collections/types";
-import {
-  isRootTrashCollection,
-  isTrashedCollection,
-} from "metabase/collections/utils";
+import { isTrashedCollection } from "metabase/collections/utils";
 import { BaseItemsTableBody } from "metabase/common/components/ItemsTable/BaseItemsTableBody/BaseItemsTableBody";
 import type { ItemRendererProps } from "metabase/common/components/ItemsTable/DefaultItemRenderer";
 import { DefaultItemRenderer } from "metabase/common/components/ItemsTable/DefaultItemRenderer";
+import { canSelectItems } from "metabase/common/components/ItemsTable/utils";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Bookmark,
@@ -156,9 +154,7 @@ export const BaseItemsTable = ({
   onClick,
   ...props
 }: BaseItemsTableProps) => {
-  const canSelect =
-    (collection?.can_write || isRootTrashCollection(collection)) &&
-    typeof onToggleSelected === "function";
+  const canSelect = canSelectItems(collection, onToggleSelected);
   const isTrashed = !!collection && isTrashedCollection(collection);
 
   return (

--- a/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/BaseItemsTable/BaseItemsTable.unit.spec.tsx
@@ -2,6 +2,8 @@ import userEvent from "@testing-library/user-event";
 import dayjs from "dayjs";
 import { Route } from "react-router";
 
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import { DEFAULT_VISIBLE_COLUMNS_LIST } from "metabase/collections/components/CollectionContent";
 import { getVisibleColumnsMap } from "metabase/common/components/ItemsTable/utils";
@@ -12,7 +14,10 @@ import {
   DEFAULT_TIME_STYLE,
 } from "metabase/utils/formatting/datetime-utils";
 import type { CollectionItem } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
 import type { BaseItemsTableProps } from "./BaseItemsTable";
 import { BaseItemsTable } from "./BaseItemsTable";
@@ -132,6 +137,31 @@ describe("BaseItemsTable", () => {
     });
 
     expect(screen.queryByLabelText("Select all items")).not.toBeInTheDocument();
+  });
+
+  describe("library collections", () => {
+    beforeEach(() => {
+      mockSettings({
+        "token-features": createMockTokenFeatures({ library: true }),
+      });
+      setupEnterpriseOnlyPlugin("library");
+    });
+
+    it("does not display select all checkbox for library collections", () => {
+      setup({
+        hasUnselected: true,
+        onSelectAll: jest.fn(),
+        onToggleSelected: jest.fn(),
+        collection: createMockCollection({
+          can_write: true,
+          type: "library",
+        }),
+      });
+
+      expect(
+        screen.queryByLabelText("Select all items"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("description", () => {

--- a/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
+++ b/frontend/src/metabase/common/components/ItemsTable/DefaultItemRenderer.tsx
@@ -2,9 +2,9 @@ import { useCallback } from "react";
 
 import type { ActionMenuProps } from "metabase/collections/components/ActionMenu";
 import type { OnToggleSelectedWithItem } from "metabase/collections/types";
-import { isRootTrashCollection } from "metabase/collections/utils";
 import type { BaseItemsTableProps } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import { Columns } from "metabase/common/components/ItemsTable/Columns";
+import { canSelectItems } from "metabase/common/components/ItemsTable/utils";
 import { useGetIcon } from "metabase/hooks/use-icon";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
@@ -39,9 +39,7 @@ export const DefaultItemRenderer = ({
   visibleColumnsMap,
 }: ItemRendererProps) => {
   const getIcon = useGetIcon();
-  const canSelect =
-    (collection?.can_write || isRootTrashCollection(collection)) &&
-    typeof onToggleSelected === "function";
+  const canSelect = canSelectItems(collection, onToggleSelected);
 
   const icon = getIcon(item);
   if (item.model === "card" || item.archived) {

--- a/frontend/src/metabase/common/components/ItemsTable/utils.ts
+++ b/frontend/src/metabase/common/components/ItemsTable/utils.ts
@@ -32,9 +32,12 @@ export const getVisibleColumnsMap = (
 export const canSelectItems = (
   collection: Collection | undefined,
   onToggleSelected: OnToggleSelectedWithItem | undefined,
-): boolean =>
-  Boolean(
-    (collection?.can_write || isRootTrashCollection(collection)) &&
-    !PLUGIN_LIBRARY.isLibraryCollectionType(collection?.type) &&
-    typeof onToggleSelected === "function",
-  );
+): boolean => {
+  if (typeof onToggleSelected !== "function") {
+    return false;
+  }
+  if (PLUGIN_LIBRARY.isLibraryCollectionType(collection?.type)) {
+    return false;
+  }
+  return Boolean(collection?.can_write) || isRootTrashCollection(collection);
+};

--- a/frontend/src/metabase/common/components/ItemsTable/utils.ts
+++ b/frontend/src/metabase/common/components/ItemsTable/utils.ts
@@ -2,7 +2,11 @@ import type {
   CollectionContentTableColumn,
   CollectionContentTableColumnsMap,
 } from "metabase/collections/components/CollectionContent";
+import type { OnToggleSelectedWithItem } from "metabase/collections/types";
+import { isRootTrashCollection } from "metabase/collections/utils";
+import { PLUGIN_LIBRARY } from "metabase/plugins";
 import { type BreakpointName, breakpoints } from "metabase/ui/theme";
+import type { Collection } from "metabase-types/api";
 
 export interface ResponsiveProps {
   /** The element will be hidden when the container's width is below this breakpoint */
@@ -24,3 +28,13 @@ export const getVisibleColumnsMap = (
     result[item] = true;
     return result;
   }, {} as CollectionContentTableColumnsMap);
+
+export const canSelectItems = (
+  collection: Collection | undefined,
+  onToggleSelected: OnToggleSelectedWithItem | undefined,
+): boolean =>
+  Boolean(
+    (collection?.can_write || isRootTrashCollection(collection)) &&
+    !PLUGIN_LIBRARY.isLibraryCollectionType(collection?.type) &&
+    typeof onToggleSelected === "function",
+  );


### PR DESCRIPTION
### Description
Refactors the Collection Content pages to not show the `select` cell and header when the collection is a library collection. Also removes a small amount of duplication so that canSelectItems is defined in one place instead of two

### How to verify
1. Ensure that there is some content in your library
2. From the main app, go to "data" or "metrics" in the side nav
3. Note that there are no checkboxes next to the contents

### Demo
<img width="1273" height="633" alt="image" src="https://github.com/user-attachments/assets/8801e3cf-a844-47c7-94dd-2e88ab3298bb" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
