### PR TITLE
Fix timeline event tooltips for stacked series

### DIFF
--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -441,6 +441,39 @@ describe("scenarios > organization > timelines > question", () => {
       H.echartsIcon("star", true).should("be.visible");
     });
 
+    it("should display the event tooltip when hovering on a stacked chart #74005", () => {
+      H.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [
+          { name: "RC1", timestamp: "2027-10-20T00:00:00Z", icon: "star" },
+        ],
+      });
+
+      H.visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"], ["sum", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+        visualization_settings: {
+          "graph.split_panels": true,
+        },
+      });
+
+      H.echartsIcon("star").should("be.visible");
+      H.echartsIcon("star").realHover();
+      cy.findByTestId("timeline-event-tooltip").within(() => {
+        cy.findByText("RC1").should("be.visible");
+      });
+    });
+
     it("should open the sidebar when clicking an event icon", () => {
       H.createTimelineWithEvents({
         timeline: { name: "Releases" },

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import _ from "underscore";
 
 import { Tooltip } from "metabase/common/components/Tooltip";
@@ -17,6 +17,45 @@ import TimelineEventTooltip from "./TimelineEventTooltip";
 export interface ChartTooltipProps {
   hovered?: HoveredObject | null;
   settings: VisualizationSettings;
+}
+
+/**
+ * Fixes a race condition where an ECharts rerender removes `element` before tippy can read its position
+ */
+function useStableTooltipTarget(element: Element | undefined | null) {
+  const proxyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      proxyRef.current?.remove();
+      proxyRef.current = null;
+    };
+  }, []);
+
+  if (!element) {
+    return null;
+  }
+
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    return proxyRef.current;
+  }
+
+  if (!proxyRef.current) {
+    proxyRef.current = document.createElement("div");
+    proxyRef.current.style.position = "fixed";
+    proxyRef.current.style.pointerEvents = "none";
+    proxyRef.current.setAttribute("data-testid", "chart-tooltip-proxy");
+    document.body.appendChild(proxyRef.current);
+  }
+
+  const proxy = proxyRef.current;
+  proxy.style.left = `${rect.left}px`;
+  proxy.style.top = `${rect.top}px`;
+  proxy.style.width = `${rect.width}px`;
+  proxy.style.height = `${rect.height}px`;
+
+  return proxy;
 }
 
 export const ChartTooltipContent = ({
@@ -62,13 +101,12 @@ const ChartTooltip = ({
   }, [hovered]);
 
   const hasTargetEvent = hovered?.event != null;
-  const hasTargetElement =
-    hovered?.element != null && document.body.contains(hovered.element);
-  const isOpen = isNotEmpty && (hasTargetElement || hasTargetEvent);
+  const proxyTarget = useStableTooltipTarget(hovered?.element);
+  const isOpen = isNotEmpty && (proxyTarget != null || hasTargetEvent);
   const isPadded = hovered?.stackedTooltipModel == null;
 
-  const target = hasTargetElement
-    ? hovered?.element
+  const target = proxyTarget
+    ? proxyTarget
     : hovered?.event != null
       ? getEventTarget(hovered.event)
       : null;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.tsx
@@ -14,7 +14,7 @@ const TimelineEventTooltip = (props: TimelineEventTooltipProps) => {
   const { timelineEvents } = hovered;
 
   return (
-    <ul className={S.timelineEventList}>
+    <ul className={S.timelineEventList} data-testid="timeline-event-tooltip">
       {timelineEvents.map((event) => (
         <li key={event.id}>
           <Flex>

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -88,8 +88,8 @@ export const getTimelineEventsSeries = (
 
     if (splitPanelYExtent) {
       const markLineData: MarkLine2DDataItemOption = [
-        { xAxis: date, y: splitPanelYExtent.topY, symbol: "none" },
         { ...itemProps, xAxis: date, y: splitPanelYExtent.bottomY },
+        { xAxis: date, y: splitPanelYExtent.topY, symbol: "none" },
       ];
       return markLineData;
     }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.unit.spec.ts
@@ -1,0 +1,57 @@
+import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
+import { DEFAULT_VISUALIZATION_THEME } from "metabase/visualizations/shared/utils/theme";
+import type { RenderingContext } from "metabase/visualizations/types";
+import { createMockTimelineEvent } from "metabase-types/api/mocks";
+
+import { getTimelineEventsSeries } from "./option";
+
+const mockRenderingContext: RenderingContext = {
+  getColor: (name) => name,
+  measureText: () => 0,
+  measureTextHeight: () => 0,
+  fontFamily: "",
+  theme: DEFAULT_VISUALIZATION_THEME,
+};
+
+describe("getTimelineEventsSeries", () => {
+  it("returns null when the model is empty", () => {
+    const result = getTimelineEventsSeries([], [], mockRenderingContext);
+    expect(result).toBeNull();
+  });
+
+  it("positions the label at the bottom of the split panel (bottomY first, topY second) #74005", () => {
+    const timelineEventsModel: TimelineEventsModel = [
+      {
+        date: "2027-10-01T00:00:00Z",
+        events: [
+          createMockTimelineEvent({ id: 1, name: "RC1" }),
+          createMockTimelineEvent({ id: 2, name: "RC2" }),
+        ],
+      },
+    ];
+
+    const result = getTimelineEventsSeries(
+      timelineEventsModel,
+      [],
+      mockRenderingContext,
+      { topY: 0, bottomY: 300 },
+    );
+
+    expect(result).not.toBeNull();
+    const markLineData = result!.markLine!.data as unknown[][];
+    expect(markLineData).toHaveLength(1);
+
+    const [startPoint, endPoint] = markLineData[0] as Array<{
+      y: number;
+      xAxis: string;
+      symbol: string;
+    }>;
+
+    expect(startPoint.y).toBe(300);
+    expect(startPoint.xAxis).toBe("2027-10-01T00:00:00Z");
+    expect(startPoint.symbol).not.toBe("none");
+    expect(endPoint.y).toBe(0);
+    expect(endPoint.xAxis).toBe("2027-10-01T00:00:00Z");
+    expect(endPoint.symbol).toBe("none");
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -861,10 +861,28 @@ export const getOtherSeriesTooltipModel = (
   };
 };
 
+const isMouseEventWithXAxis = (
+  event: EChartsSeriesMouseEvent,
+): event is EChartsSeriesMouseEvent<{ xAxis: string }> => {
+  return (
+    typeof event.data === "object" &&
+    event.data !== null &&
+    "xAxis" in event.data &&
+    typeof event.data.xAxis === "string" &&
+    event.data.xAxis.length > 0
+  );
+};
+
 export const getTimelineEventsForEvent = (
   timelineEventsModel: TimelineEventsModel,
   event: EChartsSeriesMouseEvent,
 ) => {
+  if (isMouseEventWithXAxis(event)) {
+    return timelineEventsModel.find(
+      (timelineEvents) => timelineEvents.date === event.data.xAxis,
+    )?.events;
+  }
+
   return timelineEventsModel.find(
     (timelineEvents) => timelineEvents.date === event.value,
   )?.events;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
@@ -8,12 +8,15 @@ import type {
   Datum,
   DimensionModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
+import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
 import {
   createMockColumn,
   createMockDatetimeColumn,
+  createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 
-import { getEventDimensions } from "./events";
+import { getEventDimensions, getTimelineEventsForEvent } from "./events";
 
 const CARD_ID = 107;
 
@@ -205,5 +208,49 @@ describe("getEventDimensions", () => {
       { column: createdAtColumn, value: "2027-10-01T00:00:00" },
       { column: sourceColumn, value: "Affiliate" },
     ]);
+  });
+});
+
+describe("getTimelineEventsForEvent", () => {
+  const timelineEventsModel: TimelineEventsModel = [
+    {
+      date: "2027-10-01T00:00:00Z",
+      events: [createMockTimelineEvent({ id: 1, name: "RC1" })],
+    },
+    {
+      date: "2027-11-01T00:00:00Z",
+      events: [createMockTimelineEvent({ id: 2, name: "RC2" })],
+    },
+  ];
+
+  it("finds events by event.value", () => {
+    const event = {
+      value: "2027-10-01T00:00:00Z",
+      data: null,
+    } as unknown as EChartsSeriesMouseEvent;
+
+    const result = getTimelineEventsForEvent(timelineEventsModel, event);
+    expect(result).toEqual(timelineEventsModel[0].events);
+  });
+
+  it("finds events by event.data.xAxis when value is not populated (stacked series) #74005", () => {
+    const event = {
+      value: undefined,
+      data: { xAxis: "2027-10-01T00:00:00Z" },
+    } as unknown as EChartsSeriesMouseEvent;
+
+    const result = getTimelineEventsForEvent(timelineEventsModel, event);
+    expect(result).toEqual(timelineEventsModel[0].events);
+  });
+
+  it("returns undefined when no matching date exists", () => {
+    const event = {
+      value: "9999-01-01T00:00:00Z",
+      data: null,
+    } as unknown as EChartsSeriesMouseEvent;
+
+    expect(
+      getTimelineEventsForEvent(timelineEventsModel, event),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #74005

### Description

Fixes three bugs:

- Timeline event tooltips didn't work for stacked series (#74005)
  - For stacked series, the ECharts doesn't populate `event.value`. The fix is to also check `event.data.xAxis`
- For stacked series, when multiple timeline events occurred in a single time period, the label with the count of events was unreadable at the top of the chart (see demo video)
  - Fixed by reversing the order of the items in `markLineData`
- Chart tooltips could flash at the top left of the screen, causing e2e test flakes and possibly a bad UX (see demo video)
  - Fixed by `useStableTooltipTarget`. The issue is hovering over the event causes ECharts to rerender and remove the event icon, which could happen prior to tippy reading its position (which apparently happens asynchronously). The fix is to introduce a new stable element for tippy to use instead.

### How to verify

Follow the steps in #74005, and watch the demo video.

### Demo

[Demo](https://www.loom.com/share/f797255537ab4b8cb739816965138aaa)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR