### PR TITLE
add background-secondary to setup settingspage

### DIFF
--- a/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.styled.tsx
@@ -14,8 +14,7 @@ export const StepRoot = styled.section<Props>`
   border-radius: 0.5rem;
   padding: 1rem 2rem;
   margin-bottom: 1.75rem;
-  background-color: ${(props) =>
-    color(props.isCompleted ? "background-primary" : "background-secondary")};
+  background-color: ${color("background-primary")};
 `;
 
 export const StepTitle = styled.div<Props>`

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.module.css
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.module.css
@@ -3,6 +3,10 @@
   min-height: 100vh;
 }
 
+:global(main):has(> .Page) {
+  background-color: var(--mb-color-background-secondary);
+}
+
 .PageHeader {
   margin-bottom: 4rem;
   padding: 1rem;

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.module.css
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.module.css
@@ -1,7 +1,13 @@
+.Page {
+  background-color: var(--mb-color-background-secondary);
+  min-height: 100vh;
+}
+
 .PageHeader {
   margin-bottom: 4rem;
   padding: 1rem;
   border-bottom: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
 }
 
 .Decoy {

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -44,7 +44,7 @@ export const SettingsPage = (): JSX.Element => {
   );
 
   return (
-    <div data-testid="setup-forms">
+    <div data-testid="setup-forms" className={S.Page}>
       <Box component="header" className={S.PageHeader}>
         <Flex align="center" justify="space-between">
           <Box w={SELECT_WIDTH} className={S.Decoy} />


### PR DESCRIPTION
### Description

The background color on this page which used to be there mysteriously disappeared.

### How to verify

Setup a new MB instance and make sure the page has a background-secondary background color.



### Demo

<img width="1505" height="1296" alt="image" src="https://github.com/user-attachments/assets/20af63d4-d02d-444d-80d3-f2f740028243" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


