### PR TITLE
Optimize field metadata list renders

### DIFF
--- a/frontend/src/metabase/metadata/components/FieldList/FieldItem/FieldItem.tsx
+++ b/frontend/src/metabase/metadata/components/FieldList/FieldItem/FieldItem.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import type { MouseEvent } from "react";
+import { memo, useMemo } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
@@ -17,12 +18,12 @@ type FieldItemProps = {
   active?: boolean;
   parent?: Field;
   readOnly?: boolean;
-  onSelect?: () => void;
-  onNameChange: (newName: string) => void;
-  onDescriptionChange: (newDescription: string | null) => void;
+  onSelect?: (field: Field) => void;
+  onNameChange: (field: Field, newName: string) => void;
+  onDescriptionChange: (field: Field, newDescription: string | null) => void;
 };
 
-export function FieldItem({
+const FieldItemBase = ({
   active,
   field,
   href,
@@ -31,13 +32,15 @@ export function FieldItem({
   onSelect,
   onNameChange,
   onDescriptionChange,
-}: FieldItemProps) {
-  const icon = getColumnIcon(Lib.legacyColumnTypeInfo(field));
+}: FieldItemProps) => {
+  const icon = useMemo(() => {
+    return getColumnIcon(Lib.legacyColumnTypeInfo(field));
+  }, [field]);
 
   const handleNameChange = async (newValue: string) => {
     const newName = newValue.trim();
     if (field.display_name !== newName) {
-      onNameChange(newName);
+      onNameChange(field, newName);
     }
   };
 
@@ -46,7 +49,7 @@ export function FieldItem({
     const newDescription = trimmedValue.length === 0 ? null : trimmedValue;
 
     if (field.description !== newDescription) {
-      onDescriptionChange(newDescription);
+      onDescriptionChange(field, newDescription);
     }
   };
 
@@ -69,7 +72,7 @@ export function FieldItem({
     ) {
       event.preventDefault();
     } else {
-      onSelect?.();
+      onSelect?.(field);
     }
   };
 
@@ -171,4 +174,41 @@ export function FieldItem({
       </Flex>
     </Card>
   );
+};
+
+export function areFieldItemPropsEqual(
+  prevProps: FieldItemProps,
+  nextProps: FieldItemProps,
+) {
+  return (
+    prevProps.active === nextProps.active &&
+    prevProps.href === nextProps.href &&
+    prevProps.readOnly === nextProps.readOnly &&
+    prevProps.onSelect === nextProps.onSelect &&
+    prevProps.onNameChange === nextProps.onNameChange &&
+    prevProps.onDescriptionChange === nextProps.onDescriptionChange &&
+    areFieldsEqual(prevProps.field, nextProps.field) &&
+    areParentFieldsEqual(prevProps.parent, nextProps.parent)
+  );
 }
+
+function areFieldsEqual(prevField: Field, nextField: Field) {
+  return (
+    prevField.id === nextField.id &&
+    prevField.display_name === nextField.display_name &&
+    prevField.description === nextField.description &&
+    prevField.base_type === nextField.base_type &&
+    prevField.effective_type === nextField.effective_type &&
+    prevField.semantic_type === nextField.semantic_type &&
+    prevField.fk_target_field_id === nextField.fk_target_field_id
+  );
+}
+
+function areParentFieldsEqual(prevField?: Field, nextField?: Field) {
+  return (
+    prevField?.id === nextField?.id &&
+    prevField?.display_name === nextField?.display_name
+  );
+}
+
+export const FieldItem = memo(FieldItemBase, areFieldItemPropsEqual);

--- a/frontend/src/metabase/metadata/components/FieldList/FieldList.tsx
+++ b/frontend/src/metabase/metadata/components/FieldList/FieldList.tsx
@@ -46,11 +46,9 @@ export function FieldList<T extends number | string>({
             parent={parent}
             href={getFieldHref?.(field) ?? ""}
             readOnly={readOnly}
-            onSelect={() => onSelect?.(field)}
-            onNameChange={(newName) => onNameChange(field, newName)}
-            onDescriptionChange={(newDescription) =>
-              onDescriptionChange(field, newDescription)
-            }
+            onSelect={onSelect}
+            onNameChange={onNameChange}
+            onDescriptionChange={onDescriptionChange}
           />
         );
       })}

--- a/frontend/src/metabase/metadata/components/FieldList/FieldList.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldList/FieldList.unit.spec.tsx
@@ -1,0 +1,62 @@
+import { createMockField } from "metabase-types/api/mocks";
+
+import { areFieldItemPropsEqual } from "./FieldItem/FieldItem";
+
+describe("FieldList", () => {
+  const onNameChange = jest.fn();
+  const onDescriptionChange = jest.fn();
+
+  it("keeps field items memoized when rendered field data did not change", () => {
+    const field = createMockField({
+      id: 1,
+      name: "field_1",
+      display_name: "Field 1",
+      position: 1,
+    });
+    const nextField = { ...field };
+
+    expect(
+      areFieldItemPropsEqual(
+        {
+          field,
+          href: "/field/1",
+          onNameChange,
+          onDescriptionChange,
+        },
+        {
+          field: nextField,
+          href: "/field/1",
+          onNameChange,
+          onDescriptionChange,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("rerenders field items when rendered field data changes", () => {
+    const field = createMockField({
+      id: 1,
+      name: "field_1",
+      display_name: "Field 1",
+      position: 1,
+    });
+    const nextField = { ...field, semantic_type: "type/Category" };
+
+    expect(
+      areFieldItemPropsEqual(
+        {
+          field,
+          href: "/field/1",
+          onNameChange,
+          onDescriptionChange,
+        },
+        {
+          field: nextField,
+          href: "/field/1",
+          onNameChange,
+          onDescriptionChange,
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/metabase/metadata/components/FieldList/FieldList.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldList/FieldList.unit.spec.tsx
@@ -1,8 +1,8 @@
 import { createMockField } from "metabase-types/api/mocks";
 
-import { areFieldItemPropsEqual } from "./FieldItem/FieldItem";
+import { areFieldItemPropsEqual } from "./FieldItem";
 
-describe("FieldList", () => {
+describe("areFieldItemPropsEqual", () => {
   const onNameChange = jest.fn();
   const onDescriptionChange = jest.fn();
 

--- a/frontend/src/metabase/metadata/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/components/PreviewSection/PreviewSection.tsx
@@ -104,12 +104,7 @@ const PreviewSectionBase = ({
             databaseId={databaseId}
             field={field}
             fieldId={fieldId}
-            /**
-             * Make sure internal component state is reset when changing any field settings.
-             * This is because use***Filter hooks cache some parts of state internally on mount
-             * and do not account for all prop changes during their lifecycle.
-             */
-            key={JSON.stringify(field)}
+            key={getFilteringPreviewKey(field)}
             table={table}
           />
         )}
@@ -117,5 +112,16 @@ const PreviewSectionBase = ({
     </Card>
   );
 };
+
+function getFilteringPreviewKey(field: Field) {
+  return [
+    field.id,
+    field.base_type,
+    field.effective_type,
+    field.semantic_type,
+    field.fk_target_field_id,
+    field.visibility_type,
+  ].join(":");
+}
 
 export const PreviewSection = memo(PreviewSectionBase);

--- a/frontend/src/metabase/metadata/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/components/PreviewSection/PreviewSection.tsx
@@ -121,6 +121,7 @@ function getFilteringPreviewKey(field: Field) {
     field.semantic_type,
     field.fk_target_field_id,
     field.visibility_type,
+    field.has_field_values,
   ].join(":");
 }
 

--- a/frontend/src/metabase/metadata/components/TableFieldList/TableFieldList.tsx
+++ b/frontend/src/metabase/metadata/components/TableFieldList/TableFieldList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -27,52 +27,62 @@ export const TableFieldList = ({
     return _.sortBy(table.fields ?? [], (item) => item.position);
   }, [table.fields]);
 
-  const handleNameChange = async (field: Field, name: string) => {
-    const id = getRawTableFieldId(field);
-    const { error } = await updateField({ id, display_name: name });
+  const handleGetFieldHref = useCallback(
+    (field: Field) => getFieldHref(getRawTableFieldId(field)),
+    [getFieldHref],
+  );
 
-    if (error) {
-      sendErrorToast(t`Failed to update name of ${field.display_name}`);
-    } else {
-      sendSuccessToast(t`Name of ${field.display_name} updated`, async () => {
-        const { error } = await updateField({
-          id,
-          display_name: field.display_name,
-        });
-        sendUndoToast(error);
-      });
-    }
-  };
+  const handleNameChange = useCallback(
+    async (field: Field, name: string) => {
+      const id = getRawTableFieldId(field);
+      const { error } = await updateField({ id, display_name: name });
 
-  const handleDescriptionChange = async (
-    field: Field,
-    description: string | null,
-  ) => {
-    const id = getRawTableFieldId(field);
-    const { error } = await updateField({ id, description });
-
-    if (error) {
-      sendErrorToast(t`Failed to update description of ${field.display_name}`);
-    } else {
-      sendSuccessToast(
-        t`Description of ${field.display_name} updated`,
-        async () => {
+      if (error) {
+        sendErrorToast(t`Failed to update name of ${field.display_name}`);
+      } else {
+        sendSuccessToast(t`Name of ${field.display_name} updated`, async () => {
           const { error } = await updateField({
             id,
-            description: field.description ?? "",
+            display_name: field.display_name,
           });
           sendUndoToast(error);
-        },
-      );
-    }
-  };
+        });
+      }
+    },
+    [sendErrorToast, sendSuccessToast, sendUndoToast, updateField],
+  );
+
+  const handleDescriptionChange = useCallback(
+    async (field: Field, description: string | null) => {
+      const id = getRawTableFieldId(field);
+      const { error } = await updateField({ id, description });
+
+      if (error) {
+        sendErrorToast(
+          t`Failed to update description of ${field.display_name}`,
+        );
+      } else {
+        sendSuccessToast(
+          t`Description of ${field.display_name} updated`,
+          async () => {
+            const { error } = await updateField({
+              id,
+              description: field.description ?? "",
+            });
+            sendUndoToast(error);
+          },
+        );
+      }
+    },
+    [sendErrorToast, sendSuccessToast, sendUndoToast, updateField],
+  );
 
   return (
     <FieldList
       fields={fields}
       activeFieldKey={activeFieldId}
       getFieldKey={getRawTableFieldId}
-      getFieldHref={(field) => getFieldHref(getRawTableFieldId(field))}
+      getFieldHref={handleGetFieldHref}
       onNameChange={handleNameChange}
       onDescriptionChange={handleDescriptionChange}
     />


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72916
Closes https://linear.app/metabase/issue/UXW-3789/editing-field-visibility-settings-can-freeze-the-page

### Description

Changing table fields metabase could make the page become unresponsive when the table has a lot of fields.
The fix consists in applying some memoization at the component level so that we don't have so many components rerendering when a metadata input is changed.

### How to verify

To simulate the scenario where this bug was observed, you'll need to have a table with hundreds of fields.
To have a bunch of new synthetic fields on a database table, you can ask your favorite coding AI to create them for you (e.g. "Hey Claude, can you please add 1000 synthetic fields the Accounts table in Sample Database? My warehouse db is xyz.").

- Admin > Table Metadata
- Open the target table and select a field.
- Try to edit the field's semantic type.
- Observe that the page and section do not become unresponsive.

_Note: On that section, when we select an input option, the value is only updated in the UI when the request finishes. This is not the problem described in this issue. Having the field being set to the new value right away would be better UX, especially for slow networks, but implementing that would be an overhead I preferred not to bring up to this PR._

### Demo
https://www.loom.com/share/4245af3b2c714c7f99b8c347c4ae8e41

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
