### PR TITLE
Fix row chart data label formatting for split series

### DIFF
--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
@@ -48,7 +48,10 @@ export interface RowChartProps<TDatum> {
   hasYAxis?: boolean;
 
   tickFormatters?: ChartTicksFormatters;
-  labelsFormatter?: (value: NumberValue) => string;
+  labelsFormatter?: (
+    value: NumberValue,
+    bar?: BarData<TDatum, SeriesInfo>,
+  ) => string;
   measureTextWidth: TextWidthMeasurer;
 
   xScaleType?: ContinuousScaleType;

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
@@ -231,6 +231,22 @@ describe("RowChart", () => {
         "_300_",
       ]);
     });
+
+    it("should pass the current bar to the data label formatter", () => {
+      const { dataLabels } = setup({
+        labelledSeries: ["series 1", "series 2"],
+        labelsFormatter: (value, bar) => `${bar?.series.seriesKey}_${value}`,
+      });
+
+      expect(dataLabels.map((el) => el.textContent)).toStrictEqual([
+        "series 1_100",
+        "series 1_200",
+        "series 1_300",
+        "series 2_200",
+        "series 2_400",
+        "series 2_600",
+      ]);
+    });
   });
 
   describe("goal line", () => {

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
@@ -27,7 +27,10 @@ export interface RowChartViewProps<TDatum> {
   yScale: ScaleBand<StringLike>;
   xScale: ScaleContinuousNumeric<number, number, never>;
   seriesData: SeriesData<TDatum, SeriesInfo>[];
-  labelsFormatter: (value: NumberLike) => string;
+  labelsFormatter: (
+    value: NumberLike,
+    bar?: BarData<TDatum, SeriesInfo>,
+  ) => string;
   yTickFormatter: (value: StringLike) => string;
   xTickFormatter: (value: NumberLike) => string;
   xTicks: number[];
@@ -206,7 +209,7 @@ const RowChartView = <TDatum,>({
                     y={y + height / 2}
                     verticalAnchor="middle"
                   >
-                    {labelsFormatter(label)}
+                    {labelsFormatter(label, bar)}
                   </Text>
                 )}
               </React.Fragment>

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.ts
@@ -6,10 +6,12 @@ import { getFormattingOptionsWithoutScaling } from "metabase/visualizations/echa
 import { formatValue } from "metabase/visualizations/lib/formatting";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
+import type { BarData } from "metabase/visualizations/shared/components/RowChart/types";
 import type {
-  ChartTicksFormatters,
-  ValueFormatter,
-} from "metabase/visualizations/shared/types/format";
+  GroupedDatum,
+  SeriesInfo,
+} from "metabase/visualizations/shared/types/data";
+import type { ChartTicksFormatters } from "metabase/visualizations/shared/types/format";
 import { getLabelsMetricColumn } from "metabase/visualizations/shared/utils/series";
 import type {
   DatasetColumn,
@@ -67,15 +69,22 @@ export const getFormatters = (
 export const getLabelsFormatter = (
   chartColumns: CartesianChartColumns,
   settings: VisualizationSettings,
-): ValueFormatter => {
-  const column = getLabelsMetricColumn(chartColumns).column;
-  const options = getFormattingOptionsWithoutScaling({
-    ...settings.column(column),
-    jsx: false,
-    compact: settings["graph.label_value_formatting"] === "compact",
-  });
+): ((value: any, bar?: BarData<GroupedDatum, SeriesInfo>) => string) => {
+  const fallbackColumn = getLabelsMetricColumn(chartColumns).column;
 
-  const labelsFormatter = (value: any) => String(formatValue(value, options));
+  const labelsFormatter = (
+    value: any,
+    bar?: BarData<GroupedDatum, SeriesInfo>,
+  ) => {
+    const column = bar?.series.seriesInfo?.metricColumn ?? fallbackColumn;
+    const options = getFormattingOptionsWithoutScaling({
+      ...settings.column(column),
+      jsx: false,
+      compact: settings["graph.label_value_formatting"] === "compact",
+    });
+
+    return String(formatValue(value, options));
+  };
 
   return labelsFormatter;
 };

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.unit.spec.ts
@@ -1,0 +1,84 @@
+import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import type { BarData } from "metabase/visualizations/shared/components/RowChart/types";
+import type {
+  GroupedDatum,
+  SeriesInfo,
+} from "metabase/visualizations/shared/types/data";
+import type { DatasetColumn, VisualizationSettings } from "metabase-types/api";
+import { createMockColumn } from "metabase-types/api/mocks";
+
+import { getLabelsFormatter } from "./format";
+
+const itemColumn = createMockColumn({
+  name: "ITEM",
+  display_name: "Item",
+  base_type: "type/Text",
+});
+
+const quantityColumn = createMockColumn({
+  name: "TOTAL_QUANTITY",
+  display_name: "Total Quantity",
+  base_type: "type/Integer",
+  effective_type: "type/Integer",
+  semantic_type: "type/Quantity",
+});
+
+const paidColumn = createMockColumn({
+  name: "TOTAL_PAID",
+  display_name: "Total Paid",
+  base_type: "type/Decimal",
+  effective_type: "type/Decimal",
+});
+
+const chartColumns: CartesianChartColumns = {
+  dimension: { column: itemColumn, index: 0 },
+  metrics: [
+    { column: paidColumn, index: 2 },
+    { column: quantityColumn, index: 1 },
+  ],
+};
+
+const settings = {
+  "graph.label_value_formatting": "full",
+  column: (column: DatasetColumn) => {
+    if (column.name === "TOTAL_PAID") {
+      return {
+        column,
+        currency: "USD",
+        currency_style: "symbol",
+        number_style: "currency",
+      };
+    }
+
+    return {
+      column,
+      number_style: "decimal",
+    };
+  },
+} as VisualizationSettings;
+
+const getBar = (metricColumn: DatasetColumn) =>
+  ({
+    series: {
+      seriesInfo: {
+        metricColumn,
+      },
+    },
+  }) as BarData<GroupedDatum, SeriesInfo>;
+
+describe("RowChart format", () => {
+  describe("getLabelsFormatter", () => {
+    it("formats data labels using the current series metric column", () => {
+      const formatter = getLabelsFormatter(chartColumns, settings);
+
+      expect(formatter(769.76, getBar(paidColumn))).toBe("$769.76");
+      expect(formatter(409, getBar(quantityColumn))).toBe("409");
+    });
+
+    it("falls back to the first metric when no bar is provided", () => {
+      const formatter = getLabelsFormatter(chartColumns, settings);
+
+      expect(formatter(409)).toBe("$409.00");
+    });
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70230
Closes https://linear.app/metabase/issue/UXW-3189/row-chart-with-split-series-shows-wrong-formatting

### Description

Wrong number formatting could be displayed on row charts.

### How to verify

- Start Metabase on master.
- Create a native SQL question:
```sql
SELECT 'Item C' AS item, 409 AS total_quantity, 769.76 AS total_paid
UNION ALL SELECT 'Item B', 309, 518.27
UNION ALL SELECT 'Item A', 188, 80.4
```
- Visualize as Row.
- Use item as the Y-axis.
- Add both X-axis series: total_paid and total_quantity.
- Enable data labels.
- Format total_paid as currency and total_quantity as a plain number.
'Put total_paid first.
- On master, quantity labels incorrectly render as currency, e.g. $409.00.

### Demo

Before:
<img width="1916" height="868" alt="Screenshot from 2026-05-11 18-42-40" src="https://github.com/user-attachments/assets/d8797988-51e9-4a5d-a0c4-9171ee793549" />

After:
<img width="1916" height="868" alt="Screenshot from 2026-05-11 18-44-39" src="https://github.com/user-attachments/assets/8022799b-366b-4a90-808d-4654aa38f82c" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
