### PR TITLE
Mongo x509 authentication and error reporting

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -322,7 +322,7 @@ describe("admin > database > add", () => {
           cy.button("Save", { timeout: 7000 })
             .should("not.be.disabled")
             .click();
-          cy.findByText(/Exception authenticating MongoCredential/);
+          cy.findByText(/Authentication failed/);
           cy.button("Failed");
 
           cy.findByLabelText("Paste your connection string")

--- a/mage/src/mage/start_db.clj
+++ b/mage/src/mage/start_db.clj
@@ -93,6 +93,8 @@
   [_db container-name resolved-version port]
   ["docker" "run"
    "-d"
+   "-e" "MONGO_INITDB_ROOT_USERNAME=metabase"
+   "-e" "MONGO_INITDB_ROOT_PASSWORD=metasample123"
    "-p" (str port ":27017")
    "--name" container-name
    (str "mongo:" resolved-version)])

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -25,6 +25,7 @@
    [metabase.util.performance :refer [some mapv empty? get-in]]
    [taoensso.nippy :as nippy])
   (:import
+   (com.mongodb MongoCommandException MongoSecurityException)
    (com.mongodb.client MongoClient MongoDatabase)
    (org.bson.types Binary ObjectId)))
 
@@ -49,7 +50,8 @@
 
 (defmethod driver/can-connect? :mongo
   [_ db-details]
-  (mongo.connection/with-mongo-client [^MongoClient c db-details]
+  (try
+    (mongo.connection/with-mongo-client [^MongoClient c db-details]
     (let [db-names (mongo.util/list-database-names c)
           db-name (mongo.db/db-name db-details)
           db (mongo.util/database c db-name)
@@ -60,7 +62,13 @@
           1.0)
        ;; 2. check the database is actually on the server
        ;; (this is required because (1) is true even if the database doesn't exist)
-       (boolean (some #(= % db-name) db-names))))))
+       (boolean (some #(= % db-name) db-names)))))
+    (catch MongoSecurityException e
+      (let [cause (.getCause e)]
+        ;; the outer wrapper exception has a useless "Exception authenticating" message
+        (if (instance? MongoCommandException cause)
+          (throw cause)
+          (throw e))))))
 
 (defmethod driver/humanize-connection-error-message
   :mongo

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -52,17 +52,17 @@
   [_ db-details]
   (try
     (mongo.connection/with-mongo-client [^MongoClient c db-details]
-    (let [db-names (mongo.util/list-database-names c)
-          db-name (mongo.db/db-name db-details)
-          db (mongo.util/database c db-name)
-          db-stats (mongo.util/run-command db {:dbStats 1} :keywordize true)]
-      (and
-       ;; 1. check db.dbStats command completes successfully
-       (= (float (:ok db-stats))
-          1.0)
-       ;; 2. check the database is actually on the server
-       ;; (this is required because (1) is true even if the database doesn't exist)
-       (boolean (some #(= % db-name) db-names)))))
+      (let [db-names (mongo.util/list-database-names c)
+            db-name (mongo.db/db-name db-details)
+            db (mongo.util/database c db-name)
+            db-stats (mongo.util/run-command db {:dbStats 1} :keywordize true)]
+        (and
+         ;; 1. check db.dbStats command completes successfully
+         (= (float (:ok db-stats))
+            1.0)
+         ;; 2. check the database is actually on the server
+         ;; (this is required because (1) is true even if the database doesn't exist)
+         (boolean (some #(= % db-name) db-names)))))
     (catch MongoSecurityException e
       (let [cause (.getCause e)]
         ;; the outer wrapper exception has a useless "Exception authenticating" message

--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -84,7 +84,7 @@
       (when (seq user)
         (.credential builder
                      (if (some-> additional-options
-                                 str/lower-case
+                                 u/lower-case-en
                                  (str/index-of "authmechanism=mongodb-x509"))
                        (MongoCredential/createMongoX509Credential user)
                        (MongoCredential/createCredential user

--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -70,7 +70,7 @@
    `MongoClientSettings$Builder` first. Then credentials are set and ssl context is updated in the `builder` object.
    Afterwards, `MongoClientSettings` are built using `.build`."
   ^MongoClientSettings
-  [{:keys [authdb user pass use-conn-uri ssl] :as db-details}]
+  [{:keys [authdb user pass use-conn-uri ssl additional-options] :as db-details}]
   (let [connection-string (-> db-details
                               db-details->connection-string
                               ConnectionString.)
@@ -83,9 +83,13 @@
       ;;       manually verified that's not necessary.
       (when (seq user)
         (.credential builder
-                     (MongoCredential/createCredential user
-                                                       (or (not-empty authdb) "admin")
-                                                       (char-array pass))))
+                     (if (some-> additional-options
+                                 str/lower-case
+                                 (str/index-of "authmechanism=mongodb-x509"))
+                       (MongoCredential/createMongoX509Credential user)
+                       (MongoCredential/createCredential user
+                                                         (or (not-empty authdb) "admin")
+                                                         (char-array pass)))))
       (when ssl
         (maybe-add-ssl-context-to-builder! builder db-details)))
     (.build builder)))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/connection_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/connection_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.connection-test
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.config.core :as config]
@@ -50,7 +51,20 @@
                             (-> db-details
                                 (assoc :host "localhost")
                                 mongo.db/details-normalized
-                                mongo.connection/db-details->connection-string))))))
+                                mongo.connection/db-details->connection-string))))
+    (testing "uses x509 credentials"
+      (let [db-details (assoc db-details
+                              :additional-options "authMechanism=MONGODB-X509"
+                              :use-conn-uri false
+                              :ssl true
+                              :ssl-use-client-auth true
+                              :client-ssl-key (-> "ssl/mongo/metabase.key" io/resource slurp)
+                              :client-ssl-cert (-> "ssl/mongo/metabase.crt" io/resource slurp)
+                              :ssl-cert (-> "ssl/mongo/metaca.crt" io/resource slurp))
+            settings (mongo.connection/db-details->mongo-client-settings db-details)
+            ^MongoCredential credential (.getCredential settings)]
+        (is (= "test-user" (.getUserName credential)))
+        (is (= "MONGODB-X509" (.getMechanism credential)))))))
 
 (deftest ^:parallel srv-connection-properties-test
   (testing "connection properties when using SRV"

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -42,7 +42,7 @@
    :venues])
 
 ;; in test_resources/ssl/mongo/ dir: openssl x509 -in metabase.crt -text -noout
-(def ^:private cert-subject "C=US, ST=CA, L=San Francisco, O=Metabase Inc., OU=metabase, CN=localhost, emailAddress=metabase@localhost")
+(def ^:private cert-subject "emailAddress=metabase@localhost,CN=localhost,OU=metabase,O=Metabase Inc.,L=San Francisco,ST=CA,C=US")
 
 ;; ## Tests for connection functions
 (deftest can-connect-test?
@@ -53,7 +53,9 @@
           ;; allow connecting with the client cert
           ;; https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user
           (mongo.util/run-command (mongo.util/database c "$external")
-                                  {:createUser cert-subject :roles []}))
+                                  {:createUser cert-subject
+                                   :roles [{:role "readWrite" :db "test-data"}]}))
+        ;; re-running createUser will cause failure on subsequent runs b/c user already exists
         (catch com.mongodb.MongoCommandException _))
       (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
                                                               :port   3000
@@ -75,7 +77,7 @@
                                                    :message  "should use default port 27017 if not specified"}
                                                   {:details  {:host   "localhost"
                                                               :user   cert-subject
-                                                              :dbname "$external"
+                                                              :dbname "test-data"
                                                               :additional-options "authMechanism=MONGODB-X509"}
                                                    :expected true
                                                    :message  "should use X509 authentication"}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -41,22 +41,10 @@
    :users
    :venues])
 
-;; in test_resources/ssl/mongo/ dir: openssl x509 -in metabase.crt -text -noout
-(def ^:private cert-subject "emailAddress=metabase@localhost,CN=localhost,OU=metabase,O=Metabase Inc.,L=San Francisco,ST=CA,C=US")
-
 ;; ## Tests for connection functions
 (deftest can-connect-test?
   (mt/test-driver :mongo
     (mt/dataset test-data (mt/db)
-      (try
-        (mongo.connection/with-mongo-client [c (mt/db)]
-          ;; allow connecting with the client cert
-          ;; https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user
-          (mongo.util/run-command (mongo.util/database c "$external")
-                                  {:createUser cert-subject
-                                   :roles [{:role "readWrite" :db "test-data"}]}))
-        ;; re-running createUser will cause failure on subsequent runs b/c user already exists
-        (catch com.mongodb.MongoCommandException _))
       (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
                                                               :port   3000
                                                               :dbname "bad-db-name"}
@@ -75,12 +63,6 @@
                                                               :dbname "test-data"}
                                                    :expected true
                                                    :message  "should use default port 27017 if not specified"}
-                                                  {:details  {:host   "localhost"
-                                                              :user   cert-subject
-                                                              :dbname "test-data"
-                                                              :additional-options "authMechanism=MONGODB-X509"}
-                                                   :expected true
-                                                   :message  "should use X509 authentication"}
                                                   {:details  {:host   "123.4.5.6"
                                                               :dbname "bad-db-name?connectTimeoutMS=50"}
                                                    :expected false}
@@ -99,6 +81,33 @@
           (is (= expected
                  (driver.u/can-connect-with-details? :mongo ssl-details))
               (str message)))))))
+
+;; openssl x509 -in test_resources/ssl/mongo/metabase.crt -inform PEM -subject -nameopt RFC2253
+(def cert-subject
+  "emailAddress=metabase@localhost,CN=localhost,OU=metabase,O=Metabase Inc.,L=San Francisco,ST=CA,C=US")
+
+(deftest can-connect?-with-x509
+  (if (tdm/ssl-required?)
+    (mt/test-driver :mongo
+      (mt/dataset test-data (mt/db)
+        (mongo.connection/with-mongo-client [c (mt/db)]
+          (try
+            ;; allow connecting with the client cert
+            ;; https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user
+            (mongo.util/run-command (mongo.util/database c "$external")
+                                    {:createUser cert-subject
+                                     :roles [{:role "readWrite" :db "test-data"}]})
+            (let [details {:host "localhost"
+                           :user cert-subject
+                           :dbname "test-data"
+                           :additional-options "authMechanism=MONGODB-X509"}
+                  ssl-details (tdm/conn-details details)]
+              (is (driver.u/can-connect-with-details? :mongo ssl-details)
+                  "should allow connecting with MONGODB-X509"))
+            (finally
+              (mongo.util/run-command (mongo.util/database c "$external")
+                                      {:dropUser cert-subject}))))))
+    (is true "Don't try X509 if mongo isn't configured with the necessary certs")))
 
 (deftest database-supports?-test
   (mt/test-driver :mongo

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -41,12 +41,20 @@
    :users
    :venues])
 
+;; in test_resources/ssl/mongo/ dir: openssl x509 -in metabase.crt -text -noout
+(def ^:private cert-subject "C=US, ST=CA, L=San Francisco, O=Metabase Inc., OU=metabase, CN=localhost, emailAddress=metabase@localhost")
+
 ;; ## Tests for connection functions
 (deftest can-connect-test?
-  (mt/test-driver
-    :mongo
-    (mt/dataset test-data
-      (mt/db)
+  (mt/test-driver :mongo
+    (mt/dataset test-data (mt/db)
+      (try
+        (mongo.connection/with-mongo-client [c (mt/db)]
+          ;; allow connecting with the client cert
+          ;; https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user
+          (mongo.util/run-command (mongo.util/database c "$external")
+                                  {:createUser cert-subject :roles []}))
+        (catch com.mongodb.MongoCommandException _))
       (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
                                                               :port   3000
                                                               :dbname "bad-db-name"}
@@ -66,9 +74,8 @@
                                                    :expected true
                                                    :message  "should use default port 27017 if not specified"}
                                                   {:details  {:host   "localhost"
-                                                              :user   "metabase"
-                                                              :pass   "metasample123"
-                                                              :dbname "test-data"
+                                                              :user   cert-subject
+                                                              :dbname "$external"
                                                               :additional-options "authMechanism=MONGODB-X509"}
                                                    :expected true
                                                    :message  "should use X509 authentication"}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -65,6 +65,13 @@
                                                               :dbname "test-data"}
                                                    :expected true
                                                    :message  "should use default port 27017 if not specified"}
+                                                  {:details  {:host   "localhost"
+                                                              :user   "metabase"
+                                                              :pass   "metasample123"
+                                                              :dbname "test-data"
+                                                              :additional-options "authMechanism=MONGODB-X509"}
+                                                   :expected true
+                                                   :message  "should use X509 authentication"}
                                                   {:details  {:host   "123.4.5.6"
                                                               :dbname "bad-db-name?connectTimeoutMS=50"}
                                                    :expected false}

--- a/test_resources/ssl/mongo/README.md
+++ b/test_resources/ssl/mongo/README.md
@@ -14,3 +14,8 @@ certificates needed for the backend tests are copied into the this directory.
 Although the source of truth is the docker image, the client certificates are
 checked in because there are tests like the SSL connection factory tests which
 need valid certificates and keys.
+
+## To test against the server with TLS
+
+    MB_MONGO_TEST_USER=metabase MB_MONGO_TEST_PASSWORD=metasample123 MB_TEST_MONGO_REQUIRES_SSL=1 DRIVERS=mongo clj -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+

--- a/test_resources/ssl/mongo/run-server.sh
+++ b/test_resources/ssl/mongo/run-server.sh
@@ -22,23 +22,23 @@ done
 shift $((OPTIND-1))
 [ "${1:-}" = "--" ] && shift
 
-if [ "${ssl}" == "" ]
-then
+if [ "${ssl}" == "" ]; then
     ssl="tls"
 fi
 
 params=()
-if [ "${ssl}" == "tls" ]
-then
+if [ "${ssl}" == "tls" ]; then
     params=(--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt)
 fi
 
 echo "Running mongod version ${version} in SSL mode ${ssl}"
 
-docker run -d -it --rm -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-${version} \
+docker run -d -it --rm -p 27017:27017 --name metamongo \
+       -e MONGO_INITDB_ROOT_USERNAME=metabase \
+       -e MONGO_INITDB_ROOT_PASSWORD=metasample123 \
+       metabase/qa-databases:mongo-sample-${version} \
        mongod --dbpath /data/db2/ "${params[@]}"
 
-for f in metabase.crt metabase.key metaca.crt
-do
+for f in metabase.crt metabase.key metaca.crt; do
     docker cp metamongo:/etc/mongo/$f .
 done


### PR DESCRIPTION
## Description

* Improve error reporting for connection failures on MongoDB.
* Use `createMongoX509Credential` when authmechanism is mongodb-x509.
* Update mage `start-db` to use username/password that matches CI.

Fixes https://github.com/metabase/metabase/issues/73748

## Error reporting details

Currently error reporting is very poor when there's an error trying to connect adding a new database:

Before:

> Exception authenticating.

After:

> Command execution failed on MongoDB server with error 18 (AuthenticationFailed): 'There is no x.509 client certificate matching the user.' on server localhost:27017. The full response is {"ok": 0.0, "errmsg": "There is no x.509 client certificate matching the user.", "code": 18, "codeName": "AuthenticationFailed"}

## Testing

The first test simply does a surface level "does this even try to use x509 for authentication?" check. This is not super useful; we want to know if the x509 cert will actually be able to authenticate successfully. There's a separate test for this, but it doesn't work when you run mongo from the normal dev-scripts. But if you run it using `test_resources/ssl/mongo/run-server.sh` then it'll have the CA set up, and you can set `MB_TEST_MONGO_REQUIRES_SSL=y` so that the TLS client cert test runs.