### PR TITLE
[BOT-1496] fix metabot feedback migration logical filepath

### DIFF
--- a/resources/migrations/060/20260501_metabot_source_feedback.yaml
+++ b/resources/migrations/060/20260501_metabot_source_feedback.yaml
@@ -1,10 +1,17 @@
 ## Persist Metabot source feedback
 
 databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+
   - changeSet:
       id: v60.srcefb
       author: undrfined
       comment: metabot_source_feedback table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: metabot_source_feedback
       changes:
         - createTable:
             tableName: metabot_source_feedback
@@ -70,6 +77,12 @@ databaseChangeLog:
       id: v60.srcefu
       author: undrfined
       comment: Unique constraint on metabot_source_feedback source rating
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - uniqueConstraintExists:
+                tableName: metabot_source_feedback
+                constraintName: uq_metabot_source_feedback_message_user_source
       changes:
         - addUniqueConstraint:
             tableName: metabot_source_feedback
@@ -84,6 +97,12 @@ databaseChangeLog:
       id: v60.srcefm
       author: undrfined
       comment: Index on metabot_source_feedback.message_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: metabot_source_feedback
+                indexName: idx_metabot_source_feedback_message_id
       changes:
         - createIndex:
             tableName: metabot_source_feedback
@@ -100,6 +119,11 @@ databaseChangeLog:
       id: v60.srcefk
       author: undrfined
       comment: Foreign key from metabot_source_feedback.message_id to metabot_message.id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyName: fk_metabot_source_feedback_message_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: metabot_source_feedback

--- a/resources/migrations/060/20260501_metabot_source_feedback.yaml
+++ b/resources/migrations/060/20260501_metabot_source_feedback.yaml
@@ -80,9 +80,9 @@ databaseChangeLog:
       preConditions:
         - onFail: MARK_RAN
         - not:
-            - uniqueConstraintExists:
+            - indexExists:
                 tableName: metabot_source_feedback
-                constraintName: uq_metabot_source_feedback_message_user_source
+                indexName: uq_metabot_source_feedback_message_user_source
       changes:
         - addUniqueConstraint:
             tableName: metabot_source_feedback

--- a/resources/migrations/061/20260421_metabot_message_external_id.yaml
+++ b/resources/migrations/061/20260421_metabot_message_external_id.yaml
@@ -29,9 +29,9 @@ databaseChangeLog:
       preConditions:
         - onFail: MARK_RAN
         - not:
-            - uniqueConstraintExists:
+            - indexExists:
                 tableName: metabot_message
-                constraintName: uq_metabot_message_external_id
+                indexName: uq_metabot_message_external_id
       changes:
         - addUniqueConstraint:
             tableName: metabot_message

--- a/resources/migrations/061/20260421_metabot_message_external_id.yaml
+++ b/resources/migrations/061/20260421_metabot_message_external_id.yaml
@@ -5,6 +5,12 @@ databaseChangeLog:
       id: v61.2026-04-21T10:00:00
       author: sloansparger
       comment: Add nullable external_id column to metabot_message
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabot_message
+                columnName: external_id
       changes:
         - addColumn:
             tableName: metabot_message
@@ -20,6 +26,12 @@ databaseChangeLog:
       id: v61.2026-04-21T10:00:01
       author: sloansparger
       comment: Unique constraint on metabot_message.external_id for feedback lookup
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - uniqueConstraintExists:
+                tableName: metabot_message
+                constraintName: uq_metabot_message_external_id
       changes:
         - addUniqueConstraint:
             tableName: metabot_message


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74047
Closes [BOT-1496: Upgrade to 61 beta from 60 Fails](https://linear.app/metabase/issue/BOT-1496/upgrade-to-61-beta-from-60-fails)

Upgrading from `v0.60.4.4` to any `v0.61.0.6/7/8-beta` (or future v0.61) fails when Liquibase replays `CREATE TABLE metabot_source_feedback` and Postgres rejects the duplicate.

`metabot_source_feedback` was independently backported to both release lines:

  - **v60** (PR #73785, in v0.60.4.4) — manually conflict-resolved; `resources/migrations/060/20260501_metabot_source_feedback.yaml` was given `logicalFilePath: migrations/060_update_migrations.yaml`, matching every other 060/ sibling.
  - **v61** (PR #73784, in v0.61.0.6+) — auto-backported from master verbatim; the same file shipped **without** `logicalFilePath`.

Liquibase keys `DATABASECHANGELOG` by `(id, author, filename)`. v0.60.4.4 customers recorded `v60.srcefb / srcefu / srcefm / srcefk` under filename `migrations/060_update_migrations.yaml`. On upgrade, the v61 file declares no logical path, so Liquibase computes the filename from the on-disk path, the `(id, author, filename)` lookup misses, and the changesets re-run.

### Fix

**`060/20260501_metabot_source_feedback.yaml`**
  - Add `logicalFilePath: migrations/060_update_migrations.yaml` so v60 and v61 agree on the filename.
  - Add `onFail: MARK_RAN` preconditions to each of `srcefb / srcefu / srcefm / srcefk` (`not tableExists` / `not uniqueConstraintExists` / `not indexExists` / `not foreignKeyConstraintExists`). These protect the small cohort that fresh-installed onto v0.61.0.6/7/8-beta — their changesets are recorded under the on-disk filename, so the `logicalFilePath` addition would otherwise flip the mismatch in their direction.