### PR TITLE
Fix color for selected option when moving dashboard param filters

### DIFF
--- a/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.module.css
@@ -39,6 +39,6 @@
 .MoveParameterMenuOption[aria-selected="true"] {
   .MoveParameterMenuOptionIcon,
   .MoveParameterMenuOptionText {
-    color: var(--mb-color-text-primary-inverse);
+    color: var(--mb-color-text-selected);
   }
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73932
### Description
Very small PR that adjusts the color of the selected value in the move menu for dashboard parameters

### How to verify
1. Go to a dashboard with filter parameters
2. Click Edit
3. Click on a filter, and in the sidebar, select "Move Filter"
4. Selected item should have the correct colors

### Demo
<img width="551" height="846" alt="image" src="https://github.com/user-attachments/assets/fc2a5d81-6a47-4516-b19c-10cd3bbdeaca" />
<img width="495" height="850" alt="image" src="https://github.com/user-attachments/assets/bf4338d4-11e6-4ff4-92b1-f9843ee8c077" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~