### PR TITLE
Increase min height for query builder header

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -21,6 +21,15 @@ describe("scenarios > question > saved", () => {
     H.visitQuestion(ORDERS_QUESTION_ID);
     cy.findAllByText("Orders"); // question and table name appears
 
+    // capture the view header height in the saved state to assert it does not
+    // change after the question transitions to ad-hoc (UXW-3751)
+    let savedHeaderHeight;
+    cy.findByTestId("qb-header")
+      .invoke("outerHeight")
+      .then((h) => {
+        savedHeaderHeight = h;
+      });
+
     // filter to only orders with quantity=100
     H.tableHeaderClick("Quantity");
     H.popover().findByText("Filter by this column").click();
@@ -35,10 +44,17 @@ describe("scenarios > question > saved", () => {
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 2 rows"); // query updated
 
+    // view header height should be unchanged in the ad-hoc state
+    cy.findByTestId("qb-header")
+      .invoke("outerHeight")
+      .should((h) => {
+        expect(h).to.equal(savedHeaderHeight);
+      });
+
     // check that save will give option to replace
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
-    cy.findByTestId("save-question-modal").within((modal) => {
+    cy.findByTestId("save-question-modal").within(() => {
       cy.findByText('Replace original question, "Orders"');
       cy.findByText("Save as new question");
       cy.findByText("Cancel").click();

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.tsx
@@ -31,6 +31,7 @@ export function SavedQuestionHeaderButton({
         maxLength={QUESTION_NAME_MAX_LENGTH}
         onChange={onSave}
         data-testid="saved-question-header-title"
+        lh={undefined}
       />
 
       <Flex

--- a/frontend/src/metabase/query_builder/components/view/View/ViewHeaderContainer/ViewHeaderContainer.module.css
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewHeaderContainer/ViewHeaderContainer.module.css
@@ -2,7 +2,7 @@
   border-bottom: 1px solid var(--mb-color-border);
   padding-top: 8px;
   padding-bottom: 8px;
-  min-height: 4rem;
+  min-height: 4.25rem; /* Give some extra space so various verisons of the header have a consistent height (saved question, ad-hoc, etc) */
 }
 
 .QueryBuilderViewHeaderContainer {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72599
### Description
Small change to stabilize the height of the view header in the query builder when going from various mode (mainly saved to adhoc question). Part of this is passing a prop to avoid the hard coded line height for the EditableText component

### How to verify
1. Go to a saved question
2. Open the viz settings, and modify a value while keeping an eye on the header height. It should not move

### Demo

https://github.com/user-attachments/assets/ec8dc8be-a616-4d94-99b6-a605be2858cf

### Checklist
- [x] Tests have been added/updated to cover changes in this PR