### PR TITLE
Dedupe search index entries per batch

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -327,6 +327,15 @@
                             (name table-type) table-name)
                 nil)))))))
 
+(defn- dedupe-entries
+  "Remove entries that collide on (model, model_id), keeping the last occurrence.
+   Postgres rejects `INSERT ... ON CONFLICT DO UPDATE` when the same batch contains
+   two rows that share the conflict target, and H2's unique index would also reject
+   duplicates in a single insert. Upstream ingestion can fan rows out via joins, so
+   we dedupe defensively per batch."
+  [entries]
+  (vals (into {} (map (juxt (juxt :model :model_id) identity)) entries)))
+
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
   [context documents]
@@ -343,7 +352,7 @@
 
   (let [reindexing? (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
         do-writes   (fn []
-                      (let [entries         (map document->entry documents)
+                      (let [entries         (dedupe-entries (map document->entry documents))
                             ;; No need to update the active index if we are doing a full index, as this table will be
                             ;; swapped out soon. Most updates would be no-ops anyway.
                             active-updated  (when-not (and reindexing? (pending-table))

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -688,6 +688,27 @@
           (is (false? (.contains json-str ^CharSequence NUL)) "encoded JSON has no raw NUL")
           (is (false? (.contains json-str ^CharSequence FF))  "encoded JSON has no raw form feed"))))))
 
+(deftest dedupe-entries-test
+  (let [dedupe @#'search.index/dedupe-entries]
+    (testing "passes through entries with distinct (model, model_id)"
+      (is (= [{:model "card" :model_id "1" :name "a"}
+              {:model "card" :model_id "2" :name "b"}
+              {:model "dataset" :model_id "1" :name "c"}]
+             (dedupe [{:model "card" :model_id "1" :name "a"}
+                      {:model "card" :model_id "2" :name "b"}
+                      {:model "dataset" :model_id "1" :name "c"}]))))
+    (testing "collapses entries that share (model, model_id), keeping the last one"
+      ;; Postgres rejects an `INSERT ... ON CONFLICT DO UPDATE` when two rows in the
+      ;; same batch collide on the conflict target — see issue #72427.
+      (is (= [{:model "card" :model_id "1" :name "second"}]
+             (dedupe [{:model "card" :model_id "1" :name "first"}
+                      {:model "card" :model_id "1" :name "second"}]))))
+    (testing "same model_id under different models is not a collision"
+      (is (= 2 (count (dedupe [{:model "card"    :model_id "1" :name "a"}
+                               {:model "dataset" :model_id "1" :name "b"}])))))
+    (testing "empty input returns empty"
+      (is (empty? (dedupe []))))))
+
 (deftest when-index-created
   (when (search/supports-index?)
     (binding [search.spec/*testing-only-index-version-hash* "index-age-test"]


### PR DESCRIPTION
## Summary

Fixes #72427 — the search index reindex job throws `ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time` when a batch contains two rows that collide on `(model, model_id)`. Reproduced on Cloud and on a separate instance (see [comment](https://github.com/metabase/metabase/issues/72427#issuecomment-4429410377)); reachable from the `SearchIndexReindex` Quartz job and from request paths through `metabase.search.api/+engine-cookie` → `metabase.search.core/init-index!` → `metabase.search.appdb.core/populate-index!` → `metabase.search.appdb.index/safe-batch-upsert!`.

Postgres rejects an `INSERT … ON CONFLICT DO UPDATE` whose batch proposes two rows sharing the conflict target, and H2's unique index would reject duplicates in a single `t2/insert!` too. Upstream `spec-index-reducible` only dedupes the `indexed-entity` model globally (intentionally, to avoid an unbounded set across all documents) — other models can fan rows out via joins.

This change dedupes entries on `(model, model_id)` per batch in `batch-update!`, keeping the last occurrence. Per-batch dedup is bounded at `insert-batch-size` (150), so the memory concern that drove the original global-dedup decision doesn't apply.

## Test plan

- [x] Unit test covers distinct passthrough, last-write-wins collapse, distinct-model non-collision, and empty input
- [ ] CI runs the existing `metabase.search.appdb.index-test` suite against Postgres and H2

🤖 Generated with [Claude Code](https://claude.com/claude-code)