### PR TITLE
Get rid of VisualizationSettingDefinition["hidden"]

### DIFF
--- a/frontend/src/metabase/list-view/components/ListViz/ListViz.tsx
+++ b/frontend/src/metabase/list-view/components/ListViz/ListViz.tsx
@@ -52,7 +52,7 @@ const vizDefinition: VisualizationDefinition = {
   isSensible: () => true,
 
   settings: {
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     "list.entity_icon": {
       getDefault: () => null,
     },

--- a/frontend/src/metabase/visualizations/lib/settings.ts
+++ b/frontend/src/metabase/visualizations/lib/settings.ts
@@ -194,8 +194,8 @@ function getSettingWidget<T, TValue, TProps extends Record<string, unknown>>(
     resolvedObject = object._raw;
   }
 
-  const getHiddenFn = settingDef.getHidden;
-  const { getProps, getWrapperStyle, ...settingDefProps } = settingDef;
+  const { getProps, getWrapperStyle, getHidden, ...settingDefProps } =
+    settingDef;
 
   const section = settingDef.getSection
     ? settingDef.getSection(resolvedObject, computedSettings, extra)
@@ -206,9 +206,7 @@ function getSettingWidget<T, TValue, TProps extends Record<string, unknown>>(
     id: settingId,
     value,
     section,
-    hidden: getHiddenFn
-      ? getHiddenFn(resolvedObject, computedSettings, extra)
-      : (settingDef.hidden ?? false),
+    hidden: getHidden?.(resolvedObject, computedSettings, extra) ?? false,
     props:
       getProps?.(
         resolvedObject,

--- a/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
@@ -102,10 +102,10 @@ describe("settings framework", () => {
       ]);
     });
 
-    it("should return hidden widget when `hidden` is true", () => {
+    it("should ignore provided `hidden`", () => {
       const defs = { foo: { widget: "input", hidden: true } };
       const widgets = getSettingsWidgets(defs, {}, {}, mockObject, () => {});
-      expect(widgets[0].hidden).toEqual(true);
+      expect(widgets[0].hidden).toEqual(false);
     });
 
     it("should return hidden widget when `getHidden` returns true", () => {

--- a/frontend/src/metabase/visualizations/lib/settings/column.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/column.ts
@@ -68,14 +68,13 @@ const DEFAULT_GET_COLUMNS: GetColumnsFn = (series, _vizSettings) =>
 
 export interface ColumnSettingsOptions {
   getColumns?: GetColumnsFn;
-  hidden?: boolean;
+  getHidden?: (series: Series, settings: VisualizationSettings) => boolean;
   section?: string;
   readDependencies?: string[];
 }
 
 export function columnSettings({
   getColumns = DEFAULT_GET_COLUMNS,
-  hidden,
   ...def
 }: ColumnSettingsOptions = {}) {
   return nestedSettings<"column_settings", DatasetColumn>("column_settings", {
@@ -88,7 +87,6 @@ export function columnSettings({
     component: ChartNestedSettingColumns,
     getInheritedSettingsForObject: getInheritedSettingsForColumn,
     useRawSeries: true,
-    hidden,
     ...def,
   });
 }

--- a/frontend/src/metabase/visualizations/lib/settings/graph.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.ts
@@ -96,7 +96,7 @@ export const GRAPH_DATA_SETTINGS: VisualizationSettingsDefinitions = {
         data: { cols },
       },
     ]) => cols,
-    hidden: true,
+    getHidden: () => true,
   }),
   "graph.dimensions": {
     get section() {
@@ -415,7 +415,7 @@ export const SPLIT_PANELS_SETTINGS: VisualizationSettingsDefinitions = {
 export const LEGEND_SETTINGS: VisualizationSettingsDefinitions = {
   "legend.is_reversed": {
     getDefault: (_series, settings) => getDefaultLegendIsReversed(settings),
-    hidden: true,
+    getHidden: () => true,
   },
 };
 
@@ -427,7 +427,7 @@ export const TOOLTIP_SETTINGS: VisualizationSettingsDefinitions = {
       );
       return shouldShowComparisonTooltip ? "series_comparison" : "default";
     },
-    hidden: true,
+    getHidden: () => true,
   },
   "graph.tooltip_columns": {
     get section() {
@@ -638,7 +638,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
     },
   },
   "graph.max_categories_enabled": {
-    hidden: true,
+    getHidden: () => true,
     // temporarily hiding the setting (metabase#50510)
     getDefault: () => false,
     isValid: () => false,
@@ -646,7 +646,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
   },
   "graph.max_categories": {
     widget: ChartSettingMaxCategories,
-    hidden: true,
+    getHidden: () => true,
     // temporarily hiding the setting (metabase#50510)
     getDefault: () => Number.MAX_SAFE_INTEGER,
     isValid: () => false,
@@ -666,7 +666,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => color("text-tertiary"),
   },
   "graph.other_category_aggregation_fn": {
-    hidden: true,
+    getHidden: () => true,
     getDefault: ([{ data }], settings) => {
       const [metricName] = settings["graph.metrics"] ?? [];
       const metric = data.cols.find((col) => col.name === metricName);

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -325,7 +325,6 @@ export type VisualizationSettingDefinition<
       : ComputedVisualizationSettings,
     extra?: SettingsExtra,
   ) => boolean;
-  hidden?: boolean;
   getHidden?: (
     object: T,
     settings: T extends DatasetColumn
@@ -392,11 +391,12 @@ export type CompleteVisualizationSettingDefinition<
   TProps extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<
   VisualizationSettingDefinition<T, TValue, TProps>,
-  "getProps" | "getWrapperStyle"
+  "getProps" | "getWrapperStyle" | "getHidden"
 > & {
   id: string;
   style?: CSSProperties;
   props: Partial<TProps>;
+  hidden: boolean;
 };
 
 export type DatasetColumnSettingDefinition<

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -84,7 +84,7 @@ const FunnelViz: VisualizationDefinition = {
   hasEmptyState: true,
 
   settings: {
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     ...dimensionSetting("funnel.dimension", {
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
       section: t`Data`,

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -61,7 +61,7 @@ export class Map extends Component {
   static hasEmptyState = true;
 
   static settings = {
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     "map.type": {
       get title() {
         return t`Map type`;

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.tsx
@@ -28,7 +28,7 @@ const ObjectDetailProperties: VisualizationDefinition = {
   canSavePng: false,
   disableClickBehavior: true,
   settings: {
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     ...tableColumnSettings({ isShowingDetailsOnlyColumns: true }),
   },
   columnSettings: () => {
@@ -42,9 +42,9 @@ const ObjectDetailProperties: VisualizationDefinition = {
 
       // Makes sure `column_settings` doesn't omit these settings,
       // so they can be used for formatting
-      view_as: { hidden: true },
-      link_text: { hidden: true },
-      link_url: { hidden: true },
+      view_as: { getHidden: () => true },
+      link_text: { getHidden: () => true },
+      link_url: { getHidden: () => true },
     };
   },
   isSensible: () => true,

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -97,9 +97,9 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       showColumnSetting: true,
       getDefault: (rawSeries) => getDefaultPieColumns(rawSeries).metric,
     }),
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     ...dimensionSetting("pie.dimension", {
-      hidden: true,
+      getHidden: () => true,
       get title() {
         return t`Dimension`;
       },
@@ -107,7 +107,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       getDefault: (rawSeries) => getDefaultPieColumns(rawSeries).dimension,
     }),
     "pie.rows": {
-      hidden: true,
+      getHidden: () => true,
       getValue: _.memoize(
         (series, settings) => {
           return getPieRows(series, settings, (value, options) =>
@@ -136,7 +136,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["pie.sort_rows", "pie.dimension"],
     },
     "pie.sort_rows": {
-      hidden: true,
+      getHidden: () => true,
       getDefault: getDefaultSortRows,
     },
     ...nestedSettings<

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -52,9 +52,9 @@ export const getTitleForColumn = (
 };
 
 export const settings = {
-  ...columnSettings({ hidden: true }),
+  ...columnSettings({ getHidden: () => true }),
   [COLLAPSED_ROWS_SETTING]: {
-    hidden: true,
+    getHidden: () => true,
     readDependencies: [COLUMN_SPLIT_SETTING],
     getValue: (
       [{ data }]: Series,

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -25,7 +25,7 @@ import { hasCyclicFlow } from "./utils/cycle-detection";
 const MAX_SANKEY_NODES = 150;
 
 export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
-  ...columnSettings({ hidden: true }),
+  ...columnSettings({ getHidden: () => true }),
   ...dimensionSetting("sankey.source", {
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     section: t`Data`,

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -119,12 +119,12 @@ export class Scalar extends Component<
     }),
     // used by metrics viewer
     "scalar.label": {
-      hidden: true,
+      getHidden: () => true,
       getDefault: () => undefined,
     },
     // used by metrics viewer
     "scalar.sublabel": {
-      hidden: true,
+      getHidden: () => true,
       getDefault: () => undefined,
     },
     // LEGACY scalar settings, now handled by column level settings

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -96,7 +96,7 @@ export class Table extends Component<TableProps, TableState> {
   static isPivoted = _isPivoted;
 
   static settings = {
-    ...columnSettings({ hidden: true }),
+    ...columnSettings({ getHidden: () => true }),
     "table.pagination": {
       get section() {
         return t`Columns`;


### PR DESCRIPTION
Closes [GDGT-1996](https://linear.app/metabase/issue/GDGT-1996)

### Description

Replaces `VisualizationSettingDefinition["hidden"]` with `getHidden`. Follows the same pattern as #70867 (`props` → `getProps`) and #71015 (`default` → `getDefault`).

The `columnSettings({ hidden })` helper option is renamed to `getHidden` for consistency.

### How to verify

CI is green.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR