### PR TITLE
Get rid of VisualizationSettingDefinition["section"]

### DIFF
--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -111,10 +111,13 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
     id: Key;
 
     /**
-     * Top-level section that this setting appears under in the settings sidebar
-     * (e.g. `"Data"`, `"Display"`, `"Axes"`).
+     * Returns the top-level section this setting appears under in the settings
+     * sidebar (e.g. `"Data"`, `"Display"`, `"Axes"`). Implemented as a getter so
+     * the label can be localized at call time.
+     *
+     * @returns Section to put this setting into.
      */
-    section?: string;
+    getSection?: () => string;
 
     /** Human-readable label rendered above the widget in the sidebar. */
     title?: string;

--- a/frontend/src/metabase/dashboard/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/ActionViz.tsx
@@ -37,8 +37,7 @@ const ActionViz: VisualizationDefinition = {
       dashboard: false,
     },
     actionDisplayType: {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Action Form Display`,
       widget: "radio",
@@ -51,16 +50,14 @@ const ActionViz: VisualizationDefinition = {
       }),
     },
     "button.label": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Label`,
       widget: "input",
       getHidden: isForm,
     },
     "button.variant": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Variant`,
       widget: "select",

--- a/frontend/src/metabase/dashboard/visualizations/Text/index.ts
+++ b/frontend/src/metabase/dashboard/visualizations/Text/index.ts
@@ -39,8 +39,7 @@ const TextViz: VisualizationDefinition = {
       getDefault: () => "",
     },
     "text.align_vertical": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Vertical Alignment`,
       widget: "select",
@@ -54,8 +53,7 @@ const TextViz: VisualizationDefinition = {
       getDefault: () => "top",
     },
     "text.align_horizontal": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Horizontal Alignment`,
       widget: "select",
@@ -69,8 +67,7 @@ const TextViz: VisualizationDefinition = {
       getDefault: () => "left",
     },
     "dashcard.background": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Show background`,
       dashboard: true,

--- a/frontend/src/metabase/visualizations/lib/settings.ts
+++ b/frontend/src/metabase/visualizations/lib/settings.ts
@@ -194,18 +194,19 @@ function getSettingWidget<T, TValue, TProps extends Record<string, unknown>>(
     resolvedObject = object._raw;
   }
 
-  const { getProps, getWrapperStyle, getHidden, ...settingDefProps } =
-    settingDef;
-
-  const section = settingDef.getSection
-    ? settingDef.getSection(resolvedObject, computedSettings, extra)
-    : settingDef.section;
+  const {
+    getProps,
+    getWrapperStyle,
+    getSection,
+    getHidden,
+    ...settingDefProps
+  } = settingDef;
 
   return {
     ...settingDefProps,
     id: settingId,
     value,
-    section,
+    section: getSection?.(resolvedObject, computedSettings, extra),
     hidden: getHidden?.(resolvedObject, computedSettings, extra) ?? false,
     props:
       getProps?.(

--- a/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
@@ -122,6 +122,20 @@ describe("settings framework", () => {
       expect(widgets[0].props).toEqual({});
     });
 
+    it("should ignore provided `section`", () => {
+      const defs = { foo: { widget: "input", section: "Display" } };
+      const widgets = getSettingsWidgets(defs, {}, {}, mockObject, () => {});
+      expect(widgets[0].section).toBeUndefined();
+    });
+
+    it("should resolve section via `getSection`", () => {
+      const getSection = jest.fn().mockReturnValue("Display");
+      const defs = { foo: { widget: "input", getSection } };
+      const widgets = getSettingsWidgets(defs, {}, {}, mockObject, () => {});
+      expect(widgets[0].section).toEqual("Display");
+      expect(getSection.mock.calls).toEqual([[mockObject, {}, {}]]);
+    });
+
     it("should compute props when `getProps` is provided", () => {
       const getProps = jest.fn().mockReturnValue({ hello: "world" });
       const defs = { foo: { widget: "input", getProps } };

--- a/frontend/src/metabase/visualizations/lib/settings/column.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/column.ts
@@ -69,7 +69,7 @@ const DEFAULT_GET_COLUMNS: GetColumnsFn = (series, _vizSettings) =>
 export interface ColumnSettingsOptions {
   getColumns?: GetColumnsFn;
   getHidden?: (series: Series, settings: VisualizationSettings) => boolean;
-  section?: string;
+  getSection?: () => string;
   readDependencies?: string[];
 }
 
@@ -78,7 +78,7 @@ export function columnSettings({
   ...def
 }: ColumnSettingsOptions = {}) {
   return nestedSettings<"column_settings", DatasetColumn>("column_settings", {
-    section: t`Formatting`,
+    getSection: () => t`Formatting`,
     objectName: "column",
     getObjects: getColumns,
     getObjectKey: getColumnKey,
@@ -536,9 +536,7 @@ export function tableColumnSettings({
 } = {}): VisualizationSettingsDefinitions {
   return {
     "table.columns": {
-      get section() {
-        return t`Columns`;
-      },
+      getSection: () => t`Columns`,
       // title: t`Columns`,
       widget: ChartSettingTableColumns,
       getHidden: (_series, vizSettings) => vizSettings["table.pivot"],

--- a/frontend/src/metabase/visualizations/lib/settings/goal.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/goal.ts
@@ -26,9 +26,7 @@ export const getChartGoal = (
 
 export const GRAPH_GOAL_SETTINGS: VisualizationSettingsDefinitions = {
   "graph.show_goal": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Goal line`;
     },
@@ -40,9 +38,7 @@ export const GRAPH_GOAL_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.goal_value": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Goal value`;
     },
@@ -53,9 +49,7 @@ export const GRAPH_GOAL_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["graph.show_goal"],
   },
   "graph.goal_label": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Goal label`;
     },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.ts
@@ -99,9 +99,7 @@ export const GRAPH_DATA_SETTINGS: VisualizationSettingsDefinitions = {
     getHidden: () => true,
   }),
   "graph.dimensions": {
-    get section() {
-      return t`Data`;
-    },
+    getSection: () => t`Data`,
     get title() {
       return t`X-axis`;
     },
@@ -159,9 +157,7 @@ export const GRAPH_DATA_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["graph.series_order"],
   },
   "graph.series_order": {
-    get section() {
-      return t`Data`;
-    },
+    getSection: () => t`Data`,
     widget: ChartSettingSeriesOrder,
     useRawSeries: true,
     getWrapperStyle: () => ({
@@ -210,9 +206,7 @@ export const GRAPH_DATA_SETTINGS: VisualizationSettingsDefinitions = {
     writeDependencies: ["graph.series_order_dimension"],
   },
   "graph.metrics": {
-    get section() {
-      return t`Data`;
-    },
+    getSection: () => t`Data`,
     get title() {
       return t`Y-axis`;
     },
@@ -265,9 +259,7 @@ export const GRAPH_DATA_SETTINGS: VisualizationSettingsDefinitions = {
 
 export const GRAPH_BUBBLE_SETTINGS: VisualizationSettingsDefinitions = {
   "scatter.bubble": {
-    get section() {
-      return t`Data`;
-    },
+    getSection: () => t`Data`,
     get title() {
       return t`Bubble size`;
     },
@@ -317,9 +309,7 @@ export const LINE_SETTINGS: VisualizationSettingsDefinitions = {
 
 export const STACKABLE_SETTINGS: VisualizationSettingsDefinitions = {
   "stackable.stack_type": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Stacking`;
     },
@@ -384,9 +374,7 @@ export const STACKABLE_SETTINGS: VisualizationSettingsDefinitions = {
 
 export const SPLIT_PANELS_SETTINGS: VisualizationSettingsDefinitions = {
   "graph.split_panels": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Stack series`;
     },
@@ -430,9 +418,7 @@ export const TOOLTIP_SETTINGS: VisualizationSettingsDefinitions = {
     getHidden: () => true,
   },
   "graph.tooltip_columns": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Additional tooltip columns`;
     },
@@ -459,9 +445,7 @@ export const TOOLTIP_SETTINGS: VisualizationSettingsDefinitions = {
 
 export const GRAPH_TREND_SETTINGS: VisualizationSettingsDefinitions = {
   "graph.show_trendline": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Trend line`;
     },
@@ -482,9 +466,7 @@ export const GRAPH_TREND_SETTINGS: VisualizationSettingsDefinitions = {
 
 export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
   "graph.show_values": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Show values on data points`;
     },
@@ -497,9 +479,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.label_value_frequency": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Values to show`;
     },
@@ -535,9 +515,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["graph.show_values"],
   },
   "graph.show_stack_values": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Stack values to show`;
     },
@@ -584,9 +562,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["graph.show_values", "stackable.stack_type"],
   },
   "graph.label_value_formatting": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Auto formatting`;
     },
@@ -716,9 +692,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     ]) => cols[0] && getDefaultIsHistogram(cols[0]),
   },
   "graph.x_axis.scale": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -741,9 +715,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.y_axis.scale": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Scale`;
     },
@@ -762,9 +734,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.x_axis.axis_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -810,9 +780,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.axis_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Show lines and tick marks`;
     },
@@ -840,9 +808,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.unpin_from_zero": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -866,9 +832,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["series", "graph.y_axis.auto_range"],
   },
   "graph.y_axis.auto_range": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -881,9 +845,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: getYAxisAutoRangeDefault,
   },
   "graph.y_axis.min": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -897,9 +859,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
   "graph.y_axis.max": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -913,9 +873,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
   "graph.y_axis.auto_split": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -931,9 +889,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["graph.split_panels"],
   },
   "graph.x_axis.labels_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -946,9 +902,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: getIsXAxisLabelEnabledDefault,
   },
   "graph.x_axis.title_text": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Label`;
     },
@@ -965,9 +919,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.y_axis.labels_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Show label`;
     },
@@ -980,9 +932,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: getIsYAxisLabelEnabledDefault,
   },
   "graph.y_axis.split_number": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -996,9 +946,7 @@ export const GRAPH_AXIS_SETTINGS: VisualizationSettingsDefinitions = {
     },
   },
   "graph.y_axis.title_text": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Label`;
     },
@@ -1030,9 +978,7 @@ const BOXPLOT_LABEL_VALUE_FREQUENCY_SETTING: SeriesSettingDefinition<
   "fit" | "all",
   ChartSettingEnumToggleProps<"fit" | "all">
 > = {
-  get section() {
-    return t`Display`;
-  },
+  getSection: () => t`Display`,
   get title() {
     return t`Hide overlapping labels`;
   },
@@ -1049,9 +995,7 @@ const BOXPLOT_LABEL_VALUE_FREQUENCY_SETTING: SeriesSettingDefinition<
 
 export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
   "boxplot.whisker_type": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Whiskers extend to`;
     },
@@ -1065,9 +1009,7 @@ export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "boxplot.points_mode": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Show points`;
     },
@@ -1096,9 +1038,7 @@ export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["boxplot.whisker_type"],
   },
   "boxplot.show_mean": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Show mean`;
     },
@@ -1107,9 +1047,7 @@ export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
     inline: true,
   },
   "graph.show_values": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Show values on data points`;
     },
@@ -1121,9 +1059,7 @@ export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "boxplot.show_values_mode": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Values to display`;
     },
@@ -1163,9 +1099,7 @@ export const BOXPLOT_SETTINGS: VisualizationSettingsDefinitions = {
       ChartSettingSegmentedControlProps
     >,
   "graph.label_value_formatting": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Auto formatting`;
     },

--- a/frontend/src/metabase/visualizations/lib/settings/nested.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/nested.ts
@@ -157,7 +157,7 @@ export function nestedSettings<
   type Value = VisualizationSettingsDefinitions[Key];
 
   const idDef: SeriesSettingDefinition<Value, TProps & { id: string }> = {
-    section: t`Display`,
+    getSection: () => t`Display`,
     getDefault: () => ({}),
     getProps: (series, settings, onChange, extra) => {
       const objects = getObjects(series, settings);

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -313,7 +313,6 @@ export type VisualizationSettingDefinition<
   TProps extends Record<string, unknown> = Record<string, unknown>,
 > = {
   id?: string;
-  section?: string;
   title?: string;
   placeholder?: string;
   group?: string;
@@ -393,12 +392,13 @@ export type CompleteVisualizationSettingDefinition<
   TProps extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<
   VisualizationSettingDefinition<T, TValue, TProps>,
-  "getProps" | "getWrapperStyle" | "getHidden"
+  "getProps" | "getWrapperStyle" | "getHidden" | "getSection"
 > & {
   id: string;
   style?: CSSProperties;
   props: Partial<TProps>;
   hidden: boolean;
+  section?: string;
 };
 
 export type DatasetColumnSettingDefinition<

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -86,8 +86,7 @@ const FunnelViz: VisualizationDefinition = {
   settings: {
     ...columnSettings({ getHidden: () => true }),
     ...dimensionSetting("funnel.dimension", {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
-      section: t`Data`,
+      getSection: () => t`Data`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
       title: t`Column with steps`,
       dashboard: false,
@@ -103,8 +102,7 @@ const FunnelViz: VisualizationDefinition = {
       readDependencies: ["funnel.rows"],
     },
     "funnel.rows": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
-      section: t`Data`,
+      getSection: () => t`Data`,
       widget: ChartSettingOrderedSimple,
       getValue: (
         rawSeries: RawSeries,
@@ -160,8 +158,7 @@ const FunnelViz: VisualizationDefinition = {
       dataTestId: "funnel-row-sort",
     },
     ...metricSetting("funnel.metric", {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
-      section: t`Data`,
+      getSection: () => t`Data`,
 
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
       title: t`Measure`,
@@ -174,8 +171,7 @@ const FunnelViz: VisualizationDefinition = {
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
       title: t`Funnel type`,
 
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#5504
-      section: t`Display`,
+      getSection: () => t`Display`,
 
       widget: "select",
       getProps: () => ({

--- a/frontend/src/metabase/visualizations/visualizations/Gauge/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/chart-definition.ts
@@ -64,9 +64,7 @@ export const GAUGE_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["gauge.segments"],
     },
     "gauge.segments": {
-      get section() {
-        return t`Ranges`;
-      },
+      getSection: () => t`Ranges`,
       getDefault(series) {
         let value = 100;
         try {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -88,9 +88,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
   hasEmptyState: true,
   settings: {
     ...metricSetting("pie.metric", {
-      get section() {
-        return t`Data`;
-      },
+      getSection: () => t`Data`,
       get title() {
         return t`Measure`;
       },
@@ -178,9 +176,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
     }),
 
     "pie._dimensions_widget": {
-      get section() {
-        return t`Data`;
-      },
+      getSection: () => t`Data`,
       widget: DimensionsWidget,
       getProps: (rawSeries, settings, _onChange, _extra, onChangeSettings) => ({
         rawSeries,
@@ -190,9 +186,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["pie.dimension", "pie.rows"],
     },
     "pie.show_legend": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Show legend`;
       },
@@ -204,9 +198,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       }),
     },
     "pie.show_total": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Show total`;
       },
@@ -218,9 +210,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       }),
     },
     "pie.show_labels": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Show labels`;
       },
@@ -229,9 +219,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       inline: true,
     },
     "pie.percent_visibility": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Show percentages`;
       },
@@ -267,9 +255,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       }),
     },
     "pie.decimal_places": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Number of decimal places`;
       },
@@ -286,9 +272,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["pie.percent_visibility"],
     },
     "pie.slice_threshold": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Minimum slice percentage`;
       },

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -78,9 +78,7 @@ export const settings = {
     },
   },
   [COLUMN_SPLIT_SETTING]: {
-    get section() {
-      return t`Columns`;
-    },
+    getSection: () => t`Columns`,
     widget: "fieldsPartition",
     persistDefault: true,
     getHidden: ([{ data }]: [{ data: DatasetData }]) =>
@@ -149,9 +147,7 @@ export const settings = {
     },
   },
   "pivot.show_row_totals": {
-    get section() {
-      return t`Columns`;
-    },
+    getSection: () => t`Columns`,
     get title() {
       return t`Show row totals`;
     },
@@ -160,9 +156,7 @@ export const settings = {
     inline: true,
   },
   "pivot.show_column_totals": {
-    get section() {
-      return t`Columns`;
-    },
+    getSection: () => t`Columns`,
     get title() {
       return t`Show column totals`;
     },
@@ -171,9 +165,7 @@ export const settings = {
     inline: true,
   },
   "pivot.condense_duplicate_totals": {
-    get section() {
-      return t`Columns`;
-    },
+    getSection: () => t`Columns`,
     get title() {
       return t`Condense duplicate totals`;
     },
@@ -196,9 +188,7 @@ export const settings = {
   },
   "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {
-    get section() {
-      return t`Conditional Formatting`;
-    },
+    getSection: () => t`Conditional Formatting`,
     widget: ChartSettingsTableFormatting,
     getDefault: (
       [{ data }]: [{ data: DatasetData }],

--- a/frontend/src/metabase/visualizations/visualizations/Progress/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/chart-definition.ts
@@ -35,9 +35,7 @@ export const PROGRESS_CHART_DEFINITION: VisualizationDefinition = {
   },
   settings: {
     ...fieldSetting("progress.value", {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Value`;
       },
@@ -69,9 +67,7 @@ export const PROGRESS_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["progress.value"],
     }),
     "progress.goal": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Goal`;
       },
@@ -98,9 +94,7 @@ export const PROGRESS_CHART_DEFINITION: VisualizationDefinition = {
       readDependencies: ["progress.value"],
     },
     "progress.color": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Color`;
       },

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings-definitions.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings-definitions.ts
@@ -7,9 +7,7 @@ import type { Series, VisualizationSettings } from "metabase-types/api";
 
 export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
   "stackable.stack_type": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Stacking`;
     },
@@ -41,9 +39,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
   },
   ...GRAPH_GOAL_SETTINGS,
   "graph.x_axis.scale": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -58,9 +54,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     },
   },
   "graph.y_axis.scale": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Scale`;
     },
@@ -79,9 +73,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.x_axis.axis_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -109,9 +101,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.axis_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Show lines and marks`;
     },
@@ -139,9 +129,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.auto_range": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -154,9 +142,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.min": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -170,9 +156,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
   "graph.y_axis.max": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`X-axis`;
     },
@@ -186,9 +170,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
   "graph.x_axis.labels_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get group() {
       return t`Y-axis`;
     },
@@ -201,9 +183,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.x_axis.title_text": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Label`;
     },
@@ -220,9 +200,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     }),
   },
   "graph.y_axis.labels_enabled": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Show label`;
     },
@@ -235,9 +213,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => true,
   },
   "graph.y_axis.title_text": {
-    get section() {
-      return t`Axes`;
-    },
+    getSection: () => t`Axes`,
     get title() {
       return t`Label`;
     },
@@ -266,9 +242,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     readDependencies: ["series", "graph.metrics"],
   },
   "graph.show_values": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Show values on data points`;
     },
@@ -279,9 +253,7 @@ export const ROW_CHART_SETTINGS: VisualizationSettingsDefinitions = {
     getDefault: () => false,
   },
   "graph.label_value_formatting": {
-    get section() {
-      return t`Display`;
-    },
+    getSection: () => t`Display`,
     get title() {
       return t`Value labels formatting`;
     },

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -27,8 +27,7 @@ const MAX_SANKEY_NODES = 150;
 export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
   ...columnSettings({ getHidden: () => true }),
   ...dimensionSetting("sankey.source", {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Data`,
+    getSection: () => t`Data`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Source`,
     showColumnSetting: true,
@@ -38,8 +37,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.source,
   }),
   ...dimensionSetting("sankey.target", {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Data`,
+    getSection: () => t`Data`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Target`,
     showColumnSetting: true,
@@ -49,8 +47,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.target,
   }),
   ...metricSetting("sankey.value", {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Data`,
+    getSection: () => t`Data`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Value`,
     showColumnSetting: true,
@@ -60,8 +57,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: ([series]) => findSensibleSankeyColumns(series.data)?.metric,
   }),
   "sankey.node_align": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Align`,
     widget: "select",
@@ -84,8 +80,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     }),
   },
   "sankey.show_edge_labels": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Show edge labels`,
     widget: "toggle",
@@ -93,8 +88,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     inline: true,
   },
   "sankey.label_value_formatting": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Auto formatting`,
     widget: "segmentedControl",
@@ -111,8 +105,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: () => "auto",
   },
   "sankey.edge_color": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Edge color`,
     widget: "segmentedControl",

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -70,9 +70,7 @@ export class Scalar extends Component<
 
   static settings = {
     ...fieldSetting("scalar.field", {
-      get section() {
-        return t`Formatting`;
-      },
+      getSection: () => t`Formatting`,
       get title() {
         return t`Field to show`;
       },
@@ -88,9 +86,7 @@ export class Scalar extends Component<
       ]) => cols.length < 2,
     }),
     "scalar.segments": {
-      get section() {
-        return t`Conditional colors`;
-      },
+      getSection: () => t`Conditional colors`,
       getDefault() {
         return [];
       },

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
@@ -165,15 +165,13 @@ export function SmartScalar({
 
 export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
   ...fieldSetting("scalar.field", {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Data`,
+    getSection: () => t`Data`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Primary number`,
     fieldFilter: isSuitableScalarColumn,
   }),
   "scalar.comparisons": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Data`,
+    getSection: () => t`Data`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Comparisons`,
     widget: SmartScalarComparisonWidget,
@@ -194,8 +192,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     readDependencies: ["scalar.field"],
   },
   "scalar.switch_positive_negative": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Switch positive / negative colors?`,
     widget: "toggle",
@@ -203,8 +200,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: () => VIZ_SETTINGS_DEFAULTS["scalar.switch_positive_negative"],
   },
   "scalar.compact_primary_number": {
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     title: t`Compact number`,
     widget: "toggle",
@@ -212,8 +208,7 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     getDefault: () => VIZ_SETTINGS_DEFAULTS["scalar.compact_primary_number"],
   },
   ...columnSettings({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    section: t`Display`,
+    getSection: () => t`Display`,
     getColumns: (
       [
         {

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -98,9 +98,7 @@ export class Table extends Component<TableProps, TableState> {
   static settings = {
     ...columnSettings({ getHidden: () => true }),
     "table.pagination": {
-      get section() {
-        return t`Columns`;
-      },
+      getSection: () => t`Columns`,
       get title() {
         return t`Paginate results`;
       },
@@ -110,9 +108,7 @@ export class Table extends Component<TableProps, TableState> {
       getDefault: () => false,
     },
     "table.row_index": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Show row index`;
       },
@@ -121,9 +117,7 @@ export class Table extends Component<TableProps, TableState> {
       getDefault: () => false,
     },
     "table.freeze_columns": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Freeze columns`;
       },
@@ -140,9 +134,7 @@ export class Table extends Component<TableProps, TableState> {
       },
     },
     "table.freeze_columns_count": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Number of columns to freeze`;
       },
@@ -156,9 +148,7 @@ export class Table extends Component<TableProps, TableState> {
       getProps: () => ({ min: 1 }),
     },
     "table.freeze_rows": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Freeze rows`;
       },
@@ -175,9 +165,7 @@ export class Table extends Component<TableProps, TableState> {
       },
     },
     "table.freeze_rows_count": {
-      get section() {
-        return t`Display`;
-      },
+      getSection: () => t`Display`,
       get title() {
         return t`Number of rows to freeze`;
       },
@@ -191,9 +179,7 @@ export class Table extends Component<TableProps, TableState> {
       getProps: () => ({ min: 1 }),
     },
     "table.pivot": {
-      get section() {
-        return t`Columns`;
-      },
+      getSection: () => t`Columns`,
       get title() {
         return t`Pivot table`;
       },
@@ -226,9 +212,7 @@ export class Table extends Component<TableProps, TableState> {
     },
 
     "table.pivot_column": {
-      get section() {
-        return t`Columns`;
-      },
+      getSection: () => t`Columns`,
       get title() {
         return t`Pivot column`;
       },
@@ -253,9 +237,7 @@ export class Table extends Component<TableProps, TableState> {
       persistDefault: true,
     },
     "table.cell_column": {
-      get section() {
-        return t`Columns`;
-      },
+      getSection: () => t`Columns`,
       get title() {
         return t`Cell column`;
       },
@@ -286,9 +268,7 @@ export class Table extends Component<TableProps, TableState> {
     ...tableColumnSettings({ isShowingDetailsOnlyColumns: false }),
     "table.column_widths": {},
     [DataGrid.COLUMN_FORMATTING_SETTING]: {
-      get section() {
-        return t`Conditional Formatting`;
-      },
+      getSection: () => t`Conditional Formatting`,
       widget: ChartSettingsTableFormatting,
       getDefault: () => [],
       getProps: (series: Series, settings: VisualizationSettings) => ({

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
@@ -50,22 +50,19 @@ const WaterfallViz: Omit<VisualizationDefinition, "checkRenderable"> = {
     ...GRAPH_AXIS_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
     "waterfall.increase_color": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       getProps: () => ({ title: t`Increase color` }),
       widget: "color",
       getDefault: () => color("accent1"),
     },
     "waterfall.decrease_color": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       getProps: () => ({ title: t`Decrease color` }),
       widget: "color",
       getDefault: () => color("accent3"),
     },
     "waterfall.show_total": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
       title: t`Show total`,
       widget: "toggle",
@@ -73,8 +70,7 @@ const WaterfallViz: Omit<VisualizationDefinition, "checkRenderable"> = {
       inline: true,
     },
     "waterfall.total_color": {
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      section: t`Display`,
+      getSection: () => t`Display`,
       getProps: () => ({ title: t`Total color` }),
       widget: "color",
       // Unfortunately, to get static viz to look right, we need to avoid using alpha colors here


### PR DESCRIPTION
Closes [GDGT-1999](https://linear.app/metabase/issue/GDGT-1999)

> [!NOTE]
> Stacked on top of #74074. Once that PR merges, GitHub will retarget this PR to `master`.

### Description

Replaces `VisualizationSettingDefinition["section"]` with `getSection`. Follows the same pattern as #70867 (`props` → `getProps`), #71015 (`default` → `getDefault`), and #74074 (`hidden` → `getHidden`).

Most of the diff is converting `get section() { return t\`Display\`; }` getters into `getSection: () => t\`Display\``, which also lets us drop the surrounding `eslint-disable ttag/no-module-declaration` comments.

The `columnSettings({ section })` helper option is renamed to `getSection` for consistency.

### How to verify

CI is green.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR