### PR TITLE
Get rid of VisualizationSettingDefinition["value"]

### DIFF
--- a/frontend/src/metabase/dashboard/visualizations/Heading/index.ts
+++ b/frontend/src/metabase/dashboard/visualizations/Heading/index.ts
@@ -35,7 +35,6 @@ const HeadingViz: VisualizationDefinition = {
       dashboard: false,
     },
     text: {
-      value: "",
       getDefault: () => "",
     },
     "dashcard.background": {

--- a/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameVizSettings.ts
+++ b/frontend/src/metabase/dashboard/visualizations/IFrameViz/IFrameVizSettings.ts
@@ -29,7 +29,6 @@ export const settings: VisualizationDefinition = {
       dashboard: false,
     },
     iframe: {
-      value: "",
       getDefault: () => "",
     },
   },

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkVizSettings.ts
@@ -29,9 +29,6 @@ export const settings: VisualizationDefinition = {
       dashboard: false,
     },
     link: {
-      value: {
-        url: "",
-      },
       getDefault: () => ({
         url: "",
       }),

--- a/frontend/src/metabase/dashboard/visualizations/Text/index.ts
+++ b/frontend/src/metabase/dashboard/visualizations/Text/index.ts
@@ -35,7 +35,6 @@ const TextViz: VisualizationDefinition = {
       dashboard: false,
     },
     text: {
-      value: "",
       getDefault: () => "",
     },
     "text.align_vertical": {

--- a/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings.unit.spec.ts
@@ -128,6 +128,12 @@ describe("settings framework", () => {
       expect(widgets[0].section).toBeUndefined();
     });
 
+    it("should ignore provided `value`", () => {
+      const defs = { foo: { widget: "input", value: "hardcoded" } };
+      const widgets = getSettingsWidgets(defs, {}, {}, mockObject, () => {});
+      expect(widgets[0].value).toBeUndefined();
+    });
+
     it("should resolve section via `getSection`", () => {
       const getSection = jest.fn().mockReturnValue("Display");
       const defs = { foo: { widget: "input", getSection } };

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -362,7 +362,6 @@ export type VisualizationSettingDefinition<
     extra?: SettingsExtra,
   ) => CSSProperties | undefined;
   autoOpenWhenUnset?: boolean;
-  value?: TValue;
   set?: boolean;
   persistDefault?: boolean;
   inline?: boolean;
@@ -399,6 +398,7 @@ export type CompleteVisualizationSettingDefinition<
   props: Partial<TProps>;
   hidden: boolean;
   section?: string;
+  value?: TValue;
 };
 
 export type DatasetColumnSettingDefinition<


### PR DESCRIPTION
Closes [GDGT-2000](https://linear.app/metabase/issue/GDGT-2000)

> [!NOTE]
> Stacked on top of #74077, which is stacked on top of #74074. GitHub will retarget this PR to `master` once the upstream PRs merge.

### Description

Removes `VisualizationSettingDefinition["value"]`. Follows the same cleanup pattern as #70867 (`props` → `getProps`), #71015 (`default` → `getDefault`), #74074 (`hidden` → `getHidden`), and #74077 (`section` → `getSection`).

Counterintuitive bit: there is no `value` → `getValue` rename here, just a deletion. `getComputedSetting` only ever reads `getValue` / stored / `getDefault`, and the widget builder always assigns `value` from the computed result (clobbering any `settingDef.value` carried in by the spread). So `settingDef.value` had no observable effect.

The four real call sites — `Text`, `Heading`, `IFrameViz`, `LinkViz` — each paired `value: ""` (or `value: { url: "" }`) with a matching `getDefault` that produced the same value, so removing the `value` line is a no-op at runtime. `getValue` itself is unaffected.

### How to verify

CI is green.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR