### PR TITLE
update UX for SCIM page

### DIFF
--- a/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
@@ -159,40 +159,57 @@ describe("scenarios > admin > settings > user provisioning", () => {
     });
 
     it("should properly handle errors", () => {
-      cy.log("should show error when scim token fails to load");
-      cy.intercept("GET", "/api/ee/scim/api_key", { statusCode: 500 });
-      cy.visit("/admin/settings/authentication/user-provisioning");
-      H.main().within(() => {
-        cy.findByText("Error fetching SCIM token");
+      cy.intercept("POST", "/api/ee/scim/api_key", {
+        statusCode: 500,
+        body: { message: "An error occurred" },
       });
 
-      cy.log(
-        "should show error when scim token fails to generate when scim is enabled",
-      );
-      // enable scim and stop mocking get scim api key request
+      cy.visit("/admin/settings/authentication/user-provisioning");
+
+      // toggling SCIM on triggers the failing token-generation POST
+      scimToggle().click();
+
+      // no modal is opened on failure — error surfaces directly on the form
+      H.modal().should("not.exist");
+
+      H.main().within(() => {
+        cy.findByText(
+          "Token failed to generate, please regenerate one.",
+        ).should("exist");
+        cy.findByRole("button", { name: /Retry/ }).should("exist");
+      });
+    });
+
+    it("should show a warning when SCIM is enabled without a token", () => {
+      // simulate enabling SCIM via config file / env var: enable it server-side, no token generated
       cy.intercept("GET", "/api/ee/scim/api_key", (req) => {
         req.continue();
       });
       cy.request("PUT", "api/setting/scim-enabled", { value: true });
       cy.visit("/admin/settings/authentication/user-provisioning");
+
       H.main().within(() => {
-        cy.findByText("Token failed to generate, please regenerate one.");
+        cy.findByText(
+          "Generate a SCIM token below to complete the setup.",
+        ).should("exist");
+        cy.findByRole("button", { name: /Generate/ }).should("exist");
+        cy.findByText(
+          "Token failed to generate, please regenerate one.",
+        ).should("not.exist");
       });
 
-      cy.log("should show error when scim token fails to regenerate");
-      cy.intercept("POST", "/api/ee/scim/api_key", {
-        statusCode: 500,
-        body: { message: "An error occurred" },
-      });
-      cy.findByRole("button", { name: /Regenerate/ }).click();
-
+      cy.log("warning is removed once a token has been generated");
+      cy.findByRole("button", { name: /Generate/ }).click();
       H.modal().within(() => {
-        cy.findByText("Regenerate token?").should("exist");
-        cy.findByRole("button", { name: /Regenerate now/ }).click();
+        cy.findByText("Here's what you'll need to set SCIM up").should("exist");
+        cy.findByRole("button", { name: /Done/ }).click();
       });
 
-      H.modal().within(() => {
-        cy.findByText("An error occurred");
+      H.main().within(() => {
+        cy.findByText(
+          "Generate a SCIM token below to complete the setup.",
+        ).should("not.exist");
+        cy.findByRole("button", { name: /Regenerate/ }).should("exist");
       });
     });
   });

--- a/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
@@ -173,10 +173,41 @@ describe("scenarios > admin > settings > user provisioning", () => {
       H.modal().should("not.exist");
 
       H.main().within(() => {
-        cy.findByText(
-          "Token failed to generate, please regenerate one.",
-        ).should("exist");
+        cy.findByText("Token failed to generate, Please try again.").should(
+          "exist",
+        );
         cy.findByRole("button", { name: /Retry/ }).should("exist");
+      });
+    });
+
+    it("should close the regenerate modal and surface an error on the token field when regenerate fails", () => {
+      // generate an initial token via the UI
+      cy.visit("/admin/settings/authentication/user-provisioning");
+      scimToggle().click();
+      H.modal().within(() => {
+        cy.findByRole("button", { name: /Done/ }).click();
+      });
+
+      // now make subsequent regenerate calls fail
+      cy.intercept("POST", "/api/ee/scim/api_key", {
+        statusCode: 500,
+        body: { message: "An error occurred" },
+      });
+
+      cy.findByRole("button", { name: /Regenerate/ }).click();
+      H.modal().within(() => {
+        cy.findByText("Regenerate token?").should("exist");
+        cy.findByRole("button", { name: /Regenerate now/ }).click();
+      });
+
+      // the post-confirm modal does not appear; error surfaces on the form
+      H.modal().should("not.exist");
+      H.main().within(() => {
+        cy.findByText("Failed to regenerate token. Please try again.").should(
+          "exist",
+        );
+        cy.findByText("An error occurred").should("not.exist");
+        cy.findByRole("button", { name: /Regenerate/ }).should("exist");
       });
     });
 
@@ -193,9 +224,9 @@ describe("scenarios > admin > settings > user provisioning", () => {
           "Generate a SCIM token below to complete the setup.",
         ).should("exist");
         cy.findByRole("button", { name: /Generate/ }).should("exist");
-        cy.findByText(
-          "Token failed to generate, please regenerate one.",
-        ).should("not.exist");
+        cy.findByText("Token failed to generate, Please try again.").should(
+          "not.exist",
+        );
       });
 
       cy.log("warning is removed once a token has been generated");

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
@@ -9,6 +9,7 @@ import {
 import {
   AdminSettingInput,
   BasicAdminSettingInput,
+  SetByEnvVar,
 } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import {
   useGetAdminSettingsDetailsQuery,
@@ -18,7 +19,17 @@ import {
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
-import { Button, Divider, Flex, Stack, Text, TextInput } from "metabase/ui";
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Icon,
+  Stack,
+  Text,
+  TextInput,
+} from "metabase/ui";
 import {
   useGetScimTokenQuery,
   useRegenerateScimTokenMutation,
@@ -64,16 +75,25 @@ export const UserProvisioning = () => {
 
   const isScimEnabled = !!settingValues?.["scim-enabled"];
   const isScimInitialized = !!maskedTokenRequest.data;
+  const scimEnabledSetting = fields?.["scim-enabled"];
+  const isScimSetByEnv =
+    !!scimEnabledSetting?.is_env_setting && !!scimEnabledSetting?.env_name;
 
-  // since the request to enable scim and create the first token are separate requests, it's possible
-  // that the token request failed or wasn't issued due to some interruption (network issue, instance down, etc.)
-  // we can detect this case by seeing the scim is enabled without any token after all requests for token have settled
-  // this is later used to show an error message based on this token not being found + encourage the user to go through
-  // the regenerate flow to get a new unmasked token
-  const isScimIncorrectlyIniailized = Boolean(
+  // SCIM can be enabled without a token existing — e.g. via config file or env var, or if the
+  // token-generation request failed during a previous UI-based enablement. In any of those cases
+  // we expose the SCIM configuration section so the user can generate a token themselves.
+  const isScimEnabledWithoutToken = Boolean(
     !isScimInitialized &&
     isScimEnabled &&
     !(isLoadingToken || maskedTokenRequest.isFetching),
+  );
+
+  // A token-generation attempt was made and failed (vs. "no attempt yet"). Used to surface the
+  // real failure on the token input instead of the generic "you need a token" Alert.
+  const hasTokenGenerationError = Boolean(
+    !isScimInitialized &&
+    regenerateTokenReq.error &&
+    !regenerateTokenReq.isLoading,
   );
 
   const samlUserProvisioningEnabled = useSetting(
@@ -88,7 +108,16 @@ export const UserProvisioning = () => {
     });
 
     if (!result.error && enabled && !isScimInitialized) {
-      await regenerateToken();
+      const regenerateResult = await regenerateToken();
+      if (!regenerateResult.error) {
+        openFirstEnabledModal();
+      }
+    }
+  };
+
+  const handleGenerateToken = async () => {
+    const result = await regenerateToken();
+    if (!result.error) {
       openFirstEnabledModal();
     }
   };
@@ -138,15 +167,25 @@ export const UserProvisioning = () => {
                   {t`When enabled, SAML user provisioning will be turned off in favor of SCIM.`}
                 </ScimTextWarning>
               )}
-              <BasicAdminSettingInput
-                inputType="boolean"
-                name="scim-enabled"
-                value={!!settingValues?.["scim-enabled"]}
-                onChange={(newValue) => handleScimEnabledChange(!!newValue)}
-              />
+              {isScimSetByEnv ? (
+                <SetByEnvVar varName={scimEnabledSetting.env_name!} />
+              ) : (
+                <BasicAdminSettingInput
+                  inputType="boolean"
+                  name="scim-enabled"
+                  value={!!settingValues?.["scim-enabled"]}
+                  onChange={(newValue) => handleScimEnabledChange(!!newValue)}
+                />
+              )}
+              {isScimEnabledWithoutToken && !hasTokenGenerationError && (
+                <Alert
+                  color="warning"
+                  icon={<Icon name="warning" />}
+                >{t`Generate a SCIM token below to complete the setup.`}</Alert>
+              )}
             </Stack>
 
-            {(isScimInitialized || isScimIncorrectlyIniailized) && (
+            {(isScimInitialized || isScimEnabledWithoutToken) && (
               <Stack
                 gap="2rem"
                 opacity={isScimEnabled ? 1 : 0.5}
@@ -165,24 +204,37 @@ export const UserProvisioning = () => {
                     disabled
                     w="100%"
                     error={
-                      isScimIncorrectlyIniailized &&
+                      hasTokenGenerationError &&
                       t`Token failed to generate, please regenerate one.`
                     }
                     styles={getTextInputStyles({
                       masked: true,
                       disabled: true,
                     })}
+                    inputContainer={(children) => (
+                      <Flex gap="sm">
+                        <Box style={{ flexGrow: 1 }}>{children}</Box>
+                        <Button
+                          disabled={isLoadingToken || !isScimEnabled}
+                          variant="filled"
+                          onClick={
+                            isScimInitialized
+                              ? openRegenerateModal
+                              : handleGenerateToken
+                          }
+                          style={{ flexShrink: 0 }}
+                        >
+                          {regenerateTokenReq.isLoading
+                            ? t`Generating...`
+                            : isScimInitialized
+                              ? t`Regenerate`
+                              : hasTokenGenerationError
+                                ? t`Retry`
+                                : t`Generate`}
+                        </Button>
+                      </Flex>
+                    )}
                   />
-                  <Button
-                    disabled={isLoadingToken || !isScimEnabled}
-                    variant="filled"
-                    onClick={openRegenerateModal}
-                    style={{ flexShrink: 0 }}
-                  >
-                    {regenerateTokenReq.isLoading
-                      ? t`Regenerating...`
-                      : t`Regenerate`}
-                  </Button>
                 </Flex>
               </Stack>
             )}

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
@@ -89,11 +89,10 @@ export const UserProvisioning = () => {
   );
 
   // A token-generation attempt was made and failed (vs. "no attempt yet"). Used to surface the
-  // real failure on the token input instead of the generic "you need a token" Alert.
+  // failure on the token input — both when no token existed yet (Generate failed) and when a token
+  // exists but regeneration failed.
   const hasTokenGenerationError = Boolean(
-    !isScimInitialized &&
-    regenerateTokenReq.error &&
-    !regenerateTokenReq.isLoading,
+    regenerateTokenReq.error && !regenerateTokenReq.isLoading,
   );
 
   const samlUserProvisioningEnabled = useSetting(
@@ -205,7 +204,9 @@ export const UserProvisioning = () => {
                     w="100%"
                     error={
                       hasTokenGenerationError &&
-                      t`Token failed to generate, please regenerate one.`
+                      (isScimInitialized
+                        ? t`Failed to regenerate token. Please try again.`
+                        : t`Token failed to generate, Please try again.`)
                     }
                     styles={getTextInputStyles({
                       masked: true,
@@ -264,6 +265,8 @@ export const UserProvisioning = () => {
         <UserProvisioningRegenerateTokenModal
           opened={showRegenerateModal}
           onClose={closeRegenerateModal}
+          regenerateToken={regenerateToken}
+          regenerateTokenReq={regenerateTokenReq}
         />
       </SettingsSection>
     </SettingsPageWrapper>

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import {
   findRequests,
@@ -21,9 +22,32 @@ import {
 
 import { UserProvisioning } from "./UserProvisioning";
 
+const MOCK_SCIM_TOKEN = {
+  key_prefix: "mb_/1qM",
+  key: "$2a$10$Mu6b.47KRz46Ko2eTJ8Os.3S2uKRwsjNxLZf3V1yVqiDnI3Ruv5C2",
+  masked_key: "mb_/1qM****************************************",
+  unmasked_key: "mb_/1qMpikachuoEbRrFa9XdAvRQfzyXcoiu1I0MfiEsmw=",
+  updated_by_id: 1,
+  name: "Metabase SCIM API Key - fc6a551f-d9ad-4d1a-9add-da3bedd12c87",
+  scope: "scim" as const,
+  creator_id: 1,
+  updated_at: "2025-01-12T16:08:20.164094Z",
+  created_at: "2025-01-12T16:08:20.164094Z",
+  user_id: null,
+  id: 626,
+};
+
 const setup = async ({
   settings: opts,
-}: { settings?: Partial<EnterpriseSettings> } = {}) => {
+  hasScimToken = true,
+  tokenGenerationFails = false,
+  settingDefinitions = [],
+}: {
+  settings?: Partial<EnterpriseSettings>;
+  hasScimToken?: boolean;
+  tokenGenerationFails?: boolean;
+  settingDefinitions?: Parameters<typeof setupSettingsEndpoints>[0];
+} = {}) => {
   const settings = createMockSettings({
     "token-features": createMockTokenFeatures({
       sso_jwt: true,
@@ -32,21 +56,18 @@ const setup = async ({
     ...opts,
   });
   setupPropertiesEndpoints(settings);
-  setupSettingsEndpoints([]);
-  setupScimEndpoints({
-    key_prefix: "mb_/1qM",
-    key: "$2a$10$Mu6b.47KRz46Ko2eTJ8Os.3S2uKRwsjNxLZf3V1yVqiDnI3Ruv5C2",
-    masked_key: "mb_/1qM****************************************",
-    unmasked_key: "mb_/1qMpikachuoEbRrFa9XdAvRQfzyXcoiu1I0MfiEsmw=",
-    updated_by_id: 1,
-    name: "Metabase SCIM API Key - fc6a551f-d9ad-4d1a-9add-da3bedd12c87",
-    scope: "scim",
-    creator_id: 1,
-    updated_at: "2025-01-12T16:08:20.164094Z",
-    created_at: "2025-01-12T16:08:20.164094Z",
-    user_id: null,
-    id: 626,
-  });
+  setupSettingsEndpoints(settingDefinitions);
+  if (hasScimToken) {
+    setupScimEndpoints(MOCK_SCIM_TOKEN);
+  } else {
+    fetchMock.get("path:/api/ee/scim/api_key", 404);
+    fetchMock.post(
+      "path:/api/ee/scim/api_key",
+      tokenGenerationFails
+        ? { status: 500, body: { message: "An error occurred" } }
+        : MOCK_SCIM_TOKEN,
+    );
+  }
   setupUpdateSettingEndpoint();
 
   renderWithProviders(<UserProvisioning />, {
@@ -162,5 +183,94 @@ describe("SCIM User Provisioning Settings", () => {
     expect(posts).toHaveLength(1);
     const [{ url }] = posts;
     expect(url).toMatch(/\/api\/ee\/scim\/api_key/);
+  });
+
+  describe("SCIM enabled without a token (e.g. via config file)", () => {
+    it("should show the warning and Generate button (and no error) when no token exists yet", async () => {
+      await setup({
+        settings: { "scim-enabled": true },
+        hasScimToken: false,
+      });
+
+      expect(
+        await screen.findByText(
+          "Generate a SCIM token below to complete the setup.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Generate")).toBeInTheDocument();
+      expect(screen.queryByText("Regenerate")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Token failed to generate, please regenerate one."),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should generate a token when Generate is clicked", async () => {
+      await setup({
+        settings: { "scim-enabled": true },
+        hasScimToken: false,
+      });
+
+      await userEvent.click(await screen.findByText("Generate"));
+
+      // the first-enabled modal should appear with the new token
+      await screen.findByText("Here's what you'll need to set SCIM up");
+
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+      const [{ url }] = posts;
+      expect(url).toMatch(/\/api\/ee\/scim\/api_key/);
+    });
+  });
+
+  describe("SCIM enabled with failed token generation", () => {
+    it("should show the token-failed error and a Retry button after a failed generation", async () => {
+      await setup({
+        settings: { "scim-enabled": true },
+        hasScimToken: false,
+        tokenGenerationFails: true,
+      });
+
+      // click Generate to trigger the failed attempt
+      await userEvent.click(await screen.findByText("Generate"));
+
+      // the modal is not opened on failure; the form surfaces the error directly
+      expect(
+        await screen.findByText(
+          "Token failed to generate, please regenerate one.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Retry")).toBeInTheDocument();
+      // the generic "needs a token" warning is suppressed in favor of the specific error
+      expect(
+        screen.queryByText(
+          "Generate a SCIM token below to complete the setup.",
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Here's what you'll need to set SCIM up"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("SCIM enabled via environment variable", () => {
+    it("should show the env-var message instead of the toggle when scim-enabled is set by env", async () => {
+      await setup({
+        settings: { "scim-enabled": true },
+        settingDefinitions: [
+          {
+            key: "scim-enabled",
+            is_env_setting: true,
+            env_name: "MB_SCIM_ENABLED",
+            value: true,
+          },
+        ],
+      });
+
+      expect(screen.getByTestId("setting-env-var-message")).toBeInTheDocument();
+      expect(screen.getByText(/MB_SCIM_ENABLED/)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("switch", { name: /scim/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.unit.spec.tsx
@@ -4,7 +4,6 @@ import fetchMock from "fetch-mock";
 import {
   findRequests,
   setupPropertiesEndpoints,
-  setupScimEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
@@ -58,16 +57,16 @@ const setup = async ({
   setupPropertiesEndpoints(settings);
   setupSettingsEndpoints(settingDefinitions);
   if (hasScimToken) {
-    setupScimEndpoints(MOCK_SCIM_TOKEN);
+    fetchMock.get("path:/api/ee/scim/api_key", MOCK_SCIM_TOKEN);
   } else {
     fetchMock.get("path:/api/ee/scim/api_key", 404);
-    fetchMock.post(
-      "path:/api/ee/scim/api_key",
-      tokenGenerationFails
-        ? { status: 500, body: { message: "An error occurred" } }
-        : MOCK_SCIM_TOKEN,
-    );
   }
+  fetchMock.post(
+    "path:/api/ee/scim/api_key",
+    tokenGenerationFails
+      ? { status: 500, body: { message: "An error occurred" } }
+      : MOCK_SCIM_TOKEN,
+  );
   setupUpdateSettingEndpoint();
 
   renderWithProviders(<UserProvisioning />, {
@@ -200,7 +199,7 @@ describe("SCIM User Provisioning Settings", () => {
       expect(screen.getByText("Generate")).toBeInTheDocument();
       expect(screen.queryByText("Regenerate")).not.toBeInTheDocument();
       expect(
-        screen.queryByText("Token failed to generate, please regenerate one."),
+        screen.queryByText("Token failed to generate, Please try again."),
       ).not.toBeInTheDocument();
     });
 
@@ -235,9 +234,7 @@ describe("SCIM User Provisioning Settings", () => {
 
       // the modal is not opened on failure; the form surfaces the error directly
       expect(
-        await screen.findByText(
-          "Token failed to generate, please regenerate one.",
-        ),
+        await screen.findByText("Token failed to generate, Please try again."),
       ).toBeInTheDocument();
       expect(screen.getByText("Retry")).toBeInTheDocument();
       // the generic "needs a token" warning is suppressed in favor of the specific error
@@ -249,6 +246,33 @@ describe("SCIM User Provisioning Settings", () => {
       expect(
         screen.queryByText("Here's what you'll need to set SCIM up"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("SCIM enabled with a token, regenerate fails", () => {
+    it("should close the regenerate modal and surface the error on the SCIM token field", async () => {
+      await setup({
+        settings: { "scim-enabled": true },
+        tokenGenerationFails: true,
+      });
+
+      await userEvent.click(await screen.findByText("Regenerate"));
+
+      // confirm modal
+      expect(await screen.findByText("Regenerate token?")).toBeInTheDocument();
+      await userEvent.click(await screen.findByText("Regenerate now"));
+
+      // the post-regenerate modal must NOT appear on failure
+      expect(
+        await screen.findByText(
+          "Failed to regenerate token. Please try again.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Regenerate token?")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Copy and save the SCIM token"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("An error occurred")).not.toBeInTheDocument();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioningModals.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioningModals.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { Button, Flex, Modal, type ModalProps, Stack, Text } from "metabase/ui";
-import { useRegenerateScimTokenMutation } from "metabase-enterprise/api";
+import type { useRegenerateScimTokenMutation } from "metabase-enterprise/api";
 
 import { CopyScimInput } from "./ScimInputs";
 import { ScimTextWarning } from "./ScimTextWarning";
@@ -59,26 +59,35 @@ export const UserProvisioningFirstEnabledModal = ({
   );
 };
 
-type UserProvisioningRegenerateTokenModalsProps = BaseUserProvisiongModalProps;
+type RegenerateMutation = ReturnType<typeof useRegenerateScimTokenMutation>;
+
+type UserProvisioningRegenerateTokenModalsProps =
+  BaseUserProvisiongModalProps & {
+    regenerateToken: RegenerateMutation[0];
+    regenerateTokenReq: RegenerateMutation[1];
+  };
 
 export const UserProvisioningRegenerateTokenModal = ({
   opened,
   onClose,
+  regenerateToken,
+  regenerateTokenReq,
 }: UserProvisioningRegenerateTokenModalsProps) => {
   const [confirmed, setConfirmed] = useState(false);
-  const [regenerateToken, regenerateTokenReq] =
-    useRegenerateScimTokenMutation();
 
+  // Don't reset the mutation on close — the parent form needs the error to persist.
   useEffect(() => {
     if (!opened) {
       setConfirmed(false);
-      regenerateTokenReq.reset();
     }
-  }, [opened, regenerateTokenReq]);
+  }, [opened]);
 
   const handleConfirmRegenerate = async () => {
     setConfirmed(true);
-    await regenerateToken();
+    const result = await regenerateToken();
+    if ("error" in result && result.error) {
+      onClose();
+    }
   };
 
   if (!confirmed) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72236
### Description
Quite a few changes made to the UX of the User Provisioning setup page. 
- We now show an alert if SCIM has been enabled but there is no token present in the app db
- We show an error if we try to generate a token but the request fails
- - This behaviour was previously driven by SCIM being enabled but the lack of the presence of a token. It's now driven by the request failing

### How to verify
1. Ensure that SCIM is not enabled on your instance. If there is a token, you can clear it from your app DB using `Delete from api_key where scope = 'scim';` (postgres)
2. Start up the BE with MB_SCIM_ENABLED=true
3. On the user provisioning page, you should see a warning that SCIM is not fully cconfigured. Generating a token should should dismiss the alert
4. Find a way to force an error response when generating a token, you should see an error message

### Demo
<img width="626" height="416" alt="image" src="https://github.com/user-attachments/assets/359ad305-2977-46f4-822d-d143f0b793a3" />
<img width="644" height="402" alt="image" src="https://github.com/user-attachments/assets/bcc73968-2919-4414-8bf6-1f13ad0f5643" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
