### PR TITLE
Open drills in Metabase for Claude and tweak tool description

### DIFF
--- a/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.ts
@@ -1,6 +1,7 @@
 import type { App } from "@modelcontextprotocol/ext-apps/react";
 import { useCallback } from "react";
 
+import * as Urls from "metabase/urls";
 import { utf8_to_b64 } from "metabase/utils/encoding";
 import type * as Lib from "metabase-lib";
 import type { Card } from "metabase-types/api";
@@ -33,6 +34,12 @@ const isStayDrill = (drillName: string | undefined) =>
     (prefix) => drillName === prefix || drillName.startsWith(`${prefix}.`),
   );
 
+const isClaudeHost = (app: App) => {
+  const hostVersion = app.getHostVersion();
+
+  return hostVersion?.name.toLowerCase().includes("claude");
+};
+
 type DrillThroughHandler = (
   params: { drillName?: string; nextCard: Card },
   defaultNavigate: () => Promise<void>,
@@ -48,6 +55,19 @@ export function useHandleMcpDrillThrough(app: App | null): DrillThroughHandler {
 
       const { instanceUrl, sessionToken, mcpSessionId } =
         (window.metabaseConfig as McpGlobalConfig | undefined) ?? {};
+
+      if (isClaudeHost(app)) {
+        if (!instanceUrl) {
+          await defaultNavigate();
+          return;
+        }
+
+        await app.openLink({
+          url: instanceUrl + Urls.serializedQuestion(nextCard),
+        });
+
+        return;
+      }
 
       if (!instanceUrl || !sessionToken || !mcpSessionId) {
         await defaultNavigate();

--- a/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useHandleMcpDrillThrough.unit.spec.ts
@@ -1,0 +1,92 @@
+import { renderHook } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import * as Urls from "metabase/urls";
+import { createMockCard } from "metabase-types/api/mocks";
+
+import { useHandleMcpDrillThrough } from "./useHandleMcpDrillThrough";
+
+const NEXT_CARD = createMockCard({
+  dataset_query: {
+    type: "query",
+    database: 1,
+    query: { "source-table": 2 },
+  },
+});
+
+describe("useHandleMcpDrillThrough", () => {
+  beforeEach(() => {
+    (window as any).metabaseConfig = {
+      instanceUrl: "https://metabase.example",
+      sessionToken: "session-token",
+      mcpSessionId: "mcp-session-id",
+    };
+
+    fetchMock.post("path:/api/embed-mcp/drills", { handle: "drill-handle" });
+  });
+
+  afterEach(() => {
+    delete (window as any).metabaseConfig;
+  });
+
+  it("opens drill-through questions in Metabase for Claude", async () => {
+    const app = {
+      getHostVersion: () => ({ name: "Claude Desktop", version: "1.0.0" }),
+      openLink: jest.fn(),
+      sendMessage: jest.fn(),
+    };
+
+    const defaultNavigate = jest.fn();
+    const { result } = renderHook(() => useHandleMcpDrillThrough(app as any));
+
+    await result.current(
+      { drillName: "fk-details", nextCard: NEXT_CARD },
+      defaultNavigate,
+    );
+
+    expect(app.openLink).toHaveBeenCalledWith({
+      url: "https://metabase.example" + Urls.serializedQuestion(NEXT_CARD),
+    });
+
+    // It should not do the drill operations: no saving queries, no inline navigation
+    expect(
+      fetchMock.callHistory.calls("path:/api/embed-mcp/drills"),
+    ).toHaveLength(0);
+
+    expect(app.sendMessage).not.toHaveBeenCalled();
+    expect(defaultNavigate).not.toHaveBeenCalled();
+  });
+
+  it("stores drill queries and sends a render handle for non-Claude hosts", async () => {
+    const app = {
+      getHostVersion: () => ({ name: "Cursor", version: "1.0.0" }),
+      openLink: jest.fn(),
+      sendMessage: jest.fn(),
+    };
+
+    const defaultNavigate = jest.fn();
+    const { result } = renderHook(() => useHandleMcpDrillThrough(app as any));
+
+    await result.current(
+      { drillName: "fk-details", nextCard: NEXT_CARD },
+      defaultNavigate,
+    );
+
+    expect(
+      fetchMock.callHistory.calls("path:/api/embed-mcp/drills"),
+    ).toHaveLength(1);
+
+    expect(app.sendMessage).toHaveBeenCalledWith({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Show me the result. Use handle drill-handle.",
+        },
+      ],
+    });
+
+    expect(app.openLink).not.toHaveBeenCalled();
+    expect(defaultNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -716,7 +716,11 @@
   Standard userspace query limits are enforced (2000 rows for simple queries, 10000 for aggregated)."
   {:scope metabot/agent-query-execute
    :tool  {:name "execute_query"
-           :description "Execute a previously constructed query and return the results with column metadata, row count, and execution time."
+           :description (str "Execute a previously constructed query and return raw results with column metadata, "
+                             "row count, and execution time. Use this when the user explicitly asks for raw data, "
+                             "rows, columns, counts, metadata, or programmatic query results. If the user asks to "
+                             "show, display, visualize, plot, chart, or present the result, use visualize_query "
+                             "instead.")
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -220,8 +220,12 @@
  :visualize-query
  {:name        "visualize_query"
   :description (str "Visualize a previously constructed query as an interactive chart or table. "
-                    "This renders the final answer in the UI. Do not call execute_query after "
-                    "visualize_query; showing the visualization is enough.")
+                    "Use this for prompts that ask to show, display, visualize, plot, chart, "
+                    "or present results, for example: `Show me customers in Metabase`, "
+                    "`Show me orders by month`, `Display revenue by region`, or "
+                    "`Visualize active users over time`. This renders the final answer in the UI. "
+                    "Do not call execute_query after visualize_query; showing the visualization "
+                    "is enough.")
   ;; Both fields are optional rather than expressing "at least one of" via a top-level `anyOf`.
   ;; This is because some MCP clients, e.g. the MCP inspector (mcpjam) rejects top-level combinators.
   ;; The response-fn enforces the at-least-one contract at runtime.


### PR DESCRIPTION
Closes EMB-1728

### Description

This PR adds two small MCP Apps follow-ups on top of `feat/builtin-mcp-ui`:

- In Claude Desktop hosts, external drill-throughs now open the serialized question in Metabase with `app.openLink` instead of asking Claude to render the drill result inside the MCP app. Stay-in-place drills, like zooming and sorting, still use the normal embedded navigation path.

- The MCP tool descriptions now make `visualize_query` the preferred tool for “show/display/visualize/plot/chart” prompts, while `execute_query` is scoped to raw/programmatic result requests.

### Demos

<img width="2230" height="1496" alt="CleanShot 2569-05-12 at 22 44 44@2x" src="https://github.com/user-attachments/assets/73a4e209-c540-4c45-b396-aeecd88ace62" />

### Testing Note ⚠️

You must test with `mcp-remote` on Claude Desktop by using the "Developer > Local MCP servers" section.

You **CANNOT** use Cloudflare or Ngrok tunnels with custom connectors for local testing because Claude Desktop strips HTTP domains such as `localhost:3000`, so nothing will load.

For local development: if you have tested other MCP Apps PR before, ⚠️ **please [enable and open DevTools for Claude](https://modelcontextprotocol.io/docs/tools/debugging#using-chrome-devtools) and make sure "Disable cache" is ticked**. We cache-bust in production via content hash, but in development you'll have to manually disable cache in DevTools.

(TL;DR: update `~/Library/Application Support/Claude/developer_settings.json` and set `{"allowDevTools": true}`) so you can enable Developer Tools and Disable cache)

<img width="400" src="https://github.com/user-attachments/assets/25f2e715-9105-492f-bfb7-3673eb890392" />

### How to verify

1. Start Metabase locally.

2. Connect an MCP client (e.g. [Claude Desktop](https://claude.ai/) or [MCPJam Inspector](https://app.mcpjam.com/)) to `http://localhost:3000/api/mcp`.

For Claude Desktop, edit your local MCP server config:

```bash
$EDITOR "/Users/$USER/Library/Application Support/Claude/claude_desktop_config.json"
```

Remove your previous MCP auth, if any:

```bash
rm -rf ~/.mcp-auth
```

Then change it to this:

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

Alternatively, you can try **connecting to the PR environment** i.e. https://pr74087.coredev.metabase.com/api/mcp instead of your local instance. Your Tailscale has to be on in that case. Note that if you change the AI settings, it would change it for everyone though!

```json
{
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "https://pr74087.coredev.metabase.com/api/mcp",
        "--allow-http"
      ]
    }
  }
}
```

You will see this screen in Claude Desktop's Developer settings:

<img width="600" alt="CleanShot 2569-03-27 at 07 20 04@2x" src="https://github.com/user-attachments/assets/ee099e96-76fc-4ea0-9df7-a7ea034b8a01" />

Alternatively for [MCPJam Inspector](https://app.mcpjam.com), use this setting:

<img width="600" alt="CleanShot 2569-03-27 at 07 19 25@2x" src="https://github.com/user-attachments/assets/413bd421-b7af-4921-83df-61d22f167987" />

3. With Claude enabled in AI settings, ask a prompt like “Show me customers in Metabase”. The model should prefer `visualize_query` over `execute_query`.

4. Use a drill-through that changes the question, such as "View this Orders". It should open the serialized question URL in Metabase.

5. (Optional) In a non-Claude MCP host, such as Cursor or MCPJam, try to use the same drill-through. It should keep the handle-based `render_drill_through` flow.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit tests
