### PR TITLE
Return client error when unable to acquire DB connection

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -351,7 +351,15 @@
   (binding [*connection-recursion-depth* (inc *connection-recursion-depth*)]
     (if-let [conn (:connection db-or-id-or-spec)]
       (f conn)
-      (let [get-conn (^:once fn* [] (.getConnection (do-with-resolved-connection-data-source driver db-or-id-or-spec options)))]
+      (let [get-conn (^:once fn* []
+                       (let [conn-data-source (do-with-resolved-connection-data-source driver db-or-id-or-spec options)]
+                         (try
+                           (.getConnection conn-data-source)
+                           (catch Throwable e
+                             (throw (ex-info (tru "Unable to connect to the database: {0}" (ex-message e))
+                                             {:type   driver-api/qp.error-type.unable-to-acquire-connection
+                                              :driver driver}
+                                             e))))))]
         (if (:keep-open? options)
           (f (get-conn))
           (with-open [conn ^Connection (get-conn)]

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -202,6 +202,7 @@
 (p/import-def qp.error-type/invalid-query qp.error-type.invalid-query)
 (p/import-def qp.error-type/missing-required-parameter qp.error-type.missing-required-parameter)
 (p/import-def qp.error-type/qp qp.error-type.qp)
+(p/import-def qp.error-type/unable-to-acquire-connection qp.error-type.unable-to-acquire-connection)
 (p/import-def qp.error-type/unsupported-feature qp.error-type.unsupported-feature)
 
 (def schema.common.non-blank-string

--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -109,6 +109,11 @@
   :parent invalid-query
   :show-in-embeds? true)
 
+(deferror unable-to-acquire-connection
+  "The query references a database that we are unable to acquire a connection to."
+  :parent client
+  :show-in-embeds? true)
+
 ;;;; ### Server-Side Errors
 
 (deferror server

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -227,7 +227,7 @@
       ;; before it gets to `do-with-resolved-connection-data-source`.
       (with-redefs [h2/check-read-only-statements (fn [_query] nil)
                     sql-jdbc.execute/do-with-resolved-connection-data-source
-                    (fn [driver db-or-id-or-spec options]
+                    (fn [_driver _db-or-id-or-spec _options]
                       (reify javax.sql.DataSource
                         (getConnection [_]
                           (throw (java.sql.SQLException. "connection error")))))]

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -6,6 +6,7 @@
    [metabase.driver :as driver]
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.lib.core :as lib]
    [metabase.test :as mt]
    [metabase.util.malli.registry :as mr])
   (:import
@@ -214,3 +215,12 @@
                    (fn [_conn] nil)))
                 (is (pos? (mt/metric-value system :metabase-db-connection/write-op
                                            {:connection-type "write-data"})))))))))))
+
+(deftest bad-connection-details-throw-client-error-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+    (mt/with-temp [:model/Database tmp-db {:engine  driver/*driver*
+                                           :details (assoc (:details (mt/db)) :host "badhost")}]
+      (let [mp (mt/application-database-metadata-provider (:id tmp-db))
+            query (lib/native-query mp "SELECT 1")
+            response (mt/user-http-request :crowberto :post 400 "dataset" query)]
+        (is (= "unable-to-acquire-connection" (:error_type response)))))))

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -217,6 +217,7 @@
 
 (deftest bad-connection-details-throw-client-error-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Database tmp-db {:details (assoc (:details (mt/db)) :host "badhost")
                                            :engine  driver/*driver*}]
       (let [query    {:database (:id tmp-db)

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -7,6 +7,7 @@
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [metabase.util.malli.registry :as mr])
   (:import
    (java.sql Connection DatabaseMetaData)
@@ -218,7 +219,7 @@
 (deftest bad-connection-details-throw-client-error-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
     #_{:clj-kondo/ignore [:discouraged-var]}
-    (mt/with-temp [:model/Database tmp-db {:details (assoc (:details (mt/db)) :host "badhost")
+    (mt/with-temp [:model/Database tmp-db {:details (tx/bad-connection-details driver/*driver*)
                                            :engine  driver/*driver*}]
       (let [query    {:database (:id tmp-db)
                       :type     :native

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -7,6 +7,7 @@
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.lib.core :as lib]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.test :as mt]
    [metabase.util.malli.registry :as mr])
   (:import
@@ -218,9 +219,9 @@
 
 (deftest bad-connection-details-throw-client-error-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
-    (mt/with-temp [:model/Database tmp-db {:engine  driver/*driver*
-                                           :details (assoc (:details (mt/db)) :host "badhost")}]
-      (let [mp (mt/application-database-metadata-provider (:id tmp-db))
-            query (lib/native-query mp "SELECT 1")
+    (mt/with-temp [:model/Database tmp-db {:details (assoc (:details (mt/db)) :host "badhost")
+                                           :engine  driver/*driver*}]
+      (let [mp       (lib.tu/mock-metadata-provider {:database {:id (:id tmp-db)}})
+            query    (lib/native-query mp "SELECT 1")
             response (mt/user-http-request :crowberto :post 400 "dataset" query)]
         (is (= "unable-to-acquire-connection" (:error_type response)))))))

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -6,8 +6,6 @@
    [metabase.driver :as driver]
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.lib.core :as lib]
-   [metabase.lib.test-util :as lib.tu]
    [metabase.test :as mt]
    [metabase.util.malli.registry :as mr])
   (:import
@@ -221,7 +219,8 @@
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
     (mt/with-temp [:model/Database tmp-db {:details (assoc (:details (mt/db)) :host "badhost")
                                            :engine  driver/*driver*}]
-      (let [mp       (lib.tu/mock-metadata-provider {:database {:id (:id tmp-db)}})
-            query    (lib/native-query mp "SELECT 1")
+      (let [query    {:database (:id tmp-db)
+                      :type     :native
+                      :native   {:query "SELECT 1"}}
             response (mt/user-http-request :crowberto :post 400 "dataset" query)]
         (is (= "unable-to-acquire-connection" (:error_type response)))))))

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -5,6 +5,7 @@
    [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.connection :as driver.conn]
+   [metabase.driver.h2 :as h2]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
@@ -221,8 +222,17 @@
     #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Database tmp-db {:details (tx/bad-connection-details driver/*driver*)
                                            :engine  driver/*driver*}]
-      (let [query    {:database (:id tmp-db)
-                      :type     :native
-                      :native   {:query "SELECT 1"}}
-            response (mt/user-http-request :crowberto :post 400 "dataset" query)]
-        (is (= "unable-to-acquire-connection" (:error_type response)))))))
+      ;; It's not straightforward to trigger a `.getConnection` error for some drivers (e.g. sqlite)
+      ;; so just mock the exception. Also need to mock this h2 method so that the query doesn't fail
+      ;; before it gets to `do-with-resolved-connection-data-source`.
+      (with-redefs [h2/check-read-only-statements (fn [_query] nil)
+                    sql-jdbc.execute/do-with-resolved-connection-data-source
+                    (fn [driver db-or-id-or-spec options]
+                      (reify javax.sql.DataSource
+                        (getConnection [_]
+                          (throw (java.sql.SQLException. "connection error")))))]
+        (let [query    {:database (:id tmp-db)
+                        :type     :native
+                        :native   {:query "SELECT 1"}}
+              response (mt/user-http-request :crowberto :post 400 "dataset" query)]
+          (is (= "unable-to-acquire-connection" (:error_type response))))))))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -1154,32 +1154,29 @@
 (doseq [driver [:h2 :sqlite]]
   (defmethod bad-connection-details driver
     [_driver]
-    nil))
+    {:db (u.random/random-name)}))
 
-(doseq [driver [:bigquery-cloud-sdk]]
-  (defmethod bad-connection-details driver
-    [_driver]
-    {:project-id (u.random/random-name)}))
+(defmethod bad-connection-details :bigquery-cloud-sdk
+  [_driver]
+  {:project-id (u.random/random-name)})
 
 (doseq [driver [:redshift :snowflake :vertica :sparksql]]
   (defmethod bad-connection-details driver
     [_driver]
     {:db (u.random/random-name)}))
 
-(doseq [driver [:oracle]]
-  (defmethod bad-connection-details driver
-    [_driver]
-    {:service-name (u.random/random-name)}))
+(defmethod bad-connection-details :oracle
+  [_driver]
+  {:service-name (u.random/random-name)})
 
 (doseq [driver [:presto-jdbc :databricks]]
   (defmethod bad-connection-details driver
     [_driver]
     {:catalog (u.random/random-name)}))
 
-(doseq [driver [:athena]]
-  (defmethod bad-connection-details driver
-    [_driver]
-    {:access_key (u.random/random-name)}))
+(defmethod bad-connection-details :athena
+  [_driver]
+  {:access_key (u.random/random-name)})
 
 (doseq [driver [:postgres :mysql :snowflake :databricks :redshift :sqlite :vertica :athena :oracle]]
   (defmethod driver/database-supports? [driver :test/arrays]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73516

### Description

Introduces a new client error type to return when we are unable to acquire a connection to a data warehouse. 

### How to verify

1. Set up a DWH
2. Save a question and see that it can be executed
3. Invalidate the DB details (e.g. manually update the DWH details in the app DB)
4. Now see a client error when trying to execute the question, rather than a generic metabase server error

### Demo

<details>

<summary>screenshot</summary>

<img width="804" height="357" alt="Screenshot 2026-05-12 at 11 39 39 AM" src="https://github.com/user-attachments/assets/2fdeb996-2954-418a-98e7-df6f5efa1f32" />

</details>


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
