### PR TITLE
Login requests include the user ID who successfully logged in

### DIFF
--- a/src/metabase/request/cookies.clj
+++ b/src/metabase/request/cookies.clj
@@ -37,7 +37,7 @@
   [response]
   (if (and (map? response) (contains? response :body))
     response
-    {:body response, :status 200}))
+    (with-meta {:body response, :status 200} (meta response))))
 
 (defn clear-session-cookie
   "Add a header to `response` to clear the current Metabase session cookie."

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -233,9 +233,11 @@
           (let [info           {:request       request
                                 :start-time    (u/start-timer)
                                 :call-count-fn call-count-fn
-                                :diag-info-fn  diag-info-fn
-                                :log-context   {:metabase-user-id api/*current-user-id*}}
+                                :diag-info-fn  diag-info-fn}
                 response->info (fn [response]
-                                 (assoc info :response response))
+                                 (assoc info
+                                        :response response
+                                        :log-context {:metabase-user-id (or (:metabase-user-id (meta response))
+                                                                            api/*current-user-id*)}))
                 respond        (comp respond logged-response response->info)]
             (handler request respond raise)))))))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -130,7 +130,8 @@
         request-time (t/zoned-date-time (t/zone-id "GMT"))
         do-login     (fn []
                        (let [{session-key :key, :as session} (login username password (request/device-info request))
-                             response                        {:id (str session-key)}]
+                             response                        (vary-meta {:id (str session-key)}
+                                                                        assoc :metabase-user-id (:user_id session))]
                          (request/set-session-cookies request response session request-time)))]
     (if throttling-disabled?
       (do-login)
@@ -241,10 +242,11 @@
                        :provider/emailed-secret-password-reset]
                       request-body)]
     (if (:success? auth-result)
-      (request/set-session-cookies request
-                                   {:success true :session_id (get-in auth-result [:session :key])}
-                                   (:session auth-result)
-                                   (t/zoned-date-time (t/zone-id "GMT")))
+      (let [session  (:session auth-result)
+            response (vary-meta {:success true :session_id (str (:key session))}
+                                assoc :metabase-user-id (:user_id session))]
+        (request/set-session-cookies request response session
+                                     (t/zoned-date-time (t/zone-id "GMT"))))
       (api/throw-invalid-param-exception :password (tru "Invalid reset token")))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -298,8 +300,9 @@
               (cond
                 ;; Login succeeded
                 (:success? login-result)
-                (let [session (:session login-result)
-                      response {:id (str (:key session))}]
+                (let [session  (:session login-result)
+                      response (vary-meta {:id (str (:key session))}
+                                          assoc :metabase-user-id (:user_id session))]
                   (request/set-session-cookies request
                                                response
                                                session

--- a/test/metabase/server/middleware/log_test.clj
+++ b/test/metabase/server/middleware/log_test.clj
@@ -33,3 +33,17 @@
       (is (not (#'mw.log/should-log-request? {:uri "/api/health"})))
       (is (not (#'mw.log/should-log-request? {:uri "/livez"})))
       (is (not (#'mw.log/should-log-request? {:uri "/readyz"}))))))
+
+(deftest log-api-call-captures-user-id-from-response-metadata-test
+  (testing "log-api-call reads :metabase-user-id from response metadata (#74017)"
+    (let [logged-user-id (promise)
+          handler        (mw.log/log-api-call
+                          (fn [_request respond _raise]
+                            (respond (with-meta {:status 200 :body "ok"}
+                                                {:metabase-user-id 42}))))]
+      (with-redefs [mw.log/log-info (fn [info]
+                                      (deliver logged-user-id (get-in info [:log-context :metabase-user-id])))]
+        (handler {:request-method :post :uri "/api/session"}
+                 identity
+                 identity)
+        (is (= 42 (deref logged-user-id 1000 :timed-out)))))))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -50,6 +50,20 @@
     (is (malli= SessionResponse
                 (mt/client :post 200 "session" (mt/user->credentials :rasta))))))
 
+(deftest login-logs-user-id-test
+  (testing "POST /api/session log line includes the user ID after login (#74017)"
+    (mt/with-log-messages-for-level [messages [metabase.server.middleware.log :debug]]
+      (is (malli= SessionResponse
+                  (mt/client :post 200 "session" (mt/user->credentials :rasta))))
+      (let [rasta-id (test.users/user->id :rasta)
+            log-line (->> (messages)
+                          (m/find-first (fn [{:keys [message]}]
+                                          (and (string? message)
+                                               (re-find #"POST /api/session" message)))))]
+        (is (some? log-line))
+        (is (re-find (re-pattern (str ":metabase-user-id " rasta-id))
+                     (:message log-line)))))))
+
 (deftest login-mixed-case-email-test
   (testing "POST /api/session - login with email of mixed case"
     (let [creds    (update (mt/user->credentials :rasta) :username u/upper-case-en)
@@ -634,6 +648,29 @@
                                                  "\"email\":\"test@metabase.com\"}")})]
             (is (= {:errors {:_error "Your account is disabled."}}
                    (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
+
+(deftest google-auth-logs-user-id-test
+  (testing "POST /api/session/google_auth log line includes the user ID after login (#74017)"
+    (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
+      (mt/with-temp [:model/User {user-id :id} {:email "test@metabase.com"
+                                                :is_active true}]
+        (with-redefs [http/post (constantly
+                                 {:status 200
+                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                               "\"email_verified\":\"true\","
+                                               "\"given_name\":\"test\","
+                                               "\"family_name\":\"user\","
+                                               "\"email\":\"test@metabase.com\"}")})]
+          (mt/with-log-messages-for-level [messages [metabase.server.middleware.log :debug]]
+            (is (malli= SessionResponse
+                        (mt/client :post 200 "session/google_auth" {:token "foo"})))
+            (let [log-line (->> (messages)
+                                (m/find-first (fn [{:keys [message]}]
+                                                (and (string? message)
+                                                     (re-find #"POST /api/session/google_auth" message)))))]
+              (is (some? log-line))
+              (is (re-find (re-pattern (str ":metabase-user-id " user-id))
+                           (:message log-line))))))))))
 
 ;;; ------------------------------------------- TESTS FOR LDAP AUTH STUFF --------------------------------------------
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74017
Fixes UXW-4046.

### Description

Previously, because the user was not yet logged in, the logs for
`POST /api/session` showed `{:metabase-user-id nil}` because
`api/*current-user-id*` was not set at the start of that request.

Now `server.middleware.log` tries to find the user ID in the
`(meta response)`, and falls back to `api/*current-user-id*` if it's not
set. All the login handlers now set the metadata of the `response`, and
it is propagated through the response body wrapper middleware.

### How to verify

- Check out the new integration tests.
- Log out and back in to your local instance
  - Observe that the user ID is populated for login. (`POST /api/session`)
- Likewise when using Google auth (`POST /api/session/google_auth`)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
