### PR TITLE
turn off db routing for dependencies analysis

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2952,6 +2952,7 @@
            api
            app-db
            collections
+           database-routing
            documents
            driver
            events

--- a/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.dependencies.native-validation
   (:require
    [clojure.string :as str]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.lib.core :as lib]
@@ -22,9 +23,10 @@
   parameter substitution must happen INSIDE the *compile-with-inline-parameters* binding
   to produce inline literals instead of ? placeholders."
   [query :- ::lib.schema/query]
-  (let [with-params (lib/add-parameters-for-template-tags query)
-        compiled    (qp.compile/compile-with-inline-parameters with-params)]
-    (lib/native-query with-params (:query compiled))))
+  (database-routing/with-database-routing-off
+    (let [with-params (lib/add-parameters-for-template-tags query)
+          compiled    (qp.compile/compile-with-inline-parameters with-params)]
+      (lib/native-query with-params (:query compiled)))))
 
 (defn- has-substitutable-template-tags?
   "Returns true if the query has any card or table template tags that need

--- a/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
@@ -10,7 +10,11 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- fake-query
   ([mp query]
@@ -609,3 +613,21 @@
                                                           :display-name "My Table"
                                                           :table-id     1}}))]
       (is (empty? (deps.native-validation/validate-native-query driver query))))))
+
+(deftest ^:sequential validate-native-query-with-database-routing-test
+  (testing "native query validation works on databases with routing enabled (#74084)"
+    (mt/with-premium-features #{:database-routing}
+      (let [mp     (mt/metadata-provider)
+            driver (:engine (lib.metadata/database mp))]
+        (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
+                                                :user_attribute "db_name"}]
+          (testing "validate-native-query doesn't throw"
+            ;; Without the fix, this would throw:
+            ;; "Anonymous users cannot access a database with routing enabled."
+            (is (set? (deps.native-validation/validate-native-query
+                       driver
+                       (lib/native-query mp "SELECT * FROM ORDERS")))))
+          (testing "native-query-deps doesn't throw (backfill path)"
+            (is (set? (deps.native-validation/native-query-deps
+                       driver
+                       (lib/native-query mp "SELECT * FROM ORDERS"))))))))))


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/74084

BAD:
when we analyze dependencies of a card, we hit the db routing middleware, there's no current user so it errors.

```
clojure.lang.ExceptionInfo: Error preprocessing query in #'metabase.query-processor.middleware.enterprise/attach-destination-db-middleware: Anonymous users cannot access a database with routing enabled.
{:fn #'metabase.query-processor.middleware.enterprise/attach-destination-db-middleware, :query {:lib/type :mbql/query, :lib/metadata (metabase.lib.metadata.invocation-tracker/invocation-tracker-provider (metabase.lib.metadata.cached-provider/cached-metadata-provider (metabase.lib-be.metadata.jvm/->UncachedApplicationDatabaseMetadataProvider 743))), :stages [{:lib/type :mbql.stage/native, :native "SELECT * FROM ORDERS"}], :database 743}, :type :qp}
 at metabase.query_processor.preprocess$fn__126698$preprocess126697__126699$fn__126700$fn__126701.invoke (preprocess.clj:149)
    clojure.lang.PersistentVector.reduce (PersistentVector.java:418)
    clojure.core$transduce.invokeStatic (core.clj:7025)
    clojure.core$transduce.invoke (core.clj:7012)
    metabase.query_processor.preprocess$fn__126698$preprocess126697__126699$fn__126700.invoke (preprocess.clj:123)
    metabase.query_processor.setup$fn__126674$do_with_qp_setup126673__126675.invoke (setup.clj:232)
    metabase.query_processor.setup$fn__126674$fn__126679.invoke (setup.clj:223)
    metabase.query_processor.preprocess$fn__126698$preprocess126697__126699.invoke (preprocess.clj:121)
    metabase.query_processor.preprocess$fn__126698$fn__126725.invoke (preprocess.clj:116)
    metabase.query_processor.compile$fn__126766$compile126765__126767$fn__126768.invoke (compile.clj:66)
    metabase.query_processor.setup$fn__126665$do_with_canceled_chan126664__126666$fn__126667.invoke (setup.clj:196)
    metabase.query_processor.setup$fn__126655$do_with_database_local_settings126654__126656$fn__126657.invoke (setup.clj:188)
    metabase.query_processor.setup$fn__126635$do_with_driver126634__126636$fn__126637$fn__126640.invoke (setup.clj:173)
    metabase.driver$do_with_driver.invokeStatic (driver.clj:54)
    metabase.driver$do_with_driver.invoke (driver.clj:49)
    metabase.query_processor.setup$fn__126635$do_with_driver126634__126636$fn__126637.invoke (setup.clj:172)
    metabase.query_processor.setup$fn__126622$do_with_metadata_provider126621__126623$fn__126624$fn__126625.invoke (setup.clj:141)
    metabase.query_processor.store$fn__105777$do_with_metadata_provider105776__105778.invoke (store.clj:200)
    metabase.query_processor.store$fn__105777$fn__105781.invoke (store.clj:186)
    metabase.query_processor.store$fn__105777$do_with_metadata_provider105776__105778.invoke (store.clj:193)
    metabase.query_processor.store$fn__105777$fn__105781.invoke (store.clj:186)

```

GOOD:
analyze the card's dependencies. DB routing uses identical shaped databases so this is fine and desired.

It's also possible that this puts these tasks into weird error states and then lots of them build up.