### PR TITLE
placeholder message record to fix ordering semantics

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
@@ -96,7 +96,7 @@
                             [:= :mm.conversation_id :c.id]
                             [:= :mm.role "assistant"]
                             [:= :mm.deleted_at nil]]
-                 :order-by [[:mm.created_at :asc]]
+                 :order-by [[:mm.created_at :asc] [:mm.id :asc]]
                  :limit    1}
                 :profile_id]]
    :from      [[:metabot_conversation :c]]
@@ -218,7 +218,7 @@
     (let [messages (t2/select :model/MetabotMessage
                               :conversation_id conversation-id
                               {:where    [:= :deleted_at nil]
-                               :order-by [[:created_at :asc]]})
+                               :order-by [[:created_at :asc] [:id :asc]]})
           hydrated (t2/hydrate conversation :user)]
       {:conversation_id (:id conversation)
        :created_at      (:created_at conversation)

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/queries_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/queries_test.clj
@@ -232,7 +232,7 @@
           (is (= [] rows)))))))
 
 (deftest slackbot-native-shape-blocks-are-extracted-test
-  (testing "going-forward slackbot rows are persisted via store-native-parts!, so they carry
+  (testing "going-forward slackbot rows are persisted via finalize-assistant-turn!, so they carry
             the same :type 'tool-input'/'tool-output' block shape as in-app rows and the
             analytics extractor handles them identically"
     (with-stubbed-tables! ["orders"]

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
@@ -5,7 +5,7 @@ import type { MetabotAgentTurnError, MetabotChatMessage } from "../state/types";
 import { convertSlackChatMessage } from "./slack-mrkdwn";
 
 export type FetchedChatMessage = MetabotChatMessage & {
-  finished?: boolean;
+  finished?: boolean | null;
   error?: MetabotAgentTurnError | null;
 };
 

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.unit.spec.ts
@@ -4,7 +4,10 @@ import { normalizeFetchedChatMessages } from "./normalize-fetched-chat-messages"
 const agentText = (
   id: string,
   message: string,
-  extras: { finished?: boolean; error?: { message: string } | null } = {},
+  extras: {
+    finished?: boolean | null;
+    error?: { message: string } | null;
+  } = {},
 ): FetchedChatMessage => ({
   id,
   role: "agent",
@@ -70,6 +73,14 @@ describe("normalizeFetchedChatMessages", () => {
         type: "text",
         message: "hello",
       });
+    });
+
+    it("treats finished=null as not-aborted (no trailing turn_aborted)", () => {
+      const result = normalizeFetchedChatMessages([
+        agentText("a1", "hello", { finished: null }),
+      ]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ type: "text", message: "hello" });
     });
   });
 });

--- a/resources/migrations/061/20260512_metabot_message_finished_nullable.yaml
+++ b/resources/migrations/061/20260512_metabot_message_finished_nullable.yaml
@@ -1,0 +1,20 @@
+## Make metabot_message.finished nullable so it directly carries the
+## "in-flight placeholder" concept: NULL = placeholder (or stale stub),
+## true = completed, false = aborted, true + error = errored.
+
+databaseChangeLog:
+  - changeSet:
+      id: v61.2026-05-12T11:00:00
+      author: tyler
+      comment: Drop NOT NULL on metabot_message.finished so start-turn! placeholders can write NULL
+      changes:
+        - dropNotNullConstraint:
+            tableName: metabot_message
+            columnName: finished
+            columnDataType: ${boolean.type}
+      rollback:
+        - addNotNullConstraint:
+            tableName: metabot_message
+            columnName: finished
+            columnDataType: ${boolean.type}
+            defaultNullValue: true

--- a/resources/migrations/061/20260512_metabot_message_view_v3_id_tiebreak.yaml
+++ b/resources/migrations/061/20260512_metabot_message_view_v3_id_tiebreak.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: v61.2026-05-12T10:00:00
+      author: tyler
+      runOnChange: true
+      comment: Update v_metabot_conversations to tiebreak profile subqueries on mm.id
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_conversations/v3/postgres-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_conversations/v3/mysql-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_conversations/v3/h2-metabot_conversations.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_conversations/v2/postgres-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_conversations/v2/mysql-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_conversations/v2/h2-metabot_conversations.sql
+            relativeToChangelogFile: true

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v3/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v3/h2-metabot_conversations.sql
@@ -1,0 +1,98 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)             AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+   AND m.deleted_at IS NULL
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v3/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v3/mysql-metabot_conversations.sql
@@ -1,0 +1,98 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(CONCAT(u.first_name, ' ', u.last_name), u.email)         AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+   AND m.deleted_at IS NULL
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v3/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v3/postgres-metabot_conversations.sql
@@ -1,0 +1,98 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)            AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+       AND mm.deleted_at IS NULL
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+   AND m.deleted_at IS NULL
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -644,6 +644,9 @@
                           :labels [:profile-id]
                           ;; 1KB -> 5MB
                           :buckets [1000 5000 10000 50000 100000 500000 1000000 5000000]})
+   (prometheus/counter :metabase-metabot/turn-started
+                       {:description "A metabot turn was started (user row + assistant placeholder inserted)"
+                        :labels [:profile-id]})
 
    ;; release dashboard metrics
    (prometheus/counter :metabase-sync/failures

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -9,7 +9,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
-   [metabase.app-db.core :as app-db]
    [metabase.config.core :as config]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -55,62 +54,6 @@
   (when-let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)]
     (api/check-403 (mi/can-read? conversation))))
 
-(defn- store-aiservice-messages!
-  "Store messages that are going from ai-service.
-
-  `hostname` is the always-on `embedding_hostname`; `pii-info` is the gated map
-  returned by `analytics.core/pii-fields-from` (nil when the retention flag is
-  off). Both apply only on first insert per conversation (first-writer-wins)."
-  [conversation-id profile-id hostname pii-info messages]
-  (let [finish   (let [m (u/last messages)]
-                   (when (= (:_type m) :FINISH_MESSAGE)
-                     m))
-        state    (u/seek #(and (= (:_type %) :DATA)
-                               (= (:type %) "state"))
-                         messages)
-        messages (-> (remove #(or (= % state) (= % finish)) messages)
-                     vec)
-        ai-proxy? (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))]
-    (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
-                              (fn [existing]
-                                (cond-> {}
-                                  (nil? existing)
-                                  (assoc :user_id api/*current-user-id*)
-
-                                  state
-                                  (assoc :state state)
-
-                                  (and hostname (nil? (:embedding_hostname existing)))
-                                  (assoc :embedding_hostname hostname)
-
-                                  (and (:embedding_path pii-info) (nil? (:embedding_path existing)))
-                                  (assoc :embedding_path (:embedding_path pii-info))
-
-                                  (and (:user_agent pii-info) (nil? (:user_agent existing)))
-                                  (assoc :user_agent (:user_agent pii-info))
-
-                                  (and (:sanitized_user_agent pii-info) (nil? (:sanitized_user_agent existing)))
-                                  (assoc :sanitized_user_agent (:sanitized_user_agent pii-info))
-
-                                  (and (:ip_address pii-info) (nil? (:ip_address existing)))
-                                  (assoc :ip_address (:ip_address pii-info)))))
-    ;; NOTE: this will need to be constrained at some point, see BOT-386
-    (t2/insert! :model/MetabotMessage
-                {:conversation_id conversation-id
-                 :user_id         api/*current-user-id*
-                 :data            messages
-                 :usage           (:usage finish)
-                 :role            (:role (first messages))
-                 :profile_id      profile-id
-                 :external_id     (str (random-uuid))
-                 :total_tokens    (->> (vals (:usage finish))
-                                       ;; NOTE: this filter is supporting backward-compatible usage format, can be
-                                       ;; removed when ai-service does not give us `completionTokens` in `usage`
-                                       (filter map?)
-                                       (map #(+ (:prompt %) (:completion %)))
-                                       (apply +))
-                 :ai_proxied      (boolean ai-proxy?)})))
-
 (defn- streaming-writer-rf
   "Creates a reducing function that writes AI SDK lines to an OutputStream.
 
@@ -148,11 +91,16 @@
   connection, the pipeline stops via `reduced` and collected parts are still persisted.
 
   When `:debug?` is true, enables debug logging which emits a `debug_log` data
-  part at the end of the stream with full LLM request/response data per iteration."
-  [{:keys [metabot-id profile-id message context history conversation-id state debug? hostname pii-info]}]
+  part at the end of the stream with full LLM request/response data per iteration.
+
+  `:assistant-msg-id` is the PK of the placeholder assistant row created by
+  [[metabot.persistence/start-turn!]]; the finally block UPDATEs that row.
+  `:external-id` is the assistant row's `external_id`, threaded into the AI-SDK
+  line protocol so the client can correlate streamed messages with feedback."
+  [{:keys [metabot-id profile-id message context history conversation-id state debug?
+           assistant-msg-id external-id]}]
   (let [enriched-context (metabot.context/create-context context {:metabot-id metabot-id})
-        messages         (concat history [message])
-        external-id      (str (random-uuid))]
+        messages         (concat history [message])]
     (sr/streaming-response {:content-type "text/event-stream"} [^OutputStream os canceled-chan]
       (let [parts-atom (atom [])
             canceled?  (volatile! false)
@@ -180,17 +128,16 @@
                     aborted?       @canceled?
                     error-data     (when-not aborted?
                                      (:error (u/seek #(= :error (:type %)) combined-parts)))]
-                (metabot.persistence/store-native-parts!
-                 conversation-id profile-id combined-parts
-                 :hostname    hostname
-                 :pii-info    pii-info
-                 :external-id external-id
-                 :finished?   (not aborted?)
-                 :error       error-data))
+                (metabot.persistence/finalize-assistant-turn!
+                 conversation-id assistant-msg-id combined-parts
+                 :profile-id profile-id
+                 :finished?  (not aborted?)
+                 :error      error-data))
               (catch Exception e
-                (log/error e "Failed to persist native agent parts"
-                           {:conversation-id conversation-id
-                            :external-id     external-id})))))))))
+                (log/error e "Failed to finalize assistant turn"
+                           {:conversation-id  conversation-id
+                            :assistant-msg-id assistant-msg-id
+                            :external-id      external-id})))))))))
 
 (defn streaming-request
   "Handles an incoming request, making all required tool invocation, LLM call loops, etc.
@@ -210,20 +157,22 @@
         hostname   (analytics.core/extract-hostname (:origin request-info))
         pii-info   (analytics.core/pii-fields-from request-info)]
     (check-conversation-access! conversation_id)
-    (store-aiservice-messages! conversation_id profile-id hostname pii-info [message])
-
-    (log/info "Using native Clojure agent" {:profile-id profile-id :debug? debug?})
-    (native-agent-streaming-request
-     {:metabot-id      metabot-id
-      :profile-id      profile-id
-      :message         message
-      :context         context
-      :history         history
-      :conversation-id conversation_id
-      :state           state
-      :debug?          debug?
-      :hostname        hostname
-      :pii-info        pii-info})))
+    (let [{:keys [assistant-msg-id assistant-external-id]}
+          (metabot.persistence/start-turn! conversation_id profile-id message
+                                           :hostname hostname
+                                           :pii-info pii-info)]
+      (log/info "Using native Clojure agent" {:profile-id profile-id :debug? debug?})
+      (native-agent-streaming-request
+       {:metabot-id       metabot-id
+        :profile-id       profile-id
+        :message          message
+        :context          context
+        :history          history
+        :conversation-id  conversation_id
+        :state            state
+        :debug?           debug?
+        :assistant-msg-id assistant-msg-id
+        :external-id      assistant-external-id}))))
 
 (defn- legacy->modern-query
   [query]

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -104,6 +104,12 @@
     (sr/streaming-response {:content-type "text/event-stream"} [^OutputStream os canceled-chan]
       (let [parts-atom (atom [])
             canceled?  (volatile! false)
+            ;; Captures throwables that escape the agent loop's own `catch Exception`
+            ;; (e.g. setup-phase throws before the reducible is constructed, `Error`
+            ;; subclasses, or failures from the agent's recovery `rf` write). Without
+            ;; this, such turns finalize as `:finished true :error nil` — indistinguishable
+            ;; from a clean success.
+            thrown     (volatile! nil)
             ;; In dev mode, emit usage parts in the SSE stream for debugging/benchmarking.
             xf         (comp (u/tee-xf parts-atom)
                              (self.core/aisdk-line-xf {:emit-usage? config/is-dev?
@@ -122,12 +128,30 @@
           (catch org.eclipse.jetty.io.EofException _
             (vreset! canceled? true)
             (log/debug "Client disconnected during native agent streaming"))
+          (catch Throwable t
+            ;; `Throwable` (not `Exception`) so `Error` subclasses (OOM, etc.) still
+            ;; get captured into the row before they propagate. Don't re-throw: the
+            ;; HTTP 202 has already been committed and `streaming-response` will close
+            ;; the socket cleanly when this body fn returns. The error is fully
+            ;; captured in the row via the `finally` below and in the log here.
+            (vreset! thrown t)
+            (log/error t "Native agent stream failed"
+                       {:conversation-id conversation-id
+                        :assistant-msg-id assistant-msg-id
+                        :external-id     external-id}))
           (finally
             (try
               (let [combined-parts (into [] (metabot.persistence/combine-text-parts-xf) @parts-atom)
                     aborted?       @canceled?
-                    error-data     (when-not aborted?
-                                     (:error (u/seek #(= :error (:type %)) combined-parts)))]
+                    thrown-ex      @thrown
+                    ;; Precedence: aborted > thrown > streamed `:error`.
+                    ;;   - aborted: client is gone, no point recording why — they can't see it.
+                    ;;   - thrown:  more authoritative than any partial streamed error.
+                    ;;   - streamed: today's behavior for adapter/tool errors.
+                    error-data     (cond
+                                     aborted? nil
+                                     thrown-ex (metabot.persistence/throwable->error-payload thrown-ex)
+                                     :else (:error (u/seek #(= :error (:type %)) combined-parts)))]
                 (metabot.persistence/finalize-assistant-turn!
                  conversation-id assistant-msg-id combined-parts
                  :profile-id profile-id

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -190,6 +190,8 @@
                     originator-id (assoc :user_id originator-id)
                     channel-id    (assoc :channel_id channel-id)
                     slack-msg-id  (assoc :slack_msg_id slack-msg-id)))
+      ;; `:finished nil` is the in-flight marker; `finalize-assistant-turn!`
+      ;; UPDATEs to true (success/error) or false (aborted).
       (let [pk (t2/insert-returning-pk!
                 :model/MetabotMessage
                 (cond-> {:conversation_id conversation-id
@@ -199,7 +201,7 @@
                          :external_id     assistant-external-id
                          :total_tokens    0
                          :ai_proxied      (boolean ai-proxy?)
-                         :finished        false}
+                         :finished        nil}
                   user-id    (assoc :user_id user-id)
                   channel-id (assoc :channel_id channel-id)))]
         {:assistant-msg-id      pk
@@ -220,8 +222,8 @@
      `message-persist-bytes` histogram. Defaults to `\"unknown\"` so callers
      without a profile (e.g. test helpers) don't fail.
   - `:finished?` — boolean (default true). Set `false` only for client-aborted
-     turns; the placeholder's pre-existing `finished=false` is preserved when
-     this is explicitly false (no-op).
+     turns; either way the placeholder's `:finished` flips from NULL to a
+     concrete boolean so it stops being filtered as in-flight.
   - `:error` — JSON-serializable error payload; encoded into the `error` column.
   - `:slack-msg-id`, `:channel-id` — backfill onto the assistant row when known
      at completion (Slack response posts mid-stream)."
@@ -346,9 +348,15 @@
   "Stamp `:finished` and `:error` from the parent row onto the
   *last* agent-role chat message produced from it. The annotation describes the
   row's outcome, so it belongs on a single message — the FE expands it into a
-  trailing `turn_aborted` / `turn_errored` chat message."
-  [chat-messages {:keys [finished error] :or {finished true}}]
-  (let [decoded-error  (some-> error decode-error)
+  trailing `turn_aborted` / `turn_errored` chat message.
+
+  Parent `:finished nil` (stale placeholder past the grace window) becomes
+  `:finished false` so the FE renders it as aborted."
+  [chat-messages message]
+  (let [finished       (if (contains? message :finished)
+                         (or (:finished message) false)
+                         true)
+        decoded-error  (some-> (:error message) decode-error)
         last-agent-idx (->> chat-messages
                             (keep-indexed (fn [i m] (when (= "agent" (:role m)) i)))
                             last)]
@@ -373,18 +381,22 @@
 (defn message->chat-messages
   "Convert a single `MetabotMessage` model instance into a seq of `MetabotChatMessage` maps.
    Each message's `:data` (vector of content blocks) is flattened into typed chat messages.
-   Assistant rows that produced zero chat messages but carry `:error` or
-   `:finished false` get a synthetic empty text message so the FE has something
-   to render the alert on."
+   Assistant rows that produced zero chat messages but carry `:error`,
+   `:finished false`, or `:finished nil` (a stale placeholder past the grace
+   window) get a synthetic empty text message so the FE has something to render
+   the alert on."
   [message]
   (let [blocks       (or (:data message) [])
         external-id  (:external_id message)
         chat-msgs    (into [] (keep #(convert-content-block external-id %)) blocks)
         merged       (merge-tool-results chat-msgs blocks)
+        ;; Absent :finished is treated as true (success); only explicit nil
+        ;; (stale placeholder) or false (aborted) should drive the stub branch.
+        not-finished (and (contains? message :finished)
+                          (not (true? (:finished message))))
         with-stub    (if (and (= :assistant (:role message))
                               (empty? merged)
-                              (or (some? (:error message))
-                                  (false? (:finished message))))
+                              (or (some? (:error message)) not-finished))
                        [(empty-agent-placeholder message)]
                        merged)]
     (annotate-agent-messages with-stub message)))
@@ -430,15 +442,13 @@
 
 (defn- placeholder-still-active?
   "True if `row` is an in-flight placeholder created by [[start-turn!]] for a
-  stream that hasn't yet completed: assistant role, empty `:data`, `:finished`
-  false, no `:error`, and `:created_at` within the grace window. Used by
-  [[messages->chat-messages]] to suppress live placeholders from chat reads so a
-  reload mid-stream does not render an empty `turn_aborted` stub."
-  [{:keys [role data finished error created_at]}]
+  stream that hasn't yet completed: assistant role, `:finished` IS NULL (the
+  schema-level placeholder marker), and `:created_at` within the grace window.
+  Used by [[messages->chat-messages]] to suppress live placeholders from chat
+  reads so a reload mid-stream does not render an empty `turn_aborted` stub."
+  [{:keys [role finished created_at]}]
   (and (= :assistant role)
-       (false? finished)
-       (nil? error)
-       (or (nil? data) (empty? data))
+       (nil? finished)
        (some? created_at)
        (when-let [then (->instant created_at)]
          (< (.toMillis (java.time.Duration/between then (Instant/now)))

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -9,7 +9,11 @@
    [metabase.metabot.settings :as metabot.settings]
    [metabase.util :as u]
    [metabase.util.json :as json]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.time Instant LocalDateTime OffsetDateTime ZoneOffset)))
+
+(set! *warn-on-reflection* true)
 
 (def persisted-structured-output-keys
   "Subset of `:structured-output` that must survive persistence so
@@ -78,18 +82,17 @@
              (do (vreset! pending part)
                  (if prev (rf result prev) result)))))))))
 
-(defn store-native-parts!
-  "Persist assistant response parts directly in the native agent-loop format.
+(defn start-turn!
+  "Atomically begin a turn: upsert the conversation row, insert the user-message row,
+  and insert a placeholder assistant row. The placeholder's `created_at` is pinned
+  at turn start, so a retry submitted later cannot interleave its rows ahead of an
+  earlier turn's assistant reply when reads sort by `created_at`.
 
-  Takes raw AISDK parts (ideally after `combine-text-parts-xf` merging) and stores
-  them without the lossy AI-SDK-line round-trip that would strip `:structured-output`
-  from tool-output results. Preserves the `persisted-structured-output-keys` subset
-  that the analytics reader needs.
-
-  Positional args: `conversation-id`, `profile-id`, `parts`.
+  Positional args: `conversation-id`, `profile-id`, `user-message` (a single message
+  map matching the existing `:data` block shape, e.g. `{:role \"user\" :content ...}`).
 
   Keyword args:
-  - `:hostname` — always-on `embedding_hostname`; recorded on first insert only.
+  - `:hostname` — always-on `embedding_hostname`; recorded on conversation insert only.
   - `:pii-info` — gated PII map (`analytics.core/pii-fields-from`'s shape: keys
      `:embedding_path`, `:user_agent`, `:sanitized_user_agent`, `:ip_address`).
      Nil when the retention flag is off; individual keys recorded on first
@@ -97,54 +100,37 @@
   - `:slack-msg-id`, `:channel-id`, `:slack-team-id`, `:slack-thread-ts` — slack
      metadata. `:slack-team-id`/`:channel-id`/`:slack-thread-ts` land on the
      conversation row on first insert only; `:slack-msg-id`/`:channel-id` land on
-     the message row.
-  - `:user-id` — when set, recorded on the message row (slackbot uses this to
-     record the invoking Metabase user).
-  - `:external-id` — message external id used by feedback; generated if omitted.
+     the user-message row.
+  - `:user-id` — the turn's originator. Lands on the user-message row's
+     `user_id` and (on first insert) on the conversation row's `user_id`. Also
+     lands on the assistant placeholder row when explicitly passed — slackbot
+     uses this for per-row attribution in multi-user threads; the web UI omits
+     it so the assistant row's `user_id` stays NULL. Falls back to
+     `api/*current-user-id*` when omitted.
   - `:ai-proxy?` — override; otherwise derived from `llm-metabot-provider`.
-  - `:finished?` — boolean (default true). False only for client-aborted turns.
-  - `:error` — a JSON-serialized error that contains the error part that was
-     streamed to the client.
 
-  Returns the inserted `MetabotMessage` primary key."
-  [conversation-id profile-id parts
-   & {:keys [hostname pii-info external-id
-             slack-msg-id channel-id slack-team-id slack-thread-ts
-             user-id ai-proxy? finished? error]
-      :or   {finished? true}}]
-  (let [state-part  (u/seek #(and (= :data (:type %))
-                                  (= "state" (:data-type %)))
-                            parts)
-        usage       (extract-usage parts)
-        ai-proxy?   (if (some? ai-proxy?)
-                      ai-proxy?
-                      (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider)))
-        external-id (or external-id (str (random-uuid)))
-        ;; Filter out :start, :usage, :finish stream metadata. `:error` parts
-        ;; are dropped here too, but captured in the `error` column. Data
-        ;; parts are persisted (so the analytics view can surface them) except
-        ;; :state, which is salvaged to MetabotConversation.state via
-        ;; `state-part` above.
-        content     (->> parts
-                         (remove #(#{:start :usage :finish :error} (:type %)))
-                         (filter streaming/persistable-data-part?)
-                         (mapv strip-tool-output-bloat))]
-    (analytics/observe! :metabase-metabot/message-persist-bytes
-                        {:profile-id (or profile-id "unknown")}
-                        (u/string-byte-count (json/encode content)))
+  Returns `{:assistant-msg-id <pk> :assistant-external-id <uuid-str>}`."
+  [conversation-id profile-id user-message
+   & {:keys [hostname pii-info
+             channel-id slack-msg-id slack-team-id slack-thread-ts
+             user-id ai-proxy?]}]
+  (let [;; Originator: explicit `:user-id` wins; otherwise fall back to the
+        ;; auth-bound dynamic. Used for both the conversation `user_id` (on
+        ;; first insert) and the user-message row's `user_id`.
+        originator-id          (or user-id api/*current-user-id*)
+        ai-proxy?              (if (some? ai-proxy?)
+                                 ai-proxy?
+                                 (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider)))
+        assistant-external-id  (str (random-uuid))]
+    (analytics/inc! :metabase-metabot/turn-started
+                    {:profile-id (or profile-id "unknown")})
     (t2/with-transaction [_conn]
-      ;; Always upsert the conversation row — the assistant message insert FKs
-      ;; to it, and the caller may not have written a user-message row (e.g.
-      ;; slackbot replies to follow-ups inside an existing thread). `:state` is
-      ;; only updated when we actually have a fresh state part to record.
       (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
                                 (fn [existing]
                                   ;; `:user_id` is the originator — set on insert, never overwritten.
                                   (cond-> {}
                                     (nil? existing)
-                                    (assoc :user_id api/*current-user-id*)
-                                    state-part
-                                    (assoc :state (:data state-part))
+                                    (assoc :user_id originator-id)
                                     (and hostname (nil? (:embedding_hostname existing)))
                                     (assoc :embedding_hostname hostname)
                                     (and (:embedding_path pii-info) (nil? (:embedding_path existing)))
@@ -161,67 +147,80 @@
                                     (assoc :slack_channel_id channel-id)
                                     (and slack-thread-ts (nil? (:slack_thread_ts existing)))
                                     (assoc :slack_thread_ts slack-thread-ts))))
-      (t2/insert-returning-pk! :model/MetabotMessage
-                               (cond-> {:conversation_id conversation-id
-                                        :data            content
-                                        :usage           usage
-                                        :role            :assistant
-                                        :profile_id      profile-id
-                                        :external_id     external-id
-                                        :total_tokens    (->> (vals usage)
-                                                              (map #(+ (:prompt %) (:completion %)))
-                                                              (reduce + 0))
-                                        :ai_proxied      (boolean ai-proxy?)
-                                        :finished        (boolean finished?)
-                                        :error           (some-> error json/encode)}
-                                 channel-id   (assoc :channel_id channel-id)
-                                 slack-msg-id (assoc :slack_msg_id slack-msg-id)
-                                 user-id      (assoc :user_id user-id))))))
+      (t2/insert! :model/MetabotMessage
+                  (cond-> {:conversation_id conversation-id
+                           :data            [user-message]
+                           :role            :user
+                           :profile_id      profile-id
+                           :external_id     (str (random-uuid))
+                           :total_tokens    0
+                           :ai_proxied      (boolean ai-proxy?)}
+                    originator-id (assoc :user_id originator-id)
+                    channel-id    (assoc :channel_id channel-id)
+                    slack-msg-id  (assoc :slack_msg_id slack-msg-id)))
+      (let [pk (t2/insert-returning-pk!
+                :model/MetabotMessage
+                (cond-> {:conversation_id conversation-id
+                         :data            []
+                         :role            :assistant
+                         :profile_id      profile-id
+                         :external_id     assistant-external-id
+                         :total_tokens    0
+                         :ai_proxied      (boolean ai-proxy?)
+                         :finished        false}
+                  user-id    (assoc :user_id user-id)
+                  channel-id (assoc :channel_id channel-id)))]
+        {:assistant-msg-id      pk
+         :assistant-external-id assistant-external-id}))))
 
-(defn store-message!
-  "Persist messages to MetabotConversation and MetabotMessage tables."
-  [conversation-id profile-id messages & {:keys [slack-msg-id channel-id slack-team-id slack-thread-ts user-id ai-proxy?]}]
-  (let [finish   (let [m (u/last messages)]
-                   (when (= (:_type m) :FINISH_MESSAGE)
-                     m))
-        state    (u/seek #(and (= (:_type %) :DATA)
-                               (= (:type %) "state"))
-                         messages)
-        messages (-> (remove #(or (= % state) (= % finish)) messages)
-                     vec)]
-    (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
-                              (fn [existing]
-                                ;; `:user_id` and slack metadata identify the conversation —
-                                ;; set on insert, never overwritten.
-                                (cond-> {}
-                                  (nil? existing)
-                                  (assoc :user_id api/*current-user-id*)
-                                  state
-                                  (assoc :state state)
-                                  (and slack-team-id (nil? (:slack_team_id existing)))
-                                  (assoc :slack_team_id slack-team-id)
-                                  (and channel-id (nil? (:slack_channel_id existing)))
-                                  (assoc :slack_channel_id channel-id)
-                                  (and slack-thread-ts (nil? (:slack_thread_ts existing)))
-                                  (assoc :slack_thread_ts slack-thread-ts))))
-    ;; NOTE: this will need to be constrained at some point, see BOT-386
-    (t2/insert-returning-pk! :model/MetabotMessage
-                             (cond-> {:conversation_id conversation-id
-                                      :data            messages
-                                      :usage           (:usage finish)
-                                      :role            (:role (first messages))
-                                      :profile_id      profile-id
-                                      :external_id     (str (random-uuid))
-                                      :total_tokens    (->> (vals (:usage finish))
-                                                            ;; NOTE: this filter is supporting backward-compatible usage format, can be
-                                                            ;; removed when ai-service does not give us `completionTokens` in `usage`
-                                                            (filter map?)
-                                                            (map #(+ (:prompt %) (:completion %)))
-                                                            (apply +))
-                                      :ai_proxied (boolean ai-proxy?)}
-                               channel-id   (assoc :channel_id channel-id)
-                               slack-msg-id (assoc :slack_msg_id slack-msg-id)
-                               user-id      (assoc :user_id user-id)))))
+(defn finalize-assistant-turn!
+  "UPDATE the placeholder assistant row created by [[start-turn!]] with the final
+  streamed parts. Also writes a fresh `state` value to the conversation row when
+  a state data part is present in `parts`.
+
+  `parts` should be the post-[[combine-text-parts-xf]] parts vector. Stream metadata
+  (`:start`/`:usage`/`:finish`/`:error`) is filtered out before storage; usage is
+  accumulated separately into the `usage` column; the error part body, if any,
+  is captured into the `error` column via the `:error` kwarg.
+
+  Keyword args:
+  - `:profile-id` — same value passed to [[start-turn!]]; tags the
+     `message-persist-bytes` histogram. Defaults to `\"unknown\"` so callers
+     without a profile (e.g. test helpers) don't fail.
+  - `:finished?` — boolean (default true). Set `false` only for client-aborted
+     turns; the placeholder's pre-existing `finished=false` is preserved when
+     this is explicitly false (no-op).
+  - `:error` — JSON-serializable error payload; encoded into the `error` column.
+  - `:slack-msg-id`, `:channel-id` — backfill onto the assistant row when known
+     at completion (Slack response posts mid-stream)."
+  [conversation-id assistant-msg-id parts
+   & {:keys [profile-id finished? error slack-msg-id channel-id]
+      :or   {finished? true}}]
+  (let [state-part (u/seek #(and (= :data (:type %))
+                                 (= "state" (:data-type %)))
+                           parts)
+        usage      (extract-usage parts)
+        content    (->> parts
+                        (remove #(#{:start :usage :finish :error} (:type %)))
+                        (filter streaming/persistable-data-part?)
+                        (mapv strip-tool-output-bloat))]
+    (analytics/observe! :metabase-metabot/message-persist-bytes
+                        {:profile-id (or profile-id "unknown")}
+                        (u/string-byte-count (json/encode content)))
+    (t2/with-transaction [_conn]
+      (when state-part
+        (t2/update! :model/MetabotConversation conversation-id
+                    {:state (:data state-part)}))
+      (t2/update! :model/MetabotMessage assistant-msg-id
+                  (cond-> {:data         content
+                           :usage        usage
+                           :total_tokens (->> (vals usage)
+                                              (map #(+ (:prompt %) (:completion %)))
+                                              (reduce + 0))
+                           :finished     (boolean finished?)
+                           :error        (some-> error json/encode)}
+                    slack-msg-id (assoc :slack_msg_id slack-msg-id)
+                    channel-id   (assoc :channel_id channel-id))))))
 
 (defn set-response-slack-msg-id!
   "Backfill slack_msg_id on a MetabotMessage by primary key."
@@ -301,7 +300,7 @@
 
 (defn- decode-error
   "JSON-decode a row's `:error` column value (a string written by
-  `store-native-parts!`). Falls back to the raw value if it's not a JSON object."
+  `finalize-assistant-turn!`). Falls back to the raw value if it's not a JSON object."
   [error]
   (if (string? error)
     (try (json/decode+kw error)
@@ -374,13 +373,54 @@
           []
           messages))
 
+(def ^:private placeholder-grace-period-ms
+  "How long an unfinished placeholder row is treated as an in-flight stream rather
+  than a crashed/aborted turn. Generous enough to cover any plausible live agent
+  loop — the `transforms_codegen` profile allows 30 iterations and there is no
+  client-independent LLM timeout, so a long-running turn can easily exceed
+  several minutes. Readers older than this fall back to rendering the trailing
+  `turn_aborted` alert.
+
+  Bias: this is the 'show a still-running stream as aborted' window vs. the
+  'show a crashed turn as absent' window. The first is more user-visible (a
+  mid-stream refresh would alert 'Response was interrupted' for a turn that's
+  actually fine), so prefer the longer window."
+  (* 30 60 1000))
+
+(defn- ->instant
+  "Coerce a t2-returned datetime value to a `java.time.Instant`. Postgres returns
+  `OffsetDateTime`; H2 typically returns `LocalDateTime`."
+  ^Instant [v]
+  (cond
+    (instance? Instant v)        v
+    (instance? OffsetDateTime v) (.toInstant ^OffsetDateTime v)
+    (instance? LocalDateTime v)  (.toInstant ^LocalDateTime v ZoneOffset/UTC)))
+
+(defn- placeholder-still-active?
+  "True if `row` is an in-flight placeholder created by [[start-turn!]] for a
+  stream that hasn't yet completed: assistant role, empty `:data`, `:finished`
+  false, no `:error`, and `:created_at` within the grace window. Used by
+  [[messages->chat-messages]] to suppress live placeholders from chat reads so a
+  reload mid-stream does not render an empty `turn_aborted` stub."
+  [{:keys [role data finished error created_at]}]
+  (and (= :assistant role)
+       (false? finished)
+       (nil? error)
+       (or (nil? data) (empty? data))
+       (some? created_at)
+       (when-let [then (->instant created_at)]
+         (< (.toMillis (java.time.Duration/between then (Instant/now)))
+            placeholder-grace-period-ms))))
+
 (defn messages->chat-messages
   "Convert a seq of `MetabotMessage` model instances into a flat vector of `MetabotChatMessage` maps.
-  Errored pairs are dropped unless `:include-errored? true`."
+  In-flight placeholder rows (assistant rows still streaming) are always
+  skipped. Errored pairs are dropped unless `:include-errored? true`."
   ([messages] (messages->chat-messages messages nil))
   ([messages {:keys [include-errored?]}]
-   (->> (if include-errored? messages (drop-errored-pairs messages))
-        (into [] (mapcat message->chat-messages)))))
+   (let [active (remove placeholder-still-active? messages)]
+     (->> (if include-errored? active (drop-errored-pairs active))
+          (into [] (mapcat message->chat-messages))))))
 
 (defn conversation-detail
   "Conversation-with-chat-messages snapshot. Nil if not found."

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -153,6 +153,9 @@
         assistant-external-id  (str (random-uuid))]
     (analytics/inc! :metabase-metabot/turn-started
                     {:profile-id (or profile-id "unknown")})
+    ;; The user-message and assistant-placeholder rows share `created_at` because
+    ;; the column default resolves to `transaction_timestamp()`. Readers ordering
+    ;; metabot_message rows for chat-detail rendering must tiebreak on `:id`
     (t2/with-transaction [_conn]
       (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
                                 (fn [existing]
@@ -464,4 +467,4 @@
                                   {:where    [:and
                                               [:= :conversation_id conversation-id]
                                               [:= :deleted_at nil]]
-                                   :order-by [[:created_at :asc]]}))}))
+                                   :order-by [[:created_at :asc] [:id :asc]]}))}))

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -62,6 +62,35 @@
    {}
    parts))
 
+(defn throwable->error-payload
+  "Coerce a `Throwable` into the same JSON-encodable map shape a streamed
+  `:error` part carries, so a turn that fails by *throwing* persists in the
+  same column shape as one that fails by emitting an `:error` part. The FE
+  renders both via the `turn_errored` alert path with no branching."
+  [^Throwable t]
+  (let [data (ex-data t)]
+    (cond-> {:message (or (ex-message t) (.toString t))
+             :type    (.getName (class t))}
+      (seq data) (assoc :data data))))
+
+(defn- safe-encode-error
+  "JSON-encode an error payload, falling back to a stringified `:data` if the
+  first encode throws. Defense-in-depth: `metabase.server.middleware.json`
+  registers an `Object` `.toString` fallback encoder that handles most odd
+  values, but in contexts where that middleware hasn't been loaded — early
+  init, certain unit-test setups — an unusual `ex-data` value could still
+  throw. We'd rather persist a stringified payload than fail the whole UPDATE
+  and lose the row's error column to `nil`."
+  [error]
+  (when (some? error)
+    (try (json/encode error)
+         (catch Throwable _
+           (try (json/encode (cond-> error
+                               (map? error) (assoc :data (pr-str (:data error)))))
+                (catch Throwable _
+                  (json/encode {:message      (pr-str error)
+                                :encode-error true})))))))
+
 (defn combine-text-parts-xf
   "Transducer that merges consecutive `:text` parts into a single `:text` part.
   Non-text parts pass through unchanged. Used before persistence so streaming
@@ -218,7 +247,7 @@
                                               (map #(+ (:prompt %) (:completion %)))
                                               (reduce + 0))
                            :finished     (boolean finished?)
-                           :error        (some-> error json/encode)}
+                           :error        (safe-encode-error error)}
                     slack-msg-id (assoc :slack_msg_id slack-msg-id)
                     channel-id   (assoc :channel_id channel-id))))))
 

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -9,6 +9,7 @@
    [metabase.metabot.settings :as metabot.settings]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    (java.time Instant LocalDateTime OffsetDateTime ZoneOffset)))
@@ -65,8 +66,7 @@
 (defn throwable->error-payload
   "Coerce a `Throwable` into the same JSON-encodable map shape a streamed
   `:error` part carries, so a turn that fails by *throwing* persists in the
-  same column shape as one that fails by emitting an `:error` part. The FE
-  renders both via the `turn_errored` alert path with no branching."
+  same column shape as one that fails by emitting an `:error` part."
   [^Throwable t]
   (let [data (ex-data t)]
     (cond-> {:message (or (ex-message t) (.toString t))
@@ -438,7 +438,10 @@
   (cond
     (instance? Instant v)        v
     (instance? OffsetDateTime v) (.toInstant ^OffsetDateTime v)
-    (instance? LocalDateTime v)  (.toInstant ^LocalDateTime v ZoneOffset/UTC)))
+    (instance? LocalDateTime v)  (.toInstant ^LocalDateTime v ZoneOffset/UTC)
+    :else                        (do (log/warnf "Unhandled created_at type %s; cannot apply placeholder grace window"
+                                                (some-> v class .getName))
+                                     nil)))
 
 (defn- placeholder-still-active?
   "True if `row` is an in-flight placeholder created by [[start-turn!]] for a

--- a/src/metabase/slackbot/channel.clj
+++ b/src/metabase/slackbot/channel.clj
@@ -63,27 +63,26 @@
                                         :thread-ts            thread-ts
                                         :tool-name->friendly  tool-name->friendly})
         prefetched-viz (atom {})
-        on-data        (make-viz-prefetch-callback prefetched-viz)
-        stored-msg-id  (atom nil)]
+        on-data        (make-viz-prefetch-callback prefetched-viz)]
     (set-status! "Thinking...")
     (try
-      (let [message-external-id (make-streaming-ai-request
-                                 conversation-id
-                                 prompt
-                                 thread
-                                 bot-user-id
-                                 channel-id
-                                 extra-history
-                                 {:on-text              on-text
-                                  :on-tool-start        on-tool-start
-                                  :on-tool-end          nil
-                                  :on-data              on-data
-                                  :team-id              (:team_id auth-info)
-                                  :thread-ts            thread-ts
-                                  :req-slack-msg-id     (:ts event)
-                                  :get-res-slack-msg-id nil
-                                  :request-prompt       (channel-request-prompt prompt)
-                                  :stored-msg-id        stored-msg-id})]
+      (let [{message-external-id :external-id assistant-msg-id :msg-id}
+            (make-streaming-ai-request
+             conversation-id
+             prompt
+             thread
+             bot-user-id
+             channel-id
+             extra-history
+             {:on-text              on-text
+              :on-tool-start        on-tool-start
+              :on-tool-end          nil
+              :on-data              on-data
+              :team-id              (:team_id auth-info)
+              :thread-ts            thread-ts
+              :req-slack-msg-id     (:ts event)
+              :get-res-slack-msg-id nil
+              :request-prompt       (channel-request-prompt prompt)})]
         (when (seq @prefetched-viz)
           (set-status! "Rendering results..."))
         (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
@@ -96,7 +95,7 @@
               res                     (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
                                                                          final-text :blocks final-blocks)]
           (when-let [res-ts (:ts res)]
-            (metabot.persistence/set-response-slack-msg-id! @stored-msg-id res-ts))
+            (metabot.persistence/set-response-slack-msg-id! assistant-msg-id res-ts))
           (when-not (:ok res)
             (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
                         (:error res)

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -169,27 +169,27 @@
    - req-slack-msg-id: The Slack message ts for the user's incoming message
    - get-res-slack-msg-id: Function that returns the Slack message ts for the bot's response
 
-   Returns the `external-id` stamped on the assistant `metabot_message` row so
-   callers can encode it into feedback button payloads for direct resolution
-   without relying on a (channel, slack_msg_id) lookup."
+   Returns `{:msg-id <pk> :external-id <uuid-str>}` so callers can both reference
+   the assistant `metabot_message` row by primary key (e.g. to backfill
+   `slack_msg_id` after `chat.postMessage` returns) and bake the `external_id`
+   into feedback button payloads."
   [conversation-id prompt thread bot-user-id channel-id extra-history
    {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id
-           request-prompt stored-msg-id team-id thread-ts]}]
+           request-prompt team-id thread-ts]}]
   (let [message         (metabot.envelope/user-message prompt)
         ai-proxy?       (metabot/metabase-provider? (metabot.settings/llm-metabot-provider))
-        ;; Generated up front so it can be baked into feedback button payloads
-        ;; at the same time the assistant message is persisted.
-        external-id     (str (random-uuid))
-        ;; Persist the user message before setup so failed conversations are captured.
-        ;; `:user-id` stamps the author on the message row so participation-based
+        ;; Persist a placeholder assistant row up front so its `created_at` pins
+        ;; turn ordering before any retry can sneak in earlier-timestamped rows.
+        ;; `:user-id` stamps the author on both rows so participation-based
         ;; conversation read permissions work for multi-user Slack threads.
-        _               (metabot.persistence/store-message! conversation-id "slackbot" [message]
-                                                            :channel-id      channel-id
-                                                            :slack-team-id   team-id
-                                                            :slack-thread-ts thread-ts
-                                                            :slack-msg-id    req-slack-msg-id
-                                                            :user-id         api/*current-user-id*
-                                                            :ai-proxy?       ai-proxy?)
+        {:keys [assistant-msg-id assistant-external-id]}
+        (metabot.persistence/start-turn! conversation-id "slackbot" message
+                                         :channel-id      channel-id
+                                         :slack-team-id   team-id
+                                         :slack-thread-ts thread-ts
+                                         :slack-msg-id    req-slack-msg-id
+                                         :user-id         api/*current-user-id*
+                                         :ai-proxy?       ai-proxy?)
         data-idx        (volatile! -1)
         request-message (metabot.envelope/user-message (or request-prompt prompt))
         capabilities    (compute-capabilities)
@@ -242,24 +242,16 @@
                    :tracking-opts {:source     "slackbot"
                                    :session-id conversation-id}}))
       (finally
-        ;; Persist whatever parts we collected, even if the pipeline threw.
-        ;; Stores raw native parts (not the lossy AI-SDK-message round-trip) so
-        ;; tool-output :structured-output survives for analytics extraction.
-        (let [parts @parts-atom]
-          (when (seq parts)
-            (let [pk (metabot.persistence/store-native-parts!
-                      conversation-id "slackbot"
-                      (into [] (metabot.persistence/combine-text-parts-xf) parts)
-                      :channel-id      channel-id
-                      :slack-team-id   team-id
-                      :slack-thread-ts thread-ts
-                      :slack-msg-id    (when get-res-slack-msg-id (get-res-slack-msg-id))
-                      :user-id         api/*current-user-id*
-                      :external-id     external-id
-                      :ai-proxy?       ai-proxy?)]
-              (when stored-msg-id
-                (reset! stored-msg-id pk)))))))
-    external-id))
+        ;; UPDATE the placeholder with whatever parts we collected, even if the
+        ;; pipeline threw. Raw native parts (not the lossy AI-SDK-message
+        ;; round-trip) preserve tool-output :structured-output for analytics.
+        (metabot.persistence/finalize-assistant-turn!
+         conversation-id assistant-msg-id
+         (into [] (metabot.persistence/combine-text-parts-xf) @parts-atom)
+         :profile-id   "slackbot"
+         :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id)))))
+    {:msg-id      assistant-msg-id
+     :external-id assistant-external-id}))
 
 (def ^:private viz-data-types
   "DATA part types that represent visualizations."
@@ -558,21 +550,22 @@
     (try
       ;; Start stream early so assistant persistence has :slack_msg_id.
       (request-flush! true)
-      (let [message-external-id (make-streaming-ai-request
-                                 conversation-id
-                                 prompt
-                                 thread
-                                 bot-user-id
-                                 channel-id
-                                 extra-history
-                                 {:on-text              on-text
-                                  :on-tool-start        on-tool-start
-                                  :on-tool-end          on-tool-end
-                                  :on-data              on-data
-                                  :team-id              (:team_id auth-info)
-                                  :thread-ts            thread-ts
-                                  :req-slack-msg-id     (:ts event)
-                                  :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
+      (let [{message-external-id :external-id}
+            (make-streaming-ai-request
+             conversation-id
+             prompt
+             thread
+             bot-user-id
+             channel-id
+             extra-history
+             {:on-text              on-text
+              :on-tool-start        on-tool-start
+              :on-tool-end          on-tool-end
+              :on-data              on-data
+              :team-id              (:team_id auth-info)
+              :thread-ts            thread-ts
+              :req-slack-msg-id     (:ts event)
+              :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
         (request-flush! true)
         (when-not (await-for slack-writer-await-timeout-ms slack-writer)
           (log/warn "[slackbot] Timed out waiting for slack-writer agent to flush"))

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -202,6 +202,12 @@
                          {:metabot-id metabot.config/slackbot-metabot-id})
         messages        (conj (vec history) request-message)
         parts-atom      (atom [])
+        ;; Sibling capture for throwables that escape the agent loop's own
+        ;; `catch Exception`. The slack `send-dm-response` / `send-channel-response`
+        ;; wrappers already turn the rethrown error into a user-facing slack message;
+        ;; this volatile is purely so the persisted row's `:error` column matches the
+        ;; failure shape of a streamed `:error` part.
+        thrown          (volatile! nil)
         dispatch-xf     (comp
                          (u/tee-xf parts-atom)
                          (keep (fn [part]
@@ -241,6 +247,13 @@
                    :context       context
                    :tracking-opts {:source     "slackbot"
                                    :session-id conversation-id}}))
+      (catch Throwable t
+        ;; Capture for the finally's `:error` payload, then re-throw so the
+        ;; existing slack error-handling path (DM/channel) still surfaces a
+        ;; user-facing message. Unlike the HTTP path we *do* want the throw to
+        ;; propagate — the caller flushes / posts a fallback / cancels viz.
+        (vreset! thrown t)
+        (throw t))
       (finally
         ;; UPDATE the placeholder with whatever parts we collected, even if the
         ;; pipeline threw. Raw native parts (not the lossy AI-SDK-message
@@ -249,7 +262,8 @@
          conversation-id assistant-msg-id
          (into [] (metabot.persistence/combine-text-parts-xf) @parts-atom)
          :profile-id   "slackbot"
-         :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id)))))
+         :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
+         :error        (some-> @thrown metabot.persistence/throwable->error-payload))))
     {:msg-id      assistant-msg-id
      :external-id assistant-external-id}))
 

--- a/test/metabase/metabot/api/conversations_test.clj
+++ b/test/metabase/metabot/api/conversations_test.clj
@@ -140,9 +140,9 @@
           msg      {:role "user" :content "hello"}]
       (try
         (binding [api/*current-user-id* owner-id]
-          (#'metabot.persistence/store-message! convo-id "slackbot" [msg] :user-id owner-id))
+          (metabot.persistence/start-turn! convo-id "slackbot" msg :user-id owner-id))
         (binding [api/*current-user-id* other-id]
-          (#'metabot.persistence/store-message! convo-id "slackbot" [msg] :user-id other-id))
+          (metabot.persistence/start-turn! convo-id "slackbot" msg :user-id other-id))
         (is (= owner-id
                (:user_id (t2/select-one :model/MetabotConversation :id convo-id)))
             "originator user_id must not be overwritten when a second user writes to the same conversation")

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -13,6 +13,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.agent.core :as agent]
    [metabase.metabot.api :as api]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
@@ -204,6 +205,49 @@
                             "start-turn! inserted exactly user + placeholder; no extra row from finalize")))))))))
         (finally
           (.stop llm-server))))))
+
+(deftest thrown-during-agent-setup-persists-as-errored-test
+  (testing "A throwable escaping the agent loop (e.g. permission/setup throw before
+            the reducible is constructed) finalizes the placeholder with
+            :finished? true + a structured :error payload — distinguishable from
+            both a successful turn (error nil) and a client abort (finished false)."
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]
+      (binding [scope/*current-user-metabot-permissions* scope/all-yes-permissions]
+        (let [stored-parts  (atom nil)
+              stored-kwargs (atom nil)]
+          (with-redefs [;; Pre-reducible throw: this is the exact escape path the new
+                        ;; catch covers. The agent loop's own (catch Exception) is
+                        ;; inside the reify, so a throw from `run-agent-loop` itself
+                        ;; bypasses it entirely.
+                        agent/run-agent-loop
+                        (fn [_opts]
+                          (throw (ex-info "agent setup exploded"
+                                          {:status 503 :provider :test})))
+                        metabot.persistence/finalize-assistant-turn!
+                        (fn [_conv-id _pk parts & kwargs]
+                          (reset! stored-parts parts)
+                          (reset! stored-kwargs (apply hash-map kwargs)))]
+            (mt/with-model-cleanup [:model/MetabotMessage
+                                    [:model/MetabotConversation :created_at]]
+              (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                    {:message         "go"
+                                     :context         {}
+                                     :conversation_id (str (random-uuid))
+                                     :history         []
+                                     :state           {}})
+              (u/poll {:thunk       #(deref stored-kwargs)
+                       :done?       some?
+                       :interval-ms 10
+                       :timeout-ms  3000})
+              (is (some? @stored-kwargs)
+                  "finalize-assistant-turn! is called from the finally even when setup threw")
+              (is (true? (:finished? @stored-kwargs))
+                  "a thrown turn is :finished? true — `finished=false` is reserved for client aborts")
+              (is (=? {:message #"(?i)agent setup exploded"
+                       :type    "clojure.lang.ExceptionInfo"
+                       :data    {:status 503 :provider :test}}
+                      (:error @stored-kwargs))
+                  "the throwable becomes a structured error payload"))))))))
 
 (deftest settings-get-returns-live-models-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -100,8 +100,9 @@
     ;;   → lite-aisdk-xf → agent loop → aisdk-line-xf → streaming-writer-rf → client
     ;; The test client reads one byte and closes. The streaming-writer-rf's poll
     ;; of `canceled-chan` flips the `canceled?` volatile and returns `reduced`,
-    ;; the agent loop unwinds, and `store-native-parts!` is called from the
-    ;; `finally` with `:finished? false`.
+    ;; the agent loop unwinds, and `finalize-assistant-turn!` is called from the
+    ;; `finally` with `:finished? false`, UPDATEing the placeholder row inserted
+    ;; by `start-turn!`.
     (let [total-chunks  30
           cnt           (atom total-chunks)
           stored-parts  (atom nil)
@@ -161,40 +162,46 @@
           (search.tu/with-index-disabled
             (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]
               (let [real-http-post http/post]
-                (with-redefs [llm.settings/llm-openrouter-api-key      (constantly "fake-key")
-                              llm.settings/llm-openrouter-api-base-url (constantly llm-url)
-                              scope/resolve-user-permissions           (constantly scope/all-yes-permissions)
+                (with-redefs [llm.settings/llm-openrouter-api-key            (constantly "fake-key")
+                              llm.settings/llm-openrouter-api-base-url       (constantly llm-url)
+                              scope/resolve-user-permissions                 (constantly scope/all-yes-permissions)
                               ;; The fake LLM server doesn't gzip, but clj-http wraps with
                               ;; GZIPInputStream by default. Closing mid-stream causes ZLIB errors.
-                              http/post                                (fn [url opts]
-                                                                         (real-http-post url (assoc opts :decompress-body false)))
-                              metabot.context/create-context           (fn [ctx & _] ctx)
-                              metabot.persistence/store-native-parts!  (fn [_conv-id _prof-id parts & kwargs]
-                                                                         (reset! stored-parts parts)
-                                                                         (reset! stored-kwargs (apply hash-map kwargs)))
-                              sr/async-cancellation-poll-interval-ms   5]
+                              http/post                                      (fn [url opts]
+                                                                               (real-http-post url (assoc opts :decompress-body false)))
+                              metabot.context/create-context                 (fn [ctx & _] ctx)
+                              metabot.persistence/finalize-assistant-turn!   (fn [_conv-id _pk parts & kwargs]
+                                                                               (reset! stored-parts parts)
+                                                                               (reset! stored-kwargs (apply hash-map kwargs)))
+                              sr/async-cancellation-poll-interval-ms         5]
                   (testing "Closing stream body tears down the pipeline and persists the aborted turn"
                     (reset! cnt total-chunks)
                     (reset! stored-parts nil)
                     (reset! stored-kwargs nil)
-                    (let [body (mt/user-real-request :rasta :post 202 "metabot/agent-streaming"
-                                                     {:request-options {:as              :stream
-                                                                        :decompress-body false}}
-                                                     {:message         "Test closure"
-                                                      :context         {}
-                                                      :conversation_id (str (random-uuid))
-                                                      :history         []
-                                                      :state           {}})]
-                      (.read ^java.io.InputStream body) ;; start the handler
-                      (.close ^java.io.Closeable body)
-                      (u/poll {:thunk       #(deref stored-parts)
-                               :done?       some?
-                               :interval-ms 10
-                               :timeout-ms  3000})
-                      (is (some? @stored-parts)
-                          "store-native-parts! was called even though the client disconnected")
-                      (is (false? (:finished? @stored-kwargs))
-                          "the persisted turn is marked :finished? false — the cancel was detected"))))))))
+                    (mt/with-model-cleanup [:model/MetabotMessage
+                                            [:model/MetabotConversation :created_at]]
+                      (let [conversation-id (str (random-uuid))
+                            body (mt/user-real-request :rasta :post 202 "metabot/agent-streaming"
+                                                       {:request-options {:as              :stream
+                                                                          :decompress-body false}}
+                                                       {:message         "Test closure"
+                                                        :context         {}
+                                                        :conversation_id conversation-id
+                                                        :history         []
+                                                        :state           {}})]
+                        (.read ^java.io.InputStream body) ;; start the handler
+                        (.close ^java.io.Closeable body)
+                        (u/poll {:thunk       #(deref stored-parts)
+                                 :done?       some?
+                                 :interval-ms 10
+                                 :timeout-ms  3000})
+                        (is (some? @stored-parts)
+                            "finalize-assistant-turn! was called even though the client disconnected")
+                        (is (false? (:finished? @stored-kwargs))
+                            "the finalized turn is marked :finished? false — the cancel was detected")
+                        (is (= 2 (count (t2/select :model/MetabotMessage
+                                                   :conversation_id conversation-id)))
+                            "start-turn! inserted exactly user + placeholder; no extra row from finalize")))))))))
         (finally
           (.stop llm-server))))))
 
@@ -710,73 +717,79 @@
            (into [] (metabot.persistence/combine-text-parts-xf)
                  [{:type :text, :text "solo"}])))))
 
-(defn- store-and-check!
-  "Helper: call store-native-parts! with the given provider setting, return the stored message."
+(defn- start-and-finalize-with-provider!
+  "Helper: run start-turn! + finalize-assistant-turn! under `provider`, return the
+  finalized assistant row."
   [provider]
   (binding [mb.api/*current-user-id* (mt/user->id :crowberto)]
     (let [conv-id (str (random-uuid))]
       (try
         (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider provider]
-          (metabot.persistence/store-native-parts!
-           conv-id "internal"
-           [{:type :start :id "msg-1"}
-            {:type :text :text "Hello"}
-            ;; SSE usage parts carry bare model names (from provider API response)
-            {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 100 :completionTokens 50}}
-            {:type :data :data-type "state" :data {:step 1}}
-            {:type :finish}]
-           :external-id (str (random-uuid)))
-          (t2/select-one :model/MetabotMessage :conversation_id conv-id))
+          (let [{:keys [assistant-msg-id]} (metabot.persistence/start-turn!
+                                            conv-id "internal"
+                                            {:role "user" :content "hi"})]
+            (metabot.persistence/finalize-assistant-turn!
+             conv-id assistant-msg-id
+             [{:type :start :id "msg-1"}
+              {:type :text :text "Hello"}
+              ;; SSE usage parts carry bare model names (from provider API response)
+              {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 100 :completionTokens 50}}
+              {:type :data :data-type "state" :data {:step 1}}
+              {:type :finish}])
+            (t2/select-one :model/MetabotMessage assistant-msg-id)))
         (finally
           (t2/delete! :model/MetabotMessage :conversation_id conv-id)
           (t2/delete! :model/MetabotConversation :id conv-id))))))
 
-(deftest store-native-parts-ai-proxy-test
+(deftest start-turn-ai-proxy-test
   (testing "metabase/ provider prefix sets ai_proxied true and stores bare model names"
-    (let [msg (store-and-check! "metabase/anthropic/claude-sonnet-4-6")]
+    (let [msg (start-and-finalize-with-provider! "metabase/anthropic/claude-sonnet-4-6")]
       (is (true? (:ai_proxied msg)))
       (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
              (:usage msg))
           "usage keys should be bare model names, not metabase/anthropic/...")))
 
   (testing "BYOK provider (no metabase/ prefix) sets ai_proxied false"
-    (let [msg (store-and-check! "anthropic/claude-sonnet-4-6")]
+    (let [msg (start-and-finalize-with-provider! "anthropic/claude-sonnet-4-6")]
       (is (false? (:ai_proxied msg)))
       (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
              (:usage msg))))))
 
-(deftest store-native-parts-data-part-filtering-test
+(deftest finalize-assistant-turn-data-part-filtering-test
   (testing "persistable data parts land in MetabotMessage.data; state is salvaged to conversation and excluded from data"
     (binding [mb.api/*current-user-id* (mt/user->id :crowberto)]
       (let [conv-id (str (random-uuid))]
         (try
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-sonnet-4-6"]
-            (metabot.persistence/store-native-parts!
-             conv-id "internal"
-             [{:type :start :id "msg-1"}
-              {:type :text :text "Hi"}
-              {:type :data :data-type "navigate_to" :data "/question/1"}
-              {:type :data :data-type "todo_list" :version 1 :data [{:id "1" :content "x" :status "pending" :priority "low"}]}
-              {:type :data :data-type "code_edit" :version 1 :data {:buffer_id "b" :value "v"}}
-              {:type :data :data-type "transform_suggestion" :version 1 :data {}}
-              {:type :data :data-type "adhoc_viz" :version 1 :data {:query {} :link "/q"}}
-              {:type :data :data-type "static_viz" :version 1 :data {:entity_id 1}}
-              {:type :data :data-type "state" :data {:step 1}}
-              {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 1 :completionTokens 1}}
-              {:type :finish}])
-            (let [msg        (t2/select-one :model/MetabotMessage :conversation_id conv-id)
-                  conv       (t2/select-one :model/MetabotConversation :id conv-id)
-                  data-types (into #{} (keep :data-type) (:data msg))
-                  part-types (into #{} (map :type) (:data msg))]
-              (is (= #{"navigate_to" "todo_list" "code_edit" "transform_suggestion" "adhoc_viz" "static_viz"}
-                     data-types)
-                  "all persistable data parts (not state) should be in :data")
-              (is (contains? part-types "text")
-                  "text parts survive")
-              (is (not-any? part-types #{"start" "usage" "finish"})
-                  "stream metadata is dropped")
-              (is (= {:step 1} (:state conv))
-                  "state value is salvaged to MetabotConversation.state")))
+            (let [{:keys [assistant-msg-id]} (metabot.persistence/start-turn!
+                                              conv-id "internal"
+                                              {:role "user" :content "hi"})]
+              (metabot.persistence/finalize-assistant-turn!
+               conv-id assistant-msg-id
+               [{:type :start :id "msg-1"}
+                {:type :text :text "Hi"}
+                {:type :data :data-type "navigate_to" :data "/question/1"}
+                {:type :data :data-type "todo_list" :version 1 :data [{:id "1" :content "x" :status "pending" :priority "low"}]}
+                {:type :data :data-type "code_edit" :version 1 :data {:buffer_id "b" :value "v"}}
+                {:type :data :data-type "transform_suggestion" :version 1 :data {}}
+                {:type :data :data-type "adhoc_viz" :version 1 :data {:query {} :link "/q"}}
+                {:type :data :data-type "static_viz" :version 1 :data {:entity_id 1}}
+                {:type :data :data-type "state" :data {:step 1}}
+                {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 1 :completionTokens 1}}
+                {:type :finish}])
+              (let [msg        (t2/select-one :model/MetabotMessage assistant-msg-id)
+                    conv       (t2/select-one :model/MetabotConversation :id conv-id)
+                    data-types (into #{} (keep :data-type) (:data msg))
+                    part-types (into #{} (map :type) (:data msg))]
+                (is (= #{"navigate_to" "todo_list" "code_edit" "transform_suggestion" "adhoc_viz" "static_viz"}
+                       data-types)
+                    "all persistable data parts (not state) should be in :data")
+                (is (contains? part-types "text")
+                    "text parts survive")
+                (is (not-any? part-types #{"start" "usage" "finish"})
+                    "stream metadata is dropped")
+                (is (= {:step 1} (:state conv))
+                    "state value is salvaged to MetabotConversation.state"))))
           (finally
             (t2/delete! :model/MetabotMessage :conversation_id conv-id)
             (t2/delete! :model/MetabotConversation :id conv-id)))))))
@@ -910,7 +923,10 @@
     (let [captured-args (atom nil)
           test-metabot-id metabot.config/embedded-metabot-id]
       (with-redefs [metabot.config/check-metabot-enabled! (constantly nil)
-                    api/store-aiservice-messages!         (constantly nil)
+                    api/check-conversation-access!        (constantly nil)
+                    metabot.persistence/start-turn!       (fn [& _]
+                                                            {:assistant-msg-id 1
+                                                             :assistant-external-id "ext-id"})
                     api/native-agent-streaming-request    (fn [args]
                                                             (reset! captured-args args)
                                                             ;; Return a minimal streaming response
@@ -1108,7 +1124,7 @@
     (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
                                                                                                                        :is-locked   true}}})
                   metabot.config/check-metabot-enabled!     (constantly nil)
-                  api/store-aiservice-messages!             (fn [& _]
+                  metabot.persistence/start-turn!           (fn [& _]
                                                               (throw (ex-info "should not store messages" {})))
                   api/native-agent-streaming-request        (fn [& _]
                                                               (throw (ex-info "should not call agent" {})))]

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -325,7 +325,7 @@
                              rows)))))))))))
 
 (deftest start-turn-user-and-placeholder-share-created-at-test
-  (testing "user-message and assistant-placeholder rows inserted by start-turn! share created_at;
+  (testing "user-message and assistant-placeholder rows inserted by start-turn! share an instant;
             readers must tiebreak on :id to preserve user-before-assistant ordering"
     (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
       (let [conversation-id (str (random-uuid))]
@@ -338,8 +338,8 @@
           (is (= :user      (:role u)))
           (is (= :assistant (:role a)))
           (is (< (:id u) (:id a)) "user row is inserted first; smaller :id")
-          (is (= (:created_at u) (:created_at a))
-              "intra-transaction inserts resolve current_timestamp to the same value"))))))
+          (is (<= (compare (:created_at u) (:created_at a)) 0)
+              "user row's created_at is no later than the placeholder's"))))))
 
 (deftest conversation-detail-drops-errored-pair-under-created-at-collision-test
   (testing "drop-errored-pairs works correctly when the errored user/asst rows share created_at"
@@ -403,7 +403,8 @@
                                         :external_id     (or external-id (str (random-uuid)))
                                         :total_tokens    0
                                         :data            [{:type "text" :text text :id (str (random-uuid))}]
-                                        :created_at      created-at}
+                                        :created_at      created-at
+                                        :finished        true}
                                  deleted-at (assoc :deleted_at deleted-at))))]
         (t2/insert! :model/MetabotConversation {:id conversation-id :user_id user-id})
         (insert! {:text "second" :created-at (.plusSeconds now 2)})

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -448,6 +448,59 @@
         (let [row (t2/select-one :model/MetabotMessage assistant-msg-id)]
           [row (first (metabot-persistence/message->chat-messages row))])))))
 
+(deftest throwable->error-payload-test
+  (testing "matches the streamed :error part shape produced by the agent loop's
+            own catch (agent/core/error-part), so a thrown turn and a streamed
+            :error turn render identically through the FE."
+    (testing "ExceptionInfo with ex-data carries :message, :type, :data"
+      (is (= {:message "boom" :type "clojure.lang.ExceptionInfo" :data {:status 503}}
+             (metabot-persistence/throwable->error-payload
+              (ex-info "boom" {:status 503})))))
+    (testing "throwable without a message falls back to .toString so :message is never blank"
+      (let [payload (metabot-persistence/throwable->error-payload (NullPointerException.))]
+        (is (= "java.lang.NullPointerException" (:type payload)))
+        (is (string? (:message payload)))
+        (is (seq (:message payload)))))
+    (testing "empty ex-data is omitted (no spurious :data key)"
+      (is (not (contains? (metabot-persistence/throwable->error-payload (ex-info "x" {}))
+                          :data))))
+    (testing "non-ExceptionInfo throwables carry no :data"
+      (is (not (contains? (metabot-persistence/throwable->error-payload (RuntimeException. "oops"))
+                          :data))))))
+
+(deftest safe-encode-error-falls-back-when-encode-throws-test
+  (testing "If json/encode throws (e.g. an Object fallback encoder isn't loaded
+            in some early-init context), the error payload is re-encoded with
+            :data downgraded to pr-str so the row's error column is still
+            valid JSON. Without this, an unusual ex-data value would fail the
+            whole UPDATE and the row would stay with error=nil — looking like
+            a clean success."
+    (let [real-encode json/encode
+          ;; Simulate an encoder that chokes on a specific marker value, but
+          ;; otherwise behaves normally — so the fallback's *second* encode call
+          ;; (with :data swapped for pr-str) still succeeds.
+          fail-encode (fn fail-encode
+                        ([v] (fail-encode v nil))
+                        ([v opts]
+                         (if (and (map? v)
+                                  (= ::poison (some-> v :data :marker)))
+                           (throw (ex-info "simulated encoder failure" {}))
+                           (if opts (real-encode v opts) (real-encode v)))))]
+      (with-redefs [json/encode fail-encode]
+        (let [encoded (#'metabot-persistence/safe-encode-error
+                       {:message "wrapper"
+                        :type    "java.lang.RuntimeException"
+                        :data    {:marker ::poison :other "x"}})
+              decoded (json/decode+kw encoded)]
+          (is (= "wrapper" (:message decoded))
+              "top-level message survives the fallback")
+          (is (= "java.lang.RuntimeException" (:type decoded))
+              "top-level type survives the fallback")
+          (is (string? (:data decoded))
+              ":data is downgraded to a pr-str string")
+          (is (re-find #":marker" (:data decoded))
+              "stringified :data still carries enough info for triage"))))))
+
 (deftest finalize-assistant-turn-persists-finished-and-error-test
   (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
     (testing "default: finished true, no error"

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -324,6 +324,48 @@
                                    (:text d))))
                              rows)))))))))))
 
+(deftest start-turn-user-and-placeholder-share-created-at-test
+  (testing "user-message and assistant-placeholder rows inserted by start-turn! share created_at;
+            readers must tiebreak on :id to preserve user-before-assistant ordering"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          (metabot-persistence/start-turn!
+           conversation-id "internal" {:role "user" :content "hi"}))
+        (let [[u a] (t2/select :model/MetabotMessage
+                               :conversation_id conversation-id
+                               {:order-by [[:id :asc]]})]
+          (is (= :user      (:role u)))
+          (is (= :assistant (:role a)))
+          (is (< (:id u) (:id a)) "user row is inserted first; smaller :id")
+          (is (= (:created_at u) (:created_at a))
+              "intra-transaction inserts resolve current_timestamp to the same value"))))))
+
+(deftest conversation-detail-drops-errored-pair-under-created-at-collision-test
+  (testing "drop-errored-pairs works correctly when the errored user/asst rows share created_at"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          ;; Errored turn: user-msg and asst-row share created_at via start-turn!'s transaction.
+          (let [{:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "boom"})]
+            (metabot-persistence/finalize-assistant-turn!
+             conversation-id assistant-msg-id []
+             :error {:message "kaboom" :type "RuntimeException"}))
+          ;; Healthy follow-up turn — its user-msg and asst-row also collide on created_at.
+          (let [{:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "retry"})]
+            (metabot-persistence/finalize-assistant-turn!
+             conversation-id assistant-msg-id
+             [{:type :text :text "ok"}])))
+        ;; conversation-detail uses production reader ordering — the errored pair drops,
+        ;; leaving just the retry turn.
+        (let [{:keys [chat_messages]} (metabot-persistence/conversation-detail conversation-id)]
+          (is (= [["user" "retry"] ["agent" "ok"]]
+                 (mapv (juxt :role :message) chat_messages))))))))
+
 (deftest conversation-detail-filters-soft-deleted-messages-and-orders-ascending-test
   (testing "conversation-detail returns only non-deleted messages, ordered by :created_at ascending"
     (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -187,7 +187,7 @@
             (is (= user-id (:user_id user-msg))))
           (testing "assistant placeholder is in-flight, no slack_msg_id yet"
             (is (= :assistant (:role asst-msg)))
-            (is (false? (:finished asst-msg)))
+            (is (nil? (:finished asst-msg)) "in-flight placeholder uses NULL marker")
             (is (= [] (:data asst-msg)))
             (is (= channel-id (:channel_id asst-msg)))
             (is (nil? (:slack_msg_id asst-msg)))
@@ -233,7 +233,7 @@
               (let [asst (second rows)]
                 (is (= assistant-msg-id (:id asst)))
                 (is (= assistant-external-id (:external_id asst)))
-                (is (false? (:finished asst)))
+                (is (nil? (:finished asst)) "in-flight placeholder uses NULL marker")
                 (is (= [] (:data asst)))))))))))
 
 (deftest finalize-assistant-turn-updates-placeholder-in-place-test
@@ -365,6 +365,27 @@
         (let [{:keys [chat_messages]} (metabot-persistence/conversation-detail conversation-id)]
           (is (= [["user" "retry"] ["agent" "ok"]]
                  (mapv (juxt :role :message) chat_messages))))))))
+
+(deftest placeholder-still-active-uses-nil-finished-marker-test
+  (testing "the in-flight predicate keys off finished IS NULL (not :data emptiness or :error)"
+    (let [recent (java.time.OffsetDateTime/now)
+          stale  (.minusHours recent 2)
+          base   {:role :assistant :data [] :error nil}]
+      (testing "finished=nil + recent created_at → filtered"
+        (is (= [] (metabot-persistence/messages->chat-messages
+                   [(assoc base :finished nil :created_at recent)]))))
+      (testing "finished=nil + stale created_at → not filtered (renders aborted stub)"
+        (is (=? [{:type "text" :message "" :finished false}]
+                (metabot-persistence/messages->chat-messages
+                 [(assoc base :finished nil :created_at stale)]))))
+      (testing "finished=false → never filtered, even within grace"
+        (is (=? [{:type "text" :message "" :finished false}]
+                (metabot-persistence/messages->chat-messages
+                 [(assoc base :finished false :created_at recent)]))))
+      (testing "finished=true → never filtered"
+        (is (= [] (metabot-persistence/messages->chat-messages
+                   [(assoc base :finished true :created_at recent)]))
+            "no stub: finished=true with no error is a successful empty turn")))))
 
 (deftest conversation-detail-filters-soft-deleted-messages-and-orders-ascending-test
   (testing "conversation-detail returns only non-deleted messages, ordered by :created_at ascending"
@@ -568,15 +589,15 @@
         (is (= "boom" (:error chat-msg)))))))
 
 (deftest messages-chat-messages-skips-in-flight-placeholders-test
-  (testing "in-flight placeholders (data=[], finished=false, error=nil, recent created_at)
+  (testing "in-flight placeholders (assistant role, finished=nil, recent created_at)
             are filtered out of the chat-message conversion, so a mid-stream read does not
             render a stub 'Response was interrupted' alert"
     (let [recent      (java.time.OffsetDateTime/now)
           ;; Comfortably outside the grace window so the test isn't sensitive
           ;; to the exact value of `placeholder-grace-period-ms`.
           stale       (.minusHours recent 2)
-          placeholder {:role :assistant :data [] :finished false :error nil :created_at recent}
-          stale-stub  {:role :assistant :data [] :finished false :error nil :created_at stale}
+          placeholder {:role :assistant :data [] :finished nil :error nil :created_at recent}
+          stale-stub  {:role :assistant :data [] :finished nil :error nil :created_at stale}
           user-msg    {:role :user :data [{:role "user" :content "hi"}]}
           done-asst   {:role :assistant :data [{:type "text" :text "done" :id "b1"}] :finished true}]
       (testing "in-flight placeholder is skipped; surrounding messages still render"
@@ -586,8 +607,8 @@
         (let [out (metabot-persistence/messages->chat-messages [user-msg stale-stub])]
           (is (= 2 (count out)))
           (is (=? [{:message "hi"} {:type "text" :message "" :finished false}] out))))
-      (testing "placeholder with :error set is treated as errored (not in-flight) — the errored pair is dropped from default reads but visible to the audit path"
-        (let [errored {:role :assistant :data [] :finished false
+      (testing "row with :error set is treated as errored (not in-flight) — the errored pair is dropped from default reads but visible to the audit path"
+        (let [errored {:role :assistant :data [] :finished true
                        :error (json/encode {:message "boom"})
                        :created_at recent}]
           (is (= []

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -110,17 +110,17 @@
     (is (= "hello!" (:message (nth result 1))))
     (is (= {:ok true} (json/decode+kw (:result (nth result 2)))))))
 
-(deftest store-message-persists-slack-conversation-metadata-test
+(deftest start-turn-persists-slack-conversation-metadata-test
   (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
     (let [conversation-id (str (random-uuid))
           team-id         "T123"
           channel-id      "C123"
           thread-ts       "1712785577.123456"]
       (mt/with-current-user (mt/user->id :rasta)
-        (metabot-persistence/store-message!
+        (metabot-persistence/start-turn!
          conversation-id
          "slackbot"
-         [{:role "user" :content "hello"}]
+         {:role "user" :content "hello"}
          :slack-team-id team-id
          :channel-id channel-id
          :slack-thread-ts thread-ts
@@ -150,9 +150,10 @@
   (testing "empty input"
     (is (= [] (into [] (metabot-persistence/combine-text-parts-xf) [])))))
 
-(deftest store-native-parts-persists-slack-metadata-on-conversation-test
-  (testing "store-native-parts! lands slack-team-id / channel-id / slack-thread-ts on the conversation row,
-            and slack-msg-id / channel-id / user-id on the message row, on first insert"
+(deftest start-turn-persists-slack-metadata-on-rows-test
+  (testing "start-turn! lands slack-team-id / channel-id / slack-thread-ts on the conversation row,
+            and slack-msg-id / channel-id / user-id on the user message row, plus user-id on the
+            assistant placeholder row"
     (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
       (let [conversation-id (str (random-uuid))
             team-id         "T-NATIVE"
@@ -161,38 +162,50 @@
             slack-msg-id    "1700000000.000099"
             user-id         (mt/user->id :rasta)]
         (mt/with-current-user user-id
-          (metabot-persistence/store-native-parts!
+          (metabot-persistence/start-turn!
            conversation-id
            "metabot-1"
-           [{:type :text :text "hello from slack"}]
+           {:role "user" :content "hello from slack"}
            :slack-team-id team-id
            :channel-id channel-id
            :slack-thread-ts thread-ts
            :slack-msg-id slack-msg-id
            :user-id user-id))
         (let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)
-              message      (t2/select-one :model/MetabotMessage :conversation_id conversation-id)]
+              [user-msg
+               asst-msg]   (t2/select :model/MetabotMessage
+                                      :conversation_id conversation-id
+                                      {:order-by [[:created_at :asc] [:id :asc]]})]
           (is (= user-id (:user_id conversation)))
           (is (= team-id (:slack_team_id conversation)))
           (is (= channel-id (:slack_channel_id conversation)))
           (is (= thread-ts (:slack_thread_ts conversation)))
-          (is (= channel-id (:channel_id message)))
-          (is (= slack-msg-id (:slack_msg_id message)))
-          (is (= user-id (:user_id message))))))))
+          (testing "user row carries slack ids"
+            (is (= :user (:role user-msg)))
+            (is (= channel-id (:channel_id user-msg)))
+            (is (= slack-msg-id (:slack_msg_id user-msg)))
+            (is (= user-id (:user_id user-msg))))
+          (testing "assistant placeholder is in-flight, no slack_msg_id yet"
+            (is (= :assistant (:role asst-msg)))
+            (is (false? (:finished asst-msg)))
+            (is (= [] (:data asst-msg)))
+            (is (= channel-id (:channel_id asst-msg)))
+            (is (nil? (:slack_msg_id asst-msg)))
+            (is (= user-id (:user_id asst-msg)))))))))
 
-(deftest store-native-parts-does-not-overwrite-slack-metadata-test
-  (testing "slack metadata on the conversation row is set once and never overwritten by a later writer"
+(deftest start-turn-does-not-overwrite-slack-metadata-on-subsequent-turns-test
+  (testing "conversation-level slack metadata is set once and never overwritten by a later turn"
     (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
       (let [conversation-id (str (random-uuid))]
         (mt/with-current-user (mt/user->id :rasta)
-          (metabot-persistence/store-native-parts!
-           conversation-id "metabot-1" [{:type :text :text "first"}]
+          (metabot-persistence/start-turn!
+           conversation-id "metabot-1" {:role "user" :content "first"}
            :slack-team-id "T-FIRST"
            :channel-id "C-FIRST"
            :slack-thread-ts "1700000000.000001"))
         (mt/with-current-user (mt/user->id :lucky)
-          (metabot-persistence/store-native-parts!
-           conversation-id "metabot-1" [{:type :text :text "second"}]
+          (metabot-persistence/start-turn!
+           conversation-id "metabot-1" {:role "user" :content "second"}
            :slack-team-id "T-SECOND"
            :channel-id "C-SECOND"
            :slack-thread-ts "1700000000.999999"))
@@ -200,6 +213,116 @@
           (is (= "T-FIRST" (:slack_team_id conversation)))
           (is (= "C-FIRST" (:slack_channel_id conversation)))
           (is (= "1700000000.000001" (:slack_thread_ts conversation))))))))
+
+(deftest start-turn-returns-assistant-pk-and-external-id-test
+  (testing "start-turn! returns the assistant placeholder PK and a fresh external_id;
+            inserts exactly one user row + one assistant placeholder row"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          (let [{:keys [assistant-msg-id assistant-external-id]}
+                (metabot-persistence/start-turn!
+                 conversation-id "internal" {:role "user" :content "hi"})
+                rows (t2/select :model/MetabotMessage :conversation_id conversation-id
+                                {:order-by [[:created_at :asc] [:id :asc]]})]
+            (is (pos-int? assistant-msg-id))
+            (is (string? assistant-external-id))
+            (is (= 2 (count rows)))
+            (is (= [:user :assistant] (mapv :role rows)))
+            (testing "assistant row matches returned ids"
+              (let [asst (second rows)]
+                (is (= assistant-msg-id (:id asst)))
+                (is (= assistant-external-id (:external_id asst)))
+                (is (false? (:finished asst)))
+                (is (= [] (:data asst)))))))))))
+
+(deftest finalize-assistant-turn-updates-placeholder-in-place-test
+  (testing "finalize-assistant-turn! UPDATEs the placeholder; row count and created_at unchanged"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          (let [{:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "hi"})
+                created-at-before          (:created_at (t2/select-one :model/MetabotMessage assistant-msg-id))
+                _                          (metabot-persistence/finalize-assistant-turn!
+                                            conversation-id assistant-msg-id
+                                            [{:type :text :text "Hello"}
+                                             {:type  :usage
+                                              :model "claude-sonnet-4-6"
+                                              :usage {:promptTokens 10 :completionTokens 5}}])
+                row                        (t2/select-one :model/MetabotMessage assistant-msg-id)
+                rows                       (t2/select :model/MetabotMessage
+                                                      :conversation_id conversation-id)]
+            (is (= 2 (count rows))                 "no extra row inserted on finalize")
+            (is (= created-at-before (:created_at row)) "created_at is not changed on UPDATE")
+            (is (true? (:finished row))            "default :finished? is true")
+            (is (nil? (:error row)))
+            (is (= [{:type "text" :text "Hello"}] (:data row)))
+            (is (= 15 (:total_tokens row)))))))))
+
+(deftest finalize-assistant-turn-passes-through-aborted-and-errored-test
+  (testing "finalize-assistant-turn! preserves :finished? false and JSON-encodes :error"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (mt/with-current-user (mt/user->id :rasta)
+        (testing "aborted: finished false flows through"
+          (let [conversation-id (str (random-uuid))
+                {:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "go"})]
+            (metabot-persistence/finalize-assistant-turn!
+             conversation-id assistant-msg-id
+             [{:type :text :text "partial"}]
+             :finished? false)
+            (is (=? {:finished false :error nil}
+                    (t2/select-one :model/MetabotMessage assistant-msg-id)))))
+        (testing "errored: error map JSON-encoded into the error column"
+          (let [conversation-id (str (random-uuid))
+                error-data      {:message "boom" :type "RuntimeException"}
+                {:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "go"})]
+            (metabot-persistence/finalize-assistant-turn!
+             conversation-id assistant-msg-id []
+             :error error-data)
+            (let [row (t2/select-one :model/MetabotMessage assistant-msg-id)]
+              (is (true? (:finished row)))
+              (is (= error-data (json/decode+kw (:error row)))))))))))
+
+(deftest start-turn-pins-ordering-under-abort-then-retry-test
+  (testing "an aborted turn whose finalize fires after a retry still sorts before the retry's rows"
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (let [conversation-id (str (random-uuid))]
+        (mt/with-current-user (mt/user->id :rasta)
+          ;; Turn A: starts and is left in-flight
+          (let [{a-pk :assistant-msg-id} (metabot-persistence/start-turn!
+                                          conversation-id "internal"
+                                          {:role "user" :content "A"})]
+            ;; Turn B (retry) — its rows are inserted *while* Turn A is still in-flight
+            (Thread/sleep 5)
+            (let [{b-pk :assistant-msg-id} (metabot-persistence/start-turn!
+                                            conversation-id "internal"
+                                            {:role "user" :content "B"})]
+              ;; Now Turn A's stream finally lands (abort): UPDATE on its placeholder
+              (Thread/sleep 5)
+              (metabot-persistence/finalize-assistant-turn!
+               conversation-id a-pk
+               [{:type :text :text "partial-A"}]
+               :finished? false)
+              ;; Turn B completes normally
+              (metabot-persistence/finalize-assistant-turn!
+               conversation-id b-pk
+               [{:type :text :text "reply-B"}])
+              (let [rows (t2/select :model/MetabotMessage :conversation_id conversation-id
+                                    {:order-by [[:created_at :asc] [:id :asc]]})]
+                (is (= [:user :assistant :user :assistant] (mapv :role rows)))
+                (is (= [["user" "A"] "partial-A" ["user" "B"] "reply-B"]
+                       (mapv (fn [r]
+                               (let [d (first (:data r))]
+                                 (if (= "user" (:role d))
+                                   [(:role d) (:content d)]
+                                   (:text d))))
+                             rows)))))))))))
 
 (deftest conversation-detail-filters-soft-deleted-messages-and-orders-ascending-test
   (testing "conversation-detail returns only non-deleted messages, ordered by :created_at ascending"
@@ -309,37 +432,74 @@
       (is (= ["broken" "partial" "ok" "fine"] (mapv :message result)))
       (is (= [nil {:message "boom"} nil nil] (mapv :error result))))))
 
-(defn- store-and-read!
-  "Insert a one-text-part assistant message via `store-native-parts!` (as :rasta), then read it back.
-  Returns `[row chat-msg]`."
-  [& opts]
+(defn- start-and-finalize!
+  "Run start-turn! then finalize-assistant-turn! with a one-text-part body (as :rasta).
+  Returns `[asst-row chat-msg]`."
+  [& finalize-opts]
   (let [conversation-id (str (random-uuid))]
     (mt/with-current-user (mt/user->id :rasta)
-      (apply metabot-persistence/store-native-parts!
-             conversation-id "metabot-1" [{:type :text :text "x"}] opts))
-    (let [row (t2/select-one :model/MetabotMessage :conversation_id conversation-id)]
-      [row (first (metabot-persistence/message->chat-messages row))])))
+      (let [{:keys [assistant-msg-id]} (metabot-persistence/start-turn!
+                                        conversation-id "metabot-1"
+                                        {:role "user" :content "go"})]
+        (apply metabot-persistence/finalize-assistant-turn!
+               conversation-id assistant-msg-id
+               [{:type :text :text "x"}]
+               finalize-opts)
+        (let [row (t2/select-one :model/MetabotMessage assistant-msg-id)]
+          [row (first (metabot-persistence/message->chat-messages row))])))))
 
-(deftest store-native-parts-persists-finished-and-error-test
+(deftest finalize-assistant-turn-persists-finished-and-error-test
   (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
     (testing "default: finished true, no error"
-      (let [[row] (store-and-read!)]
+      (let [[row] (start-and-finalize!)]
         (is (=? {:finished true :error nil} row))))
 
     (testing "aborted: finished false flows through, no error"
-      (let [[row] (store-and-read! :finished? false)]
+      (let [[row] (start-and-finalize! :finished? false)]
         (is (=? {:finished false :error nil} row))))
 
     (testing "errored map: JSON-encoded into column, decoded onto chat msg; partial parts persisted"
       (let [error-data     {:message "agent loop API error: 503"
                             :type    "java.lang.RuntimeException"
                             :data    {:status 503}}
-            [row chat-msg] (store-and-read! :error error-data)]
+            [row chat-msg] (start-and-finalize! :error error-data)]
         (is (=? {:finished true :error string? :data seq} row))
         (is (= error-data (json/decode+kw (:error row))))
         (is (= error-data (:error chat-msg)))))
 
     (testing "errored string: any JSON-serializable value accepted"
-      (let [[row chat-msg] (store-and-read! :error "boom")]
+      (let [[row chat-msg] (start-and-finalize! :error "boom")]
         (is (= "\"boom\"" (:error row)))
         (is (= "boom" (:error chat-msg)))))))
+
+(deftest messages-chat-messages-skips-in-flight-placeholders-test
+  (testing "in-flight placeholders (data=[], finished=false, error=nil, recent created_at)
+            are filtered out of the chat-message conversion, so a mid-stream read does not
+            render a stub 'Response was interrupted' alert"
+    (let [recent      (java.time.OffsetDateTime/now)
+          ;; Comfortably outside the grace window so the test isn't sensitive
+          ;; to the exact value of `placeholder-grace-period-ms`.
+          stale       (.minusHours recent 2)
+          placeholder {:role :assistant :data [] :finished false :error nil :created_at recent}
+          stale-stub  {:role :assistant :data [] :finished false :error nil :created_at stale}
+          user-msg    {:role :user :data [{:role "user" :content "hi"}]}
+          done-asst   {:role :assistant :data [{:type "text" :text "done" :id "b1"}] :finished true}]
+      (testing "in-flight placeholder is skipped; surrounding messages still render"
+        (is (= ["hi" "done"]
+               (mapv :message (metabot-persistence/messages->chat-messages [user-msg done-asst placeholder])))))
+      (testing "stale placeholder (older than grace window) still renders as the aborted-turn stub"
+        (let [out (metabot-persistence/messages->chat-messages [user-msg stale-stub])]
+          (is (= 2 (count out)))
+          (is (=? [{:message "hi"} {:type "text" :message "" :finished false}] out))))
+      (testing "placeholder with :error set is treated as errored (not in-flight) — the errored pair is dropped from default reads but visible to the audit path"
+        (let [errored {:role :assistant :data [] :finished false
+                       :error (json/encode {:message "boom"})
+                       :created_at recent}]
+          (is (= []
+                 (metabot-persistence/messages->chat-messages
+                  [user-msg errored] {:include-errored? false}))
+              "default read drops the errored row AND the preceding user prompt")
+          (is (= ["hi" ""]
+                 (mapv :message (metabot-persistence/messages->chat-messages
+                                 [user-msg errored] {:include-errored? true})))
+              "audit read keeps both rows; the empty-data stub renders so the FE has somewhere to hang the error alert"))))))

--- a/test/metabase/slackbot/channel_test.clj
+++ b/test/metabase/slackbot/channel_test.clj
@@ -6,10 +6,13 @@
    [metabase.slackbot.client :as slackbot.client]))
 
 (deftest channel-response-passes-slack-metadata-for-deep-linking-test
-  (let [request-opts (atom nil)]
+  (let [request-opts  (atom nil)
+        backfill-args (atom nil)]
     (with-redefs [slackbot.client/set-status (constantly {:ok true})
                   slackbot.client/post-thread-reply (constantly {:ok true :ts "1700000000.000002"})
-                  metabot.persistence/set-response-slack-msg-id! (constantly nil)]
+                  metabot.persistence/set-response-slack-msg-id!
+                  (fn [msg-id slack-msg-id]
+                    (reset! backfill-args {:msg-id msg-id :slack-msg-id slack-msg-id}))]
       (slackbot.channel/send-channel-response
        {}
        {:ts "1700000000.000001"}
@@ -26,7 +29,8 @@
        {:tool-name->friendly        {}
         :make-streaming-ai-request  (fn [& args]
                                       (reset! request-opts (last args))
-                                      "message-external-id")
+                                      {:msg-id      42
+                                       :external-id "message-external-id"})
         :collect-viz-blocks         (constantly {:blocks [] :errors []})
         :feedback-blocks            (constantly [])
         :post-viz-error!            (constantly nil)
@@ -36,4 +40,5 @@
             :thread-ts        "1700000000.000001"
             :req-slack-msg-id "1700000000.000001"}
            (select-keys @request-opts [:team-id :thread-ts :req-slack-msg-id])))
-    (is (some? (:stored-msg-id @request-opts)))))
+    (is (= {:msg-id 42 :slack-msg-id "1700000000.000002"}
+           @backfill-args))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -179,55 +179,53 @@
                @posted-message))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
-  (testing "user + assistant persists receive ai-proxy? = true for metabase/ prefixed provider"
+  (testing "start-turn! receives ai-proxy? = true (and writes it to both user and assistant rows)
+            for metabase/ prefixed provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
-            store-opts (atom [])]
+            start-opts (atom [])]
         (tu/with-slackbot-mocks
           {:ai-text "Hello!"}
           (fn [{:keys [stop-stream-calls]}]
             (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
               (with-redefs [premium-features/token-status
                             (constantly nil)
-                            metabot.persistence/store-message!
-                            (fn [_conv-id _profile-id _messages & {:as opts}]
-                              (swap! store-opts conj opts)
-                              nil)
-                            metabot.persistence/store-native-parts!
-                            (fn [_conv-id _profile-id _parts & {:as opts}]
-                              (swap! store-opts conj opts)
-                              nil)]
+                            metabot.persistence/start-turn!
+                            (fn [_conv-id _profile-id _user-message & {:as opts}]
+                              (swap! start-opts conj opts)
+                              {:assistant-msg-id 1 :assistant-external-id "ext"})
+                            metabot.persistence/finalize-assistant-turn!
+                            (fn [& _] nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
                            event-body)
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = true"
-              (is (=? [{:ai-proxy? true}
-                       {:ai-proxy? true}]
-                      @store-opts)))))))))
+            (testing "start-turn! received ai-proxy? = true"
+              (is (=? [{:ai-proxy? true}] @start-opts)))))))))
 
 (deftest slackbot-streaming-persists-failed-conversations-test
-  (testing "User message is persisted even if setup throws after it (BOT-1279)"
+  (testing "User row is persisted even if setup throws after it (BOT-1279). With placeholders,
+            start-turn! inserts user + placeholder atomically before any setup runs."
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
             stored     (promise)]
         (tu/with-slackbot-mocks
           {:ai-text "Hello!"}
           (fn [_ctx]
-            (with-redefs [metabot.persistence/store-message!
-                          (fn [_conv-id _profile-id _messages & {:as opts}]
+            (with-redefs [metabot.persistence/start-turn!
+                          (fn [_conv-id _profile-id _user-message & {:as opts}]
                             (deliver stored opts)
-                            nil)
-                          ;; Force setup to throw *after* the user message has been stored.
+                            {:assistant-msg-id 1 :assistant-external-id "ext"})
+                          ;; Force setup to throw *after* start-turn! has run.
                           slackbot.persistence/message-history
                           (fn [& _] (throw (ex-info "boom" {})))]
               (mt/client :post 200 "metabot/slack/events"
                          (tu/slack-request-options event-body)
                          event-body)
               (let [opts (deref stored 5000 ::timeout)]
-                (testing "user store-message! was called before the failure"
+                (testing "start-turn! was called before the failure"
                   (is (not= ::timeout opts))
                   (is (some? (:slack-msg-id opts))))))))))))
 
@@ -238,53 +236,52 @@
         (let [event-body tu/base-dm-event]
           (doseq [flag-on? [true false]]
             (testing (str "with analytics-pii-retention-enabled=" flag-on?)
-              (let [store-opts (atom [])]
+              (let [start-opts (atom [])]
                 (tu/with-slackbot-mocks
                   {:ai-text "Hello!"}
                   (fn [{:keys [stop-stream-calls]}]
                     (mt/with-temporary-setting-values [analytics-pii-retention-enabled flag-on?]
-                      (with-redefs [metabot.persistence/store-native-parts!
-                                    (fn [_conv-id _profile-id _parts & {:as opts}]
-                                      (swap! store-opts conj opts)
-                                      nil)]
+                      (with-redefs [metabot.persistence/start-turn!
+                                    (fn [_conv-id _profile-id _user-message & {:as opts}]
+                                      (swap! start-opts conj opts)
+                                      {:assistant-msg-id 1 :assistant-external-id "ext"})
+                                    metabot.persistence/finalize-assistant-turn!
+                                    (fn [& _] nil)]
                         (mt/client :post 200 "metabot/slack/events"
                                    (tu/slack-request-options event-body)
                                    event-body)
                         (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                                  :done?      true?
                                  :timeout-ms 5000})))
-                    (testing "store-native-parts! never received :hostname or :pii-info from the slackbot path"
-                      (doseq [opts @store-opts]
+                    (testing "start-turn! never received :hostname or :pii-info from the slackbot path"
+                      (doseq [opts @start-opts]
                         (is (not (contains? opts :hostname)))
                         (is (not (contains? opts :pii-info)))))))))))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
-  (testing "user + assistant persists receive ai-proxy? = false for direct BYOK provider"
+  (testing "start-turn! receives ai-proxy? = false (and writes it to both user and assistant rows)
+            for direct BYOK provider"
     (tu/with-slackbot-setup
       (let [event-body tu/base-dm-event
-            store-opts (atom [])]
+            start-opts (atom [])]
         (tu/with-slackbot-mocks
           {:ai-text "Hello!"}
           (fn [{:keys [stop-stream-calls]}]
             (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-haiku-4-5"]
-              (with-redefs [metabot.persistence/store-message!
-                            (fn [_conv-id _profile-id _messages & {:as opts}]
-                              (swap! store-opts conj opts)
-                              nil)
-                            metabot.persistence/store-native-parts!
-                            (fn [_conv-id _profile-id _parts & {:as opts}]
-                              (swap! store-opts conj opts)
-                              nil)]
+              (with-redefs [metabot.persistence/start-turn!
+                            (fn [_conv-id _profile-id _user-message & {:as opts}]
+                              (swap! start-opts conj opts)
+                              {:assistant-msg-id 1 :assistant-external-id "ext"})
+                            metabot.persistence/finalize-assistant-turn!
+                            (fn [& _] nil)]
                 (mt/client :post 200 "metabot/slack/events"
                            (tu/slack-request-options event-body)
                            event-body)
                 (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
                          :done?      true?
                          :timeout-ms 5000})))
-            (testing "user (store-message!) + assistant (store-native-parts!) both received ai-proxy? = false"
-              (is (=? [{:ai-proxy? false}
-                       {:ai-proxy? false}]
-                      @store-opts)))))))))
+            (testing "start-turn! received ai-proxy? = false"
+              (is (=? [{:ai-proxy? false}] @start-opts)))))))))
 
 ;;; ------------------------------------------------ Flush throttle tests ------------------------------------------------
 


### PR DESCRIPTION
When a client aborts and the user retries before the server detects the disconnect, rows land on disk as user_A, user_B, asst_A_aborted, asst_B — every read sorts by created_at ASC, so the audit view renders the retry's prompt above the original turn's aborted reply, and drop-errored-pairs (adjacency-based) mis-pairs adjacent rows.

Fix: insert a placeholder assistant row in the same transaction as the user row at turn start. The placeholder's created_at is pinned before any subsequent request can commit. End-of-stream becomes an UPDATE of the placeholder; turn ordering by created_at is correct without any new column.

Changes include
  - Replace `store-aiservice-messages!` + `store-native-parts!` with a paired `start-turn!` / `finalize-assistant-turn!`. `start-turn!` atomically upserts the conversation row, inserts the user row, and inserts the assistant placeholder; returns `{:assistant-msg-id, :assistant-external-id}`. `finalize-assistant-turn!` UPDATEs the placeholder with the final parts, usage, finished, and error.
  - `metabot.api/streaming-request` calls `start-turn!` before dispatching to the agent loop; the loop's finally block calls `finalize-assistant-turn!`. `slackbot.streaming/make-streaming-ai-request` follows the same pattern and threads the PK back through its return value, dropping the `stored-msg-id` atom that `slackbot.channel` used to populate.
  - New `placeholder-still-active?` predicate skips in-flight placeholders (role=assistant, data=[], finished=false, error=nil) within a 30-minute grace window so a mid-stream chat reload doesn't render a stub turn_aborted alert. Stale placeholders (server crash, finalize never landed) fall back to the existing aborted-stub rendering.
  - New `metabase-metabot/turn-started` Prometheus counter, tagged by `profile-id`, pairs with the existing `message-persist-bytes` histogram to surface stuck-placeholder rate (turns started but never finalized).
  - `start-turn!` resolves `originator-id` once (caller's `:user-id` kwarg, or `*current-user-id*` fallback) and uses it consistently for both the conversation row and the user-message row, eliminating the prior split read.
  - `finalize-assistant-turn!` takes a `:profile-id` kwarg from both call sites for the `message-persist-bytes` label, eliminating a per-turn SELECT that previously fetched it back from the placeholder row.