### PR TITLE
fix: default date filder should include today

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/useFilterOptions.ts
@@ -11,7 +11,7 @@ import type { GroupListQuery } from "metabase-types/api";
 
 import type { FilterUrlState } from "./url-state";
 
-export const DEFAULT_DATE = "past30days";
+export const DEFAULT_DATE = "past30days~";
 export const DEFAULT_GROUP = "1"; // All Users group
 export const ALL_USERS_SYNTHETIC = "all";
 


### PR DESCRIPTION
Closes [BOT-1441: Usage analytics default date filter should include today](https://linear.app/metabase/issue/BOT-1441/usage-analytics-default-date-filter-should-include-today)

### Description

AI usage analytics filters didn't include today by default.

### How to verify

1. Admin settings -> AI -> Usage analytics
2. Observe the filter value being set to "Previous 30 days or today"

### Demo

![image.png](https://app.graphite.com/user-attachments/assets/54a68c5e-338d-45bf-8eee-bdeda93c1f93.png)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass stress testing~~