### PR TITLE
[git] Validate remote sync settings before marking collections remote

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -160,6 +160,12 @@
     (let [effective-type (or remote-sync-type (settings/remote-sync-type))]
       (api/check-400 (not (and (seq collections) (= :read-only effective-type)))
                      "Cannot change synced collections when remote-sync-type is read-only."))
+    (try
+      (settings/check-and-update-remote-settings! (dissoc settings :collections))
+      (catch Exception e
+        (throw (ex-info (or (ex-message e) "Invalid settings")
+                        {:error       (ex-message e)
+                         :status-code 400} e))))
     (when (seq collections)
       (try
         (remote-sync.core/bulk-set-remote-sync collections)
@@ -167,12 +173,6 @@
           (throw (ex-info (or (ex-message e) "Invalid collection settings")
                           {:error       (ex-message e)
                            :status-code 400} e)))))
-    (try
-      (settings/check-and-update-remote-settings! (dissoc settings :collections))
-      (catch Exception e
-        (throw (ex-info (or (ex-message e) "Invalid settings")
-                        {:error       (ex-message e)
-                         :status-code 400} e))))
     (events/publish-event! :event/remote-sync-settings-update
                            {:details {:remote-sync-type remote-sync-type}
                             :user-id api/*current-user-id*})

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -1132,6 +1132,19 @@
             (is (= "Transforms" (:name (first dirty-items))))
             (is (= "delete" (:sync_status (first dirty-items))))))))))
 
+(deftest settings-collections-not-marked-synced-when-settings-validation-fails-test
+  (testing "PUT /api/ee/remote-sync/settings does not mark collections as synced when settings validation fails"
+    (mt/with-temporary-setting-values [remote-sync-type :read-write]
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :location "/" :is_remote_synced false}]
+        (with-redefs [settings/check-and-update-remote-settings!
+                      (fn [_] (throw (ex-info "Authentication is required" {:status-code 400})))
+                      impl/finish-remote-config! (constantly nil)]
+          (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
+                                {:remote-sync-url   "https://github.com/test/private-repo.git"
+                                 :remote-sync-type  :read-write
+                                 :collections       {coll-id true}})
+          (is (false? (:is_remote_synced (t2/select-one :model/Collection :id coll-id)))))))))
+
 ;; ---------- API-level guard sweep --------------------------------------------------------------
 ;;
 ;; Boundary tests verifying that every mutating remote-sync HTTP endpoint surfaces the guard's


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72745
Fixes UXW-3774.

### Description

Collections were being (almost) unconditionally marked
`:is_remote_collection` in one transaction, then the remote sync
settings (e.g. git auth) were checked. So if you tried to enable
remote sync for some collections but with a blank auth token, the
collections would be marked anyway but then the setup would fail.
Worse, it was almost impossible to remove them!

With this change, the remote sync settings are checked first, then if
they are validated the collections are marked as synced.

### How to verify

Try to enable remote sync, specifying some collections, but leaving the auth token blank.

Observe that the request fails, but the collections still claim to be synced. Also you can't disable sync for those collections!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
