### PR TITLE
docs - AI updates

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -56,9 +56,9 @@ If the site URL doesn't match an address your MCP client can reach, like if you'
 
 ## MCP server requests are handled by the AI client
 
-MCP server requests are handled by the AI client - not Metabase. Metabase just handles the MCP call (like searching for an entity or running the query).
+MCP server requests are handled by whatever AI client you're using (like an desktop AI app or editor plugin). The MCP server just provides tools (like searching for an entity or running the query) for your AI.
 
-This means that if you ask Claude "what's our q3 revenue" and instruct it to use Metabase MCP server, _Claude itself_ will determine which tools it needs to use and how - for example, it can decide that it needs to use the tool **construct_query** and **execute_query**, and what those queries might be - and Metabase will just diligently oblige (construct and execute the queries), but nothing more.
+For example, if you ask your AI client to use your Metabase's MCP server "what's our q3 revenue," your client will interact with the MCP server to figure out which tools it needs to field your request. Your AI can decide that it needs to use the tool **construct_query** and **execute_query**, and what those queries might be. Then your client will call those tools for Metabase to run.
 
 You don't need to have an [AI provider](settings.md#supported-providers) configured in Metabase to use your Metabase's MCP server. If you _do_ have an AI provider configured in Metabase to power Metabot, that provider will _not_ be used for MCP server requests. MCP calls by your local client have no effect on token usage for your Metabase's AI connection.
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -54,6 +54,18 @@ Some explanation: OAuth discovery starts with Metabase returning a `WWW-Authenti
 
 If the site URL doesn't match an address your MCP client can reach, like if you're running Metabase in Docker and the site URL got auto-detected from an internal hostname like `metabase-dev:3000`, the client will register but fail the handshake. Your MCP client will typically report a connection failure rather than prompting you to authenticate (for example, Claude Code shows `✗ Failed to connect` rather than `! Needs authentication`).
 
+## MCP server requests are handled by the AI client
+
+MCP server requests are handled by the AI client - not Metabase. Metabase just handles the MCP call (like searching for an entity or running the query).
+
+This means that if you ask Claude "what's our q3 revenue" and instruct it to use Metabase MCP server, _Claude itself_ will determine which tools it needs to use and how - for example, it can decide that it needs to use the tool **construct_query** and **execute_query**, and what those queries might be - and Metabase will just diligently oblige (construct and execute the queries), but nothing more.
+
+In particular, this means that:
+
+- You don't need to have an [AI provider](settings.md#supported-providers) configured in Metabase (because the AI part is handled by your AI client, not Metabase);
+- If you do have an AI provider configured in Metabase (for example, for [Metabot](metabot.md)), that provider will _not_ be used for MCP server requestsl
+- MCP server uses the tokens from the third-party AI client you connected to the MCP server, not from the Metabase's AI provider.
+
 ## Available tools
 
 Some clients (like Claude Desktop) will ask you to approve each tool the first time it's used. The MCP server builds on Metabase's [Agent API](./agent-api.md), and exposes the following tools. If you're building a custom integration and need full control, use the [Agent API](./agent-api.md) directly instead.
@@ -66,6 +78,7 @@ Some clients (like Claude Desktop) will ask you to approve each tool the first t
 - **construct_query**: Construct a query against a table or metric. Returns an opaque query string that can be executed with `execute_query`.
 - **execute_query**: Execute a previously constructed query and return the results with column metadata, row count, and execution time.
 - **query**: Query a table or metric and return results.
+- **create_question**:
 
 ## Use the MCP server with file-based development
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -60,11 +60,7 @@ MCP server requests are handled by the AI client - not Metabase. Metabase just h
 
 This means that if you ask Claude "what's our q3 revenue" and instruct it to use Metabase MCP server, _Claude itself_ will determine which tools it needs to use and how - for example, it can decide that it needs to use the tool **construct_query** and **execute_query**, and what those queries might be - and Metabase will just diligently oblige (construct and execute the queries), but nothing more.
 
-In particular, this means that:
-
-- You don't need to have an [AI provider](settings.md#supported-providers) configured in Metabase (because the AI part is handled by your AI client, not Metabase);
-- If you do have an AI provider configured in Metabase (for example, for [Metabot](metabot.md)), that provider will _not_ be used for MCP server requestsl
-- MCP server uses the tokens from the third-party AI client you connected to the MCP server, not from the Metabase's AI provider.
+You don't need to have an [AI provider](settings.md#supported-providers) configured in Metabase to use your Metabase's MCP server. If you _do_ have an AI provider configured in Metabase to power Metabot, that provider will _not_ be used for MCP server requests. MCP calls by your local client have no effect on token usage for your Metabase's AI connection.
 
 ## Available tools
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -78,7 +78,8 @@ Some clients (like Claude Desktop) will ask you to approve each tool the first t
 - **construct_query**: Construct a query against a table or metric. Returns an opaque query string that can be executed with `execute_query`.
 - **execute_query**: Execute a previously constructed query and return the results with column metadata, row count, and execution time.
 - **query**: Query a table or metric and return results.
-- **create_question**:
+- **create_question**: Create questions.
+- **create_dashboard**: Create dashboards.
 
 ## Use the MCP server with file-based development
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -54,7 +54,7 @@ Some explanation: OAuth discovery starts with Metabase returning a `WWW-Authenti
 
 If the site URL doesn't match an address your MCP client can reach, like if you're running Metabase in Docker and the site URL got auto-detected from an internal hostname like `metabase-dev:3000`, the client will register but fail the handshake. Your MCP client will typically report a connection failure rather than prompting you to authenticate (for example, Claude Code shows `✗ Failed to connect` rather than `! Needs authentication`).
 
-## MCP server requests are handled by the AI client
+## With the MCP server, your client provides the AI
 
 MCP server requests are handled by whatever AI client you're using (like an desktop AI app or editor plugin). The MCP server just provides tools (like searching for an entity or running the query) for your AI.
 

--- a/docs/ai/metabot.md
+++ b/docs/ai/metabot.md
@@ -15,16 +15,17 @@ To set up Metabot, see [Metabot settings](./settings.md).
 
 ## What Metabot can do
 
-Metabot can help you to:
+Here's a non-exhaustive list of things Metabot can help with:
 
-- [AI exploration](#ai-exploration).
+- [Answer data questions asked with natural language](#ai-exploration).
 - [Create a chart using the query builder](#how-metabot-uses-the-query-builder) from a natural language query.
 - [Generate SQL in the native editor](../questions/native-editor/writing-sql.md) from natural language. (Currently, only SQL is supported.)
 - [Edit SQL directly in the native editor](#inline-sql-editing).
 - [Analyze a chart](#analyze-charts-with-metabot).
 - [Fix errors in SQL code](#have-metabot-fix-sql-queries).
-- Answer questions from our documentation (as in, the literature you're reading right now).
-- [Chat with Metabot in Slack](./metabot-slack.md).
+- [Generate transforms](../data-studio/transforms/transforms-overview.md#use-metabot-to-generate-code-for-transforms)
+- [Generate charts in documents](../documents/introduction.md)
+- [Answer questions from Slack](./metabot-slack.md).
 
 Like with all generative AI, you'll always need to double-check results.
 
@@ -129,8 +130,6 @@ When answering questions in AI exploration, Metabot searches a limited set of co
 
 Metabot is getting smarter all the time, but there are some things it can't do yet:
 
-- **Custom expressions.** Metabot can't use [custom expressions](../questions/query-builder/expressions-list.md) in query builder questions.
-- **Multi-level aggregation.** Metabot is limited to a single level of aggregation and grouping.
 - **SQL variables.** Metabot can't generate SQL queries that include [SQL parameters](../questions/native-editor/sql-parameters.md) (like filters or field filters).
 - **Goal lines.** Metabot can't add [goal lines](../questions/visualizations/line-bar-and-area-charts.md#goal-lines) to charts.
 - **Chart formatting.** Metabot can't change visualization settings like colors, axis labels, or number formatting.

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -11,7 +11,6 @@ There are three main ways you can use AI with your Metabase:
 - [MCP server](#mcp-server)
 - [Agent-driven file-based development workflow](#agent-driven-development-workflow)
 
-Each has its own uses and
 
 ## Metabot
 
@@ -23,12 +22,12 @@ Each has its own uses and
 
 **Controls:** Metabot will only see what the person using it can see. Metabot also comes with additional permission controls and usage limits so that you control who can use which Metabot tools (e.g. chat vs SQL generation) and how many tokens they can spend.
 
-**Provider**: You can configure the AI provider used to process and respond people's requests:
+**Provider**:  Choose from:
 
-- Metabase's own model (available on Metabase Cloud only, comes with an additional charge)
+- Metabase's own AI Service (available as an add-on exclusively for Metabase Cloud)
 - Third-party models via an API key (Anthropic models only for now).
 
-**Plans**: available on all plans. You can only use the model hosted by Metabase on Metabase Cloud.
+**Plans**: available on all plans. You can only use Metabase's AI Service on Metabase Cloud.
 
 ## MCP server
 

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -7,30 +7,55 @@ summary: Overview of all the ways you can use AI with Metabase.
 
 There are three main ways you can use AI with your Metabase:
 
-- Metabot
-- MCP server
-- Agent-driven file-based workflow
+- [Metabot](#metabot)
+- [MCP server](#mcp-server)
+- [Agent-driven file-based development workflow](#agent-driven-development-workflow)
+
+Each has its own uses and
 
 ## Metabot
 
-See [Metabot](./metabot-slack.md)
+> See [full docs for Metabot](metabot.md).
 
-Metabot is Metabase's built-in AI agent. It can help you with tasks around Metabase, like answering questions about your data, generating
+**Best for: daily tasks in Metabase; granular control over people's AI usage.**
 
-- MCP server: best for
+**Functionality:** Metabot is Metabase's built-in AI agent. Metabot can help you with most daily tasks around Metabase, like answering questions about your data, creating queries, generating SQL code, explaining charts, or creating Documents. See [non-exhaustive list of things Metabot can do](metabot.md#what-metabot-can-do), as well as its [limitations](metabot.md#current-limitations).
 
-Metabot is Metabase's built-in AI agent. ... : . Whenever you want to do something
+**Controls:** Metabot will only see what the person using it can see. Metabot also comes with additional permission controls and usage limits so that you control who can use which Metabot tools (e.g. chat vs SQL generation) and how many tokens they can spend.
 
-Non-exaustive list of
+**Provider**: You can configure the AI provider used to process and respond people's requests:
 
-- Chat interface, see []
-- AI exploration - a place for natural language querying
-- Code generation for SQL queries or transforms, and fixing tr
-- Analyzing a chart
-- Generating charts in documnents
+- Metabase's own model (available on Metabase Cloud only, comes with an additional charge)
+- Third-party models via an API key (Anthropic models only for now).
+
+**Plans**: available on all plans. You can only use the model hosted by Metabase on Metabase Cloud.
 
 ## MCP server
 
-You can set up your favorite third-party AI tool - like Claude or Codes
+> See [full docs for MCP server](mcp.md).
 
-MCP server has restricted functionality compared to the built-in Metabot, and doesn't come with granular usage controls (although the data _access_ is still scoped to user's permissions)
+**Best for: askng ad-hoc, ephemeral questions; combining data from Metabase with data from other tools.**
+
+**Functionality**: Connect your favorite third-party AI tool - like Claude or Codex - to the Metabase MCP server. MCP server's main functionality is designed to for answering in-the-moment questions like "hey btw what's our q3 revenue?". It's also useful when combined with other MCP servers - for example, you can ask Claude a question about your customer that combines data from Metabase, Salesforce, and Zendesk.
+
+Compared to the built-in Metabot, MCP server has somewhat restricted functionality (for example, it can't generate code or built transforms for now). See [the ever-expanding list of MCP server tools](mcp.md#available-tools).
+
+**Controls**: Metabase MCP server requires people to authenticate into Metabase, and all the responses it provides will be scoped to their permissions. However, Unlike built-in Metabot, MCP server doesn't come with granular control over which _tools_ people can use.
+
+**Provider**: Requests to Metabase MCP server are handled by the provider you choose connect to the MCP server (e.g. Claude, Cursor, etc).
+
+**Plans**: MCP server is available on all plans.
+
+## Agent-driven development workflow
+
+> See [full docs for agent-driven workflow](./file-based-development.md)
+
+Best for: developers creating stuff that other people will use.
+
+**Functionality** Use a coding agent like Claude Code to understand your database's metadata, generate Metabase content as YAML files locally, verify the schema, then sync and import the generated into your production Metabase. Sky's the limit on what you can accomplish.
+
+**Controls**: Only admins can sync content to Metabase instances.
+
+**Provider**: Everything is handled by your coding agent of choice.
+
+**Plans**: Agent-driven workflows require a Pro/Enterprise plan.

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -13,50 +13,49 @@ Here are the different ways to use AI with Metabase:
 - [MCP server](#mcp-server)
 - [Agent-driven file-based development workflow](#agent-driven-development-workflow)
 
-
 ## Metabot
-
-> See [full docs for Metabot](metabot.md).
 
 **Best for: daily tasks in Metabase; granular control over people's AI usage.**
 
-**Functionality:** Metabot is Metabase's built-in AI agent. Metabot can help you with most daily tasks around Metabase, like answering questions about your data, creating queries, generating SQL code, explaining charts, or creating Documents. See [non-exhaustive list of things Metabot can do](metabot.md#what-metabot-can-do), as well as its [limitations](metabot.md#current-limitations).
+Metabot is Metabase's built-in AI agent. Metabot can help you with most daily tasks around Metabase, like answering questions about your data, creating queries, generating SQL code, explaining charts, or creating Documents. If you're embedding Metabase into your product, you can get the Metabot agent through the [AI chat component](../embedding/components.md#ai-chat). See [non-exhaustive list of things Metabot can do](metabot.md#what-metabot-can-do), as well as its [limitations](metabot.md#current-limitations).
 
 **Controls:** Metabot will only see what the person using it can see. Metabot also comes with additional permission controls and usage limits so that you control who can use which Metabot tools (e.g. chat vs SQL generation) and how many tokens they can spend.
 
-**Provider**:  Choose from:
+**Provider**: Choose from:
 
 - Metabase's own AI Service (available as an add-on exclusively for Metabase Cloud)
 - Third-party models via an API key (Anthropic models only for now).
 
 **Plans**: available on all plans. You can only use Metabase's AI Service on Metabase Cloud.
 
+See [full docs for Metabot](metabot.md) and [embedded AI chat](../embedding/components.md#ai-chat).
+
 ## MCP server
 
-> See [full docs for MCP server](mcp.md).
+**Best for: asking ad-hoc, ephemeral questions; combining data from Metabase with data from other tools.**
 
-**Best for: askng ad-hoc, ephemeral questions; combining data from Metabase with data from other tools.**
-
-**Functionality**: Connect your favorite third-party AI tool - like Claude or Codex - to the Metabase MCP server. MCP server's main functionality is designed to for answering in-the-moment questions like "hey btw what's our q3 revenue?". It's also useful when combined with other MCP servers - for example, you can ask Claude a question about your customer that combines data from Metabase, Salesforce, and Zendesk.
+Connect your favorite third-party AI tool - like Claude or Codex - to the Metabase MCP server. MCP server's main functionality is designed to for answering in-the-moment questions like "hey btw what's our q3 revenue?". The MCP server is also useful when combined with other MCP servers. for eFample, you can ask Claude a question about your customers that combines data from Metabase, your CRM, and your support ticket platform.
 
 Compared to the built-in Metabot, MCP server has somewhat restricted functionality (for example, it can't generate code or built transforms for now). See [the ever-expanding list of MCP server tools](mcp.md#available-tools).
 
-**Controls**: Metabase MCP server requires people to authenticate into Metabase, and all the responses it provides will be scoped to their permissions. However, Unlike built-in Metabot, MCP server doesn't come with granular control over which _tools_ people can use.
+**Controls**: Metabase MCP server requires people to authenticate into Metabase, and all the responses it provides will be scoped to their permissions. However, Unlike built-in Metabot, MCP server doesn't come with granular control over which _tools_ people can use, or disable MCP server altogether.
 
 **Provider**: Requests to Metabase MCP server are handled by the provider you choose connect to the MCP server (e.g. Claude, Cursor, etc).
 
 **Plans**: MCP server is available on all plans.
 
+See [full docs for MCP server](mcp.md).
+
 ## Agent-driven development workflow
 
-> See [full docs for agent-driven workflow](./file-based-development.md)
+**Best for: developers creating stuff that other people will use.**
 
-Best for: developers creating stuff that other people will use.
-
-**Functionality** Use a coding agent like Claude Code to understand your database's metadata, generate Metabase content as YAML files locally, verify the schema, then sync and import the generated into your production Metabase. Sky's the limit on what you can accomplish.
+Use a coding agent like Claude Code to understand your database's metadata, generate Metabase content as YAML files locally, verify the schema, then sync and import the generated into your production Metabase. Sky's the limit on what you can accomplish.
 
 **Controls**: Only admins can sync content to Metabase instances.
 
 **Provider**: Everything is handled by your coding agent of choice.
 
 **Plans**: Agent-driven workflows require a Pro/Enterprise plan.
+
+See [full docs for agent-driven workflow](./file-based-development.md)

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -1,0 +1,36 @@
+---
+title: AI in Metabase
+summary: Overview of all the ways you can use AI with Metabase.
+---
+
+# AI in Metabase
+
+There are three main ways you can use AI with your Metabase:
+
+- Metabot
+- MCP server
+- Agent-driven file-based workflow
+
+## Metabot
+
+See [Metabot](./metabot-slack.md)
+
+Metabot is Metabase's built-in AI agent. It can help you with tasks around Metabase, like answering questions about your data, generating
+
+- MCP server: best for
+
+Metabot is Metabase's built-in AI agent. ... : . Whenever you want to do something
+
+Non-exaustive list of
+
+- Chat interface, see []
+- AI exploration - a place for natural language querying
+- Code generation for SQL queries or transforms, and fixing tr
+- Analyzing a chart
+- Generating charts in documnents
+
+## MCP server
+
+You can set up your favorite third-party AI tool - like Claude or Codes
+
+MCP server has restricted functionality compared to the built-in Metabot, and doesn't come with granular usage controls (although the data _access_ is still scoped to user's permissions)

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -5,7 +5,9 @@ summary: Overview of all the ways you can use AI with Metabase.
 
 # AI in Metabase
 
-There are three main ways you can use AI with your Metabase:
+AI is in Metabase optional. You can use Metabase without AI at all. But if you do want to use AI to interact with Metabase, we have you covered.
+
+Here are the different ways to use AI with Metabase:
 
 - [Metabot](#metabot)
 - [MCP server](#mcp-server)


### PR DESCRIPTION
made an overview page, and yes I KNOW it's mostly repeating information stated elsewhere, but it just compiles it in one place rather than 30. Also in the AI overview doc i didn't want to make H3 headers because those are too aggressive and create an impression that there's just Too. Much. Stuff to read, so I settled on bolded words