### PR TITLE
Mark `mt/mbql-query` and friends as deprecated

### DIFF
--- a/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
+++ b/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
@@ -2,6 +2,7 @@
   "EE-only tests for `metabase.notification.payload.execute`. Kept in its own ns to avoid
   colliding with the OSS `metabase.notification.payload.execute-test` ns, which lives under
   `test/` and would otherwise shadow this file on the classpath."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.payload.execute-ee-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.notification.payload.execute :as notification.payload.execute]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.advanced-permissions.api.subscription-test
   "Permissions tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.advanced-permissions.api.subscription-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.notification.test-util :as notification.tu]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.query-processor.middleware.permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.advanced-permissions.query-processor.middleware.permissions-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.cache.cache-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.cache.cache-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.cache.strategies-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.cache.strategies-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.cache.task.refresh-cache-configs-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.cache.task.refresh-cache-configs-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.data-studio.permissions.query-test
   "Tests for published table query permissions.
   Published tables can be queried via collection permissions instead of data permissions."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.data-studio.permissions.query-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :refer [*current-user-id* *current-user-permissions-set* *is-superuser?*]]

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase-enterprise.database-routing.e2e-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase-enterprise.database-routing.e2e-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase-enterprise.database-routing.e2e-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase-enterprise.database-routing.e2e-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]

--- a/enterprise/backend/test/metabase_enterprise/database_routing/query_execution_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/query_execution_test.clj
@@ -2,6 +2,7 @@
   "Integration tests that verify `is_db_routed` is recorded on `:model/QueryExecution` rows when a query is routed
   to a destination database via DB routing. Drives a full userland query through the QP and inspects the persisted
   row."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.database-routing.query-execution-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.database-routing.e2e-test :as e2e]

--- a/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.dependencies.models.dependency-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.dependencies.models.dependency-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer [deftest is testing]]

--- a/enterprise/backend/test/metabase_enterprise/dependencies/task/backfill_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/task/backfill_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.dependencies.task.backfill-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.dependencies.task.backfill-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [environ.core :as env]

--- a/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.impersonation.cache-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.impersonation.cache-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.test :refer [deftest testing is]]

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase-enterprise.impersonation.driver-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase-enterprise.impersonation.driver-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase-enterprise.impersonation.driver-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/enterprise/backend/test/metabase_enterprise/impersonation/query_execution_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/query_execution_test.clj
@@ -2,6 +2,7 @@
   "Integration tests that verify `is_impersonated` is recorded on `:model/QueryExecution` rows when a query runs
   under an active connection-impersonation policy. Distinct from [[metabase-enterprise.impersonation.driver-test]]
   which tests role resolution; here we drive a full userland query through the QP and inspect the persisted row."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.impersonation.query-execution-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.impersonation.util-test :as impersonation.util-test]

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.permission-debug.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.permission-debug.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.permissions.core :as perms]

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.permission-debug.impl-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.permission-debug.impl-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.permission-debug.impl :as permission-debug.impl]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [diehard.core :as dh]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/collection_api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.collection-api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.collection-api-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.core-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.core-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.core :as core]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.dashboard-api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.dashboard-api-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/events_test.clj
@@ -2,6 +2,7 @@
   "Tests for the remote-sync events system.
 
    Tests event publishing, handling, and model change tracking functionality."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.events-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.impl-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.impl-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/models/remote_sync_object_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/models/remote_sync_object_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.remote-sync.models.remote-sync-object-test
   "Unit tests for the remote-sync-object namespace.
   Tests the public methods: dirty? and dirty-objects."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.models.remote-sync-object-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.models.remote-sync-object :as rs-object]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.remote-sync.permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.permissions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.settings :as settings]

--- a/enterprise/backend/test/metabase_enterprise/replacement/runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/runner_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.replacement.runner-test
   "Tests for bulk metadata loading in the replacement runner."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.replacement.runner-test]}}}}}}
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.dependencies.events]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.card-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.card-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.sandbox.api.dashboard-test
   "Tests for special behavior of `/api/metabase/dashboard` endpoints in the Metabase Enterprise Edition."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.dashboard-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.dataset-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.dataset-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.download-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.download-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.sandbox.api.field-test
   "Tests for special behavior of `/api/metabase/field` endpoints in the Metabase Enterprise Edition."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.field-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.test-util :as mt.tu]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.gtap-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.gtap-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/metric_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/metric_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.metric-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.metric-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.test-util :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.permissions-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.api.table-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.api.table-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.api.table :as table]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.models.params.chain-filter-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.models.params.chain-filter-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.models.params.field-values-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.models.params.field-values-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/sandbox_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/sandbox_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.models.sandbox-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.models.sandbox-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.models.sandbox :as sandboxes]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/notification_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.notification-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.notification-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.pulse-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.pulse-test]}}}}}}
   #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.data.csv :as csv]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase-enterprise.sandbox.query-processor.middleware.sandboxing-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase-enterprise.sandbox.query-processor.middleware.sandboxing-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase-enterprise.sandbox.query-processor.middleware.sandboxing-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase-enterprise.sandbox.query-processor.middleware.sandboxing-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/update_used_cards_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/update_used_cards_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.query-processor.middleware.update-used-cards-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.query-processor.middleware.update-used-cards-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.search.scoring-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.search.scoring-test]}}}}}}
   (:require
    [clojure.math.combinatorics :as math.combo]
    [clojure.set :as set]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.semantic-search.index-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.semantic-search.index-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.semantic-search.test-util
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.semantic-search.test-util]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.serialization.v2.e2e-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.serialization.v2.e2e-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1,4 +1,7 @@
 (ns metabase-enterprise.serialization.v2.extract-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase-enterprise.serialization.v2.extract-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase-enterprise.serialization.v2.extract-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase-enterprise.serialization.v2.extract-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.serialization.v2.load-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.serialization.v2.load-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/snippet_collections/models/native_query_snippet/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/snippet_collections/models/native_query_snippet/permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.snippet-collections.models.native-query-snippet.permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.snippet-collections.models.native-query-snippet.permissions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]

--- a/enterprise/backend/test/metabase_enterprise/stale/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/impl_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.stale.impl-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.stale.impl-test]}}}}}}
   (:require
    [clojure.test :refer [deftest is are testing]]
    [metabase-enterprise.stale.impl :as stale]

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.tenants.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.tenants.api-test]}}}}}}
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [metabase.collections.models.collection :as collection]

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests ^:mb/transforms-python-test metabase-enterprise.transforms.incremental-test
   "Tests for incremental transforms functionality."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.transforms.incremental-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.athena-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.athena-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.bigquery-cloud-sdk.params-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.bigquery-cloud-sdk.params-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.test :as qp]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.bigquery-cloud-sdk.query-processor-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.bigquery-cloud-sdk.query-processor-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.bigquery-cloud-sdk.query-processor-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase.driver.bigquery-cloud-sdk-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.driver.bigquery-cloud-sdk-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.driver.bigquery-cloud-sdk-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.bigquery-cloud-sdk-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
@@ -1381,4 +1384,3 @@
       (is (= ["INSERT INTO `PRODUCTS_COPY` SELECT * FROM products" nil]
              (driver/compile-insert :bigquery-cloud-sdk {:query {:query "SELECT * FROM products"}
                                                          :output-table :PRODUCTS_COPY}))))))
-

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-data-types-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.clickhouse-data-types-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.clickhouse-data-types-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-impersonation-test
   "SET ROLE (connection impersonation feature) tests with single node or on-premise cluster setups."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.clickhouse-impersonation-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.impersonation.util-test :as impersonation.tu]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_introspection_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_introspection_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-introspection-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.clickhouse-introspection-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.clickhouse-introspection-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-temporal-bucketing-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.clickhouse-temporal-bucketing-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.clickhouse-temporal-bucketing-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-test
   "Tests for specific behavior of the ClickHouse driver."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.clickhouse-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.databricks-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.databricks-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.databricks-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/query_processor_test.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/query_processor_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.druid-jdbc.query-processor-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.druid-jdbc.query-processor-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.druid-jdbc.query-processor-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.timeseries-test.util :as tqpt]

--- a/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc_test.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.druid-jdbc-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.druid-jdbc-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.druid-jdbc-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.druid.client-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.druid.client-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.test :refer :all]

--- a/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.druid.execute-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.druid.execute-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.druid.execute-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.driver.druid.query-processor-test
   "Some tests to make sure the Druid Query Processor is generating sane Druid queries when compiling MBQL."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.druid.query-processor-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.druid.query-processor-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [clojure.tools.macro :as tools.macro]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.execute-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.mongo.execute-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mongo.execute-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.test :refer :all]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.parameters-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.driver.mongo.parameters-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.driver.mongo.parameters-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mongo.parameters-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.query-processor-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.mongo.query-processor-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mongo.query-processor-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.driver.mongo-test
   "Tests for Mongo driver."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.mongo-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mongo-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.driver.oracle-test
   "Tests for specific behavior of the Oracle driver."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.oracle-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.oracle-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.presto-jdbc-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.presto-jdbc-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.redshift-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.redshift-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.snowflake-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.snowflake-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.snowflake-test]}}}}}}
   (:require
    [clojure.data :as data]
    [clojure.java.jdbc :as jdbc]

--- a/modules/drivers/sparksql/test/metabase/driver/sparksql_test.clj
+++ b/modules/drivers/sparksql/test/metabase/driver/sparksql_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.sparksql-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sparksql-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.sqlite-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sqlite-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sqlite-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.sqlserver-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sqlserver-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sqlserver-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.starburst-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.starburst-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.starburst-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
+++ b/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.vertica-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.vertica-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.actions.actions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions.actions-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.actions.actions-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]

--- a/test/metabase/actions/execution_test.clj
+++ b/test/metabase/actions/execution_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.actions.execution-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions.execution-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.actions.execution :as actions.execution]

--- a/test/metabase/actions/execution_write_pool_test.clj
+++ b/test/metabase/actions/execution_write_pool_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.actions.execution-write-pool-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions.execution-write-pool-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.actions.execution :as actions.execution]

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.actions.models-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions.models-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.actions.test-util
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions.test-util]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.actions.test-util]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.actions-rest.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.actions-rest.api-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.actions-rest.api-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/analyze/query_results_test.clj
+++ b/test/metabase/analyze/query_results_test.clj
@@ -1,4 +1,6 @@
 (ns metabase.analyze.query-results-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.analyze.query-results-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.analyze.query-results-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.analyze.fingerprint.fingerprinters :as fingerprinters]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -11,6 +11,7 @@
   - Alert attachments
 
   TODO (Cam 9/17/25) -- these tests need to get moved into appropriate module(s)."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.api.downloads-exports-test]}}}}}}
   (:require
    [clojure.data :as data]
    [clojure.data.csv :as csv]

--- a/test/metabase/app_db/query_test.clj
+++ b/test/metabase/app_db/query_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.app-db.query-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.app-db.query-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/auth_provider/impl_test.clj
+++ b/test/metabase/auth_provider/impl_test.clj
@@ -1,4 +1,6 @@
 (ns metabase.auth-provider.impl-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.auth-provider.impl-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.auth-provider.impl-test]}}}}}}
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase.auth-provider.impl :as auth-provider]

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.channel.impl.http-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.channel.impl.http-test]}}}}}}
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.channel.render.body-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.channel.render.body-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.channel.render.card-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.channel.render.card-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [hiccup.core :as hiccup]

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,4 +1,6 @@
 (ns metabase.cmd.load-from-h2-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.cmd.load-from-h2-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.cmd.load-from-h2-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.app-db.connection :as mdb.connection]

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.collections.models.collection-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.collections.models.collection-test]}}}}}}
   (:refer-clojure :exclude [descendants])
   (:require
    [clojure.math.combinatorics :as math.combo]

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.collections-rest.api-test
   "Tests for /api/collection endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.collections-rest.api-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.dashboards-rest.api-test
   "Tests for /api/dashboard endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.dashboards-rest.api-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.dashboards-rest.api-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.set :as set]

--- a/test/metabase/documents/api/document_test.clj
+++ b/test/metabase/documents/api/document_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.documents.api.document-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.documents.api.document-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/documents/models/document_test.clj
+++ b/test/metabase/documents/models/document_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.documents.models.document-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.documents.models.document-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.collections.models.collection :as collection]

--- a/test/metabase/documents/search_test.clj
+++ b/test/metabase/documents/search_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.documents.search-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.documents.search-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.common.parameters.values-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.common.parameters.values-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/test/metabase/driver/common_test.clj
+++ b/test/metabase/driver/common_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.common-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.common-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.common-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.h2-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.h2-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,4 +1,6 @@
 (ns metabase.driver.mysql-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.mysql-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mysql-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1,5 +1,8 @@
 (ns metabase.driver.postgres-test
   "Tests for features/capabilities specific to PostgreSQL driver, such as support for Postgres UUID or enum types."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.driver.postgres-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.driver.postgres-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.postgres-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.java.jdbc :as jdbc]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.sql.parameters.substitute-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql.parameters.substitute-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
+++ b/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sql.query-processor.boolean-to-comparison-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql.query-processor.boolean-to-comparison-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver.sql.query-processor :as sql.qp]

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.sql.query-processor-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql.query-processor-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sql.query-processor-test]}}}}}}
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -1,6 +1,8 @@
 (ns ^:mb/driver-tests metabase.driver.sql-jdbc.actions-test
   "Most of the tests for code in [[metabase.driver.sql-jdbc.actions]] are e2e tests that live
   in [[metabase.actions-rest.api-test]]."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc.actions-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sql-jdbc.actions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.actions.actions :as actions]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -2,7 +2,9 @@
   {:clj-kondo/config '{:linters
                        ;; allowing this for now since we sorta need to put real DBs in the app DB to test the DB ID
                        ;; -> connection pool stuff
-                       {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+                       {:discouraged-var {metabase.test/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc.connection-test]}
+                                                   metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sql-jdbc.connection-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]

--- a/test/metabase/driver/sql_jdbc/execute/diagnostic_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute/diagnostic_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.sql-jdbc.execute.diagnostic-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc.execute.diagnostic-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.driver.sql-jdbc.execute.diagnostic-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/driver/sql_jdbc/metadata_test.clj
+++ b/test/metabase/driver/sql_jdbc/metadata_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sql-jdbc.metadata-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc.metadata-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver.sql-jdbc.metadata :as sql-jdbc.metadata]

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -1,7 +1,8 @@
 (ns ^:mb/driver-tests metabase.driver.sql-jdbc.sync.describe-database-test
   {:clj-kondo/config '{:linters
                        ;; allowing this for now since sync doesn't work with Metadata Providers
-                       {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+                       {:discouraged-var {metabase.test/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc.sync.describe-database-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.sql-jdbc-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.sql-jdbc-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.embedding-rest.api.embed-test
   "Tests for /api/embed endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.embedding-rest.api.embed-test]}}}}}}
   (:require
    [buddy.sign.jwt :as jwt]
    [buddy.sign.util :as buddy-util]

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase.embedding-rest.api.preview-embed-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.embedding-rest.api.preview-embed-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.embedding-rest.api.preview-embed-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.embedding-rest.api.preview-embed-test]}}}}}}
   (:require
    [buddy.sign.jwt :as jwt]
    [clojure.test :refer :all]

--- a/test/metabase/indexed_entities/api_test.clj
+++ b/test/metabase/indexed_entities/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.indexed-entities.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.indexed-entities.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.analytics.snowplow-test :as snowplow-test]

--- a/test/metabase/indexed_entities/models/model_index_test.clj
+++ b/test/metabase/indexed_entities/models/model_index_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.indexed-entities.models.model-index-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.indexed-entities.models.model-index-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/indexed_entities/task/index_values_test.clj
+++ b/test/metabase/indexed_entities/task/index_values_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.indexed-entities.task.index-values-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.indexed-entities.task.index-values-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.indexed-entities.models.model-index-test :refer [with-scheduler-setup!]]

--- a/test/metabase/lib_be/hash_test.clj
+++ b/test/metabase/lib_be/hash_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.lib-be.hash-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.lib-be.hash-test]}}}}}}
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.test :refer :all]

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.lib-be.metadata.jvm-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.lib-be.metadata.jvm-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [malli.error :as me]

--- a/test/metabase/measures/api_test.clj
+++ b/test/metabase/measures/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.measures.api-test
   "Tests for /api/measure endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.measures.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.metabot.tools.entity-details-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metabot.tools.entity-details-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/metabot/tools/field_stats_test.clj
+++ b/test/metabase/metabot/tools/field_stats_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.metabot.tools.field-stats-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metabot.tools.field-stats-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.tools.field-stats :as metabot.tools.field-stats]

--- a/test/metabase/metrics/api_arithmetic_test.clj
+++ b/test/metabase/metrics/api_arithmetic_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.metrics.api-arithmetic-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metrics.api-arithmetic-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/metrics/api_dataset_test.clj
+++ b/test/metabase/metrics/api_dataset_test.clj
@@ -12,6 +12,7 @@
    - Error handling
 
    Some tests may fail for unimplemented features - this is expected."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metrics.api-dataset-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/metrics/api_test.clj
+++ b/test/metabase/metrics/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.metrics.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metrics.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/metrics/permissions_test.clj
+++ b/test/metabase/metrics/permissions_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.metrics.permissions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metrics.permissions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.metrics.permissions :as metrics.perms]

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.api.notification-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.api.notification-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.models-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.models-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.channel.api.channel-test :as api.channel-test]

--- a/test/metabase/notification/payload/execute_test.clj
+++ b/test/metabase/notification/payload/execute_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.payload.execute-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.payload.execute-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.notification.payload.execute :as notification.payload.execute]

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.payload.impl.card-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.payload.impl.card-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/test/metabase/notification/payload/temp_storage_test.clj
+++ b/test/metabase/notification/payload/temp_storage_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.payload.temp-storage-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.payload.temp-storage-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.notification.payload.temp-storage :as temp-storage]

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.notification.send-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.send-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -1,5 +1,6 @@
 (ns metabase.notification.test-util
   "Define the `metabase-test` channel and notification test utilities."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.notification.test-util]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.parameters.custom-values-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.parameters.custom-values-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.parameters.custom-values :as custom-values]

--- a/test/metabase/parameters/dashboard_test.clj
+++ b/test/metabase/parameters/dashboard_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.parameters.dashboard-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.parameters.dashboard-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :as api]

--- a/test/metabase/parameters/params_test.clj
+++ b/test/metabase/parameters/params_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.parameters.params-test
   "Tests for the utility functions for dealing with parameters in `metabase.parameters.params`."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.parameters.params-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.parameters.params :as params]

--- a/test/metabase/public_sharing_rest/api_documents_test.clj
+++ b/test/metabase/public_sharing_rest/api_documents_test.clj
@@ -2,6 +2,7 @@
   "Tests for public sharing endpoints for Documents.
 
   These tests verify that public document endpoints work correctly."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.public-sharing-rest.api-documents-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.documents.test-util :as documents.test-util]

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.public-sharing-rest.api-test
   "Tests for `api/public/` (public links) endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.public-sharing-rest.api-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.set :as set]

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.pulse.api.pulse-test
   "Tests for /api/pulse endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.pulse.api.pulse-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.pulse.dashboard-subscription-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.pulse.dashboard-subscription-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -3,6 +3,7 @@
 
   These tests should build content then mock out distrubution by usual channels (e.g. email) and check the results of
   the distributed content for correctness."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.pulse.pulse-integration-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.string :as str]

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.pulse.send-test
   "These are mostly Alerts test, dashboard subscriptions could be found in
   [[metabase.pulse.dashboard-subscription-test]]."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.pulse.send-test]}}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -1,4 +1,5 @@
 (ns metabase.pulse.test-util
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.pulse.test-util]}}}}}}
   (:require
    [medley.core :as m]
    [metabase.channel.core :as channel]

--- a/test/metabase/queries/metadata_test.clj
+++ b/test/metabase/queries/metadata_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.queries.metadata-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.queries.metadata-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.queries.models.card-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.queries.models.card-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.queries-rest.api.card-test
   "Tests for /api/card endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.queries-rest.api.card-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.queries-rest.api.card-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.set :as set]

--- a/test/metabase/query_permissions/impl_test.clj
+++ b/test/metabase/query_permissions/impl_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-permissions.impl-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-permissions.impl-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*]]

--- a/test/metabase/query_processor/advanced_math_test.clj
+++ b/test/metabase/query_processor/advanced_math_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.advanced-math-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.advanced-math-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.advanced-math-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/aggregation_test.clj
+++ b/test/metabase/query_processor/aggregation_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.aggregation-test
   "Tests for MBQL aggregations."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.aggregation-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.aggregation-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as =?]

--- a/test/metabase/query_processor/alternative_date_test.clj
+++ b/test/metabase/query_processor/alternative_date_test.clj
@@ -1,6 +1,8 @@
 (ns ^:mb/driver-tests metabase.query-processor.alternative-date-test
   "Tests for columns that mimic dates: integral types as UNIX timestamps and string columns as ISO8601DateTimeString and
   related types."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.alternative-date-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.alternative-date-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -6,7 +6,8 @@
                        ;; allowing `with-temp` here for now since this tests the REST API which doesn't fully use
                        ;; metadata providers.
                        {:discouraged-var {metabase.test/with-temp           {:level :off}
-                                          toucan2.tools.with-temp/with-temp {:level :off}}}}}
+                                          toucan2.tools.with-temp/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.api-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.set :as set]

--- a/test/metabase/query_processor/binning_test.clj
+++ b/test/metabase/query_processor/binning_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.binning-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.binning-test]}}}}}}
   (:require
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]

--- a/test/metabase/query_processor/breakout_test.clj
+++ b/test/metabase/query_processor/breakout_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.breakout-test
   "Tests for the `:breakout` clause."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.breakout-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.breakout-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -4,7 +4,8 @@
                        ;; allowing `with-temp` here for now since this tests the REST API which doesn't fully use
                        ;; metadata providers.
                        {:discouraged-var {metabase.test/with-temp           {:level :off}
-                                          toucan2.tools.with-temp/with-temp {:level :off}}}}}
+                                          toucan2.tools.with-temp/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.card-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/case_test.clj
+++ b/test/metabase/query_processor/case_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.case-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.case-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.case-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/cast_test.clj
+++ b/test/metabase/query_processor/cast_test.clj
@@ -5,7 +5,8 @@
                         ;; there are several legacy usages of `field-is-type?` here, and I don't really want to add
                         ;; clj-kondo/ignores to all of them... so this will take care of it. We do still want to remove
                         ;; them soon.
-                        :deprecated-var {:exclude {metabase.types.core/field-is-type? {:namespaces ["metabase\\.query-processor\\.cast-test"]}}}
+                        :deprecated-var        {:exclude {metabase.types.core/field-is-type? {:namespaces [metabase.query-processor.cast-test]}
+                                                          metabase.test.data/mbql-query      {:namespaces [metabase.query-processor.cast-test]}}}
                         ;; this is also ok here since this is a drivers namespace
                         :discouraged-var       {metabase.lib.core/->legacy-MBQL {:level :off}}}}}
   (:require

--- a/test/metabase/query_processor/constraints_test.clj
+++ b/test/metabase/query_processor/constraints_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.constraints-test
   "Test for MBQL `:constraints`"
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.constraints-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.compile :as qp.compile]

--- a/test/metabase/query_processor/count_where_test.clj
+++ b/test/metabase/query_processor/count_where_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.count-where-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.count-where-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.count-where-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/cumulative_aggregation_test.clj
+++ b/test/metabase/query_processor/cumulative_aggregation_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.cumulative-aggregation-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.cumulative-aggregation-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.cumulative-aggregation-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.query-processor.dashboard-test
   "There are more e2e tests in [[metabase.dashboards-rest.api-test]]."
   {:clj-kondo/config '{:linters {:discouraged-var {metabase.test/with-temp           {:level :off}
-                                                   toucan2.tools.with-temp/with-temp {:level :off}}}}}
+                                                   toucan2.tools.with-temp/with-temp {:level :off}}
+                                 :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.dashboard-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]

--- a/test/metabase/query_processor/date_bucketing_test.clj
+++ b/test/metabase/query_processor/date_bucketing_test.clj
@@ -14,6 +14,9 @@
 
   If a report timezone is specified and the database supports it, the JVM timezone should have no impact on queries or
   their results."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.date-bucketing-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.query-processor.date-bucketing-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.date-bucketing-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.date-time-zone-functions-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.date-time-zone-functions-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.date-time-zone-functions-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/distinct_where_test.clj
+++ b/test/metabase/query_processor/distinct_where_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.distinct-where-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.distinct-where-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.distinct-where-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/execute_test.clj
+++ b/test/metabase/query_processor/execute_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.execute-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.execute-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.test :as qp]

--- a/test/metabase/query_processor/explicit_joins_test.clj
+++ b/test/metabase/query_processor/explicit_joins_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.explicit-joins-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.explicit-joins-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.explicit-joins-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/query_processor/expression_aggregations_test.clj
+++ b/test/metabase/query_processor/expression_aggregations_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.expression-aggregations-test
   "Tests for expression aggregations and for named aggregations."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.expression-aggregations-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.expression-aggregations-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.expressions-test
   "Tests for expressions (calculated columns)."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.expressions-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.expressions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/field_ref_repro_test.clj
+++ b/test/metabase/query_processor/field_ref_repro_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.field-ref-repro-test
   "Reproduction tests for field ref(erence) issues. These are negative tests, if some fail,
   we might have actually fixed a bug."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.field-ref-repro-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/field_visibility_test.clj
+++ b/test/metabase/query_processor/field_visibility_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.field-visibility-test
   "Tests for behavior of fields with different visibility settings."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.field-visibility-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.field-visibility-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/fields_test.clj
+++ b/test/metabase/query_processor/fields_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.fields-test
   "Tests for the `:fields` clause."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.fields-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.fields-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.filter-test
   "Tests for the `:filter` clause."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.filter-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.filter-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/implicit_joins_test.clj
+++ b/test/metabase/query_processor/implicit_joins_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.implicit-joins-test
   "Tests for joins that are created automatically when an `:fk->` column is present."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.implicit-joins-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.implicit-joins-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.metadata-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.metadata-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.add-implicit-clauses-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.add-implicit-clauses-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.add-implicit-joins-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.add-implicit-joins-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/middleware/add_remaps_test.clj
+++ b/test/metabase/query_processor/middleware/add_remaps_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.add-remaps-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.add-remaps-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/middleware/add_rows_truncated_test.clj
+++ b/test/metabase/query_processor/middleware/add_rows_truncated_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.add-rows-truncated-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.add-rows-truncated-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.test-metadata :as meta]

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.annotate-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.annotate-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.annotate-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -1,5 +1,7 @@
 (ns metabase.query-processor.middleware.binning-test
   "There are more 'e2e' tests related to binning in [[metabase.query-processor.breakout-test]]."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.binning-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.binning-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.cache-test
   "Tests for the Query Processor cache."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.cache-test]}}}}}}
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.core.async :as a]

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.catch-exceptions-test
   "There are additional tests in [[metabase.query-processor.failure-test]]."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.catch-exceptions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.fetch-source-query-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.fetch-source-query-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/query_processor/middleware/fix_bad_field_id_refs_test.clj
+++ b/test/metabase/query_processor/middleware/fix_bad_field_id_refs_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.fix-bad-field-id-refs-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.fix-bad-field-id-refs-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.format-rows-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.format-rows-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.format-rows-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.metrics-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.metrics-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer [deftest is testing]]

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -1,5 +1,8 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.parameters.mbql-test
   "Tests for *MBQL* parameter substitution."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.middleware.parameters.mbql-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.query-processor.middleware.parameters.mbql-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.parameters.mbql-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/middleware/parameters/native_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/native_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.middleware.parameters.native-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.parameters.native-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.parameters-test
   "Testings to make sure the parameter substitution middleware works as expected. Even though the below tests are
   SQL-specific, they still confirm that the middleware itself is working correctly."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.parameters-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.permissions-test
   "Tests for the middleware that checks whether the current user has permissions to run a given query."
-  {:clj-kondo/config '{:linters {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+  {:clj-kondo/config '{:linters {:discouraged-var {metabase.test/with-temp {:level :off}}
+                                 :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.permissions-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.common :as api]

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -1,4 +1,7 @@
 (ns metabase.query-processor.middleware.process-userland-query-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.middleware.process-userland-query-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.query-processor.middleware.process-userland-query-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.process-userland-query-test]}}}}}}
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.core.async :as a]

--- a/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
+++ b/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.middleware.remove-inactive-field-refs-test
   "See also [[metabase.query-processor.inactive-fields-test]] (for e2e tests related to inactive fields in other
   situations)."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.remove-inactive-field-refs-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.remove-inactive-field-refs-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.resolve-referenced-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.resolve-referenced-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -2,7 +2,10 @@
   {:clj-kondo/config '{:linters
                        ;; allowing with-temp in this namespace since it's checking whether we actually save stuff to the
                        ;; app DB
-                       {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+                       {:discouraged-var {metabase.test/with-temp {:level :off}}
+                        :deprecated-var  {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.middleware.results-metadata-test]}
+                                                    metabase.test.data/query          {:namespaces [metabase.query-processor.middleware.results-metadata-test]}
+                                                    metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.results-metadata-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/middleware/update_used_cards_test.clj
+++ b/test/metabase/query_processor/middleware/update_used_cards_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.query-processor.middleware.update-used-cards-test
   {:clj-kondo/config '{:linters
                        ;; allowing `with-temp` here since this actually tests what we persist to the app DB
-                       {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+                       {:discouraged-var {metabase.test/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.update-used-cards-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/middleware/validate_temporal_bucketing_test.clj
+++ b/test/metabase/query_processor/middleware/validate_temporal_bucketing_test.clj
@@ -1,4 +1,6 @@
 (ns metabase.query-processor.middleware.validate-temporal-bucketing-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.middleware.validate-temporal-bucketing-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.middleware.validate-temporal-bucketing-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.native-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.native-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/nested_array_test.clj
+++ b/test/metabase/query_processor/nested_array_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.nested-array-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.nested-array-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/nested_field_test.clj
+++ b/test/metabase/query_processor/nested_field_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.nested-field-test
   "Tests for nested field access."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.nested-field-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.nested-field-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.test :as qp]

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -1,5 +1,8 @@
 (ns ^:mb/driver-tests metabase.query-processor.nested-queries-test
   "Tests for handling queries with nested expressions."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.nested-queries-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.query-processor.nested-queries-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.nested-queries-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/query_processor/null_array_test.clj
+++ b/test/metabase/query_processor/null_array_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.null-array-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.null-array-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/offset_test.clj
+++ b/test/metabase/query_processor/offset_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.offset-test
   "Tests for the new :offset window function clause (#9393)."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.offset-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/query_processor/order_by_test.clj
+++ b/test/metabase/query_processor/order_by_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.order-by-test
   "Tests for the `:order-by` clause."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.order-by-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.order-by-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/page_test.clj
+++ b/test/metabase/query_processor/page_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.page-test
   "Tests for the `:page` clause."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.page-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/parameters/temporal_units_test.clj
+++ b/test/metabase/query_processor/parameters/temporal_units_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.parameters.temporal-units-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.parameters.temporal-units-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/parameters_test.clj
+++ b/test/metabase/query_processor/parameters_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.parameters-test
   "Tests for support for parameterized queries in drivers that support it. (There are other tests for parameter support
   in various places; these are mainly for high-level verification that parameters are working.)"
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.parameters-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -1,7 +1,8 @@
 (ns ^:mb/driver-tests metabase.query-processor.persistence-test
   {:clj-kondo/config '{:linters
                        ;; allowing with-temp in this namespace since model persistence needs to hit the app DB
-                       {:discouraged-var {metabase.test/with-temp {:level :off}}}}}
+                       {:discouraged-var {metabase.test/with-temp {:level :off}}
+                        :deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.persistence-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]

--- a/test/metabase/query_processor/pivot/test_util.clj
+++ b/test/metabase/query_processor/pivot/test_util.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.pivot.test-util
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.pivot.test-util]}}}}}}
   (:require
    [metabase.lib.core :as lib]
    [metabase.test :as mt]))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.pivot-test
   "Tests for pivot table actions for the query processor"
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.pivot-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/postprocess_test.clj
+++ b/test/metabase/query_processor/postprocess_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.postprocess-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.postprocess-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.preprocess-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.preprocess-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/query_to_native_test.clj
+++ b/test/metabase/query_processor/query_to_native_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.query-to-native-test
   "Tests around the `compile` function."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.query-to-native-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.compile :as qp.compile]

--- a/test/metabase/query_processor/remapping_test.clj
+++ b/test/metabase/query_processor/remapping_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.remapping-test
   "Tests for the remapping results"
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.remapping-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.remapping-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/share_test.clj
+++ b/test/metabase/query_processor/share_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.share-test
   "Tests for the `:share` aggregation."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.share-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.share-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.streaming.csv-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.streaming.csv-test]}}}}}}
   (:require
    [clojure.data.csv :as csv]
    [clojure.string :as str]

--- a/test/metabase/query_processor/streaming/json_test.clj
+++ b/test/metabase/query_processor/streaming/json_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.streaming.json-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.streaming.json-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.streaming :as qp.streaming]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.streaming-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.streaming-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.data.csv :as csv]

--- a/test/metabase/query_processor/string_extracts_test.clj
+++ b/test/metabase/query_processor/string_extracts_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.string-extracts-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.string-extracts-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.string-extracts-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/sum_where_test.clj
+++ b/test/metabase/query_processor/sum_where_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.sum-where-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.sum-where-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.sum-where-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -5,6 +5,7 @@
   The various QP Store functions & macros in this namespace are primarily meant to help write QP Middleware tests, so
   you can test a given piece of middleware without having to worry about putting things in the QP Store
   yourself (since this is usually done by other middleware in the first place)."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.test-util]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/query_processor/time_field_test.clj
+++ b/test/metabase/query_processor/time_field_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.time-field-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.time-field-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.time-field-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/timeseries_test.clj
+++ b/test/metabase/query_processor/timeseries_test.clj
@@ -1,8 +1,10 @@
 (ns metabase.query-processor.timeseries-test
   "Query processor tests for DBs that are event-based, like Druid.
   There architecture is different enough that we can't test them along with our 'normal' DBs in `query-procesor-test`."
-  {:clj-kondo/config '{:hooks {:analyze-call {metabase.query-processor.timeseries-test/run-mbql-query
-                                              hooks.metabase.test.data/mbql-query}}}}
+  {:clj-kondo/config '{:hooks   {:analyze-call {metabase.query-processor.timeseries-test/run-mbql-query
+                                                hooks.metabase.test.data/mbql-query}}
+                       :linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.timeseries-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.timeseries-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/timezones_test.clj
+++ b/test/metabase/query_processor/timezones_test.clj
@@ -1,4 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.timezones-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.query-processor.timezones-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.query-processor.timezones-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.timezones-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.util.nest-query-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.util.nest-query-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor/util/relative_datetime_test.clj
+++ b/test/metabase/query_processor/util/relative_datetime_test.clj
@@ -1,4 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor.util.relative-datetime-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.util.relative-datetime-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.util.relative-datetime-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [honey.sql :as sql]

--- a/test/metabase/query_processor/uuid_test.clj
+++ b/test/metabase/query_processor/uuid_test.clj
@@ -1,5 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor.uuid-test
   "Tests for queries involving uuids."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.query-processor.uuid-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.query-processor.uuid-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.revisions.api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.revisions.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.config.core :as config]

--- a/test/metabase/revisions/impl/card_test.clj
+++ b/test/metabase/revisions/impl/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.revisions.impl.card-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.revisions.impl.card-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -58,10 +58,10 @@
    :dashboardcard_count        nil
    :database_name              nil
    :description                nil
-   :display                    nil   :id                         true
-   :initial_sync_status        nil   :model_name
-
-   nil
+   :display                    nil
+   :id                         true
+   :initial_sync_status        nil
+   :model_name                 nil
    :moderated_status           nil
    :last_editor_common_name    nil
    :last_editor_id             false

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1,6 +1,9 @@
 (ns metabase.search.api-test
   "There are more tests around search in [[metabase.search.impl-test]]. TODO: we should move more of the tests
   below into that namespace."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query     {:namespaces [metabase.search.api-test]}
+                                                            metabase.test.data/query          {:namespaces [metabase.search.api-test]}
+                                                            metabase.test.data/run-mbql-query {:namespaces [metabase.search.api-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -55,10 +58,10 @@
    :dashboardcard_count        nil
    :database_name              nil
    :description                nil
-   :display                    nil
-   :id                         true
-   :initial_sync_status        nil
-   :model_name                 nil
+   :display                    nil   :id                         true
+   :initial_sync_status        nil   :model_name
+
+   nil
    :moderated_status           nil
    :last_editor_common_name    nil
    :last_editor_id             false

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.search.appdb.index-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.search.appdb.index-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/search/in_place/scoring_test.clj
+++ b/test/metabase/search/in_place/scoring_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.search.in-place.scoring-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.search.in-place.scoring-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/segments/api_test.clj
+++ b/test/metabase/segments/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.segments.api-test
   "Tests for /api/segment endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.segments.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]

--- a/test/metabase/segments/models/segment_test.clj
+++ b/test/metabase/segments/models/segment_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.segments.models.segment-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.segments.models.segment-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.models.interface :as mi]

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -134,7 +134,9 @@
    (mbql-query-impl/parse-tokens table-name `(do ~@body))))
 
 (defmacro mbql-query
-  "Macro for easily building MBQL queries for test purposes.
+  "DEPRECATED: Use Lib to generate MBQL queries instead of hand-rolling legacy MBQL queries in new tests.
+
+  Macro for easily building MBQL queries for test purposes.
 
   *  `$`  = `:field` clause wrapping Field ID
   *  `$$` = table ID
@@ -150,7 +152,7 @@
      complete details.
   *  Wraps 'inner' query with the standard `{:database (data/id), :type :query, :query {...}}` boilerplate
   *  Adds `:source-table` clause if `:source-table` or `:source-query` is not already present"
-  {:style/indent :defn}
+  {:style/indent :defn, :deprecated "0.61.0"}
   ([table-name]
    `(mbql-query ~table-name {}))
 
@@ -162,10 +164,12 @@
      (mbql-query-impl/wrap-inner-query <>))))
 
 (defmacro query
-  "Like `mbql-query`, but operates on an entire 'outer' query rather than the 'inner' MBQL query. Like `mbql-query`,
+  "DEPRECATED: Use Lib to generate MBQL queries instead of hand-rolling legacy MBQL queries in new tests.
+
+  Like `mbql-query`, but operates on an entire 'outer' query rather than the 'inner' MBQL query. Like `mbql-query`,
   automatically adds `:database` and `:type` to the top-level 'outer' query, and `:source-table` to the 'inner' MBQL
   query if not present."
-  {:style/indent 1}
+  {:style/indent 1, :deprecated "0.61.0"}
   ([table-name]
    `(query ~table-name {}))
 
@@ -180,8 +184,11 @@
 (declare id)
 
 (mu/defn native-query :- ::mbql.s/Query
-  "Like `mbql-query`, but for native queries."
+  "DEPRECATED: Use Lib to generate MBQL queries instead of hand-rolling legacy MBQL queries in new tests.
+
+  Like `mbql-query`, but for native queries."
   [inner-native-query :- :map]
+  {:deprecated "0.61.0"}
   #_{:clj-kondo/ignore [:deprecated-var]}
   {:database (id)
    :type     :native
@@ -197,9 +204,13 @@
                       e)))))
 
 (defmacro run-mbql-query
-  "Like `mbql-query`, but runs the query as well."
-  {:style/indent :defn}
+  "DEPRECATED: Use Lib to generate MBQL queries and [[metabase.query-processor/process-query]] instead of hand-rolling
+  legacy MBQL queries in new tests.
+
+  Like `mbql-query`, but runs the query as well."
+  {:style/indent :defn, :deprecated "0.61.0"}
   [table-name & [query]]
+  #_{:clj-kondo/ignore [:deprecated-var]}
   `(run-mbql-query* (mbql-query ~table-name ~(or query {}))))
 
 (def ^:private FormattableName

--- a/test/metabase/test/data/sql.clj
+++ b/test/metabase/test/data/sql.clj
@@ -1,5 +1,6 @@
 (ns metabase.test.data.sql
   "Common test extension functionality for all SQL drivers."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.test.data.sql]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.walk :as walk]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1021,6 +1021,7 @@
         called-query? (promise)
         pause-query (promise)
         query-thunk (fn []
+                      #_{:clj-kondo/ignore [:deprecated-var]}
                       (data/run-mbql-query checkins
                         {:aggregation [[:count]]}))
         ;; When the query is ran via the datasets endpoint, it will run in a future. That future can be canceled,
@@ -1317,6 +1318,7 @@
          (= (first x) 'values-of))
     (let [[_ table+field] x
           [table field] (str/split (str table+field) #"\.")]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       `(into {} (get-in (data/run-mbql-query ~(symbol table)
                           {:fields [~'$id ~(symbol (str \$ field))]})
                         [:data :rows])))

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.tiles.api-test
   "Tests for `/api/tiles` endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.tiles.api-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]

--- a/test/metabase/transforms/search_test.clj
+++ b/test/metabase/transforms/search_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.transforms.search-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.transforms.search-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.transforms.util-test
   "Tests for transform utility functions."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.transforms.util-test]}}}}}}
   (:require
    [clojure.core.async :as a]
    [clojure.test :refer :all]

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.transforms-rest.api.transform-test
   "Tests for /api/transform endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.transforms-rest.api.transform-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]

--- a/test/metabase/view_log/events/view_log_test.clj
+++ b/test/metabase/view_log/events/view_log_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.view-log.events.view-log-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.view-log.events.view-log-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.warehouse-schema-rest.api.table-test
   "Tests for /api/table endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.warehouse-schema-rest.api.table-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.warehouses-rest.api-test
   "Tests for /api/database endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.warehouses-rest.api-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/xrays/api/automagic_dashboards_test.clj
+++ b/test/metabase/xrays/api/automagic_dashboards_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.xrays.api.automagic-dashboards-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.xrays.api.automagic-dashboards-test]}}}}}}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.xrays.automagic-dashboards.core-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.xrays.automagic-dashboards.core-test]}}}}}}
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/test/metabase/xrays/automagic_dashboards/util_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/util_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.xrays.automagic-dashboards.util-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.xrays.automagic-dashboards.util-test]}}}}}}
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]

--- a/test/metabase/xrays/related_test.clj
+++ b/test/metabase/xrays/related_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.xrays.related-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.xrays.related-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]


### PR DESCRIPTION
Resolves QUE2-574

I'm still reviewing PRs from other teams with tests that still hand-roll legacy MBQL, let's make it clear we don't want people doing this any more.

There were ~2400 usages of `mt/mbql-query` and friends, so marking them all `:clj-kondo/ignore` would take forever, so I just updated the ~250 namespaces that used them to disable these specific Kondo warnings... this means we should at least catch new usages of them when people add new files.