### PR TITLE
BOT-1506 Add pre-conditions on metabot_message.external_id migration in v61

### DIFF
--- a/resources/migrations/060/20260501_metabot_source_feedback.yaml
+++ b/resources/migrations/060/20260501_metabot_source_feedback.yaml
@@ -4,6 +4,53 @@ databaseChangeLog:
   - logicalFilePath: migrations/060_update_migrations.yaml
 
   - changeSet:
+      id: v60.2026-05-01T10:00:00
+      author: undrfined
+      comment: Add nullable external_id column to metabot_message
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v61.2026-04-21T10:00:00
+              author: sloansparger
+              changeLogFile: migrations/061_update_migrations.yaml
+      changes:
+        - addColumn:
+            tableName: metabot_message
+            columns:
+              - column:
+                  name: external_id
+                  type: varchar(36)
+                  remarks: Stable id shared with clients and used to resolve feedback submissions
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: metabot_message
+            columnName: external_id
+
+  - changeSet:
+      id: v60.2026-05-01T10:00:01
+      author: undrfined
+      comment: Unique constraint on metabot_message.external_id for feedback lookup
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v61.2026-04-21T10:00:01
+              author: sloansparger
+              changeLogFile: migrations/061_update_migrations.yaml
+      changes:
+        - addUniqueConstraint:
+            tableName: metabot_message
+            columnNames: external_id
+            constraintName: uq_metabot_message_external_id
+      rollback:
+        - dropUniqueConstraint:
+            tableName: metabot_message
+            constraintName: uq_metabot_message_external_id
+
+  - changeSet:
       id: v60.srcefb
       author: undrfined
       comment: metabot_source_feedback table

--- a/resources/migrations/061/20260421_metabot_message_external_id.yaml
+++ b/resources/migrations/061/20260421_metabot_message_external_id.yaml
@@ -5,6 +5,13 @@ databaseChangeLog:
       id: v61.2026-04-21T10:00:00
       author: sloansparger
       comment: Add nullable external_id column to metabot_message
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-05-01T10:00:00
+              author: undrfined
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - addColumn:
             tableName: metabot_message
@@ -15,17 +22,22 @@ databaseChangeLog:
                   remarks: Stable id shared with clients and used to resolve feedback submissions
                   constraints:
                     nullable: true
+      rollback: ""
 
   - changeSet:
       id: v61.2026-04-21T10:00:01
       author: sloansparger
       comment: Unique constraint on metabot_message.external_id for feedback lookup
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-05-01T10:00:01
+              author: undrfined
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - addUniqueConstraint:
             tableName: metabot_message
             columnNames: external_id
             constraintName: uq_metabot_message_external_id
-      rollback:
-        - dropUniqueConstraint:
-            tableName: metabot_message
-            constraintName: uq_metabot_message_external_id
+      rollback: ""


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74124

### Description

Prevents migration failure when upgrading from v60 -> v61.

Context:

v61 (release-x.61.x) has this original migration:
  - resources/migrations/061/20260421_metabot_message_external_id.yaml
  - Changeset id v61.2026-04-21T10:00:00
  - Adds external_id column to metabot_message — with no preConditions

v60 (release-x.60.x) has this backport:
  - resources/migrations/060/20260501_metabot_source_feedback.yaml
  - Changeset id v60.2026-05-01T10:00:00
  - Adds external_id column to metabot_message (and the unique constraint)
  - Came in via commit 3caa0125e91 — "🤖 backported '[Metabot] Data source feedback' (#73785)"

Users upgrading from v60 after 3caa0125e91 will therefore already have external_id and we need a guard on the v61
changesets to prevent running them. At the same time, we need a guard on the v60 migration to prevent downgrade
conflicts if someone happened to install from a version of v61 prior to these changes.

The specific fix here (empty rollback in v61, pre-conditions on both changesets) mirrors the strategy suggested for
the `ai_usage_log` backport in #72651

### Tests

These tests were done by backporting my changes to the v61 and v60 release branches locally, then building jars for those branches + this branch (called v1.62.x in the tables below) and testing upgrades/downgrades between them.

Tested the following upgrade / downgrade single-step paths:

```
  Direction  Source   Target   Result
  Upgrade    v1.59.x  v1.60.x  OK
  Upgrade    v1.60.x  v1.61.x  OK
  Upgrade    v1.61.x  v1.62.x  OK
  Downgrade  v1.62.x  v1.61.x  OK
  Downgrade  v1.61.x  v1.60.x  OK
  Downgrade  v1.60.x  v1.59.x  OK
```

Also tested a full upgrade/downgrade multi-step path: v60 -> v61 -> v62 (master) -> v61 -> v60 -> v59

```
  #      Transition  Direction      Result
  start  —           start v1.60.x  OK
  1      v60 → v61   upgrade        OK
  2      v61 → v62   upgrade        OK
  3      v62 → v61   downgrade      OK
  4      v61 → v60   downgrade      OK
  5      v60 → v59   downgrade      OK
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
