### PR TITLE
Move trackCustomHomepageDashboardEnabled to shared

### DIFF
--- a/frontend/lint/eslint-plugin-metabase/rules/no-analytics-import-outside-analytics-files.js
+++ b/frontend/lint/eslint-plugin-metabase/rules/no-analytics-import-outside-analytics-files.js
@@ -1,24 +1,26 @@
 /**
  * @fileoverview Rule that restricts `trackSchemaEvent` and `trackSimpleEvent`
- * imports from `metabase/analytics` to files named `analytics.{ts,tsx,js,jsx}`.
+ * imports from `metabase/analytics` to files named `analytics.{ts,tsx,js,jsx}`
+ * or files inside an `analytics/` directory.
  *
- * Every Snowplow event must be wrapped in a feature-local `analytics.ts` so
- * tracking stays auditable and each feature owns the shape of its events.
- * Other exports from the barrel (`createSnowplowTracker`, `trackPageView`) are
- * infrastructure and may be imported anywhere.
+ * Every Snowplow event must be wrapped in a feature-local `analytics.ts` (or
+ * a file inside an `analytics/` folder) so tracking stays auditable and each
+ * feature owns the shape of its events. Other exports from the barrel
+ * (`createSnowplowTracker`, `trackPageView`) are infrastructure and may be
+ * imported anywhere.
  */
 
 const BARREL = "metabase/analytics";
 const FORBIDDEN_SPECIFIERS = new Set(["trackSchemaEvent", "trackSimpleEvent"]);
 
 const errorMessage = (name) =>
-  `importing \`${name}\` from "${BARREL}" is only allowed in files named "analytics". Please create a type-safe wrapper in an analytics.ts file and call that wrapper from your component or module.`;
+  `importing \`${name}\` from "${BARREL}" is only allowed in files named "analytics" or inside an "analytics/" directory. Please create a type-safe wrapper in an analytics.ts file (or under an analytics/ folder) and call that wrapper from your component or module.`;
 
 module.exports = {
   meta: {
     type: "problem",
     docs: {
-      description: `Restrict ${[...FORBIDDEN_SPECIFIERS].join(" and ")} imports from "${BARREL}" to analytics.ts files.`,
+      description: `Restrict ${[...FORBIDDEN_SPECIFIERS].join(" and ")} imports from "${BARREL}" to analytics.ts files or files inside an analytics/ directory.`,
       category: "Best Practices",
       recommended: true,
     },
@@ -26,10 +28,12 @@ module.exports = {
   },
   create(context) {
     const filename = context.getFilename();
-    const baseFilename = filename.split("/").pop() || "";
+    const segments = filename.split("/");
+    const baseFilename = segments[segments.length - 1] || "";
     const isAnalyticsFile = /^analytics\.(ts|tsx|js|jsx)$/.test(baseFilename);
+    const isInAnalyticsDir = segments.slice(0, -1).includes("analytics");
 
-    if (isAnalyticsFile) {
+    if (isAnalyticsFile || isInAnalyticsDir) {
       return {};
     }
 

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -72,6 +72,7 @@ const elements = [
   createElement({ type: "shared", name: "forms", enforceOutgoing: true }),
   createElement({ type: "shared", name: "history", enforceOutgoing: true }),
   createElement({ type: "shared", name: "hoc", enforceOutgoing: true }),
+  createElement({ type: "shared", name: "home", enforceOutgoing: true }),
   createElement({ type: "shared", name: "hooks", enforceOutgoing: true }),
   createElement({ type: "shared", name: "i18n", enforceOutgoing: true }),
   createElement({ type: "shared", name: "metadata", enforceOutgoing: true }),

--- a/frontend/lint/tests/no-analytics-import-outside-analytics-files.unit.spec.js
+++ b/frontend/lint/tests/no-analytics-import-outside-analytics-files.unit.spec.js
@@ -10,7 +10,8 @@ const ruleTester = new RuleTester({
   },
 });
 
-const errorMessage = /is only allowed in files named "analytics"/;
+const errorMessage =
+  /is only allowed in files named "analytics" or inside an "analytics\/" directory/;
 
 const VALID_CASES = [
   // Non-restricted specifiers may be imported from the barrel anywhere.
@@ -42,6 +43,19 @@ const VALID_CASES = [
   {
     code: `import { trackSchemaEvent } from "metabase/analytics";`,
     filename: "/path/to/analytics.jsx",
+  },
+  // Restricted specifiers are fine in files inside an analytics/ directory.
+  {
+    code: `import { trackSchemaEvent } from "metabase/analytics";`,
+    filename: "frontend/src/metabase/common/analytics/homepage.ts",
+  },
+  {
+    code: `import { trackSimpleEvent } from "metabase/analytics";`,
+    filename: "frontend/src/metabase/common/analytics/index.ts",
+  },
+  {
+    code: `import { trackSchemaEvent } from "metabase/analytics";`,
+    filename: "frontend/src/metabase/common/analytics/subdir/file.ts",
   },
   // Imports of other modules are unaffected.
   {

--- a/frontend/src/metabase/admin/settings/analytics.ts
+++ b/frontend/src/metabase/admin/settings/analytics.ts
@@ -16,12 +16,3 @@ export const trackAnalyticsPiiRetentionChanged = (isEnabled: boolean) => {
     triggered_from: "admin",
   });
 };
-
-export const trackCustomHomepageDashboardEnabled = (
-  source: "admin" | "homepage",
-) => {
-  trackSchemaEvent("settings", {
-    event: "homepage_dashboard_enabled",
-    source,
-  });
-};

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
@@ -1,13 +1,13 @@
 import { t } from "ttag";
 
 import { useAdminSetting } from "metabase/api/utils";
+import { trackCustomHomepageDashboardEnabled } from "metabase/common/analytics";
 import { DashboardSelector } from "metabase/common/components/DashboardSelector";
 import { useDispatch } from "metabase/redux";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { Stack } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
-import { trackCustomHomepageDashboardEnabled } from "../../analytics";
 import { SettingHeader } from "../SettingHeader";
 
 import { BasicAdminSettingInput } from "./AdminSettingInput";

--- a/frontend/src/metabase/common/analytics/homepage.ts
+++ b/frontend/src/metabase/common/analytics/homepage.ts
@@ -1,0 +1,10 @@
+import { trackSchemaEvent } from "metabase/analytics";
+
+export const trackCustomHomepageDashboardEnabled = (
+  source: "admin" | "homepage",
+) => {
+  trackSchemaEvent("settings", {
+    event: "homepage_dashboard_enabled",
+    source,
+  });
+};

--- a/frontend/src/metabase/common/analytics/index.ts
+++ b/frontend/src/metabase/common/analytics/index.ts
@@ -1,0 +1,1 @@
+export { trackCustomHomepageDashboardEnabled } from "./homepage";

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { jt, t } from "ttag";
 
-import { trackCustomHomepageDashboardEnabled } from "metabase/admin/settings/analytics";
+import { trackCustomHomepageDashboardEnabled } from "metabase/common/analytics";
 import { DashboardSelector } from "metabase/common/components/DashboardSelector/DashboardSelector";
 import { Link } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";


### PR DESCRIPTION
This tracking function is used in two features. It's quite a rare case, so I had to add a new common/analytics folder for it and update our lint rule to allow files in an `analytics/` directory to work (otherwise it would have had to have been `common/analytics/homepage/analytics.ts`