### PR TITLE
Add trusted deps to limit install scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -403,6 +403,10 @@
       },
     },
   },
+  "trustedDependencies": [
+    "esbuild",
+    "cypress",
+  ],
   "overrides": {
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=22",
     "bun": ">=1.0.0"
   },
+  "trustedDependencies": ["cypress", "esbuild"],
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.10.1",


### PR DESCRIPTION
By default, [Bun blocks install scripts](https://bun.com/docs/guides/install/trusted) **except** for the top 500 popular npm packages.

By adding trusted deps we limit install scripts to only those trusted deps, limiting our potential exposure to malicious packages. 

cypress and esbuild were already in the default list, so this PR is limiting exposure, not adding any.