### PR TITLE
Derive viz settings sidebar error from useMemo instead of setState

### DIFF
--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo, useState } from "react";
+import { forwardRef, useCallback, useMemo } from "react";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useDispatch, useSelector } from "metabase/redux";
@@ -22,8 +22,6 @@ export function VizSettingsSidebar({ className }: { className?: string }) {
   const settings = useSelector(getVisualizerComputedSettings);
   const dispatch = useDispatch();
 
-  const [error, setError] = useState<Error | null>(null);
-
   const handleChangeSettings = useCallback(
     (settings: VisualizationSettings) => {
       dispatch(updateSettings(settings));
@@ -31,27 +29,27 @@ export function VizSettingsSidebar({ className }: { className?: string }) {
     [dispatch],
   );
 
-  const widgets = useMemo(() => {
+  const { widgets, error } = useMemo(() => {
     if (transformedSeries.length === 0) {
-      return [];
+      return { widgets: [], error: null };
     }
 
     try {
-      setError(null);
       const widgets = getSettingsWidgetsForSeries(
         transformedSeries,
         handleChangeSettings,
         true,
       );
-      return widgets.filter((widget) => {
-        return (
-          typeof widget.id !== "string" ||
-          !HIDDEN_SETTING_WIDGETS.includes(widget.id)
-        );
-      });
+      return {
+        widgets: widgets.filter(
+          (widget) =>
+            typeof widget.id !== "string" ||
+            !HIDDEN_SETTING_WIDGETS.includes(widget.id),
+        ),
+        error: null,
+      };
     } catch (error) {
-      setError(error as Error);
-      return [];
+      return { widgets: [], error: error as Error };
     }
   }, [transformedSeries, handleChangeSettings]);
 


### PR DESCRIPTION
### Description

Fixes [GDGT-1847](https://linear.app/metabase/issue/GDGT-1847/rules-of-hooks-violation-setstate-called-in-usememo-in).

Calling `setError` inside `useMemo` was a rules-of-hooks violation: setState during render forces an extra render commit, and if the memo deps ever land as fresh references it turns into an infinite re-render loop. Returning the error from the memo alongside the widgets makes it derived state, so a single render produces the final UI and the loop risk is gone.

### How to verify

- [ ] Open a question in the visualizer, swap displays, and confirm the settings sidebar still renders normally and recovers gracefully when an unsupported config triggers a widget error.

### Demo

n/a
