### PR TITLE
Add viz settings to click object, apply column formatting to link template

### DIFF
--- a/frontend/src/metabase/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase/parameters/utils/click-behavior.ts
@@ -19,6 +19,7 @@ import {
 import { getParameterColumns } from "metabase-lib/v1/parameters/utils/targets";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type { ClickObjectDataRow } from "metabase-lib/v1/queries/drills/types";
+import { getColumnSettings } from "metabase-lib/v1/queries/utils/column-key";
 import { TYPE } from "metabase-lib/v1/types/constants";
 import { isDate, isa } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -26,6 +27,7 @@ import type {
   ClickBehaviorDimensionTarget,
   ClickBehaviorSource,
   ClickBehaviorTarget,
+  ColumnSettings,
   Dashboard,
   DashboardId,
   DatasetColumn,
@@ -34,6 +36,7 @@ import type {
   ParameterValueOrArray,
   QuestionDashboardCard,
   UserAttributeMap,
+  VisualizationSettings,
 } from "metabase-types/api";
 import { isImplicitActionClickBehavior } from "metabase-types/guards";
 
@@ -62,6 +65,7 @@ export function getDataFromClicked({
   extraData: { dashboard, parameterValuesBySlug = {}, userAttributes } = {},
   dimensions = [],
   data = [],
+  settings,
 }: {
   extraData?: {
     dashboard?: Dashboard;
@@ -72,6 +76,11 @@ export function getDataFromClicked({
   data?: (ClickObjectDataRow & {
     clickBehaviorValue?: ClickObjectDataRow["value"];
   })[];
+  // Accept computed viz settings (with the per-column resolver) so
+  // we can read user-configured formatting + type-derived defaults.
+  settings?: VisualizationSettings & {
+    column?: (col: DatasetColumn) => ColumnSettings;
+  };
 }): ValueAndColumnForColumnNameDate {
   const column = [
     ...dimensions,
@@ -91,7 +100,23 @@ export function getDataFromClicked({
         const name = column.name.toLowerCase();
 
         if (acc[name] === undefined) {
-          return { ...acc, [name]: { value, column } };
+          // The raw DatasetColumn only carries metadata-level settings.
+          // Pull the computed per-column viz settings (which include
+          // user-saved formatting + type-derived defaults like
+          // `number_style: "currency"` for currency columns) so
+          // downstream formatters (e.g. renderLinkTextForClick) can
+          // apply them. Fall back to the raw column_settings lookup if
+          // the computed resolver isn't attached (e.g. some non-cell
+          // click contexts).
+          const vizColumnSettings =
+            settings?.column?.(column) ?? getColumnSettings(settings, column);
+          const columnWithSettings = vizColumnSettings
+            ? {
+                ...column,
+                settings: { ...(column.settings ?? {}), ...vizColumnSettings },
+              }
+            : column;
+          return { ...acc, [name]: { value, column: columnWithSettings } };
         }
 
         return acc;

--- a/frontend/src/metabase/visualizations/lib/formatting/link.ts
+++ b/frontend/src/metabase/visualizations/lib/formatting/link.ts
@@ -1,5 +1,6 @@
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { isSameOrSiteUrlOrigin } from "metabase/utils/dom";
+import type { OptionsType } from "metabase/utils/formatting/types";
 import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type { ParameterValueOrArray } from "metabase-types/api";
 import type { DatasetColumn, RowValue } from "metabase-types/api/dataset";
@@ -30,6 +31,25 @@ function formatValueForLinkTemplate(value: Value, column: DatasetColumn) {
   return value;
 }
 
+// Strip per-column settings that describe the link itself or the header so
+// the substituted value is formatted as a plain value, not as another link.
+// `view_as`, `link_text`, `link_url`, `click_behavior` would route formatValue
+// back through the link branches (recursion); `column_title` only affects the
+// column header.
+function pickColumnFormattingOptions(
+  settings: DatasetColumn["settings"] = {},
+): OptionsType {
+  const {
+    view_as: _view_as,
+    link_text: _link_text,
+    link_url: _link_url,
+    click_behavior: _click_behavior,
+    column_title: _column_title,
+    ...formatting
+  } = settings;
+  return formatting;
+}
+
 export function renderLinkTextForClick(
   template: string,
   data: ValueAndColumnForColumnNameDate,
@@ -37,8 +57,10 @@ export function renderLinkTextForClick(
   return renderTemplateForClick(
     template,
     data,
-    ({ value, column }: TemplateForClickFormatFunctionParamsType) =>
-      formatValue(value, { column }),
+    ({ value, column }: TemplateForClickFormatFunctionParamsType) => {
+      const columnSettings = pickColumnFormattingOptions(column?.settings);
+      return formatValue(value, { ...columnSettings, column });
+    },
   );
 }
 

--- a/frontend/src/metabase/visualizations/lib/formatting/url.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/url.unit.spec.tsx
@@ -8,7 +8,10 @@ import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensur
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
 import { TYPE } from "metabase-lib/v1/types/constants";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import {
+  createMockColumn,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
 import { formatUrl, slugify } from "./url";
 import { formatValue } from "./value";
@@ -227,6 +230,118 @@ describe("formatUrl", () => {
       expect(isElementOfType(formatted, ExternalLink)).toEqual(true);
       expect(formatted.props.children).toEqual("metabase link");
       expect(formatted.props.href).toEqual("http://metabase.com");
+    });
+
+    it("should apply the column's number formatting settings to the link text when link_text references the current column (metabase#56876)", () => {
+      const column = createMockColumn({
+        name: "hubspot_id",
+        base_type: TYPE.Integer,
+      });
+      const value = 35660212261;
+      const formatted = formatValue(value, {
+        jsx: true,
+        rich: true,
+        column,
+        view_as: "link",
+        link_text: "{{hubspot_id}}",
+        link_url: "http://example.com/{{hubspot_id}}",
+        number_style: "decimal",
+        // No thousand separator: the user has chosen to render the value
+        // without group separators (e.g. for ID-like numbers).
+        number_separators: ".",
+        clicked: {
+          value,
+          column,
+          data: [{ value, col: column }],
+          settings: {
+            column_settings: {
+              '["name","hubspot_id"]': {
+                number_style: "decimal",
+                number_separators: ".",
+              },
+            },
+          },
+        },
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, ExternalLink)).toBe(true);
+      expect(formatted.props.children).toBe("35660212261");
+    });
+
+    it("should apply the column's separator-style setting to a link text referencing the current column", () => {
+      const column = createMockColumn({
+        name: "amount",
+        base_type: TYPE.Float,
+      });
+      const value = 1234567.89;
+      const formatted = formatValue(value, {
+        jsx: true,
+        rich: true,
+        column,
+        view_as: "link",
+        link_text: "{{amount}}",
+        link_url: "http://example.com",
+        number_style: "decimal",
+        // European-style separators: "." for thousands, "," for decimals.
+        number_separators: ",.",
+        clicked: {
+          value,
+          column,
+          data: [{ value, col: column }],
+          settings: {
+            column_settings: {
+              '["name","amount"]': {
+                number_style: "decimal",
+                number_separators: ",.",
+              },
+            },
+          },
+        },
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, ExternalLink)).toBe(true);
+      expect(formatted.props.children).toBe("1.234.567,89");
+    });
+
+    it("should apply a different column's formatting when link_text references that other column", () => {
+      const linkColumn = createMockColumn({
+        name: "name",
+        base_type: TYPE.Text,
+      });
+      const amountColumn = createMockColumn({
+        name: "amount",
+        base_type: TYPE.Float,
+      });
+      const linkValue = "Widget";
+      const amountValue = 1234567.89;
+      const formatted = formatValue(linkValue, {
+        jsx: true,
+        rich: true,
+        column: linkColumn,
+        view_as: "link",
+        link_text: "Buy for {{amount}}",
+        link_url: "http://example.com",
+        clicked: {
+          value: linkValue,
+          column: linkColumn,
+          data: [
+            { value: linkValue, col: linkColumn },
+            { value: amountValue, col: amountColumn },
+          ],
+          settings: {
+            column_settings: {
+              '["name","amount"]': {
+                number_style: "currency",
+                currency: "USD",
+                currency_style: "symbol",
+              },
+            },
+          },
+        },
+      }) as ReactElement;
+
+      expect(isElementOfType(formatted, ExternalLink)).toBe(true);
+      expect(formatted.props.children).toBe("Buy for $1,234,567.89");
     });
 
     it("should not return an ExternalLink in jsx + rich mode if there's click behavior", () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56876

### Description

Formats link templates using referenced columns formatting. 

### How to verify
1. New -> Question -> Orders -> Visualize
2. Take one of the number columns, and apply some formatting to it
3. In another column, set the formatting to display as a link, and in the link text, reference the column you formatted. EG: {{TOTAL}}. Also provide a url
4. The link that is rendered should have the same visual formatting as what is referenced

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
