### PR TITLE
Clarify labels in incremental transforms

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms-incremental.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-incremental.cy.spec.ts
@@ -127,12 +127,12 @@ describe("scenarios > admin > transforms incremental", () => {
       cy.log("go to Transform Settings and reset checkpoint");
       cy.go("back");
       H.DataStudio.Transforms.settingsTab().click();
-      cy.findByRole("group", { name: /Current checkpoint/i }).within(() => {
+      cy.findByRole("group", { name: /Last processed/i }).within(() => {
         cy.findByText(/31/).should("exist");
       });
-      cy.button("Reset checkpoint").click();
+      cy.button("Reprocess all data").click();
       H.modal().within(() => {
-        cy.button("Reset").click();
+        cy.button("Reprocess on next run").click();
       });
       cy.wait("@resetCheckpoint");
 
@@ -249,12 +249,12 @@ def transform(animals):
         cy.log("go to Transform Settings and reset checkpoint");
         cy.go("back");
         H.DataStudio.Transforms.settingsTab().click();
-        cy.findByRole("group", { name: /Current checkpoint/i }).within(() => {
+        cy.findByRole("group", { name: /Last processed/i }).within(() => {
           cy.findByText(/31/).should("exist");
         });
-        cy.button("Reset checkpoint").click();
+        cy.button("Reprocess all data").click();
         H.modal().within(() => {
-          cy.button("Reset").click();
+          cy.button("Reprocess on next run").click();
         });
         cy.wait("@resetCheckpoint");
 
@@ -362,12 +362,12 @@ def transform(animals):
       cy.log("go to Transform Settings and reset checkpoint");
       cy.go("back");
       H.DataStudio.Transforms.settingsTab().click();
-      cy.findByRole("group", { name: /Current checkpoint/i }).within(() => {
+      cy.findByRole("group", { name: /Last processed/i }).within(() => {
         cy.findByText(/31/).should("exist");
       });
-      cy.button("Reset checkpoint").click();
+      cy.button("Reprocess all data").click();
       H.modal().within(() => {
-        cy.button("Reset").click();
+        cy.button("Reprocess on next run").click();
       });
       cy.wait("@resetCheckpoint");
 

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/ResetCheckpointSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/ResetCheckpointSection.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import { useId } from "react";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import {
   skipToken,
@@ -11,7 +11,7 @@ import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { CheckpointValue } from "metabase/transforms/components/CheckpointValue";
 import { isTransformRunning } from "metabase/transforms/utils";
-import { Box, Button, Group, Icon, Text } from "metabase/ui";
+import { Box, Button, Code, Group, Icon, Text } from "metabase/ui";
 import type { Transform } from "metabase-types/api";
 
 export function ResetCheckpointSection({
@@ -47,10 +47,19 @@ export function ResetCheckpointSection({
     return null;
   }
 
+  const checkpointFieldName = checkpointField?.display_name;
+  const label = checkpointFieldName
+    ? jt`Last processed ${(
+        <Code key="field" bg="background-tertiary">
+          {checkpointFieldName}
+        </Code>
+      )}`
+    : t`Last processed record`;
+
   return (
     <Group gap="md" align="center">
       <Box c="text-secondary" role="group" aria-labelledby={labelId}>
-        <span id={labelId}>{t`Current checkpoint`}: </span>
+        <span id={labelId}>{label}: </span>
         <Text component="span" fw="bold" c="text-primary">
           <CheckpointValue
             value={transform.last_checkpoint_value}
@@ -63,15 +72,15 @@ export function ResetCheckpointSection({
         disabled={isTransformRunning(transform) || isLoading}
         onClick={openModal}
       >
-        {t`Reset checkpoint`}
+        {t`Reprocess all data`}
       </Button>
       <ConfirmModal
-        title={t`Reset checkpoint?`}
+        title={t`Reprocess all data?`}
         message={t`This will cause the next run to reprocess all data from scratch instead of only new rows.`}
         opened={isModalOpen}
         onClose={closeModal}
         onConfirm={handleConfirm}
-        confirmButtonText={t`Reset`}
+        confirmButtonText={t`Reprocess on next run`}
       />
     </Group>
   );


### PR DESCRIPTION
Closes [GDGT-2127](https://linear.app/metabase/issue/GDGT-2127)

### Description

Renames "Current checkpoint" → `Last processed <column>:`, "Reset checkpoint" → "Reprocess all data", and the confirm modal's title/button to "Reprocess all data?" / "Reprocess on next run". Picked "Last processed" over "Next record to process" because the stored `last_checkpoint_value` is the max value already written — the next run filters with `:>` (strictly greater than), so the stored value is inclusive of what's done, not the next row to fetch.

### How to verify

1. Open an incremental transform's **Settings** tab.
2. Label reads `Last processed <column-name>:` followed by the stored value.
3. Click **Reprocess all data** → modal title "Reprocess all data?", confirm button "Reprocess on next run".

### Checklist

- [x] Tests have been added/updated to cover changes in this PR