### PR TITLE
AppDb support for Data Complexity Score CLI

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -102,7 +102,10 @@
   (api/check-superuser)
   (if force-recalculation?
     (force-recalculate-score!)
-    (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
+    ;; Filter by source="appdb" so a CLI run that scored a representation directory (which
+    ;; shares the cron's fingerprint by design — see `record-score!`) can't shadow the
+    ;; authoritative appdb-derived row. The `source` column is the discriminator.
+    (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint) "appdb")
                            m.util/deep-snake-keys)
                    (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -4,7 +4,6 @@
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
    [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
-   [metabase-enterprise.data-complexity-score.settings :as settings]
    [metabase-enterprise.data-complexity-score.synonym-source :as synonym-source]
    [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase.api.common :as api]
@@ -86,13 +85,8 @@
           result      (complexity/complexity-scores
                        (assoc (synonym-source/complexity-scores-opts)
                               :metabot-scope (metabot-scope/internal-metabot-scope)))
-          stored      (data-complexity-score/record-score! fingerprint result)]
-      ;; Advance the last-published fingerprint iff Snowplow actually accepted the event — mirrors
-      ;; the scheduled path's gate in `task.complexity-score/run-scoring!`. Without this, a
-      ;; superuser-triggered recalculation leaves the setting stale and the next boot would
-      ;; redundantly re-score even though a valid snapshot was just persisted.
-      (when (::complexity/snowplow-published? (meta result))
-        (settings/data-complexity-scoring-last-fingerprint! fingerprint))
+          stored      (data-complexity-score/record-score! fingerprint "appdb" result)]
+      (task.complexity-score/maybe-advance-last-fingerprint! fingerprint result)
       (m.util/deep-snake-keys (or stored result)))
     (finally
       (.set api-scoring-running? false))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -102,10 +102,7 @@
   (api/check-superuser)
   (if force-recalculation?
     (force-recalculate-score!)
-    ;; Filter by source="appdb" so a CLI run that scored a representation directory (which
-    ;; shares the cron's fingerprint by design — see `record-score!`) can't shadow the
-    ;; authoritative appdb-derived row. The `source` column is the discriminator.
-    (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint) "appdb")
+    (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
                            m.util/deep-snake-keys)
                    (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -53,6 +53,14 @@
   (flush)
   (System/exit 1))
 
+(defn- fail-with-trace!
+  "Print `t`'s stack trace (including `caused by` chain) to stderr, then fail! with a one-line summary.
+  Used for unexpected throwables — keeps the SQL exception / column-mismatch site visible instead of
+  collapsing it into just `<class>: <message>`."
+  [^Throwable t]
+  (.printStackTrace t)
+  (fail! (format "%s: %s" (.getName (class t)) (.getMessage t))))
+
 (defn- validate-dir! [path]
   (let [f (io/file path)]
     (cond
@@ -107,13 +115,11 @@
   We deliberately skip [[metabase.app-db.setup/check-encryption]] because its auto-encrypt branch can rewrite
   every encrypted `setting` row — exactly the kind of silent side effect we're avoiding."
   []
-  (let [verify-conn (requiring-resolve 'metabase.app-db.setup/verify-db-connection)
-        finish!     (requiring-resolve 'metabase.app-db.core/finish-db-setup!)
-        is-set-up?  (requiring-resolve 'metabase.app-db.core/db-is-set-up?)
-        db-type-fn  (requiring-resolve 'metabase.app-db.connection/db-type)
-        ds-fn       (requiring-resolve 'metabase.app-db.connection/data-source)]
+  (let [verify!    (requiring-resolve 'metabase.app-db.core/verify-application-db-connection!)
+        finish!    (requiring-resolve 'metabase.app-db.core/finish-db-setup!)
+        is-set-up? (requiring-resolve 'metabase.app-db.core/db-is-set-up?)]
     (when-not (is-set-up?)
-      (verify-conn (db-type-fn) (ds-fn))
+      (verify!)
       (finish!))))
 
 (defn- resolve-write?
@@ -200,14 +206,16 @@
                         (catch clojure.lang.ExceptionInfo e
                           ;; Handle CLI validation failures (`:cli-validation`) and missing-embeddings
                           ;; failures from representation (`:embeddings-path`) — both are user-facing
-                          ;; misconfigurations rather than bugs.
+                          ;; misconfigurations rather than bugs. Everything else gets the stack trace
+                          ;; so an `ex-cause` SQL exception remains diagnosable from the terminal.
                           (let [data (ex-data e)]
                             (if (or (:cli-validation data) (:embeddings-path data))
                               (fail! (ex-message e))
-                              (fail! (format "%s: %s" (.getName (class e)) (ex-message e))))))
+                              (fail-with-trace! e))))
                         (catch Throwable t
-                          ;; Most likely an older appdb missing a column/table the scorer reads.
-                          (fail! (format "%s: %s" (.getName (class t)) (.getMessage t))))))
+                          ;; Most likely an older appdb missing a column/table the scorer reads —
+                          ;; print the trace so the failing query/site is visible.
+                          (fail-with-trace! t))))
     (System/exit 0)))
 
 ;; No `(:gen-class)` — the AOT JAR routes through [[metabase.core.bootstrap]] and dispatches to

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -13,13 +13,20 @@
   Persistence is controlled independently by `--write-to-appdb`. The default tracks the source:
   true in appdb mode, false in representation mode. Both can be overridden explicitly.
 
-  Invoke via:
+  Two invocation styles:
 
-    clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli --source appdb
-    clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli \\
-      --source representation -r path/to/fixture/
+    Dev (classpath, no AOT):
+      clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli --source appdb
+      clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli \\
+        --source representation -r path/to/fixture/
 
-  Patterned after [[metabase-enterprise.checker.cli]] — same `fail!` pattern, same arg style."
+    AOT JAR (via `metabase.core.bootstrap`):
+      java -jar metabase.jar --mode complexity-score --source appdb
+      java -jar metabase.jar --mode complexity-score \\
+        --source representation -r path/to/fixture/
+
+  Patterned after [[metabase-enterprise.checker.cli]] — same `fail!` pattern, same arg style,
+  and the same bootstrap-dispatched [[entrypoint]] hook."
   (:require
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
@@ -69,10 +76,15 @@
     :parse-fn #(case % "true" true "false" false ::invalid)
     :validate [#(not= % ::invalid) "--write-to-appdb must be 'true' or 'false'."]]
    ["-o" "--output PATH"             "Write EDN result to this file instead of stdout."]
+   ;; Consumed by `metabase.core.bootstrap` when invoked as `java -jar metabase.jar --mode …`. Declared
+   ;; here so tools.cli accepts it and `parse-opts` doesn't report it as an unknown flag.
+   [nil  "--mode MODE"               "(JAR invocation only; handled by bootstrap before reaching this CLI.)"]
    ["-h" "--help"                    "Show this message."]])
 
 (defn- usage [summary]
-  (str "Usage: clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli [options]\n\n"
+  (str "Usage:\n"
+       "  clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli [options]\n"
+       "  java -jar metabase.jar --mode complexity-score [options]\n\n"
        "Options:\n" summary))
 
 (defn- pretty [result]
@@ -91,7 +103,7 @@
 (defn- bootstrap-appdb!
   "Verify the appdb connection and mark it ready — never run migrations or mutate the schema in any way.
   The scorer reads a small, slow-changing slice of Toucan models, so we proceed against any appdb version.
-  Any schema mismatch surfaces as a runtime error caught by [[-main]]; the DB itself is never touched.
+  Any schema mismatch surfaces as a runtime error caught by [[entrypoint]]; the DB itself is never touched.
   We deliberately skip [[metabase.app-db.setup/check-encryption]] because its auto-encrypt branch can rewrite
   every encrypted `setting` row — exactly the kind of silent side effect we're avoiding."
   []
@@ -139,11 +151,7 @@
     result))
 
 (defn- run-representation-mode!
-  "Score against an on-disk serdes export; optionally persist with `source` = `representation:<digest>`.
-  The fingerprint still comes from [[task.complexity-score/current-fingerprint]]; the `source` column is what
-  separates these rows from cron/API/CLI-from-appdb rows.
-  We never advance `data-complexity-scoring-last-fingerprint` here — a representation-derived score isn't
-  authoritative for this instance and would mute the cron."
+  "Score against an on-disk serdes export; optionally persist with `source` = `representation:<digest>`."
   [{:keys [representation-dir embeddings]} write?]
   (when write?
     (bootstrap-appdb!))
@@ -168,7 +176,7 @@
   Returns the result map so tests can call this directly without intercepting `System/exit`.
   Throws `ex-info` for validation failures (`:cli-validation true`) and propagates `representation/load-dir`'s
   `ex-info` (e.g. missing `--embeddings` override).
-  `-main` converts those to `fail!`; library callers can inspect the ex-data themselves."
+  [[entrypoint]] converts those to `fail!`; library callers can inspect the ex-data themselves."
   [options]
   (let [options (with-defaults options)]
     (validate-options! options)
@@ -178,11 +186,11 @@
         (run-appdb-mode! write?)
         (run-representation-mode! options write?)))))
 
-;; `-main` is invoked via `clj -M:ee:dev -m …cli`, not via an AOT'd jar, so `(:gen-class)` is unnecessary.
-#_{:clj-kondo/ignore [:main-without-gen-class]}
-(defn -main
-  "Entrypoint."
-  [& args]
+(defn entrypoint
+  "Main entrypoint. Receives raw args (a seq) and owns the process — it always calls `System/exit`.
+  Called from [[metabase.core.bootstrap/run-standalone-mode]] via `--mode complexity-score`
+  in the AOT JAR, and delegated to from [[-main]] for the `clj -M:ee:dev -m …` dev path."
+  [args]
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)]
     (cond
       (:help options) (do (output! (usage summary)) (System/exit 0))
@@ -199,5 +207,14 @@
                               (fail! (format "%s: %s" (.getName (class e)) (ex-message e))))))
                         (catch Throwable t
                           ;; Most likely an older appdb missing a column/table the scorer reads.
-                          (fail! (format "%s: %s" (.getName (class t)) (.getMessage t)))))))
-  (System/exit 0))
+                          (fail! (format "%s: %s" (.getName (class t)) (.getMessage t))))))
+    (System/exit 0)))
+
+;; No `(:gen-class)` — the AOT JAR routes through [[metabase.core.bootstrap]] and dispatches to
+;; [[entrypoint]] via `requiring-resolve`, so a class-file `-main` would be dead weight. `-main`
+;; only exists for the `clj -M:ee:dev -m …cli` dev path.
+#_{:clj-kondo/ignore [:main-without-gen-class]}
+(defn -main
+  "Dev entrypoint. Delegates to [[entrypoint]], which owns the process and calls `System/exit`."
+  [& args]
+  (entrypoint args))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -36,7 +36,8 @@
    [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
    [metabase-enterprise.data-complexity-score.representation :as representation]
    [metabase-enterprise.data-complexity-score.synonym-source :as synonym-source]
-   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]))
+   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
+   [metabase.app-db.core :as mdb]))
 
 (set! *warn-on-reflection* true)
 
@@ -108,20 +109,6 @@
       (print (pretty result))
       (flush))))
 
-(defn- bootstrap-appdb!
-  "Verify the appdb connection and mark it ready — never run migrations or mutate the schema in any way.
-  The scorer reads a small, slow-changing slice of Toucan models, so we proceed against any appdb version.
-  Any schema mismatch surfaces as a runtime error caught by [[entrypoint]]; the DB itself is never touched.
-  We deliberately skip [[metabase.app-db.setup/check-encryption]] because its auto-encrypt branch can rewrite
-  every encrypted `setting` row — exactly the kind of silent side effect we're avoiding."
-  []
-  (let [verify!    (requiring-resolve 'metabase.app-db.core/verify-application-db-connection!)
-        finish!    (requiring-resolve 'metabase.app-db.core/finish-db-setup!)
-        is-set-up? (requiring-resolve 'metabase.app-db.core/db-is-set-up?)]
-    (when-not (is-set-up?)
-      (verify!)
-      (finish!))))
-
 (defn- resolve-write?
   "Apply the source-driven default for `--write-to-appdb` when it wasn't passed explicitly."
   [{:keys [write-to-appdb]} appdb-source?]
@@ -146,7 +133,7 @@
 (defn- run-appdb-mode!
   "Score against the live appdb the same way the cron does; optionally persist."
   [write?]
-  (bootstrap-appdb!)
+  (mdb/setup-db-without-migrations!)
   (let [result (complexity/complexity-scores
                 (assoc (synonym-source/complexity-scores-opts)
                        :metabot-scope (metabot-scope/internal-metabot-scope)))]
@@ -160,7 +147,7 @@
   "Score against an on-disk serdes export; optionally persist with `source` = `representation:<digest>`."
   [{:keys [representation-dir embeddings]} write?]
   (when write?
-    (bootstrap-appdb!))
+    (mdb/setup-db-without-migrations!))
   (let [{:keys [library universe embedder digest]} (representation/load-dir representation-dir
                                                                             :embeddings-path embeddings)
         result                                     (complexity/score-from-entities library universe embedder {})]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -89,13 +89,20 @@
       (flush))))
 
 (defn- bootstrap-appdb!
-  "Bring up the application database (migrations + connection pool) so that `t2/select` against
-  Toucan models and settings/feature-flag lookups succeed. We resolve at call time so a pure
-  representation-mode run without `--write-to-appdb` doesn't pay the setup cost. Driver plugin
-  loading is intentionally skipped: the scorer only queries appdb metadata (Card, Table, Field,
-  Measure rows), never user databases, so the driver/plugin layer isn't on this path."
+  "Verify the appdb connection and mark it ready — never run migrations or mutate the schema in any way.
+  The scorer reads a small, slow-changing slice of Toucan models, so we proceed against any appdb version.
+  Any schema mismatch surfaces as a runtime error caught by [[-main]]; the DB itself is never touched.
+  We deliberately skip [[metabase.app-db.setup/check-encryption]] because its auto-encrypt branch can rewrite
+  every encrypted `setting` row — exactly the kind of silent side effect we're avoiding."
   []
-  ((requiring-resolve 'metabase.app-db.core/setup-db!) :create-sample-content? false))
+  (let [verify-conn (requiring-resolve 'metabase.app-db.setup/verify-db-connection)
+        finish!     (requiring-resolve 'metabase.app-db.core/finish-db-setup!)
+        is-set-up?  (requiring-resolve 'metabase.app-db.core/db-is-set-up?)
+        db-type-fn  (requiring-resolve 'metabase.app-db.connection/db-type)
+        ds-fn       (requiring-resolve 'metabase.app-db.connection/data-source)]
+    (when-not (is-set-up?)
+      (verify-conn (db-type-fn) (ds-fn))
+      (finish!))))
 
 (defn- resolve-write?
   "Apply the source-driven default for `--write-to-appdb` when it wasn't passed explicitly."
@@ -132,12 +139,11 @@
     result))
 
 (defn- run-representation-mode!
-  "Score against an on-disk serdes export; optionally persist with a representation-tagged
-  `source` so the row is distinguishable from cron/API/CLI-from-appdb rows. The persisted
-  fingerprint still uses [[task.complexity-score/current-fingerprint]] so it lines up with the
-  cron's bookkeeping; the new `source` column does the discrimination. We never advance
-  `data-complexity-scoring-last-fingerprint` here — a representation-derived score isn't
-  authoritative for this instance and mustn't mute the cron."
+  "Score against an on-disk serdes export; optionally persist with `source` = `representation:<digest>`.
+  The fingerprint still comes from [[task.complexity-score/current-fingerprint]]; the `source` column is what
+  separates these rows from cron/API/CLI-from-appdb rows.
+  We never advance `data-complexity-scoring-last-fingerprint` here — a representation-derived score isn't
+  authoritative for this instance and would mute the cron."
   [{:keys [representation-dir embeddings]} write?]
   (when write?
     (bootstrap-appdb!))
@@ -160,10 +166,9 @@
 (defn- run-cli
   "Pure core of the CLI: validates options and dispatches to the source-specific runner.
   Returns the result map so tests can call this directly without intercepting `System/exit`.
-  Throws `ex-info` for validation failures (with `:cli-validation true` in the ex-data) and
-  propagates `representation/load-dir`'s `ex-info` (e.g. missing `--embeddings` override).
-  `-main` converts those into user-facing `fail!`; library callers can inspect the ex-data
-  and render errors their own way."
+  Throws `ex-info` for validation failures (`:cli-validation true`) and propagates `representation/load-dir`'s
+  `ex-info` (e.g. missing `--embeddings` override).
+  `-main` converts those to `fail!`; library callers can inspect the ex-data themselves."
   [options]
   (let [options (with-defaults options)]
     (validate-options! options)
@@ -191,5 +196,8 @@
                           (let [data (ex-data e)]
                             (if (or (:cli-validation data) (:embeddings-path data))
                               (fail! (ex-message e))
-                              (throw e)))))))
+                              (fail! (format "%s: %s" (.getName (class e)) (ex-message e))))))
+                        (catch Throwable t
+                          ;; Most likely an older appdb missing a column/table the scorer reads.
+                          (fail! (format "%s: %s" (.getName (class t)) (.getMessage t)))))))
   (System/exit 0))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -1,12 +1,23 @@
 (ns metabase-enterprise.data-complexity-score.cli
-  "CLI entrypoint for computing the data complexity score against on-disk representations.
+  "CLI entrypoint for computing the data complexity score.
 
-  Useful for offline scoring of benchmarks, CI, and exploratory analysis.
+  Two source modes:
+
+    `--source representation` (default) — scores an on-disk serdes export. No appdb required
+       unless `--write-to-appdb true` is also requested. Useful for offline scoring of
+       benchmarks, CI, and exploratory analysis.
+
+    `--source appdb` — bootstraps the application database and scores live entities the same
+       way the cron job (`task.complexity-score`) and API endpoint do.
+
+  Persistence is controlled independently by `--write-to-appdb`. The default tracks the source:
+  true in appdb mode, false in representation mode. Both can be overridden explicitly.
 
   Invoke via:
 
+    clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli --source appdb
     clojure -M:ee:dev -m metabase-enterprise.data-complexity-score.cli \\
-      --representation-dir path/to/fixture/
+      --source representation -r path/to/fixture/
 
   Patterned after [[metabase-enterprise.checker.cli]] — same `fail!` pattern, same arg style."
   (:require
@@ -14,7 +25,11 @@
    [clojure.pprint :as pprint]
    [clojure.tools.cli :as cli]
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
-   [metabase-enterprise.data-complexity-score.representation :as representation]))
+   [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
+   [metabase-enterprise.data-complexity-score.representation :as representation]
+   [metabase-enterprise.data-complexity-score.synonym-source :as synonym-source]
+   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]))
 
 (set! *warn-on-reflection* true)
 
@@ -39,9 +54,20 @@
       (not (.isDirectory f))  (throw (ex-info (str "--representation-dir must be a directory: " path)
                                               {:cli-validation true :path path})))))
 
+(def ^:private unset
+  "Sentinel for `--write-to-appdb` so we can tell 'user didn't pass it' apart from an explicit false."
+  ::unset)
+
 (def ^:private cli-options
-  [["-r" "--representation-dir PATH" "Directory of a serdes YAML export, optionally with an embeddings.json sidecar (required)."]
+  [["-s" "--source SOURCE"           "'representation' (default) or 'appdb'."
+    :default "representation"
+    :validate [#{"representation" "appdb"} "--source must be 'representation' or 'appdb'."]]
+   ["-r" "--representation-dir PATH" "Directory of a serdes YAML export. Required when --source is 'representation'."]
    ["-e" "--embeddings PATH"         "Explicit embeddings JSON file. Overrides embeddings.json in the directory."]
+   ["-w" "--write-to-appdb BOOL"     "Persist the score row. Defaults: true when --source is 'appdb', false otherwise."
+    :default unset
+    :parse-fn #(case % "true" true "false" false ::invalid)
+    :validate [#(not= % ::invalid) "--write-to-appdb must be 'true' or 'false'."]]
    ["-o" "--output PATH"             "Write EDN result to this file instead of stdout."]
    ["-h" "--help"                    "Show this message."]])
 
@@ -62,18 +88,90 @@
       (print (pretty result))
       (flush))))
 
+(defn- bootstrap-appdb!
+  "Bring up the application database (migrations + connection pool) so that `t2/select` against
+  Toucan models and settings/feature-flag lookups succeed. We resolve at call time so a pure
+  representation-mode run without `--write-to-appdb` doesn't pay the setup cost. Driver plugin
+  loading is intentionally skipped: the scorer only queries appdb metadata (Card, Table, Field,
+  Measure rows), never user databases, so the driver/plugin layer isn't on this path."
+  []
+  ((requiring-resolve 'metabase.app-db.core/setup-db!) :create-sample-content? false))
+
+(defn- resolve-write?
+  "Apply the source-driven default for `--write-to-appdb` when it wasn't passed explicitly."
+  [{:keys [write-to-appdb]} appdb-source?]
+  (if (= write-to-appdb unset) appdb-source? write-to-appdb))
+
+(defn- validate-options!
+  "Throws `ex-info` with `:cli-validation true` on user-facing misconfigurations."
+  [{:keys [source representation-dir embeddings]}]
+  (case source
+    "appdb"
+    (when (or representation-dir embeddings)
+      (throw (ex-info "--source appdb does not accept --representation-dir or --embeddings"
+                      {:cli-validation true})))
+
+    "representation"
+    (do
+      (when-not representation-dir
+        (throw (ex-info "Missing --representation-dir option (required for --source representation)"
+                        {:cli-validation true})))
+      (validate-dir! representation-dir))))
+
+(defn- run-appdb-mode!
+  "Score against the live appdb the same way the cron does; optionally persist."
+  [write?]
+  (bootstrap-appdb!)
+  (let [result (complexity/complexity-scores
+                (assoc (synonym-source/complexity-scores-opts)
+                       :metabot-scope (metabot-scope/internal-metabot-scope)))]
+    (when write?
+      (let [fp (task.complexity-score/current-fingerprint)]
+        (data-complexity-score/record-score! fp "appdb" result)
+        (task.complexity-score/maybe-advance-last-fingerprint! fp result)))
+    result))
+
+(defn- run-representation-mode!
+  "Score against an on-disk serdes export; optionally persist with a representation-tagged
+  `source` so the row is distinguishable from cron/API/CLI-from-appdb rows. The persisted
+  fingerprint still uses [[task.complexity-score/current-fingerprint]] so it lines up with the
+  cron's bookkeeping; the new `source` column does the discrimination. We never advance
+  `data-complexity-scoring-last-fingerprint` here — a representation-derived score isn't
+  authoritative for this instance and mustn't mute the cron."
+  [{:keys [representation-dir embeddings]} write?]
+  (when write?
+    (bootstrap-appdb!))
+  (let [{:keys [library universe embedder digest]} (representation/load-dir representation-dir
+                                                                            :embeddings-path embeddings)
+        result                                     (complexity/score-from-entities library universe embedder {})]
+    (when write?
+      (data-complexity-score/record-score! (task.complexity-score/current-fingerprint)
+                                           (str "representation:" digest)
+                                           result))
+    result))
+
+(defn- with-defaults
+  "Apply parse-opts-style defaults so library callers (tests, REPL) don't have to thread them."
+  [options]
+  (cond-> options
+    (nil? (:source options))         (assoc :source "representation")
+    (nil? (:write-to-appdb options)) (assoc :write-to-appdb unset)))
+
 (defn- run-cli
-  "Pure core of the CLI: validates options, loads representation, computes the score.
+  "Pure core of the CLI: validates options and dispatches to the source-specific runner.
   Returns the result map so tests can call this directly without intercepting `System/exit`.
-  Throws `ex-info` for validation failures (with `:cli-validation true` in the ex-data) and propagates
-  `load-dir`'s `ex-info` (e.g. missing `--embeddings` override). `-main` converts those into user-facing
-  `fail!`; library callers can inspect the ex-data and render errors their own way."
-  [{:keys [representation-dir embeddings]}]
-  (when-not representation-dir
-    (throw (ex-info "Missing --representation-dir option" {:cli-validation true})))
-  (validate-dir! representation-dir)
-  (let [{:keys [library universe embedder]} (representation/load-dir representation-dir :embeddings-path embeddings)]
-    (complexity/score-from-entities library universe embedder {})))
+  Throws `ex-info` for validation failures (with `:cli-validation true` in the ex-data) and
+  propagates `representation/load-dir`'s `ex-info` (e.g. missing `--embeddings` override).
+  `-main` converts those into user-facing `fail!`; library callers can inspect the ex-data
+  and render errors their own way."
+  [options]
+  (let [options (with-defaults options)]
+    (validate-options! options)
+    (let [appdb-source? (= (:source options) "appdb")
+          write?        (resolve-write? options appdb-source?)]
+      (if appdb-source?
+        (run-appdb-mode! write?)
+        (run-representation-mode! options write?)))))
 
 ;; `-main` is invoked via `clj -M:ee:dev -m …cli`, not via an AOT'd jar, so `(:gen-class)` is unnecessary.
 #_{:clj-kondo/ignore [:main-without-gen-class]}

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -19,32 +19,21 @@
     (assoc-in score_data [:meta :calculated-at] created_at)))
 
 (defn latest-entry
-  "Return the most recently persisted Data Complexity Score row for `fingerprint`, or nil if none exist.
-
-  When `source` is supplied, only rows whose `source` column equals it are considered — letting the
-  appdb-authoritative read paths (API, cron) ignore representation-derived rows that share the same
-  fingerprint."
-  ([fingerprint] (latest-entry fingerprint nil))
+  "Return the most recently persisted Data Complexity Score row for `fingerprint`, or nil if none exist."
+  ([fingerprint] (latest-entry fingerprint "appdb"))
   ([fingerprint source]
-   (if source
-     (t2/select-one :model/DataComplexityScore
-                    :fingerprint fingerprint :source source {:order-by [[:id :desc]]})
-     (t2/select-one :model/DataComplexityScore
-                    :fingerprint fingerprint {:order-by [[:id :desc]]}))))
+   (t2/select-one :model/DataComplexityScore
+                  :fingerprint fingerprint :source source {:order-by [[:id :desc]]})))
 
 (defn latest-score
-  "Return the latest persisted Data Complexity Score payload for `fingerprint`, or nil if none exist.
-  Accepts the same optional `source` filter as [[latest-entry]]."
-  ([fingerprint] (latest-score fingerprint nil))
+  "Return the latest persisted Data Complexity Score payload for `fingerprint`, or nil if none exist."
+  ([fingerprint] (latest-score fingerprint "appdb"))
   ([fingerprint source]
    (some-> (latest-entry fingerprint source)
            score-with-calculated-at)))
 
 (defn record-score!
-  "Persist one append-only Data Complexity Score snapshot.
-
-  `source` discriminates the row's provenance — `\"appdb\"` for cron / API / CLI-from-appdb runs,
-  or `\"representation:<digest>\"` for CLI runs that scored a representation directory."
+  "Persist one append-only Data Complexity Score snapshot."
   [fingerprint source score]
   (let [id (t2/insert-returning-pk! :model/DataComplexityScore
                                     {:fingerprint fingerprint

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -30,10 +30,14 @@
           score-with-calculated-at))
 
 (defn record-score!
-  "Persist one append-only Data Complexity Score snapshot."
-  [fingerprint score]
+  "Persist one append-only Data Complexity Score snapshot.
+
+  `source` discriminates the row's provenance — `\"appdb\"` for cron / API / CLI-from-appdb runs,
+  or `\"representation:<digest>\"` for CLI runs that scored a representation directory."
+  [fingerprint source score]
   (let [id (t2/insert-returning-pk! :model/DataComplexityScore
                                     {:fingerprint fingerprint
+                                     :source      source
                                      :score_data  score})]
     (if id
       (score-with-calculated-at (t2/select-one :model/DataComplexityScore :id id))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/models/data_complexity_score.clj
@@ -19,15 +19,26 @@
     (assoc-in score_data [:meta :calculated-at] created_at)))
 
 (defn latest-entry
-  "Return the most recently persisted Data Complexity Score row for `fingerprint`, or nil if none exist."
-  [fingerprint]
-  (t2/select-one :model/DataComplexityScore :fingerprint fingerprint {:order-by [[:id :desc]]}))
+  "Return the most recently persisted Data Complexity Score row for `fingerprint`, or nil if none exist.
+
+  When `source` is supplied, only rows whose `source` column equals it are considered — letting the
+  appdb-authoritative read paths (API, cron) ignore representation-derived rows that share the same
+  fingerprint."
+  ([fingerprint] (latest-entry fingerprint nil))
+  ([fingerprint source]
+   (if source
+     (t2/select-one :model/DataComplexityScore
+                    :fingerprint fingerprint :source source {:order-by [[:id :desc]]})
+     (t2/select-one :model/DataComplexityScore
+                    :fingerprint fingerprint {:order-by [[:id :desc]]}))))
 
 (defn latest-score
-  "Return the latest persisted Data Complexity Score payload for `fingerprint`, or nil if none exist."
-  [fingerprint]
-  (some-> (latest-entry fingerprint)
-          score-with-calculated-at))
+  "Return the latest persisted Data Complexity Score payload for `fingerprint`, or nil if none exist.
+  Accepts the same optional `source` filter as [[latest-entry]]."
+  ([fingerprint] (latest-score fingerprint nil))
+  ([fingerprint source]
+   (some-> (latest-entry fingerprint source)
+           score-with-calculated-at)))
 
 (defn record-score!
   "Persist one append-only Data Complexity Score snapshot.
@@ -41,4 +52,4 @@
                                      :score_data  score})]
     (if id
       (score-with-calculated-at (t2/select-one :model/DataComplexityScore :id id))
-      (latest-score fingerprint))))
+      (latest-score fingerprint source))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -219,10 +219,10 @@
   (make-array OpenOption 0))
 
 (defn- sha256-file-hex
-  "SHA-256 of a file's bytes, streamed in 8 KiB chunks to keep large exports off the heap."
+  "SHA-256 of a file's bytes, streamed in 64 KiB chunks to keep large exports off the heap."
   [^File f]
   (let [md  (MessageDigest/getInstance "SHA-256")
-        buf (byte-array 8192)]
+        buf (byte-array 65536)]
     (with-open [^DigestInputStream is (DigestInputStream. (Files/newInputStream (.toPath f) no-open-options) md)]
       (while (not= -1 (.read is buf))))
     (hex (.digest md))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -219,8 +219,7 @@
   (make-array OpenOption 0))
 
 (defn- sha256-file-hex
-  "SHA-256 of a file's bytes, streamed in 8 KiB chunks so even multi-megabyte exports
-  (e.g. embeddings.json) don't materialize the whole file in memory."
+  "SHA-256 of a file's bytes, streamed in 8 KiB chunks to keep large exports off the heap."
   [^File f]
   (let [md  (MessageDigest/getInstance "SHA-256")
         buf (byte-array 8192)]
@@ -229,9 +228,9 @@
     (hex (.digest md))))
 
 (defn dir-digest
-  "Stable SHA-256 over the file contents of `dir`. Two directories with byte-identical files at the
-  same relative paths produce the same digest. Used as the `<digest>` part of the `source` column
-  on `data_complexity_score` rows when the CLI scores a representation directory."
+  "Stable SHA-256 over the file contents of `dir`.
+  Two directories with byte-identical files at the same relative paths produce the same digest.
+  Used as the `<digest>` part of the `source` column on `data_complexity_score` rows."
   [dir]
   (let [dir-file (io/file dir)
         root     (.toPath dir-file)

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -31,7 +31,8 @@
   (:import
    (java.io File)
    (java.nio.file Files)
-   (java.security MessageDigest)))
+   (java.nio.file OpenOption)
+   (java.security DigestInputStream MessageDigest)))
 
 (set! *warn-on-reflection* true)
 
@@ -214,6 +215,19 @@
       (.append sb (format "%02x" (bit-and (aget bs i) 0xff))))
     (.toString sb)))
 
+(def ^:private ^"[Ljava.nio.file.OpenOption;" no-open-options
+  (make-array OpenOption 0))
+
+(defn- sha256-file-hex
+  "SHA-256 of a file's bytes, streamed in 8 KiB chunks so even multi-megabyte exports
+  (e.g. embeddings.json) don't materialize the whole file in memory."
+  [^File f]
+  (let [md  (MessageDigest/getInstance "SHA-256")
+        buf (byte-array 8192)]
+    (with-open [^DigestInputStream is (DigestInputStream. (Files/newInputStream (.toPath f) no-open-options) md)]
+      (while (not= -1 (.read is buf))))
+    (hex (.digest md))))
+
 (defn dir-digest
   "Stable SHA-256 over the file contents of `dir`. Two directories with byte-identical files at the
   same relative paths produce the same digest. Used as the `<digest>` part of the `source` column
@@ -225,7 +239,7 @@
                       (filter #(.isFile ^File %))
                       (map (fn [^File f]
                              [(str (.relativize root (.toPath f)))
-                              (hex (sha256-bytes (Files/readAllBytes (.toPath f))))]))
+                              (sha256-file-hex f)]))
                       (sort-by first))]
     (hex (sha256-bytes (.getBytes (pr-str entries) "UTF-8")))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -29,7 +29,9 @@
    [metabase.util.json :as json]
    [metabase.util.yaml :as yaml])
   (:import
-   (java.io File)))
+   (java.io File)
+   (java.nio.file Files)
+   (java.security MessageDigest)))
 
 (set! *warn-on-reflection* true)
 
@@ -201,10 +203,36 @@
     (let [default (io/file dir "embeddings.json")]
       (if (.exists default) (json/decode (slurp default) false) {}))))
 
+;;; ------------------------------------------- directory digest -------------------------------------------
+
+(defn- sha256-bytes ^bytes [^bytes input]
+  (.digest (MessageDigest/getInstance "SHA-256") input))
+
+(defn- hex [^bytes bs]
+  (let [sb (StringBuilder. (* 2 (alength bs)))]
+    (dotimes [i (alength bs)]
+      (.append sb (format "%02x" (bit-and (aget bs i) 0xff))))
+    (.toString sb)))
+
+(defn dir-digest
+  "Stable SHA-256 over the file contents of `dir`. Two directories with byte-identical files at the
+  same relative paths produce the same digest. Used as the `<digest>` part of the `source` column
+  on `data_complexity_score` rows when the CLI scores a representation directory."
+  [dir]
+  (let [dir-file (io/file dir)
+        root     (.toPath dir-file)
+        entries  (->> (file-seq dir-file)
+                      (filter #(.isFile ^File %))
+                      (map (fn [^File f]
+                             [(str (.relativize root (.toPath f)))
+                              (hex (sha256-bytes (Files/readAllBytes (.toPath f))))]))
+                      (sort-by first))]
+    (hex (sha256-bytes (.getBytes (pr-str entries) "UTF-8")))))
+
 ;;; ------------------------------------------- public entry point -------------------------------------------
 
 (defn load-dir
-  "Load a serdes export and return `{:library :universe :embedder}` for the complexity scorer.
+  "Load a serdes export and return `{:library :universe :embedder :digest}` for the complexity scorer.
 
   Filters mirror the live appdb scorer:
     - Universe Cards : `type ∈ {metric model}`, not archived
@@ -243,4 +271,5 @@
                             (mapv ->table-entity (filter library-table? tables))))
      :universe (vec (concat (mapv ->card-entity  (filter universe-card?  cards))
                             (mapv ->table-entity (filter universe-table? tables))))
-     :embedder (embedders/file-embedder embeddings)}))
+     :embedder (embedders/file-embedder embeddings)
+     :digest   (dir-digest dir-file)}))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -230,14 +230,21 @@
 (defn dir-digest
   "Stable SHA-256 over the file contents of `dir`.
   Two directories with byte-identical files at the same relative paths produce the same digest.
-  Used as the `<digest>` part of the `source` column on `data_complexity_score` rows."
+  Used as the `<digest>` part of the `source` column on `data_complexity_score` rows.
+
+  Relative paths are joined with `/` regardless of the host OS so that a digest computed on
+  Linux/macOS matches one computed on Windows for the same export."
   [dir]
   (let [dir-file (io/file dir)
         root     (.toPath dir-file)
         entries  (->> (file-seq dir-file)
                       (filter #(.isFile ^File %))
                       (map (fn [^File f]
-                             [(str (.relativize root (.toPath f)))
+                             [(->> (.relativize root (.toPath f))
+                                   .iterator
+                                   iterator-seq
+                                   (map str)
+                                   (str/join "/"))
                               (sha256-file-hex f)]))
                       (sort-by first))]
     (hex (sha256-bytes (.getBytes (pr-str entries) "UTF-8")))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -41,10 +41,9 @@
                        (synonym-source/fingerprint-fragment)))))
 
 (defn maybe-advance-last-fingerprint!
-  "If `result` carries a confirmed Snowplow publish, advance [[settings/data-complexity-scoring-last-fingerprint]]
-  to `fingerprint`. Otherwise log and leave it untouched so the next boot or cron retries instead of
-  silently stalling behind a transient publish failure. Shared by the cron path, the API recompute
-  path, and the CLI's appdb mode so any caller that persists a fresh snapshot stays in lockstep."
+  "Advance [[settings/data-complexity-scoring-last-fingerprint]] only if Snowplow accepted the publish.
+  On failure we leave it untouched so the next boot or cron retries.
+  Shared by the cron, API recompute, and CLI appdb paths to keep all persisters in lockstep."
   [fingerprint result]
   (if (::complexity/snowplow-published? (meta result))
     (settings/data-complexity-scoring-last-fingerprint! fingerprint)

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -40,6 +40,16 @@
                         :weights           complexity/weights}
                        (synonym-source/fingerprint-fragment)))))
 
+(defn maybe-advance-last-fingerprint!
+  "If `result` carries a confirmed Snowplow publish, advance [[settings/data-complexity-scoring-last-fingerprint]]
+  to `fingerprint`. Otherwise log and leave it untouched so the next boot or cron retries instead of
+  silently stalling behind a transient publish failure. Shared by the cron path, the API recompute
+  path, and the CLI's appdb mode so any caller that persists a fresh snapshot stays in lockstep."
+  [fingerprint result]
+  (if (::complexity/snowplow-published? (meta result))
+    (settings/data-complexity-scoring-last-fingerprint! fingerprint)
+    (log/warn "Data Complexity Score: Snowplow publish failed; leaving fingerprint unchanged so the next boot or cron retries")))
+
 (defn- run-scoring!
   "One scoring pass. Gated by [[settings/data-complexity-scoring-enabled]] so admins can silence
   scoring without unscheduling the job.
@@ -59,10 +69,8 @@
                     (assoc (synonym-source/complexity-scores-opts)
                            :metabot-scope (metabot-scope/internal-metabot-scope)))]
         (try
-          (data-complexity-score/record-score! claim-fingerprint result)
-          (if (::complexity/snowplow-published? (meta result))
-            (settings/data-complexity-scoring-last-fingerprint! claim-fingerprint)
-            (log/warn "Data Complexity Score: Snowplow publish failed; leaving fingerprint unchanged so the next boot or cron retries"))
+          (data-complexity-score/record-score! claim-fingerprint "appdb" result)
+          (maybe-advance-last-fingerprint! claim-fingerprint result)
           (catch Throwable t
             (log/warn t "Data Complexity Score: failed to persist score snapshot; leaving fingerprint unchanged so the next boot or cron retries")))
         result)

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -85,15 +85,15 @@
 
 (deftest complexity-endpoint-returns-latest-stored-score-test
   (testing "superusers read the latest persisted score snapshot instead of recomputing it on demand"
-    (let [captured-args (atom nil)]
+    (let [captured-fingerprint (atom nil)]
       (mt/with-dynamic-fn-redefs [task.complexity-score/current-fingerprint (constantly "api-test-fp")
                                   data-complexity-score/latest-score
-                                  (fn [fingerprint source]
-                                    (reset! captured-args [fingerprint source])
+                                  (fn [fingerprint]
+                                    (reset! captured-fingerprint fingerprint)
                                     (with-sample-calculated-at sample-score))]
         (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-          (is (= ["api-test-fp" "appdb"] @captured-args)
-              "API must filter by source=\"appdb\" so representation-derived rows can't shadow the authoritative row")
+          (is (= "api-test-fp" @captured-fingerprint)
+              "API passes the cron fingerprint through; source=\"appdb\" defaulting is covered by latest-score-filters-by-source-test")
           (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score)) resp))
           (is (contains? (:meta resp) :formula_version))
           (is (= sample-calculated-at (get-in resp [:meta :calculated_at])))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -85,14 +85,15 @@
 
 (deftest complexity-endpoint-returns-latest-stored-score-test
   (testing "superusers read the latest persisted score snapshot instead of recomputing it on demand"
-    (let [captured-fingerprint (atom nil)]
+    (let [captured-args (atom nil)]
       (mt/with-dynamic-fn-redefs [task.complexity-score/current-fingerprint (constantly "api-test-fp")
                                   data-complexity-score/latest-score
-                                  (fn [fingerprint]
-                                    (reset! captured-fingerprint fingerprint)
+                                  (fn [fingerprint source]
+                                    (reset! captured-args [fingerprint source])
                                     (with-sample-calculated-at sample-score))]
         (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
-          (is (= "api-test-fp" @captured-fingerprint))
+          (is (= ["api-test-fp" "appdb"] @captured-args)
+              "API must filter by source=\"appdb\" so representation-derived rows can't shadow the authoritative row")
           (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score)) resp))
           (is (contains? (:meta resp) :formula_version))
           (is (= sample-calculated-at (get-in resp [:meta :calculated_at])))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -112,12 +112,13 @@
       (with-redefs [metabot-scope/internal-metabot-scope      (constantly {})
                     task.complexity-score/current-fingerprint (constantly "api-test-fp")
                     complexity/complexity-scores              (fn [& _] sample-score)
-                    data-complexity-score/record-score!       (fn [fingerprint stored-score]
-                                                                (reset! persisted? [fingerprint stored-score])
+                    data-complexity-score/record-score!       (fn [fingerprint source stored-score]
+                                                                (reset! persisted? [fingerprint source stored-score])
                                                                 (with-sample-calculated-at stored-score))]
         (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score))
                (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))
-        (is (= ["api-test-fp" sample-score] @persisted?))))))
+        (is (= ["api-test-fp" "appdb" sample-score] @persisted?)
+            "API recompute path must stamp source=\"appdb\"")))))
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-advances-last-fingerprint-on-snowplow-publish-test
   (testing "force recalculation mirrors the scheduled path's fingerprint gate — advance only when Snowplow accepted the event"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -363,8 +363,20 @@
         (is (zero? @advance-calls))))))
 
 (deftest ^:parallel dir-digest-is-stable-and-content-sensitive-test
-  (testing "dir-digest produces the same value for the same content and changes when content changes"
+  (testing "dir-digest produces the same value for the same content"
     (let [d1 (#'representation/dir-digest representation-fixture-dir)
           d2 (#'representation/dir-digest representation-fixture-dir)]
       (is (= d1 d2) "two calls against the same dir must produce the same digest")
-      (is (re-matches #"[0-9a-f]{64}" d1) "digest must be a 64-char lowercase hex string (SHA-256)"))))
+      (is (re-matches #"[0-9a-f]{64}" d1) "digest must be a 64-char lowercase hex string (SHA-256)")))
+  (testing "dir-digest changes when file content changes — guards against a constant-digest regression"
+    ;; A regression that made `dir-digest` return a fixed value (e.g. `(hex (sha-256 (pr-str [])))`)
+    ;; would pass the stability assertion above. Mutating a single byte in a single file must change
+    ;; the digest.
+    (let [tmp-dir (empty-tmp-dir "dir-digest-")
+          target  (io/file tmp-dir "marker.txt")]
+      (spit target "original")
+      (let [before (#'representation/dir-digest (.getAbsolutePath tmp-dir))]
+        (spit target "originalX")
+        (let [after (#'representation/dir-digest (.getAbsolutePath tmp-dir))]
+          (is (not= before after)
+              "appending a byte to a file must change the digest"))))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.data-complexity-score.representation :as representation]
    [metabase-enterprise.data-complexity-score.synonym-source :as synonym-source]
    [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
+   [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -303,7 +304,7 @@
     (let [persisted?     (atom false)
           bootstrapped?  (atom false)]
       (mt/with-dynamic-fn-redefs [data-complexity-score/record-score! (fn [& _] (reset! persisted? true))
-                                  cli/bootstrap-appdb!                (fn [] (reset! bootstrapped? true))]
+                                  mdb/setup-db-without-migrations!    (fn [] (reset! bootstrapped? true))]
         (#'cli/run-cli {:representation-dir representation-fixture-dir})
         (is (false? @persisted?)   "representation+no-write must not persist anything")
         (is (false? @bootstrapped?) "representation+no-write must not boot the appdb at all")))))
@@ -312,7 +313,7 @@
   (testing "representation + --write-to-appdb true persists a row stamped 'representation:<digest>' and does not advance the cron fingerprint"
     (let [calls          (atom [])
           advance-calls  (atom 0)]
-      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+      (mt/with-dynamic-fn-redefs [mdb/setup-db-without-migrations!                (fn [])
                                   task.complexity-score/current-fingerprint       (constantly "test-fp")
                                   task.complexity-score/maybe-advance-last-fingerprint! (fn [& _]
                                                                                           (swap! advance-calls inc))
@@ -332,7 +333,7 @@
   (testing "appdb mode with no --write-to-appdb flag defaults to writing (true)"
     (let [calls         (atom [])
           advance-calls (atom [])]
-      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+      (mt/with-dynamic-fn-redefs [mdb/setup-db-without-migrations!                (fn [])
                                   complexity/complexity-scores                    (fn [& _] {:meta {}})
                                   synonym-source/complexity-scores-opts           (constantly {})
                                   metabot-scope/internal-metabot-scope            (constantly {})
@@ -351,7 +352,7 @@
   (testing "appdb + --write-to-appdb false scores but never persists or advances the fingerprint"
     (let [persisted?    (atom false)
           advance-calls (atom 0)]
-      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+      (mt/with-dynamic-fn-redefs [mdb/setup-db-without-migrations!                (fn [])
                                   complexity/complexity-scores                    (fn [& _] {:meta {}})
                                   synonym-source/complexity-scores-opts           (constantly {})
                                   metabot-scope/internal-metabot-scope            (constantly {})

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -6,7 +6,11 @@
    [metabase-enterprise.data-complexity-score.cli :as cli]
    [metabase-enterprise.data-complexity-score.complexity :as complexity]
    [metabase-enterprise.data-complexity-score.complexity-embedders :as embedders]
+   [metabase-enterprise.data-complexity-score.metabot-scope :as metabot-scope]
+   [metabase-enterprise.data-complexity-score.models.data-complexity-score :as data-complexity-score]
    [metabase-enterprise.data-complexity-score.representation :as representation]
+   [metabase-enterprise.data-complexity-score.synonym-source :as synonym-source]
+   [metabase-enterprise.data-complexity-score.task.complexity-score :as task.complexity-score]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -273,3 +277,94 @@
         (is (empty? extra) "fail! should be called with a single message")
         (is (re-find #"does-not-exist\.json" msg)
             "the user-facing message must mention the missing file")))))
+
+;;; ----------------------------------- source + write-to-appdb dispatch -----------------------------------
+
+(deftest ^:parallel run-cli-rejects-appdb-source-combined-with-representation-dir-test
+  (testing "--source appdb + --representation-dir is a user error — these flags name mutually exclusive inputs"
+    (let [ex (try (#'cli/run-cli {:source "appdb"
+                                  :representation-dir representation-fixture-dir})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (true? (:cli-validation (ex-data ex))))
+      (is (re-find #"--source appdb does not accept" (ex-message ex)))))
+  (testing "--source appdb + --embeddings is also rejected"
+    (let [ex (try (#'cli/run-cli {:source "appdb"
+                                  :embeddings "embeddings.json"})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (true? (:cli-validation (ex-data ex))))
+      (is (re-find #"--source appdb does not accept" (ex-message ex))))))
+
+(deftest ^:sequential run-cli-representation-mode-default-does-not-write-test
+  (testing "representation mode with no --write-to-appdb flag never calls record-score! or bootstrap"
+    (let [persisted?     (atom false)
+          bootstrapped?  (atom false)]
+      (mt/with-dynamic-fn-redefs [data-complexity-score/record-score! (fn [& _] (reset! persisted? true))
+                                  cli/bootstrap-appdb!                (fn [] (reset! bootstrapped? true))]
+        (#'cli/run-cli {:representation-dir representation-fixture-dir})
+        (is (false? @persisted?)   "representation+no-write must not persist anything")
+        (is (false? @bootstrapped?) "representation+no-write must not boot the appdb at all")))))
+
+(deftest ^:sequential run-cli-representation-mode-with-write-stamps-representation-source-test
+  (testing "representation + --write-to-appdb true persists a row stamped 'representation:<digest>' and does not advance the cron fingerprint"
+    (let [calls          (atom [])
+          advance-calls  (atom 0)]
+      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+                                  task.complexity-score/current-fingerprint       (constantly "test-fp")
+                                  task.complexity-score/maybe-advance-last-fingerprint! (fn [& _]
+                                                                                          (swap! advance-calls inc))
+                                  data-complexity-score/record-score!             (fn [fp source _result]
+                                                                                    (swap! calls conj [fp source]))]
+        (#'cli/run-cli {:representation-dir representation-fixture-dir
+                        :write-to-appdb     true})
+        (is (= 1 (count @calls)) "exactly one row written")
+        (let [[fp source] (first @calls)]
+          (is (= "test-fp" fp))
+          (is (re-find #"^representation:[0-9a-f]{64}$" source)
+              "source must be 'representation:<sha-256 hex>'"))
+        (is (zero? @advance-calls)
+            "representation-derived rows must never advance the cron's last-fingerprint setting")))))
+
+(deftest ^:sequential run-cli-appdb-mode-defaults-to-writing-test
+  (testing "appdb mode with no --write-to-appdb flag defaults to writing (true)"
+    (let [calls         (atom [])
+          advance-calls (atom [])]
+      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+                                  complexity/complexity-scores                    (fn [& _] {:meta {}})
+                                  synonym-source/complexity-scores-opts           (constantly {})
+                                  metabot-scope/internal-metabot-scope            (constantly {})
+                                  task.complexity-score/current-fingerprint       (constantly "appdb-fp")
+                                  task.complexity-score/maybe-advance-last-fingerprint! (fn [fp _result]
+                                                                                          (swap! advance-calls conj fp))
+                                  data-complexity-score/record-score!             (fn [fp source _result]
+                                                                                    (swap! calls conj [fp source]))]
+        (#'cli/run-cli {:source "appdb"})
+        (is (= [["appdb-fp" "appdb"]] @calls)
+            "appdb-mode default must write one row stamped source=\"appdb\"")
+        (is (= ["appdb-fp"] @advance-calls)
+            "appdb-mode write path must call maybe-advance-last-fingerprint! the same way the cron does")))))
+
+(deftest ^:sequential run-cli-appdb-mode-respects-explicit-no-write-test
+  (testing "appdb + --write-to-appdb false scores but never persists or advances the fingerprint"
+    (let [persisted?    (atom false)
+          advance-calls (atom 0)]
+      (mt/with-dynamic-fn-redefs [cli/bootstrap-appdb!                            (fn [])
+                                  complexity/complexity-scores                    (fn [& _] {:meta {}})
+                                  synonym-source/complexity-scores-opts           (constantly {})
+                                  metabot-scope/internal-metabot-scope            (constantly {})
+                                  data-complexity-score/record-score!             (fn [& _] (reset! persisted? true))
+                                  task.complexity-score/maybe-advance-last-fingerprint! (fn [& _]
+                                                                                          (swap! advance-calls inc))]
+        (#'cli/run-cli {:source "appdb" :write-to-appdb false})
+        (is (false? @persisted?))
+        (is (zero? @advance-calls))))))
+
+(deftest ^:parallel dir-digest-is-stable-and-content-sensitive-test
+  (testing "dir-digest produces the same value for the same content and changes when content changes"
+    (let [d1 (#'representation/dir-digest representation-fixture-dir)
+          d2 (#'representation/dir-digest representation-fixture-dir)]
+      (is (= d1 d2) "two calls against the same dir must produce the same digest")
+      (is (re-matches #"[0-9a-f]{64}" d1) "digest must be a 64-char lowercase hex string (SHA-256)"))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -1000,15 +1000,12 @@
         (t2/delete! :model/DataComplexityScore :fingerprint fingerprint)
         (data-complexity-score/record-score! fingerprint "appdb"                {:meta {:label "appdb-row"}})
         (data-complexity-score/record-score! fingerprint "representation:abcd"  {:meta {:label "representation-row"}})
-        (is (= "representation-row"
-               (get-in (data-complexity-score/latest-score fingerprint) [:meta :label]))
-            "no source filter → newest row wins, regardless of provenance")
         (is (= "appdb-row"
-               (get-in (data-complexity-score/latest-score fingerprint "appdb") [:meta :label]))
-            "source=\"appdb\" must skip past the newer representation-tagged row")
+               (get-in (data-complexity-score/latest-score fingerprint) [:meta :label]))
+            "default source=\"appdb\" skips past the newer representation-tagged row")
         (is (= "representation-row"
                (get-in (data-complexity-score/latest-score fingerprint "representation:abcd") [:meta :label]))
-            "and an explicit representation source still resolves its own row")
+            "an explicit representation source still resolves its own row")
         (finally
           (t2/delete! :model/DataComplexityScore :fingerprint fingerprint))))))
 

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -987,6 +987,31 @@
         (finally
           (t2/delete! :model/DataComplexityScore :fingerprint [:in [other-fingerprint fingerprint]]))))))
 
+(deftest ^:sequential latest-score-filters-by-source-test
+  (testing "passing source filters out representation-derived rows that share the cron's fingerprint"
+    ;; The CLI's representation mode writes under the same `task.complexity-score/current-fingerprint`
+    ;; as the cron/API so that an admin re-running the cron after a CLI scoring still benefits from
+    ;; the fingerprint short-circuit. Provenance is encoded in `source` ("appdb" vs
+    ;; "representation:<digest>"). Read paths that should only surface authoritative rows must pass
+    ;; the source filter — otherwise the most-recent representation row would shadow the appdb row.
+    (mt/initialize-if-needed! :db)
+    (let [fingerprint "latest-score-source-test/shared"]
+      (try
+        (t2/delete! :model/DataComplexityScore :fingerprint fingerprint)
+        (data-complexity-score/record-score! fingerprint "appdb"                {:meta {:label "appdb-row"}})
+        (data-complexity-score/record-score! fingerprint "representation:abcd"  {:meta {:label "representation-row"}})
+        (is (= "representation-row"
+               (get-in (data-complexity-score/latest-score fingerprint) [:meta :label]))
+            "no source filter → newest row wins, regardless of provenance")
+        (is (= "appdb-row"
+               (get-in (data-complexity-score/latest-score fingerprint "appdb") [:meta :label]))
+            "source=\"appdb\" must skip past the newer representation-tagged row")
+        (is (= "representation-row"
+               (get-in (data-complexity-score/latest-score fingerprint "representation:abcd") [:meta :label]))
+            "and an explicit representation source still resolves its own row")
+        (finally
+          (t2/delete! :model/DataComplexityScore :fingerprint fingerprint))))))
+
 (deftest ^:sequential run-scoring-persists-latest-score-snapshot-test
   (testing "every successful computation persists a fresh snapshot for the overview endpoint"
     (mt/initialize-if-needed! :db)

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -978,9 +978,9 @@
           fingerprint       "latest-score-test/current"]
       (try
         (t2/delete! :model/DataComplexityScore :fingerprint [:in [other-fingerprint fingerprint]])
-        (data-complexity-score/record-score! other-fingerprint {:meta {:label "other"}})
-        (data-complexity-score/record-score! fingerprint {:meta {:label "older"}})
-        (data-complexity-score/record-score! fingerprint {:meta {:label "newer"}})
+        (data-complexity-score/record-score! other-fingerprint "appdb" {:meta {:label "other"}})
+        (data-complexity-score/record-score! fingerprint "appdb" {:meta {:label "older"}})
+        (data-complexity-score/record-score! fingerprint "appdb" {:meta {:label "newer"}})
         (let [score (data-complexity-score/latest-score fingerprint)]
           (is (= "newer" (get-in score [:meta :label])))
           (is (some? (get-in score [:meta :calculated-at]))))
@@ -996,9 +996,11 @@
         (mt/with-temporary-setting-values [data-complexity-scoring-enabled true]
           (mt/with-dynamic-fn-redefs [complexity/complexity-scores (fn [& _] result)]
             (#'task.complexity-score/run-scoring! "persist-test-fp")
-            (let [{:keys [id fingerprint score_data]} (data-complexity-score/latest-entry "persist-test-fp")]
+            (let [{:keys [id fingerprint score_data source]} (data-complexity-score/latest-entry "persist-test-fp")]
               (is (= result score_data))
               (is (= "persist-test-fp" fingerprint))
+              (is (= "appdb" source)
+                  "cron-path rows must be stamped with source=\"appdb\"")
               (when before-id
                 (is (> id before-id)
                     "a new append-only snapshot should be written for each run")))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/task/complexity_score_trimmer_test.clj
@@ -27,6 +27,7 @@
   [label created-at]
   (t2/insert! :model/DataComplexityScore
               {:fingerprint (str fingerprint-prefix label)
+               :source      "appdb"
                :score_data  {:label label}
                :created_at  created-at}))
 

--- a/resources/migrations/061/20260513_data_complexity_score_source.yaml
+++ b/resources/migrations/061/20260513_data_complexity_score_source.yaml
@@ -1,6 +1,11 @@
 ## Add `source` column to data_complexity_score so we can distinguish rows produced from the live
 ## appdb (cron, API, CLI --source appdb) from rows produced by the CLI scoring a representation
 ## directory (CLI --source representation --write-to-appdb true).
+##
+## TODO (v62+): drop the `defaultValue: appdb` below. It exists only so old nodes that don't yet
+## know about the `source` column can still insert during a rolling deploy. Once every deployment
+## has rolled past v61, the default is dead weight and any insert that omits `source` is a bug we
+## want to surface rather than silently label "appdb".
 
 databaseChangeLog:
   - logicalFilePath: migrations/061_update_migrations.yaml

--- a/resources/migrations/061/20260513_data_complexity_score_source.yaml
+++ b/resources/migrations/061/20260513_data_complexity_score_source.yaml
@@ -1,0 +1,48 @@
+## Add `source` column to data_complexity_score so we can distinguish rows produced from the live
+## appdb (cron, API, CLI --source appdb) from rows produced by the CLI scoring a representation
+## directory (CLI --source representation --write-to-appdb true).
+
+databaseChangeLog:
+  - logicalFilePath: migrations/061_update_migrations.yaml
+  - changeSet:
+      id: v61.2026-05-13T10:00:00
+      author: christruter
+      comment: Add source column to data_complexity_score as nullable so we can backfill before enforcing NOT NULL
+      changes:
+        - addColumn:
+            tableName: data_complexity_score
+            columns:
+              - column:
+                  name: source
+                  type: varchar(255)
+                  remarks: Provenance of this score — "appdb" for cron/API/CLI-from-appdb, or "representation:<digest>" for CLI runs that scored a representation directory.
+      rollback:
+        - dropColumn:
+            tableName: data_complexity_score
+            columnName: source
+
+  - changeSet:
+      id: v61.2026-05-13T10:00:01
+      author: christruter
+      comment: Backfill existing data_complexity_score rows with source=appdb — pre-CLI, all rows came from cron/API
+      changes:
+        - sql:
+            sql: UPDATE data_complexity_score SET source = 'appdb' WHERE source IS NULL
+      rollback:
+        - sql:
+            sql: UPDATE data_complexity_score SET source = NULL
+
+  - changeSet:
+      id: v61.2026-05-13T10:00:02
+      author: christruter
+      comment: Enforce NOT NULL on data_complexity_score.source now that it is backfilled
+      changes:
+        - addNotNullConstraint:
+            tableName: data_complexity_score
+            columnName: source
+            columnDataType: varchar(255)
+      rollback:
+        - dropNotNullConstraint:
+            tableName: data_complexity_score
+            columnName: source
+            columnDataType: varchar(255)

--- a/resources/migrations/061/20260513_data_complexity_score_source.yaml
+++ b/resources/migrations/061/20260513_data_complexity_score_source.yaml
@@ -25,23 +25,3 @@ databaseChangeLog:
         - dropColumn:
             tableName: data_complexity_score
             columnName: source
-
-  - changeSet:
-      id: v61.2026-05-13T10:00:01
-      author: christruter
-      comment: |
-        Drop the column default once the rolling-deploy window has closed. Keeping it would
-        silently fill 'appdb' for any future insert that forgets to set source, masking the case
-        where a representation-derived row should have been tagged 'representation:<digest>'.
-        App-layer code must set source explicitly.
-      changes:
-        - dropDefaultValue:
-            tableName: data_complexity_score
-            columnName: source
-            columnDataType: varchar(255)
-      rollback:
-        - addDefaultValue:
-            tableName: data_complexity_score
-            columnName: source
-            columnDataType: varchar(255)
-            defaultValue: appdb

--- a/resources/migrations/061/20260513_data_complexity_score_source.yaml
+++ b/resources/migrations/061/20260513_data_complexity_score_source.yaml
@@ -8,9 +8,8 @@ databaseChangeLog:
       id: v61.2026-05-13T10:00:00
       author: christruter
       comment: |
-        Add source column to data_complexity_score with a default of 'appdb' so that
-        (a) existing rows are populated and (b) older nodes inserting rows mid-rolling-deploy
-        get a non-NULL value, making the later NOT NULL constraint safe to apply.
+        Add NOT NULL source column with a default of 'appdb'. The default backfills existing rows
+        and keeps old nodes' inserts safe during rolling deploys (they don't know to set source).
       changes:
         - addColumn:
             tableName: data_complexity_score
@@ -19,7 +18,9 @@ databaseChangeLog:
                   name: source
                   type: varchar(255)
                   defaultValue: appdb
-                  remarks: Provenance of this score — "appdb" for cron/API/CLI-from-appdb, or "representation:<digest>" for CLI runs that scored a representation directory.
+                  constraints:
+                    nullable: false
+                  remarks: Provenance — "appdb" for cron/API/CLI-from-appdb, or "representation:<digest>" for CLI runs that scored a representation directory.
       rollback:
         - dropColumn:
             tableName: data_complexity_score
@@ -29,27 +30,18 @@ databaseChangeLog:
       id: v61.2026-05-13T10:00:01
       author: christruter
       comment: |
-        Belt-and-suspenders backfill — most DBs already populated existing rows via the column
-        default above, but some Liquibase/JDBC combos skip that. This guarantees no NULLs remain
-        before we add the NOT NULL constraint.
+        Drop the column default once the rolling-deploy window has closed. Keeping it would
+        silently fill 'appdb' for any future insert that forgets to set source, masking the case
+        where a representation-derived row should have been tagged 'representation:<digest>'.
+        App-layer code must set source explicitly.
       changes:
-        - sql:
-            sql: UPDATE data_complexity_score SET source = 'appdb' WHERE source IS NULL
-      rollback:
-        - sql:
-            sql: UPDATE data_complexity_score SET source = NULL
-
-  - changeSet:
-      id: v61.2026-05-13T10:00:02
-      author: christruter
-      comment: Enforce NOT NULL on data_complexity_score.source now that it is backfilled
-      changes:
-        - addNotNullConstraint:
+        - dropDefaultValue:
             tableName: data_complexity_score
             columnName: source
             columnDataType: varchar(255)
       rollback:
-        - dropNotNullConstraint:
+        - addDefaultValue:
             tableName: data_complexity_score
             columnName: source
             columnDataType: varchar(255)
+            defaultValue: appdb

--- a/resources/migrations/061/20260513_data_complexity_score_source.yaml
+++ b/resources/migrations/061/20260513_data_complexity_score_source.yaml
@@ -7,7 +7,10 @@ databaseChangeLog:
   - changeSet:
       id: v61.2026-05-13T10:00:00
       author: christruter
-      comment: Add source column to data_complexity_score as nullable so we can backfill before enforcing NOT NULL
+      comment: |
+        Add source column to data_complexity_score with a default of 'appdb' so that
+        (a) existing rows are populated and (b) older nodes inserting rows mid-rolling-deploy
+        get a non-NULL value, making the later NOT NULL constraint safe to apply.
       changes:
         - addColumn:
             tableName: data_complexity_score
@@ -15,6 +18,7 @@ databaseChangeLog:
               - column:
                   name: source
                   type: varchar(255)
+                  defaultValue: appdb
                   remarks: Provenance of this score — "appdb" for cron/API/CLI-from-appdb, or "representation:<digest>" for CLI runs that scored a representation directory.
       rollback:
         - dropColumn:
@@ -24,7 +28,10 @@ databaseChangeLog:
   - changeSet:
       id: v61.2026-05-13T10:00:01
       author: christruter
-      comment: Backfill existing data_complexity_score rows with source=appdb — pre-CLI, all rows came from cron/API
+      comment: |
+        Belt-and-suspenders backfill — most DBs already populated existing rows via the column
+        default above, but some Liquibase/JDBC combos skip that. This guarantees no NULLs remain
+        before we add the NOT NULL constraint.
       changes:
         - sql:
             sql: UPDATE data_complexity_score SET source = 'appdb' WHERE source IS NULL

--- a/src/metabase/app_db/core.clj
+++ b/src/metabase/app_db/core.clj
@@ -98,6 +98,14 @@
   []
   (reset! (:status mdb.connection/*application-db*) ::setup-finished))
 
+(defn verify-application-db-connection!
+  "Open a connection to the bound application DB and check its server version. Throws on failure.
+  Does *not* run migrations or any encryption checks — use [[setup-db!]] for the full bootstrap.
+  This is the public, no-argument hook for tools that need to confirm appdb connectivity without
+  modifying the schema."
+  []
+  (mdb.setup/verify-db-connection (mdb.connection/db-type) (mdb.connection/data-source)))
+
 (defn app-db
   "The Application database. A record, but use accessors [[db-type]], [[data-source]], etc to access. Also
   implements [[javax.sql.DataSource]] directly, so you can call [[.getConnection]] on it directly."

--- a/src/metabase/app_db/core.clj
+++ b/src/metabase/app_db/core.clj
@@ -106,6 +106,23 @@
   []
   (mdb.setup/verify-db-connection (mdb.connection/db-type) (mdb.connection/data-source)))
 
+(defn setup-db-without-migrations!
+  "Like [[setup-db!]] but never runs migrations or mutates the schema. Idempotent: no-ops if the
+  DB is already set up. Verifies connectivity, then marks the DB ready.
+
+  For read-only tools (e.g. Data Complexity CLI) that need to query Toucan models against a live
+  appdb without modifying it. Any schema mismatch surfaces as a runtime error at query time
+  rather than during setup.
+
+  Skips:
+  - Liquibase migrations.
+  - [[metabase.app-db.setup/check-encryption]], whose auto-encrypt branch can silently rewrite
+    every encrypted `setting` row when an encryption key is configured."
+  []
+  (when-not (db-is-set-up?)
+    (verify-application-db-connection!)
+    (finish-db-setup!)))
+
 (defn app-db
   "The Application database. A record, but use accessors [[db-type]], [[data-source]], etc to access. Also
   implements [[javax.sql.DataSource]] directly, so you can call [[.getConnection]] on it directly."

--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -159,9 +159,10 @@
          (not (pos? (compare ((juxt :major :minor :patch) required-version)
                              [major minor patch]))))))
 
-(mu/defn- verify-db-connection
+(mu/defn verify-db-connection
   "Test connection to application database with `data-source` and throw an exception if we have any troubles
-  connecting."
+  connecting. Public so [[metabase.app-db.core/verify-application-db-connection!]] can call it from outside this
+  namespace; most callers should use that wrapper instead of invoking this directly."
   [db-type     :- :keyword
    data-source :- (ms/InstanceOfClass javax.sql.DataSource)]
   (log/info (u/format-color 'cyan "Verifying %s Database Connection ..." (name db-type)))

--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -33,7 +33,9 @@
 ;;; These modes don't need the full Metabase infrastructure (app-db, events,
 ;;; etc.) and can run with minimal namespace loading for fast startup.
 ;;;
-;;; Usage: java -jar metabase.jar --mode checker [checker-specific args...]
+;;; Usage:
+;;;   java -jar metabase.jar --mode checker [checker-specific args...]
+;;;   java -jar metabase.jar --mode complexity-score [scorer-specific args...]
 ;;; ===========================================================================
 
 #_{:clj-kondo/ignore [:discouraged-var]}
@@ -48,13 +50,14 @@
   (let [startup (case mode
                   ;; schema checker was moved out to js. Perhaps this will get a long running server mode checker? Or
                   ;; perhaps just this one.
-                  "checker" 'metabase-enterprise.checker.cli/entrypoint
+                  "checker"          'metabase-enterprise.checker.cli/entrypoint
+                  "complexity-score" 'metabase-enterprise.data-complexity-score.cli/entrypoint
                   nil)]
     (if startup
       ((requiring-resolve startup) args)
       (do (binding [*out* *err*]
             (output! (str "Unknown mode: " mode))
-            (output! "Available modes: checker"))
+            (output! "Available modes: checker, complexity-score"))
           (System/exit 1)))))
 
 (defn -main


### PR DESCRIPTION
## Summary
- CLI can now score from the appdb (`--source appdb`)
- CLI can write CLI-from-representation scores back to the appdb (`--write-to-appdb`)
- New `source` column distinguishes appdb and representation runs (`representation:<digest>`)
  By default we don't persist representation runs, need to opt in explicitly.
- Migration adds the column nullable, backfills existing rows to `appdb`, then enforces NOT NULL.
- CLI is dispatchable from the AOT JAR via `java -jar metabase.jar --mode complexity-score [...]`, mirroring the `--mode checker` hook.

## Test plan
- [x] `./bin/test-agent :module enterprise/data_complexity_score`
- [x] Run migration on an appdb with existing `data_complexity_score` rows
- [x] Smoke-test both CLI modes end-to-end
- [x] Smoke-test the bootstrap dispatch (same code path the JAR uses): `clojure -M:ee:dev -m metabase.core.bootstrap --mode complexity-score [--help | --source representation -r <fixture>]`