### PR TITLE
Add type hints to fix reflection in data-complexity-score cli_test (release-x.61.x)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -187,10 +187,10 @@
     (testing "relative path resolves under the representation dir, not cwd"
       (let [resolved (#'representation/resolve-embeddings-file (.getAbsolutePath tmp-dir)
                                                                "embeddings/variant.json")]
-        (is (= (.getCanonicalPath present) (.getCanonicalPath resolved)))))
+        (is (= (.getCanonicalPath present) (.getCanonicalPath ^java.io.File resolved)))))
     (testing "absolute path is honored as-is, regardless of dir"
       (let [resolved (#'representation/resolve-embeddings-file "/tmp" (.getAbsolutePath present))]
-        (is (= (.getCanonicalPath present) (.getCanonicalPath resolved)))))
+        (is (= (.getCanonicalPath present) (.getCanonicalPath ^java.io.File resolved)))))
     (testing "missing file throws ex-info carrying both the request and the resolved path"
       (let [ex (try (#'representation/resolve-embeddings-file (.getAbsolutePath tmp-dir)
                                                               "embeddings/does-not-exist.json")


### PR DESCRIPTION
## Summary

- Mirrors the master fix from #73684 (labelled `no-backport`) directly onto `release-x.61.x`.
- Adds `^java.io.File` type hints on two `.getCanonicalPath` calls in `cli_test.clj`.
- Unblocks the `Eastwood (tests only)` safety net, which started running on `release-*` pushes after #74079 landed and immediately surfaced these latent reflection warnings (introduced via the CLI for Data Complexity Score backport, #73643).

## Test plan

- [x] `Eastwood (tests only)` job passes on this PR / on the next push to `release-x.61.x` after merge.