### PR TITLE
Update third step of embed wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
@@ -1,8 +1,10 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
-import { Card, Stack, Text } from "metabase/ui";
+import { useDocsUrl } from "metabase/common/hooks";
+import { Anchor, Card, Divider, Stack, Text } from "metabase/ui";
 
+import { UTM_LOCATION } from "../../../analytics";
 import { CopyCodeSnippetButton } from "../../GetCode/CopyCodeSnippetButton";
 
 interface EmbedCodeCardProps {
@@ -10,23 +12,50 @@ interface EmbedCodeCardProps {
   onCopy: () => void;
 }
 
-export const EmbedCodeCard = ({ snippet, onCopy }: EmbedCodeCardProps) => (
-  <Card p="md">
-    <Text size="lg" fw="bold" mb="md">
-      {t`Embed code`}
-    </Text>
+const utmTags = {
+  utm_source: "product",
+  utm_campaign: "embedding_get_code",
+  utm_content: UTM_LOCATION,
+};
 
-    <Stack gap="sm">
-      <div onCopy={onCopy}>
-        <CodeEditor
-          language="html"
-          value={snippet}
-          readOnly
-          lineNumbers={false}
-        />
-      </div>
+export const EmbedCodeCard = ({ snippet, onCopy }: EmbedCodeCardProps) => {
+  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- Only for admins
+  const { url: docsUrl } = useDocsUrl("embedding/modular-embedding", {
+    anchor: "add-the-embedding-script-to-your-app",
+    utm: utmTags,
+  });
 
-      <CopyCodeSnippetButton snippet={snippet} onCopy={onCopy} />
-    </Stack>
-  </Card>
-);
+  const docsLink = (
+    <Anchor key="docs" href={docsUrl} target="_blank">
+      {t`docs`}
+    </Anchor>
+  );
+
+  return (
+    <Card p="md">
+      <Stack gap="xs" mb="md">
+        <Text size="lg" fw="bold">
+          {t`Embed code`}
+        </Text>
+        <Text size="sm" c="text-secondary">
+          {jt`Add this snippet to your app. To modify this code and tweak additional options, refer to the ${docsLink}.`}
+        </Text>
+      </Stack>
+
+      <Divider mb="md" />
+
+      <Stack gap="sm">
+        <div onCopy={onCopy}>
+          <CodeEditor
+            language="html"
+            value={snippet}
+            readOnly
+            lineNumbers={false}
+          />
+        </div>
+
+        <CopyCodeSnippetButton snippet={snippet} onCopy={onCopy} />
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
@@ -1,4 +1,4 @@
-import { jt, t } from "ttag";
+import { c, t } from "ttag";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { useDocsUrl } from "metabase/common/hooks";
@@ -38,7 +38,8 @@ export const EmbedCodeCard = ({ snippet, onCopy }: EmbedCodeCardProps) => {
           {t`Embed code`}
         </Text>
         <Text size="sm" c="text-secondary">
-          {jt`Add this snippet to your app. To modify this code and tweak additional options, refer to the ${docsLink}.`}
+          {c("{0} is a link labeled 'docs'")
+            .jt`Add this snippet to your app. To modify this code and tweak additional options, refer to the ${docsLink}.`}
         </Text>
       </Stack>
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/MetabaseAccountCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/MetabaseAccountCard.tsx
@@ -38,50 +38,57 @@ export const MetabaseAccountCard = () => {
   };
 
   return (
-    <>
-      <Card p="md">
-        <Stack gap="md" p="xs">
-          <Text size="lg" fw="bold">
-            {
-              // eslint-disable-next-line metabase/no-literal-metabase-strings -- Public Facing string
-              t`Metabase account`
+    <Card p="md">
+      <Stack gap="md" p="xs">
+        <Text size="lg" fw="bold">
+          {
+            // eslint-disable-next-line metabase/no-literal-metabase-strings -- Public Facing string
+            t`Metabase account`
+          }
+        </Text>
+
+        <Radio.Group value={authSubType} onChange={handleAuthSubTypeChange}>
+          <Stack gap="sm">
+            <Radio
+              disabled={!isSsoEnabledAndConfigured}
+              value="sso"
+              label={t`Single sign-on`}
+            />
+
+            <Radio
+              value="user-session"
+              label={t`Existing session (local testing only)`}
+            />
+          </Stack>
+        </Radio.Group>
+
+        {!isSsoEnabledAndConfigured && !!settings.useExistingUserSession && (
+          <Alert
+            icon={
+              <Icon
+                name="warning_triangle_filled"
+                c="text-secondary"
+                size={16}
+              />
             }
-          </Text>
-
-          <Radio.Group value={authSubType} onChange={handleAuthSubTypeChange}>
-            <Stack gap="sm">
-              <Radio
-                disabled={!isSsoEnabledAndConfigured}
-                value="sso"
-                label={t`Single sign-on`}
-              />
-
-              <Radio
-                value="user-session"
-                label={t`Existing session (local testing only)`}
-              />
-            </Stack>
-          </Radio.Group>
-        </Stack>
-      </Card>
-
-      {!isSsoEnabledAndConfigured && !!settings.useExistingUserSession && (
-        <Alert icon={<Icon name="warning" size={16} />} color="warning">
-          <Text size="md" lh="lg">
-            {jt`The code below will only work for local testing. To get production ready code, configure ${(
-              <Anchor
-                key="configure-sso"
-                href={setupSsoUrl}
-                target="_blank"
-                size="md"
-                lh="lg"
-              >
-                {t`JWT SSO or SAML`}
-              </Anchor>
-            )}.`}
-          </Text>
-        </Alert>
-      )}
-    </>
+            color="warning"
+          >
+            <Text size="md" lh="lg">
+              {jt`The code below will only work for local testing. To get production ready code, configure ${(
+                <Anchor
+                  key="configure-sso"
+                  href={setupSsoUrl}
+                  target="_blank"
+                  size="md"
+                  lh="lg"
+                >
+                  {t`JWT SSO or SAML`}
+                </Anchor>
+              )}.`}
+            </Text>
+          </Alert>
+        )}
+      </Stack>
+    </Card>
   );
 };


### PR DESCRIPTION
Closes [EMB-1724: State updates in the embedding wizard third step](https://linear.app/metabase/issue/EMB-1724/state-updates-in-the-embedding-wizard-third-step)

> [!NOTE]
> Stacked on top of #74138 — review/merge that one first.

### Description

Two visual updates to the "Get code" step of the embed wizard:

- Move the "code only works for local testing" warning inside the **Metabase account** card (below the radio group) instead of rendering it as a sibling card. Also switches the icon to `warning_triangle_filled` in a muted grey tone.
- Add a short description with a link to the modular embedding docs above the snippet in the **Embed code** card: *"Add this snippet to your app. To modify this code and tweak additional options, refer to the docs."*

### How to verify

1. Admin → Embedding → New embed → click through to the third step ("Get code").
2. With JWT/SAML **not** configured and "Existing session" selected: the warning alert renders inside the *Metabase account* card with a filled grey warning triangle.
3. The *Embed code* card now shows a description line and a docs link above the code snippet.

### Demo

<img width="1493" height="758" alt="image" src="https://github.com/user-attachments/assets/faefc553-dff6-4fc9-8981-6be4b9fde974" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

(Existing e2e assertions in `get-code.cy.spec.ts` still apply — the warning text is unchanged.)