### PR TITLE
Add .clj-surgeon.edn for custom defining-form classification

### DIFF
--- a/.clj-surgeon.edn
+++ b/.clj-surgeon.edn
@@ -1,0 +1,3 @@
+{:aliases {"defendpoint"   :defn
+           "defenterprise" :defn
+           "defsetting"    :def}}


### PR DESCRIPTION
## Summary

Adds `.clj-surgeon.edn` at repo root so [clj-surgeon](https://github.com/realgenekim/clj-surgeon) recognizes Metabase's custom defining forms (`defendpoint`, `defenterprise`, `defsetting`) when engineers use it for structural exploration or refactors.

```clojure
{:aliases {"defendpoint"   :defn
           "defenterprise" :defn
           "defsetting"    :def}}
```

## Why

clj-surgeon is a babashka CLI + Claude Code skill for AST-level Clojure ops: outlining files, finding deps, topo-sorting, moving forms between namespaces, eliminating forward declares. Measured ~150x more token-efficient than spawning Explore agents for codebase mapping.

Without this config, clj-surgeon treats `defendpoint` / `defenterprise` / `defsetting` as opaque non-def forms. They're invisible to `:deps`, `:topo`, `:ls-extract`, and `:fix-declares` -- i.e. any API namespace looks like it has no endpoints, and structural ops can't reason about them.

With this config, those macros are classified the same way as `defn` (or `def` for `defsetting`, which has no arglist vector).

## Scope

Zero runtime impact. Pure dev-tooling config. No new dependency added to Metabase itself -- engineers who want clj-surgeon install babashka + the clj-surgeon CLI locally. Same pattern as `.clj-kondo/config.edn` and `.cljfmt.edn` already checked in.

## Status: Draft

Held until upstream clj-surgeon ships `.clj-surgeon.edn` support. Tracking: [realgenekim/clj-surgeon#6](https://github.com/realgenekim/clj-surgeon/issues/6).

Mark ready once a clj-surgeon release exists that reads this file.
