### PR TITLE
fix: label of run button in queries generated section of ai usage

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -233,7 +233,7 @@ function FeedbackCard({
   );
 }
 
-function GeneratedQueryCard({ query }: { query: GeneratedQuery }) {
+export function GeneratedQueryCard({ query }: { query: GeneratedQuery }) {
   if (query.query_type === "notebook" && query.mbql) {
     return (
       <NotebookGeneratedQueryCard mbql={query.mbql} display={query.display} />
@@ -270,7 +270,13 @@ function SqlGeneratedQueryCard({ query }: { query: GeneratedQuery }) {
     <Card withBorder shadow="none" p="md">
       <Stack gap="sm">
         <Flex justify="space-between" align="center" gap="sm">
-          <Text size="lg" fw={700}>{t`SQL query`}</Text>
+          <Text
+            size="lg"
+            fw={700}
+            style={{ flex: "1 1 auto", minWidth: 0, overflowWrap: "anywhere" }}
+          >
+            {t`SQL query`}
+          </Text>
           {runUrl && (
             <Button
               component="a"
@@ -279,6 +285,7 @@ function SqlGeneratedQueryCard({ query }: { query: GeneratedQuery }) {
               rel="noreferrer"
               variant="filled"
               leftSection={<Icon name="play_outlined" aria-hidden />}
+              style={{ flexShrink: 0 }}
             >
               {t`Run`}
             </Button>
@@ -363,7 +370,11 @@ function NotebookGeneratedQueryCard({
     >
       <Stack gap="md">
         <Flex justify="space-between" align="center" gap="sm">
-          <Text size="lg" fw={700}>
+          <Text
+            size="lg"
+            fw={700}
+            style={{ flex: "1 1 auto", minWidth: 0, overflowWrap: "anywhere" }}
+          >
             {title}
           </Text>
           <Button
@@ -373,6 +384,7 @@ function NotebookGeneratedQueryCard({
             rel="noreferrer"
             variant="filled"
             leftSection={<Icon name="play_outlined" aria-hidden />}
+            style={{ flexShrink: 0 }}
           >
             {t`Run`}
           </Button>


### PR DESCRIPTION
Closes [BOT-1473: Label of run button in `Queries generated` section of conversation detail in AI analytics is cropped off when query title is long](https://linear.app/metabase/issue/BOT-1473/label-of-run-button-in-queries-generated-section-of-conversation)

### Description

Button was shrinked too much

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

![image.png](https://app.graphite.com/user-attachments/assets/80307ad5-2bf9-4f15-9205-e9c34a07cf6b.png)



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)