### PR TITLE
Show collection breadcrumbs on collection pages

### DIFF
--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -395,12 +395,13 @@ describe("scenarios > organization > timelines > collection", () => {
         cy.wait("@updateTimeline");
       });
 
-      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Our analytics events").should("be.visible");
-      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(`${H.getFullName(admin)}'s Personal Collection`).should(
-        "be.visible",
-      );
+      H.modal().within(() => {
+        cy.findByText("Our analytics events").should("be.visible");
+        cy.button(/close/).click();
+      });
+      H.main()
+        .findByText(`${H.getFullName(admin)}'s Personal Collection`)
+        .should("be.visible");
     });
 
     it("should archive a timeline and undo", () => {

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -260,6 +260,17 @@ describe("AppBar", () => {
 
         expect(await screen.findByText("Foo Collection")).toBeInTheDocument();
       });
+
+      it("should work for collection pages (UXW-249)", async () => {
+        setup({
+          initialRoute: `/collection/${FOO_COLLECTION.id}-foo-collection`,
+          embedOptions: {
+            breadcrumbs: true,
+          },
+        });
+
+        expect(await screen.findByText("Foo Collection")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -18,6 +18,7 @@ import {
   getIsEmbeddingIframe,
 } from "metabase/selectors/embed";
 import { getUser } from "metabase/selectors/user";
+import * as Urls from "metabase/urls";
 
 import { getSetting } from "./settings";
 
@@ -45,6 +46,10 @@ const PATHS_WITH_COLLECTION_BREADCRUMBS = [
   /\/dashboard\//,
   /\/document\//,
 ];
+
+// Paths where collection identity comes from the URL itself, so breadcrumbs
+// can render without needing a question/dashboard/document in redux state.
+const STANDALONE_COLLECTION_BREADCRUMB_PATHS = [/\/collection\//];
 const PATHS_WITH_QUESTION_LINEAGE = [/\/question/, /\/model/];
 
 export const getRouterPath = (state: State, props: RouterProps) => {
@@ -83,6 +88,14 @@ export const getIsCollectionPathVisible = createSelector(
 
     const isModelDetail = /\/model\/.*\/detail\/.*/.test(path);
     if (isModelDetail) {
+      return true;
+    }
+
+    if (
+      STANDALONE_COLLECTION_BREADCRUMB_PATHS.some((pattern) =>
+        pattern.test(path),
+      )
+    ) {
       return true;
     }
 
@@ -229,8 +242,9 @@ export const getCollectionId = createSelector(
     getDashboardId,
     getCurrentDocument,
     getDetailViewState,
+    getRouterPath,
   ],
-  (question, dashboard, dashboardId, document, detailView) => {
+  (question, dashboard, dashboardId, document, detailView, path) => {
     if (detailView) {
       return detailView.collectionId;
     }
@@ -243,7 +257,13 @@ export const getCollectionId = createSelector(
       return dashboard?.collection_id;
     }
 
-    return question?.collectionId();
+    const questionCollectionId = question?.collectionId();
+    if (questionCollectionId != null) {
+      return questionCollectionId;
+    }
+
+    // On a collection page the URL itself identifies the current collection.
+    return Urls.extractCollectionIdFromPath(path);
   },
 );
 

--- a/frontend/src/metabase/selectors/app.unit.spec.ts
+++ b/frontend/src/metabase/selectors/app.unit.spec.ts
@@ -1,0 +1,43 @@
+import type { Location } from "history";
+
+import { createMockState } from "metabase/redux/store/mocks";
+
+import { type RouterProps, getIsCollectionPathVisible } from "./app";
+
+const createLocation = (pathname: string): Location =>
+  ({
+    pathname,
+    search: "",
+    hash: "",
+    state: undefined,
+    action: "PUSH",
+    key: "",
+    query: {},
+  }) as unknown as Location;
+
+const createRouterProps = (pathname: string): RouterProps => ({
+  location: createLocation(pathname),
+});
+
+describe("getIsCollectionPathVisible", () => {
+  it("is true on a collection page even when no question/dashboard/document is loaded", () => {
+    const state = createMockState();
+    const props = createRouterProps("/collection/5-foo");
+
+    expect(getIsCollectionPathVisible(state, props)).toBe(true);
+  });
+
+  it("is true on the root collection page", () => {
+    const state = createMockState();
+    const props = createRouterProps("/collection/root");
+
+    expect(getIsCollectionPathVisible(state, props)).toBe(true);
+  });
+
+  it("is false on unrelated pages like /browse", () => {
+    const state = createMockState();
+    const props = createRouterProps("/browse/databases");
+
+    expect(getIsCollectionPathVisible(state, props)).toBe(false);
+  });
+});

--- a/frontend/src/metabase/urls/collections.ts
+++ b/frontend/src/metabase/urls/collections.ts
@@ -80,3 +80,10 @@ export function extractCollectionId(slug = ""): CollectionId | undefined {
   }
   return extractEntityId(slug);
 }
+
+export function extractCollectionIdFromPath(
+  path: string,
+): CollectionId | undefined {
+  const match = path.match(/^\/collection\/([^/]+)/);
+  return match ? extractCollectionId(match[1]) : undefined;
+}

--- a/frontend/src/metabase/urls/urls.unit.spec.ts
+++ b/frontend/src/metabase/urls/urls.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   collection,
   dashboard,
   extractCollectionId,
+  extractCollectionIdFromPath,
   extractEntityId,
   extractQueryParams,
   isCollectionPath,
@@ -357,6 +358,52 @@ describe("urls", () => {
     testCases.forEach(({ path, expected }) => {
       it(`returns ${expected} for ${path}`, () => {
         expect(isCollectionPath(path)).toBe(expected);
+      });
+    });
+  });
+
+  describe("extractCollectionIdFromPath", () => {
+    const testCases: {
+      path: string;
+      expected: CollectionId | undefined;
+    }[] = [
+      // Numeric collection IDs (with and without slug suffixes)
+      { path: "/collection/1", expected: 1 },
+      { path: "/collection/123", expected: 123 },
+      { path: "/collection/1-stats", expected: 1 },
+      { path: "/collection/123-stats-stats", expected: 123 },
+      // Nested paths under a collection still resolve to the parent id
+      { path: "/collection/1-stats/new", expected: 1 },
+      { path: "/collection/1-stats/nested/url", expected: 1 },
+      // Magic slugs preserved as-is
+      { path: "/collection/root", expected: "root" },
+      { path: "/collection/users", expected: "users" },
+      { path: "/collection/tenant-specific", expected: "tenant-specific" },
+      { path: "/collection/tenant-users", expected: "tenant-users" },
+
+      // Anchored at start — `/collection/` must be the leading segment
+      {
+        path: "/admin/permissions/collections/1",
+        expected: undefined,
+      },
+      { path: "foo/collection/1", expected: undefined },
+
+      // Non-collection paths
+      { path: "/dashboard/1", expected: undefined },
+      { path: "/question/1-orders", expected: undefined },
+      { path: "/browse/databases/1", expected: undefined },
+
+      // Slug present but not parseable to a collection id
+      { path: "/collection/no-id-here", expected: undefined },
+
+      // Empty / malformed
+      { path: "", expected: undefined },
+      { path: "/collection/", expected: undefined },
+    ];
+
+    testCases.forEach(({ path, expected }) => {
+      it(`returns ${JSON.stringify(expected)} for "${path}"`, () => {
+        expect(extractCollectionIdFromPath(path)).toBe(expected);
       });
     });
   });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #46512
### Description
Small adjustment to the app bar to show collection breadcrumbs on collection pages, the same way we do for question / dashboard / document pages. Added a utility function for pulling a collectionId from a full path, along with unit tests. 

### How to verify
1. Go to any collection page and close the sidebar
2. You should see collection breadcrumbs at the top of the screen
3. Navigate with them

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
