### PR TITLE
Optimize chain filter with joins

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -793,6 +793,15 @@
     stage-number :- :int]
    (lib.join/joins a-query stage-number)))
 
+(mu/defn joined-thing
+  "Return metadata about the origin of `a-join` (the joined Table or Card) using `metadata-providerable` as the source
+  of information. Use this when you need to construct a fresh query against the same source as an existing join — e.g.
+  to rebuild a join with a narrowed projection.
+
+  **Code Health:** Healthy. This is a core API."
+  [metadata-providerable a-join]
+  (lib.join/joined-thing metadata-providerable a-join))
+
 ;;; ### Join Strategies
 
 (mu/defn join-strategy :- ::lib.schema.join/strategy.option
@@ -1607,6 +1616,7 @@
   validation-exception-error]
  [metabase.lib.walk.util
   all-field-ids
+  all-field-ids-by-join-alias
   all-referenced-entity-ids
   all-implicitly-joined-field-ids
   all-implicitly-joined-table-ids

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -6,6 +6,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.walk :as lib.walk]
@@ -195,6 +196,20 @@
                                                (walk-clause clause)))
       (lib.walk/walk-clause query-or-clause walk-clause))
     (persistent! @joined-field-ids)))
+
+(mu/defn all-field-ids-by-join-alias :- [:map-of ::lib.schema.join/alias [:set ::lib.schema.id/field]]
+  "Return `{join-alias #{field-id ...}}` — the set of Field IDs referenced via each `:join-alias` in `query`.
+  Refs without a `:join-alias` (e.g. source-Table refs, refs inside a join's own inner stage) don't contribute."
+  [query :- ::lib.schema/query]
+  (let [acc (volatile! (transient {}))]
+    (lib.walk/walk-clauses
+     query
+     (fn [_query _path-type _path clause]
+       (match/match-one clause
+         [:field {:join-alias (a :guard string?)} (id :guard pos-int?)]
+         (vswap! acc assoc! a (conj (get @acc a #{}) id)))
+       nil))
+    (persistent! @acc)))
 
 (mu/defn all-implicitly-joined-table-ids :- [:maybe [:set {:min 1} ::lib.schema.id/table]]
   "Set of all Table IDs referenced via implicit joins in `query` or nil if no such IDs can be found."

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -65,15 +65,17 @@
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [honey.sql :as sql]
    [metabase.app-db.core :as mdb]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.util :as lib.util]
+   [metabase.lib.walk.util :as lib.walk.util]
    [metabase.parameters.chain-filter.dedupe-joins :as dedupe]
    [metabase.parameters.field-values :as params.field-values]
    [metabase.parameters.params :as params]
@@ -403,23 +405,6 @@
    query
    joins))
 
-(defn- referenced-field-ids-by-join-alias
-  "Walk an MBQL query and return `{join-alias #{field-id ...}}` — the set of Field IDs the query references via each
-  `:join-alias` anywhere outside the join's own inner stage (refs inside the inner subquery have no `:join-alias` and
-  so don't contribute)."
-  [query]
-  (let [acc (volatile! {})]
-    (walk/postwalk
-     (fn [x]
-       (when (and (vector? x) (= :field (first x)) (= 3 (count x)))
-         (let [opts (nth x 1)
-               id   (nth x 2)]
-           (when (and (map? opts) (string? (:join-alias opts)) (integer? id))
-             (vswap! acc update (:join-alias opts) (fnil conj #{}) id))))
-       x)
-     query)
-    @acc))
-
 (mu/defn- tighten-join-projections :- ::lib.schema/query
   "After the full chain-filter pipeline has built the query, narrow each join's inner-stage `:fields` to the Field IDs
   the rest of the query actually references through that join's alias. This is what makes
@@ -431,25 +416,25 @@
   BigQuery-partitioned joined Tables) automatically contributes to the projection — its references are visible in the
   finished MBQL when we walk it."
   [query :- ::lib.schema/query]
-  (if-let [joins (not-empty (get-in query [:stages 0 :joins]))]
-    (let [refs (referenced-field-ids-by-join-alias query)]
-      (assoc-in
-       query
-       [:stages 0 :joins]
-       (mapv
-        (fn [a-join]
-          (let [a-alias      (lib/current-join-alias a-join)
-                field-ids    (get refs a-alias #{})
-                rhs-table-id (get-in a-join [:stages 0 :source-table])
-                rhs-table    (lib.metadata/table query rhs-table-id)
-                field-mds    (mapv #(lib.metadata/field query %) field-ids)
-                inner-query  (lib/with-fields (lib/query query rhs-table) field-mds)]
-            (-> (lib/join-clause inner-query)
-                (lib/with-join-fields :none)
-                (lib/with-join-alias a-alias)
-                (lib/with-join-conditions (lib/join-conditions a-join)))))
-        joins)))
-    query))
+  (if (empty? (lib.join/joins query))
+    query
+    (let [refs (lib.walk.util/all-field-ids-by-join-alias query)]
+      (lib.util/update-query-stage
+       query 0
+       update :joins
+       (fn [joins]
+         (mapv
+          (fn [a-join]
+            (let [a-alias     (lib/current-join-alias a-join)
+                  field-ids   (get refs a-alias #{})
+                  joinable    (lib.join/joined-thing query a-join)
+                  field-mds   (mapv #(lib.metadata/field query %) field-ids)
+                  inner-query (lib/with-fields (lib/query query joinable) field-mds)]
+              (-> (lib/join-clause inner-query)
+                  (lib/with-join-fields :none)
+                  (lib/with-join-alias a-alias)
+                  (lib/with-join-conditions (lib/join-conditions a-join)))))
+          joins))))))
 
 (mr/def ::options
   ;; if original-field-id is specified, we'll include this in the results. For Field->Field remapping.

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -410,7 +410,6 @@
                                   (distinct (cons rhs-field-id (get field-ids-by-table rhs-table-id))))
              inner-query    (lib/with-fields (lib/query query rhs-table) inner-fields)
              join           (-> (lib/join-clause inner-query)
-                                (lib/with-join-fields :none)
                                 (lib/with-join-alias rhs-join-alias)
                                 (lib/with-join-conditions [(lib/=
                                                             (cond-> lhs-field

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -390,6 +390,7 @@
            rhs-field (lib.metadata/field query rhs-field-id)
            rhs-table (lib.metadata/table query rhs-table-id)
            join      (-> (lib/join-clause rhs-table)
+                         (lib/with-join-fields :none)
                          (lib/with-join-alias (joined-table-alias rhs-table-id))
                          (lib/with-join-conditions [(lib/=
                                                      (cond-> lhs-field
@@ -438,6 +439,7 @@
       (log/tracef "Generating joins and filters for source %s with joins info\n%s"
                   (name-for-logging :model/Table source-table-id) (u/cprint-to-str joins)))
     (-> (lib/query mp (lib.metadata/table mp source-table-id))
+        (lib/with-fields [field])
         ;; return the lesser of limit (if set) or max results
         (lib/limit ((fnil min Integer/MAX_VALUE) limit max-results))
         (assoc-in [:middleware :disable-remaps?] true)

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -69,13 +69,11 @@
    [metabase.app-db.core :as mdb]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
-   [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
-   [metabase.lib.walk.util :as lib.walk.util]
    [metabase.parameters.chain-filter.dedupe-joins :as dedupe]
    [metabase.parameters.field-values :as params.field-values]
    [metabase.parameters.params :as params]
@@ -416,9 +414,9 @@
   BigQuery-partitioned joined Tables) automatically contributes to the projection — its references are visible in the
   finished MBQL when we walk it."
   [query :- ::lib.schema/query]
-  (if (empty? (lib.join/joins query))
+  (if (empty? (lib/joins query))
     query
-    (let [refs (lib.walk.util/all-field-ids-by-join-alias query)]
+    (let [refs (lib/all-field-ids-by-join-alias query)]
       (lib.util/update-query-stage
        query 0
        update :joins
@@ -427,7 +425,7 @@
           (fn [a-join]
             (let [a-alias     (lib/current-join-alias a-join)
                   field-ids   (get refs a-alias #{})
-                  joinable    (lib.join/joined-thing query a-join)
+                  joinable    (lib/joined-thing query a-join)
                   field-mds   (mapv #(lib.metadata/field query %) field-ids)
                   inner-query (lib/with-fields (lib/query query joinable) field-mds)]
               (-> (lib/join-clause inner-query)

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -65,6 +65,7 @@
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
    [clojure.string :as str]
+   [clojure.walk :as walk]
    [honey.sql :as sql]
    [metabase.app-db.core :as mdb]
    [metabase.lib-be.core :as lib-be]
@@ -367,8 +368,7 @@
 
 (mu/defn- add-joins :- ::lib.schema/query
   "Add joins to the MBQL `query` we're generating. The Field for which we are returning values is the \"source Field\",
-  and the Table it belongs to is the source Table; `field-ids` is a set of Fields belonging to Tables other than the
-  source Table.
+  and the Table it belongs to is the source Table; `joins` is a sequence of FK hops to add.
 
   When we generate joins, we must determine the other Tables we must join against so that we have access to the other
   Fields. The relationship between these other Tables and the source Table may go in either direction, i.e. the source
@@ -379,49 +379,77 @@
     -- or
     source_table.pk = other_table.fk
 
-  Since we're not sure which way the relationship goes, `resolve-fk-id` fetches all possible relationships between the
-  two Tables and we generate the appropriate join against the other Table.
+  Joins are added with the default `:fields :all` shape; [[tighten-join-projections]] narrows each join's inner-stage
+  `:fields` as a post-pass once the full query has been built."
+  [query           :- ::lib.schema/query
+   source-table-id :- ::lib.schema.id/table
+   joins]
+  (reduce
+   (fn [query {{lhs-table-id :table, lhs-field-id :field} :lhs, {rhs-table-id :table, rhs-field-id :field} :rhs}]
+     (let [lhs-field (lib.metadata/field query lhs-field-id)
+           rhs-field (lib.metadata/field query rhs-field-id)
+           rhs-table (lib.metadata/table query rhs-table-id)
+           join      (-> (lib/join-clause rhs-table)
+                         (lib/with-join-alias (joined-table-alias rhs-table-id))
+                         (lib/with-join-conditions [(lib/=
+                                                     (cond-> lhs-field
+                                                       (not= lhs-table-id source-table-id)
+                                                       (lib/with-join-alias (joined-table-alias lhs-table-id)))
+                                                     (-> rhs-field
+                                                         (lib/with-join-alias (joined-table-alias rhs-table-id))))]))]
+       (log/tracef "Adding join against %s\n%s"
+                   (name-for-logging :model/Table rhs-table-id) (u/cprint-to-str join))
+       (lib/join query join)))
+   query
+   joins))
 
-  `selected-field-ids` is the set of joined-Table Field IDs actually referenced by the outer query (currently:
-  constraint filter Fields on joined Tables). For each join, we pre-populate the join's inner stage `:fields` with
-  refs to those Fields plus the join-condition RHS column. This makes
-  [[metabase.query-processor.middleware.add-implicit-clauses/should-add-implicit-fields?]] short-circuit (it skips
-  stages that already have `:fields`), so the QP doesn't blow the projection up to every column on the source Table."
-  [query              :- ::lib.schema/query
-   source-table-id    :- ::lib.schema.id/table
-   joins
-   selected-field-ids :- [:maybe [:set ::lib.schema.id/field]]]
-  (let [;; for each joined Table, the Fields its inner stage must expose: those used by the outer query
-        ;; (`selected-field-ids`) plus any Field that another join uses as its LHS (which means the join references it
-        ;; via this Table's alias and so the inner stage must project it).
-        field-ids-by-table (reduce (fn [m {{:keys [table field]} :lhs}]
-                                     (cond-> m
-                                       (not= table source-table-id)
-                                       (update table (fnil conj []) field)))
-                                   (group-by field/field-id->table-id selected-field-ids)
-                                   joins)]
-    (reduce
-     (fn [query {{lhs-table-id :table, lhs-field-id :field} :lhs, {rhs-table-id :table, rhs-field-id :field} :rhs}]
-       (let [lhs-field      (lib.metadata/field query lhs-field-id)
-             rhs-field      (lib.metadata/field query rhs-field-id)
-             rhs-table      (lib.metadata/table query rhs-table-id)
-             rhs-join-alias (joined-table-alias rhs-table-id)
-             inner-fields   (mapv #(lib.metadata/field query %)
-                                  (distinct (cons rhs-field-id (get field-ids-by-table rhs-table-id))))
-             inner-query    (lib/with-fields (lib/query query rhs-table) inner-fields)
-             join           (-> (lib/join-clause inner-query)
-                                (lib/with-join-alias rhs-join-alias)
-                                (lib/with-join-conditions [(lib/=
-                                                            (cond-> lhs-field
-                                                              (not= lhs-table-id source-table-id)
-                                                              (lib/with-join-alias (joined-table-alias lhs-table-id)))
-                                                            (-> rhs-field
-                                                                (lib/with-join-alias rhs-join-alias)))]))]
-         (log/tracef "Adding join against %s\n%s"
-                     (name-for-logging :model/Table rhs-table-id) (u/cprint-to-str join))
-         (lib/join query join)))
-     query
-     joins)))
+(defn- referenced-field-ids-by-join-alias
+  "Walk an MBQL query and return `{join-alias #{field-id ...}}` — the set of Field IDs the query references via each
+  `:join-alias` anywhere outside the join's own inner stage (refs inside the inner subquery have no `:join-alias` and
+  so don't contribute)."
+  [query]
+  (let [acc (volatile! {})]
+    (walk/postwalk
+     (fn [x]
+       (when (and (vector? x) (= :field (first x)) (= 3 (count x)))
+         (let [opts (nth x 1)
+               id   (nth x 2)]
+           (when (and (map? opts) (string? (:join-alias opts)) (integer? id))
+             (vswap! acc update (:join-alias opts) (fnil conj #{}) id))))
+       x)
+     query)
+    @acc))
+
+(mu/defn- tighten-join-projections :- ::lib.schema/query
+  "After the full chain-filter pipeline has built the query, narrow each join's inner-stage `:fields` to the Field IDs
+  the rest of the query actually references through that join's alias. This is what makes
+  [[metabase.query-processor.middleware.add-implicit-clauses/should-add-implicit-fields?]] short-circuit — once the
+  inner stage has explicit `:fields`, the middleware won't expand it to every column on the joined Table.
+
+  Running this as a post-pass instead of computing the field set up front means any clause builder downstream of
+  [[add-joins]] (e.g. [[schema.metadata-queries/add-required-filters-if-needed]] adding partition filters on
+  BigQuery-partitioned joined Tables) automatically contributes to the projection — its references are visible in the
+  finished MBQL when we walk it."
+  [query :- ::lib.schema/query]
+  (if-let [joins (not-empty (get-in query [:stages 0 :joins]))]
+    (let [refs (referenced-field-ids-by-join-alias query)]
+      (assoc-in
+       query
+       [:stages 0 :joins]
+       (mapv
+        (fn [a-join]
+          (let [a-alias      (lib/current-join-alias a-join)
+                field-ids    (get refs a-alias #{})
+                rhs-table-id (get-in a-join [:stages 0 :source-table])
+                rhs-table    (lib.metadata/table query rhs-table-id)
+                field-mds    (mapv #(lib.metadata/field query %) field-ids)
+                inner-query  (lib/with-fields (lib/query query rhs-table) field-mds)]
+            (-> (lib/join-clause inner-query)
+                (lib/with-join-fields :none)
+                (lib/with-join-alias a-alias)
+                (lib/with-join-conditions (lib/join-conditions a-join)))))
+        joins)))
+    query))
 
 (mr/def ::options
   ;; if original-field-id is specified, we'll include this in the results. For Field->Field remapping.
@@ -438,25 +466,18 @@
    constraints                       :- [:maybe ::constraints]
    {:keys [original-field-id limit]} :- [:maybe ::options]]
   (log/tracef "Chain filter %s with constraints %s" (name-for-logging :model/Field field-id) (u/cprint-to-str constraints))
-  (let [database-id        (field/field-id->database-id field-id)
-        mp                 (lib-be/application-database-metadata-provider database-id)
-        source-table-id    (field/field-id->table-id field-id)
-        joins              (find-all-joins source-table-id (cond-> (set (map :field-id constraints))
-                                                             original-field-id (conj original-field-id)))
-        joined-table-ids   (set (map #(get-in % [:rhs :table]) joins))
-        on-joined-table?   (fn [a-field-id]
-                             (contains? joined-table-ids (field/field-id->table-id a-field-id)))
-        selected-field-ids (cond-> (into #{}
-                                         (comp (map :field-id) (filter on-joined-table?))
-                                         constraints)
-                             (and original-field-id (on-joined-table? original-field-id))
-                             (conj original-field-id))
-        field              (lib.metadata/field mp field-id)
-        original-field     (when original-field-id
-                             (let [original-table-id (field/field-id->table-id original-field-id)]
-                               (cond-> (lib.metadata/field mp original-field-id)
-                                 (not= source-table-id original-table-id)
-                                 (lib/with-join-alias (joined-table-alias original-table-id)))))]
+  (let [database-id      (field/field-id->database-id field-id)
+        mp               (lib-be/application-database-metadata-provider database-id)
+        source-table-id  (field/field-id->table-id field-id)
+        joins            (find-all-joins source-table-id (cond-> (set (map :field-id constraints))
+                                                           original-field-id (conj original-field-id)))
+        joined-table-ids (set (map #(get-in % [:rhs :table]) joins))
+        field            (lib.metadata/field mp field-id)
+        original-field   (when original-field-id
+                           (let [original-table-id (field/field-id->table-id original-field-id)]
+                             (cond-> (lib.metadata/field mp original-field-id)
+                               (not= source-table-id original-table-id)
+                               (lib/with-join-alias (joined-table-alias original-table-id)))))]
     (when original-field-id
       (log/tracef "Finding values of %s, remapped from %s."
                   (name-for-logging :model/Field field-id)
@@ -465,11 +486,10 @@
       (log/tracef "Generating joins and filters for source %s with joins info\n%s"
                   (name-for-logging :model/Table source-table-id) (u/cprint-to-str joins)))
     (-> (lib/query mp (lib.metadata/table mp source-table-id))
-        (lib/with-fields [field])
         ;; return the lesser of limit (if set) or max results
         (lib/limit ((fnil min Integer/MAX_VALUE) limit max-results))
         (assoc-in [:middleware :disable-remaps?] true)
-        (add-joins source-table-id joins selected-field-ids)
+        (add-joins source-table-id joins)
         (cond-> original-field (->
                                 ;; don't return rows that don't have values for the original Field. e.g. if
                                 ;; venues.category_id is remapped to categories.name and we do a search with query
@@ -489,7 +509,8 @@
                                 (lib/order-by field))
                 (not original-field) (lib/breakout field))
         (add-filters source-table-id joined-table-ids constraints)
-        schema.metadata-queries/add-required-filters-if-needed)))
+        schema.metadata-queries/add-required-filters-if-needed
+        tighten-join-projections)))
 
 ;;; ------------------------ Chain filter (powers GET /api/dashboard/:id/params/:key/values) -------------------------
 

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -380,29 +380,49 @@
     source_table.pk = other_table.fk
 
   Since we're not sure which way the relationship goes, `resolve-fk-id` fetches all possible relationships between the
-  two Tables and we generate the appropriate join against the other Table."
-  [query           :- ::lib.schema/query
-   source-table-id :- ::lib.schema.id/table
-   joins]
-  (reduce
-   (fn [query {{lhs-table-id :table, lhs-field-id :field} :lhs, {rhs-table-id :table, rhs-field-id :field} :rhs}]
-     (let [lhs-field (lib.metadata/field query lhs-field-id)
-           rhs-field (lib.metadata/field query rhs-field-id)
-           rhs-table (lib.metadata/table query rhs-table-id)
-           join      (-> (lib/join-clause rhs-table)
-                         (lib/with-join-fields :none)
-                         (lib/with-join-alias (joined-table-alias rhs-table-id))
-                         (lib/with-join-conditions [(lib/=
-                                                     (cond-> lhs-field
-                                                       (not= lhs-table-id source-table-id)
-                                                       (lib/with-join-alias (joined-table-alias lhs-table-id)))
-                                                     (-> rhs-field
-                                                         (lib/with-join-alias (joined-table-alias rhs-table-id))))]))]
-       (log/tracef "Adding join against %s\n%s"
-                   (name-for-logging :model/Table rhs-table-id) (u/cprint-to-str join))
-       (lib/join query join)))
-   query
-   joins))
+  two Tables and we generate the appropriate join against the other Table.
+
+  `selected-field-ids` is the set of joined-Table Field IDs actually referenced by the outer query (currently:
+  constraint filter Fields on joined Tables). For each join, we pre-populate the join's inner stage `:fields` with
+  refs to those Fields plus the join-condition RHS column. This makes
+  [[metabase.query-processor.middleware.add-implicit-clauses/should-add-implicit-fields?]] short-circuit (it skips
+  stages that already have `:fields`), so the QP doesn't blow the projection up to every column on the source Table."
+  [query              :- ::lib.schema/query
+   source-table-id    :- ::lib.schema.id/table
+   joins
+   selected-field-ids :- [:maybe [:set ::lib.schema.id/field]]]
+  (let [;; for each joined Table, the Fields its inner stage must expose: those used by the outer query
+        ;; (`selected-field-ids`) plus any Field that another join uses as its LHS (which means the join references it
+        ;; via this Table's alias and so the inner stage must project it).
+        field-ids-by-table (reduce (fn [m {{:keys [table field]} :lhs}]
+                                     (cond-> m
+                                       (not= table source-table-id)
+                                       (update table (fnil conj []) field)))
+                                   (group-by field/field-id->table-id selected-field-ids)
+                                   joins)]
+    (reduce
+     (fn [query {{lhs-table-id :table, lhs-field-id :field} :lhs, {rhs-table-id :table, rhs-field-id :field} :rhs}]
+       (let [lhs-field      (lib.metadata/field query lhs-field-id)
+             rhs-field      (lib.metadata/field query rhs-field-id)
+             rhs-table      (lib.metadata/table query rhs-table-id)
+             rhs-join-alias (joined-table-alias rhs-table-id)
+             inner-fields   (mapv #(lib.metadata/field query %)
+                                  (distinct (cons rhs-field-id (get field-ids-by-table rhs-table-id))))
+             inner-query    (lib/with-fields (lib/query query rhs-table) inner-fields)
+             join           (-> (lib/join-clause inner-query)
+                                (lib/with-join-fields :none)
+                                (lib/with-join-alias rhs-join-alias)
+                                (lib/with-join-conditions [(lib/=
+                                                            (cond-> lhs-field
+                                                              (not= lhs-table-id source-table-id)
+                                                              (lib/with-join-alias (joined-table-alias lhs-table-id)))
+                                                            (-> rhs-field
+                                                                (lib/with-join-alias rhs-join-alias)))]))]
+         (log/tracef "Adding join against %s\n%s"
+                     (name-for-logging :model/Table rhs-table-id) (u/cprint-to-str join))
+         (lib/join query join)))
+     query
+     joins)))
 
 (mr/def ::options
   ;; if original-field-id is specified, we'll include this in the results. For Field->Field remapping.
@@ -419,18 +439,25 @@
    constraints                       :- [:maybe ::constraints]
    {:keys [original-field-id limit]} :- [:maybe ::options]]
   (log/tracef "Chain filter %s with constraints %s" (name-for-logging :model/Field field-id) (u/cprint-to-str constraints))
-  (let [database-id      (field/field-id->database-id field-id)
-        mp               (lib-be/application-database-metadata-provider database-id)
-        source-table-id  (field/field-id->table-id field-id)
-        joins            (find-all-joins source-table-id (cond-> (set (map :field-id constraints))
-                                                           original-field-id (conj original-field-id)))
-        joined-table-ids (set (map #(get-in % [:rhs :table]) joins))
-        field            (lib.metadata/field mp field-id)
-        original-field   (when original-field-id
-                           (let [original-table-id (field/field-id->table-id original-field-id)]
-                             (cond-> (lib.metadata/field mp original-field-id)
-                               (not= source-table-id original-table-id)
-                               (lib/with-join-alias (joined-table-alias original-table-id)))))]
+  (let [database-id        (field/field-id->database-id field-id)
+        mp                 (lib-be/application-database-metadata-provider database-id)
+        source-table-id    (field/field-id->table-id field-id)
+        joins              (find-all-joins source-table-id (cond-> (set (map :field-id constraints))
+                                                             original-field-id (conj original-field-id)))
+        joined-table-ids   (set (map #(get-in % [:rhs :table]) joins))
+        on-joined-table?   (fn [a-field-id]
+                             (contains? joined-table-ids (field/field-id->table-id a-field-id)))
+        selected-field-ids (cond-> (into #{}
+                                         (comp (map :field-id) (filter on-joined-table?))
+                                         constraints)
+                             (and original-field-id (on-joined-table? original-field-id))
+                             (conj original-field-id))
+        field              (lib.metadata/field mp field-id)
+        original-field     (when original-field-id
+                             (let [original-table-id (field/field-id->table-id original-field-id)]
+                               (cond-> (lib.metadata/field mp original-field-id)
+                                 (not= source-table-id original-table-id)
+                                 (lib/with-join-alias (joined-table-alias original-table-id)))))]
     (when original-field-id
       (log/tracef "Finding values of %s, remapped from %s."
                   (name-for-logging :model/Field field-id)
@@ -443,7 +470,7 @@
         ;; return the lesser of limit (if set) or max results
         (lib/limit ((fnil min Integer/MAX_VALUE) limit max-results))
         (assoc-in [:middleware :disable-remaps?] true)
-        (add-joins source-table-id joins)
+        (add-joins source-table-id joins selected-field-ids)
         (cond-> original-field (->
                                 ;; don't return rows that don't have values for the original Field. e.g. if
                                 ;; venues.category_id is remapped to categories.name and we do a search with query

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -4,10 +4,8 @@
    [clojure.test :refer :all]
    [metabase.lib-be.metadata.jvm :as lib-be]
    [metabase.lib.core :as lib]
-   [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util :as lib.util]
-   [metabase.lib.walk.util :as lib.walk.util]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.field-values :as params.field-values]
    [metabase.query-processor.compile :as qp.compile]
@@ -624,7 +622,7 @@
   "Return a seq of diagnostic maps (one per offending join) or nil if the invariant holds:
   inner-stage :fields equals the set of field-ids referenced via that join's alias."
   [query]
-  (let [refs (lib.walk.util/all-field-ids-by-join-alias query)
+  (let [refs (lib/all-field-ids-by-join-alias query)
         proj (inner-projection-by-join-alias query)]
     (not-empty
      (vec
@@ -668,7 +666,7 @@
                             (sql-tools/referenced-fields driver nq))
         mbql-proj (into {}
                         (for [a-join (lib/joins query)
-                              :let [tid    (:id (lib.join/joined-thing query a-join))
+                              :let [tid    (:id (lib/joined-thing query a-join))
                                     fields (set (keep (fn [clause]
                                                         (when (lib.util/clause-of-type? clause :field)
                                                           (let [id (last clause)]
@@ -683,7 +681,7 @@
                  :when (seq extra)]
              [tid {:declared declared, :actual actual, :extra extra}])))))
 
-(defn- check-tight-projections!
+(defn- check-tight-projections
   "Run both the MBQL-level and SQL-level invariants on a chain-filter query."
   [query]
   (testing "MBQL: each join's inner-stage :fields equals the fields referenced via its alias"
@@ -718,7 +716,7 @@
   (mt/dataset test-data
     (doseq [{:keys [label build]} projection-scenarios]
       (testing label
-        (check-tight-projections! (build))))))
+        (check-tight-projections (build))))))
 
 (deftest ^:sequential chain-filter-preserves-required-partition-filter-on-joined-table-test
   ;; `add-required-filters-if-needed` runs at the END of `chain-filter-mbql-query`, after joins
@@ -745,7 +743,7 @@
           (let [q    (mbql-for (mt/id :categories :name)
                                (mt/id :venues :category_id)
                                nil)
-                refs (get (lib.walk.util/all-field-ids-by-join-alias q) venues-alias)]
+                refs (get (lib/all-field-ids-by-join-alias q) venues-alias)]
             (is (contains? refs partition-fid)
                 (str "expected refs on " venues-alias " to include " partition-fid
                      " (venues.price); got " refs))))))))

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -588,25 +588,6 @@
               :has_more_values false}
              (chain-filter-search venues.category_id {venues.price 4} "zzzzz"))))))
 
-(deftest ^:parallel chain-filter-mbql-query-projects-only-needed-fields-test
-  (testing "chain-filter-mbql-query keeps the source-stage `:fields` and each join's inner-stage `:fields` tight"
-    (testing "without FK remapping"
-      (let [query (#'chain-filter/chain-filter-mbql-query (mt/id :categories :name) nil nil)]
-        (is (= 1 (count (lib/fields query))))
-        (is (empty? (lib/joins query)))))
-    (testing "with FK remapping"
-      (let [query (#'chain-filter/chain-filter-mbql-query
-                   (mt/id :categories :name)
-                   nil
-                   {:original-field-id (mt/id :venues :category_id)})]
-        (is (= 1 (count (lib/fields query))))
-        (is (seq (lib/joins query)))
-        (doseq [a-join (lib/joins query)]
-          (is (= :none (lib/join-fields a-join)))
-          ;; Pre-populated by `add-joins` so the implicit-fields middleware doesn't expand the inner
-          ;; subquery's projection to every column on the joined Table.
-          (is (= 1 (count (:fields (first (:stages a-join)))))))))))
-
 ;;; ------------ Structural invariant: tight inner-stage :fields per join (GHY-3586) ------------
 ;;;
 ;;; The fix narrows each chain-filter join's inner subquery to project only those columns the
@@ -751,6 +732,36 @@
     (doseq [{:keys [label build]} projection-scenarios]
       (testing label
         (check-tight-projections! (build))))))
+
+(deftest ^:sequential chain-filter-preserves-required-partition-filter-on-joined-table-test
+  ;; `add-required-filters-if-needed` runs at the END of `chain-filter-mbql-query`, after joins
+  ;; are built. For tables that require partition filters (currently BigQuery partitioned
+  ;; tables), it adds a `[:> partition-col <epoch>]` clause referencing the joined Table's
+  ;; partition column via the join alias.
+  ;;
+  ;; On master, `visible-columns` includes joined-Table columns (default `:fields :all`), so the
+  ;; partition field resolves and the filter is added. A fix that narrows the join's projection
+  ;; up front — and doesn't account for filters added later — silently elides the partition
+  ;; filter, because the joined-Table column it would reference is no longer in
+  ;; `visible-columns`. That's a behavior regression on BigQuery: the partition filter master
+  ;; would have emitted is missing from the SQL.
+  ;;
+  ;; This test pins the contract: after the full chain-filter pipeline runs, the joined-Table
+  ;; alias must reference the partition column. Any fix shape that drops the filter or fails to
+  ;; project the column will fail this test.
+  (mt/dataset test-data
+    (let [venues-id     (mt/id :venues)
+          partition-fid (mt/id :venues :price)
+          venues-alias  (str "table_" venues-id)]
+      (mt/with-temp-vals-in-db :model/Table venues-id {:database_require_filter true}
+        (mt/with-temp-vals-in-db :model/Field partition-fid {:database_partitioned true}
+          (let [q    (mbql-for (mt/id :categories :name)
+                               (mt/id :venues :category_id)
+                               nil)
+                refs (get (field-refs-by-join-alias q) venues-alias)]
+            (is (contains? refs partition-fid)
+                (str "expected refs on " venues-alias " to include " partition-fid
+                     " (venues.price); got " refs))))))))
 
 ;; Detail: Key (entity_id)=(6nmVTpCpKFRkZJigvqSVm) already exists.
 (deftest use-cached-field-values-test

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -2,10 +2,12 @@
   (:require
    [clojure.set]
    [clojure.test :refer :all]
-   [clojure.walk]
    [metabase.lib-be.metadata.jvm :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.util :as lib.util]
+   [metabase.lib.walk.util :as lib.walk.util]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.field-values :as params.field-values]
    [metabase.query-processor.compile :as qp.compile]
@@ -604,44 +606,25 @@
 ;;; The structural invariant: for every join, inner :fields equals "field-ids referenced via
 ;;; this join's :alias anywhere else in the query."
 
-(defn- field-ref-ids
-  "Collect field-ids from a sequence of MBQL clauses (`:fields` lists, breakout lists, etc.)."
-  [clauses]
-  (set (keep (fn [c]
-               (when (and (vector? c) (= :field (first c)) (= 3 (count c)) (integer? (nth c 2)))
-                 (nth c 2)))
-             clauses)))
-
-(defn- field-refs-by-join-alias
-  "Walk an MBQL query and return {join-alias #{field-id ...}} for every `[:field id {:join-alias …}]`
-  reference anywhere in the query (including inside join conditions, but inner stages contribute
-  only refs that themselves carry a :join-alias — bare refs in a subquery have no alias)."
-  [query]
-  (let [acc (atom {})]
-    (clojure.walk/postwalk
-     (fn [x]
-       (when (and (vector? x) (= :field (first x)) (= 3 (count x)))
-         (let [opts (nth x 1)
-               id   (nth x 2)]
-           (when (and (map? opts) (string? (:join-alias opts)) (integer? id))
-             (swap! acc update (:join-alias opts) (fnil conj #{}) id))))
-       x)
-     query)
-    @acc))
-
 (defn- inner-projection-by-join-alias
-  "Return {join-alias #{field-id ...}} — the field-ids each join's inner-stage :fields projects."
+  "Return {join-alias #{field-id ...}} — the field-ids each join's inner-stage :fields projects.
+  Inspects the MBQL directly because the assertion we're after is specifically about the shape
+  of the inner stage's projection list, not all field refs anywhere in the join."
   [query]
   (into {}
-        (for [a-join (get-in query [:stages 0 :joins])]
-          [(:alias a-join)
-           (field-ref-ids (:fields (first (:stages a-join))))])))
+        (for [a-join (lib/joins query)]
+          [(lib/current-join-alias a-join)
+           (set (keep (fn [clause]
+                        (when (lib.util/clause-of-type? clause :field)
+                          (let [id (last clause)]
+                            (when (pos-int? id) id))))
+                      (:fields (first (:stages a-join)))))])))
 
 (defn- projection-violations
   "Return a seq of diagnostic maps (one per offending join) or nil if the invariant holds:
   inner-stage :fields equals the set of field-ids referenced via that join's alias."
   [query]
-  (let [refs (field-refs-by-join-alias query)
+  (let [refs (lib.walk.util/all-field-ids-by-join-alias query)
         proj (inner-projection-by-join-alias query)]
     (not-empty
      (vec
@@ -684,9 +667,13 @@
                             {}
                             (sql-tools/referenced-fields driver nq))
         mbql-proj (into {}
-                        (for [a-join (get-in query [:stages 0 :joins])
-                              :let [tid    (get-in a-join [:stages 0 :source-table])
-                                    fields (field-ref-ids (:fields (first (:stages a-join))))]]
+                        (for [a-join (lib/joins query)
+                              :let [tid    (:id (lib.join/joined-thing query a-join))
+                                    fields (set (keep (fn [clause]
+                                                        (when (lib.util/clause-of-type? clause :field)
+                                                          (let [id (last clause)]
+                                                            (when (pos-int? id) id))))
+                                                      (:fields (first (:stages a-join)))))]]
                           [tid fields]))]
     (not-empty
      (into {}
@@ -758,7 +745,7 @@
           (let [q    (mbql-for (mt/id :categories :name)
                                (mt/id :venues :category_id)
                                nil)
-                refs (get (field-refs-by-join-alias q) venues-alias)]
+                refs (get (lib.walk.util/all-field-ids-by-join-alias q) venues-alias)]
             (is (contains? refs partition-fid)
                 (str "expected refs on " venues-alias " to include " partition-fid
                      " (venues.price); got " refs))))))))

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -584,7 +584,7 @@
              (chain-filter-search venues.category_id {venues.price 4} "zzzzz"))))))
 
 (deftest ^:parallel chain-filter-mbql-query-projects-only-needed-fields-test
-  (testing "chain-filter-mbql-query selects only one field on the source stage and `:none` on each join"
+  (testing "chain-filter-mbql-query keeps the source-stage `:fields` and each join's inner-stage `:fields` tight"
     (testing "without FK remapping"
       (let [query (#'chain-filter/chain-filter-mbql-query (mt/id :categories :name) nil nil)]
         (is (= 1 (count (lib/fields query))))
@@ -597,7 +597,10 @@
         (is (= 1 (count (lib/fields query))))
         (is (seq (lib/joins query)))
         (doseq [a-join (lib/joins query)]
-          (is (= :none (lib/join-fields a-join))))))))
+          (is (= :none (lib/join-fields a-join)))
+          ;; Pre-populated by `add-joins` so the implicit-fields middleware doesn't expand the inner
+          ;; subquery's projection to every column on the joined Table.
+          (is (= 1 (count (:fields (first (:stages a-join)))))))))))
 
 ;; Detail: Key (entity_id)=(6nmVTpCpKFRkZJigvqSVm) already exists.
 (deftest use-cached-field-values-test

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -583,6 +583,22 @@
               :has_more_values false}
              (chain-filter-search venues.category_id {venues.price 4} "zzzzz"))))))
 
+(deftest ^:parallel chain-filter-mbql-query-projects-only-needed-fields-test
+  (testing "chain-filter-mbql-query selects only one field on the source stage and `:none` on each join"
+    (testing "without FK remapping"
+      (let [query (#'chain-filter/chain-filter-mbql-query (mt/id :categories :name) nil nil)]
+        (is (= 1 (count (lib/fields query))))
+        (is (empty? (lib/joins query)))))
+    (testing "with FK remapping"
+      (let [query (#'chain-filter/chain-filter-mbql-query
+                   (mt/id :categories :name)
+                   nil
+                   {:original-field-id (mt/id :venues :category_id)})]
+        (is (= 1 (count (lib/fields query))))
+        (is (seq (lib/joins query)))
+        (doseq [a-join (lib/joins query)]
+          (is (= :none (lib/join-fields a-join))))))))
+
 ;; Detail: Key (entity_id)=(6nmVTpCpKFRkZJigvqSVm) already exists.
 (deftest use-cached-field-values-test
   (testing "chain-filter should use cached FieldValues if applicable (#13832)"

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -1,10 +1,15 @@
 (ns metabase.parameters.chain-filter-test
   (:require
+   [clojure.set]
    [clojure.test :refer :all]
+   [clojure.walk]
+   [metabase.lib-be.metadata.jvm :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.field-values :as params.field-values]
+   [metabase.query-processor.compile :as qp.compile]
+   [metabase.sql-tools.core :as sql-tools]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -601,6 +606,151 @@
           ;; Pre-populated by `add-joins` so the implicit-fields middleware doesn't expand the inner
           ;; subquery's projection to every column on the joined Table.
           (is (= 1 (count (:fields (first (:stages a-join)))))))))))
+
+;;; ------------ Structural invariant: tight inner-stage :fields per join (GHY-3586) ------------
+;;;
+;;; The fix narrows each chain-filter join's inner subquery to project only those columns the
+;;; rest of the query references via that join's alias. Two failure modes need to be ruled out:
+;;;
+;;;   - UNDER-projection — some column the query references via this alias is missing from the
+;;;     inner :fields. The SQL won't compile (or projects the wrong shape) and the query
+;;;     returns wrong/missing values.
+;;;
+;;;   - OVER-projection — the inner :fields contains a column nothing references. The SQL
+;;;     compiles fine and values are correct, but we're still materializing columns we don't
+;;;     need, defeating the point of the fix.
+;;;
+;;; The structural invariant: for every join, inner :fields equals "field-ids referenced via
+;;; this join's :alias anywhere else in the query."
+
+(defn- field-ref-ids
+  "Collect field-ids from a sequence of MBQL clauses (`:fields` lists, breakout lists, etc.)."
+  [clauses]
+  (set (keep (fn [c]
+               (when (and (vector? c) (= :field (first c)) (= 3 (count c)) (integer? (nth c 2)))
+                 (nth c 2)))
+             clauses)))
+
+(defn- field-refs-by-join-alias
+  "Walk an MBQL query and return {join-alias #{field-id ...}} for every `[:field id {:join-alias …}]`
+  reference anywhere in the query (including inside join conditions, but inner stages contribute
+  only refs that themselves carry a :join-alias — bare refs in a subquery have no alias)."
+  [query]
+  (let [acc (atom {})]
+    (clojure.walk/postwalk
+     (fn [x]
+       (when (and (vector? x) (= :field (first x)) (= 3 (count x)))
+         (let [opts (nth x 1)
+               id   (nth x 2)]
+           (when (and (map? opts) (string? (:join-alias opts)) (integer? id))
+             (swap! acc update (:join-alias opts) (fnil conj #{}) id))))
+       x)
+     query)
+    @acc))
+
+(defn- inner-projection-by-join-alias
+  "Return {join-alias #{field-id ...}} — the field-ids each join's inner-stage :fields projects."
+  [query]
+  (into {}
+        (for [a-join (get-in query [:stages 0 :joins])]
+          [(:alias a-join)
+           (field-ref-ids (:fields (first (:stages a-join))))])))
+
+(defn- projection-violations
+  "Return a seq of diagnostic maps (one per offending join) or nil if the invariant holds:
+  inner-stage :fields equals the set of field-ids referenced via that join's alias."
+  [query]
+  (let [refs (field-refs-by-join-alias query)
+        proj (inner-projection-by-join-alias query)]
+    (not-empty
+     (vec
+      (for [a-alias (sort (into (set (keys refs)) (keys proj)))
+            :let [r (get refs a-alias #{})
+                  p (get proj a-alias #{})]
+            :when (not= r p)]
+        {:alias                   a-alias
+         :referenced              r
+         :projected               p
+         :missing-from-projection (clojure.set/difference r p)
+         :extra-in-projection     (clojure.set/difference p r)})))))
+
+(defn- mbql-for
+  "Convenience: build the chain-filter-mbql-query for a given field/original/constraints triple."
+  [field-id original-field-id constraints]
+  (#'chain-filter/chain-filter-mbql-query
+   field-id
+   (when (seq constraints)
+     (vec (for [[fid v] constraints]
+            (shorthand->constraint fid v))))
+   (when original-field-id {:original-field-id original-field-id})))
+
+(defn- sql-over-projections
+  "Return a map of `{table-id {:declared #{…} :actual #{…} :extra #{…}}}` for any joined Table
+  whose compiled-SQL field references aren't a subset of the MBQL inner-stage `:fields` for that
+  join. Returns nil if the SQL is tight.
+
+  This is the SQL-level analogue of `projection-violations`. Where that one asserts the chain-filter
+  builder produces correct MBQL, this asserts that the QP compiled that MBQL into the expected SQL
+  — guarding against a future middleware change that would decouple the two."
+  [query]
+  (let [database-id (:database query)
+        driver      (t2/select-one-fn :engine :model/Database :id database-id)
+        sql         (:query (qp.compile/compile query))
+        mp          (lib-be/application-database-metadata-provider database-id)
+        nq          (lib/native-query mp sql)
+        sql-refs    (reduce (fn [m {:keys [table-id id]}]
+                              (update m table-id (fnil conj #{}) id))
+                            {}
+                            (sql-tools/referenced-fields driver nq))
+        mbql-proj (into {}
+                        (for [a-join (get-in query [:stages 0 :joins])
+                              :let [tid    (get-in a-join [:stages 0 :source-table])
+                                    fields (field-ref-ids (:fields (first (:stages a-join))))]]
+                          [tid fields]))]
+    (not-empty
+     (into {}
+           (for [[tid declared] mbql-proj
+                 :let [actual (get sql-refs tid #{})
+                       extra  (clojure.set/difference actual declared)]
+                 :when (seq extra)]
+             [tid {:declared declared, :actual actual, :extra extra}])))))
+
+(defn- check-tight-projections!
+  "Run both the MBQL-level and SQL-level invariants on a chain-filter query."
+  [query]
+  (testing "MBQL: each join's inner-stage :fields equals the fields referenced via its alias"
+    (is (nil? (projection-violations query))))
+  (testing "SQL: the compiled query references no joined-Table columns outside MBQL :fields"
+    (is (nil? (sql-over-projections query)))))
+
+;;; Scenarios that exercise the join-building paths in `chain-filter-mbql-query`. Each `:build`
+;;; thunk runs inside `mt/dataset test-data` so `mt/id` resolves correctly. Add scenarios here as
+;;; new code paths emerge.
+(def ^:private projection-scenarios
+  [{:label "no-joins"
+    :build #(mbql-for (mt/id :categories :name) nil nil)}
+   {:label "fk-remap-only (GHY-3586)"
+    :build #(mbql-for (mt/id :categories :name) (mt/id :venues :category_id) nil)}
+   {:label "fk-remap + same-table constraint"
+    :build #(mbql-for (mt/id :categories :name) (mt/id :venues :category_id)
+                      {(mt/id :venues :price) 4})}
+   {:label "constraint only, reverse-direction join"
+    :build #(mbql-for (mt/id :categories :name) nil {(mt/id :venues :price) 4})}
+   {:label "constraint on a different joined table"
+    :build #(mbql-for (mt/id :venues :name) nil {(mt/id :categories :name) "BBQ"})}
+   {:label "multi-hop chain (categories→venues→checkins→users)"
+    :build #(mbql-for (mt/id :categories :name) nil
+                      {(mt/id :users :name) "Charles Lindbergh"})}
+   {:label "multi-hop + multi-table constraints"
+    :build #(mbql-for (mt/id :categories :name) nil
+                      {(mt/id :venues :price) 4
+                       (mt/id :users :name) "Charles Lindbergh"})}])
+
+(deftest ^:parallel tight-projections-test
+  (mt/dataset test-data
+    (doseq [{:keys [label build]} projection-scenarios]
+      (testing label
+        (check-tight-projections! (build))))))
 
 ;; Detail: Key (entity_id)=(6nmVTpCpKFRkZJigvqSVm) already exists.
 (deftest use-cached-field-values-test


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74154
Related to https://linear.app/metabase/issue/GIT-10056/dashboard-filter-bypasses-cached-fieldvalues-when-fk-remapping-exists

Doesn't select fields that we don't need for a chain filter query.