### PR TITLE
Prevent text selection when clicking around Data Studio Tables tree

### DIFF
--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.module.css
@@ -30,6 +30,7 @@
 .content {
   display: flex;
   cursor: pointer;
+  user-select: none;
 
   &:hover {
     background-color: var(--mb-color-background-hover);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73178
### Description

Fixes [UXW-3867](https://linear.app/metabase/issue/UXW-3867/clicking-around-tables-view-in-data-studio-selects-text-for-no-reason).

The clickable rows in Data Studio's Tables tree had `cursor: pointer` but allowed native text selection, so rapid clicks (and especially shift+click on the row checkboxes) would highlight label text. Disable user selection on the row.

### How to verify

- [ ] In Data Studio > Tables, rapidly click and shift+click around the database/schema/table tree and confirm no row text gets highlighted while expand/collapse and checkbox toggling still work.
