### PR TITLE
fix: library shows up in the model path incorrectly

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
@@ -14,6 +14,7 @@ import { ForwardRefLink } from "metabase/common/components/Link";
 import { useToast } from "metabase/common/hooks";
 import { deserializeCardFromQuery } from "metabase/common/utils/card";
 import {
+  getCollectionLocationLabel,
   getCollectionLocationParts,
   getDatabaseLocationParts,
 } from "metabase/common/utils/source-location";
@@ -406,7 +407,7 @@ const CardPill = ({ id, messageId }: { id: number; messageId?: string }) => {
       iconName={iconName}
       label={card?.name}
       location={{
-        parts: getCollectionLocationParts(card.collection?.name),
+        parts: [getCollectionLocationLabel(card.collection?.name)],
       }}
       messageId={messageId}
       source={{

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.unit.spec.tsx
@@ -10,6 +10,7 @@ import type {
 } from "metabase-types/api";
 import {
   createMockCard,
+  createMockCollection,
   createMockDatabase,
   createMockTable,
 } from "metabase-types/api/mocks";
@@ -328,6 +329,46 @@ describe("MetabotAgentDataSourcePills", () => {
         }),
       ).toHaveLength(1),
     );
+  });
+
+  it("does not show Library in a model source path for normal collections", async () => {
+    const sql = "SELECT * FROM {{#4-revenue_model}}";
+    const templateTags: TemplateTags = {
+      "#4-revenue_model": {
+        id: "1",
+        name: "#4-revenue_model",
+        "display-name": "Revenue Model",
+        type: "card",
+        "card-id": 4,
+      },
+    };
+    fetchMock.post(EXTRACT_SOURCES_ENDPOINT, {
+      tables: [],
+      card_ids: [4],
+    });
+    fetchMock.get(
+      "path:/api/card/4",
+      createMockCard({
+        id: 4,
+        name: "Revenue Model",
+        type: "model",
+        collection: createMockCollection({
+          id: 10,
+          name: "Marketing & Growth",
+        }),
+      }),
+    );
+    fetchMock.get("path:/api/database/1", DATABASE);
+
+    renderWithProviders(
+      <NavigateToTablePills path={createNativePath(sql, 1, templateTags)} />,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Revenue Model" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Marketing & Growth")).toBeInTheDocument();
+    expect(screen.queryByText("Library")).not.toBeInTheDocument();
   });
 
   it("shows source links without feedback buttons when message id is not provided", async () => {


### PR DESCRIPTION
Closes [BOT-1514: `Library` shows up in the model path incorrectly](https://linear.app/metabase/issue/BOT-1514/library-shows-up-in-the-model-path-incorrectly)

### Description

It was using the wrong method, which was designed for tables in the library. Now it's using the correct one. 

### How to verify

1. Go to metabot.
2. Type a message referencing some model.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
