### PR TITLE
run reset-errored-triggers as a daemon thread to not block startup

### DIFF
--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -108,12 +108,33 @@
   from which it will never recover.
 
   Actually fixing this odd and undesirable behavior would be the ideal solution, but as a stopgap, let's just
-  automatically reset all `ERROR`ed triggers to `WAITING` on startup."
+  automatically reset all `ERROR`ed triggers to `WAITING`.
+
+  Runs on a daemon thread so it doesn't block startup — the sweep can take several minutes on instances with many
+  triggers because each [[Scheduler/resetTriggerFromErrorState]] call is a JDBC round trip under Quartz's
+  `TRIGGER_ACCESS` lock. ERRORed triggers can't fire either way, so deferring just means they resume firing as the
+  sweep progresses instead of all at once."
   [^Scheduler scheduler]
-  (doseq [^TriggerKey tk (.getTriggerKeys scheduler nil)]
-    ;; From dox: "Only affects triggers that are in ERROR state - if identified trigger is not
-    ;; in that state then the result is a no-op."
-    (.resetTriggerFromErrorState scheduler tk)))
+  (doto (Thread.
+         ^Runnable (bound-fn []
+                     (let [timer (u/start-timer)]
+                       (try
+                         (let [trigger-keys (.getTriggerKeys scheduler nil)]
+                           (log/infof "Resetting any ERROR-state Quartz triggers (%d total to check)"
+                                      (count trigger-keys))
+                           (doseq [^TriggerKey tk trigger-keys]
+                             ;; From dox: "Only affects triggers that are in ERROR state - if identified trigger is not
+                             ;; in that state then the result is a no-op."
+                             (.resetTriggerFromErrorState scheduler tk))
+                           (log/infof "Finished resetting ERROR-state Quartz triggers in %s"
+                                      (u/format-milliseconds (u/since-ms timer))))
+                         (catch InterruptedException _
+                           (log/info "Quartz trigger error-state reset interrupted"))
+                         (catch Throwable e
+                           (log/error e "Error resetting ERROR-state Quartz triggers")))))
+         "quartz-error-trigger-reset")
+    (.setDaemon true)
+    .start))
 
 (defn init-scheduler!
   "Initialize our Quartzite scheduler which allows jobs to be submitted and triggers to scheduled. Puts scheduler in

--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -129,6 +129,7 @@
                            (log/infof "Finished resetting ERROR-state Quartz triggers in %s"
                                       (u/format-milliseconds (u/since-ms timer))))
                          (catch InterruptedException _
+                           (.interrupt (Thread/currentThread))
                            (log/info "Quartz trigger error-state reset interrupted"))
                          (catch Throwable e
                            (log/error e "Error resetting ERROR-state Quartz triggers")))))

--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -152,8 +152,11 @@
         ;; Register Prometheus listeners
 
         (delete-jobs-with-no-class!)
-        (reset-errored-triggers! new-scheduler)
-        (init-tasks!)))))
+        (init-tasks!)
+        ;; Run AFTER init-tasks! — the background sweep contends with task scheduling for the
+        ;; Quartz `TRIGGER_ACCESS` lock, so letting init-tasks! finish its rescheduling first
+        ;; keeps that path snappy.
+        (reset-errored-triggers! new-scheduler)))))
 
 ;;; this is a function mostly to facilitate testing.
 (defn- disable-scheduler? []

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -187,12 +187,17 @@
               (swap! processed conj tk)
               (when (= (count @processed) (count trigger-keys))
                 (deliver done :all-processed))))]
-      (#'task.impl/reset-errored-triggers! mock-scheduler)
-      (testing "function returns before the worker does any reset work"
-        (is (= :ready (deref ready 5000 :timeout))
-            "worker thread should have entered getTriggerKeys")
-        (is (empty? @processed)
-            "no triggers should have been reset yet — worker is parked at the gate"))
+      ;; Wrap in a future so a regression to synchronous behavior fails with a timeout instead
+      ;; of deadlocking the suite (the worker parks inside getTriggerKeys before the gate is
+      ;; delivered, so a sync call would never return).
+      (let [call-future (future (#'task.impl/reset-errored-triggers! mock-scheduler))]
+        (testing "function returns before the worker does any reset work"
+          (is (not= :timeout (deref call-future 1000 :timeout))
+              "reset-errored-triggers! must not block the caller while the worker runs")
+          (is (= :ready (deref ready 5000 :timeout))
+              "worker thread should have entered getTriggerKeys")
+          (is (empty? @processed)
+              "no triggers should have been reset yet — worker is parked at the gate")))
       (testing "worker thread is a daemon with the expected name"
         (is (= {:name "quartz-error-trigger-reset", :daemon? true}
                @worker-info)))

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -169,31 +169,35 @@
     (let [trigger-keys (mapv #(TriggerKey. (str "tk-" %)) (range 50))
           processed    (atom [])
           worker-info  (atom nil)
-          done         (promise)
-          ;; A mock Scheduler that records each resetTriggerFromErrorState call and simulates a
-          ;; slow JDBC round trip so we can tell sync from async.
+          ready        (promise) ; delivered by worker once it has entered getTriggerKeys
+          gate         (promise) ; awaited by worker before it returns from getTriggerKeys
+          done         (promise) ; delivered by worker after the final reset call
+          ;; Mock Scheduler that lets us deterministically observe the worker mid-flight: it
+          ;; parks inside getTriggerKeys until the test releases the gate, so we can assert
+          ;; the main thread already returned with no reset work yet performed.
           mock-scheduler
           (proxy [Scheduler] []
             (getTriggerKeys [_matcher]
-              ;; Capture thread metadata from inside the background worker before any work happens.
               (let [t (Thread/currentThread)]
                 (reset! worker-info {:name (.getName t), :daemon? (.isDaemon t)}))
+              (deliver ready :ready)
+              @gate
               (java.util.HashSet. ^java.util.Collection trigger-keys))
             (resetTriggerFromErrorState [tk]
-              (Thread/sleep 5)
               (swap! processed conj tk)
               (when (= (count @processed) (count trigger-keys))
-                (deliver done :all-processed))))
-          start-ns (System/nanoTime)
-          _        (#'task.impl/reset-errored-triggers! mock-scheduler)
-          elapsed-ms (/ (- (System/nanoTime) start-ns) 1e6)]
-      (testing "function returns immediately (well under the 50 * 5ms = 250ms of synchronous work)"
-        (is (< elapsed-ms 100)
-            (format "reset-errored-triggers! took %.1fms; expected to return immediately" elapsed-ms)))
+                (deliver done :all-processed))))]
+      (#'task.impl/reset-errored-triggers! mock-scheduler)
+      (testing "function returns before the worker does any reset work"
+        (is (= :ready (deref ready 5000 :timeout))
+            "worker thread should have entered getTriggerKeys")
+        (is (empty? @processed)
+            "no triggers should have been reset yet — worker is parked at the gate"))
+      (testing "worker thread is a daemon with the expected name"
+        (is (= {:name "quartz-error-trigger-reset", :daemon? true}
+               @worker-info)))
+      (deliver gate :go)
       (testing "background thread completes the sweep"
         (is (= :all-processed (deref done 5000 :timeout))))
       (testing "every trigger key was processed"
-        (is (= (set trigger-keys) (set @processed))))
-      (testing "worker thread is a daemon with the expected name"
-        (is (= {:name "quartz-error-trigger-reset", :daemon? true}
-               @worker-info))))))
+        (is (= (set trigger-keys) (set @processed)))))))

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -7,6 +7,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.task.core :as task]
+   [metabase.task.impl :as task.impl]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
@@ -14,7 +15,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
-   (org.quartz CronTrigger JobDetail)))
+   (org.quartz CronTrigger JobDetail Scheduler TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -162,3 +163,37 @@
         (if scheduler-initialized?
           (task/start-scheduler!)
           (task/stop-scheduler!))))))
+
+(deftest reset-errored-triggers-runs-on-background-daemon-thread-test
+  (testing "reset-errored-triggers! returns immediately and does its work on a named daemon thread"
+    (let [trigger-keys (mapv #(TriggerKey. (str "tk-" %)) (range 50))
+          processed    (atom [])
+          worker-info  (atom nil)
+          done         (promise)
+          ;; A mock Scheduler that records each resetTriggerFromErrorState call and simulates a
+          ;; slow JDBC round trip so we can tell sync from async.
+          mock-scheduler
+          (proxy [Scheduler] []
+            (getTriggerKeys [_matcher]
+              ;; Capture thread metadata from inside the background worker before any work happens.
+              (let [t (Thread/currentThread)]
+                (reset! worker-info {:name (.getName t), :daemon? (.isDaemon t)}))
+              (java.util.HashSet. ^java.util.Collection trigger-keys))
+            (resetTriggerFromErrorState [tk]
+              (Thread/sleep 5)
+              (swap! processed conj tk)
+              (when (= (count @processed) (count trigger-keys))
+                (deliver done :all-processed))))
+          start-ns (System/nanoTime)
+          _        (#'task.impl/reset-errored-triggers! mock-scheduler)
+          elapsed-ms (/ (- (System/nanoTime) start-ns) 1e6)]
+      (testing "function returns immediately (well under the 50 * 5ms = 250ms of synchronous work)"
+        (is (< elapsed-ms 100)
+            (format "reset-errored-triggers! took %.1fms; expected to return immediately" elapsed-ms)))
+      (testing "background thread completes the sweep"
+        (is (= :all-processed (deref done 5000 :timeout))))
+      (testing "every trigger key was processed"
+        (is (= (set trigger-keys) (set @processed))))
+      (testing "worker thread is a daemon with the expected name"
+        (is (= {:name "quartz-error-trigger-reset", :daemon? true}
+               @worker-info))))))


### PR DESCRIPTION
### Description

Run reset-errored-triggers as a daemon thread to not block startup. Currently the processing of the reset-errored-triggers impacts the startup even though startup shouldn't be dependant on it.
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
