### PR TITLE
[sync] Remove sync records for contents of de-synced collections

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -111,13 +111,22 @@
                                  (for [collection sync-on]
                                    [:like :location (str (collections/location-path collection) "%")]))]}))
       (when (seq sync-off)
-        (t2/query {:update (t2/table-name :model/Collection)
-                   :set {:is_remote_synced false}
-                   :where [:and
-                           [:= :is_remote_synced true]
-                           (into [:or [:in :id (map :id sync-off)]]
-                                 (for [collection sync-off]
-                                   [:like :location (str (collections/location-path collection) "%")]))]}))
+        (let [affected-collection-ids
+              (t2/select-pks-set :model/Collection
+                                 {:where [:and
+                                          [:= :is_remote_synced true]
+                                          (into [:or [:in :id (map :id sync-off)]]
+                                                (for [collection sync-off]
+                                                  [:like :location (str (collections/location-path collection) "%")]))]})]
+          (when (seq affected-collection-ids)
+            (t2/query {:update (t2/table-name :model/Collection)
+                       :set {:is_remote_synced false}
+                       :where [:in :id affected-collection-ids]})
+            (t2/delete! :model/RemoteSyncObject
+                        :model_type "Collection"
+                        :model_id [:in affected-collection-ids])
+            (t2/delete! :model/RemoteSyncObject
+                        :model_collection_id [:in affected-collection-ids]))))
       (doseq [collection sync-on]
         (collections/check-non-remote-synced-dependencies collection))
       (doseq [collection sync-off]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/core_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.remote-sync.core-test
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase-enterprise.remote-sync.core :as core]
    [metabase.collections.test-utils :refer [with-library-synced with-library-not-synced]]
    [metabase.events.core :as events]
@@ -261,6 +262,56 @@
       (is (false? (:is_remote_synced (t2/select-one :model/Collection :id parent-id))))
       (is (false? (:is_remote_synced (t2/select-one :model/Collection :id child1-id))))
       (is (false? (:is_remote_synced (t2/select-one :model/Collection :id child2-id)))))))
+
+;;; ------------------------------------------- RSO Cleanup Tests -------------------------------------------
+
+(deftest bulk-set-remote-sync-cleans-up-rsos-on-disable-test
+  (testing "bulk-set-remote-sync deletes RemoteSyncObject entries for un-synced collections and their contents"
+    (mt/with-temp [:model/Collection {coll-id :id} {:name "Test Collection" :location "/" :is_remote_synced true}
+                   :model/Card {card-id :id} {:name "Test Card" :collection_id coll-id
+                                              :database_id (mt/id)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (let [now (t/offset-date-time)]
+        (t2/insert! :model/RemoteSyncObject
+                    {:model_type "Collection" :model_id coll-id :model_name "Test Collection"
+                     :status "update" :status_changed_at now})
+        (t2/insert! :model/RemoteSyncObject
+                    {:model_type "Card" :model_id card-id :model_name "Test Card"
+                     :model_collection_id coll-id :status "update" :status_changed_at now})
+        (is (= 2 (t2/count :model/RemoteSyncObject
+                           {:where [:or
+                                    [:and [:= :model_type "Collection"] [:= :model_id coll-id]]
+                                    [:= :model_collection_id coll-id]]})))
+        (mt/with-dynamic-fn-redefs [events/publish-event! (constantly nil)]
+          (core/bulk-set-remote-sync {coll-id false}))
+        (is (= 0 (t2/count :model/RemoteSyncObject
+                           {:where [:or
+                                    [:and [:= :model_type "Collection"] [:= :model_id coll-id]]
+                                    [:= :model_collection_id coll-id]]})))))))
+
+(deftest bulk-set-remote-sync-cleans-up-descendant-rsos-test
+  (testing "bulk-set-remote-sync deletes RSOs for descendant collections and their contents"
+    (mt/with-temp [:model/Collection {parent-id :id} {:name "Parent" :location "/" :is_remote_synced true}
+                   :model/Collection {child-id :id} {:name "Child" :location (format "/%d/" parent-id)
+                                                     :is_remote_synced true}
+                   :model/Card {card-id :id} {:name "Child Card" :collection_id child-id
+                                              :database_id (mt/id)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (let [now (t/offset-date-time)]
+        (t2/insert! :model/RemoteSyncObject
+                    {:model_type "Collection" :model_id parent-id :model_name "Parent"
+                     :status "update" :status_changed_at now})
+        (t2/insert! :model/RemoteSyncObject
+                    {:model_type "Collection" :model_id child-id :model_name "Child"
+                     :status "update" :status_changed_at now})
+        (t2/insert! :model/RemoteSyncObject
+                    {:model_type "Card" :model_id card-id :model_name "Child Card"
+                     :model_collection_id child-id :status "create" :status_changed_at now})
+        (mt/with-dynamic-fn-redefs [events/publish-event! (constantly nil)]
+          (core/bulk-set-remote-sync {parent-id false}))
+        (is (false? (t2/exists? :model/RemoteSyncObject :model_type "Collection" :model_id parent-id)))
+        (is (false? (t2/exists? :model/RemoteSyncObject :model_type "Collection" :model_id child-id)))
+        (is (false? (t2/exists? :model/RemoteSyncObject :model_id card-id)))))))
 
 ;;; ------------------------------------------- batch-model-eligible? Tests -------------------------------------------
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73880
Fixes UXW-4027.

### Description

If you made edits to e.g. a dashboard in a synced collection, but then
disabled sync for that collection, the collection would be correctly
marked as removed from the git repo, but the changed contents would
still be marked dirty. All pushes then failed, since it was dirty but
the set of things to push came back empty.

With this change, all entities in a de-synced collection have any
pending sync records dropped too.

### How to verify

1. Set up remote sync for some collections.
2. Make an edit to something in one of the synced collections **but don't push.**
3. Disable sync for that collection.
4. Try to push.

Previously, you would get an error that there was nothing to sync. Now it correctly shows a clean slate after de-syncing the collection.

Note that the original code works if you have other changes which are in still-synced collections. It finds non-zero things to sync, and then does a blanket update of all sync states.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
