### PR TITLE
Swap join order when doing remapping field values

### DIFF
--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -418,18 +418,30 @@
    constraints                       :- [:maybe ::constraints]
    {:keys [original-field-id limit]} :- [:maybe ::options]]
   (log/tracef "Chain filter %s with constraints %s" (name-for-logging :model/Field field-id) (u/cprint-to-str constraints))
-  (let [database-id      (field/field-id->database-id field-id)
-        mp               (lib-be/application-database-metadata-provider database-id)
-        source-table-id  (field/field-id->table-id field-id)
-        joins            (find-all-joins source-table-id (cond-> (set (map :field-id constraints))
-                                                           original-field-id (conj original-field-id)))
-        joined-table-ids (set (map #(get-in % [:rhs :table]) joins))
-        field            (lib.metadata/field mp field-id)
-        original-field   (when original-field-id
-                           (let [original-table-id (field/field-id->table-id original-field-id)]
-                             (cond-> (lib.metadata/field mp original-field-id)
-                               (not= source-table-id original-table-id)
-                               (lib/with-join-alias (joined-table-alias original-table-id)))))]
+  (let [database-id       (field/field-id->database-id field-id)
+        mp                (lib-be/application-database-metadata-provider database-id)
+        field-table-id    (field/field-id->table-id field-id)
+        original-table-id (when original-field-id (field/field-id->table-id original-field-id))
+        ;; When the original (FK) field lives on a different table, reverse the join direction:
+        ;; make the original field's table the source and join the label table. The original table
+        ;; is typically the large fact table; putting it on the right side of a JOIN can OOM on
+        ;; engines like ClickHouse that materialize the right side in memory.
+        reversed?         (and original-table-id (not= original-table-id field-table-id))
+        source-table-id   (if reversed? original-table-id field-table-id)
+        joins             (find-all-joins source-table-id
+                                          (cond-> (set (map :field-id constraints))
+                                            reversed?       (conj field-id)
+                                            (not reversed?) (cond-> original-field-id (conj original-field-id))))
+        joined-table-ids  (set (map #(get-in % [:rhs :table]) joins))
+        field             (cond-> (lib.metadata/field mp field-id)
+                            reversed? (lib/with-join-alias (joined-table-alias field-table-id)))
+        original-field    (when original-field-id
+                            (if reversed?
+                              ;; reversed: original field is on the source table, no alias
+                              (lib.metadata/field mp original-field-id)
+                              (cond-> (lib.metadata/field mp original-field-id)
+                                (not= field-table-id original-table-id)
+                                (lib/with-join-alias (joined-table-alias original-table-id)))))]
     (when original-field-id
       (log/tracef "Finding values of %s, remapped from %s."
                   (name-for-logging :model/Field field-id)


### PR DESCRIPTION
Bit more context: we think the tables in clickhouse have no stats on them. Ordinarily the optimizer should figure this out for us. But if it's flying blind, we can help it out by putting the smaller table on the right hand side.

```clojure
chain-filter-test=> (run-tests)

Testing metabase.parameters.chain-filter-test
Ran 60 tests containing 113 assertions.
0 failures, 0 errors.
{:test 60, :pass 113, :fail 0, :error 0, :type :summary}
```

The gist:
We have a "label" table that is smaller than the "fact" table for remapping. Imagine orders and products. You (hopefully) have more orders than products. You have more categories than things in the categories. If it's 1:1, presumably the order doesn't matter.

Clickhouse sometimes will materialize the RHS of a join. So let's put the smaller table on the RHS and try to help out.

so before:
```clojure
chain-filter=> (-> (metabase.query-processor.core/compile
                     (chain-filter-mbql-query 17 nil {:limit 1000 :original-field-id 14}))
                   :query println)
SELECT "table_2"."PRODUCT_ID" AS "table_2__PRODUCT_ID", "PUBLIC"."PRODUCTS"."TITLE" AS "TITLE" FROM "PUBLIC"."PRODUCTS" LEFT JOIN (SELECT "PUBLIC"."ORDERS"."ID" AS "ID",
"PUBLIC"."ORDERS"."USER_ID" AS "USER_ID", "PUBLIC"."ORDERS"."PRODUCT_ID" AS "PRODUCT_ID", "PUBLIC"."ORDERS"."SUBTOTAL" AS "SUBTOTAL", "PUBLIC"."ORDERS"."TAX" AS "TAX", "PUBLIC"."ORDERS"."TOTAL"
AS "TOTAL", "PUBLIC"."ORDERS"."DISCOUNT" AS "DISCOUNT", "PUBLIC"."ORDERS"."CREATED_AT" AS "CREATED_AT", "PUBLIC"."ORDERS"."QUANTITY" AS "QUANTITY" FROM "PUBLIC"."ORDERS") AS "table_2" ON
"PUBLIC"."PRODUCTS"."ID" = "table_2"."PRODUCT_ID" WHERE "table_2"."PRODUCT_ID" IS NOT NULL GROUP BY "table_2"."PRODUCT_ID", "PUBLIC"."PRODUCTS"."TITLE" ORDER BY "PUBLIC"."PRODUCTS"."TITLE" ASC,
"table_2"."PRODUCT_ID" ASC LIMIT 1000
```

has the shape

```sql
select product_id, title
from products -- small table
left join (select <> from orders) -- big table on RHS
```

and now

```clojure
chain-filter=> (-> (metabase.query-processor.core/compile
                     (chain-filter-mbql-query 17 nil {:limit 1000 :original-field-id 14}))
                   :query println)

SELECT "PUBLIC"."ORDERS"."PRODUCT_ID" AS "PRODUCT_ID", "table_3"."TITLE" AS "table_3__TITLE" FROM "PUBLIC"."ORDERS" LEFT JOIN (SELECT "PUBLIC"."PRODUCTS"."ID" AS "ID", "PUBLIC"."PRODUCTS"."EAN"
AS "EAN", "PUBLIC"."PRODUCTS"."TITLE" AS "TITLE", "PUBLIC"."PRODUCTS"."CATEGORY" AS "CATEGORY", "PUBLIC"."PRODUCTS"."VENDOR" AS "VENDOR", "PUBLIC"."PRODUCTS"."PRICE" AS "PRICE",
"PUBLIC"."PRODUCTS"."RATING" AS "RATING", "PUBLIC"."PRODUCTS"."CREATED_AT" AS "CREATED_AT" FROM "PUBLIC"."PRODUCTS") AS "table_3" ON "PUBLIC"."ORDERS"."PRODUCT_ID" = "table_3"."ID" WHERE
"PUBLIC"."ORDERS"."PRODUCT_ID" IS NOT NULL GROUP BY "PUBLIC"."ORDERS"."PRODUCT_ID", "table_3"."TITLE" ORDER BY "table_3"."TITLE" ASC, "PUBLIC"."ORDERS"."PRODUCT_ID" ASC LIMIT 1000
```

with the shape:
```sql
select product_id, title
from orders -- big table
left join (select <> from products) -- small table on RHS
```