### PR TITLE
Fix flaky visitDashboard helper waiting on dashcard queries

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -214,7 +214,7 @@ function visitDashboardById(dashboard_id, config) {
     if (canViewDashboard && validQuestions) {
       // If dashboard has valid questions (GUI or native),
       // we need to alias each request and wait for their reponses
-      const aliases = validQuestions.map(
+      const dashcardAliases = validQuestions.map(
         ({ id, card_id, card: { display } }) => {
           const baseUrl =
             display === "pivot"
@@ -236,7 +236,10 @@ function visitDashboardById(dashboard_id, config) {
         qs: config.params,
       });
 
-      cy.wait(aliases);
+      // Wait for the dashboard itself to load before waiting on dashcard queries
+      cy.wait(`@${dashboardAlias}`);
+
+      cy.wait(dashcardAliases);
     } else {
       // For a dashboard:
       //  - without questions (can be empty or markdown only) or


### PR DESCRIPTION
Closes [GDGT-2382](https://linear.app/metabase/issue/GDGT-2382)

### Description

This PR attempts to resolve a test flake. My suspicion is that the dashboard does a lot of heavy work before the dashboard card requests get fired, so they don't make it within the window Cypress waits for them — `cy.wait` then fails with `No request ever occurred` for a `dashcardQueryNN` route.

The fix is to first wait for the request that loads the dashboard itself (`GET /api/dashboard/:id`), and only then wait for the individual dashboard card requests. Hopefully, this will give enough time to load everything without introducing arbitrary timeouts. It also brings this branch in sync with the `else` branch (waiting for empty dashboard load) which already waits for this request.

**Note** that the Linear ticket mentions another failure — a missing save button — but that appeared to be a one-time failure on that particular branch (maybe related to code there, maybe not, it was too much code to sift through). The request-waiting issue happens more often and looks like a general flake.

### How to verify

CI is green and we don't see this flake anymore.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR