### PR TITLE
Skip milestone backfill instead of throwing when no PR is referenced

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -253,7 +253,10 @@ export async function setMilestoneForCommits({
       .filter(isNotNull)
   );
   if (!PRsToCheck.length) {
-    throw new Error('No PRs found in commit messages');
+    // Not every commit on a release branch is a squash-merged PR (e.g. the
+    // version-bump commit from cutting the branch). Nothing to backfill here.
+    console.log('No PRs found in commit messages, skipping milestone backfill');
+    return;
   }
 
   console.log(`Checking ${PRsToCheck.length} PRs for issues to tag`);

--- a/release/src/milestones.unit.spec.ts
+++ b/release/src/milestones.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getNextMilestone } from "./milestones";
+import { getNextMilestone, setMilestoneForCommits } from "./milestones";
 import type { Milestone } from "./types";
 
 describe('milestones', () => {
@@ -69,6 +69,33 @@ describe('milestones', () => {
         openMilestones: testMilestones,
         majorVersion: 61,
       })?.number).toBe(612);
+    });
+  });
+
+  describe('setMilestoneForCommits', () => {
+    const buildGithub = () => ({
+      paginate: jest.fn().mockResolvedValue(testMilestones),
+      rest: {
+        issues: {
+          listMilestones: jest.fn(),
+          update: jest.fn(),
+        },
+      },
+    });
+
+    it('is a no-op when no commit messages reference a PR', async () => {
+      const github = buildGithub();
+
+      // e.g. the version-bump commit created when cutting a release branch
+      await expect(setMilestoneForCommits({
+        github: github as any,
+        owner: 'metabase',
+        repo: 'metabase',
+        branchName: 'release-x.57.x',
+        commitMessages: ['Bump version to v0.57'],
+      })).resolves.toBeUndefined();
+
+      expect(github.rest.issues.update).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Resolves DEV-1967

## Summary 

Not every commit on a release branch is a squash-merged PR — e.g. the version-bump commit created when cutting the branch has no (#NNN) in its subject. Treat that as a no-op rather than an error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
