### PR TITLE
Don't navigate away from notebook when opening QB sidesheet

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1,7 +1,10 @@
 const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ADMIN_USER_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -10,6 +13,34 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
+  });
+
+  it("keeps the notebook editor mounted when opening the question info sidebar (UXW-224)", () => {
+    H.activateToken("pro-self-hosted");
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.openNotebook();
+
+    // The Visualize button only renders while the notebook editor is mounted.
+    cy.location("pathname").should("include", "/notebook");
+    cy.button("Visualize").should("be.visible");
+
+    // Open the question info sidesheet — the notebook should stay mounted behind it.
+    H.questionInfoButton().click();
+    H.sidesheet().should("be.visible");
+    cy.button("Visualize").should("be.visible");
+
+    // Closing the sidesheet should leave us in notebook mode with the editor intact.
+    H.sidesheet().findByLabelText("Close").click();
+    cy.location("pathname").should("include", "/notebook");
+    cy.button("Visualize").should("be.visible");
+
+    // Open Edit settings from the actions menu — same expectation.
+    // ("Edit settings" only appears with granular caching enabled, so this
+    // step requires EE.)
+    H.openQuestionActions("Edit settings");
+    H.sidesheet().should("be.visible");
+    cy.location("pathname").should("include", "/notebook");
+    cy.button("Visualize").should("be.visible");
   });
 
   it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {

--- a/frontend/src/metabase/query_builder/reducers.ts
+++ b/frontend/src/metabase/query_builder/reducers.ts
@@ -310,7 +310,6 @@ export const uiControls = createReducer<QueryBuilderUIControls>(
           ...UI_CONTROLS_SIDEBAR_DEFAULTS,
           ...CLOSED_NATIVE_EDITOR_SIDEBARS,
           isShowingQuestionInfoSidebar: true,
-          queryBuilderMode: "view",
         }),
       )
       .addCase(CLOSE_QUESTION_INFO, (state) => ({
@@ -321,7 +320,6 @@ export const uiControls = createReducer<QueryBuilderUIControls>(
         setUIControls(state, {
           ...(UI_CONTROLS_SIDEBAR_DEFAULTS as Partial<QueryBuilderUIControls>),
           isShowingQuestionSettingsSidebar: true,
-          queryBuilderMode: "view",
         } as Partial<QueryBuilderUIControls>),
       )
       .addCase(CLOSE_QUESTION_SETTINGS, (state) => ({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #53826
### Description

Small change to stop us from changing the UI state when we are in the QB notebook editor and open the info or settings side sheets

### How to verify
1. Go to a question
2. Open the notebook editor
3. From here, open the Info side panel. You should stay on the notebook page
4. Same for Opening the settings side panel (requires EE).

### Demo


https://github.com/user-attachments/assets/276d2d7c-8948-403b-93f5-97313741b5ac



### Checklist

- [x] Tests have been added/updated to cover changes in this PR