### PR TITLE
Extract release milestone management into a reusable workflow

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -187,43 +187,13 @@ jobs:
     # so any PRs that merge while the build is in flight are tagged with the next
     # milestone (not the one about to be released). Gated on the preflight checks
     # so a bad version/commit input doesn't rotate the milestone spuriously.
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     needs: [check-version, check-commit]
-    timeout-minutes: 15
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        sparse-checkout: |
-          release
-          .github
-    - name: Prepare release scripts
-      uses: ./.github/actions/prepare-release-scripts
-    - name: Update milestones
-      uses: actions/github-script@v7
-      with:
-        script: | # js
-          const { closeMilestone, openNextMilestones, isPreReleaseVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
-
-          const version = '${{ inputs.version }}';
-
-          if (isPreReleaseVersion(version)) {
-            console.log("This is a prerelease version, skipping milestone management");
-            return;
-          }
-
-          await closeMilestone({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version,
-          }).catch(console.error);
-
-          await openNextMilestones({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version,
-          }).catch(console.error);
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/release-milestone-manage.yml
+    with:
+      version: ${{ inputs.version }}
 
   build-uberjar-for-release:
     needs: [check-version, check-commit, get-build-requirements]

--- a/.github/workflows/release-milestone-manage.yml
+++ b/.github/workflows/release-milestone-manage.yml
@@ -1,0 +1,63 @@
+name: Release Milestone Management
+run-name: Manage milestones for ${{ inputs.version }}
+
+# Closes the milestone we're about to ship and opens the next one.
+# Reusable so the release workflows can run it before building/tagging, and
+# exposed via workflow_dispatch so it can be run by hand if a release misses it.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  manage-milestones:
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          release
+          .github
+    - name: Prepare release scripts
+      uses: ./.github/actions/prepare-release-scripts
+    - name: Update milestones
+      uses: actions/github-script@v7
+      with:
+        script: | # js
+          const { closeMilestone, openNextMilestones, isPreReleaseVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          const version = '${{ inputs.version }}';
+
+          if (isPreReleaseVersion(version)) {
+            console.log("This is a prerelease version, skipping milestone management");
+            return;
+          }
+
+          await closeMilestone({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version,
+          }).catch(console.error);
+
+          await openNextMilestones({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version,
+          }).catch(console.error);

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -139,6 +139,19 @@ jobs:
           || (echo "Commit not found in correct release branch" && exit 1)
         git checkout -
 
+  manage-milestones:
+    # Close the milestone we're about to ship and open the next one BEFORE tagging,
+    # so any PRs that merge while the release is in flight are tagged with the next
+    # milestone (not the one about to be released). Gated on the preflight checks
+    # so a bad version/commit input doesn't rotate the milestone spuriously.
+    needs: [check-version, check-commit]
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/release-milestone-manage.yml
+    with:
+      version: ${{ inputs.version }}
+
   tag-uberjar-for-release:
     needs: [check-version, check-commit]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}


### PR DESCRIPTION
Resolves DEV-1970

## Summary

Auto minor release automation moved from build-for-release to tag-for-release, but the milestone close/open job stayed behind, so minor releases stopped rotating milestones (DEV-1970).

Lift the manage-milestones job into release-milestone-manage.yml with workflow_call + workflow_dispatch triggers, and call it from both build-for-release and tag-for-release, still gated on the preflight checks so the milestone only rotates for a valid version/commit.

## Test

### Happy path

https://github.com/iethree/metabase/actions/runs/25870829580

- [x] Closed the existing v0.88.8
- [x] Opened a new v0.88.9

### Testing for idempotency

https://github.com/iethree/metabase/actions/runs/25870934321/job/76025678951#step:4:34

- [x] Didn't see v0.88.8 because it was closed (nothing to do)
- [x] Recognized that there is already v0.88.9 (swallowed `422` error)

