### PR TITLE
Pin com.google.code.gson/gson dependency at root deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,6 +48,7 @@
   com.github.steffan-westcott/clj-otel-sdk  {:mvn/version "0.2.10"}             ; OpenTelemetry SDK for programmatic configuration
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.auth/google-auth-library-credentials {:mvn/version "1.40.0"}       ; dep for BigQuery, Databricks, and Snowflake. Require here rather than letting different dep versions stomp on each other — see #70908
+  com.google.code.gson/gson                 {:mvn/version "2.12.1"}             ; dep for BigQuery, Databricks, and Snowflake. Pin here so driver plugin JARs all use the same version — see #73736
   com.google.guava/guava                    {:mvn/version "33.5.0-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
   {:mvn/version "2.1.214"}            ; embedded SQL database


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73736

### Description

This dependency was still being overridden by another driver bringing it in transitively. Pin the dependency at the project root to avoid this. 

### How to verify

`clojure -X:build:drivers:build/driver :driver :bigquery-cloud-sdk :edition :ee`

should see `SKIP com.google.code.gson/gson (provided by metabase-core)`

`clojure -Stree | grep gson`

should see `com.google.code.gson/gson 2.12.1`



### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
