### PR TITLE
Make database metadata request respect `remove_inactive` flag

### DIFF
--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -562,8 +562,13 @@
   ;; TODO - do we want to include tables that should be `:hidden`?
   (t2/select :model/Table :db_id id :active true {:order-by [[:%lower.display_name :asc]]}))
 
+(def ^:dynamic *hydrate-inactive-tables*
+  "Bind this to true to make the `:tables` hydration below include inactive tables."
+  false)
+
 (methodical/defmethod t2/batched-hydrate [:model/Database :tables]
-  "Batch hydrate `Tables` for the given `Database`."
+  "Batch hydrate `Tables` for the given `Database`. Inactive tables are excluded by default, but they will be
+  included if [[*hydrate-inactive-tables*]] is set to true."
   [_model k databases]
   (mi/instances-with-hydrated-data
    databases k
@@ -571,8 +576,10 @@
               ;; TODO - do we want to include tables that should be `:hidden`?
               (t2/select :model/Table
                          :db_id  [:in (map :id databases)]
-                         :active true
-                         {:order-by [[:db_id :asc] [:%lower.display_name :asc]]}))
+                         {:where    (if *hydrate-inactive-tables*
+                                      [:= [:inline 1] [:inline 1]]
+                                      [:= :active true])
+                          :order-by [[:db_id :asc] [:%lower.display_name :asc]]}))
    :id
    {:default []}))
 

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -515,8 +515,13 @@
   ;; TODO - do we want to include tables that should be `:hidden`?
   (t2/select :model/Table :db_id id :active true {:order-by [[:%lower.display_name :asc]]}))
 
+(def ^:dynamic *hydrate-inactive-tables*
+  "Bind this to true to make the `:tables` hydration below include inactive tables."
+  false)
+
 (methodical/defmethod t2/batched-hydrate [:model/Database :tables]
-  "Batch hydrate `Tables` for the given `Database`."
+  "Batch hydrate `Tables` for the given `Database`. Inactive tables are excluded by default, but they will be
+  included if [[*hydrate-inactive-tables*]] is set to true."
   [_model k databases]
   (mi/instances-with-hydrated-data
    databases k
@@ -524,8 +529,10 @@
               ;; TODO - do we want to include tables that should be `:hidden`?
               (t2/select :model/Table
                          :db_id  [:in (map :id databases)]
-                         :active true
-                         {:order-by [[:db_id :asc] [:%lower.display_name :asc]]}))
+                         {:where    (if *hydrate-inactive-tables*
+                                      [:= [:inline 1] [:inline 1]]
+                                      [:= :active true])
+                          :order-by [[:db_id :asc] [:%lower.display_name :asc]]}))
    :id
    {:default []}))
 

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -625,21 +625,20 @@
   (saved-cards-virtual-db-metadata :question :include-tables? true, :include-fields? true))
 
 (defn- db-metadata [id include-hidden? include-editable-data-model? remove_inactive? skip-fields?]
-  (let [db (-> (warehouses/get-database id {:include-editable-data-model? include-editable-data-model?})
-               (t2/hydrate
-                (if skip-fields?
-                  [:tables :segments :metrics]
-                  [:tables [:fields :has_field_values [:target :has_field_values]] :segments :metrics])))
-        db (if include-editable-data-model?
+  (let [db (binding [database/*hydrate-inactive-tables* (not remove_inactive?)]
+             (-> (warehouses/get-database id {:include-editable-data-model? include-editable-data-model?})
+                 (t2/hydrate
+                  (if skip-fields?
+                    [:tables :segments :metrics]
+                    [:tables [:fields :has_field_values [:target :has_field_values]] :segments :metrics]))))
+        db (cond-> db
              ;; We need to check data model perms after hydrating tables, since this will also filter out tables for
              ;; which the *current-user* does not have data model perms
-             (check-db-data-model-perms db)
-             db)
-        ;; Filter out columns hidden by the current user's column-restricting sandbox source card. No-op for
-        ;; non-sandboxed users.
-        db (if skip-fields?
-             db
-             (update db :tables apply-sandbox-column-filter))]
+             include-editable-data-model? check-db-data-model-perms
+             ;; Filter out columns hidden by the current user's column-restricting sandbox source card. No-op for
+             ;; non-sandboxed users.
+             (not skip-fields?)           (update :tables apply-sandbox-column-filter))]
+    ;; TODO: (bshepherdson, 2026/05/14) Rewrite this into a transducer pipeline instead of repeated lazy filters.
     (-> db
         (update :tables (if include-hidden?
                           identity
@@ -674,7 +673,8 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/metadata"
   "Get metadata about a `Database`, including all of its `Tables` and `Fields`. Returns DB, fields, and field values.
-  By default only non-hidden tables and fields are returned. Passing include_hidden=true includes them.
+  By default only active, non-hidden tables and fields are returned. Passing `include_hidden=true` includes active
+  hidden tables. Passing `remove_inactive=false` includes inactive tables.
 
   Passing include_editable_data_model will only return tables for which the current user has data model editing
   permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present.
@@ -686,7 +686,7 @@
    :- [:map
        [:include_hidden              {:default false} [:maybe ms/BooleanValue]]
        [:include_editable_data_model {:default false} [:maybe ms/BooleanValue]]
-       [:remove_inactive             {:default false} [:maybe ms/BooleanValue]]
+       [:remove_inactive             {:default true}  [:maybe ms/BooleanValue]]
        [:skip_fields                 {:default false} [:maybe ms/BooleanValue]]]]
   (db-metadata id
                include_hidden

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -562,16 +562,18 @@
   (saved-cards-virtual-db-metadata :question :include-tables? true, :include-fields? true))
 
 (defn- db-metadata [id include-hidden? include-editable-data-model? remove_inactive? skip-fields?]
-  (let [db (-> (warehouses/get-database id {:include-editable-data-model? include-editable-data-model?})
-               (t2/hydrate
-                (if skip-fields?
-                  [:tables :segments :metrics]
-                  [:tables [:fields :has_field_values [:target :has_field_values]] :segments :metrics])))
+  (let [db (binding [database/*hydrate-inactive-tables* (not remove_inactive?)]
+             (-> (warehouses/get-database id {:include-editable-data-model? include-editable-data-model?})
+                 (t2/hydrate
+                  (if skip-fields?
+                    [:tables :segments :metrics]
+                    [:tables [:fields :has_field_values [:target :has_field_values]] :segments :metrics]))))
         db (if include-editable-data-model?
              ;; We need to check data model perms after hydrating tables, since this will also filter out tables for
              ;; which the *current-user* does not have data model perms
              (check-db-data-model-perms db)
              db)]
+    ;; TODO: (bshepherdson, 2026/05/14) Rewrite this into a transducer pipeline instead of repeated lazy filters.
     (-> db
         (update :tables (if include-hidden?
                           identity
@@ -606,7 +608,8 @@
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id/metadata"
   "Get metadata about a `Database`, including all of its `Tables` and `Fields`. Returns DB, fields, and field values.
-  By default only non-hidden tables and fields are returned. Passing include_hidden=true includes them.
+  By default only active, non-hidden tables and fields are returned. Passing `include_hidden=true` includes active
+  hidden tables. Passing `remove_inactive=false` includes inactive tables.
 
   Passing include_editable_data_model will only return tables for which the current user has data model editing
   permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present.
@@ -618,7 +621,7 @@
    :- [:map
        [:include_hidden              {:default false} [:maybe ms/BooleanValue]]
        [:include_editable_data_model {:default false} [:maybe ms/BooleanValue]]
-       [:remove_inactive             {:default false} [:maybe ms/BooleanValue]]
+       [:remove_inactive             {:default true}  [:maybe ms/BooleanValue]]
        [:skip_fields                 {:default false} [:maybe ms/BooleanValue]]]]
   (db-metadata id
                include_hidden

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -973,11 +973,16 @@
 
 (deftest ^:parallel fetch-database-metadata-remove-inactive-test
   (mt/with-temp [:model/Database {db-id :id} {}
-                 :model/Table    _ {:db_id db-id, :active false}]
-    (testing "GET /api/database/:id/metadata?include_hidden=true"
+                 :model/Table    {active-table-id :id} {:db_id db-id, :active true, :name "ACTIVE_TABLE"}
+                 :model/Table    {inactive-table-id :id} {:db_id db-id, :active false, :name "INACTIVE_TABLE"}]
+    (testing "remove_inactive=true excludes inactive tables"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=true" db-id))
                         :tables)]
-        (is (= () tables))))))
+        (is (= [active-table-id] (map :id tables)))))
+    (testing "remove_inactive=false (default) includes inactive tables (#UXW-3530)"
+      (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=false" db-id))
+                        :tables)]
+        (is (= #{active-table-id inactive-table-id} (set (map :id tables))))))))
 
 (deftest fetch-database-metadata-skip-fields-test
   (mt/with-empty-h2-app-db!

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -853,11 +853,16 @@
 
 (deftest ^:parallel fetch-database-metadata-remove-inactive-test
   (mt/with-temp [:model/Database {db-id :id} {}
-                 :model/Table    _ {:db_id db-id, :active false}]
-    (testing "GET /api/database/:id/metadata?include_hidden=true"
+                 :model/Table    {active-table-id :id} {:db_id db-id, :active true, :name "ACTIVE_TABLE"}
+                 :model/Table    {inactive-table-id :id} {:db_id db-id, :active false, :name "INACTIVE_TABLE"}]
+    (testing "remove_inactive=true excludes inactive tables"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=true" db-id))
                         :tables)]
-        (is (= () tables))))))
+        (is (= [active-table-id] (map :id tables)))))
+    (testing "remove_inactive=false (default) includes inactive tables (#UXW-3530)"
+      (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=false" db-id))
+                        :tables)]
+        (is (= #{active-table-id inactive-table-id} (set (map :id tables))))))))
 
 (deftest fetch-database-metadata-skip-fields-test
   (mt/with-empty-h2-app-db!


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71822
Fixes UXW-3530.

### Description

The `:tables` hydration for databases always filtered to active
tables only. That's still the default, but there's now a dynamic var
that can be overridden to include all tables. (A parameter would be
better but there's no way to do that in the context of hydration.)

This also changes the default for the `remove_inactive` flag to true.
That's not really an API change, since we haven't been returning
inactive tables regardless of that parameter.

### How to verify

Have some inactive tables on some database, and make `GET /api/database/$ID/metadata?remove_inactive=false`
requests. Now that flag is properly respected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
