### PR TITLE
Sync table and column descriptions from BigQuery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -240,19 +240,33 @@
                                      :where [:and
                                              [:= :o.table_name :t.table_name]
                                              [:= :o.option_name "require_partition_filter"]]}
-                                    :require_partition_filter]]
+                                    :require_partition_filter]
+                                   ;; BigQuery stores table descriptions in INFORMATION_SCHEMA.TABLE_OPTIONS as a
+                                   ;; DDL string literal (e.g. `"my description"`). BigQuery string literals follow
+                                   ;; JSON escape rules, so JSON_VALUE unwraps the literal to its raw text.
+                                   [{:select [[[:json_value :o.option_value]]]
+                                     :from [[(information-schema-table project-id dataset-id "TABLE_OPTIONS") :o]]
+                                     :where [:and
+                                             [:= :o.table_name :t.table_name]
+                                             [:= :o.option_name "description"]]}
+                                    :description]]
                           :from [[(information-schema-table project-id dataset-id "TABLES") :t]]}))
-        table-info (fn [dataset-id {table-name :table_name table-type :table_type require-partition-filter :require_partition_filter}]
-                     {:schema dataset-id
-                      :name table-name
-                      :database_require_filter
-                      (boolean (and
-                                ;; Materialized views can be partitioned, and whether the view require a filter or not is based
-                                ;; on the base table it selects from, without parsing the view query we can't find out the base table,
-                                ;; thus we can't know whether the view require a filter or not.
-                                ;; Maybe this is something we can do once we can parse sql
-                                (= "BASE TABLE" table-type)
-                                require-partition-filter))})]
+        table-info (fn [dataset-id {table-name :table_name
+                                    table-type :table_type
+                                    require-partition-filter :require_partition_filter
+                                    description :description}]
+                     (cond-> {:schema dataset-id
+                              :name table-name
+                              :database_require_filter
+                              (boolean (and
+                                        ;; Materialized views can be partitioned, and whether the view require a filter or not is based
+                                        ;; on the base table it selects from, without parsing the view query we can't find out the base table,
+                                        ;; thus we can't know whether the view require a filter or not.
+                                        ;; Maybe this is something we can do once we can parse sql
+                                        (= "BASE TABLE" table-type)
+                                        require-partition-filter))}
+                       (not (str/blank? description))
+                       (assoc :description description)))]
     (->> (list-datasets details :logging-schema-exclusions? true)
          (eduction (mapcat (fn [dataset-id] (eduction (map #(table-info dataset-id %)) (query-dataset dataset-id))))))))
 
@@ -374,7 +388,7 @@
   (let [results (try (query-honeysql
                       driver
                       database
-                      {:select [:table_name :column_name :data_type :field_path]
+                      {:select [:table_name :column_name :data_type :field_path :description]
                        :from [[(information-schema-table project-id dataset-id "COLUMN_FIELD_PATHS") :c]]
                        :where [:and
                                [:in :table_name table-names]
@@ -382,16 +396,21 @@
                                [:> [:strpos :field_path "."] 0]]})
                      (catch Throwable e
                        (log/warnf e "error in get-nested-columns-for-tables for dataset: %s" dataset-id)))
-        nested-column-info (fn [{data-type :data_type field-path-str :field_path table-name :table_name}]
+        nested-column-info (fn [{data-type :data_type
+                                 field-path-str :field_path
+                                 table-name :table_name
+                                 description :description}]
                              (let [field-path (str/split field-path-str #"\.")
                                    [database-type base-type] (raw-type->database+base-type data-type)]
                                (when-let [nfc-path (not-empty (pop field-path))]
-                                 {:name (peek field-path)
-                                  :table-name table-name
-                                  :table-schema dataset-id
-                                  :database-type database-type
-                                  :base-type base-type
-                                  :nfc-path nfc-path})))]
+                                 (cond-> {:name (peek field-path)
+                                          :table-name table-name
+                                          :table-schema dataset-id
+                                          :database-type database-type
+                                          :base-type base-type
+                                          :nfc-path nfc-path}
+                                   (not (str/blank? description))
+                                   (assoc :field-comment description)))))]
     (transduce
      (keep nested-column-info)
      (completing
@@ -416,18 +435,21 @@
      (fn [{column-name :column_name
            data-type :data_type
            database-position :ordinal_position
-           partitioned? :partitioned}]
+           partitioned? :partitioned
+           description :description}]
        (let [database-position (or (some-> database-position dec) max-position)
              [database-type base-type] (raw-type->database+base-type data-type)]
          (cond-> [(maybe-add-nested-fields
                    nested-column-lookup
-                   {:name column-name
-                    :table-name table-name
-                    :table-schema dataset-id
-                    :database-type database-type
-                    :base-type base-type
-                    :database-partitioned partitioned?
-                    :database-position database-position}
+                   (cond-> {:name column-name
+                            :table-name table-name
+                            :table-schema dataset-id
+                            :database-type database-type
+                            :base-type base-type
+                            :database-partitioned partitioned?
+                            :database-position database-position}
+                     (not (str/blank? description))
+                     (assoc :field-comment description))
                    nil
                    database-position)]
            ;; _PARTITIONDATE does not appear so add it in if we see _PARTITIONTIME
@@ -444,11 +466,21 @@
 (defn- describe-dataset-fields-reducible
   [driver database project-id dataset-id table-names]
   (assert (seq table-names))
-  (let [named-rows-query {:select [:table_name :column_name :data_type :ordinal_position
-                                   [[:= :is_partitioning_column "YES"] :partitioned]]
+  (let [named-rows-query {:select [:c.table_name :c.column_name :c.data_type :c.ordinal_position
+                                   [[:= :c.is_partitioning_column "YES"] :partitioned]
+                                   ;; Column descriptions live in INFORMATION_SCHEMA.COLUMN_FIELD_PATHS rather than
+                                   ;; COLUMNS, so we LEFT JOIN on (table, column, field_path = column) to fetch the
+                                   ;; top-level field description. Nested field descriptions are handled by
+                                   ;; get-nested-columns-for-tables.
+                                   :cfp.description]
                           :from [[(information-schema-table project-id dataset-id "COLUMNS") :c]]
-                          :where [:in :table_name table-names]
-                          :order-by [:table_name]}
+                          :left-join [[(information-schema-table project-id dataset-id "COLUMN_FIELD_PATHS") :cfp]
+                                      [:and
+                                       [:= :c.table_name :cfp.table_name]
+                                       [:= :c.column_name :cfp.column_name]
+                                       [:= :cfp.field_path :c.column_name]]]
+                          :where [:in :c.table_name table-names]
+                          :order-by [:c.table_name]}
         named-rows (try (query-honeysql driver database named-rows-query)
                         (catch Throwable e
                           (log/warnf e "error in describe-fields for dataset: %s" dataset-id)))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -407,6 +407,70 @@
                     {:source-table (mt/id view-name)
                      :order-by     [[:asc (mt/id view-name :id)]]})))))))))
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                            Description sync (#18872)                                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(def ^:private descriptions-dataset
+  "Dataset for #18872 sync test. Carries table-level, top-level column, and nested RECORD subfield descriptions."
+  (tx/map->DatabaseDefinition
+   {:database-name "descriptions-dataset"
+    :options       {}
+    :table-definitions
+    [(tx/map->TableDefinition
+      {:table-name    "described_table"
+       :table-comment "Top-level table description for sync test (#18872)."
+       :rows          []
+       :field-definitions
+       [(tx/map->FieldDefinition
+         {:field-name    "described_text"
+          :base-type     :type/Text
+          :field-comment "Top-level column description for sync test (#18872)."})
+        (tx/map->FieldDefinition
+         {:field-name "undescribed_text"
+          :base-type  :type/Text})
+        (tx/map->FieldDefinition
+         {:field-name    "described_record"
+          :base-type     :type/Dictionary
+          :nested-fields [(tx/map->FieldDefinition
+                           {:field-name    "described_nested"
+                            :base-type     :type/Text
+                            :field-comment "Nested column description for sync test (#18872)."})
+                          (tx/map->FieldDefinition
+                           {:field-name "undescribed_nested"
+                            :base-type  :type/Text})]})]})]}))
+
+(deftest sync-descriptions-test
+  (testing "BigQuery driver propagates table and column descriptions during sync (#18872)"
+    (mt/test-driver
+      :bigquery-cloud-sdk
+      (mt/dataset
+        descriptions-dataset
+        (let [table-name  "described_table"
+              schema-name (get-test-data-name)]
+          (testing "describe-database carries the table-level description"
+            (let [tables    (:tables (driver/describe-database :bigquery-cloud-sdk (mt/db)))
+                  described (first (filter #(= table-name (:name %)) tables))]
+              (is (some? described)
+                  "the test table should be visible to describe-database")
+              (is (= "Top-level table description for sync test (#18872)."
+                     (:description described)))))
+          (testing "describe-fields carries top-level column descriptions"
+            (let [fields  (into [] (driver/describe-fields :bigquery-cloud-sdk (mt/db)
+                                                           {:table-names  [table-name]
+                                                            :schema-names [schema-name]}))
+                  by-name (into {} (map (juxt :name identity)) fields)]
+              (is (= "Top-level column description for sync test (#18872)."
+                     (:field-comment (by-name "described_text"))))
+              (testing "columns without a BigQuery description are emitted without :field-comment"
+                (is (not (contains? (by-name "undescribed_text") :field-comment))))
+              (testing "RECORD subfield descriptions are also propagated"
+                (let [nested-by-name (into {} (map (juxt :name identity))
+                                           (:nested-fields (by-name "described_record")))]
+                  (is (= "Nested column description for sync test (#18872)."
+                         (:field-comment (nested-by-name "described_nested"))))
+                  (is (not (contains? (nested-by-name "undescribed_nested") :field-comment))))))))))))
+
 (deftest sync-materialized-view-test
   (mt/test-driver
     :bigquery-cloud-sdk

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -182,7 +182,7 @@
 (defn- field-definitions->Fields [field-definitions]
   (into
    []
-   (map (fn [{:keys [field-name base-type nested-fields collection-type]}]
+   (map (fn [{:keys [field-name base-type nested-fields collection-type field-comment]}]
           (let [field-type (or (some-> collection-type base-type->bigquery-type)
                                (base-type->bigquery-type base-type)
                                (let [message (format "Don't know what BigQuery type to use for base type: %s" base-type)]
@@ -193,27 +193,35 @@
                          (LegacySQLTypeName/valueOf (name field-type))
                          ^"[Lcom.google.cloud.bigquery.Field;" (into-array Field (field-definitions->Fields nested-fields)))]
             (cond-> builder
-              (isa? :type/Collection base-type) (.setMode Field$Mode/REPEATED)
-              :always (.build)))))
+              (isa? :type/Collection base-type)  (.setMode Field$Mode/REPEATED)
+              (not (str/blank? field-comment))   (.setDescription ^String field-comment)
+              :always                            (.build)))))
    field-definitions))
 
 (defn- create-table*!
-  [dataset-id table-id field-definitions]
-  (let [tbl-id (TableId/of dataset-id table-id)
-        schema (Schema/of (u/varargs Field (field-definitions->Fields (cons {:field-name "id"
-                                                                             :base-type :type/Integer}
-                                                                            field-definitions))))
-        tbl    (TableInfo/of tbl-id (StandardTableDefinition/of schema))]
-    (.create (bigquery) tbl (u/varargs BigQuery$TableOption))))
+  ([dataset-id table-id field-definitions]
+   (create-table*! dataset-id table-id field-definitions nil))
+  ([dataset-id table-id field-definitions table-comment]
+   (let [tbl-id              (TableId/of dataset-id table-id)
+         schema              (Schema/of (u/varargs Field (field-definitions->Fields (cons {:field-name "id"
+                                                                                           :base-type :type/Integer}
+                                                                                          field-definitions))))
+         ^TableInfo tbl-info (cond-> (TableInfo/newBuilder tbl-id (StandardTableDefinition/of schema))
+                               (not (str/blank? table-comment)) (.setDescription ^String table-comment)
+                               :always                          (.build))]
+     (.create (bigquery) tbl-info (u/varargs BigQuery$TableOption)))))
 
 (mu/defn- create-table!
-  [^String dataset-id :- ::lib.schema.common/non-blank-string
-   ^String table-id :- ::lib.schema.common/non-blank-string
-   field-definitions]
-  (create-table*! dataset-id table-id field-definitions)
-  ;; now verify that the Table was created
-  (.listTables (bigquery) dataset-id (u/varargs BigQuery$TableListOption))
-  (log/info (u/format-color 'blue "Created BigQuery table `%s.%s.%s`." (project-id) dataset-id table-id)))
+  ([dataset-id table-id field-definitions]
+   (create-table! dataset-id table-id field-definitions nil))
+  ([^String dataset-id :- ::lib.schema.common/non-blank-string
+    ^String table-id :- ::lib.schema.common/non-blank-string
+    field-definitions
+    table-comment]
+   (create-table*! dataset-id table-id field-definitions table-comment)
+   ;; now verify that the Table was created
+   (.listTables (bigquery) dataset-id (u/varargs BigQuery$TableListOption))
+   (log/info (u/format-color 'blue "Created BigQuery table `%s.%s.%s`." (project-id) dataset-id table-id))))
 
 (defn- table-row-count ^Integer [^String dataset-id, ^String table-id]
   (let [sql (format "SELECT count(*) FROM `%s.%s.%s`" (project-id) dataset-id table-id)]
@@ -321,9 +329,9 @@
       (assoc (zipmap field-names row)
              :id (inc i)))))
 
-(defn- load-tabledef! [dataset-id {:keys [table-name field-definitions], :as tabledef}]
+(defn- load-tabledef! [dataset-id {:keys [table-name field-definitions table-comment], :as tabledef}]
   (let [table-name (normalize-name table-name)]
-    (create-table! dataset-id table-name field-definitions)
+    (create-table! dataset-id table-name field-definitions table-comment)
     (when (seq (:rows tabledef))
       ;; retry the `insert-data!` step up to 5 times because it seems to fail silently a lot. Since each row is given a
       ;; unique key it shouldn't result in duplicates.


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18872

### Description

The BigQuery driver previously didn't read description metadata from `INFORMATION_SCHEMA` during sync, so `metabase_table.description` and `metabase_field.description` stayed empty even when descriptions existed at the source. Admins had to fill them in manually via Table Metadata (or via the API).

Three changes in `bigquery_cloud_sdk.clj`:

- **Table descriptions** come from `INFORMATION_SCHEMA.TABLE_OPTIONS` (rows where `option_name = 'description'`). BigQuery stores option values as DDL string literals with JSON-style escaping, so `JSON_VALUE` unwraps the literal cleanly.
- **Top-level column descriptions** come from `INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`, LEFT JOINed against `COLUMNS` (which doesn't expose a `description` column on the BigQuery side). The join condition `cfp.field_path = c.column_name` keeps this to top-level fields.
- **Nested STRUCT/RECORD subfield descriptions** flow through the existing `get-nested-columns-for-tables` path with `description` added to its SELECT.

All three paths wire into the existing `:description` and `:field-comment` keys that `metabase.sync.sync-metadata.tables` / `fields.sync-metadata` already handle, so they inherit the same "only write when destination is blank" semantics that the Postgres/MySQL drivers use today. Admin-edited descriptions are not overwritten.

The BigQuery test fixture is extended so test datasets can attach descriptions via `Field.Builder.setDescription` and `TableInfo.Builder.setDescription`.

### How to verify

```
DRIVERS=bigquery-cloud-sdk clojure -X:dev:drivers:drivers-dev:test \
  :only metabase.driver.bigquery-cloud-sdk-test/sync-descriptions-test
```

Result locally against a real BigQuery project: `Ran 1 tests in 26.824 seconds. 6 assertions, 0 failures, 0 errors.` The test covers table-level descriptions, top-level column descriptions, nested RECORD subfield descriptions, and the case where a column has no description (verifies absent descriptions don't surface as empty strings).

### Out of scope

- Refreshing descriptions when they change on the source side after Metabase already has one — controlled by the sync framework's existing "first-sync-only" logic (#70029), not the driver.
- Equivalent fixes for SQL Server (#18500), Oracle (#12974), and Trino/Presto/Athena (#56022) — happy to follow up in separate PRs.

### Checklist

- [x] Tests added for the new sync path
- [x] Verified locally against a real BigQuery project
- [x] CLA signed
