### PR TITLE
Migrate Event Timeline menus to mantine, allow close on click outside

### DIFF
--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.tsx
@@ -1,8 +1,8 @@
 import { memo } from "react";
 import { t } from "ttag";
 
-import { EntityMenu } from "metabase/common/components/EntityMenu";
-import { Link } from "metabase/common/components/Link";
+import { ForwardRefLink, Link } from "metabase/common/components/Link";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import Settings from "metabase/utils/settings";
 import { formatDateTimeWithUnit } from "metabase/visualizations/lib/formatting";
@@ -65,7 +65,14 @@ const EventCard = ({
       </CardBody>
       {menuItems.length > 0 && (
         <CardAside>
-          <EntityMenu items={menuItems} triggerIcon="ellipsis" />
+          <Menu position="bottom-end" shadow="md">
+            <Menu.Target>
+              <ActionIcon variant="subtle" aria-label={t`Event menu`}>
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>{menuItems}</Menu.Dropdown>
+          </Menu>
         </CardAside>
       )}
     </CardRoot>
@@ -84,29 +91,36 @@ const getMenuItems = (
 
   if (!event.archived) {
     return [
-      {
-        title: t`Edit event`,
-        link: Urls.editEventInCollection(event, timeline),
-      },
-      {
-        title: t`Move event`,
-        link: Urls.moveEventInCollection(event, timeline),
-      },
-      {
-        title: t`Archive event`,
-        action: () => onArchive?.(event),
-      },
+      <Menu.Item
+        key="edit-event"
+        component={ForwardRefLink}
+        to={Urls.editEventInCollection(event, timeline)}
+      >
+        {t`Edit event`}
+      </Menu.Item>,
+      <Menu.Item
+        key="move-event"
+        component={ForwardRefLink}
+        to={Urls.moveEventInCollection(event, timeline)}
+      >
+        {t`Move event`}
+      </Menu.Item>,
+      <Menu.Item key="archive-event" onClick={() => onArchive?.(event)}>
+        {t`Archive event`}
+      </Menu.Item>,
     ];
   } else {
     return [
-      {
-        title: t`Unarchive event`,
-        action: () => onUnarchive?.(event),
-      },
-      {
-        title: t`Delete event`,
-        link: Urls.deleteEventInCollection(event, timeline),
-      },
+      <Menu.Item key="unarchive-event" onClick={() => onUnarchive?.(event)}>
+        {t`Unarchive event`}
+      </Menu.Item>,
+      <Menu.Item
+        key="delete-event"
+        component={ForwardRefLink}
+        to={Urls.deleteEventInCollection(event, timeline)}
+      >
+        {t`Delete event`}
+      </Menu.Item>,
     ];
   }
 };

--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
@@ -80,7 +80,7 @@ describe("EventCard", () => {
 
     render(<EventCard {...props} />);
     await userEvent.click(screen.getByLabelText("ellipsis icon"));
-    await screen.findByRole("dialog");
+    await screen.findByRole("menu");
 
     expect(screen.getByText("Edit event")).toBeInTheDocument();
     expect(screen.getByText("Archive event")).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe("EventCard", () => {
 
     render(<EventCard {...props} />);
     await userEvent.click(screen.getByLabelText("ellipsis icon"));
-    await screen.findByRole("dialog");
+    await screen.findByRole("menu");
 
     expect(screen.getByText("Unarchive event")).toBeInTheDocument();
     expect(screen.getByText("Delete event")).toBeInTheDocument();

--- a/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.tsx
@@ -1,11 +1,12 @@
 import { memo } from "react";
 import { msgid, ngettext, t } from "ttag";
 
-import { EntityMenu } from "metabase/common/components/EntityMenu";
+import { ForwardRefLink } from "metabase/common/components/Link";
 import {
   getEventCount,
   getTimelineName,
 } from "metabase/common/utils/timelines";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { IconName, Timeline } from "metabase-types/api";
 
@@ -46,7 +47,14 @@ const TimelineCard = ({
       </CardBody>
       {hasMenuItems && (
         <CardMenu>
-          <EntityMenu items={menuItems} triggerIcon="ellipsis" />
+          <Menu position="bottom-end" shadow="md">
+            <Menu.Target>
+              <ActionIcon variant="subtle" aria-label={t`Timeline menu`}>
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>{menuItems}</Menu.Dropdown>
+          </Menu>
         </CardMenu>
       )}
       {hasEventCount && (
@@ -71,14 +79,16 @@ const getMenuItems = (
   }
 
   return [
-    {
-      title: t`Unarchive timeline`,
-      action: () => onUnarchive?.(timeline),
-    },
-    {
-      title: t`Delete timeline`,
-      link: Urls.deleteTimelineInCollection(timeline),
-    },
+    <Menu.Item key="unarchive-timeline" onClick={() => onUnarchive?.(timeline)}>
+      {t`Unarchive timeline`}
+    </Menu.Item>,
+    <Menu.Item
+      key="delete-timeline"
+      component={ForwardRefLink}
+      to={Urls.deleteTimelineInCollection(timeline)}
+    >
+      {t`Delete timeline`}
+    </Menu.Item>,
   ];
 };
 

--- a/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -2,18 +2,18 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { EntityMenu } from "metabase/common/components/EntityMenu";
 import type { InputProps } from "metabase/common/components/Input";
+import { ForwardRefLink } from "metabase/common/components/Link";
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { getTimelineName } from "metabase/common/utils/timelines";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import ModalHeader from "metabase/timelines/common/components/ModalHeader";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import { parseTimestamp } from "metabase/utils/time-dayjs";
 import type { Timeline, TimelineEvent } from "metabase-types/api";
 
-import type { MenuItem } from "../../types";
 import EventList from "../EventList";
 import SearchEmptyState from "../SearchEmptyState";
 import TimelineEmptyState from "../TimelineEmptyState";
@@ -81,7 +81,14 @@ const TimelineDetailsModal = ({
         onGoBack={canGoBack ? handleGoBack : undefined}
       >
         {menuItems.length > 0 && (
-          <EntityMenu items={menuItems} triggerIcon="ellipsis" />
+          <Menu position="bottom-end" shadow="md">
+            <Menu.Target>
+              <ActionIcon variant="subtle" aria-label={t`Timeline menu`}>
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>{menuItems}</Menu.Dropdown>
+          </Menu>
         )}
       </ModalHeader>
       {(isNotEmpty || isSearching) && (
@@ -148,37 +155,56 @@ const getMenuItems = (
   isArchive: boolean,
   isOnlyTimeline: boolean,
 ) => {
-  const items: MenuItem[] = [];
+  const items: JSX.Element[] = [];
 
   if (timeline.collection?.can_write && !isArchive) {
     items.push(
-      {
-        title: t`New timeline`,
-        link: Urls.newTimelineInCollection(timeline.collection),
-      },
-      {
-        title: t`Edit timeline details`,
-        link: Urls.editTimelineInCollection(timeline),
-      },
-      {
-        title: t`Move timeline`,
-        link: Urls.moveTimelineInCollection(timeline),
-      },
+      <Menu.Item
+        key="new-timeline"
+        component={ForwardRefLink}
+        to={Urls.newTimelineInCollection(timeline.collection)}
+      >
+        {t`New timeline`}
+      </Menu.Item>,
+      <Menu.Item
+        key="edit-timeline-details"
+        component={ForwardRefLink}
+        to={Urls.editTimelineInCollection(timeline)}
+      >
+        {t`Edit timeline details`}
+      </Menu.Item>,
+      <Menu.Item
+        key="move-timeline"
+        component={ForwardRefLink}
+        to={Urls.moveTimelineInCollection(timeline)}
+      >
+        {t`Move timeline`}
+      </Menu.Item>,
     );
   }
 
   if (!isArchive) {
-    items.push({
-      title: t`View archived events`,
-      link: Urls.timelineArchiveInCollection(timeline),
-    });
+    items.push(
+      <Menu.Item
+        key="view-archived-events"
+        component={ForwardRefLink}
+        to={Urls.timelineArchiveInCollection(timeline)}
+      >
+        {t`View archived events`}
+      </Menu.Item>,
+    );
   }
 
   if (isOnlyTimeline) {
-    items.push({
-      title: t`View archived timelines`,
-      link: Urls.timelinesArchiveInCollection(timeline.collection),
-    });
+    items.push(
+      <Menu.Item
+        key="view-archived-timelines"
+        component={ForwardRefLink}
+        to={Urls.timelinesArchiveInCollection(timeline.collection)}
+      >
+        {t`View archived timelines`}
+      </Menu.Item>,
+    );
   }
 
   return items;

--- a/frontend/src/metabase/timelines/collections/components/TimelineListModal/TimelineListModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineListModal/TimelineListModal.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import { EntityMenu } from "metabase/common/components/EntityMenu";
+import { ForwardRefLink } from "metabase/common/components/Link";
 import {
   getDefaultTimelineName,
   getSortedTimelines,
 } from "metabase/common/utils/timelines";
 import ModalHeader from "metabase/timelines/common/components/ModalHeader";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Collection, Timeline } from "metabase-types/api";
 
@@ -60,7 +61,14 @@ const TimelineListModal = ({
         pathOptions={pathOptions}
       >
         {hasMenuItems && (
-          <EntityMenu items={menuItems} triggerIcon="ellipsis" />
+          <Menu position="bottom-end" shadow="md">
+            <Menu.Target>
+              <ActionIcon variant="subtle" aria-label={t`Timelines menu`}>
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>{menuItems}</Menu.Dropdown>
+          </Menu>
         )}
       </ModalHeader>
       <ModalBody isTopAligned={hasTimelines}>
@@ -96,14 +104,20 @@ const getMenuItems = (collection: Collection, isArchive: boolean) => {
   }
 
   return [
-    {
-      title: t`New timeline`,
-      link: Urls.newTimelineInCollection(collection),
-    },
-    {
-      title: t`View archived timelines`,
-      link: Urls.timelinesArchiveInCollection(collection),
-    },
+    <Menu.Item
+      key="new-timeline"
+      component={ForwardRefLink}
+      to={Urls.newTimelineInCollection(collection)}
+    >
+      {t`New timeline`}
+    </Menu.Item>,
+    <Menu.Item
+      key="view-archived-timelines"
+      component={ForwardRefLink}
+      to={Urls.timelinesArchiveInCollection(collection)}
+    >
+      {t`View archived timelines`}
+    </Menu.Item>,
   ];
 };
 

--- a/frontend/src/metabase/timelines/collections/routes.tsx
+++ b/frontend/src/metabase/timelines/collections/routes.tsx
@@ -23,7 +23,9 @@ const getRoutes = () => {
         {...{
           path: "timelines",
           modal: TimelineIndexModal,
-          modalProps: { enableTransition: false },
+          // enableMouseEvents lets Mantine's click-outside detection work
+          // for the overflow menus inside (UXW-264).
+          modalProps: { enableTransition: false, enableMouseEvents: true },
         }}
       />
       <ModalRoute
@@ -37,14 +39,16 @@ const getRoutes = () => {
         {...{
           path: "timelines/archive",
           modal: TimelineListArchiveModal,
-          modalProps: { enableTransition: false },
+          modalProps: { enableTransition: false, enableMouseEvents: true },
         }}
       />
       <ModalRoute
         {...{
           path: "timelines/:timelineId",
           modal: TimelineDetailsModal,
-          modalProps: { enableTransition: false },
+          // enableMouseEvents lets Mantine's click-outside detection work
+          // for the overflow menus inside (UXW-264).
+          modalProps: { enableTransition: false, enableMouseEvents: true },
         }}
       />
       <ModalRoute
@@ -66,7 +70,7 @@ const getRoutes = () => {
         {...{
           path: "timelines/:timelineId/archive",
           modal: TimelineArchiveModal,
-          modalProps: { enableTransition: false },
+          modalProps: { enableTransition: false, enableMouseEvents: true },
         }}
       />
       <ModalRoute

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -3,8 +3,8 @@ import { memo, useCallback } from "react";
 import { t } from "ttag";
 
 import { CheckBox as Checkbox } from "metabase/common/components/CheckBox/CheckBox";
-import { EntityMenu } from "metabase/common/components/EntityMenu";
 import { useScrollOnMount } from "metabase/common/hooks/use-scroll-on-mount";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import Settings from "metabase/utils/settings";
 import { formatDateTimeWithUnit } from "metabase/visualizations/lib/formatting";
 import type { IconName, Timeline, TimelineEvent } from "metabase-types/api";
@@ -100,7 +100,14 @@ const EventCard = ({
       </CardBody>
       {menuItems.length > 0 && (
         <CardAside onClick={handleAsideClick}>
-          <EntityMenu items={menuItems} triggerIcon="ellipsis" />
+          <Menu position="bottom-end" shadow="md">
+            <Menu.Target>
+              <ActionIcon variant="subtle" aria-label={t`Event menu`}>
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>{menuItems}</Menu.Dropdown>
+          </Menu>
         </CardAside>
       )}
     </CardRoot>
@@ -119,18 +126,15 @@ const getMenuItems = (
   }
 
   return [
-    {
-      title: t`Edit event`,
-      action: () => onEdit?.(event),
-    },
-    {
-      title: t`Move event`,
-      action: () => onMove?.(event),
-    },
-    {
-      title: t`Archive event`,
-      action: () => onArchive?.(event),
-    },
+    <Menu.Item key="edit-event" onClick={() => onEdit?.(event)}>
+      {t`Edit event`}
+    </Menu.Item>,
+    <Menu.Item key="move-event" onClick={() => onMove?.(event)}>
+      {t`Move event`}
+    </Menu.Item>,
+    <Menu.Item key="archive-event" onClick={() => onArchive?.(event)}>
+      {t`Archive event`}
+    </Menu.Item>,
   ];
 };
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #41617
### Description

Migrates Collection Event Timeline management away from <EntityMenu> and to <Menu>, but also fixes the click events not getting to the menus allowing them to close. 

Note: I didn't add tests here because this seemed like it's built in functionality that should just work. The real fix is asserting that the Modal no longer captures mouse events. Adding an e2e is possible if we want

### How to verify

1. Go to a collection
2. open up events
3. The entity menus should now close when clicking outside the dropdowns when they're open

### Demo


https://github.com/user-attachments/assets/00081ace-388a-4b11-8e56-fdb56a6f4c0e



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
