### PR TITLE
Move from deprecated param parsing code to Lib version in config files

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2666,6 +2666,7 @@
            api-keys
            app-db
            driver
+           lib
            permissions
            premium-features
            settings

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -101,19 +101,16 @@
    [metabase-enterprise.advanced-config.file.interface :as advanced-config.file.i]
    [metabase-enterprise.advanced-config.file.settings]
    [metabase-enterprise.advanced-config.file.users]
-   ;; TODO (Cam 10/3/25) -- update this to use the Lib versions of these namespaces
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters]
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters.parse :as params.parse]
+   [metabase.lib.core :as lib]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [metabase.util.yaml :as yaml]))
 
 (comment
-  ;; for parameter parsing
-  metabase.driver.common.parameters/keep-me
   ;; for `settings:` section code
   metabase-enterprise.advanced-config.file.settings/keep-me
   ;; for `databases:` section code
@@ -190,7 +187,7 @@
 
 (defmulti ^:private expand-template-str-part
   {:arglists '([part])}
-  type)
+  (some-fn :lib/type type))
 
 (defmethod expand-template-str-part String
   [s]
@@ -204,8 +201,8 @@
   (s/or :env (s/cat :template-type (s/and symbol? valid-template-type?)
                     :env-var-name  symbol?)))
 
-(defmethod expand-template-str-part metabase.driver.common.parameters.Param
-  [{s :k}]
+(mu/defmethod expand-template-str-part :metabase.lib.parameters.parse.types/param
+  [{s :k} :- :metabase.lib.parameters.parse.types/param]
   {:pre [(string? s)]}
   (when (seq s)
     (when-let [obj (try
@@ -216,16 +213,16 @@
       (s/assert* ::template-form obj)
       (expand-parsed-template-form obj))))
 
-(defmethod expand-template-str-part metabase.driver.common.parameters.Optional
-  [{:keys [args]}]
+(mu/defmethod expand-template-str-part :metabase.lib.parameters.parse.types/optional
+  [{:keys [args]} :- :metabase.lib.parameters.parse.types/optional]
   (let [parts (map expand-template-str-part args)]
     (when (every? seq parts)
       (str/join parts))))
 
 (defn- expand-templates-in-str [s]
-  (if-let [[_, raw-string] (re-matches #"\{\{\{(.+)\}\}\}" s)]
+  (if-let [[_ raw-string] (re-matches #"\{\{\{(.+)\}\}\}" s)]
     (str/trim raw-string)
-    (str/join (map expand-template-str-part (params.parse/parse s)))))
+    (str/join (map expand-template-str-part (lib/parse-parameters s)))))
 
 (defn- expand-templates [m]
   (walk/postwalk

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -49,7 +49,7 @@
   [{:parser #(= % "today")
     :range  (fn [_ dt]
               (let [dt-res (t/local-date dt)]
-                {:start dt-res,
+                {:start dt-res
                  :end   dt-res
                  :unit  :day}))
     :filter (fn [_ field-clause]

--- a/src/metabase/driver/common/parameters/parse.clj
+++ b/src/metabase/driver/common/parameters/parse.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.common.parameters.parse
   "DEPRECATED: `driver.common.parameters.*` namespaces deal with legacy MBQL queries. Migrate to MBQL-5-friendly
-  replacement namespaces. The replacement for this namespace is [[metabase.lib.parameters.parse]]."
+  replacement namespaces. The replacement for this namespace is [[metabase.lib.parameters.parse]]
+  (aliased as [[metabase.lib.core/parse-parameters]])."
   {:deprecated "0.57.0"}
   (:require
    [clojure.string :as str]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1674,3 +1674,16 @@
   Prefer this over setting the `:case-sensitive false` option directly."
   [boolean-expression :- ::lib.schema.expression/boolean]
   (lib.options/update-options boolean-expression assoc :case-sensitive false))
+
+(mu/defn parse-parameters :- [:sequential ::lib.parameters.parse/parsed-token]
+  "Attempts to parse parameters in string `s`. Parses any optional clauses or parameters found, and returns a sequence
+   of non-parameter string fragments (possibly) interposed with `Param` or `Optional` instances.
+
+   If `handle-sql-comments` is true (default) then we make a best effort to ignore params in SQL comments.
+
+  **Code Health:** Healthy"
+  ([s :- :string]
+   (lib.parameters.parse/parse s))
+  ([s                   :- :string
+    handle-sql-comments :- :boolean]
+   (lib.parameters.parse/parse s handle-sql-comments)))


### PR DESCRIPTION
Pursuant to QUE2-420

This is the first in a series of PRs where I'll move everything from the old parameter code in `drivers.common` to the modern stuff in Lib and friends