### PR TITLE
Use Lib parameter parsing in HTTP actions

### DIFF
--- a/src/metabase/actions/http_action.clj
+++ b/src/metabase/actions/http_action.clj
@@ -2,13 +2,13 @@
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters :as params]
-   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters.parse :as params.parse]
+   [metabase.lib.core :as lib]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu])
   (:import
    (com.fasterxml.jackson.databind ObjectMapper)
    (net.thisptr.jackson.jq BuiltinFunctionLoader JsonQuery Output Scope Versions)))
@@ -27,18 +27,25 @@
 ;; May go away if parameters substitution is taken out of query-processing/db dependency
 (declare substitute*)
 
-(defn- substitute-param [param->value [sql missing] _in-optional? {:keys [k]}]
+(mu/defn- substitute-param
+  [param->value
+   [sql missing]
+   _in-optional?
+   {:keys [k]} :- :metabase.lib.parameters.parse.types/param]
   (if-not (contains? param->value k)
     [sql (conj missing k)]
     (let [v (get param->value k)]
       (cond
-        (= params/no-value v)
+        (= v :metabase.lib.parameters.parse.types/no-value)
         [sql (conj missing k)]
 
         :else
         [(str sql v) missing]))))
 
-(defn- substitute-optional [param->value [sql missing] {subclauses :args}]
+(mu/defn- substitute-optional
+  [param->value
+   [sql missing]
+   {subclauses :args} :- :metabase.lib.parameters.parse.types/optional]
   (let [[opt-sql opt-missing] (substitute* param->value subclauses true)]
     (if (seq opt-missing)
       [sql missing]
@@ -53,15 +60,15 @@
        (string? x)
        [(str sql x) missing]
 
-       (params/Param? x)
+       (= (:lib/type x) :metabase.lib.parameters.parse.types/param)
        (substitute-param param->value [sql missing] in-optional? x)
 
-       (params/Optional? x)
+       (= (:lib/type x) :metabase.lib.parameters.parse.types/optional)
        (substitute-optional param->value [sql missing] x)))
    nil
    parsed))
 
-(defn substitute
+(defn- substitute
   "Substitute `Optional` and `Param` objects in a `parsed-template`, a sequence of parsed string fragments and tokens, with
   the values from the map `param->value` (using logic from `substitution` to decide what replacement SQL should be
   generated).
@@ -90,7 +97,7 @@
 (defn- parse-and-substitute [s params->value]
   (when s
     (-> s
-        params.parse/parse
+        lib/parse-parameters
         (substitute params->value))))
 ;;
 

--- a/src/metabase/lib/parameters/parse/types.cljc
+++ b/src/metabase/lib/parameters/parse/types.cljc
@@ -10,12 +10,16 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
+;; TODO (Cam 2025-05-14) Consider whether to remove this and the predicate functions below and just rely on the types
+;; directly
 (def no-value
   "Convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param
   values."
   ::no-value)
 
 (mr/def ::no-value
+  "Convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param
+  values."
   [:= ::no-value])
 
 (mr/def ::field-filter.value.map

--- a/test/metabase/actions/http_action_test.clj
+++ b/test/metabase/actions/http_action_test.clj
@@ -1,0 +1,19 @@
+(ns metabase.actions.http-action-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.actions.http-action :as actions.http-action]))
+
+(deftest ^:parallel parse-and-substitute-test
+  (are [params expected] (= expected
+                            (#'actions.http-action/parse-and-substitute "https://example.com/{{param}}[[/{{optional-param}}]]" params))
+    {"param" "X"}
+    "https://example.com/X"
+
+    {"param" "X", "optional-param" "Y"}
+    "https://example.com/X/Y"))
+
+(deftest ^:parallel parse-and-substitute-error-test
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"\QCannot call the service: missing required parameters: param\E"
+       (#'actions.http-action/parse-and-substitute "https://example.com/{{param}}[[/{{optional-param}}]]" nil))))


### PR DESCRIPTION
Pursuant to [QUE2-420](https://linear.app/metabase/issue/QUE2-420)

Number two in a series of PRs where I'll move everything from the old parameter code in `drivers.common` to the modern stuff in Lib and friends