### PR TITLE
[perms] Cap perms for audit collection at `:read`, don't throw on `:write`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -62,18 +62,19 @@
                           outer-query)))))))
 
 (defenterprise update-audit-collection-permissions!
-  "Will remove or grant audit db (AppDB) permissions, if the instance analytics collection permissions changes. This
-  technically isn't necessary, because we block all audit DB queries if a user doesn't have collection permissions.
-  But it's cleaner to keep the audit DB permission paths in the database consistent."
+  "Updates audit db (AppDB) permissions when the instance analytics collection permissions change, and downgrades
+  :write to :read for the audit collection (it must never be writable). Returns the (possibly modified) changes map."
   :feature :audit-app
   [group-id changes]
-  (let [[change-id tyype] (first (filter #(= (first %) (:id (audit/default-audit-collection))) changes))]
-    (when change-id
+  (let [audit-collection-id (:id (audit/default-audit-collection))
+        [change-id tyype] (first (filter #(= (first %) audit-collection-id) changes))]
+    (if change-id
       (let [create-queries-value (case tyype
-                                   :read  :query-builder
-                                   :none  :no
-                                   :write (throw (ex-info (tru "Unable to make audit collections writable.")
-                                                          {:status-code 400})))
+                                   (:read :write) :query-builder
+                                   :none  :no)
             view-tables         (t2/select :model/Table :db_id audit/audit-db-id :name [:in audit-db-view-names])]
         (doseq [table view-tables]
-          (perms/set-table-permission! group-id table :perms/create-queries create-queries-value))))))
+          (perms/set-table-permission! group-id table :perms/create-queries create-queries-value))
+        (cond-> changes
+          (= tyype :write) (assoc audit-collection-id :read)))
+      changes)))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -116,11 +116,14 @@
           (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id (:id collection)] :read))
           (is (= :unrestricted (data-perms/table-permission-for-groups #{group-id} :perms/view-data database-id (:id view-table))))
           (is (= :query-builder (data-perms/table-permission-for-groups #{group-id} :perms/create-queries database-id (:id view-table)))))
-        (testing "Unable to update instance analytics to writable"
-          (is (thrown-with-msg?
-               Exception
-               #"Unable to make audit collections writable."
-               (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id (:id collection)] :write)))))))))
+        (testing "Setting audit collection to :write downgrades to :read instead of throwing (#71300)"
+          (update-graph! (assoc-in (graph :clear-revisions? true :collections [collection] :groups [group-id])
+                                   [:groups group-id (:id collection)] :write))
+          (is (= :read (get-in (graph :clear-revisions? true :collections [collection] :groups [group-id])
+                               [:groups group-id (:id collection)]))
+              "Audit collection permission should be stored as :read, not :write")
+          (is (= :unrestricted (data-perms/table-permission-for-groups #{group-id} :perms/view-data database-id (:id view-table))))
+          (is (= :query-builder (data-perms/table-permission-for-groups #{group-id} :perms/create-queries database-id (:id view-table)))))))))
 
 ;; TODO: re-enable these tests once they're no longer flaky
 (defn install-audit-db-if-needed!

--- a/src/metabase/permissions/models/collection/graph.clj
+++ b/src/metabase/permissions/models/collection/graph.clj
@@ -212,8 +212,8 @@
 
 (defenterprise update-audit-collection-permissions!
   "OSS implementation of `audit-db/update-audit-collection-permissions!`, which is an enterprise feature, so does nothing in the OSS
-  version."
-  metabase-enterprise.audit-app.permissions [_ _] ::noop)
+  version. Returns the changes map unchanged."
+  metabase-enterprise.audit-app.permissions [_ changes] changes)
 
 (defn create-perms-revision!
   "Increments the current revision number and writes it to the database. This lets us track the permissions graph
@@ -336,8 +336,8 @@
      (when (seq changes)
        (let [revision-id (t2/with-transaction [_conn]
                            (doseq [[group-id changes] changes]
-                             (update-audit-collection-permissions! group-id changes)
-                             (update-group-permissions! collection-namespace group-id changes))
+                             (let [changes (update-audit-collection-permissions! group-id changes)]
+                               (update-group-permissions! collection-namespace group-id changes)))
                            (:id (create-perms-revision! (:revision old-graph))))]
          ;; The graph is updated infrequently, but `diff-old` and `old-graph` can get huge on larger instances.
          (perms.u/log-permissions-changes diff-old changes)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71300
Fixes UXW-3396.

**NOTE:** As always, permissions changes need extra care! I don't have a very clear sense of the intended behaviour
for permissions on the magic Audit collection. My understanding is that no one, including admins, can have `:write`
permissions for it, but groups can be set to `:none` or `:read`.

There might be unintended consequences of this change, if the rewrite of a requested `:write` to a `:read` breaks things.
I don't know if there's prior art for this.

### Description

Trying to set `:write` perms for a collection including the magic Audit
collections while setting `Include Subfolders` was throwing a 400.

The cause was that it tried to set `:write` perms for the Audit collection,
which threw an error. This change updates it to treat `:write` as `:read`,
so that the permissions update can succeed.

The FE handles `Include Subfolders` by fetching the tree of
subcollections, and it doesn't handle the Audit collection specially.

### How to verify

See the steps in the issue.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
