### PR TITLE
search: add :metabot weights context and curation-tier scorers

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
@@ -39,50 +39,50 @@
   be attempted."
   3)
 
+(defn- alter-index-tables!
+  "Run `alter-fn` against each existing index table whose `index_version` is below `target-version`, then bump those
+   rows' `index_version` to `target-version`. `alter-fn` is `(fn [execute! table-name])`. Tables listed in
+   `index_metadata` but missing from the database (e.g. dropped externally) are skipped — leaving the metadata row
+   in place to be cleaned up or re-created elsewhere."
+  [tx index-metadata target-version alter-fn]
+  (let [metadata-table  (keyword (:metadata-table-name index-metadata))
+        execute!        (fn [q] (jdbc/execute! tx (sql/format q)))
+        candidate-names (->> (execute! {:select-distinct [:table_name]
+                                        :from            [metadata-table]
+                                        :where           [[:< :index_version target-version]]})
+                             (mapcat vals))
+        existing-names  (when (seq candidate-names)
+                          (->> (execute! {:select [:tablename]
+                                          :from   [:pg_tables]
+                                          :where  [:in :tablename (vec candidate-names)]})
+                               (mapcat vals)
+                               set))
+        table-names     (filter existing-names candidate-names)]
+    (when (seq table-names)
+      (doseq [table-name table-names]
+        (alter-fn execute! table-name))
+      (execute! {:update metadata-table
+                 :set    {:index_version target-version}
+                 :where  [[:in :table_name (vec table-names)]]}))))
+
 (defn- add-personal-owner-id-column!
   "Migration 2: Add `personal_owner_id` column to index tables for SQL-level personal collection filtering."
   [tx index-metadata]
-  (let [index-metadata (keyword (:metadata-table-name index-metadata))
-        execute!       (fn [q] (jdbc/execute! tx (sql/format q)))
-        table-names    (->> (execute! {:select-distinct [:table_name]
-                                       :from            [index-metadata]
-                                       :where           [[:< :index_version 2]]})
-                            (mapcat vals))]
-    (when (seq table-names)
-      (doseq [table-name table-names]
-        (execute! {:alter-table [(keyword table-name)]
-                   :add-column  [[:personal_owner_id :int :if-not-exists]]}))
-      (execute! {:update index-metadata
-                 :set    {:index_version 2}
-                 :where  [[:in :table_name (vec table-names)]]}))))
+  (alter-index-tables! tx index-metadata 2
+                       (fn [execute! table-name]
+                         (execute! {:alter-table [(keyword table-name)]
+                                    :add-column  [[:personal_owner_id :int :if-not-exists]]}))))
 
 (defn- add-collection-type-and-data-layer-columns!
   "Migration 3: Add `collection_type` and `data_layer` columns to index tables for the new ranking signals
-  (`:library` on `collection_type`; `:final`/`:internal`/`:hidden` on `data_layer`)."
+  (`:library` on `collection_type`; `:data-layer` per-tier weights on `data_layer`)."
   [tx index-metadata]
-  (let [metadata-table   (keyword (:metadata-table-name index-metadata))
-        execute!         (fn [q] (jdbc/execute! tx (sql/format q)))
-        candidate-names  (->> (execute! {:select-distinct [:table_name]
-                                         :from            [metadata-table]
-                                         :where           [[:< :index_version 3]]})
-                              (mapcat vals))
-        ;; Skip tables that have been deleted externally — their metadata row may still be present.
-        existing-names   (when (seq candidate-names)
-                           (->> (execute! {:select [:tablename]
-                                           :from   [:pg_tables]
-                                           :where  [:in :tablename (vec candidate-names)]})
-                                (mapcat vals)
-                                set))
-        table-names      (filter existing-names candidate-names)]
-    (when (seq table-names)
-      (doseq [table-name table-names]
-        (execute! {:alter-table [(keyword table-name)]
-                   :add-column  [[:collection_type :text :if-not-exists]]})
-        (execute! {:alter-table [(keyword table-name)]
-                   :add-column  [[:data_layer :text :if-not-exists]]}))
-      (execute! {:update metadata-table
-                 :set    {:index_version 3}
-                 :where  [[:in :table_name (vec table-names)]]}))))
+  (alter-index-tables! tx index-metadata 3
+                       (fn [execute! table-name]
+                         (execute! {:alter-table [(keyword table-name)]
+                                    :add-column  [[:collection_type :text :if-not-exists]]})
+                         (execute! {:alter-table [(keyword table-name)]
+                                    :add-column  [[:data_layer :text :if-not-exists]]}))))
 
 (defn migrate-dynamic-schema!
   "Migrate runtime-managed schema, ie. schema of `index_table_...` tables. Migration author is responsible for removing

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
@@ -37,7 +37,7 @@
 (def dynamic-schema-version
   "Code version of dynamic schema (index_table_xyzs). If higher than what's found in db dynamic schema migration will
   be attempted."
-  2)
+  3)
 
 (defn- add-personal-owner-id-column!
   "Migration 2: Add `personal_owner_id` column to index tables for SQL-level personal collection filtering."
@@ -56,10 +56,32 @@
                  :set    {:index_version 2}
                  :where  [[:in :table_name (vec table-names)]]}))))
 
+(defn- add-collection-type-and-data-layer-columns!
+  "Migration 3: Add `collection_type` and `data_layer` columns to index tables for the new ranking signals
+  (`:library` on `collection_type`; `:final`/`:internal`/`:hidden` on `data_layer`)."
+  [tx index-metadata]
+  (let [index-metadata (keyword (:metadata-table-name index-metadata))
+        execute!       (fn [q] (jdbc/execute! tx (sql/format q)))
+        table-names    (->> (execute! {:select-distinct [:table_name]
+                                       :from            [index-metadata]
+                                       :where           [[:< :index_version 3]]})
+                            (mapcat vals))]
+    (when (seq table-names)
+      (doseq [table-name table-names]
+        (execute! {:alter-table [(keyword table-name)]
+                   :add-column  [[:collection_type :text :if-not-exists]]})
+        (execute! {:alter-table [(keyword table-name)]
+                   :add-column  [[:data_layer :text :if-not-exists]]}))
+      (execute! {:update index-metadata
+                 :set    {:index_version 3}
+                 :where  [[:in :table_name (vec table-names)]]}))))
+
 (defn migrate-dynamic-schema!
   "Migrate runtime-managed schema, ie. schema of `index_table_...` tables. Migration author is responsible for removing
   leftovers if necessary."
   [tx {:keys [index-metadata] :as _opts}]
   ;; migration 1: all tables dropped in schema migration in single function call
   ;; migration 2: add personal_owner_id column to index tables
-  (add-personal-owner-id-column! tx index-metadata))
+  ;; migration 3: add collection_type and data_layer columns to index tables
+  (add-personal-owner-id-column! tx index-metadata)
+  (add-collection-type-and-data-layer-columns! tx index-metadata))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
@@ -60,19 +60,27 @@
   "Migration 3: Add `collection_type` and `data_layer` columns to index tables for the new ranking signals
   (`:library` on `collection_type`; `:final`/`:internal`/`:hidden` on `data_layer`)."
   [tx index-metadata]
-  (let [index-metadata (keyword (:metadata-table-name index-metadata))
-        execute!       (fn [q] (jdbc/execute! tx (sql/format q)))
-        table-names    (->> (execute! {:select-distinct [:table_name]
-                                       :from            [index-metadata]
-                                       :where           [[:< :index_version 3]]})
-                            (mapcat vals))]
+  (let [metadata-table   (keyword (:metadata-table-name index-metadata))
+        execute!         (fn [q] (jdbc/execute! tx (sql/format q)))
+        candidate-names  (->> (execute! {:select-distinct [:table_name]
+                                         :from            [metadata-table]
+                                         :where           [[:< :index_version 3]]})
+                              (mapcat vals))
+        ;; Skip tables that have been deleted externally — their metadata row may still be present.
+        existing-names   (when (seq candidate-names)
+                           (->> (execute! {:select [:tablename]
+                                           :from   [:pg_tables]
+                                           :where  [:in :tablename (vec candidate-names)]})
+                                (mapcat vals)
+                                set))
+        table-names      (filter existing-names candidate-names)]
     (when (seq table-names)
       (doseq [table-name table-names]
         (execute! {:alter-table [(keyword table-name)]
                    :add-column  [[:collection_type :text :if-not-exists]]})
         (execute! {:alter-table [(keyword table-name)]
                    :add-column  [[:data_layer :text :if-not-exists]]}))
-      (execute! {:update index-metadata
+      (execute! {:update metadata-table
                  :set    {:index_version 3}
                  :where  [[:in :table_name (vec table-names)]]}))))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -284,7 +284,7 @@
   (let [table-name (or table-name (model-table-name embedding-model))]
     {:embedding-model embedding-model
      :table-name table-name
-     :version 2}))
+     :version 3}))
 
 (defn- upsert-embedding!-fn [connectable index text->docs]
   (fn [text->embedding]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -66,6 +66,8 @@
      [:official_collection :boolean]
      [:pinned :boolean]
      [:verified :boolean]
+     [:collection_type :text]
+     [:data_layer :text]
      [:dashboardcard_count :int]
      [:view_count :int]
      [:created_at :timestamp-with-time-zone [:default [:raw "CURRENT_TIMESTAMP"]] :not-null]
@@ -150,7 +152,7 @@
   "Convert a document to a database record with a provided embedding."
   [owner-ids {:keys [model id embedding searchable_text embeddable_text native_query created_at creator_id updated_at
                      last_editor_id archived verified official_collection database_id collection_id display_type legacy_input
-                     pinned dashboardcard_count view_count last_viewed_at] :as doc}]
+                     pinned dashboardcard_count view_count last_viewed_at collection_type data_layer] :as doc}]
   {:model               model
    :model_id            id
    :collection_id       collection_id
@@ -165,6 +167,8 @@
    :official_collection (some-> official_collection to-boolean)
    :pinned              (some-> pinned to-boolean)
    :verified            (some-> verified to-boolean)
+   :collection_type     collection_type
+   :data_layer          data_layer
    :dashboardcard_count dashboardcard_count
    :view_count          view_count
    :model_created_at    (some-> created_at to-instant)
@@ -580,6 +584,8 @@
    [:official_collection :official_collection]
    [:pinned :pinned]
    [:verified :verified]
+   [:collection_type :collection_type]
+   [:data_layer :data_layer]
    [:dashboardcard_count :dashboardcard_count]
    [:view_count :view_count]
    [:model_created_at :model_created_at]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -173,11 +173,13 @@
                                :index_metadata/table_name)]
               (is (=? #{"archived"
                         "collection_id"
+                        "collection_type"
                         "content"
                         "created_at"
                         "creator_id"
                         "dashboardcard_count"
                         "database_id"
+                        "data_layer"
                         "display_type"
                         "embedding"
                         "id"

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -73,6 +73,13 @@
   "The value of the `:type` field for collections that only allow metrics."
   "library-metrics")
 
+(def library-collection-types
+  "All library `:type` values — collections users curate as the canonical place to find content.
+   Kept as a set so callers (e.g. search ranking) can enumerate them without hard-coding strings."
+  #{library-collection-type
+    library-data-collection-type
+    library-metrics-collection-type})
+
 (def ^:constant tenant-specific-root-collection-type
   "The value of the `:type` field for root collections that belong to a single tenant"
   "tenant-specific-root-collection")
@@ -2405,20 +2412,24 @@
 
 (search.spec/define-spec "collection"
   {:model        :model/Collection
-   :attrs        {:collection-id   :id
-                  :creator-id      false
-                  :database-id     false
-                  :archived        true
-                  :created-at      true
+   :attrs        {:collection-id       :id
+                  :collection-type     :type
+                  :collection-location :location
+                  :creator-id          false
+                  :database-id         false
+                  :archived            true
+                  :created-at          true
                   ;; intentionally not tracked
-                  :updated-at      false
-                  :collection-type :type}
+                  :updated-at          false}
    :search-terms [:name]
    :render-terms {:archived-directly          true
                   ;; Why not make this a search term? I suspect it was just overlooked before.
                   :description                true
                   :collection_authority_level :authority_level
                   :collection_name            :name
+                  ;; `:location` is read by the toucan2 effective-location hydration when collection
+                  ;; results pass through `metabase.search.impl/add-collection-effective-location`.
+                  ;; Keep the snake_case `location` key flowing alongside the indexed `collection_location`.
                   :location                   true}
    :where [:or [:= :namespace nil]
            [:= :namespace "analytics"]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -2405,20 +2405,20 @@
 
 (search.spec/define-spec "collection"
   {:model        :model/Collection
-   :attrs        {:collection-id :id
-                  :creator-id    false
-                  :database-id   false
-                  :archived      true
-                  :created-at    true
+   :attrs        {:collection-id   :id
+                  :creator-id      false
+                  :database-id     false
+                  :archived        true
+                  :created-at      true
                   ;; intentionally not tracked
-                  :updated-at    false}
+                  :updated-at      false
+                  :collection-type :type}
    :search-terms [:name]
    :render-terms {:archived-directly          true
                   ;; Why not make this a search term? I suspect it was just overlooked before.
                   :description                true
                   :collection_authority_level :authority_level
                   :collection_name            :name
-                  :collection_type            :type
                   :location                   true}
    :where [:or [:= :namespace nil]
            [:= :namespace "analytics"]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -189,6 +189,47 @@
   []
   (t2/select-one :model/Collection :type library-collection-type))
 
+(def ^{:arglists '([id])} root-collection-type-by-id
+  "Return the `:type` of the top-level (root) collection with the given `id`, or `nil` if no
+   top-level collection has that id. Caching is keyed by `[app-db-id collection-id]` per the
+   `metabase.app-db.core/memoize-for-application-db` docstring — different ids never share cache
+   entries, which keeps tests isolated even when other tests run ingestion in parallel.
+
+   Top-level collections change infrequently, so a 1-hour TTL is fine."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id]
+     (when id
+       (t2/select-one-fn :type :model/Collection :id id :location "/")))
+   :ttl/threshold (* 60 60 1000)))
+
+(defn root-collection-type
+  "Return the `:type` of the top-level ancestor collection given a collection's materialized path and
+   its own type/id. Used by the search ranking spec to power the `:library` scorer for items nested
+   inside library trees.
+
+   Resolution rules:
+     - `:collection_id` `nil`  →  `nil` (item has no collection)
+     - location is `\"/\"` or `nil`  →  the collection's own `:collection_type` (it IS a root)
+     - otherwise  →  parse the first id out of the materialized path and look up its type
+
+   Reads `:collection_id`, `:collection_location`, `:collection_type` from the ingestion record map."
+  [{:keys [collection_id collection_location collection_type]}]
+  (cond
+    (nil? collection_id)
+    nil
+
+    (or (nil? collection_location) (= "/" collection_location))
+    collection_type
+
+    :else
+    (when-let [root-id (some-> collection_location
+                               (str/split #"/")
+                               (->> (remove str/blank?))
+                               first
+                               parse-long)]
+      (root-collection-type-by-id root-id))))
+
 (def library-entity-id
   "The entity_id for the Library collection."
   "librarylibrarylibrary")
@@ -2412,15 +2453,16 @@
 
 (search.spec/define-spec "collection"
   {:model        :model/Collection
-   :attrs        {:collection-id       :id
-                  :collection-type     :type
-                  :collection-location :location
-                  :creator-id          false
-                  :database-id         false
-                  :archived            true
-                  :created-at          true
+   :attrs        {:collection-id        :id
+                  :collection-type      :type
+                  :collection-location  :location
+                  :root-collection-type {:fn root-collection-type}
+                  :creator-id           false
+                  :database-id          false
+                  :archived             true
+                  :created-at           true
                   ;; intentionally not tracked
-                  :updated-at          false}
+                  :updated-at           false}
    :search-terms [:name]
    :render-terms {:archived-directly          true
                   ;; Why not make this a search term? I suspect it was just overlooked before.

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -484,7 +484,8 @@
                   :created-at     true
                   :updated-at     true
                   :collection-type :collection.type
-                  :collection-location :collection.location}
+                  :collection-location :collection.location
+                  :root-collection-type {:fn collection/root-collection-type}}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -482,14 +482,14 @@
                   :verified       [:= "verified" :mr.status]
                   :view-count     true
                   :created-at     true
-                  :updated-at     true}
+                  :updated-at     true
+                  :collection-type :collection.type}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true
-                  :collection-type            :collection.type
                   :moderated-status           :mr.status}
    :where        []
    :bookmark     [:model/DashboardBookmark [:and

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -483,7 +483,8 @@
                   :view-count     true
                   :created-at     true
                   :updated-at     true
-                  :collection-type :collection.type}
+                  :collection-type :collection.type
+                  :collection-location :collection.location}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1463,6 +1463,7 @@
                   :created-at           true
                   :updated-at           true
                   :display-type         :this.display
+                  :collection-type      :collection.type
                   :temporal-info        {:fn       extract-temporal-info
                                          :fields   [:dataset_query :query_type]
                                          :provides [:has-temporal-dim :non-temporal-dim-ids]}}
@@ -1473,7 +1474,6 @@
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true
-                  :collection-type            :collection.type
                   ;; This field can become stale, unless we change to calculate it just-in-time.
                   :display                    true
                   :moderated-status           :mr.status}

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1465,6 +1465,7 @@
                   :display-type         :this.display
                   :collection-type      :collection.type
                   :collection-location  :collection.location
+                  :root-collection-type {:fn collection/root-collection-type}
                   :temporal-info        {:fn       extract-temporal-info
                                          :fields   [:dataset_query :query_type]
                                          :provides [:has-temporal-dim :non-temporal-dim-ids]}}

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1464,13 +1464,13 @@
                   :updated-at           true
                   :display-type         :this.display
                   :collection-type      :collection.type
+                  :collection-location  :collection.location
                   :temporal-info        {:fn       extract-temporal-info
                                          :fields   [:dataset_query :query_type]
                                          :provides [:has-temporal-dim :non-temporal-dim-ids]}}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level
-                  :collection-location        :collection.location
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -40,35 +40,6 @@
                                        (into [:case] cat cases)
                                        1))))
 
-(defn- library-collection-ids
-  "All `:id`s of collections whose `:type` is a library variant (top-level libraries, library-data,
-   library-metrics). Used by `library-score-expr` to find items in library trees via location-path match."
-  []
-  (t2/select-fn-set :id :model/Collection
-                    :type [:in (vec collection/library-collection-types)]))
-
-(defn- library-score-expr
-  "SQL expression for the `:library` scorer. Returns 1 when the row's `collection_id` is itself a
-   library collection (i.e. the row IS a library collection, or is a card/dashboard/table directly
-   parented to one), OR when the row's `collection_location` path contains a library collection id
-   (i.e. the row is inside a sub-collection of a library). Returns 0 otherwise.
-
-   Library ids are queried at scorer build time — there are typically only a handful per instance,
-   so the `OR`-of-LIKEs stays small."
-  []
-  (let [lib-ids (library-collection-ids)]
-    (if (empty? lib-ids)
-      [:inline 0]
-      [:case
-       (into [:or]
-             (concat
-              (for [id lib-ids]
-                [:= :search_index.collection_id [:inline id]])
-              (for [id lib-ids]
-                [:like :search_index.collection_location [:inline (str "%/" id "/%")]])))
-       [:inline 1]
-       :else [:inline 0]])))
-
 (defn base-scorers
   "The default constituents of the search ranking scores."
   [{:keys [search-string] :as search-ctx}]
@@ -93,11 +64,16 @@
                      ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
                      (search.scoring/prefix [:lower :search_index.name] (u/lower-case-en search-string))
                      [:inline 0])
-     ;; :library matches items directly in library collections AND items in sub-collections of library
-     ;; collections (their immediate `collection_type` is non-library, but their `collection_location`
-     ;; path contains a library collection's id). We resolve library ids at scorer build time — there are
-     ;; usually very few library collections per instance, so the resulting OR-of-LIKEs stays small.
-     :library      (library-score-expr)
+     ;; :library matches items whose root (top-level) ancestor collection is one of the library types.
+     ;; The :root-collection-type attr is computed at ingestion time by walking the collection's
+     ;; materialized path (see metabase.collections.models.collection/root-collection-type), so items
+     ;; in arbitrarily deep sub-collections of a library tree still match here.
+     :library      [:case
+                    (into [:or]
+                          (for [t (sort collection/library-collection-types)]
+                            [:= :search_index.root_collection_type [:inline t]]))
+                    [:inline 1]
+                    :else [:inline 0]]
      ;; :data-layer mirrors the :model/* pattern — one scorer, per-tier weights live under :data-layer/*
      ;; (see metabase.search.config/scorer-param). Final/internal/hidden are mutually exclusive.
      :data-layer   [:case

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.core.memoize :as memoize]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.appdb.index :as search.index]
@@ -39,6 +40,35 @@
                                        (into [:case] cat cases)
                                        1))))
 
+(defn- library-collection-ids
+  "All `:id`s of collections whose `:type` is a library variant (top-level libraries, library-data,
+   library-metrics). Used by `library-score-expr` to find items in library trees via location-path match."
+  []
+  (t2/select-fn-set :id :model/Collection
+                    :type [:in (vec collection/library-collection-types)]))
+
+(defn- library-score-expr
+  "SQL expression for the `:library` scorer. Returns 1 when the row's `collection_id` is itself a
+   library collection (i.e. the row IS a library collection, or is a card/dashboard/table directly
+   parented to one), OR when the row's `collection_location` path contains a library collection id
+   (i.e. the row is inside a sub-collection of a library). Returns 0 otherwise.
+
+   Library ids are queried at scorer build time — there are typically only a handful per instance,
+   so the `OR`-of-LIKEs stays small."
+  []
+  (let [lib-ids (library-collection-ids)]
+    (if (empty? lib-ids)
+      [:inline 0]
+      [:case
+       (into [:or]
+             (concat
+              (for [id lib-ids]
+                [:= :search_index.collection_id [:inline id]])
+              (for [id lib-ids]
+                [:like :search_index.collection_location [:inline (str "%/" id "/%")]])))
+       [:inline 1]
+       :else [:inline 0]])))
+
 (defn base-scorers
   "The default constituents of the search ranking scores."
   [{:keys [search-string] :as search-ctx}]
@@ -63,15 +93,21 @@
                      ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
                      (search.scoring/prefix [:lower :search_index.name] (u/lower-case-en search-string))
                      [:inline 0])
-     :library      [:case
-                    [:or [:= :search_index.collection_type [:inline "library"]]
-                     [:= :search_index.collection_type [:inline "library-data"]]
-                     [:= :search_index.collection_type [:inline "library-metrics"]]]
-                    [:inline 1]
-                    :else [:inline 0]]
-     :final        (search.scoring/equal :search_index.data_layer [:inline "final"])
-     :internal     (search.scoring/equal :search_index.data_layer [:inline "internal"])
-     :hidden       (search.scoring/equal :search_index.data_layer [:inline "hidden"])}))
+     ;; :library matches items directly in library collections AND items in sub-collections of library
+     ;; collections (their immediate `collection_type` is non-library, but their `collection_location`
+     ;; path contains a library collection's id). We resolve library ids at scorer build time — there are
+     ;; usually very few library collections per instance, so the resulting OR-of-LIKEs stays small.
+     :library      (library-score-expr)
+     ;; :data-layer mirrors the :model/* pattern — one scorer, per-tier weights live under :data-layer/*
+     ;; (see metabase.search.config/scorer-param). Final/internal/hidden are mutually exclusive.
+     :data-layer   [:case
+                    [:= :search_index.data_layer [:inline "final"]]
+                    [:inline (or (search.config/scorer-param search-ctx :data-layer :final) 0)]
+                    [:= :search_index.data_layer [:inline "internal"]]
+                    [:inline (or (search.config/scorer-param search-ctx :data-layer :internal) 0)]
+                    [:= :search_index.data_layer [:inline "hidden"]]
+                    [:inline (or (search.config/scorer-param search-ctx :data-layer :hidden) 0)]
+                    :else [:inline 0]]}))
 
 (defenterprise scorers
   "Return the select-item expressions used to calculate the score for each search result."

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -62,7 +62,16 @@
      :prefix       (if search-string
                      ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
                      (search.scoring/prefix [:lower :search_index.name] (u/lower-case-en search-string))
-                     [:inline 0])}))
+                     [:inline 0])
+     :library      [:case
+                    [:or [:= :search_index.collection_type [:inline "library"]]
+                     [:= :search_index.collection_type [:inline "library-data"]]
+                     [:= :search_index.collection_type [:inline "library-metrics"]]]
+                    [:inline 1]
+                    :else [:inline 0]]
+     :final        (search.scoring/equal :search_index.data_layer [:inline "final"])
+     :internal     (search.scoring/equal :search_index.data_layer [:inline "internal"])
+     :hidden       (search.scoring/equal :search_index.data_layer [:inline "hidden"])}))
 
 (defenterprise scorers
   "Return the select-item expressions used to calculate the score for each search result."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -112,9 +112,10 @@
    {:library             100
     :official-collection 80
     :verified            80
-    :final               33
-    :internal            10
-    :hidden              1}})
+    :data-layer          1     ; overall multiplier; per-tier weights live under :data-layer/* below
+    :data-layer/final    33
+    :data-layer/internal 10
+    :data-layer/hidden   1}})
 
 (def ^:private FilterDef
   "A relaxed definition, capturing how we can write the filter - with some fields omitted."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -107,7 +107,14 @@
    {:model/table    1
     :model/dataset  1
     :model/metric   1
-    :model/question 0}})
+    :model/question 0}
+   :metabot
+   {:library             100
+    :official-collection 80
+    :verified            80
+    :final               33
+    :internal            10
+    :hidden              1}})
 
 (def ^:private FilterDef
   "A relaxed definition, capturing how we can write the filter - with some fields omitted."

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -140,7 +140,11 @@
                         (update :archived boolean)
                         (assoc
                          :display_data (display-data m)
-                         :legacy_input (json/encode (dissoc m :pinned :view_count :last_viewed_at :native_query :dataset_query))
+                         ;; :data_layer is an internal scoring signal (see search.appdb.scoring); it lives on the index
+                         ;; for ranking but should not surface in API responses. (:collection_type is consumed by
+                         ;; metabase.search.impl/serialize to build :collection.type — must stay in legacy_input.)
+                         :legacy_input (json/encode (dissoc m :pinned :view_count :last_viewed_at :native_query :dataset_query
+                                                            :data_layer))
                          :searchable_text (searchable-text m)
                          :embeddable_text (embeddable-text m)))]
     (merge fn-results sql-results)))

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -140,11 +140,7 @@
                         (update :archived boolean)
                         (assoc
                          :display_data (display-data m)
-                         ;; :data_layer is an internal scoring signal (see search.appdb.scoring); it lives on the index
-                         ;; for ranking but should not surface in API responses. (:collection_type is consumed by
-                         ;; metabase.search.impl/serialize to build :collection.type — must stay in legacy_input.)
-                         :legacy_input (json/encode (dissoc m :pinned :view_count :last_viewed_at :native_query :dataset_query
-                                                            :data_layer))
+                         :legacy_input (json/encode (apply dissoc m search.spec/legacy-input-excluded-keys))
                          :searchable_text (searchable-text m)
                          :embeddable_text (embeddable-text m)))]
     (merge fn-results sql-results)))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -122,6 +122,7 @@
    :source-type             :text
    :collection-type         :text
    :collection-location     :text
+   :root-collection-type    :text
    :data-layer              :text})
 
 (def ^:private explicit-attrs
@@ -147,8 +148,9 @@
          :temporal-info
          :is-published
          :source-type
-         :collection-type                                   ;;  indexed for :library scorer (collection.type ∈ library/library-data/library-metrics)
-         :collection-location                               ;;  indexed for :library scorer — lets sub-collections inherit the boost via location-path LIKE
+         :collection-type                                   ;;  surfaced for downstream consumers (metabase.search.impl/serialize)
+         :collection-location                               ;;  surfaced for downstream consumers (add-dataset-collection-hierarchy)
+         :root-collection-type                              ;;  indexed for :library scorer — type of the top-level ancestor collection
          :data-layer])                                      ;;  indexed for the :data-layer scorer (table.data_layer; per-tier weights under :data-layer/*)
        distinct
        vec))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -83,6 +83,17 @@
        (mapcat :fields)
        distinct))
 
+(def legacy-input-excluded-keys
+  "Keys present on the ingestion document `m` that must NOT be encoded into `legacy_input`. These are
+   internal signals (ranking, filtering, ingestion bookkeeping) that the search API response should not
+   surface to clients. Consumers: `metabase.search.ingestion/->document`."
+  ;; `:collection_type` and `:collection_location` deliberately stay IN `legacy_input`:
+  ;; - `metabase.search.impl/serialize` reads `:collection_type` to build the response's `:collection.type`
+  ;; - `metabase.search.impl/add-dataset-collection-hierarchy` reads `:collection_location` to hydrate
+  ;;   `:collection_effective_ancestors`, and the collection-result hydration path reads `:location` from
+  ;;   the toucan instance (which the render-term keeps populated).
+  #{:pinned :view_count :last_viewed_at :native_query :dataset_query :data_layer})
+
 (def attr-types
   "The abstract types of each attribute."
   {:archived                :boolean
@@ -110,6 +121,7 @@
    :is-published            :boolean
    :source-type             :text
    :collection-type         :text
+   :collection-location     :text
    :data-layer              :text})
 
 (def ^:private explicit-attrs
@@ -136,7 +148,8 @@
          :is-published
          :source-type
          :collection-type                                   ;;  indexed for :library scorer (collection.type ∈ library/library-data/library-metrics)
-         :data-layer])                                      ;;  indexed for :final/:internal/:hidden scorers (table.data_layer)
+         :collection-location                               ;;  indexed for :library scorer — lets sub-collections inherit the boost via location-path LIKE
+         :data-layer])                                      ;;  indexed for the :data-layer scorer (table.data_layer; per-tier weights under :data-layer/*)
        distinct
        vec))
 

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -108,7 +108,9 @@
    :temporal-info           nil
    :display-type            :text
    :is-published            :boolean
-   :source-type             :text})
+   :source-type             :text
+   :collection-type         :text
+   :data-layer              :text})
 
 (def ^:private explicit-attrs
   "These attributes must be explicitly defined, omitting them could be a source of bugs."
@@ -132,7 +134,9 @@
          :updated-at
          :temporal-info
          :is-published
-         :source-type])
+         :source-type
+         :collection-type                                   ;;  indexed for :library scorer (collection.type ∈ library/library-data/library-metrics)
+         :data-layer])                                      ;;  indexed for :final/:internal/:hidden scorers (table.data_layer)
        distinct
        vec))
 

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -666,9 +666,10 @@
                   :view-count      true
                   :created-at      true
                   :updated-at      true
-                  :is-published    :is_published
-                  :collection-type :collection.type
-                  :data-layer      :data_layer}
+                  :is-published        :is_published
+                  :collection-type     :collection.type
+                  :collection-location :collection.location
+                  :data-layer          :data_layer}
    :search-terms {:name         search.spec/explode-camel-case
                   :display_name true
                   :description  true}
@@ -679,7 +680,6 @@
                   :table-schema               :schema
                   :database-name              :db.name
                   :collection-authority_level :collection.authority_level
-                  :collection-location        :collection.location
                   ;; For published tables with no collection, show "Our analytics" as the collection name
                   :collection-name            [:coalesce :collection.name
                                                [:case

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -658,15 +658,17 @@
   {:model        :model/Table
    :attrs        {;; legacy search uses :active for this, but then has a rule to only ever show active tables
                   ;; so we moved that to the where clause
-                  :archived      false
+                  :archived        false
                   ;; For published tables with no collection, we want to show "root" as the collection id
-                  :collection-id true
-                  :creator-id    false
-                  :database-id   :db_id
-                  :view-count    true
-                  :created-at    true
-                  :updated-at    true
-                  :is-published  :is_published}
+                  :collection-id   true
+                  :creator-id      false
+                  :database-id     :db_id
+                  :view-count      true
+                  :created-at      true
+                  :updated-at      true
+                  :is-published    :is_published
+                  :collection-type :collection.type
+                  :data-layer      :data_layer}
    :search-terms {:name         search.spec/explode-camel-case
                   :display_name true
                   :description  true}
@@ -683,8 +685,7 @@
                                                [:case
                                                 [:and :this.is_published
                                                  [:= :this.collection_id nil]] [:inline "Our analytics"]
-                                                :else nil]]
-                  :collection-type            :collection.type}
+                                                :else nil]]}
    :where        [:and
                   :active
                   [:= :visibility_type nil]

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -669,6 +669,7 @@
                   :is-published        :is_published
                   :collection-type     :collection.type
                   :collection-location :collection.location
+                  :root-collection-type {:fn collection/root-collection-type}
                   :data-layer          :data_layer}
    :search-terms {:name         search.spec/explode-camel-case
                   :display_name true

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -928,7 +928,8 @@
      :database_id         true
      :database_name       "test-data (h2)"
      :pk_ref              nil
-     :initial_sync_status "complete"})))
+     :initial_sync_status "complete"
+     :data_layer          "internal"})))
 
 (defmacro ^:private do-test-users {:style/indent 1} [[user-binding users] & body]
   `(doseq [user# ~users

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -928,8 +928,7 @@
      :database_id         true
      :database_name       "test-data (h2)"
      :pk_ref              nil
-     :initial_sync_status "complete"
-     :data_layer          "internal"})))
+     :initial_sync_status "complete"})))
 
 (defmacro ^:private do-test-users {:style/indent 1} [[user-binding users] & body]
   `(doseq [user# ~users

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -316,3 +316,50 @@
       (is (= [["card" 2 "this card is aerie mon"]
               ["card" 1 "crow's fly card"]]
              (search-results :mine "card" {:current-user-id rasta}))))))
+
+(deftest ^:parallel library-test
+  (testing "Cards in library collections rank above non-library cards"
+    (with-index-contents
+      [{:model "card" :id 1 :name "card plain"      :collection_type nil}
+       {:model "card" :id 2 :name "card in library" :collection_type "library"}
+       {:model "card" :id 3 :name "card in library-data"    :collection_type "library-data"}
+       {:model "card" :id 4 :name "card in library-metrics" :collection_type "library-metrics"}
+       {:model "card" :id 5 :name "card in trash"   :collection_type "trash"}]
+      (let [ids-with-library    (->> (with-weights {:library 1} (search-results* "card"))
+                                     (filter (fn [[_ id _]] (#{2 3 4} id)))
+                                     (map second)
+                                     set)
+            ids-without-library (->> (with-weights {:library -1} (search-results* "card"))
+                                     (filter (fn [[_ id _]] (#{2 3 4} id)))
+                                     (map second)
+                                     set)]
+        (testing "All three library variants get the boost"
+          (is (= #{2 3 4} ids-with-library))
+          (is (= #{2 3 4} ids-without-library))))
+      (testing "Library cards lead with positive :library weight"
+        (let [results (with-weights {:library 1} (search-results* "card"))
+              first-three-ids (set (map second (take 3 results)))]
+          (is (= #{2 3 4} first-three-ids)))))))
+
+(deftest ^:parallel data-layer-test
+  (testing ":final, :internal, and :hidden each boost the matching data_layer value"
+    (with-index-contents
+      [{:model "table" :id 1 :name "table no layer"}
+       {:model "table" :id 2 :name "table final"    :data_layer "final"}
+       {:model "table" :id 3 :name "table internal" :data_layer "internal"}
+       {:model "table" :id 4 :name "table hidden"   :data_layer "hidden"}]
+      (testing "final tables lead when :final weight is set"
+        (is (= 2 (-> (with-weights {:final 1} (search-results* "table")) first second))))
+      (testing "internal tables lead when :internal weight is set"
+        (is (= 3 (-> (with-weights {:internal 1} (search-results* "table")) first second))))
+      (testing "hidden tables lead when :hidden weight is set"
+        (is (= 4 (-> (with-weights {:hidden 1} (search-results* "table")) first second))))))
+  (testing "Metabot tier ordering: final > internal > hidden when all weights active"
+    (with-index-contents
+      [{:model "table" :id 1 :name "metabot table final"    :data_layer "final"}
+       {:model "table" :id 2 :name "metabot table internal" :data_layer "internal"}
+       {:model "table" :id 3 :name "metabot table hidden"   :data_layer "hidden"}]
+      (is (= [1 2 3]
+             (->> (with-weights {:final 33 :internal 10 :hidden 1}
+                    (search-results* "metabot table"))
+                  (map second)))))))

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -317,49 +317,61 @@
               ["card" 1 "crow's fly card"]]
              (search-results :mine "card" {:current-user-id rasta}))))))
 
-(deftest ^:parallel library-test
-  (testing "Cards in library collections rank above non-library cards"
-    (with-index-contents
-      [{:model "card" :id 1 :name "card plain"      :collection_type nil}
-       {:model "card" :id 2 :name "card in library" :collection_type "library"}
-       {:model "card" :id 3 :name "card in library-data"    :collection_type "library-data"}
-       {:model "card" :id 4 :name "card in library-metrics" :collection_type "library-metrics"}
-       {:model "card" :id 5 :name "card in trash"   :collection_type "trash"}]
-      (let [ids-with-library    (->> (with-weights {:library 1} (search-results* "card"))
-                                     (filter (fn [[_ id _]] (#{2 3 4} id)))
-                                     (map second)
-                                     set)
-            ids-without-library (->> (with-weights {:library -1} (search-results* "card"))
-                                     (filter (fn [[_ id _]] (#{2 3 4} id)))
-                                     (map second)
-                                     set)]
-        (testing "All three library variants get the boost"
-          (is (= #{2 3 4} ids-with-library))
-          (is (= #{2 3 4} ids-without-library))))
-      (testing "Library cards lead with positive :library weight"
-        (let [results (with-weights {:library 1} (search-results* "card"))
-              first-three-ids (set (map second (take 3 results)))]
-          (is (= #{2 3 4} first-three-ids)))))))
+(deftest library-test
+  (testing "Library-collection cards rank above non-library cards"
+    ;; Real Collections are needed in appdb so `library-score-expr` resolves their ids and matches the
+    ;; index rows by id and by `collection_location` path.
+    (mt/with-temp [:model/Collection lib       {:name "lib top"        :type "library"        :location "/"}
+                   :model/Collection lib-data  {:name "lib data"       :type "library-data"   :location "/"}
+                   :model/Collection lib-met   {:name "lib metrics"    :type "library-metrics" :location "/"}
+                   :model/Collection sub       {:name "sub of lib"     :location (format "/%d/" (:id lib))}
+                   :model/Collection sub-sub   {:name "sub of sub"     :location (format "/%d/%d/" (:id lib) (:id sub))}
+                   :model/Collection other     {:name "non-library"    :location "/"}]
+      (with-index-contents
+        [{:model "card" :id 1 :name "card plain"           :collection_id (:id other)    :collection_location (:location other)}
+         {:model "card" :id 2 :name "card in library"      :collection_id (:id lib)      :collection_location (:location lib)      :collection_type "library"}
+         {:model "card" :id 3 :name "card in library-data" :collection_id (:id lib-data) :collection_location (:location lib-data) :collection_type "library-data"}
+         {:model "card" :id 4 :name "card in lib-metrics"  :collection_id (:id lib-met)  :collection_location (:location lib-met)  :collection_type "library-metrics"}
+         {:model "card" :id 5 :name "card in sub of lib"   :collection_id (:id sub)      :collection_location (:location sub)}
+         {:model "card" :id 6 :name "card in sub of sub"   :collection_id (:id sub-sub)  :collection_location (:location sub-sub)}
+         {:model "card" :id 7 :name "card in trash"        :collection_type "trash"}]
+        (let [library-id? #{2 3 4 5 6}
+              in-library? (fn [[_ id _]] (boolean (library-id? id)))]
+          (testing "with positive :library weight, items inside library trees come first"
+            (is (= [true true true true true false false]
+                   (map in-library? (with-weights {:library 1} (search-results* "card"))))))
+          (testing "with negative :library weight, library items come last"
+            (is (= [false false true true true true true]
+                   (map in-library? (with-weights {:library -1} (search-results* "card")))))))))))
 
 (deftest ^:parallel data-layer-test
-  (testing ":final, :internal, and :hidden each boost the matching data_layer value"
+  (testing ":data-layer scorer reads the active per-tier weight via :data-layer/* params"
     (with-index-contents
       [{:model "table" :id 1 :name "table no layer"}
        {:model "table" :id 2 :name "table final"    :data_layer "final"}
        {:model "table" :id 3 :name "table internal" :data_layer "internal"}
        {:model "table" :id 4 :name "table hidden"   :data_layer "hidden"}]
-      (testing "final tables lead when :final weight is set"
-        (is (= 2 (-> (with-weights {:final 1} (search-results* "table")) first second))))
-      (testing "internal tables lead when :internal weight is set"
-        (is (= 3 (-> (with-weights {:internal 1} (search-results* "table")) first second))))
-      (testing "hidden tables lead when :hidden weight is set"
-        (is (= 4 (-> (with-weights {:hidden 1} (search-results* "table")) first second))))))
+      (testing "final tables lead when only :data-layer/final is positive"
+        (is (= 2 (-> (with-weights {:data-layer 1 :data-layer/final 1}
+                       (search-results* "table"))
+                     first second))))
+      (testing "internal tables lead when only :data-layer/internal is positive"
+        (is (= 3 (-> (with-weights {:data-layer 1 :data-layer/internal 1}
+                       (search-results* "table"))
+                     first second))))
+      (testing "hidden tables lead when only :data-layer/hidden is positive"
+        (is (= 4 (-> (with-weights {:data-layer 1 :data-layer/hidden 1}
+                       (search-results* "table"))
+                     first second))))))
   (testing "Metabot tier ordering: final > internal > hidden when all weights active"
     (with-index-contents
       [{:model "table" :id 1 :name "metabot table final"    :data_layer "final"}
        {:model "table" :id 2 :name "metabot table internal" :data_layer "internal"}
        {:model "table" :id 3 :name "metabot table hidden"   :data_layer "hidden"}]
       (is (= [1 2 3]
-             (->> (with-weights {:final 33 :internal 10 :hidden 1}
+             (->> (with-weights {:data-layer          1
+                                 :data-layer/final    33
+                                 :data-layer/internal 10
+                                 :data-layer/hidden   1}
                     (search-results* "metabot table"))
                   (map second)))))))

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -319,8 +319,8 @@
 
 (deftest library-test
   (testing "Library-collection cards rank above non-library cards"
-    ;; Real Collections are needed in appdb so `library-score-expr` resolves their ids and matches the
-    ;; index rows by id and by `collection_location` path.
+    ;; Real Collections are needed in appdb so the `:root-collection-type` fn attr can resolve the
+    ;; top-level ancestor's `:type` from each row's `:collection_location` materialized path.
     (mt/with-temp [:model/Collection lib       {:name "lib top"        :type "library"        :location "/"}
                    :model/Collection lib-data  {:name "lib data"       :type "library-data"   :location "/"}
                    :model/Collection lib-met   {:name "lib metrics"    :type "library-metrics" :location "/"}

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -24,20 +24,19 @@
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
 
 (deftest metabot-weights-test
-  (testing "the :metabot context returns the tuned curation tier weights"
-    (let [w (search.config/weights {:context :metabot})]
-      (is (= 100 (:library w)))
-      (is (= 80  (:official-collection w)))
-      (is (= 80  (:verified w)))
-      (is (= 33  (:final w)))
-      (is (= 10  (:internal w)))
-      (is (= 1   (:hidden w)))))
-  (testing "the :metabot context still inherits :default scorers it doesn't override"
-    (let [defaults (search.config/weights {:context :default})
-          metabot  (search.config/weights {:context :metabot})]
-      (doseq [k [:text :exact :rrf :model :view-count :recency]]
-        (is (= (get defaults k) (get metabot k))
-            (str "Inherited " k " from :default")))))
+  (testing "the :metabot context resolves the tuned curation tier weights and inherits :default"
+    (is (=? {:library             100
+             :official-collection 80
+             :verified            80
+             :data-layer          1
+             :data-layer/final    33
+             :data-layer/internal 10
+             :data-layer/hidden   1
+             ;; sanity check on inherited :default weights — if any of these change in :default,
+             ;; this test will flag whether :metabot still inherits or has overridden them.
+             :text                5
+             :rrf                 500}
+            (search.config/weights {:context :metabot}))))
   (testing "request-level :weights override beats :metabot static weights"
     (is (= 7 (-> (search.config/weights {:context :metabot :weights {:library 7}})
                  :library)))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -22,3 +22,22 @@
            (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))
     (is (= "exclude-others"
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
+
+(deftest metabot-weights-test
+  (testing "the :metabot context returns the tuned curation tier weights"
+    (let [w (search.config/weights {:context :metabot})]
+      (is (= 100 (:library w)))
+      (is (= 80  (:official-collection w)))
+      (is (= 80  (:verified w)))
+      (is (= 33  (:final w)))
+      (is (= 10  (:internal w)))
+      (is (= 1   (:hidden w)))))
+  (testing "the :metabot context still inherits :default scorers it doesn't override"
+    (let [defaults (search.config/weights {:context :default})
+          metabot  (search.config/weights {:context :metabot})]
+      (doseq [k [:text :exact :rrf :model :view-count :recency]]
+        (is (= (get defaults k) (get metabot k))
+            (str "Inherited " k " from :default")))))
+  (testing "request-level :weights override beats :metabot static weights"
+    (is (= 7 (-> (search.config/weights {:context :metabot :weights {:library 7}})
+                 :library)))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -24,18 +24,14 @@
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
 
 (deftest metabot-weights-test
-  (testing "the :metabot context resolves the tuned curation tier weights and inherits :default"
+  (testing "the :metabot context defines the tuned curation tier weights"
     (is (=? {:library             100
              :official-collection 80
              :verified            80
              :data-layer          1
              :data-layer/final    33
              :data-layer/internal 10
-             :data-layer/hidden   1
-             ;; sanity check on inherited :default weights — if any of these change in :default,
-             ;; this test will flag whether :metabot still inherits or has overridden them.
-             :text                5
-             :rrf                 500}
+             :data-layer/hidden   1}
             (search.config/weights {:context :metabot}))))
   (testing "request-level :weights override beats :metabot static weights"
     (is (= 7 (-> (search.config/weights {:context :metabot :weights {:library 7}})

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -101,7 +101,8 @@
                                {:search-model "table",
                                 :fields
                                 #{:active :description :schema :name :id :db_id :initial_sync_status :display_name
-                                  :visibility_type :view_count :created_at :updated_at :collection_id :is_published}
+                                  :visibility_type :view_count :created_at :updated_at :collection_id :is_published
+                                  :data_layer}
                                 :where        [:= :updated.id :this.id]}},
                  :Database   #{{:search-model "table"
                                 :fields #{:name :router_database_id}


### PR DESCRIPTION
Tune search ranking for Metabot's data-selection stage so curated content dominates results. Metabot already passes :context :metabot to the search context, but no :metabot entry existed in static-weights, so it fell back to :default where curation signals carry weight 1 — too weak to outrank text/recency.

New :metabot weights: library=100, official-collection=80, verified=80, final=33, internal=10, hidden=1.

To support this, promote :collection-type to an indexed search attr on card/dataset/metric/dashboard/collection/table, and add :data-layer as an indexed attr on table. Add four new appdb scorers (:library on Collection.type ∈ {library, library-data, library-metrics}; :final, :internal, :hidden on Table.data_layer). The appdb index reindex fires automatically via index-version-hash; the semantic index gains a migration-3 that ALTERs existing index tables to add the two columns.