### PR TITLE
Clarify landing page format and show override hint on custom homepage

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
@@ -54,7 +54,7 @@ export function LandingPageWidget() {
         id="landing-page"
         data-testid="landing-page"
         aria-label={t`Landing page custom destination`}
-        placeholder="/"
+        placeholder="/dashboard/1"
         error={error}
         value={String(inputValue ?? "")}
         onChange={(e) => {

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
@@ -5,7 +5,7 @@ import { trackCustomHomepageDashboardEnabled } from "metabase/common/analytics";
 import { DashboardSelector } from "metabase/common/components/DashboardSelector";
 import { useDispatch } from "metabase/redux";
 import { refreshCurrentUser } from "metabase/redux/user";
-import { Stack } from "metabase/ui";
+import { Stack, Text } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
 import { SettingHeader } from "../SettingHeader";
@@ -21,6 +21,8 @@ export function CustomHomepageDashboardSetting() {
   const { value: customHomepageDashboardId } = useAdminSetting(
     "custom-homepage-dashboard",
   );
+  const { value: landingPage } = useAdminSetting("landing-page");
+  const isOverridden = Boolean(landingPage && landingPage !== "/");
   const dispatch = useDispatch();
 
   const handleDashboardChange = async (newDashboardId?: DashboardId) => {
@@ -69,20 +71,27 @@ export function CustomHomepageDashboardSetting() {
         title={t`Custom homepage`}
         description={description}
       />
-      <BasicAdminSettingInput
-        name="custom-homepage"
-        inputType="boolean"
-        value={customHomepage}
-        onChange={(newValue) => handleToggleChange(Boolean(newValue))}
-      />
-      {customHomepage && (
-        <div data-testid="custom-homepage-dashboard-setting">
-          <DashboardSelector
-            value={customHomepageDashboardId ?? undefined}
-            onChange={handleDashboardChange}
-          />
-        </div>
+      {isOverridden && (
+        <Text c="text-secondary" fs="italic" size="sm">
+          {t`Currently overridden by the Landing page setting below.`}
+        </Text>
       )}
+      <Stack opacity={isOverridden ? 0.5 : 1}>
+        <BasicAdminSettingInput
+          name="custom-homepage"
+          inputType="boolean"
+          value={customHomepage}
+          onChange={(newValue) => handleToggleChange(Boolean(newValue))}
+        />
+        {customHomepage && (
+          <div data-testid="custom-homepage-dashboard-setting">
+            <DashboardSelector
+              value={customHomepageDashboardId ?? undefined}
+              onChange={handleDashboardChange}
+            />
+          </div>
+        )}
+      </Stack>
     </Stack>
   );
 }

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -57,7 +57,7 @@
     :else landing-page))
 
 (defsetting landing-page
-  (deferred-tru "Enter a URL of the landing page to show the user. This overrides the custom homepage setting above.")
+  (deferred-tru "Enter a relative URL like /dashboard/1 or /collection/2. When set, this overrides the Custom homepage above.")
   :encryption :no
   :visibility :public
   :export?    true


### PR DESCRIPTION
### Description

Fixes [UXW-3474](https://linear.app/metabase/issue/UXW-3474/admin-homepage-settings-overwrite-each-other).

The two homepage settings (Custom homepage and Landing page) sit side-by-side and read as duplicates, the Landing page field gives no hint about its required URL format, and there is no visual signal that Landing page wins when both are set.

- Reword the Landing page description to spell out the required relative-URL format with concrete examples.
- Replace the bare `/` placeholder with `/dashboard/1`.
- Dim the Custom homepage controls and show "Currently overridden by the Landing page setting below." when Landing page has a value.

### How to verify

- [ ] On a whitelabel-enabled instance, open Admin > Settings > General and set Landing page to `/dashboard/1`. Confirm the Custom homepage toggle and dashboard picker dim and the override hint appears. Clear Landing page and confirm both restore to normal.

### Demo

#### Before

#### After
<img width="1560" height="712" alt="image" src="https://github.com/user-attachments/assets/2721d5b3-ce8c-4dc6-8caf-9224cec1cf2b" />
<img width="1544" height="656" alt="image" src="https://github.com/user-attachments/assets/6ea61dbc-124e-4fb3-87bd-bc5a59f0ab8a" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)