### PR TITLE
Fix click/hover behavior for "Install in Cursor" link

### DIFF
--- a/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
@@ -43,6 +43,28 @@ describe("admin > MCP apps settings > Cursor install link", () => {
           expect(decoded.url).to.eq(`${Cypress.config("baseUrl")}/api/mcp`);
         });
 
+      cy.log(
+        "link is hoverable — :hover styles apply when the pointer is on it",
+      );
+      cy.findByRole("link", { name: "Install in Cursor" })
+        .should("have.css", "text-decoration-line", "none")
+        .realHover()
+        // Mantine Anchor (underline="hover") underlines on :hover. If the switch
+        // track is covering the link, :hover never fires and this stays "none".
+        .should("have.css", "text-decoration-line", "underline");
+
+      cy.log("clicking the link does not toggle the parent switch");
+      cy.findByRole("link", { name: "Install in Cursor" })
+        .then(($link) => {
+          // Prevent the cursor:// deeplink from being followed during the test
+          $link.on("click", (event) => event.preventDefault());
+        })
+        .click();
+
+      cy.findByRole("switch", { name: /cursor and vs code/i }).should(
+        "be.checked",
+      );
+
       cy.log("disable Cursor and VS Code");
       cy.findByRole("switch", { name: /cursor and vs code/i }).click({
         force: true,

--- a/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
@@ -44,14 +44,21 @@ describe("admin > MCP apps settings > Cursor install link", () => {
         });
 
       cy.log(
-        "link is hoverable — :hover styles apply when the pointer is on it",
+        "link is hoverable — pointer events reach it (not the switch track)",
       );
+      const hoverState = { mouseEntered: false };
       cy.findByRole("link", { name: "Install in Cursor" })
-        .should("have.css", "text-decoration-line", "none")
+        .then(($link) => {
+          $link[0].addEventListener("mouseenter", () => {
+            hoverState.mouseEntered = true;
+          });
+        })
         .realHover()
-        // Mantine Anchor (underline="hover") underlines on :hover. If the switch
-        // track is covering the link, :hover never fires and this stays "none".
-        .should("have.css", "text-decoration-line", "underline");
+        // If the switch track is covering the link, the pointer hits the track
+        // and `mouseenter` never fires on the link.
+        .should(() => {
+          expect(hoverState.mouseEntered).to.be.true;
+        });
 
       cy.log("clicking the link does not toggle the parent switch");
       cy.findByRole("link", { name: "Install in Cursor" })

--- a/frontend/src/metabase/admin/ai/CursorInstallLink.tsx
+++ b/frontend/src/metabase/admin/ai/CursorInstallLink.tsx
@@ -30,6 +30,7 @@ export const CursorInstallLink = () => {
       href={buildCursorInstallUrl(mcpUrl)}
       fz="sm"
       w="fit-content"
+      pos="relative"
       onClick={(event) => event.stopPropagation()}
     >
       {t`Install in Cursor`}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74258
Fix click/hover behavior for "Install in Cursor" link

Added regression test.

Important. The link is clickable. Area on the right side of link still trigger switcher as it's still a part of the switcher.

How to test:
- locally open admin UI/AI => MCP. Toggle `Cursor` and click `install in cursor`

