### PR TITLE
fix: hide empty Usage tracking section on Cloud Starter

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -87,11 +87,13 @@ export function GeneralSettingsPage() {
         />
       </SettingsSection>
 
-      <SettingsSection title={t`Usage tracking`}>
-        {enableAnonymousTracking && <AnonymousTrackingInput />}
+      {(enableAnonymousTracking || hasAuditAppFeature) && (
+        <SettingsSection title={t`Usage tracking`}>
+          {enableAnonymousTracking && <AnonymousTrackingInput />}
 
-        {hasAuditAppFeature && <CollectUserDataInput />}
-      </SettingsSection>
+          {hasAuditAppFeature && <CollectUserDataInput />}
+        </SettingsSection>
+      )}
 
       <UpsellDevInstances location="settings-general" />
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -87,6 +87,7 @@ export function GeneralSettingsPage() {
         />
       </SettingsSection>
 
+      {/* On starter plan, both conditions are `false` */}
       {(enableAnonymousTracking || hasAuditAppFeature) && (
         <SettingsSection title={t`Usage tracking`}>
           {enableAnonymousTracking && <AnonymousTrackingInput />}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
@@ -199,4 +199,30 @@ describe("GeneralSettingsPage", () => {
       screen.queryByText("Collect user data to display in usage analytics"),
     ).not.toBeInTheDocument();
   });
+
+  describe("Usage tracking section visibility", () => {
+    it("should hide the Usage tracking section on Starter Cloud (hosting without audit_app)", async () => {
+      await setup({ isCloudPlan: true, hasAuditApp: false });
+
+      expect(screen.queryByText("Usage tracking")).not.toBeInTheDocument();
+    });
+
+    it("should show the Usage tracking section on Pro Cloud (hosting with audit_app)", async () => {
+      await setup({ isCloudPlan: true, hasAuditApp: true });
+
+      expect(screen.getByText("Usage tracking")).toBeInTheDocument();
+    });
+
+    it("should show the Usage tracking section on self-hosted OSS (no hosting, no audit_app)", async () => {
+      await setup({ isCloudPlan: false, hasAuditApp: false });
+
+      expect(screen.getByText("Usage tracking")).toBeInTheDocument();
+    });
+
+    it("should show the Usage tracking section on self-hosted EE (no hosting, audit_app)", async () => {
+      await setup({ isCloudPlan: false, hasAuditApp: true });
+
+      expect(screen.getByText("Usage tracking")).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Closes [EMB-1743](https://linear.app/metabase/issue/EMB-1743/hide-usage-tracking-settings-on-starter-plans)

### Description

Backport because this section exist in 61.

On Cloud Starter, `enableAnonymousTracking` is set to `false` because `const enableAnonymousTracking = !hasHostingFeature;` and `audit_app` is not available, so the `Usage tracking` section in admin General settings rendered with just a title and an empty body.

Fix: only render the `Usage tracking` section when at least one of its inputs would render.

### How to verify

1. Start a Cloud Starter-like instance (use `CYPRESS_MB_STARTER_CLOUD_TOKEN`)
2. Admin → Settings → General → confirm the `Usage tracking` section is gone.
3. Repeat on Pro Cloud (hosting + `audit_app`), self-hosted OSS, self-hosted EE → section still visible with its inputs.

### Demo

#### After fix
<img width="887" height="705" alt="image" src="https://github.com/user-attachments/assets/9eb252c5-78e5-49df-8f44-725be230b31b" />

#### Before fix
<img width="894" height="826" alt="image" src="https://github.com/user-attachments/assets/a8011491-10c9-4d25-adbc-7faa6edce153" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)