### PR TITLE
fix: keep save button right-aligned in notebook editor

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -205,7 +205,7 @@ export const SdkQuestionDefaultView = ({
               <DefaultViewTitle title={title} />
             </Stack>
           </RenderIfHasContent>
-          {showSaveButton && <SaveButton onClick={openSaveModal} />}
+          {showSaveButton && <SaveButton onClick={openSaveModal} ml="auto" />}
         </RenderIfHasContent>
         {queryResults && (
           <RenderIfHasContent


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73835

### Description

Add `ml="auto"` to `SaveButton` in `SdkQuestionDefaultView` so it stays right-aligned when the left title/back-button group is empty.

https://github.com/metabase/metabase/blob/06184c58fcf49f62a5930cac221fc7be4fb06c63/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx#L202-L208

So, this problem happens when only the save button is rendered.

### How to verify

#### Another scenario
1. run storybook with `bun run storybook-embedding-sdk`, and run your BE with any command of your choice.
2. Visit any interactive dashboard story and modify the question then observe the save button position.

#### Originally reported
1. Open `<metabase-browser>` or any SDK consumer using `SdkQuestionDefaultView`.
3. Start a new exploration / open the notebook editor for an unnamed question.
4. Confirm the Save button stays on the right.
5. Open a saved question — layout unchanged.

### Demo

#### After
<img width="1382" height="678" alt="Screenshot 2026-05-18 at 3 22 32 PM" src="https://github.com/user-attachments/assets/840f318d-c358-4650-8b43-2cd50631d91f" />

#### Before
<img width="1390" height="646" alt="Screenshot 2026-05-18 at 3 24 49 PM" src="https://github.com/user-attachments/assets/3cbc68bc-31f1-44e7-9aff-48aabfb54d56" />

Other situations e.g. on storybook: "InteractiveDashboard -> question -> modify question" don't have any regression

#### After
<img width="1182" height="769" alt="image" src="https://github.com/user-attachments/assets/3912c4ac-1bc8-4879-b113-deabaf3c0abd" />



#### Before

<img width="1194" height="689" alt="Screenshot 2026-05-18 at 3 32 03 PM" src="https://github.com/user-attachments/assets/08312b26-2640-4f7f-b4cf-4a4ecb3fe1d3" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Honestly, I don't know how to write a meaningful test, so this requires another eyeball test 🙏 
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)