### PR TITLE
Data Complexity Score rating bands

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -23,24 +23,21 @@
     [:measurement  number?]
     [:score        nat-int?]
     [:rating       nil?]
-    [:rating_label nil?]
-    [:rating_color nil?]]
+    [:rating_label nil?]]
    [:map {:closed true}
     [:measurement  nil?]
     [:score        nil?]
     [:error        string?]
     [:rating       nil?]
-    [:rating_label nil?]
-    [:rating_color nil?]]])
+    [:rating_label nil?]]])
 
 (def ^:private Catalog
   "One catalog's total + per-component breakdown.
-  A failed sub-score cascades nil through both the total and the three rating keys."
+  A failed sub-score cascades nil through both the total and the rating keys."
   [:map
    [:total        [:maybe nat-int?]]
    [:rating       [:maybe [:enum "low" "medium" "high"]]]
    [:rating_label [:maybe string?]]
-   [:rating_color [:maybe [:enum "green" "orange" "red"]]]
    [:components
     [:map
      [:entity_count      SubScore]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -97,7 +97,7 @@
                               :metabot-scope (metabot-scope/internal-metabot-scope)))
           stored      (data-complexity-score/record-score! fingerprint "appdb" result)]
       (task.complexity-score/maybe-advance-last-fingerprint! fingerprint result)
-      (m.util/deep-snake-keys (or stored result)))
+      (m.util/deep-snake-keys (complexity/decorate-with-ratings (or stored result))))
     (finally
       (.set api-scoring-running? false))))
 
@@ -113,6 +113,7 @@
   (if force-recalculation?
     (force-recalculate-score!)
     (api/check-404 (some-> (data-complexity-score/latest-score (task.complexity-score/current-fingerprint))
+                           complexity/decorate-with-ratings
                            m.util/deep-snake-keys)
                    (tru "Data Complexity Score has not been computed yet. Recompute it to create the first snapshot."))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -17,9 +17,7 @@
 
 (def ^:private SubScore
   "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`).
-  `:rating`/`:rating_label`/`:rating_color` are always nil at the sub-component level — only the
-  catalog `:total` is bucketed today. Keys are present (not omitted) so the FE doesn't have to
-  branch on presence."
+  Rating keys are present but always nil — thresholds apply to the catalog total only."
   [:or
    [:map {:closed true}
     [:measurement  number?]
@@ -37,8 +35,7 @@
 
 (def ^:private Catalog
   "One catalog's total + per-component breakdown.
-  `:total` is nil when any sub-score couldn't be computed — failures cascade through aggregates,
-  and the three rating keys cascade nil alongside it."
+  A failed sub-score cascades nil through both the total and the three rating keys."
   [:map
    [:total        [:maybe nat-int?]]
    [:rating       [:maybe [:enum "low" "medium" "high"]]]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -15,28 +15,30 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private Rating
+  "A rating band label drawn from `complexity-thresholds`."
+  [:maybe [:enum "low" "medium" "high"]])
+
 (def ^:private SubScore
-  "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`).
-  Rating keys are present but always nil — thresholds apply to the catalog total only."
+  "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`)."
   [:or
    [:map {:closed true}
     [:measurement  number?]
     [:score        nat-int?]
-    [:rating       nil?]
-    [:rating_label nil?]]
+    [:rating       Rating]
+    [:rating_label [:maybe string?]]]
    [:map {:closed true}
     [:measurement  nil?]
     [:score        nil?]
     [:error        string?]
-    [:rating       nil?]
-    [:rating_label nil?]]])
+    [:rating       Rating]
+    [:rating_label [:maybe string?]]]])
 
 (def ^:private Catalog
-  "One catalog's total + per-component breakdown.
-  A failed sub-score cascades nil through both the total and the rating keys."
+  "One catalog's total + per-component breakdown."
   [:map
    [:total        [:maybe nat-int?]]
-   [:rating       [:maybe [:enum "low" "medium" "high"]]]
+   [:rating       Rating]
    [:rating_label [:maybe string?]]
    [:components
     [:map

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -16,37 +16,23 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private Rating
-  "A rating band label drawn from `complexity-thresholds`."
+  "A rating band label drawn from `complexity-bands`."
   [:maybe [:enum "low" "medium" "high"]])
 
-(def ^:private SubScore
-  "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`)."
-  [:or
-   [:map {:closed true}
-    [:measurement  number?]
-    [:score        nat-int?]
-    [:rating       Rating]
-    [:rating_label [:maybe string?]]]
-   [:map {:closed true}
-    [:measurement  nil?]
-    [:score        nil?]
-    [:error        string?]
-    [:rating       Rating]
-    [:rating_label [:maybe string?]]]])
-
 (def ^:private Catalog
-  "One catalog's total + per-component breakdown."
-  [:map
-   [:total        [:maybe nat-int?]]
-   [:rating       Rating]
-   [:rating_label [:maybe string?]]
-   [:components
-    [:map
-     [:entity_count      SubScore]
-     [:name_collisions   SubScore]
-     [:synonym_pairs     SubScore]
-     [:field_count       SubScore]
-     [:repeated_measures SubScore]]]])
+  "Recursive score node.
+  Regular nodes carry `:score` + `:rating` plus optional `:measurement` (leaf) or `:components` (keyword→Catalog).
+  Error leaves carry only `:error`."
+  [:schema
+   {:registry {::node [:or
+                       [:map {:closed true} [:error string?]]
+                       [:map {:closed true}
+                        [:score                       [:maybe nat-int?]]
+                        [:rating                      Rating]
+                        [:rating_label                [:maybe string?]]
+                        [:measurement {:optional true} number?]
+                        [:components  {:optional true} [:map-of :keyword [:ref ::node]]]]]}}
+   [:ref ::node]])
 
 (def ^:private EmbeddingModelMeta
   "Identifies the embedding model backing the synonym calculations, so benchmark consumers can pin to it.
@@ -65,6 +51,7 @@
    [:meta
     [:map
      [:formula_version   pos-int?]
+     [:format_version     pos-int?]
      [:synonym_threshold number?]
      [:calculated_at {:optional true} some?]
      [:embedding_model {:optional true} EmbeddingModelMeta]]]])

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -19,19 +19,32 @@
   "A rating band label drawn from `complexity-bands`."
   [:maybe [:enum "low" "medium" "high"]])
 
-(def ^:private Catalog
-  "Recursive score node.
-  Regular nodes carry `:score` + `:rating` plus optional `:measurement` (leaf) or `:components` (keyword→Catalog).
-  Error leaves carry only `:error`."
+(def ^:private Failure
+  "Sub-score that couldn't be computed; carries only the failure message.
+  (Named `Failure` rather than `Error` to avoid shadowing `java.lang.Error`.)"
+  [:map {:closed true}
+   [:error string?]])
+
+(def ^:private Leaf
+  "Computed leaf sub-score with a raw `:measurement` and its weighted `:score`."
+  [:map {:closed true}
+   [:measurement  number?]
+   [:score        nat-int?]
+   [:rating       Rating]
+   [:rating_label [:maybe string?]]])
+
+(def ^:private Grouping
+  "Internal node whose `:score` is the rolled-up sum of its `:components` children."
+  [:map {:closed true}
+   [:score        [:maybe nat-int?]]
+   [:rating       Rating]
+   [:rating_label [:maybe string?]]
+   [:components   [:map-of :keyword [:ref ::node]]]])
+
+(def ^:private Node
+  "Recursive score node: a [[Failure]], a [[Leaf]], or a [[Grouping]] whose children are themselves Nodes."
   [:schema
-   {:registry {::node [:or
-                       [:map {:closed true} [:error string?]]
-                       [:map {:closed true}
-                        [:score                       [:maybe nat-int?]]
-                        [:rating                      Rating]
-                        [:rating_label                [:maybe string?]]
-                        [:measurement {:optional true} number?]
-                        [:components  {:optional true} [:map-of :keyword [:ref ::node]]]]]}}
+   {:registry {::node [:or Failure Leaf Grouping]}}
    [:ref ::node]])
 
 (def ^:private EmbeddingModelMeta
@@ -45,9 +58,9 @@
 (def ^:private ComplexityScoresResponse
   "Full response body for `GET /api/ee/data-complexity-score/complexity`."
   [:map
-   [:library  Catalog]
-   [:universe Catalog]
-   [:metabot  Catalog]
+   [:library  Node]
+   [:universe Node]
+   [:metabot  Node]
    [:meta
     [:map
      [:formula_version   pos-int?]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -17,7 +17,7 @@
 
 (def ^:private Rating
   "A rating band label drawn from `complexity-bands`."
-  [:maybe [:enum "low" "medium" "high"]])
+  [:enum "low" "medium" "high"])
 
 (def ^:private Failure
   "Sub-score that couldn't be computed; carries only the failure message.
@@ -30,14 +30,14 @@
   [:map {:closed true}
    [:measurement  number?]
    [:score        nat-int?]
-   [:rating       Rating]
+   [:rating       [:maybe Rating]]
    [:rating_label [:maybe string?]]])
 
 (def ^:private Grouping
   "Internal node whose `:score` is the rolled-up sum of its `:components` children."
   [:map {:closed true}
    [:score        [:maybe nat-int?]]
-   [:rating       Rating]
+   [:rating       [:maybe Rating]]
    [:rating_label [:maybe string?]]
    [:components   [:map-of :keyword [:ref ::node]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -64,7 +64,7 @@
    [:meta
     [:map
      [:formula_version   pos-int?]
-     [:format_version     pos-int?]
+     [:format_version    pos-int?]
      [:synonym_threshold number?]
      [:calculated_at {:optional true} some?]
      [:embedding_model {:optional true} EmbeddingModelMeta]]]])

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/api.clj
@@ -16,21 +16,34 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private SubScore
-  "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`)."
+  "Either a computed sub-score (`:measurement` + `:score`) or an uncomputed one (`:error`).
+  `:rating`/`:rating_label`/`:rating_color` are always nil at the sub-component level — only the
+  catalog `:total` is bucketed today. Keys are present (not omitted) so the FE doesn't have to
+  branch on presence."
   [:or
    [:map {:closed true}
-    [:measurement number?]
-    [:score       nat-int?]]
+    [:measurement  number?]
+    [:score        nat-int?]
+    [:rating       nil?]
+    [:rating_label nil?]
+    [:rating_color nil?]]
    [:map {:closed true}
-    [:measurement nil?]
-    [:score       nil?]
-    [:error       string?]]])
+    [:measurement  nil?]
+    [:score        nil?]
+    [:error        string?]
+    [:rating       nil?]
+    [:rating_label nil?]
+    [:rating_color nil?]]])
 
 (def ^:private Catalog
   "One catalog's total + per-component breakdown.
-  `:total` is nil when any sub-score couldn't be computed — failures cascade through aggregates."
+  `:total` is nil when any sub-score couldn't be computed — failures cascade through aggregates,
+  and the three rating keys cascade nil alongside it."
   [:map
-   [:total [:maybe nat-int?]]
+   [:total        [:maybe nat-int?]]
+   [:rating       [:maybe [:enum "low" "medium" "high"]]]
+   [:rating_label [:maybe string?]]
+   [:rating_color [:maybe [:enum "green" "orange" "red"]]]
    [:components
     [:map
      [:entity_count      SubScore]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -68,10 +68,10 @@
   [tables {:keys [total] :as catalog}]
   (-> catalog
       (merge (rating-for-score (tables :total) total))
-      (u/update-if-exists :components
-                          #(reduce-kv (fn [m k {:keys [score] :as c}]
-                                        (assoc m k (merge c (rating-for-score (tables k) score))))
-                                      {} %))))
+      (update :components
+              #(reduce-kv (fn [m k {:keys [score] :as c}]
+                            (assoc m k (merge c (rating-for-score (tables k) score))))
+                          {} %))))
 
 ;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
 ;; against the raw total without re-applying the thresholds.

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -461,18 +461,15 @@
   Internal nodes use a `<path>.total` key with the rolled-up `:score` (the root emits as `total`).
   `:score` is omitted when nil; see [[with-score]]."
   [base catalog path node]
-  (let [leaf? (not (:components node))
-        ;; `:total` here is the Snowplow wire-format suffix for rollup nodes, not an in-memory field.
-        key   (if leaf?
-                (apply dotted-key path)
-                (apply dotted-key (conj (vec path) :total)))
+  (let [;; `:total` here is the Snowplow wire-format suffix for rollup nodes, not an in-memory field.
+        key   (apply dotted-key (if (:components node) (conj path :total) path))
         event (cond-> (-> base
                           (assoc :catalog catalog :key key)
                           (with-score (:score node)))
-                (and leaf? (not (:error node))) (assoc :measurement (:measurement node))
-                (:error node)                   (assoc :error (truncate-error (:error node))))]
+                (:measurement node) (assoc :measurement (:measurement node))
+                (:error node)       (assoc :error (truncate-error (:error node))))]
     (cons event
-          (mapcat (fn [[k child]] (node->events base catalog (conj (vec path) k) child))
+          (mapcat (fn [[k child]] (node->events base catalog (conj path k) child))
                   (:components node)))))
 
 (defn- emit-snowplow!

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -34,6 +34,29 @@
    :field            1
    :repeated-measure 2})
 
+(def complexity-thresholds
+  "Bands for translating a catalog `:total` into a categorical complexity rating.
+  Each band covers scores up through its `:max`; the final band is unbounded.
+  Public so callers (and the FE) can introspect the table rather than re-encoding it.
+  Values are strings rather than keywords so they survive the JSON round-trip on the wire
+  unchanged — JSON consumers see exactly the values declared here.
+  Applies to catalog totals only — sub-component ratings are nil for now."
+  [{:rating "low"    :label "Low complexity"    :color "green"  :max 999}
+   {:rating "medium" :label "Medium complexity" :color "orange" :max 9999}
+   {:rating "high"   :label "High complexity"   :color "red"}])
+
+(defn- rating-for-score
+  "Return `{:rating :rating-label :rating-color}` for `score` using [[complexity-thresholds]].
+  All three keys are nil when `score` is nil — an uncomputed total cascades the nil through
+  the rating fields the same way `nil-safe-sum` does for the total itself."
+  [score]
+  (let [band (when (some? score)
+               (some (fn [{:keys [max] :as b}] (when (or (nil? max) (<= score max)) b))
+                     complexity-thresholds))]
+    {:rating       (:rating band)
+     :rating-label (:label band)
+     :rating-color (:color band)}))
+
 (def ^:private component->group
   "Thematic parent per sub-component — drives the `<group>.total` + `<group>.<component>` rollup in
   emitted keys so operators can tell `size` from `ambiguity` without SQL.
@@ -327,15 +350,24 @@
     (reduce + xs)))
 
 (defn score-catalog
-  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`."
+  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`.
+  Each component sub-score and the catalog total carry uniform `:rating`, `:rating-label`, and
+  `:rating-color` keys; thresholds apply to the catalog total only, so component values are nil."
   [entities embedder]
-  (let [components {:entity-count      (score-entity-count entities)
-                    :name-collisions   (score-name-collisions entities)
-                    :synonym-pairs     (score-synonym-pairs entities embedder)
-                    :field-count       (score-field-count entities)
-                    :repeated-measures (score-repeated-measures entities)}]
-    {:total      (nil-safe-sum (map (comp :score val) components))
-     :components components}))
+  (let [nil-rating {:rating nil :rating-label nil :rating-color nil}
+        components (-> {:entity-count      (score-entity-count entities)
+                        :name-collisions   (score-name-collisions entities)
+                        :synonym-pairs     (score-synonym-pairs entities embedder)
+                        :field-count       (score-field-count entities)
+                        :repeated-measures (score-repeated-measures entities)}
+                       ;; `(merge sub nil-rating)` preserves the sub-score's own keys
+                       ;; (`:measurement`/`:score`, plus `:error` when synonym scoring failed)
+                       ;; — only the three rating keys are added.
+                       (update-vals #(merge % nil-rating)))
+        total      (nil-safe-sum (map (comp :score val) components))]
+    (merge {:total      total
+            :components components}
+           (rating-for-score total))))
 
 ;;; ----------------------------------- public API ------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -512,7 +512,7 @@
                  universe-score
                  (score-catalog metabot-entities embedder))
      :meta     (cond-> {:formula-version   formula-version
-                        :format-version     format-version
+                        :format-version    format-version
                         :synonym-threshold synonym-similarity-threshold
                         :weights           weights}
                  embedding-model-meta (assoc :embedding-model embedding-model-meta)
@@ -580,7 +580,7 @@
                             :universe universe-score
                             :metabot  metabot-score
                             :meta     (cond-> {:formula-version   formula-version
-                                               :format-version     format-version
+                                               :format-version    format-version
                                                :synonym-threshold synonym-similarity-threshold}
                                         embedding-model-meta (assoc :embedding-model embedding-model-meta)
                                         text-variant         (assoc :text-variant    text-variant))}

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -35,20 +35,16 @@
    :repeated-measure 2})
 
 (def complexity-thresholds
-  "Bands for translating a catalog `:total` into a categorical complexity rating.
-  Each band covers scores up through its `:max`; the final band is unbounded.
-  Public so callers (and the FE) can introspect the table rather than re-encoding it.
-  Values are strings rather than keywords so they survive the JSON round-trip on the wire
-  unchanged — JSON consumers see exactly the values declared here.
-  Applies to catalog totals only — sub-component ratings are nil for now."
+  "Thresholds for the catalog-total complexity rating.
+  Public — consumers introspect this rather than reproduce the table.
+  Values are strings so the JSON round-trip is a no-op.
+  Applies to the catalog total only; sub-component ratings are nil."
   [{:rating "low"    :label "Low complexity"    :color "green"  :max 999}
    {:rating "medium" :label "Medium complexity" :color "orange" :max 9999}
    {:rating "high"   :label "High complexity"   :color "red"}])
 
 (defn- rating-for-score
-  "Return `{:rating :rating-label :rating-color}` for `score` using [[complexity-thresholds]].
-  All three keys are nil when `score` is nil — an uncomputed total cascades the nil through
-  the rating fields the same way `nil-safe-sum` does for the total itself."
+  "Nil cascades through all three return keys so an uncomputed total isn't bucketed as low."
   [score]
   (let [band (when (some? score)
                (some (fn [{:keys [max] :as b}] (when (or (nil? max) (<= score max)) b))
@@ -351,8 +347,7 @@
 
 (defn score-catalog
   "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`.
-  Each component sub-score and the catalog total carry uniform `:rating`, `:rating-label`, and
-  `:rating-color` keys; thresholds apply to the catalog total only, so component values are nil."
+  Rating fields are present on every component but nil — thresholds apply to the catalog total only."
   [entities embedder]
   (let [nil-rating {:rating nil :rating-label nil :rating-color nil}
         components (-> {:entity-count      (score-entity-count entities)
@@ -360,9 +355,6 @@
                         :synonym-pairs     (score-synonym-pairs entities embedder)
                         :field-count       (score-field-count entities)
                         :repeated-measures (score-repeated-measures entities)}
-                       ;; `(merge sub nil-rating)` preserves the sub-score's own keys
-                       ;; (`:measurement`/`:score`, plus `:error` when synonym scoring failed)
-                       ;; — only the three rating keys are added.
                        (update-vals #(merge % nil-rating)))
         total      (nil-safe-sum (map (comp :score val) components))]
     (merge {:total      total

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -17,11 +17,13 @@
 (set! *warn-on-reflection* true)
 
 (def formula-version
-  "Bump when the scoring formula changes in a way that would break historical comparisons.
+  "Bump when the scoring formula changes in a way that would break historical score comparisons.
+  Weight changes, new/removed components, and rollup-affecting restructures count; pure-shape changes do not.
+  Tunables in the fingerprint (`embedding-model`, `synonym-threshold`, `text-variant`, etc) don't need a bump."
+  1)
 
-  Changes to `embedding-model`, `synonym-threshold`, `text-variant`, etc don't need a bump.
-  These parameters are already captured in the fingerprint.
-  Formula versioning is reserved for cases where the actual formulas or components change."
+(def format-version
+  "Bump when the response shape changes in a way that breaks consumer parsing, even when scores are equivalent."
   1)
 
 (def weights
@@ -34,28 +36,37 @@
    :field            1
    :repeated-measure 2})
 
-(def complexity-thresholds
-  "Rating bands keyed by catalog field; only `:total` is populated for now."
-  {:total [{:rating "low"    :label "Low complexity"    :max 999}
+(def complexity-bands
+  "Tree of rating bands mirroring [[score-catalog]]'s output.
+  Each node's `:bands` rates that node's `:score`; `:components` follows the same nesting as the scored catalog."
+  {:bands [{:rating "low"    :label "Low complexity"    :max 999}
            {:rating "medium" :label "Medium complexity" :max 9999}
            {:rating "high"   :label "High complexity"}]})
 
 (def ^:private nil-rating {:rating nil :rating-label nil})
 
-(defn- ->rating-table
-  "Bundle `bands` with a pre-built `:rating`→presentation `:lookup`."
+(defn- ->band-lookup
+  "Bundle `bands` with a pre-built `:rating`→presentation `:lookup` for fast rating-by-score."
   [bands]
   {:bands  bands
    :lookup (u/for-map [{:keys [rating label]} bands]
              [rating {:rating rating :rating-label label}])})
 
-(def ^:private rating-tables
-  (update-vals complexity-thresholds ->rating-table))
+(defn- compile-bands
+  "Replace each node's `:bands` in the bands tree with a precomputed `:band-lookup`."
+  [bands]
+  (cond-> {}
+    (:bands bands)
+    (assoc :band-lookup (->band-lookup (:bands bands)))
+
+    (:components bands)
+    (assoc :components (update-vals (:components bands) compile-bands))))
+
+(def ^:private compiled-bands
+  (compile-bands complexity-bands))
 
 (defn- rating-for-score
-  "Presentation for `score` from a preprocessed `rating-table`, or `nil-rating` when nothing matches.
-  Private because the table shape is an internal detail of [[->rating-table]]; the public path is
-  [[decorate-with-ratings]], which wires the preprocessed tables in itself."
+  "Look up `score`'s rating in a preprocessed `band-lookup`, or `nil-rating` when nothing matches."
   [{:keys [bands lookup]} score]
   (or (when (some? score)
         (some (fn [{:keys [rating max]}]
@@ -65,31 +76,30 @@
       nil-rating))
 
 (defn- decorate-with-ratings*
-  "Rate `:total` and each `:components` value of one catalog via the matching `tables` entry."
-  [tables {:keys [total] :as catalog}]
-  (let [rate-component (fn [m k {:keys [score] :as c}]
-                         (assoc m k (merge c (rating-for-score (tables k) score))))]
-    (-> catalog
-        (merge (rating-for-score (tables :total) total))
-        (update :components (partial reduce-kv rate-component {})))))
+  "Walk a catalog `node` and the matching `bands` subtree in parallel, merging rating fields onto every node.
+  Each node is rated against its own `:band-lookup`, or `nil-rating` when absent.
+  Error leaves carry only `:error` and are left untouched. Children recurse along `:components`."
+  [bands node]
+  (if (:error node)
+    node
+    (let [decorated (merge node (rating-for-score (:band-lookup bands) (:score node)))]
+      (cond-> decorated
+        (:components node)
+        (update :components
+                (fn [components]
+                  (reduce-kv (fn [m k child]
+                               (assoc m k (decorate-with-ratings* (get-in bands [:components k])
+                                                                  child)))
+                             {}
+                             components)))))))
 
 ;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
-;; against the raw total without re-applying the thresholds.
+;; against the raw score without re-applying the bands.
 (defn decorate-with-ratings
-  "Decorate each catalog with rating fields per `complexity-thresholds`."
+  "Decorate each catalog with rating fields per `complexity-bands`."
   [score]
-  (let [decorate (partial decorate-with-ratings* rating-tables)]
+  (let [decorate (partial decorate-with-ratings* compiled-bands)]
     (reduce #(u/update-if-exists %1 %2 decorate) score [:library :universe :metabot])))
-
-(def ^:private component->group
-  "Thematic parent per sub-component — drives the `<group>.total` + `<group>.<component>` rollup in
-  emitted keys so operators can tell `size` from `ambiguity` without SQL.
-  Must cover every key produced by [[score-catalog]] or the missing ones emit as `nil.<component>`."
-  {:entity-count      :size
-   :field-count       :size
-   :name-collisions   :ambiguity
-   :synonym-pairs     :ambiguity
-   :repeated-measures :ambiguity})
 
 (def synonym-similarity-threshold
   "Cosine-similarity cutoff for flagging two names as synonyms.
@@ -343,10 +353,10 @@
        :value-doesnt-matter))))
 
 (defn- score-synonym-pairs
-  "Compute the synonym sub-score for `entities` using `embedder`. On embedder failure, returns nil
-   `:score`/`:measurement` plus an `:error` string so the failure cascades through aggregates
-   instead of being mistaken for a real zero. A nil `embedder` produces an empty lookup and scores
-   a real zero."
+  "Compute the synonym sub-score for `entities` using `embedder`.
+  On embedder failure returns an `{:error \"...\"}`-only leaf, so the failure cascades through aggregates
+  (their `:score` rolls up to nil) and consumers can branch on `:error` presence.
+  A nil `embedder` produces an empty lookup and scores a real zero."
   [entities embedder]
   (try
     (let [name->vec     (or (and embedder (embedder entities)) {})
@@ -364,7 +374,7 @@
             err (if (str/blank? msg)
                   (or (some-> (class t) .getName) "synonym detection failed")
                   msg)]
-        {:measurement nil :score nil :error err}))))
+        {:error err}))))
 
 (defn- nil-safe-sum
   "Sum `xs` (numbers and/or nils). Returns nil if any element is nil — used to cascade an
@@ -373,16 +383,33 @@
   (when (every? some? xs)
     (reduce + xs)))
 
-(defn score-catalog
-  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`."
+(defn- score-tree-leaves
+  "Pure: build the leaves-only tree of sub-score maps for one catalog.
+  Each leaf is a `{:measurement <num-or-nil> :score <num-or-nil> [:error <str>]}` map; the surrounding shape
+  defines the `:size`/`:ambiguity` grouping that [[score-catalog]] then rolls up."
   [entities embedder]
-  (let [components {:entity-count      (score-entity-count entities)
-                    :name-collisions   (score-name-collisions entities)
-                    :synonym-pairs     (score-synonym-pairs entities embedder)
-                    :field-count       (score-field-count entities)
-                    :repeated-measures (score-repeated-measures entities)}]
-    {:total      (nil-safe-sum (map (comp :score val) components))
-     :components components}))
+  {:size      {:entity-count (score-entity-count entities)
+               :field-count  (score-field-count entities)}
+   :ambiguity {:name-collisions   (score-name-collisions entities)
+               :synonym-pairs     (score-synonym-pairs entities embedder)
+               :repeated-measures (score-repeated-measures entities)}})
+
+(defn- rollup-node
+  "Recursively roll up a node's children into `{:score <sum> :components {...}}`.
+  Leaves — maps carrying `:score` (computed) or `:error` (uncomputed) — pass through unchanged.
+  `:score` cascades nil through aggregates so an uncomputed sub-score nils out everything it feeds."
+  [node]
+  (if (or (contains? node :score) (contains? node :error))
+    node
+    (let [components (update-vals node rollup-node)]
+      {:score      (nil-safe-sum (map (comp :score val) components))
+       :components components})))
+
+(defn score-catalog
+  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`.
+  Returns `{:score <sum> :components {:size {...} :ambiguity {...}}}`; see [[score-tree-leaves]] for the leaf layout."
+  [entities embedder]
+  (rollup-node (score-tree-leaves entities embedder)))
 
 ;;; ----------------------------------- public API ------------------------------------
 
@@ -428,6 +455,26 @@
   [event score]
   (cond-> event (some? score) (assoc :score score)))
 
+(defn- node->events
+  "Walk one catalog and emit a Snowplow event per node.
+  Computed leaves use a `<path>` key and carry `:measurement`; error leaves use the same `<path>` key with `:error`.
+  Internal nodes use a `<path>.total` key with the rolled-up `:score` (the root emits as `total`).
+  `:score` is omitted when nil; see [[with-score]]."
+  [base catalog path node]
+  (let [leaf? (not (:components node))
+        ;; `:total` here is the Snowplow wire-format suffix for rollup nodes, not an in-memory field.
+        key   (if leaf?
+                (apply dotted-key path)
+                (apply dotted-key (conj (vec path) :total)))
+        event (cond-> (-> base
+                          (assoc :catalog catalog :key key)
+                          (with-score (:score node)))
+                (and leaf? (not (:error node))) (assoc :measurement (:measurement node))
+                (:error node)                   (assoc :error (truncate-error (:error node))))]
+    (cons event
+          (mapcat (fn [[k child]] (node->events base catalog (conj (vec path) k) child))
+                  (:components node)))))
+
 (defn- emit-snowplow!
   "Submits Snowplow events for every score, every group aggregation, and the grand total.
   Returns true when they are all successfully delivered.
@@ -437,27 +484,8 @@
                 :batch_id        (str (random-uuid))
                 :formula_version (:formula-version meta)
                 :parameters      (parameters-map meta)}
-        events (for [[catalog result] [[:library library] [:universe universe] [:metabot metabot]]
-                     event (concat (for [[component sub] (:components result)]
-                                     ;; leaf component
-                                     (cond-> (-> base
-                                                 (assoc :catalog     catalog
-                                                        :key         (dotted-key (component->group component) component)
-                                                        :measurement (:measurement sub))
-                                                 (with-score (:score sub)))
-                                       (:error sub) (assoc :error (truncate-error (:error sub)))))
-                                   (for [[group entries] (group-by #(component->group (key %)) (:components result))]
-                                     ;; group total
-                                     (-> base
-                                         (assoc :catalog catalog
-                                                :key     (dotted-key group :total))
-                                         (with-score (nil-safe-sum (map (comp :score val) entries)))))
-                                   ;; grand total
-                                   [(-> base
-                                        (assoc :catalog catalog
-                                               :key     (dotted-key :total))
-                                        (with-score (:total result)))])]
-                 event)]
+        events (mapcat (fn [[catalog result]] (node->events base catalog [] result))
+                       [[:library library] [:universe universe] [:metabot metabot]])]
     ;; No short-circuiting - even if they are failures, attempt the rest.
     (reduce (fn [all-ok? event]
               (and (analytics/track-event! :snowplow/data_complexity event) all-ok?))
@@ -487,6 +515,7 @@
                  universe-score
                  (score-catalog metabot-entities embedder))
      :meta     (cond-> {:formula-version   formula-version
+                        :format-version     format-version
                         :synonym-threshold synonym-similarity-threshold
                         :weights           weights}
                  embedding-model-meta (assoc :embedding-model embedding-model-meta)
@@ -509,10 +538,11 @@
 
   Returns a map of the shape:
 
-      {:library  {:total n :components {...}}
-       :universe {:total n :components {...}}
-       :metabot  {:total n :components {...}}
+      {:library  {:score n :components {...}}
+       :universe {:score n :components {...}}
+       :metabot  {:score n :components {...}}
        :meta     {:formula-version 1
+                  :format-version 1
                   :synonym-threshold 0.80
                   :embedding-model {:provider ..., :model-name ..., :model-dimensions ...}
                   :text-variant :names-split}}
@@ -553,6 +583,7 @@
                             :universe universe-score
                             :metabot  metabot-score
                             :meta     (cond-> {:formula-version   formula-version
+                                               :format-version     format-version
                                                :synonym-threshold synonym-similarity-threshold}
                                         embedding-model-meta (assoc :embedding-model embedding-model-meta)
                                         text-variant         (assoc :text-variant    text-variant))}

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -35,8 +35,7 @@
    :repeated-measure 2})
 
 (def complexity-thresholds
-  "Rating bands keyed by catalog field: `:total` for the catalog total, component keys for
-  sub-component scores. Only `:total` is populated for now."
+  "Rating bands keyed by catalog field; only `:total` is populated for now."
   {:total [{:rating "low"    :label "Low complexity"    :max 999}
            {:rating "medium" :label "Medium complexity" :max 9999}
            {:rating "high"   :label "High complexity"}]})
@@ -66,12 +65,11 @@
 (defn decorate-with-ratings*
   "Rate `:total` and each `:components` value of one catalog via the matching `tables` entry."
   [tables {:keys [total] :as catalog}]
-  (-> catalog
-      (merge (rating-for-score (tables :total) total))
-      (update :components
-              #(reduce-kv (fn [m k {:keys [score] :as c}]
-                            (assoc m k (merge c (rating-for-score (tables k) score))))
-                          {} %))))
+  (let [rate-component (fn [m k {:keys [score] :as c}]
+                         (assoc m k (merge c (rating-for-score (tables k) score))))]
+    (-> catalog
+        (merge (rating-for-score (tables :total) total))
+        (update :components (partial reduce-kv rate-component {})))))
 
 ;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
 ;; against the raw total without re-applying the thresholds.

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -68,10 +68,10 @@
   [tables {:keys [total] :as catalog}]
   (-> catalog
       (merge (rating-for-score (tables :total) total))
-      (update :components
-              #(reduce-kv (fn [m k {:keys [score] :as c}]
-                            (assoc m k (merge c (rating-for-score (tables k) score))))
-                          {} %))))
+      (u/update-if-exists :components
+                          #(reduce-kv (fn [m k {:keys [score] :as c}]
+                                        (assoc m k (merge c (rating-for-score (tables k) score))))
+                                      {} %))))
 
 ;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
 ;; against the raw total without re-applying the thresholds.

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -50,17 +50,14 @@
      :rating-label (:label band)}))
 
 (defn decorate-with-ratings
-  "Annotate each catalog in a complexity-scores response with rating fields derived from its `:total`.
-  Components get present-but-nil rating keys so the response shape is uniform."
+  "Decorate each catalog total with rating fields; sub-components get present-but-nil rating keys."
   [score]
   (let [nil-rating {:rating nil :rating-label nil}
-        decorate   (fn [catalog]
-                     (-> catalog
-                         (merge (rating-for-score (:total catalog)))
-                         (update :components update-vals #(merge % nil-rating))))]
-    (reduce (fn [s k] (cond-> s (get s k) (update k decorate)))
-            score
-            [:library :universe :metabot])))
+        decorate  (fn [{:keys [total] :as catalog}]
+                    (-> catalog
+                        (merge (rating-for-score total))
+                        (update :components update-vals #(merge % nil-rating))))]
+    (reduce #(u/update-if-exists %1 %2 decorate) score [:library :universe :metabot])))
 
 (def ^:private component->group
   "Thematic parent per sub-component — drives the `<group>.total` + `<group>.<component>` rollup in

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -35,16 +35,13 @@
    :repeated-measure 2})
 
 (def complexity-thresholds
-  "Thresholds for the catalog-total complexity rating.
-  Public — consumers introspect this rather than reproduce the table.
-  Values are strings so the JSON round-trip is a no-op.
-  Applies to the catalog total only; sub-component ratings are nil."
+  "Catalog-total rating bands. Applied at the API boundary, not persisted."
   [{:rating "low"    :label "Low complexity"    :color "green"  :max 999}
    {:rating "medium" :label "Medium complexity" :color "orange" :max 9999}
    {:rating "high"   :label "High complexity"   :color "red"}])
 
-(defn- rating-for-score
-  "Nil cascades through all three return keys so an uncomputed total isn't bucketed as low."
+(defn rating-for-score
+  "Nil score cascades nil through all three return keys."
   [score]
   (let [band (when (some? score)
                (some (fn [{:keys [max] :as b}] (when (or (nil? max) (<= score max)) b))
@@ -52,6 +49,19 @@
     {:rating       (:rating band)
      :rating-label (:label band)
      :rating-color (:color band)}))
+
+(defn decorate-with-ratings
+  "Annotate each catalog in a complexity-scores response with rating fields derived from its `:total`.
+  Components get present-but-nil rating keys so the response shape is uniform."
+  [score]
+  (let [nil-rating {:rating nil :rating-label nil :rating-color nil}
+        decorate   (fn [catalog]
+                     (-> catalog
+                         (merge (rating-for-score (:total catalog)))
+                         (update :components update-vals #(merge % nil-rating))))]
+    (reduce (fn [s k] (cond-> s (get s k) (update k decorate)))
+            score
+            [:library :universe :metabot])))
 
 (def ^:private component->group
   "Thematic parent per sub-component — drives the `<group>.total` + `<group>.<component>` rollup in
@@ -346,20 +356,15 @@
     (reduce + xs)))
 
 (defn score-catalog
-  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`.
-  Rating fields are present on every component but nil — thresholds apply to the catalog total only."
+  "Pure: compute the score breakdown for a catalog given its `entities` and an optional `embedder`."
   [entities embedder]
-  (let [nil-rating {:rating nil :rating-label nil :rating-color nil}
-        components (-> {:entity-count      (score-entity-count entities)
-                        :name-collisions   (score-name-collisions entities)
-                        :synonym-pairs     (score-synonym-pairs entities embedder)
-                        :field-count       (score-field-count entities)
-                        :repeated-measures (score-repeated-measures entities)}
-                       (update-vals #(merge % nil-rating)))
-        total      (nil-safe-sum (map (comp :score val) components))]
-    (merge {:total      total
-            :components components}
-           (rating-for-score total))))
+  (let [components {:entity-count      (score-entity-count entities)
+                    :name-collisions   (score-name-collisions entities)
+                    :synonym-pairs     (score-synonym-pairs entities embedder)
+                    :field-count       (score-field-count entities)
+                    :repeated-measures (score-repeated-measures entities)}]
+    {:total      (nil-safe-sum (map (comp :score val) components))
+     :components components}))
 
 ;;; ----------------------------------- public API ------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -49,6 +49,8 @@
     {:rating       (:rating band)
      :rating-label (:label band)}))
 
+;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
+;; against the raw total without re-applying the thresholds.
 (defn decorate-with-ratings
   "Decorate each catalog total with rating fields; sub-components get present-but-nil rating keys."
   [score]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -35,30 +35,50 @@
    :repeated-measure 2})
 
 (def complexity-thresholds
-  "Catalog-total rating bands. Applied at the API boundary, not persisted."
-  [{:rating "low"    :label "Low complexity"    :max 999}
-   {:rating "medium" :label "Medium complexity" :max 9999}
-   {:rating "high"   :label "High complexity"}])
+  "Rating bands keyed by catalog field: `:total` for the catalog total, component keys for
+  sub-component scores. Only `:total` is populated for now."
+  {:total [{:rating "low"    :label "Low complexity"    :max 999}
+           {:rating "medium" :label "Medium complexity" :max 9999}
+           {:rating "high"   :label "High complexity"}]})
+
+(def ^:private nil-rating {:rating nil :rating-label nil})
+
+(defn- ->rating-table
+  "Bundle `bands` with a pre-built `:rating`→presentation `:lookup`."
+  [bands]
+  {:bands  bands
+   :lookup (u/for-map [{:keys [rating label]} bands]
+             [rating {:rating rating :rating-label label}])})
+
+(def ^:private rating-tables
+  (update-vals complexity-thresholds ->rating-table))
 
 (defn rating-for-score
-  "Nil score cascades nil through both return keys."
-  [score]
-  (let [band (when (some? score)
-               (some (fn [{:keys [max] :as b}] (when (or (nil? max) (<= score max)) b))
-                     complexity-thresholds))]
-    {:rating       (:rating band)
-     :rating-label (:label band)}))
+  "Presentation for `score` from `rating-table`, or `nil-rating` when nothing matches."
+  [{:keys [bands lookup]} score]
+  (or (when (some? score)
+        (some (fn [{:keys [rating max]}]
+                (when (or (nil? max) (<= score max))
+                  (lookup rating)))
+              bands))
+      nil-rating))
+
+(defn decorate-with-ratings*
+  "Rate `:total` and each `:components` value of one catalog via the matching `tables` entry."
+  [tables {:keys [total] :as catalog}]
+  (-> catalog
+      (merge (rating-for-score (tables :total) total))
+      (update :components
+              #(reduce-kv (fn [m k {:keys [score] :as c}]
+                            (assoc m k (merge c (rating-for-score (tables k) score))))
+                          {} %))))
 
 ;; TODO: also emit the rating onto Snowplow events so benchmark consumers can correlate the band
 ;; against the raw total without re-applying the thresholds.
 (defn decorate-with-ratings
-  "Decorate each catalog total with rating fields; sub-components get present-but-nil rating keys."
+  "Decorate each catalog with rating fields per `complexity-thresholds`."
   [score]
-  (let [nil-rating {:rating nil :rating-label nil}
-        decorate  (fn [{:keys [total] :as catalog}]
-                    (-> catalog
-                        (merge (rating-for-score total))
-                        (update :components update-vals #(merge % nil-rating))))]
+  (let [decorate (partial decorate-with-ratings* rating-tables)]
     (reduce #(u/update-if-exists %1 %2 decorate) score [:library :universe :metabot])))
 
 (def ^:private component->group

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -36,25 +36,24 @@
 
 (def complexity-thresholds
   "Catalog-total rating bands. Applied at the API boundary, not persisted."
-  [{:rating "low"    :label "Low complexity"    :color "green"  :max 999}
-   {:rating "medium" :label "Medium complexity" :color "orange" :max 9999}
-   {:rating "high"   :label "High complexity"   :color "red"}])
+  [{:rating "low"    :label "Low complexity"    :max 999}
+   {:rating "medium" :label "Medium complexity" :max 9999}
+   {:rating "high"   :label "High complexity"}])
 
 (defn rating-for-score
-  "Nil score cascades nil through all three return keys."
+  "Nil score cascades nil through both return keys."
   [score]
   (let [band (when (some? score)
                (some (fn [{:keys [max] :as b}] (when (or (nil? max) (<= score max)) b))
                      complexity-thresholds))]
     {:rating       (:rating band)
-     :rating-label (:label band)
-     :rating-color (:color band)}))
+     :rating-label (:label band)}))
 
 (defn decorate-with-ratings
   "Annotate each catalog in a complexity-scores response with rating fields derived from its `:total`.
   Components get present-but-nil rating keys so the response shape is uniform."
   [score]
-  (let [nil-rating {:rating nil :rating-label nil :rating-color nil}
+  (let [nil-rating {:rating nil :rating-label nil}
         decorate   (fn [catalog]
                      (-> catalog
                          (merge (rating-for-score (:total catalog)))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -52,8 +52,10 @@
 (def ^:private rating-tables
   (update-vals complexity-thresholds ->rating-table))
 
-(defn rating-for-score
-  "Presentation for `score` from `rating-table`, or `nil-rating` when nothing matches."
+(defn- rating-for-score
+  "Presentation for `score` from a preprocessed `rating-table`, or `nil-rating` when nothing matches.
+  Private because the table shape is an internal detail of [[->rating-table]]; the public path is
+  [[decorate-with-ratings]], which wires the preprocessed tables in itself."
   [{:keys [bands lookup]} score]
   (or (when (some? score)
         (some (fn [{:keys [rating max]}]
@@ -62,7 +64,7 @@
               bands))
       nil-rating))
 
-(defn decorate-with-ratings*
+(defn- decorate-with-ratings*
   "Rate `:total` and each `:components` value of one catalog via the matching `tables` entry."
   [tables {:keys [total] :as catalog}]
   (let [rate-component (fn [m k {:keys [score] :as c}]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -23,19 +23,13 @@
 (def ^:private trigger-key (triggers/key "metabase.task.data-complexity-score.trigger"))
 
 (defn current-fingerprint
-  "String capturing everything that changes the meaning of an emitted score.
-
-  Mirrors the Snowplow `formula_version` + `parameters` fields. `weights` is included so re-tuning
-  forces a re-score without a `formula-version` bump; only structural scoring-algorithm changes
-  need that.
-
-  The synonym-axis fragment comes from [[synonym-source/fingerprint-fragment]] so the fingerprint
-  reacts to the source toggle and the configured model — and on the search-index path also picks
-  up swaps in the active pgvector model so a re-index that swaps the model invalidates prior
-  scores."
+  "String capturing everything that changes the meaning or shape of an emitted score.
+  Includes `formula-version`, `format-version`, `weights`, `synonym-threshold`, and the synonym-axis fragment
+  from [[synonym-source/fingerprint-fragment]] (source toggles, configured embedder, pgvector index swaps)."
   []
   (pr-str (into (sorted-map)
                 (merge {:formula-version   complexity/formula-version
+                        :format-version     complexity/format-version
                         :synonym-threshold complexity/synonym-similarity-threshold
                         :weights           complexity/weights}
                        (synonym-source/fingerprint-fragment)))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/task/complexity_score.clj
@@ -29,7 +29,7 @@
   []
   (pr-str (into (sorted-map)
                 (merge {:formula-version   complexity/formula-version
-                        :format-version     complexity/format-version
+                        :format-version    complexity/format-version
                         :synonym-threshold complexity/synonym-similarity-threshold
                         :weights           complexity/weights}
                        (synonym-source/fingerprint-fragment)))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -55,25 +55,43 @@
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 endpoint :force-recalculation true)))))
 
+(defn- nil-rating
+  "Component-level rating fields are always nil (only the catalog total is bucketed)."
+  [sub]
+  (assoc sub :rating nil :rating-label nil :rating-color nil))
+
+(defn- low-rating
+  "Sample scores in this file all land in the low band — keep one definition so a band tweak
+  here doesn't silently desync the fixtures."
+  [catalog]
+  (assoc catalog
+         :rating "low"
+         :rating-label "Low complexity"
+         :rating-color "green"
+         :components (update-vals (:components catalog) nil-rating)))
+
 (def ^:private sample-score
-  {:library  {:total 18
-              :components {:entity-count      {:measurement 1.0 :score 10}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 8.0 :score 8}
-                           :repeated-measures {:measurement 0.0 :score 0}}}
-   :universe {:total 54
-              :components {:entity-count      {:measurement 2.0 :score 20}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 24.0 :score 24}
-                           :repeated-measures {:measurement 5.0 :score 10}}}
-   :metabot  {:total 30
-              :components {:entity-count      {:measurement 1.0 :score 10}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 20.0 :score 20}
-                           :repeated-measures {:measurement 0.0 :score 0}}}
+  {:library  (low-rating
+              {:total 18
+               :components {:entity-count      {:measurement 1.0 :score 10}
+                            :name-collisions   {:measurement 0.0 :score 0}
+                            :synonym-pairs     {:measurement 0.0 :score 0}
+                            :field-count       {:measurement 8.0 :score 8}
+                            :repeated-measures {:measurement 0.0 :score 0}}})
+   :universe (low-rating
+              {:total 54
+               :components {:entity-count      {:measurement 2.0 :score 20}
+                            :name-collisions   {:measurement 0.0 :score 0}
+                            :synonym-pairs     {:measurement 0.0 :score 0}
+                            :field-count       {:measurement 24.0 :score 24}
+                            :repeated-measures {:measurement 5.0 :score 10}}})
+   :metabot  (low-rating
+              {:total 30
+               :components {:entity-count      {:measurement 1.0 :score 10}
+                            :name-collisions   {:measurement 0.0 :score 0}
+                            :synonym-pairs     {:measurement 0.0 :score 0}
+                            :field-count       {:measurement 20.0 :score 20}
+                            :repeated-measures {:measurement 0.0 :score 0}}})
    :meta     {:formula-version 3
               :synonym-threshold 0.9}})
 
@@ -305,11 +323,12 @@
                 ":universe must be unscoped regardless of Metabot.collection_id")))))))
 
 (def ^:private empty-catalog
-  {:total 0 :components {:entity-count      {:measurement 0.0 :score 0}
-                         :name-collisions   {:measurement 0.0 :score 0}
-                         :synonym-pairs     {:measurement 0.0 :score 0}
-                         :field-count       {:measurement 0.0 :score 0}
-                         :repeated-measures {:measurement 0.0 :score 0}}})
+  (low-rating
+   {:total 0 :components {:entity-count      {:measurement 0.0 :score 0}
+                          :name-collisions   {:measurement 0.0 :score 0}
+                          :synonym-pairs     {:measurement 0.0 :score 0}
+                          :field-count       {:measurement 0.0 :score 0}
+                          :repeated-measures {:measurement 0.0 :score 0}}}))
 
 (def ^:private stub-scores
   {:library empty-catalog :universe empty-catalog :metabot empty-catalog

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -55,45 +55,34 @@
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 endpoint :force-recalculation true)))))
 
-(defn- nil-rating
-  "Component-level rating fields are always nil (only the catalog total is bucketed)."
-  [sub]
-  (assoc sub :rating nil :rating-label nil :rating-color nil))
-
-(defn- low-rating
-  "Sample scores in this file all land in the low band — keep one definition so a band tweak
-  here doesn't silently desync the fixtures."
-  [catalog]
-  (assoc catalog
-         :rating "low"
-         :rating-label "Low complexity"
-         :rating-color "green"
-         :components (update-vals (:components catalog) nil-rating)))
-
 (def ^:private sample-score
-  {:library  (low-rating
-              {:total 18
-               :components {:entity-count      {:measurement 1.0 :score 10}
-                            :name-collisions   {:measurement 0.0 :score 0}
-                            :synonym-pairs     {:measurement 0.0 :score 0}
-                            :field-count       {:measurement 8.0 :score 8}
-                            :repeated-measures {:measurement 0.0 :score 0}}})
-   :universe (low-rating
-              {:total 54
-               :components {:entity-count      {:measurement 2.0 :score 20}
-                            :name-collisions   {:measurement 0.0 :score 0}
-                            :synonym-pairs     {:measurement 0.0 :score 0}
-                            :field-count       {:measurement 24.0 :score 24}
-                            :repeated-measures {:measurement 5.0 :score 10}}})
-   :metabot  (low-rating
-              {:total 30
-               :components {:entity-count      {:measurement 1.0 :score 10}
-                            :name-collisions   {:measurement 0.0 :score 0}
-                            :synonym-pairs     {:measurement 0.0 :score 0}
-                            :field-count       {:measurement 20.0 :score 20}
-                            :repeated-measures {:measurement 0.0 :score 0}}})
+  "Raw shape — what `complexity-scores` returns and what persistence stores. The API decorates
+  this with rating fields on the way out."
+  {:library  {:total 18
+              :components {:entity-count      {:measurement 1.0 :score 10}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 8.0 :score 8}
+                           :repeated-measures {:measurement 0.0 :score 0}}}
+   :universe {:total 54
+              :components {:entity-count      {:measurement 2.0 :score 20}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 24.0 :score 24}
+                           :repeated-measures {:measurement 5.0 :score 10}}}
+   :metabot  {:total 30
+              :components {:entity-count      {:measurement 1.0 :score 10}
+                           :name-collisions   {:measurement 0.0 :score 0}
+                           :synonym-pairs     {:measurement 0.0 :score 0}
+                           :field-count       {:measurement 20.0 :score 20}
+                           :repeated-measures {:measurement 0.0 :score 0}}}
    :meta     {:formula-version 3
               :synonym-threshold 0.9}})
+
+(defn- expected-response
+  "Apply the same decoration + snake-casing the API does, to compare against an `mt/user-http-request` body."
+  [score]
+  (m.util/deep-snake-keys (complexity/decorate-with-ratings score)))
 
 (def ^:private sample-calculated-at "2026-04-23T12:00:00Z")
 
@@ -112,7 +101,7 @@
         (let [resp (mt/user-http-request :crowberto :get 200 endpoint)]
           (is (= "api-test-fp" @captured-fingerprint)
               "API passes the cron fingerprint through; source=\"appdb\" defaulting is covered by latest-score-filters-by-source-test")
-          (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score)) resp))
+          (is (= (expected-response (with-sample-calculated-at sample-score)) resp))
           (is (contains? (:meta resp) :formula_version))
           (is (= sample-calculated-at (get-in resp [:meta :calculated_at])))
           (is (not (contains? (:meta resp) :formula-version)))
@@ -134,7 +123,7 @@
                     data-complexity-score/record-score!       (fn [fingerprint source stored-score]
                                                                 (reset! persisted? [fingerprint source stored-score])
                                                                 (with-sample-calculated-at stored-score))]
-        (is (= (m.util/deep-snake-keys (with-sample-calculated-at sample-score))
+        (is (= (expected-response (with-sample-calculated-at sample-score))
                (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))
         (is (= ["api-test-fp" "appdb" sample-score] @persisted?)
             "API recompute path must stamp source=\"appdb\"")))))
@@ -174,7 +163,7 @@
                     task.complexity-score/current-fingerprint (constantly "api-test-fp")
                     complexity/complexity-scores              (fn [& _] sample-score)
                     data-complexity-score/record-score!       (fn [& _] nil)]
-        (is (= (m.util/deep-snake-keys sample-score)
+        (is (= (expected-response sample-score)
                (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))))))
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-superuser-gets-consistent-totals-test
@@ -323,12 +312,11 @@
                 ":universe must be unscoped regardless of Metabot.collection_id")))))))
 
 (def ^:private empty-catalog
-  (low-rating
-   {:total 0 :components {:entity-count      {:measurement 0.0 :score 0}
-                          :name-collisions   {:measurement 0.0 :score 0}
-                          :synonym-pairs     {:measurement 0.0 :score 0}
-                          :field-count       {:measurement 0.0 :score 0}
-                          :repeated-measures {:measurement 0.0 :score 0}}}))
+  {:total 0 :components {:entity-count      {:measurement 0.0 :score 0}
+                         :name-collisions   {:measurement 0.0 :score 0}
+                         :synonym-pairs     {:measurement 0.0 :score 0}
+                         :field-count       {:measurement 0.0 :score 0}
+                         :repeated-measures {:measurement 0.0 :score 0}}})
 
 (def ^:private stub-scores
   {:library empty-catalog :universe empty-catalog :metabot empty-catalog
@@ -348,7 +336,7 @@
                       (fn [& _]
                         (reset! scoring-ran? true)
                         stub-scores)]
-          (is (= (m.util/deep-snake-keys stub-scores)
+          (is (= (expected-response stub-scores)
                  (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)))
           (is (true? @scoring-ran?)
               "force recalculation should compute independently of scheduled claims")

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -58,25 +58,32 @@
 (def ^:private sample-score
   "Raw shape — what `complexity-scores` returns and what persistence stores.
   The API decorates this with rating fields on the way out."
-  {:library  {:total 18
-              :components {:entity-count      {:measurement 1.0 :score 10}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 8.0 :score 8}
-                           :repeated-measures {:measurement 0.0 :score 0}}}
-   :universe {:total 54
-              :components {:entity-count      {:measurement 2.0 :score 20}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 24.0 :score 24}
-                           :repeated-measures {:measurement 5.0 :score 10}}}
-   :metabot  {:total 30
-              :components {:entity-count      {:measurement 1.0 :score 10}
-                           :name-collisions   {:measurement 0.0 :score 0}
-                           :synonym-pairs     {:measurement 0.0 :score 0}
-                           :field-count       {:measurement 20.0 :score 20}
-                           :repeated-measures {:measurement 0.0 :score 0}}}
-   :meta     {:formula-version 3
+  {:library  {:score 18
+              :components {:size      {:score      18
+                                       :components {:entity-count {:measurement 1.0 :score 10}
+                                                    :field-count  {:measurement 8.0 :score 8}}}
+                           :ambiguity {:score      0
+                                       :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                    :synonym-pairs     {:measurement 0.0 :score 0}
+                                                    :repeated-measures {:measurement 0.0 :score 0}}}}}
+   :universe {:score 54
+              :components {:size      {:score      44
+                                       :components {:entity-count {:measurement  2.0 :score 20}
+                                                    :field-count  {:measurement 24.0 :score 24}}}
+                           :ambiguity {:score      10
+                                       :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                    :synonym-pairs     {:measurement 0.0 :score 0}
+                                                    :repeated-measures {:measurement 5.0 :score 10}}}}}
+   :metabot  {:score 30
+              :components {:size      {:score      30
+                                       :components {:entity-count {:measurement  1.0 :score 10}
+                                                    :field-count  {:measurement 20.0 :score 20}}}
+                           :ambiguity {:score      0
+                                       :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                    :synonym-pairs     {:measurement 0.0 :score 0}
+                                                    :repeated-measures {:measurement 0.0 :score 0}}}}}
+   :meta     {:formula-version   3
+              :format-version    1
               :synonym-threshold 0.9}})
 
 (defn- expected-response
@@ -105,8 +112,11 @@
           (is (contains? (:meta resp) :formula_version))
           (is (= sample-calculated-at (get-in resp [:meta :calculated_at])))
           (is (not (contains? (:meta resp) :formula-version)))
-          (is (contains? (get-in resp [:library :components]) :entity_count))
-          (is (not (contains? (get-in resp [:library :components]) :entity-count))))))))
+          (is (contains? (get-in resp [:library :components]) :size)
+              "groups appear at the catalog level")
+          (is (contains? (get-in resp [:library :components :size :components]) :entity_count)
+              "leaf sub-scores live one level down and are snake-cased")
+          (is (not (contains? (get-in resp [:library :components :size :components]) :entity-count))))))))
 
 (deftest complexity-endpoint-404s-when-no-score-has-been-persisted-yet-test
   (testing "the endpoint 404s until the background scorer has produced its first snapshot"
@@ -176,8 +186,16 @@
                                 (constantly {:embedder random-synonym-embedder})]
       (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
         (let [resp             (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)
-              measurement      (fn [cat k] (get-in resp [cat :components k :measurement]))
-              component-score  (fn [cat k] (get-in resp [cat :components k :score]))
+              leaf-path        {:entity_count      [:size      :entity_count]
+                                :field_count       [:size      :field_count]
+                                :name_collisions   [:ambiguity :name_collisions]
+                                :synonym_pairs     [:ambiguity :synonym_pairs]
+                                :repeated_measures [:ambiguity :repeated_measures]}
+              leaf-field       (fn [cat k field]
+                                 (let [[group leaf] (leaf-path k)]
+                                   (get-in resp [cat :components group :components leaf field])))
+              measurement      (fn [cat k] (leaf-field cat k :measurement))
+              component-score  (fn [cat k] (leaf-field cat k :score))
               ;; NOTE: `:synonym_pairs` is intentionally included here even though it's *theoretically*
               ;; non-monotonic — `score-synonym-pairs` dedupes by normalized name and keeps whichever
               ;; embedding the provider returns for that name, so adding universe-only entities that
@@ -188,13 +206,15 @@
               ;; invariant holds, and asserting it keeps us honest about regressions in the common
               ;; case. If the edge case ever actually trips this, *that* is the surprising thing we
               ;; want to see and we'll deal with it then.
-              component-keys   [:entity_count :name_collisions :synonym_pairs
-                                :field_count :repeated_measures]]
-          (testing ":total equals the sum of its component :score values"
+              component-keys   (keys leaf-path)]
+          (testing ":score at every node equals the sum of its children's :score values"
             (doseq [catalog [:library :universe :metabot]
-                    :let [{:keys [total components]} (get resp catalog)]]
-              (is (= total (reduce + (map :score (vals components))))
-                  (format "%s :total should equal sum of component :score values" catalog))))
+                    :let    [{catalog-score :score :keys [components]} (get resp catalog)]]
+              (is (= catalog-score (reduce + (map :score (vals components))))
+                  (format "%s :score should equal sum of group :score values" catalog))
+              (doseq [[group {grp-score :score grp-components :components}] components]
+                (is (= grp-score (reduce + (map :score (vals grp-components))))
+                    (format "%s.%s :score should equal sum of leaf :score values" catalog group)))))
           (testing "universe is a superset of library: every measurement and score >= library's"
             (doseq [k      component-keys
                     getter [measurement component-score]
@@ -235,8 +255,8 @@
                                  {:use_verified_content true :collection_id nil}
           (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
             (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
-              (is (< (get-in resp [:metabot  :components :entity_count :measurement])
-                     (get-in resp [:universe :components :entity_count :measurement]))
+              (is (< (get-in resp [:metabot  :components :size :components :entity_count :measurement])
+                     (get-in resp [:universe :components :size :components :entity_count :measurement]))
                   ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card"))))))))
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-metabot-collection-scope-test
@@ -282,8 +302,8 @@
                                                             :collection_id cid}
                                     (with-redefs [data-complexity-score/record-score! (fn [& _] nil)]
                                       (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
-                                        {:metabot  (get-in resp [:metabot  :components :entity_count :measurement])
-                                         :universe (get-in resp [:universe :components :entity_count :measurement])}))))
+                                        {:metabot  (get-in resp [:metabot  :components :size :components :entity_count :measurement])
+                                         :universe (get-in resp [:universe :components :size :components :entity_count :measurement])}))))
               empty-counts   (counts-with-scope empty-id)
               parent-counts  (counts-with-scope parent-id)
               sibling-counts (counts-with-scope sibling-id)
@@ -312,15 +332,18 @@
                 ":universe must be unscoped regardless of Metabot.collection_id")))))))
 
 (def ^:private empty-catalog
-  {:total 0 :components {:entity-count      {:measurement 0.0 :score 0}
-                         :name-collisions   {:measurement 0.0 :score 0}
-                         :synonym-pairs     {:measurement 0.0 :score 0}
-                         :field-count       {:measurement 0.0 :score 0}
-                         :repeated-measures {:measurement 0.0 :score 0}}})
+  {:score 0
+   :components {:size      {:score      0
+                            :components {:entity-count {:measurement 0.0 :score 0}
+                                         :field-count  {:measurement 0.0 :score 0}}}
+                :ambiguity {:score      0
+                            :components {:name-collisions   {:measurement 0.0 :score 0}
+                                         :synonym-pairs     {:measurement 0.0 :score 0}
+                                         :repeated-measures {:measurement 0.0 :score 0}}}}})
 
 (def ^:private stub-scores
   {:library empty-catalog :universe empty-catalog :metabot empty-catalog
-   :meta {:formula-version 1 :synonym-threshold 0.0}})
+   :meta {:formula-version 1 :format-version 1 :synonym-threshold 0.0}})
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-allows-active-scheduled-claim-test
   (testing "manual API recalculation does not share the cron/boot scoring claim"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -56,8 +56,8 @@
            (mt/user-http-request :rasta :get 403 endpoint :force-recalculation true)))))
 
 (def ^:private sample-score
-  "Raw shape — what `complexity-scores` returns and what persistence stores. The API decorates
-  this with rating fields on the way out."
+  "Raw shape — what `complexity-scores` returns and what persistence stores.
+  The API decorates this with rating fields on the way out."
   {:library  {:total 18
               :components {:entity-count      {:measurement 1.0 :score 10}
                            :name-collisions   {:measurement 0.0 :score 0}

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -44,27 +44,21 @@
     ;;                 events (extra universe repeat).
     (let [result (#'cli/run-cli {:representation-dir representation-fixture-dir})]
       (testing "library score matches the hand-derived total"
-        (is (=? {:total        215
-                 :rating       "low"
-                 :rating-label "Low complexity"
-                 :rating-color "green"
-                 :components   {:entity-count      {:measurement 6.0 :score 60}
-                                :name-collisions   {:measurement 1.0 :score 100}
-                                :synonym-pairs     {:measurement 1.0 :score 50}
-                                :field-count       {:measurement 3.0 :score 3}
-                                :repeated-measures {:measurement 1.0 :score 2}}}
-                (:library result))))
+        (is (= {:total      215
+                :components {:entity-count      {:measurement 6.0 :score 60}
+                             :name-collisions   {:measurement 1.0 :score 100}
+                             :synonym-pairs     {:measurement 1.0 :score 50}
+                             :field-count       {:measurement 3.0 :score 3}
+                             :repeated-measures {:measurement 1.0 :score 2}}}
+               (:library result))))
       (testing "universe score matches the hand-derived total"
-        (is (=? {:total        409
-                 :rating       "low"
-                 :rating-label "Low complexity"
-                 :rating-color "green"
-                 :components   {:entity-count      {:measurement 10.0 :score 100}
-                                :name-collisions   {:measurement 2.0  :score 200}
-                                :synonym-pairs     {:measurement 2.0  :score 100}
-                                :field-count       {:measurement 5.0  :score 5}
-                                :repeated-measures {:measurement 2.0  :score 4}}}
-                (:universe result))))
+        (is (= {:total      409
+                :components {:entity-count      {:measurement 10.0 :score 100}
+                             :name-collisions   {:measurement 2.0  :score 200}
+                             :synonym-pairs     {:measurement 2.0  :score 100}
+                             :field-count       {:measurement 5.0  :score 5}
+                             :repeated-measures {:measurement 2.0  :score 4}}}
+               (:universe result))))
       (testing "meta has formula-version + threshold + weights but no :embedding-model (offline mode)"
         (is (= {:formula-version   1
                 :synonym-threshold 0.8

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -44,23 +44,34 @@
     ;;                 events (extra universe repeat).
     (let [result (#'cli/run-cli {:representation-dir representation-fixture-dir})]
       (testing "library score matches the hand-derived total"
-        (is (= {:total      215
-                :components {:entity-count      {:measurement 6.0 :score 60}
-                             :name-collisions   {:measurement 1.0 :score 100}
-                             :synonym-pairs     {:measurement 1.0 :score 50}
-                             :field-count       {:measurement 3.0 :score 3}
-                             :repeated-measures {:measurement 1.0 :score 2}}}
+        ;;  size  = 60 (entity) + 3 (field) = 63
+        ;;  amb   = 100 (collisions) + 50 (synonyms) + 2 (repeated-measures) = 152
+        ;;  total = 215
+        (is (= {:score      215
+                :components {:size      {:score      63
+                                         :components {:entity-count {:measurement 6.0 :score 60}
+                                                      :field-count  {:measurement 3.0 :score 3}}}
+                             :ambiguity {:score      152
+                                         :components {:name-collisions   {:measurement 1.0 :score 100}
+                                                      :synonym-pairs     {:measurement 1.0 :score 50}
+                                                      :repeated-measures {:measurement 1.0 :score 2}}}}}
                (:library result))))
       (testing "universe score matches the hand-derived total"
-        (is (= {:total      409
-                :components {:entity-count      {:measurement 10.0 :score 100}
-                             :name-collisions   {:measurement 2.0  :score 200}
-                             :synonym-pairs     {:measurement 2.0  :score 100}
-                             :field-count       {:measurement 5.0  :score 5}
-                             :repeated-measures {:measurement 2.0  :score 4}}}
+        ;;  size  = 100 (entity) + 5 (field) = 105
+        ;;  amb   = 200 (collisions) + 100 (synonyms) + 4 (repeated-measures) = 304
+        ;;  total = 409
+        (is (= {:score      409
+                :components {:size      {:score      105
+                                         :components {:entity-count {:measurement 10.0 :score 100}
+                                                      :field-count  {:measurement 5.0  :score 5}}}
+                             :ambiguity {:score      304
+                                         :components {:name-collisions   {:measurement 2.0  :score 200}
+                                                      :synonym-pairs     {:measurement 2.0  :score 100}
+                                                      :repeated-measures {:measurement 2.0  :score 4}}}}}
                (:universe result))))
-      (testing "meta has formula-version + threshold + weights but no :embedding-model (offline mode)"
-        (is (= {:formula-version   1
+      (testing "meta has formula-version + format-version + threshold + weights but no :embedding-model (offline mode)"
+        (is (= {:formula-version   complexity/formula-version
+                :format-version     complexity/format-version
                 :synonym-threshold 0.8
                 :weights           complexity/weights
                 :metabot-source    :universe-fallback}
@@ -97,13 +108,13 @@
   (let [result (#'cli/run-cli {:representation-dir representation-fixture-dir})]
     (testing "without --output, stdout gets single-line JSON"
       (let [stdout (with-out-str (#'cli/write-result! result nil))]
-        (is (= 215 (-> stdout (json/decode true) :library :total)))
+        (is (= 215 (-> stdout (json/decode true) :library :score)))
         (is (not (re-find #"\n.+" stdout)) "stdout JSON should be single-line")))
     (testing "with --output, the file gets pretty JSON and stdout stays silent"
       (let [tmp    (doto (java.io.File/createTempFile "complexity-cli-output-" ".json") .deleteOnExit)
             stdout (with-out-str (#'cli/write-result! result (.getAbsolutePath tmp)))]
         (is (= "" stdout))
-        (is (= 215 (-> (slurp tmp) (json/decode true) :library :total)))))))
+        (is (= 215 (-> (slurp tmp) (json/decode true) :library :score)))))))
 
 ;;; ------------------------------------- pure embedder/scoring tests -------------------------------------
 
@@ -134,7 +145,7 @@
                                    []
                                    (embedders/file-embedder embeddings)
                                    {})
-                                  [:library :components :synonym-pairs :measurement]))]
+                                  [:library :components :ambiguity :components :synonym-pairs :measurement]))]
         (testing "cosine ≈ 0.50 — above the old 0.30 cutoff, below 0.80: NOT a synonym"
           (is (= 0.0 (score-pairs {"alpha" [1.0 0.0]
                                    "beta"  [0.5 0.866]}))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -44,21 +44,27 @@
     ;;                 events (extra universe repeat).
     (let [result (#'cli/run-cli {:representation-dir representation-fixture-dir})]
       (testing "library score matches the hand-derived total"
-        (is (= {:total      215
-                :components {:entity-count      {:measurement 6.0 :score 60}
-                             :name-collisions   {:measurement 1.0 :score 100}
-                             :synonym-pairs     {:measurement 1.0 :score 50}
-                             :field-count       {:measurement 3.0 :score 3}
-                             :repeated-measures {:measurement 1.0 :score 2}}}
-               (:library result))))
+        (is (=? {:total        215
+                 :rating       "low"
+                 :rating-label "Low complexity"
+                 :rating-color "green"
+                 :components   {:entity-count      {:measurement 6.0 :score 60}
+                                :name-collisions   {:measurement 1.0 :score 100}
+                                :synonym-pairs     {:measurement 1.0 :score 50}
+                                :field-count       {:measurement 3.0 :score 3}
+                                :repeated-measures {:measurement 1.0 :score 2}}}
+                (:library result))))
       (testing "universe score matches the hand-derived total"
-        (is (= {:total      409
-                :components {:entity-count      {:measurement 10.0 :score 100}
-                             :name-collisions   {:measurement 2.0  :score 200}
-                             :synonym-pairs     {:measurement 2.0  :score 100}
-                             :field-count       {:measurement 5.0  :score 5}
-                             :repeated-measures {:measurement 2.0  :score 4}}}
-               (:universe result))))
+        (is (=? {:total        409
+                 :rating       "low"
+                 :rating-label "Low complexity"
+                 :rating-color "green"
+                 :components   {:entity-count      {:measurement 10.0 :score 100}
+                                :name-collisions   {:measurement 2.0  :score 200}
+                                :synonym-pairs     {:measurement 2.0  :score 100}
+                                :field-count       {:measurement 5.0  :score 5}
+                                :repeated-measures {:measurement 2.0  :score 4}}}
+                (:universe result))))
       (testing "meta has formula-version + threshold + weights but no :embedding-model (offline mode)"
         (is (= {:formula-version   1
                 :synonym-threshold 0.8

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/cli_test.clj
@@ -70,8 +70,10 @@
                                                       :repeated-measures {:measurement 2.0  :score 4}}}}}
                (:universe result))))
       (testing "meta has formula-version + format-version + threshold + weights but no :embedding-model (offline mode)"
-        (is (= {:formula-version   complexity/formula-version
-                :format-version     complexity/format-version
+        ;; Literal 1/1 here is intentional — flags accidental version bumps that would invalidate the
+        ;; emitted fingerprint without an explicit code-change reviewer call.
+        (is (= {:formula-version   1
+                :format-version    1
                 :synonym-threshold 0.8
                 :weights           complexity/weights
                 :metabot-source    :universe-fallback}

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -102,23 +102,23 @@
 
 (deftest ^:parallel rating-for-score-boundaries-test
   (testing "score buckets respect the inclusive upper bounds of `complexity-thresholds`"
-    (doseq [[score expected] [[0     {:rating "low"    :rating-label "Low complexity"    :rating-color "green"}]
-                              [999   {:rating "low"    :rating-label "Low complexity"    :rating-color "green"}]
-                              [1000  {:rating "medium" :rating-label "Medium complexity" :rating-color "orange"}]
-                              [9999  {:rating "medium" :rating-label "Medium complexity" :rating-color "orange"}]
-                              [10000 {:rating "high"   :rating-label "High complexity"   :rating-color "red"}]
-                              [1e9   {:rating "high"   :rating-label "High complexity"   :rating-color "red"}]
-                              [nil   {:rating nil      :rating-label nil                 :rating-color nil}]]]
+    (doseq [[score expected] [[0     {:rating "low"    :rating-label "Low complexity"}]
+                              [999   {:rating "low"    :rating-label "Low complexity"}]
+                              [1000  {:rating "medium" :rating-label "Medium complexity"}]
+                              [9999  {:rating "medium" :rating-label "Medium complexity"}]
+                              [10000 {:rating "high"   :rating-label "High complexity"}]
+                              [1e9   {:rating "high"   :rating-label "High complexity"}]
+                              [nil   {:rating nil      :rating-label nil}]]]
       (testing (str "score=" score)
         (is (= expected (complexity/rating-for-score score)))))))
 
 (deftest ^:parallel decorate-with-ratings-test
   (testing "catalog totals get rating fields; components get present-but-nil rating keys"
-    (is (=? {:library  {:total 0    :rating "low"    :rating-label "Low complexity"    :rating-color "green"
+    (is (=? {:library  {:total 0    :rating "low"    :rating-label "Low complexity"
                         :components {:entity-count {:measurement 0.0 :score 0
-                                                    :rating nil :rating-label nil :rating-color nil}}}
-             :universe {:total 1500 :rating "medium" :rating-label "Medium complexity" :rating-color "orange"}
-             :metabot  {:total nil  :rating nil      :rating-label nil                 :rating-color nil}}
+                                                    :rating nil :rating-label nil}}}
+             :universe {:total 1500 :rating "medium" :rating-label "Medium complexity"}
+             :metabot  {:total nil  :rating nil      :rating-label nil}}
             (complexity/decorate-with-ratings
              {:library  {:total 0    :components {:entity-count {:measurement 0.0 :score 0}}}
               :universe {:total 1500 :components {}}

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -50,137 +50,149 @@
      (mapv #(when-let [v (get name->vec-literal %)] (float-array v)) names))))
 
 (deftest ^:parallel score-catalog-pure-test
-  (testing "empty catalog scores zero"
-    (is (=? {:total 0
-             :components {:entity-count      {:measurement 0.0 :score 0}
-                          :name-collisions   {:measurement 0.0 :score 0}
-                          :synonym-pairs     {:measurement 0.0 :score 0}
-                          :field-count       {:measurement 0.0 :score 0}
-                          :repeated-measures {:measurement 0.0 :score 0}}}
+  (testing "empty catalog scores zero — every leaf reports the zero, group totals roll up zero"
+    (is (=? {:score 0
+             :components {:size      {:score      0
+                                      :components {:entity-count {:measurement 0.0 :score 0}
+                                                   :field-count  {:measurement 0.0 :score 0}}}
+                          :ambiguity {:score      0
+                                      :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                   :synonym-pairs     {:measurement 0.0 :score 0}
+                                                   :repeated-measures {:measurement 0.0 :score 0}}}}}
             (#'complexity/score-catalog [] nil))))
 
-  (testing "entity count contributes +10 per entity"
+  (testing "entity count contributes +10 per entity (lives under :size)"
     (let [es [(entity :name "orders")
               (entity :name "customers")
               (entity :name "products")]]
-      (is (=? {:total 30
-               :components {:entity-count {:measurement 3.0 :score 30}}}
+      (is (=? {:score 30
+               :components {:size {:score      30
+                                   :components {:entity-count {:measurement 3.0 :score 30}}}}}
               (#'complexity/score-catalog es nil)))))
 
-  (testing "name collisions stack linearly: 3 identical names = +200"
+  (testing "name collisions stack linearly: 3 identical names = +200 (lives under :ambiguity)"
     (let [es [(entity :name "orders")
               (entity :name "orders")
               (entity :name "orders")]]
-      (is (=? {:components {:entity-count    {:measurement 3.0 :score 30}
-                            :name-collisions {:measurement 2.0 :score 200}}}
+      (is (=? {:components {:size      {:components {:entity-count    {:measurement 3.0 :score 30}}}
+                            :ambiguity {:components {:name-collisions {:measurement 2.0 :score 200}}}}}
               (#'complexity/score-catalog es nil)))))
 
   (testing "collision detection is case-insensitive and trims whitespace"
     (let [es [(entity :name "Orders")
               (entity :name " orders ")
               (entity :name "ORDERS")]]
-      (is (=? {:components {:name-collisions {:measurement 2.0 :score 200}}}
+      (is (=? {:components {:ambiguity {:components {:name-collisions {:measurement 2.0 :score 200}}}}}
               (#'complexity/score-catalog es nil)))))
 
-  (testing "field count contributes +1 per field, summed across entities"
+  (testing "field count contributes +1 per field (lives under :size, summed across entities)"
     (let [es [(entity :name "a" :field-count 10)
               (entity :name "b" :field-count 25)]]
-      (is (=? {:components {:field-count {:measurement 35.0 :score 35}}}
+      (is (=? {:components {:size {:components {:field-count {:measurement 35.0 :score 35}}}}}
               (#'complexity/score-catalog es nil)))))
 
-  (testing "repeated measures contribute +2 per repeat (measure name appearing on >1 entity)"
+  (testing "repeated measures contribute +2 per repeat (lives under :ambiguity)"
     (let [es [(entity :name "invoices"      :measure-names ["revenue" "discount"])
               (entity :name "subscriptions" :measure-names ["revenue"])
               (entity :name "products"      :measure-names ["price"])]]
-      (is (=? {:components {:repeated-measures {:measurement 1.0 :score 2}}}
+      (is (=? {:components {:ambiguity {:components {:repeated-measures {:measurement 1.0 :score 2}}}}}
               (#'complexity/score-catalog es nil)))))
 
   (testing "nil embedder disables synonym scoring"
     (let [es [(entity :name "customers") (entity :name "clients")]]
-      (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
+      (is (=? {:components {:ambiguity {:components {:synonym-pairs {:measurement 0.0 :score 0}}}}}
               (#'complexity/score-catalog es nil))))))
 
-(deftest ^:parallel complexity-thresholds-well-formed-test
-  (testing "every threshold table: last entry is unbounded; earlier entries have strictly ascending :max"
-    (doseq [[k bands] complexity/complexity-thresholds
-            :let [bounded   (butlast bands)
-                  unbounded (last bands)]]
-      (testing (str "bands for " k)
-        (is (every? :max bounded))
-        (is (not (contains? unbounded :max)))
-        (when (next bounded)
-          (is (apply < (map :max bounded))))))))
+(deftest ^:parallel complexity-bands-well-formed-test
+  (testing "every band list in the bands tree: last entry is unbounded; earlier entries have strictly ascending :max"
+    (let [collect-bands (fn collect-bands [node]
+                          (concat (when-let [bands (:bands node)] [bands])
+                                  (mapcat collect-bands (vals (:components node)))))]
+      (doseq [bands (collect-bands complexity/complexity-bands)
+              :let  [bounded   (butlast bands)
+                     unbounded (last bands)]]
+        (testing (str "bands=" bands)
+          (is (every? :max bounded))
+          (is (not (contains? unbounded :max)))
+          (when (next bounded)
+            (is (apply < (map :max bounded)))))))))
 
 (deftest ^:parallel rating-for-score-boundaries-test
-  (let [expectations
-        {:total [[0     {:rating "low"    :rating-label "Low complexity"}]
-                 [999   {:rating "low"    :rating-label "Low complexity"}]
-                 [1000  {:rating "medium" :rating-label "Medium complexity"}]
-                 [9999  {:rating "medium" :rating-label "Medium complexity"}]
-                 [10000 {:rating "high"   :rating-label "High complexity"}]
-                 [1e9   {:rating "high"   :rating-label "High complexity"}]
-                 [nil   {:rating nil      :rating-label nil}]]}]
-    (testing "expectations cover every rating-table key (add cases when component bands land)"
-      (is (= (set (keys @#'complexity/rating-tables)) (set (keys expectations)))))
-    (doseq [[k cases] expectations
-            :let [table (get @#'complexity/rating-tables k)]
-            [score expected] cases]
-      (testing (str k " score=" score)
-        (is (= expected (@#'complexity/rating-for-score table score))))))
-  (testing "nil or empty rating-table falls through to nil-rating"
+  (let [root-lookup (:band-lookup @#'complexity/compiled-bands)
+        cases       [[0     {:rating "low"    :rating-label "Low complexity"}]
+                     [999   {:rating "low"    :rating-label "Low complexity"}]
+                     [1000  {:rating "medium" :rating-label "Medium complexity"}]
+                     [9999  {:rating "medium" :rating-label "Medium complexity"}]
+                     [10000 {:rating "high"   :rating-label "High complexity"}]
+                     [1e9   {:rating "high"   :rating-label "High complexity"}]
+                     [nil   {:rating nil      :rating-label nil}]]]
+    (testing "root band-lookup is populated (per-group/per-leaf bands land here once configured)"
+      (is (some? root-lookup)))
+    (doseq [[score expected] cases]
+      (testing (str "root score=" score)
+        (is (= expected (@#'complexity/rating-for-score root-lookup score))))))
+  (testing "nil or empty band-lookup falls through to nil-rating"
     (is (= {:rating nil :rating-label nil} (@#'complexity/rating-for-score nil 12345)))
     (is (= {:rating nil :rating-label nil} (@#'complexity/rating-for-score {} 12345)))))
 
 (deftest ^:parallel decorate-with-ratings-test
-  (testing "catalog totals get rating fields; components get present-but-nil rating keys"
-    (is (=? {:library  {:total        0
+  (testing "every node (root catalog, group, leaf) gets rating keys; nodes without configured bands get nil ratings"
+    (is (=? {:library  {:score        0
                         :rating       "low"
                         :rating-label "Low complexity"
-                        :components   {:entity-count {:measurement  0.0
-                                                      :score        0
-                                                      :rating       nil
-                                                      :rating-label nil}}}
-             :universe {:total        1500
+                        :components   {:size {:score        0
+                                              :rating       nil
+                                              :rating-label nil
+                                              :components   {:entity-count {:measurement  0.0
+                                                                            :score        0
+                                                                            :rating       nil
+                                                                            :rating-label nil}}}}}
+             :universe {:score        1500
                         :rating       "medium"
                         :rating-label "Medium complexity"}
-             :metabot  {:total        nil
+             :metabot  {:score        nil
                         :rating       nil
                         :rating-label nil}}
             (complexity/decorate-with-ratings
-             {:library  {:total      0
-                         :components {:entity-count {:measurement 0.0
-                                                     :score       0}}}
-              :universe {:total      1500
+             {:library  {:score      0
+                         :components {:size {:score      0
+                                             :components {:entity-count {:measurement 0.0
+                                                                         :score       0}}}}}
+              :universe {:score      1500
                          :components {}}
-              :metabot  {:total      nil
+              :metabot  {:score      nil
                          :components {}}}))))
   (testing "missing catalogs are left alone (no rating fields injected)"
     (is (= {:meta {:formula-version 1}}
            (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))
 
 (deftest ^:parallel decorate-with-ratings*-component-bands-test
-  (testing "components with bands get rated; components without bands cascade nil-rating"
-    (let [rating-tables (update-vals
-                         {:total        [{:rating "small" :label "Small" :max 100}
-                                         {:rating "big"   :label "Big"}]
-                          :entity-count [{:rating "few"  :label "Few"  :max 5}
-                                         {:rating "many" :label "Many"}]}
-                         #'complexity/->rating-table)
-          catalog       {:total      150
-                         :components {:entity-count {:measurement 8.0  :score 8}
-                                      :field-count  {:measurement 50.0 :score 50}}}]
-      (is (=? {:total        150
+  (testing "bands at any depth get applied; nodes without bands cascade nil-rating"
+    (let [bands   (@#'complexity/compile-bands
+                   {:bands      [{:rating "small" :label "Small" :max 100}
+                                 {:rating "big"   :label "Big"}]
+                    :components {:size {:components {:entity-count
+                                                     {:bands [{:rating "few"  :label "Few"  :max 5}
+                                                              {:rating "many" :label "Many"}]}}}}})
+          catalog {:score      150
+                   :components {:size {:score      58
+                                       :components {:entity-count {:measurement 8.0  :score 8}
+                                                    :field-count  {:measurement 50.0 :score 50}}}}}]
+      (is (=? {:score        150
                :rating       "big"
                :rating-label "Big"
-               :components   {:entity-count {:measurement  8.0
-                                             :score        8
-                                             :rating       "many"
-                                             :rating-label "Many"}
-                              :field-count  {:measurement  50.0
-                                             :score        50
-                                             :rating       nil
-                                             :rating-label nil}}}
-              (@#'complexity/decorate-with-ratings* rating-tables catalog))))))
+               :components   {:size {:score        58
+                                     :rating       nil
+                                     :rating-label nil
+                                     :components   {:entity-count {:measurement  8.0
+                                                                   :score        8
+                                                                   :rating       "many"
+                                                                   :rating-label "Many"}
+                                                    :field-count  {:measurement  50.0
+                                                                   :score        50
+                                                                   :rating       nil
+                                                                   :rating-label nil}}}}}
+              (@#'complexity/decorate-with-ratings* bands catalog))))))
 
 (deftest ^:parallel score-from-entities-metabot-fallback-test
   (testing "score-from-entities marks :metabot as a universe fallback when no metabot-entities are passed"
@@ -205,22 +217,22 @@
     (let [es       [(entity :name "customers") (entity :name "clients")]
           embedder (mock-embedder {"customers" [1.0 0.0 0.0]
                                    "clients"   [0.9 0.1 0.0]})]
-      (is (=? {:components {:synonym-pairs {:measurement 1.0 :score 50}}}
+      (is (=? {:components {:ambiguity {:components {:synonym-pairs {:measurement 1.0 :score 50}}}}}
               (#'complexity/score-catalog es embedder)))))
 
   (testing "orthogonal embeddings produce no synonym pairs"
     (let [es       [(entity :name "customers") (entity :name "widgets")]
           embedder (mock-embedder {"customers" [1.0 0.0]
                                    "widgets"   [0.0 1.0]})]
-      (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
+      (is (=? {:components {:ambiguity {:components {:synonym-pairs {:measurement 0.0 :score 0}}}}}
               (#'complexity/score-catalog es embedder)))))
 
   (testing "exact-name duplicates don't double-count as synonym pairs"
     (let [es       [(entity :name "orders") (entity :name "orders") (entity :name "tickets")]
           embedder (mock-embedder {"orders"  [1.0 0.0]
                                    "tickets" [0.0 1.0]})]
-      (is (=? {:components {:name-collisions {:measurement 1.0 :score 100}
-                            :synonym-pairs   {:measurement 0.0 :score 0}}}
+      (is (=? {:components {:ambiguity {:components {:name-collisions {:measurement 1.0 :score 100}
+                                                     :synonym-pairs   {:measurement 0.0 :score 0}}}}}
               (#'complexity/score-catalog es embedder)))))
 
   (testing "entities without a vector from the embedder are simply skipped"
@@ -228,33 +240,38 @@
           ;; "ghost" is missing → not considered. The remaining two are synonyms.
           embedder (mock-embedder {"customers" [1.0 0.0]
                                    "clients"   [0.99 0.01]})]
-      (is (=? {:components {:synonym-pairs {:measurement 1.0 :score 50}}}
+      (is (=? {:components {:ambiguity {:components {:synonym-pairs {:measurement 1.0 :score 50}}}}}
               (#'complexity/score-catalog es embedder)))))
 
   (testing "embedder failure cascades nil through the catalog (no zero-fallback)"
     (let [es       [(entity :name "customers") (entity :name "clients")]
           embedder (fn [_] (throw (ex-info "boom" {})))]
-      (is (=? {:total nil
-               :components {:synonym-pairs {:measurement nil :score nil :error "boom"}
-                            ;; Sibling sub-scores still compute their real values — only the rollup
-                            ;; cascades nil — so consumers can still see the unaffected dimensions.
-                            :entity-count {:measurement 2.0 :score 20}}}
-              (#'complexity/score-catalog es embedder)))))
+      (is (= {:score nil
+              :components {:ambiguity {:score      nil
+                                       :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                    :synonym-pairs     {:error "boom"}
+                                                    :repeated-measures {:measurement 0.0 :score 0}}}
+                           ;; Sibling sub-scores still compute their real values — only aggregates
+                           ;; that include the failed leaf cascade nil, so consumers can still see
+                           ;; the unaffected dimensions.
+                           :size      {:score      20
+                                       :components {:entity-count {:measurement 2.0 :score 20}
+                                                    :field-count  {:measurement 0.0 :score 0}}}}}
+             (#'complexity/score-catalog es embedder)))))
 
   (testing "throwable with a nil/blank message still records :error as a nonblank string"
     ;; Regression: we must keep :error present so an embedder failure is distinguishable from a
     ;; genuine zero-synonym result. Fall back to the exception class name.
     (let [es         [(entity :name "customers") (entity :name "clients")]
-          synonym-of #(get-in (#'complexity/score-catalog es %) [:components :synonym-pairs])]
+          synonym-of #(get-in (#'complexity/score-catalog es %)
+                              [:components :ambiguity :components :synonym-pairs])]
       (doseq [[label embedder expected] [["nil message"   (fn [_] (throw (NullPointerException.)))
                                           "java.lang.NullPointerException"]
                                          ["blank message" (fn [_] (throw (RuntimeException. "   ")))
                                           "java.lang.RuntimeException"]]]
         (testing label
-          (let [sub (synonym-of embedder)]
-            (is (nil? (:score sub)))
-            (is (= expected (:error sub))
-                (format ":error must be a nonblank string when the throwable's message is %s" label))))))))
+          (is (= {:error expected} (synonym-of embedder))
+              (format ":error must be a nonblank string when the throwable's message is %s" label)))))))
 
 (deftest ^:sequential complexity-scores-metabot-scope-opt-test
   (testing ":verified-only? true flows the caller's metabot-scope through to enumerate-catalogs"
@@ -270,8 +287,8 @@
                                           :metabot-scope {:verified-only? true :collection-id nil})]
           (is (= {:verified-only? true :collection-id nil} @captured-scope)
               "enumerate-catalogs was invoked with the caller's scope")
-          (is (= 1.0 (get-in metabot  [:components :entity-count :measurement])))
-          (is (= 2.0 (get-in universe [:components :entity-count :measurement])))))))
+          (is (= 1.0 (get-in metabot  [:components :size :components :entity-count :measurement])))
+          (is (= 2.0 (get-in universe [:components :size :components :entity-count :measurement])))))))
   (testing ":collection-id alone also flows through to enumerate-catalogs (no verified flag required)"
     (let [captured-scope (atom nil)]
       (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs
@@ -284,7 +301,7 @@
                                  :embedder nil
                                  :metabot-scope {:verified-only? false :collection-id 42})]
           (is (= {:verified-only? false :collection-id 42} @captured-scope))
-          (is (= 1.0 (get-in metabot [:components :entity-count :measurement])))))))
+          (is (= 1.0 (get-in metabot [:components :size :components :entity-count :measurement])))))))
   (testing "empty scope (or no :metabot-scope opt) still runs enumerate-catalogs with that scope so metabot's table-visibility filter still narrows the catalog"
     ;; Regression: we used to reuse the :universe score verbatim when scope was empty. That hid the
     ;; fact that Metabot's table visibility (`:visibility_type nil`, non-routed DB) already narrows
@@ -303,8 +320,8 @@
             (is (= scope @captured-scope)
                 (format "enumerate-catalogs was invoked with the caller's (possibly empty) scope=%s"
                         (pr-str scope)))
-            (is (= 1.0 (get-in metabot  [:components :entity-count :measurement])))
-            (is (= 2.0 (get-in universe [:components :entity-count :measurement])))))))))
+            (is (= 1.0 (get-in metabot  [:components :size :components :entity-count :measurement])))
+            (is (= 2.0 (get-in universe [:components :size :components :entity-count :measurement])))))))))
 
 (deftest ^:sequential metabot-catalog-excludes-hidden-tables-test
   (testing ":metabot tables filter out hidden (`visibility_type` non-nil) and routed-DB tables so the
@@ -375,15 +392,17 @@
                     :model/Table    _           {:db_id db-id :name "contributes_to_universe" :active true}]
        (let [{:keys [library universe]} (complexity/complexity-scores :embedder nil)]
          (testing "library is empty (no collection tree)"
-           (is (= {:total 0
-                   :components {:entity-count      {:measurement 0.0 :score 0}
-                                :name-collisions   {:measurement 0.0 :score 0}
-                                :synonym-pairs     {:measurement 0.0 :score 0}
-                                :field-count       {:measurement 0.0 :score 0}
-                                :repeated-measures {:measurement 0.0 :score 0}}}
+           (is (= {:score 0
+                   :components {:size      {:score      0
+                                            :components {:entity-count {:measurement 0.0 :score 0}
+                                                         :field-count  {:measurement 0.0 :score 0}}}
+                                :ambiguity {:score      0
+                                            :components {:name-collisions   {:measurement 0.0 :score 0}
+                                                         :synonym-pairs     {:measurement 0.0 :score 0}
+                                                         :repeated-measures {:measurement 0.0 :score 0}}}}}
                   library)))
          (testing "universe still enumerates appdb content (our temp table + whatever else is there)"
-           (is (pos? (:total universe)))))))))
+           (is (pos? (:score universe)))))))))
 
 (deftest ^:sequential library-excludes-audit-content-test
   (testing "published audit-db content in the Library tree is excluded so :library stays a subset of :universe"
@@ -417,7 +436,7 @@
                                                      :archived     false    :collection_id mets-id}]
       (with-redefs [audit/audit-db-id audit-db]
         (let [{:keys [library]} (complexity/complexity-scores :embedder nil)]
-          (is (= 2.0 (get-in library [:components :entity-count :measurement]))
+          (is (= 2.0 (get-in library [:components :size :components :entity-count :measurement]))
               "only the two non-audit entities count (audit table + audit metric card excluded)"))))))
 
 ;; We're only reading the method table via `methods`, not calling the impure `!` fn — safe in parallel.
@@ -451,8 +470,8 @@
             (semantic.tu/with-test-db! {:mode :mock-indexed}
               (reset! captured (complexity/complexity-scores
                                 :embedder semantic-search/search-index-embedder)))))
-        (is (=? {:universe {:components {:synonym-pairs {:measurement number?
-                                                         :score       nat-int?}}}}
+        (is (=? {:universe {:components {:ambiguity {:components {:synonym-pairs {:measurement number?
+                                                                                  :score       nat-int?}}}}}}
                 @captured)
             "embedder returned vectors from pgvector and the synonym axis produced a real measurement")))))
 
@@ -471,9 +490,7 @@
                                [{:id 1 :name "orders" :kind :table}]))))
       (testing "score-synonym-pairs converts the propagated failure into :error on the sub-score"
         (let [es [(entity :name "customers") (entity :name "clients")]]
-          (is (=? {:components {:synonym-pairs {:measurement nil
-                                                :score       nil
-                                                :error       string?}}}
+          (is (=? {:components {:ambiguity {:components {:synonym-pairs {:error string?}}}}}
                   (#'complexity/score-catalog es semantic-search/search-index-embedder))))))))
 
 (defn- stub-fetch-batch
@@ -743,28 +760,22 @@
        (map :data)
        (filter #(= "data_complexity_scoring" (get % "event")))))
 
-(def ^:private leaf-key->group
-  "Mirrors `complexity/component->group` for test assertions. Kept in snake-case string form
-  (matching how keys land in the Snowplow payload)."
-  {"entity_count"      "size"
-   "field_count"       "size"
-   "name_collisions"   "ambiguity"
-   "synonym_pairs"     "ambiguity"
-   "repeated_measures" "ambiguity"})
-
 (defn- snake [k] (-> k name (str/replace "-" "_")))
 
 (defn- expected-keys-for-catalog
-  "For a catalog result, return `#{[key score], ...}` matching what emit-snowplow! should emit:
-   grand `total`, one `<group>.total` per group, and one `<group>.<leaf>` per sub-component."
-  [{:keys [total components]}]
-  (let [leaves      (into {} (map (fn [[k sub]] [(snake k) (:score sub)]) components))
-        group-total (reduce-kv (fn [acc leaf score]
-                                 (update acc (leaf-key->group leaf) (fnil + 0) score))
-                               {} leaves)]
-    (set (concat [["total" total]]
-                 (for [[g s] group-total] [(str g ".total") s])
-                 (for [[leaf s] leaves]   [(str (leaf-key->group leaf) "." leaf) s])))))
+  "For a catalog result, return `#{[wire-key score], ...}` matching what emit-snowplow! should emit:
+   grand `total`, one `<group>.total` per group, and one `<group>.<leaf>` per sub-component (the
+   `total` suffix is a Snowplow wire-format convention — the in-memory node uses `:score`). Walks
+   the score tree directly, so any future restructuring (extra depth, renamed groups) is exercised
+   by the helper and the production walk together."
+  [{root-score :score :keys [components]}]
+  (set
+   (cons ["total" root-score]
+         (for [[group {group-score :score group-components :components}] components
+               event (cons [(str (snake group) ".total") group-score]
+                           (for [[leaf {:keys [score]}] group-components]
+                             [(str (snake group) "." (snake leaf)) score]))]
+           event))))
 
 (deftest ^:sequential emit-snowplow-publishes-total-and-each-subscore-test
   (testing "one event per (catalog × key) — grand total, group rollups, and leaves — with correct scores"
@@ -925,8 +936,12 @@
                                 analytics/track-event!       (fn [& _] (throw (RuntimeException. "snowplow down")))]
       (mt/with-log-messages-for-level [messages [metabase-enterprise.data-complexity-score.complexity :warn]]
         (let [result (complexity/complexity-scores :embedder nil)]
-          (is (=? {:library  {:total 10 :components {:entity-count {:measurement 1.0 :score 10}}}
-                   :universe {:total 10 :components {:entity-count {:measurement 1.0 :score 10}}}}
+          (is (=? {:library  {:score 10
+                              :components {:size {:score      10
+                                                  :components {:entity-count {:measurement 1.0 :score 10}}}}}
+                   :universe {:score 10
+                              :components {:size {:score      10
+                                                  :components {:entity-count {:measurement 1.0 :score 10}}}}}}
                   result))
           (is (some #(re-find #"Failed to publish complexity score" (:message %))
                     (messages))
@@ -1021,18 +1036,20 @@
             {:keys [library universe]} (complexity/complexity-scores :embedder embedder)]
         (testing "library reflects exactly what we put in the Library collection tree"
           ;; Library: 4 tables + 2 metric cards = 6 entities.
-          ;;  entity-count       6 × 10 = 60
-          ;;  name-collisions    "revenue" (2 metric cards) = 1 pair × 100 = 100
-          ;;  synonym-pairs      clients ↔ customers = 1 × 50 = 50
+          ;;  entity-count       6 × 10 = 60   → :size      = 63
           ;;  field-count        orders(2) + subscriptions(1) + others(0) = 3 × 1 = 3
+          ;;  name-collisions    "revenue" (2 metric cards) = 1 pair × 100 = 100   → :ambiguity = 152
+          ;;  synonym-pairs      clients ↔ customers = 1 × 50 = 50
           ;;  repeated-measures  "revenue" on orders + subscriptions = 1 × 2 = 2
-          ;;  total              60 + 100 + 50 + 3 + 2 = 215
-          (is (= {:total      215
-                  :components {:entity-count      {:measurement 6.0 :score 60}
-                               :name-collisions   {:measurement 1.0 :score 100}
-                               :synonym-pairs     {:measurement 1.0 :score 50}
-                               :field-count       {:measurement 3.0 :score 3}
-                               :repeated-measures {:measurement 1.0 :score 2}}}
+          ;;  total              63 + 152 = 215
+          (is (= {:score      215
+                  :components {:size      {:score      63
+                                           :components {:entity-count {:measurement 6.0 :score 60}
+                                                        :field-count  {:measurement 3.0 :score 3}}}
+                               :ambiguity {:score      152
+                                           :components {:name-collisions   {:measurement 1.0 :score 100}
+                                                        :synonym-pairs     {:measurement 1.0 :score 50}
+                                                        :repeated-measures {:measurement 1.0 :score 2}}}}}
                  library)))
         (testing "universe is a strict superset of library on every component: every measurement and score is higher"
           ;; Note: :synonym-pairs is monotonic on this fixture but not in general — score-synonym-pairs
@@ -1040,22 +1057,27 @@
           ;; sharing a normalized name with a library entity could in theory flip which vector wins and
           ;; decrease the pair count/score. Our fixture doesn't hit that case; if this assertion ever
           ;; flakes, that's the reason.
-          (doseq [component [:entity-count :name-collisions :synonym-pairs :field-count :repeated-measures]
-                  k         [:measurement :score]
-                  :let      [lib-v (get-in library  [:components component k])
-                             uni-v (get-in universe [:components component k])]]
+          (doseq [[group component] [[:size      :entity-count]
+                                     [:ambiguity :name-collisions]
+                                     [:ambiguity :synonym-pairs]
+                                     [:size      :field-count]
+                                     [:ambiguity :repeated-measures]]
+                  k                 [:measurement :score]
+                  :let              [path  [:components group :components component k]
+                                     lib-v (get-in library  path)
+                                     uni-v (get-in universe path)]]
             (is (> uni-v lib-v)
                 (format "universe %s %s (%s) should be strictly > library %s %s (%s)"
                         component k uni-v component k lib-v))))
         (testing "universe total is strictly higher than library total"
-          (is (> (:total universe) (:total library))))))))
+          (is (> (:score universe) (:score library))))))))
 
 (defn- stub-result
   "Build a `complexity/complexity-scores` stand-in whose metadata records whether publishing worked."
   [published?]
   (with-meta
-   {:library {:total 0 :components {}} :universe {:total 0 :components {}}
-    :metabot {:total 0 :components {}} :meta {}}
+   {:library {:score 0 :components {}} :universe {:score 0 :components {}}
+    :metabot {:score 0 :components {}} :meta {}}
    {:metabase-enterprise.data-complexity-score.complexity/snowplow-published? published?}))
 
 (deftest ^:sequential latest-score-filters-by-fingerprint-test

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -50,13 +50,21 @@
      (mapv #(when-let [v (get name->vec-literal %)] (float-array v)) names))))
 
 (deftest ^:parallel score-catalog-pure-test
-  (testing "empty catalog scores zero"
-    (is (=? {:total 0
-             :components {:entity-count      {:measurement 0.0 :score 0}
-                          :name-collisions   {:measurement 0.0 :score 0}
-                          :synonym-pairs     {:measurement 0.0 :score 0}
-                          :field-count       {:measurement 0.0 :score 0}
-                          :repeated-measures {:measurement 0.0 :score 0}}}
+  (testing "empty catalog scores zero and lands in the low-complexity band"
+    (is (=? {:total        0
+             :rating       "low"
+             :rating-label "Low complexity"
+             :rating-color "green"
+             :components   {:entity-count      {:measurement 0.0 :score 0
+                                                :rating nil :rating-label nil :rating-color nil}
+                            :name-collisions   {:measurement 0.0 :score 0
+                                                :rating nil :rating-label nil :rating-color nil}
+                            :synonym-pairs     {:measurement 0.0 :score 0
+                                                :rating nil :rating-label nil :rating-color nil}
+                            :field-count       {:measurement 0.0 :score 0
+                                                :rating nil :rating-label nil :rating-color nil}
+                            :repeated-measures {:measurement 0.0 :score 0
+                                                :rating nil :rating-label nil :rating-color nil}}}
             (#'complexity/score-catalog [] nil))))
 
   (testing "entity count contributes +10 per entity"
@@ -98,7 +106,39 @@
   (testing "nil embedder disables synonym scoring"
     (let [es [(entity :name "customers") (entity :name "clients")]]
       (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
-              (#'complexity/score-catalog es nil))))))
+              (#'complexity/score-catalog es nil)))))
+
+  (testing "catalog total bucketed into the right rating band"
+    ;; 100 entities at weight 10 = 1000 → top of `:medium`. Avoids touching unrelated axes.
+    (let [es (vec (for [i (range 100)] (entity :name (str "t" i))))]
+      (is (=? {:total        1000
+               :rating       "medium"
+               :rating-label "Medium complexity"
+               :rating-color "orange"}
+              (#'complexity/score-catalog es nil)))))
+
+  (testing "catalog total cascading nil zeroes out the rating fields too"
+    ;; An exploding embedder cascades nil through `:total`; the rating must follow suit so a nil
+    ;; total can't sneak past as `:low`.
+    (let [es       [(entity :name "customers") (entity :name "clients")]
+          embedder (fn [_] (throw (ex-info "boom" {})))]
+      (is (=? {:total        nil
+               :rating       nil
+               :rating-label nil
+               :rating-color nil}
+              (#'complexity/score-catalog es embedder))))))
+
+(deftest ^:parallel rating-for-score-boundaries-test
+  (testing "score buckets respect the inclusive upper bounds of `complexity-thresholds`"
+    (doseq [[score expected] [[0     {:rating "low"    :rating-label "Low complexity"    :rating-color "green"}]
+                              [999   {:rating "low"    :rating-label "Low complexity"    :rating-color "green"}]
+                              [1000  {:rating "medium" :rating-label "Medium complexity" :rating-color "orange"}]
+                              [9999  {:rating "medium" :rating-label "Medium complexity" :rating-color "orange"}]
+                              [10000 {:rating "high"   :rating-label "High complexity"   :rating-color "red"}]
+                              [1e9   {:rating "high"   :rating-label "High complexity"   :rating-color "red"}]
+                              [nil   {:rating nil      :rating-label nil                 :rating-color nil}]]]
+      (testing (str "score=" score)
+        (is (= expected (#'complexity/rating-for-score score)))))))
 
 (deftest ^:parallel score-from-entities-metabot-fallback-test
   (testing "score-from-entities marks :metabot as a universe fallback when no metabot-entities are passed"
@@ -293,13 +333,13 @@
                     :model/Table    _           {:db_id db-id :name "contributes_to_universe" :active true}]
        (let [{:keys [library universe]} (complexity/complexity-scores :embedder nil)]
          (testing "library is empty (no collection tree)"
-           (is (= {:total 0
-                   :components {:entity-count      {:measurement 0.0 :score 0}
-                                :name-collisions   {:measurement 0.0 :score 0}
-                                :synonym-pairs     {:measurement 0.0 :score 0}
-                                :field-count       {:measurement 0.0 :score 0}
-                                :repeated-measures {:measurement 0.0 :score 0}}}
-                  library)))
+           (is (=? {:total      0
+                    :components {:entity-count      {:measurement 0.0 :score 0}
+                                 :name-collisions   {:measurement 0.0 :score 0}
+                                 :synonym-pairs     {:measurement 0.0 :score 0}
+                                 :field-count       {:measurement 0.0 :score 0}
+                                 :repeated-measures {:measurement 0.0 :score 0}}}
+                   library)))
          (testing "universe still enumerates appdb content (our temp table + whatever else is there)"
            (is (pos? (:total universe)))))))))
 
@@ -945,13 +985,16 @@
           ;;  field-count        orders(2) + subscriptions(1) + others(0) = 3 × 1 = 3
           ;;  repeated-measures  "revenue" on orders + subscriptions = 1 × 2 = 2
           ;;  total              60 + 100 + 50 + 3 + 2 = 215
-          (is (= {:total      215
-                  :components {:entity-count      {:measurement 6.0 :score 60}
-                               :name-collisions   {:measurement 1.0 :score 100}
-                               :synonym-pairs     {:measurement 1.0 :score 50}
-                               :field-count       {:measurement 3.0 :score 3}
-                               :repeated-measures {:measurement 1.0 :score 2}}}
-                 library)))
+          (is (=? {:total        215
+                   :rating       "low"
+                   :rating-label "Low complexity"
+                   :rating-color "green"
+                   :components   {:entity-count      {:measurement 6.0 :score 60}
+                                  :name-collisions   {:measurement 1.0 :score 100}
+                                  :synonym-pairs     {:measurement 1.0 :score 50}
+                                  :field-count       {:measurement 3.0 :score 3}
+                                  :repeated-measures {:measurement 1.0 :score 2}}}
+                  library)))
         (testing "universe is a strict superset of library on every component: every measurement and score is higher"
           ;; Note: :synonym-pairs is monotonic on this fixture but not in general — score-synonym-pairs
           ;; dedupes by normalized name and picks one embedding per name, so a universe-only entity

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -101,26 +101,35 @@
               (#'complexity/score-catalog es nil))))))
 
 (deftest ^:parallel complexity-thresholds-well-formed-test
-  (let [bands         complexity/complexity-thresholds
-        bounded       (butlast bands)
-        unbounded     (last bands)]
-    (testing "all but the last entry have a :max, in strictly ascending order"
-      (is (every? :max bounded))
-      (is (apply < (map :max bounded))))
-    (testing "the last entry is the only one without a :max"
-      (is (not (contains? unbounded :max))))))
+  (testing "every threshold table: last entry is unbounded; earlier entries have strictly ascending :max"
+    (doseq [[k bands] complexity/complexity-thresholds
+            :let [bounded   (butlast bands)
+                  unbounded (last bands)]]
+      (testing (str "bands for " k)
+        (is (every? :max bounded))
+        (is (not (contains? unbounded :max)))
+        (when (next bounded)
+          (is (apply < (map :max bounded))))))))
 
 (deftest ^:parallel rating-for-score-boundaries-test
-  (testing "score buckets respect the inclusive upper bounds of `complexity-thresholds`"
-    (doseq [[score expected] [[0     {:rating "low"    :rating-label "Low complexity"}]
-                              [999   {:rating "low"    :rating-label "Low complexity"}]
-                              [1000  {:rating "medium" :rating-label "Medium complexity"}]
-                              [9999  {:rating "medium" :rating-label "Medium complexity"}]
-                              [10000 {:rating "high"   :rating-label "High complexity"}]
-                              [1e9   {:rating "high"   :rating-label "High complexity"}]
-                              [nil   {:rating nil      :rating-label nil}]]]
-      (testing (str "score=" score)
-        (is (= expected (complexity/rating-for-score score)))))))
+  (let [expectations
+        {:total [[0     {:rating "low"    :rating-label "Low complexity"}]
+                 [999   {:rating "low"    :rating-label "Low complexity"}]
+                 [1000  {:rating "medium" :rating-label "Medium complexity"}]
+                 [9999  {:rating "medium" :rating-label "Medium complexity"}]
+                 [10000 {:rating "high"   :rating-label "High complexity"}]
+                 [1e9   {:rating "high"   :rating-label "High complexity"}]
+                 [nil   {:rating nil      :rating-label nil}]]}]
+    (testing "expectations cover every rating-table key (add cases when component bands land)"
+      (is (= (set (keys @#'complexity/rating-tables)) (set (keys expectations)))))
+    (doseq [[k cases] expectations
+            :let [table (get @#'complexity/rating-tables k)]
+            [score expected] cases]
+      (testing (str k " score=" score)
+        (is (= expected (complexity/rating-for-score table score))))))
+  (testing "nil or empty rating-table falls through to nil-rating"
+    (is (= {:rating nil :rating-label nil} (complexity/rating-for-score nil 12345)))
+    (is (= {:rating nil :rating-label nil} (complexity/rating-for-score {} 12345)))))
 
 (deftest ^:parallel decorate-with-ratings-test
   (testing "catalog totals get rating fields; components get present-but-nil rating keys"
@@ -148,6 +157,30 @@
   (testing "missing catalogs are left alone (no rating fields injected)"
     (is (= {:meta {:formula-version 1}}
            (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))
+
+(deftest ^:parallel decorate-with-ratings*-component-bands-test
+  (testing "components with bands get rated; components without bands cascade nil-rating"
+    (let [rating-tables (update-vals
+                         {:total        [{:rating "small" :label "Small" :max 100}
+                                         {:rating "big"   :label "Big"}]
+                          :entity-count [{:rating "few"  :label "Few"  :max 5}
+                                         {:rating "many" :label "Many"}]}
+                         #'complexity/->rating-table)
+          catalog       {:total      150
+                         :components {:entity-count {:measurement 8.0  :score 8}
+                                      :field-count  {:measurement 50.0 :score 50}}}]
+      (is (=? {:total        150
+               :rating       "big"
+               :rating-label "Big"
+               :components   {:entity-count {:measurement  8.0
+                                             :score        8
+                                             :rating       "many"
+                                             :rating-label "Many"}
+                              :field-count  {:measurement  50.0
+                                             :score        50
+                                             :rating       nil
+                                             :rating-label nil}}}
+              (complexity/decorate-with-ratings* rating-tables catalog))))))
 
 (deftest ^:parallel score-from-entities-metabot-fallback-test
   (testing "score-from-entities marks :metabot as a universe fallback when no metabot-entities are passed"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -100,6 +100,16 @@
       (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
               (#'complexity/score-catalog es nil))))))
 
+(deftest ^:parallel complexity-thresholds-well-formed-test
+  (let [bands         complexity/complexity-thresholds
+        bounded       (butlast bands)
+        unbounded     (last bands)]
+    (testing "all but the last entry have a :max, in strictly ascending order"
+      (is (every? :max bounded))
+      (is (apply < (map :max bounded))))
+    (testing "the last entry is the only one without a :max"
+      (is (not (contains? unbounded :max))))))
+
 (deftest ^:parallel rating-for-score-boundaries-test
   (testing "score buckets respect the inclusive upper bounds of `complexity-thresholds`"
     (doseq [[score expected] [[0     {:rating "low"    :rating-label "Low complexity"}]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -156,7 +156,12 @@
                          :components {}}}))))
   (testing "missing catalogs are left alone (no rating fields injected)"
     (is (= {:meta {:formula-version 1}}
-           (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))
+           (complexity/decorate-with-ratings {:meta {:formula-version 1}}))))
+  (testing "a catalog without a `:components` key keeps it absent (not injected as `{}`)"
+    (is (= {:library {:total        0
+                      :rating       "low"
+                      :rating-label "Low complexity"}}
+           (complexity/decorate-with-ratings {:library {:total 0}})))))
 
 (deftest ^:parallel decorate-with-ratings*-component-bands-test
   (testing "components with bands get rated; components without bands cascade nil-rating"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -124,15 +124,27 @@
 
 (deftest ^:parallel decorate-with-ratings-test
   (testing "catalog totals get rating fields; components get present-but-nil rating keys"
-    (is (=? {:library  {:total 0    :rating "low"    :rating-label "Low complexity"
-                        :components {:entity-count {:measurement 0.0 :score 0
-                                                    :rating nil :rating-label nil}}}
-             :universe {:total 1500 :rating "medium" :rating-label "Medium complexity"}
-             :metabot  {:total nil  :rating nil      :rating-label nil}}
+    (is (=? {:library  {:total        0
+                        :rating       "low"
+                        :rating-label "Low complexity"
+                        :components   {:entity-count {:measurement  0.0
+                                                      :score        0
+                                                      :rating       nil
+                                                      :rating-label nil}}}
+             :universe {:total        1500
+                        :rating       "medium"
+                        :rating-label "Medium complexity"}
+             :metabot  {:total        nil
+                        :rating       nil
+                        :rating-label nil}}
             (complexity/decorate-with-ratings
-             {:library  {:total 0    :components {:entity-count {:measurement 0.0 :score 0}}}
-              :universe {:total 1500 :components {}}
-              :metabot  {:total nil  :components {}}}))))
+             {:library  {:total      0
+                         :components {:entity-count {:measurement 0.0
+                                                     :score       0}}}
+              :universe {:total      1500
+                         :components {}}
+              :metabot  {:total      nil
+                         :components {}}}))))
   (testing "missing catalogs are left alone (no rating fields injected)"
     (is (= {:meta {:formula-version 1}}
            (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -108,8 +108,8 @@
       (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
               (#'complexity/score-catalog es nil)))))
 
-  (testing "catalog total bucketed into the right rating band"
-    ;; 100 entities at weight 10 = 1000 → top of `:medium`. Avoids touching unrelated axes.
+  (testing "catalog total at the medium-band upper bound buckets as medium"
+    ;; 100 entities × weight 10 = 1000 — pin the boundary, not an arbitrary midpoint.
     (let [es (vec (for [i (range 100)] (entity :name (str "t" i))))]
       (is (=? {:total        1000
                :rating       "medium"
@@ -117,9 +117,7 @@
                :rating-color "orange"}
               (#'complexity/score-catalog es nil)))))
 
-  (testing "catalog total cascading nil zeroes out the rating fields too"
-    ;; An exploding embedder cascades nil through `:total`; the rating must follow suit so a nil
-    ;; total can't sneak past as `:low`.
+  (testing "a nil total cascades nil through the rating fields rather than bucketing as low"
     (let [es       [(entity :name "customers") (entity :name "clients")]
           embedder (fn [_] (throw (ex-info "boom" {})))]
       (is (=? {:total        nil

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -50,21 +50,13 @@
      (mapv #(when-let [v (get name->vec-literal %)] (float-array v)) names))))
 
 (deftest ^:parallel score-catalog-pure-test
-  (testing "empty catalog scores zero and lands in the low-complexity band"
-    (is (=? {:total        0
-             :rating       "low"
-             :rating-label "Low complexity"
-             :rating-color "green"
-             :components   {:entity-count      {:measurement 0.0 :score 0
-                                                :rating nil :rating-label nil :rating-color nil}
-                            :name-collisions   {:measurement 0.0 :score 0
-                                                :rating nil :rating-label nil :rating-color nil}
-                            :synonym-pairs     {:measurement 0.0 :score 0
-                                                :rating nil :rating-label nil :rating-color nil}
-                            :field-count       {:measurement 0.0 :score 0
-                                                :rating nil :rating-label nil :rating-color nil}
-                            :repeated-measures {:measurement 0.0 :score 0
-                                                :rating nil :rating-label nil :rating-color nil}}}
+  (testing "empty catalog scores zero"
+    (is (=? {:total 0
+             :components {:entity-count      {:measurement 0.0 :score 0}
+                          :name-collisions   {:measurement 0.0 :score 0}
+                          :synonym-pairs     {:measurement 0.0 :score 0}
+                          :field-count       {:measurement 0.0 :score 0}
+                          :repeated-measures {:measurement 0.0 :score 0}}}
             (#'complexity/score-catalog [] nil))))
 
   (testing "entity count contributes +10 per entity"
@@ -106,25 +98,7 @@
   (testing "nil embedder disables synonym scoring"
     (let [es [(entity :name "customers") (entity :name "clients")]]
       (is (=? {:components {:synonym-pairs {:measurement 0.0 :score 0}}}
-              (#'complexity/score-catalog es nil)))))
-
-  (testing "catalog total at the medium-band upper bound buckets as medium"
-    ;; 100 entities × weight 10 = 1000 — pin the boundary, not an arbitrary midpoint.
-    (let [es (vec (for [i (range 100)] (entity :name (str "t" i))))]
-      (is (=? {:total        1000
-               :rating       "medium"
-               :rating-label "Medium complexity"
-               :rating-color "orange"}
-              (#'complexity/score-catalog es nil)))))
-
-  (testing "a nil total cascades nil through the rating fields rather than bucketing as low"
-    (let [es       [(entity :name "customers") (entity :name "clients")]
-          embedder (fn [_] (throw (ex-info "boom" {})))]
-      (is (=? {:total        nil
-               :rating       nil
-               :rating-label nil
-               :rating-color nil}
-              (#'complexity/score-catalog es embedder))))))
+              (#'complexity/score-catalog es nil))))))
 
 (deftest ^:parallel rating-for-score-boundaries-test
   (testing "score buckets respect the inclusive upper bounds of `complexity-thresholds`"
@@ -136,7 +110,22 @@
                               [1e9   {:rating "high"   :rating-label "High complexity"   :rating-color "red"}]
                               [nil   {:rating nil      :rating-label nil                 :rating-color nil}]]]
       (testing (str "score=" score)
-        (is (= expected (#'complexity/rating-for-score score)))))))
+        (is (= expected (complexity/rating-for-score score)))))))
+
+(deftest ^:parallel decorate-with-ratings-test
+  (testing "catalog totals get rating fields; components get present-but-nil rating keys"
+    (is (=? {:library  {:total 0    :rating "low"    :rating-label "Low complexity"    :rating-color "green"
+                        :components {:entity-count {:measurement 0.0 :score 0
+                                                    :rating nil :rating-label nil :rating-color nil}}}
+             :universe {:total 1500 :rating "medium" :rating-label "Medium complexity" :rating-color "orange"}
+             :metabot  {:total nil  :rating nil      :rating-label nil                 :rating-color nil}}
+            (complexity/decorate-with-ratings
+             {:library  {:total 0    :components {:entity-count {:measurement 0.0 :score 0}}}
+              :universe {:total 1500 :components {}}
+              :metabot  {:total nil  :components {}}}))))
+  (testing "missing catalogs are left alone (no rating fields injected)"
+    (is (= {:meta {:formula-version 1}}
+           (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))
 
 (deftest ^:parallel score-from-entities-metabot-fallback-test
   (testing "score-from-entities marks :metabot as a universe fallback when no metabot-entities are passed"
@@ -331,13 +320,13 @@
                     :model/Table    _           {:db_id db-id :name "contributes_to_universe" :active true}]
        (let [{:keys [library universe]} (complexity/complexity-scores :embedder nil)]
          (testing "library is empty (no collection tree)"
-           (is (=? {:total      0
-                    :components {:entity-count      {:measurement 0.0 :score 0}
-                                 :name-collisions   {:measurement 0.0 :score 0}
-                                 :synonym-pairs     {:measurement 0.0 :score 0}
-                                 :field-count       {:measurement 0.0 :score 0}
-                                 :repeated-measures {:measurement 0.0 :score 0}}}
-                   library)))
+           (is (= {:total 0
+                   :components {:entity-count      {:measurement 0.0 :score 0}
+                                :name-collisions   {:measurement 0.0 :score 0}
+                                :synonym-pairs     {:measurement 0.0 :score 0}
+                                :field-count       {:measurement 0.0 :score 0}
+                                :repeated-measures {:measurement 0.0 :score 0}}}
+                  library)))
          (testing "universe still enumerates appdb content (our temp table + whatever else is there)"
            (is (pos? (:total universe)))))))))
 
@@ -983,16 +972,13 @@
           ;;  field-count        orders(2) + subscriptions(1) + others(0) = 3 × 1 = 3
           ;;  repeated-measures  "revenue" on orders + subscriptions = 1 × 2 = 2
           ;;  total              60 + 100 + 50 + 3 + 2 = 215
-          (is (=? {:total        215
-                   :rating       "low"
-                   :rating-label "Low complexity"
-                   :rating-color "green"
-                   :components   {:entity-count      {:measurement 6.0 :score 60}
-                                  :name-collisions   {:measurement 1.0 :score 100}
-                                  :synonym-pairs     {:measurement 1.0 :score 50}
-                                  :field-count       {:measurement 3.0 :score 3}
-                                  :repeated-measures {:measurement 1.0 :score 2}}}
-                  library)))
+          (is (= {:total      215
+                  :components {:entity-count      {:measurement 6.0 :score 60}
+                               :name-collisions   {:measurement 1.0 :score 100}
+                               :synonym-pairs     {:measurement 1.0 :score 50}
+                               :field-count       {:measurement 3.0 :score 3}
+                               :repeated-measures {:measurement 1.0 :score 2}}}
+                 library)))
         (testing "universe is a strict superset of library on every component: every measurement and score is higher"
           ;; Note: :synonym-pairs is monotonic on this fixture but not in general — score-synonym-pairs
           ;; dedupes by normalized name and picks one embedding per name, so a universe-only entity

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -126,10 +126,10 @@
             :let [table (get @#'complexity/rating-tables k)]
             [score expected] cases]
       (testing (str k " score=" score)
-        (is (= expected (complexity/rating-for-score table score))))))
+        (is (= expected (@#'complexity/rating-for-score table score))))))
   (testing "nil or empty rating-table falls through to nil-rating"
-    (is (= {:rating nil :rating-label nil} (complexity/rating-for-score nil 12345)))
-    (is (= {:rating nil :rating-label nil} (complexity/rating-for-score {} 12345)))))
+    (is (= {:rating nil :rating-label nil} (@#'complexity/rating-for-score nil 12345)))
+    (is (= {:rating nil :rating-label nil} (@#'complexity/rating-for-score {} 12345)))))
 
 (deftest ^:parallel decorate-with-ratings-test
   (testing "catalog totals get rating fields; components get present-but-nil rating keys"
@@ -180,7 +180,7 @@
                                              :score        50
                                              :rating       nil
                                              :rating-label nil}}}
-              (complexity/decorate-with-ratings* rating-tables catalog))))))
+              (@#'complexity/decorate-with-ratings* rating-tables catalog))))))
 
 (deftest ^:parallel score-from-entities-metabot-fallback-test
   (testing "score-from-entities marks :metabot as a universe fallback when no metabot-entities are passed"

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -156,12 +156,7 @@
                          :components {}}}))))
   (testing "missing catalogs are left alone (no rating fields injected)"
     (is (= {:meta {:formula-version 1}}
-           (complexity/decorate-with-ratings {:meta {:formula-version 1}}))))
-  (testing "a catalog without a `:components` key keeps it absent (not injected as `{}`)"
-    (is (= {:library {:total        0
-                      :rating       "low"
-                      :rating-label "Low complexity"}}
-           (complexity/decorate-with-ratings {:library {:total 0}})))))
+           (complexity/decorate-with-ratings {:meta {:formula-version 1}})))))
 
 (deftest ^:parallel decorate-with-ratings*-component-bands-test
   (testing "components with bands get rated; components without bands cascade nil-rating"

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
@@ -26,9 +26,25 @@ import type {
   DataComplexityCatalog,
   DataComplexityCatalogId,
   DataComplexityComponentId,
+  DataComplexityGroup,
   DataComplexityGroupId,
   DataComplexitySubScore,
 } from "../../types";
+
+// Each group only carries its own component IDs (size: entity_count/field_count;
+// ambiguity: name_collisions/synonym_pairs/repeated_measures). The data-driven
+// iteration over COMPONENT_GROUPS uses the wide union, so cast to a permissive
+// view for the lookup — missing keys yield undefined.
+function getSubScore(
+  group: DataComplexityGroup,
+  componentId: DataComplexityComponentId,
+): DataComplexitySubScore | undefined {
+  return (
+    group.components as Partial<
+      Record<DataComplexityComponentId, DataComplexitySubScore>
+    >
+  )[componentId];
+}
 
 const CATALOG_IDS: DataComplexityCatalogId[] = [
   "library",
@@ -166,7 +182,7 @@ function DataComplexityBreakdown({
 
             <Stack gap="sm" mt="md">
               {componentIds.map((componentId) => {
-                const component = group.components[componentId];
+                const component = getSubScore(group, componentId);
                 if (!component) {
                   return null;
                 }

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
@@ -26,6 +26,8 @@ import type {
   DataComplexityCatalog,
   DataComplexityCatalogId,
   DataComplexityComponentId,
+  DataComplexityGroupId,
+  DataComplexitySubScore,
 } from "../../types";
 
 const CATALOG_IDS: DataComplexityCatalogId[] = [
@@ -34,10 +36,8 @@ const CATALOG_IDS: DataComplexityCatalogId[] = [
   "metabot",
 ];
 
-type DataComplexityComponentGroupId = "size" | "ambiguity";
-
 const COMPONENT_GROUPS: {
-  groupId: DataComplexityComponentGroupId;
+  groupId: DataComplexityGroupId;
   componentIds: DataComplexityComponentId[];
 }[] = [
   {
@@ -97,11 +97,11 @@ function DataComplexityCard({
           <Icon name="chevronright" size={12} c="text-tertiary" />
         </Flex>
         <Text c="text-secondary">{subtitle}</Text>
-        {match(catalog.total)
-          .with(P.number, (total) => (
+        {match(catalog.score)
+          .with(P.number, (score) => (
             <Stack align="center" gap="sm" my="sm">
               <Text size="4rem" fw={700}>
-                {formatNumber(total, { maximumFractionDigits: 0 })}
+                {formatNumber(score, { maximumFractionDigits: 0 })}
               </Text>
               <Text c="text-secondary">{t`Lower is better`}</Text>
             </Stack>
@@ -134,7 +134,7 @@ function DataComplexityBreakdown({
 }: {
   catalog: DataComplexityCatalog;
 }) {
-  const hasError = catalog.total == null;
+  const hasError = catalog.score == null;
 
   return (
     <Stack gap="lg">
@@ -155,6 +155,7 @@ function DataComplexityBreakdown({
             description: t`Signals that similar or repeated names could make answers harder to trust.`,
           }))
           .exhaustive();
+        const group = catalog.components[groupId];
 
         return (
           <Box key={groupId}>
@@ -164,13 +165,19 @@ function DataComplexityBreakdown({
             </Text>
 
             <Stack gap="sm" mt="md">
-              {componentIds.map((componentId) => (
-                <DataComplexityComponentItem
-                  key={componentId}
-                  componentId={componentId}
-                  catalog={catalog}
-                />
-              ))}
+              {componentIds.map((componentId) => {
+                const component = group.components[componentId];
+                if (!component) {
+                  return null;
+                }
+                return (
+                  <DataComplexityComponentItem
+                    key={componentId}
+                    componentId={componentId}
+                    component={component}
+                  />
+                );
+              })}
             </Stack>
           </Box>
         );
@@ -181,13 +188,12 @@ function DataComplexityBreakdown({
 
 function DataComplexityComponentItem({
   componentId,
-  catalog,
+  component,
 }: {
   componentId: DataComplexityComponentId;
-  catalog: DataComplexityCatalog;
+  component: DataComplexitySubScore;
 }) {
-  const component = catalog.components[componentId];
-  const measurement = component.measurement;
+  const measurement = "measurement" in component ? component.measurement : null;
 
   const { title, description, count } = match(componentId)
     .with("entity_count", () => ({
@@ -263,7 +269,7 @@ function DataComplexityComponentItem({
             <Text size="sm" c="text-secondary">
               {description}
             </Text>
-            {component.score === null && (
+            {"error" in component && (
               <Text mt="sm" size="sm" c="error" role="alert">
                 {component.error}
               </Text>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.unit.spec.tsx
@@ -28,37 +28,68 @@ const cleanForSnapshot = (element: Element) => {
 
 const mockScores: DataComplexityScoresResponse = {
   library: {
-    total: 18,
+    score: 18,
     components: {
-      entity_count: { measurement: 1, score: 10 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 8, score: 8 },
-      repeated_measures: { measurement: 0, score: 0 },
+      size: {
+        score: 18,
+        components: {
+          entity_count: { measurement: 1, score: 10 },
+          field_count: { measurement: 8, score: 8 },
+        },
+      },
+      ambiguity: {
+        score: 0,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 0, score: 0 },
+        },
+      },
     },
   },
   universe: {
-    total: 54,
+    score: 54,
     components: {
-      entity_count: { measurement: 2, score: 20 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 24, score: 24 },
-      repeated_measures: { measurement: 5, score: 10 },
+      size: {
+        score: 44,
+        components: {
+          entity_count: { measurement: 2, score: 20 },
+          field_count: { measurement: 24, score: 24 },
+        },
+      },
+      ambiguity: {
+        score: 10,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 5, score: 10 },
+        },
+      },
     },
   },
   metabot: {
-    total: 30,
+    score: 30,
     components: {
-      entity_count: { measurement: 1, score: 10 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 20, score: 20 },
-      repeated_measures: { measurement: 0, score: 0 },
+      size: {
+        score: 30,
+        components: {
+          entity_count: { measurement: 1, score: 10 },
+          field_count: { measurement: 20, score: 20 },
+        },
+      },
+      ambiguity: {
+        score: 0,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 0, score: 0 },
+        },
+      },
     },
   },
   meta: {
     formula_version: 3,
+    format_version: 1,
     synonym_threshold: 0.9,
   },
 };
@@ -66,13 +97,17 @@ const mockScores: DataComplexityScoresResponse = {
 const mockScoresWithError: DataComplexityScoresResponse = {
   ...mockScores,
   metabot: {
-    total: null,
+    score: null,
     components: {
       ...mockScores.metabot.components,
-      synonym_pairs: {
-        measurement: null,
+      ambiguity: {
         score: null,
-        error: "Embedding service timed out",
+        components: {
+          ...mockScores.metabot.components.ambiguity.components,
+          synonym_pairs: {
+            error: "Embedding service timed out",
+          },
+        },
       },
     },
   },

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexitySection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexitySection.unit.spec.tsx
@@ -11,37 +11,68 @@ import { DataComplexitySection } from "./ConversationStatsPage";
 
 const mockScores: DataComplexityScoresResponse = {
   library: {
-    total: 18,
+    score: 18,
     components: {
-      entity_count: { measurement: 1, score: 10 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 8, score: 8 },
-      repeated_measures: { measurement: 0, score: 0 },
+      size: {
+        score: 18,
+        components: {
+          entity_count: { measurement: 1, score: 10 },
+          field_count: { measurement: 8, score: 8 },
+        },
+      },
+      ambiguity: {
+        score: 0,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 0, score: 0 },
+        },
+      },
     },
   },
   universe: {
-    total: 54,
+    score: 54,
     components: {
-      entity_count: { measurement: 2, score: 20 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 24, score: 24 },
-      repeated_measures: { measurement: 5, score: 10 },
+      size: {
+        score: 44,
+        components: {
+          entity_count: { measurement: 2, score: 20 },
+          field_count: { measurement: 24, score: 24 },
+        },
+      },
+      ambiguity: {
+        score: 10,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 5, score: 10 },
+        },
+      },
     },
   },
   metabot: {
-    total: 30,
+    score: 30,
     components: {
-      entity_count: { measurement: 1, score: 10 },
-      name_collisions: { measurement: 0, score: 0 },
-      synonym_pairs: { measurement: 0, score: 0 },
-      field_count: { measurement: 20, score: 20 },
-      repeated_measures: { measurement: 0, score: 0 },
+      size: {
+        score: 30,
+        components: {
+          entity_count: { measurement: 1, score: 10 },
+          field_count: { measurement: 20, score: 20 },
+        },
+      },
+      ambiguity: {
+        score: 0,
+        components: {
+          name_collisions: { measurement: 0, score: 0 },
+          synonym_pairs: { measurement: 0, score: 0 },
+          repeated_measures: { measurement: 0, score: 0 },
+        },
+      },
     },
   },
   meta: {
     formula_version: 3,
+    format_version: 1,
     synonym_threshold: 0.9,
   },
 };

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -114,9 +114,7 @@ export type DataComplexitySubScore =
 
 export type DataComplexityGroup = {
   score: number | null;
-  components: Partial<
-    Record<DataComplexityComponentId, DataComplexitySubScore>
-  >;
+  components: Record<DataComplexityComponentId, DataComplexitySubScore>;
 };
 
 export type DataComplexityCatalog = {

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -100,34 +100,34 @@ export type ConversationDetail = {
 };
 
 export type DataComplexityCatalogId = "library" | "universe" | "metabot";
+export type DataComplexityGroupId = "size" | "ambiguity";
 export type DataComplexityComponentId =
   | "entity_count"
+  | "field_count"
   | "name_collisions"
   | "synonym_pairs"
-  | "field_count"
   | "repeated_measures";
 
 export type DataComplexitySubScore =
-  | {
-      measurement: null;
-      score: null;
-      error: string;
-    }
-  | {
-      measurement: number;
-      score: number;
-    };
+  | { error: string }
+  | { measurement: number; score: number };
+
+export type DataComplexityGroup = {
+  score: number | null;
+  components: Partial<
+    Record<DataComplexityComponentId, DataComplexitySubScore>
+  >;
+};
 
 export type DataComplexityCatalog = {
-  total: number | null;
-  components: {
-    [K in DataComplexityComponentId]: DataComplexitySubScore;
-  };
+  score: number | null;
+  components: Record<DataComplexityGroupId, DataComplexityGroup>;
 };
 
 export type DataComplexityScoresResponse = {
   meta: {
     formula_version: number;
+    format_version: number;
     synonym_threshold: number;
     calculated_at?: string;
     embedding_model?: {

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -101,25 +101,43 @@ export type ConversationDetail = {
 
 export type DataComplexityCatalogId = "library" | "universe" | "metabot";
 export type DataComplexityGroupId = "size" | "ambiguity";
-export type DataComplexityComponentId =
-  | "entity_count"
-  | "field_count"
+
+export type DataComplexitySizeComponentId = "entity_count" | "field_count";
+export type DataComplexityAmbiguityComponentId =
   | "name_collisions"
   | "synonym_pairs"
   | "repeated_measures";
+export type DataComplexityComponentId =
+  | DataComplexitySizeComponentId
+  | DataComplexityAmbiguityComponentId;
 
 export type DataComplexitySubScore =
   | { error: string }
   | { measurement: number; score: number };
 
-export type DataComplexityGroup = {
+export type DataComplexitySizeGroup = {
   score: number | null;
-  components: Record<DataComplexityComponentId, DataComplexitySubScore>;
+  components: Record<DataComplexitySizeComponentId, DataComplexitySubScore>;
 };
+
+export type DataComplexityAmbiguityGroup = {
+  score: number | null;
+  components: Record<
+    DataComplexityAmbiguityComponentId,
+    DataComplexitySubScore
+  >;
+};
+
+export type DataComplexityGroup =
+  | DataComplexitySizeGroup
+  | DataComplexityAmbiguityGroup;
 
 export type DataComplexityCatalog = {
   score: number | null;
-  components: Record<DataComplexityGroupId, DataComplexityGroup>;
+  components: {
+    size: DataComplexitySizeGroup;
+    ambiguity: DataComplexityAmbiguityGroup;
+  };
 };
 
 export type DataComplexityScoresResponse = {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/data_complexity/jsonschema/1-0-0
@@ -57,7 +57,7 @@
             "maximum": 2147483647
         },
         "measurement": {
-            "description": "Raw pre-score measurement (absent on aggregates; null on uncomputed leaves). Number, not integer, to future-proof.",
+            "description": "Raw pre-score measurement (absent on aggregates and on error leaves). Number, not integer, to future-proof.",
             "type": [
                 "number",
                 "null"


### PR DESCRIPTION
## Summary

Closes [BOT-1529: Return Complexity Score rating from Backend](https://linear.app/metabase/issue/BOT-1529/return-complexity-score-rating-from-backend)

- Add `complexity-thresholds` (3 bands: 0–999 low, 1,000–9,999 medium, 10,000+ high) and `rating-for-score` in the Data Complexity Score module.
- Decorate the `/complexity` API response with `:rating` and `:rating-label` per catalog at the API boundary — derived on read from each catalog's `:total`, never persisted.
- Sub-component scores get the same keys with `nil` values so the response shape is uniform.
- Extend the Malli return schema to require the new keys.

Bands:

| Score range   | Rating    | Label                |
|---------------|-----------|----------------------|
| 0 – 999       | `low`     | "Low complexity"     |
| 1,000 – 9,999 | `medium`  | "Medium complexity"  |
| 10,000+       | `high`    | "High complexity"    |

## Design decisions

**Backend masters the thresholds.** They're product semantics, not styling — every consumer (web, future SDK/API clients, analytics) reading from the same source avoids drift.

**Decorate the main score API rather than ship thresholds for the FE to apply.** The FE wants to render the band, not compute it; serving the answer is one call, not two. A separate thresholds endpoint also makes the contract harder to evolve.

**Decorate at the API boundary rather than inside `score-catalog`.** Ratings are presentation, not scoring. Computing on read means threshold tweaks apply to existing snapshots immediately and persisted JSON stays minimal.

**Color is left to the FE.** Backend returns the band identifier; mapping `low/medium/high` to a color is pure presentation and may differ by theme.

## Test plan

- [x] `./bin/test-agent :module enterprise/data_complexity_score` — 79 tests / 307 assertions pass
- [x] `rating-for-score-boundaries-test` covers 0, 999, 1000, 9999, 10000, 1e9, nil
- [x] `decorate-with-ratings-test` covers the per-catalog decoration including nil-total cascade
- [x] API tests round-trip raw `sample-score` through the endpoint and assert against `(expected-response sample-score)`
- [x] Manual: hit `GET /api/ee/data-complexity-score/complexity` and confirm `rating`, `rating_label` at catalog level and null on each component