### PR TITLE
feat(mcp): add database tool and enhance search functionality to output DB info

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -170,7 +170,8 @@
               request
               server
               settings
-              util}
+              util
+              warehouses}
    :model-imports #{:model/Card
                     :model/Dashboard
                     :model/DashboardCard

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -33,6 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouses.core :as warehouses]
    [toucan2.core :as t2]))
 
 ;;; --------------------------------------------------- Defaults ------------------------------------------------------
@@ -208,11 +209,38 @@
    [:statistics {:optional true} [:maybe ::statistics]]
    [:values {:optional true} [:maybe [:sequential :any]]]])
 
+(def ^:private agent-database-projection
+  "Allowlist of database fields exposed to LLM agents. Explicit deny-by-default;
+   extending requires updating this vector AND `::database` (closed schema). The
+   test [[metabase.agent-api.api-test/list-databases-test]] asserts set equality
+   on response keys, so accidental additions fail loudly."
+  [:id :name :engine :description :is_sample :is_attached_dwh :created_at :updated_at])
+
+(mr/def ::database
+  "LLM-safe database summary. Never includes connection details (credentials),
+   settings, sync schedules, or routing config. Allowlist enforced by `:closed`
+   plus the [[->agent-database]] projection — defense in depth."
+  [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en) :closed true}
+   [:id :int]
+   [:name :string]
+   [:engine :string]
+   [:description     {:optional true} [:maybe :string]]
+   [:is_sample       {:optional true} [:maybe :boolean]]
+   [:is_attached_dwh {:optional true} [:maybe :boolean]]
+   [:created_at      {:optional true} [:maybe :any]]
+   [:updated_at      {:optional true} [:maybe :any]]])
+
+(mr/def ::database-list-response
+  "Response shape for listing databases visible to the current user."
+  [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en)}
+   [:data        [:sequential ::database]]
+   [:total_count :int]])
+
 (mr/def ::search-result-item
-  "A table or metric returned from search."
+  "A table, metric, or database returned from search."
   [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en)}
    [:id :int]
-   [:type [:enum "table" "metric"]]
+   [:type [:enum "table" "metric" "database"]]
    [:name :string]
    [:display_name {:optional true} [:maybe :string]]
    [:description {:optional true} [:maybe :string]]
@@ -317,6 +345,44 @@
      :field-id    field-id
      :limit       (or (request/limit) default-field-values-limit)})))
 
+;;; ----------------------------------------------------- Databases --------------------------------------------------
+
+(defn- ->agent-database
+  "Project a `:model/Database` row to the LLM-safe shape via the allowlist. Explicit
+  projection — never rely on `mi/to-json` to strip sensitive fields, since that only
+  removes `:details` and depends on `mi/can-write?` plumbing.
+
+  `:engine` is stored as a keyword on the model; render it as a plain string so the
+  response schema (and JSON consumers) get a stable type."
+  [db]
+  (cond-> (select-keys db agent-database-projection)
+    (keyword? (:engine db)) (update :engine name)))
+
+(api.macros/defendpoint :get "/v1/database" :- ::database-list-response
+  "List connected databases visible to the current user."
+  ;; HTTP GET implies read-only + idempotent — these annotations are inferred by the
+  ;; tools manifest (`metabase.api.macros.defendpoint.tools-manifest/infer-annotations`),
+  ;; so do NOT add an `:annotations` map here — explicit duplicates throw at manifest gen.
+  {:scope metabot/agent-metadata-read
+   :tool  {:name "list_databases"
+           :description (str "List connected databases (data warehouses) visible to the current user. "
+                             "Databases are the root of Metabase's data hierarchy — call this first "
+                             "when you need to know which data sources exist before searching tables.")}}
+  []
+  (let [databases (mapv ->agent-database (warehouses/visible-databases))]
+    {:data        databases
+     :total_count (count databases)}))
+
+(api.macros/defendpoint :get "/v1/database/:id" :- ::database
+  "Get details about a single connected database by ID."
+  {:scope metabot/agent-metadata-read
+   :tool  {:name "get_database"
+           :description "Get details about a single connected database by ID."}}
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (->agent-database (warehouses/get-database id {})))
+
+;;; ----------------------------------------------------- Search ------------------------------------------------------
+
 (defn- coerce-query-list
   "Defensive coercion for `/v1/search`'s query arguments. Some MCP clients (notably
    Codex) serialize array args through a string layer, so a caller that intended to
@@ -336,33 +402,49 @@
                         [v])
     :else           v))
 
+(def ^:private search-entity-types
+  "Entity types the agent-api `/v1/search` endpoint exposes."
+  #{"table" "metric" "database"})
+
+(def ^:private default-search-entity-types
+  "Entity types searched when the caller doesn't specify `entity_types`. Kept to
+  table+metric for backward compatibility — callers must opt in to `\"database\"`."
+  ["table" "metric"])
+
 (api.macros/defendpoint :post "/v1/search" :- ::search-response
-  "Search for tables and metrics.
+  "Search for tables, metrics, and databases.
 
   Supports both term-based and semantic search queries. Results are ranked using
   Reciprocal Rank Fusion when both query types are provided."
   {:scope metabot/agent-search
    :tool  {:name "search"
-           :title "Search Tables and Metrics"
-           :description (str "Search for tables and metrics in Metabase. "
+           :title "Search Tables, Metrics, and Databases"
+           :description (str "Search for tables, metrics, and databases in Metabase. "
                              "Use term_queries for keyword search or semantic_queries for natural language search. "
-                             "Both arguments are arrays of strings, for example term_queries: [\"orders\", \"revenue\"].")
+                             "Both arguments are arrays of strings, for example term_queries: [\"orders\", \"revenue\"]. "
+                             "Pass entity_types to restrict result types — e.g. [\"database\"] to find a connected "
+                             "data source by name. To enumerate all connected databases without a search term, use "
+                             "the `list_databases` tool instead.")
            :annotations {:read-only? true}}}
   [_route-params
    _query-params
    {term-queries     :term_queries
-    semantic-queries :semantic_queries}
+    semantic-queries :semantic_queries
+    entity-types     :entity_types}
    :- [:map
        [:term_queries {:optional true
                        :tool/description "Keyword search queries as an array of strings, for example [\"orders\", \"revenue\"]."}
         [:maybe [:or [:sequential ms/NonBlankString] ms/NonBlankString]]]
        [:semantic_queries {:optional true
                            :tool/description "Natural-language search queries as an array of strings, for example [\"how much revenue did we make\"]."}
-        [:maybe [:or [:sequential ms/NonBlankString] ms/NonBlankString]]]]]
+        [:maybe [:or [:sequential ms/NonBlankString] ms/NonBlankString]]]
+       [:entity_types {:optional true
+                       :tool/description "Restrict results to specific entity types. Defaults to [\"table\", \"metric\"]; pass [\"database\"] to find a connected data source by name, or combine to widen results."}
+        [:maybe [:sequential (into [:enum] (sort search-entity-types))]]]]]
   (let [results (metabot-search/search
                  {:term-queries     (or (coerce-query-list term-queries) [])
                   :semantic-queries (or (coerce-query-list semantic-queries) [])
-                  :entity-types     ["table" "metric"]
+                  :entity-types     (or (seq entity-types) default-search-entity-types)
                   :limit            (or (request/limit) 50)})]
     {:data        results
      :total_count (count results)}))

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -209,26 +209,34 @@
    [:statistics {:optional true} [:maybe ::statistics]]
    [:values {:optional true} [:maybe [:sequential :any]]]])
 
-(def ^:private agent-database-projection
-  "Allowlist of database fields exposed to LLM agents. Explicit deny-by-default;
-   extending requires updating this vector AND `::database` (closed schema). The
-   test [[metabase.agent-api.api-test/list-databases-test]] asserts set equality
-   on response keys, so accidental additions fail loudly."
-  [:id :name :engine :description :is_sample :is_attached_dwh :created_at :updated_at])
+(def ^:private agent-database-fields
+  "Single source of truth for the LLM-safe database allowlist. Each entry is a Malli
+   `:map` child — `[key schema]` (required) or `[key {:optional true} schema]`
+   (optional). Drives both the `::database` Malli schema (`into [:map ...]` below) and
+   [[->agent-database]]'s `select-keys` projection (via [[agent-database-projection]]).
 
-(mr/def ::database
-  "LLM-safe database summary. Never includes connection details (credentials),
-   settings, sync schedules, or routing config. Allowlist enforced by `:closed`
-   plus the [[->agent-database]] projection — defense in depth."
-  [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en) :closed true}
-   [:id :int]
-   [:name :string]
-   [:engine :string]
+   Anything not listed here is rejected by the `:closed` schema. Fields with
+   security implications (e.g. `details`, `settings`, `metadata_sync_schedule`,
+   `router_database_id`) are deliberately absent."
+  [[:id              :int]
+   [:name            :string]
+   [:engine          :string]
    [:description     {:optional true} [:maybe :string]]
    [:is_sample       {:optional true} [:maybe :boolean]]
    [:is_attached_dwh {:optional true} [:maybe :boolean]]
    [:created_at      {:optional true} [:maybe :any]]
    [:updated_at      {:optional true} [:maybe :any]]])
+
+(def ^:private agent-database-projection
+  "Allowlist vector derived from [[agent-database-fields]] — used by
+   [[->agent-database]] to drop everything outside the schema before serialization."
+  (mapv first agent-database-fields))
+
+(mr/def ::database
+  "LLM-safe database summary. Schema is generated from [[agent-database-fields]];
+   `:closed true` rejects any field not in that allowlist."
+  (into [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en) :closed true}]
+        agent-database-fields))
 
 (mr/def ::database-list-response
   "Response shape for listing databases visible to the current user."

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -218,7 +218,11 @@
   "Merge route, query, and body param schemas into a single inputSchema object.
   Route params are always required. For body schemas that aren't simple maps (e.g. `:or`),
   the full JSON Schema is used directly. If route/query/body share a property name,
-  later sources (body > query > route) take precedence."
+  later sources (body > query > route) take precedence.
+
+  Always returns an `:inputSchema` object — tools without any parameters get an empty
+  `{:type \"object\" :properties {}}`, since the MCP spec expects `inputSchema` to be
+  present on every tool definition."
   [form]
   (let [route-parts (schema->properties-and-required (get-in form [:params :route :schema]))
         query-parts (schema->properties-and-required (get-in form [:params :query :schema]))
@@ -236,7 +240,7 @@
                            (:required body-parts)])]
     (cond
       (and body-full (empty? all-props)) body-full
-      (seq all-props)                    (cond-> {:type "object" :properties all-props}
+      :else                              (cond-> {:type "object" :properties (or all-props {})}
                                            (seq all-req) (assoc :required all-req)))))
 
 (defn- response-schema->json-schema

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -13,6 +13,7 @@
   provider-and-model->provider]
  [metabase.metabot.scope
   agent-dashboard-create
+  agent-metadata-read
   agent-metric-read
   agent-question-create
   agent-query-construct

--- a/src/metabase/warehouses/core.clj
+++ b/src/metabase/warehouses/core.clj
@@ -17,4 +17,5 @@
  [metabase.warehouses.util
   get-database
   test-connection-details
-  test-database-connection])
+  test-database-connection
+  visible-databases])

--- a/src/metabase/warehouses/util.clj
+++ b/src/metabase/warehouses/util.clj
@@ -3,12 +3,37 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
+   [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
+
+(defn visible-databases
+  "Return all `:model/Database`s visible to the current user, ordered by name then
+  engine. Visibility OR's together data-access, manage-database, and
+  manage-table-metadata permission clauses — same filter the legacy
+  `GET /api/database` endpoint uses (see `metabase.warehouses-rest.api/dbs-list`).
+  Excludes the analytics/audit DB and destination DBs created by database routing."
+  []
+  (let [user-info      {:user-id          api/*current-user-id*
+                        :is-superuser?    (mi/superuser?)
+                        :is-data-analyst? api/*is-data-analyst?*}
+        visible-clause [:or
+                        (:clause (mi/visible-filter-clause :model/Database :id user-info
+                                                           {:perms/create-queries :query-builder}))
+                        (:clause (mi/visible-filter-clause :model/Database :id user-info
+                                                           {:perms/manage-database :yes}))
+                        (:clause (mi/visible-filter-clause :model/Database :id user-info
+                                                           {:perms/manage-table-metadata :yes}))]]
+    (t2/select :model/Database
+               {:order-by [:%lower.name :%lower.engine]
+                :where    [:and
+                           [:= :is_audit false]
+                           [:= :router_database_id nil]
+                           visible-clause]})))
 
 (mu/defn get-database
   "Retrieve database respecting `include-editable-data-model?`, `exclude-uneditable-details?` and `include-mirror-databases?`"

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -2,6 +2,8 @@
   "Agent API functional tests using session-based authentication.
    JWT and scope-related tests live in metabase-enterprise.agent-api.api-test."
   (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [environ.core :as env]
    [java-time.api :as t]
@@ -221,6 +223,126 @@
       (is (= "Field 999999 not found"
              (mt/user-http-request :crowberto :get 404 (format "agent/v1/table/%d/field/999999/values" table-id)))))))
 
+;;; -------------------------------------------------- Databases --------------------------------------------------
+
+(def ^:private agent-database-allowed-keys
+  "Mirror of [[metabase.agent-api.api/agent-database-projection]] kept here as the
+   single source of truth for the security test: the response must contain ONLY
+   these keys, never `:details`, `:settings`, or sync-schedule fields."
+  #{:id :name :engine :description :is_sample :is_attached_dwh :created_at :updated_at})
+
+(deftest list-databases-test
+  (testing "Returns at least the sample test DB to a superuser, with only allowlisted fields"
+    ;; Use crowberto (superuser) here: this test asserts the response *shape* and the
+    ;; allowlist projection. Permission-filter semantics are covered by
+    ;; `mi/visible-filter-clause :model/Database` and the existing
+    ;; `metabase.warehouses-rest.api-test/databases-list-test`.
+    ;; `(mt/id)` forces the test dataset to lazy-load, otherwise app-DB has zero rows
+    ;; under the `:db :web-server :test-users` fixture chain and the endpoint would
+    ;; trivially return `:total_count 0`.
+    (mt/id)
+    (let [{:keys [data total_count]} (mt/user-http-request :crowberto :get 200 "agent/v1/database")
+          sample-db                  (m/find-first #(= (mt/id) (:id %)) data)]
+      (is (pos? total_count))
+      (is (= total_count (count data)))
+      (is (some? sample-db) "Sample DB should be visible to the superuser")
+      (testing "response items contain only allowlisted keys (nothing else may leak)"
+        (doseq [db data]
+          (is (= agent-database-allowed-keys
+                 (set (keys db)))
+              (format "Database id=%s leaked keys: %s"
+                      (:id db) (set/difference (set (keys db)) agent-database-allowed-keys))))))))
+
+(deftest list-databases-superuser-superset-test
+  (testing "A non-superuser's view of `/v1/database` is always a subset of a superuser's"
+    ;; Structural guarantee: a non-superuser cannot see a DB the superuser shortcut
+    ;; wouldn't surface. Strict perm-deny semantics are exercised by
+    ;; `list-databases-blocked-perms-test` below.
+    (mt/with-temp [:model/Database _ {:name   "agent-api-superset-canary-db"
+                                      :engine :h2}]
+      (let [admin-ids (->> (mt/user-http-request :crowberto :get 200 "agent/v1/database")
+                           :data (map :id) set)
+            user-ids  (->> (mt/user-http-request :rasta :get 200 "agent/v1/database")
+                           :data (map :id) set)]
+        (is (contains? admin-ids (t2/select-one-pk :model/Database
+                                                   :name "agent-api-superset-canary-db"))
+            "Superuser sees the freshly-created DB")
+        (is (set/subset? user-ids admin-ids))))))
+
+(deftest list-databases-blocked-perms-test
+  (testing "A user with all data-permissions revoked on a DB does NOT see it via /v1/database"
+    ;; Create a DB, wipe its default DataPermissions (which `mt/with-temp` grants to
+    ;; `All Users` by default), so no group has any grant — rasta loses access from every
+    ;; angle. Superuser still sees it via the `is-superuser?` short-circuit in
+    ;; `perms/visible-database-filter-select`.
+    (mt/with-temp [:model/Database {db-id :id} {:name   "agent-api-blocked-perms-db"
+                                                :engine :h2}]
+      (t2/delete! :model/DataPermissions :db_id db-id)
+      (let [admin-ids (->> (mt/user-http-request :crowberto :get 200 "agent/v1/database")
+                           :data (map :id) set)
+            user-ids  (->> (mt/user-http-request :rasta :get 200 "agent/v1/database")
+                           :data (map :id) set)]
+        (is (contains? admin-ids db-id)
+            "Superuser sees the blocked DB (superuser short-circuit)")
+        (is (not (contains? user-ids db-id))
+            "Rasta MUST NOT see a DB she has zero data-permissions on")))))
+
+(deftest get-database-blocked-perms-test
+  (testing "`api/read-check` denies `/v1/database/:id` for a DB the user cannot access"
+    (mt/with-temp [:model/Database {db-id :id} {:name   "agent-api-get-blocked-db"
+                                                :engine :h2}]
+      (t2/delete! :model/DataPermissions :db_id db-id)
+      ;; Sanity check: superuser still gets a 200 — confirms the DB exists and the URL
+      ;; routes correctly; the only reason rasta is rejected is the read-check.
+      (is (=? {:id db-id}
+              (mt/user-http-request :crowberto :get 200 (str "agent/v1/database/" db-id))))
+      ;; `api/read-check` raises 403 with "You don't have permissions to do that." for
+      ;; the non-superuser. We don't pin the exact message — just the status code, since
+      ;; that's the contract of the endpoint.
+      (mt/user-http-request :rasta :get 403 (str "agent/v1/database/" db-id)))))
+
+(deftest list-databases-no-credential-leak-test
+  (testing "Sensitive fields in :details are never exposed via the agent endpoint"
+    (mt/with-temp [:model/Database {db-id :id} {:name    "agent-api-credential-leak-db"
+                                                :engine  :h2
+                                                :details {:db       "mem:leak-canary"
+                                                          :password "super-secret-canary"
+                                                          :ssh-key  "-----BEGIN RSA PRIVATE KEY-----"}}]
+      (let [response     (mt/user-http-request :crowberto :get 200 "agent/v1/database")
+            leak-db      (m/find-first #(= db-id (:id %)) (:data response))
+            json-encoded (json/encode response)]
+        (is (some? leak-db) "Newly created DB should appear in the superuser's list")
+        (is (= agent-database-allowed-keys (set (keys leak-db))))
+        (testing "no credential payload appears anywhere in the serialized response"
+          (is (not (str/includes? json-encoded "super-secret-canary")))
+          (is (not (str/includes? json-encoded "BEGIN RSA PRIVATE KEY"))))))))
+
+(deftest get-database-test
+  (testing "Returns single database details for valid ID"
+    ;; Force-load the test dataset so the sample DB exists in the app DB.
+    (let [db-id (mt/id)
+          db    (mt/user-http-request :crowberto :get 200 (str "agent/v1/database/" db-id))]
+      (is (=? {:id     db-id
+               :name   string?
+               :engine string?}
+              db))
+      (is (= agent-database-allowed-keys (set (keys db))))))
+
+  (testing "Returns 404 for non-existent database"
+    (is (= "Not found."
+           (mt/user-http-request :crowberto :get 404 "agent/v1/database/999999"))))
+
+  (testing "Sensitive :details never appear on the single-DB endpoint"
+    (mt/with-temp [:model/Database {db-id :id} {:name    "agent-api-single-leak-db"
+                                                :engine  :h2
+                                                :details {:db       "mem:single-leak-canary"
+                                                          :password "single-secret-canary"}}]
+      (let [db (mt/user-http-request :crowberto :get 200 (str "agent/v1/database/" db-id))]
+        (is (= agent-database-allowed-keys (set (keys db))))
+        (is (not (str/includes? (json/encode db) "single-secret-canary")))))))
+
+;;; --------------------------------------------------- Search ---------------------------------------------------
+
 (deftest search-test
   (binding [search.ingestion/*force-sync* true]
     (search.tu/with-new-search-if-available-otherwise-legacy
@@ -230,6 +352,17 @@
                    :total_count 1}
                   (mt/user-http-request :rasta :post 200 "agent/v1/search"
                                         {:term_queries ["AgentSearchTestTable"]}))))))))
+
+(deftest search-databases-test
+  (testing "Search returns databases when entity_types includes \"database\""
+    (binding [search.ingestion/*force-sync* true]
+      (search.tu/with-new-search-if-available-otherwise-legacy
+        (mt/with-temp [:model/Database _ {:name "AgentSearchTestWarehouse" :engine :h2}]
+          (is (=? {:data        [{:type "database" :name "AgentSearchTestWarehouse"}]
+                   :total_count 1}
+                  (mt/user-http-request :rasta :post 200 "agent/v1/search"
+                                        {:term_queries ["AgentSearchTestWarehouse"]
+                                         :entity_types ["database"]}))))))))
 
 (deftest coerce-query-list-test
   (let [coerce #'agent-api.api/coerce-query-list]

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -13,6 +13,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.normalize :as lib.normalize]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
    [metabase.session.models.session :as session.models]
@@ -286,6 +288,49 @@
             "Superuser sees the blocked DB (superuser short-circuit)")
         (is (not (contains? user-ids db-id))
             "Rasta MUST NOT see a DB she has zero data-permissions on")))))
+
+(deftest list-databases-partial-visibility-test
+  (testing "User sees only the DBs she has permission for, not all the temp DBs in the test run"
+    ;; The real-world scenario: a user's group has access to DB A but not DB B.
+    ;; `list_databases` must return A and omit B — proving the perm-filter partitions
+    ;; visibility per-database, not all-or-nothing.
+    (mt/with-temp [:model/Database {db-a-id :id} {:name   "agent-api-partial-vis-db-A"
+                                                  :engine :h2}
+                   :model/Database {db-b-id :id} {:name   "agent-api-partial-vis-db-B"
+                                                  :engine :h2}]
+      ;; Wipe defaults on both, then grant data-access ONLY on A. B is left with zero grants.
+      (t2/delete! :model/DataPermissions :db_id db-a-id)
+      (t2/delete! :model/DataPermissions :db_id db-b-id)
+      (data-perms/set-database-permission! (perms-group/all-users) db-a-id
+                                           :perms/view-data :unrestricted)
+      (data-perms/set-database-permission! (perms-group/all-users) db-a-id
+                                           :perms/create-queries :query-builder)
+      (let [user-ids  (->> (mt/user-http-request :rasta :get 200 "agent/v1/database")
+                           :data (map :id) set)
+            admin-ids (->> (mt/user-http-request :crowberto :get 200 "agent/v1/database")
+                           :data (map :id) set)]
+        (is (contains? user-ids db-a-id) "Rasta sees DB A (granted)")
+        (is (not (contains? user-ids db-b-id)) "Rasta MUST NOT see DB B (no grants)")
+        (testing "superuser still sees both — confirms the test fixtures, not just denial"
+          (is (contains? admin-ids db-a-id))
+          (is (contains? admin-ids db-b-id)))))))
+
+(deftest list-databases-metadata-only-perms-test
+  (testing "A user with ONLY :perms/manage-table-metadata sees the DB (no data-access required)"
+    ;; Positive test for the `manage-table-metadata` OR-branch in
+    ;; `warehouses/visible-databases`. Wipe defaults, grant only that one perm to All
+    ;; Users — rasta (in All Users) has zero data-access but should still see the DB.
+    ;; Without this test a typo like `:perms/manage-table-metadata :no` in the OR clause
+    ;; would silently pass every other test.
+    (mt/with-temp [:model/Database {db-id :id} {:name   "agent-api-metadata-only-db"
+                                                :engine :h2}]
+      (t2/delete! :model/DataPermissions :db_id db-id)
+      (data-perms/set-database-permission! (perms-group/all-users) db-id
+                                           :perms/manage-table-metadata :yes)
+      (let [user-ids (->> (mt/user-http-request :rasta :get 200 "agent/v1/database")
+                          :data (map :id) set)]
+        (is (contains? user-ids db-id)
+            "Rasta should see a DB she can only edit table metadata on")))))
 
 (deftest get-database-blocked-perms-test
   (testing "`api/read-check` denies `/v1/database/:id` for a DB the user cannot access"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -178,10 +178,12 @@
     "create_dashboard"
     "create_question"
     "execute_query"
+    "get_database"
     "get_metric"
     "get_metric_field_values"
     "get_table"
     "get_table_field_values"
+    "list_databases"
     "query"
     "render_drill_through"
     "search"
@@ -507,8 +509,8 @@
    below) — the test compares this set against the Agent API-backed tools and
    fails when they diverge, ensuring no Agent API tool ships without a basic
    invocation check."
-  #{"get_table" "get_table_field_values" "get_metric" "get_metric_field_values"
-    "search" "construct_query" "query" "execute_query"
+  #{"get_database" "get_table" "get_table_field_values" "get_metric" "get_metric_field_values"
+    "list_databases" "search" "construct_query" "query" "execute_query"
     "create_question" "create_dashboard"})
 
 (deftest tools-call-smoke-test
@@ -531,6 +533,8 @@
               dash-id        (atom nil)]
           (try
             (let [;; Read tools — call-tool helper asserts (not :isError) internally.
+                  _              (call-tool session-id "list_databases" {})
+                  _              (call-tool session-id "get_database" {:id (mt/id)})
                   table-data     (call-tool session-id "get_table" {:id orders-id})
                   table-fid      (-> table-data :fields first :field_id)
                   _              (call-tool session-id "get_table_field_values"


### PR DESCRIPTION
### Summary
Adds MCP tools `list_databases` and `get_database`; extends `search` with `entity_types: ["database"]`. Gives agents a way to discover data sources at the root of the hierarchy.

### Security
Response uses an explicit field allowlist (`id`, `name`, `engine`, `description`, `is_sample`, `is_attached_dwh`, timestamps) enforced by a `:closed` Malli schema **and** `select-keys` projection — defense in depth. 
Permission filtering reuses `mi/visible-filter-clause :model/Database` (same path as `/api/database`); `api/read-check` denies inaccessible DBs with 403.
The `list_databases` respects permissions and outputs only DBs that user has access to.

### Side fix
`tools_manifest` now emits empty `inputSchema` for inputless tools per MCP spec.

###
Preview

<img width="1812" height="546" alt="image" src="https://github.com/user-attachments/assets/6a81812c-399d-4730-87ae-6a1efc33dfae" />

Case when we restrict access to a DB via sandboxing
<img width="2050" height="872" alt="image" src="https://github.com/user-attachments/assets/65f492b9-3e2f-4fec-b8ac-2846b71d925d" />


### 
How to test:
- run this branch locally, start dev server
- in Claude Desktop => Settings => Developer => Edit config
- add 
```
  "mcpServers": {
    "metabase": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote",
        "http://localhost:3000/api/mcp",
        "--allow-http"
      ]
    }
  }
```
- add a new DB
- after that the new connector should be added.
- ask something like "show available databases in metabase", you'll see a list of DBs
- you'll see 2 DBs - sample DB + the newly added DB

#### Now let's test permissions
- create a new group 'limited access'
- create a new user, put it under this new group
- for new DB setup permissions to be not accessible for the `limited access` group
- login as the new user
- run `rm -rf ~/.mcp-auth` to clear auth for MCP
- relaunch claude code
- you'll be asked to authoruze it for MCP server
- after it ask again "show available databases in metabase", you'll see a list of DBs containing only the sample DB