### PR TITLE
Fix Sankey click data for extra columns

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -44,7 +44,11 @@ const ChartItemTooltip = ({ chartModel, params }: ChartItemTooltipProps) => {
     const targetNode = chartModel.data.nodes.find(
       (node) => node.rawName === data.target,
     );
-    header = `${formatters.source(node?.displayName ?? data.source)} → ${formatters.target(targetNode?.displayName ?? data.target)}`;
+    const headerSource = formatters.source(node?.displayName ?? data.source);
+    const headerTarget = formatters.target(
+      targetNode?.displayName ?? data.target,
+    );
+    header = `${headerSource} → ${headerTarget}`;
   }
 
   if (!node) {

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -44,7 +44,7 @@ const ChartItemTooltip = ({ chartModel, params }: ChartItemTooltipProps) => {
     const targetNode = chartModel.data.nodes.find(
       (node) => node.rawName === data.target,
     );
-    header = `${formatters.source(node.displayName)} → ${formatters.target(targetNode?.displayName ?? data.target)}`;
+    header = `${formatters.source(node?.displayName ?? data.source)} → ${formatters.target(targetNode?.displayName ?? data.target)}`;
   }
 
   if (!node) {

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
@@ -17,12 +17,7 @@ import type {
 import type { EChartsEventHandler } from "metabase/visualizations/types/echarts";
 import Question from "metabase-lib/v1/Question";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
-import type {
-  Card,
-  DatasetColumn,
-  RawSeries,
-  RowValue,
-} from "metabase-types/api";
+import type { Card, RawSeries, RowValue } from "metabase-types/api";
 
 const getSankeyClickData = (
   [
@@ -31,9 +26,8 @@ const getSankeyClickData = (
     },
   ]: RawSeries,
   columnValues: Record<ColumnKey, RowValue>,
-  predicate: (col: DatasetColumn, index: number) => boolean = () => true,
 ) => {
-  return cols.filter(predicate).map((col) => {
+  return cols.map((col) => {
     return {
       col,
       value: columnValues[getColumnKey(col)],
@@ -69,31 +63,28 @@ export const createSankeyClickData = (
   if (isSankeyNodeEvent(event)) {
     const source = sankeyColumns.source;
     const target = sankeyColumns.target;
+    const columnValues = event.data.hasInputs
+      ? event.data.inputColumnValues
+      : event.data.outputColumnValues;
 
     clickData.column = event.data.hasInputs ? target.column : source.column;
     clickData.value = event.data.rawName;
 
-    clickData.data = getSankeyClickData(
-      rawSeries,
-      event.data.inputColumnValues,
-      (_col, index) => index === source.index || index === target.index,
-    );
+    clickData.data = getSankeyClickData(rawSeries, columnValues);
   } else if (isSankeyEdgeEvent(event)) {
-    if (isNativeQuery(rawSeries[0].card)) {
-      return null;
-    }
-
     clickData.data = getSankeyClickData(rawSeries, event.data.columnValues);
-    clickData.dimensions = [
-      {
-        column: sankeyColumns.source.column,
-        value: event.data.source,
-      },
-      {
-        column: sankeyColumns.target.column,
-        value: event.data.target,
-      },
-    ];
+    if (!isNativeQuery(rawSeries[0].card)) {
+      clickData.dimensions = [
+        {
+          column: sankeyColumns.source.column,
+          value: event.data.source,
+        },
+        {
+          column: sankeyColumns.target.column,
+          value: event.data.target,
+        },
+      ];
+    }
   }
 
   return clickData;

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
@@ -1,6 +1,9 @@
 import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
-import { createMockCard } from "metabase-types/api/mocks/card";
+import {
+  createMockCard,
+  createMockNativeCard,
+} from "metabase-types/api/mocks/card";
 import {
   createMockColumn,
   createMockDatasetData,
@@ -25,13 +28,18 @@ describe("createSankeyClickData", () => {
       display_name: "Amount",
       base_type: "type/Number",
     }),
+    createMockColumn({
+      name: "Raw Vendor",
+      display_name: "Raw Vendor",
+      base_type: "type/Text",
+    }),
   ];
 
   const rawSeries = [
     {
       card: createMockCard(),
       data: createMockDatasetData({
-        rows: [["A", "B", 10]],
+        rows: [["A", "B", 10, "Vendor 1"]],
         cols: columns,
       }),
     },
@@ -50,7 +58,7 @@ describe("createSankeyClickData", () => {
     },
   } as unknown as EChartsSeriesMouseEvent["event"];
 
-  it("should create click data for node events without inputs", () => {
+  it("should create click data for node events without inputs (#72932)", () => {
     const nodeEvent = {
       dataType: "node",
       data: {
@@ -60,12 +68,13 @@ describe("createSankeyClickData", () => {
         hasInputs: false,
         hasOutputs: true,
         origin: "both" as const,
-        inputColumnValues: {
+        inputColumnValues: {},
+        outputColumnValues: {
           [getColumnKey(columns[0])]: "A",
           [getColumnKey(columns[1])]: "B",
           [getColumnKey(columns[2])]: 10,
+          [getColumnKey(columns[3])]: "Vendor 1",
         },
-        outputColumnValues: {},
         outputLinkByTarget: new Map(),
       },
       event: mockEvent,
@@ -88,11 +97,14 @@ describe("createSankeyClickData", () => {
       data: expect.arrayContaining([
         expect.objectContaining({ col: columns[0], value: "A" }),
         expect.objectContaining({ col: columns[1], value: "B" }),
+        expect.objectContaining({ col: columns[2], value: 10 }),
+        expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
       ]),
     });
+    expect(clickData?.data).toHaveLength(columns.length);
   });
 
-  it("should create click data for node events with inputs", () => {
+  it("should create click data for node events with inputs (#72932)", () => {
     const nodeEvent = {
       dataType: "node",
       data: {
@@ -106,6 +118,7 @@ describe("createSankeyClickData", () => {
           [getColumnKey(columns[0])]: "A",
           [getColumnKey(columns[1])]: "B",
           [getColumnKey(columns[2])]: 10,
+          [getColumnKey(columns[3])]: "Vendor 1",
         },
         outputColumnValues: {},
         outputLinkByTarget: new Map(),
@@ -130,8 +143,11 @@ describe("createSankeyClickData", () => {
       data: expect.arrayContaining([
         expect.objectContaining({ col: columns[0], value: "A" }),
         expect.objectContaining({ col: columns[1], value: "B" }),
+        expect.objectContaining({ col: columns[2], value: 10 }),
+        expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
       ]),
     });
+    expect(clickData?.data).toHaveLength(columns.length);
   });
 
   it("should create click data for edge events", () => {
@@ -167,6 +183,7 @@ describe("createSankeyClickData", () => {
           [getColumnKey(columns[0])]: "A",
           [getColumnKey(columns[1])]: "B",
           [getColumnKey(columns[2])]: 10,
+          [getColumnKey(columns[3])]: "Vendor 1",
         },
         sourceNode,
         targetNode,
@@ -194,7 +211,79 @@ describe("createSankeyClickData", () => {
         expect.objectContaining({ col: columns[0], value: "A" }),
         expect.objectContaining({ col: columns[1], value: "B" }),
         expect.objectContaining({ col: columns[2], value: 10 }),
+        expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
       ]),
     });
+    expect(clickData?.data).toHaveLength(columns.length);
+  });
+
+  it("should create click data for native query edge events (#72932)", () => {
+    const sourceNode = {
+      rawName: "A",
+      displayName: "A",
+      level: 0,
+      hasInputs: false,
+      hasOutputs: true,
+      inputColumnValues: {},
+      outputColumnValues: {},
+      outputLinkByTarget: new Map(),
+    };
+
+    const targetNode = {
+      rawName: "B",
+      displayName: "B",
+      level: 1,
+      hasInputs: true,
+      hasOutputs: false,
+      inputColumnValues: {},
+      outputColumnValues: {},
+      outputLinkByTarget: new Map(),
+    };
+
+    const edgeEvent = {
+      dataType: "edge",
+      data: {
+        source: "A",
+        target: "B",
+        value: 10,
+        columnValues: {
+          [getColumnKey(columns[0])]: "A",
+          [getColumnKey(columns[1])]: "B",
+          [getColumnKey(columns[2])]: 10,
+          [getColumnKey(columns[3])]: "Vendor 1",
+        },
+        sourceNode,
+        targetNode,
+      },
+      event: mockEvent,
+      value: 10,
+      seriesType: "sankey",
+    };
+
+    const nativeRawSeries = [
+      {
+        ...rawSeries[0],
+        card: createMockNativeCard(),
+      },
+    ];
+
+    const clickData = createSankeyClickData(
+      edgeEvent,
+      sankeyColumns,
+      nativeRawSeries,
+      settings,
+    );
+
+    expect(clickData).toEqual({
+      event: mockEvent.event,
+      settings,
+      data: expect.arrayContaining([
+        expect.objectContaining({ col: columns[0], value: "A" }),
+        expect.objectContaining({ col: columns[1], value: "B" }),
+        expect.objectContaining({ col: columns[2], value: 10 }),
+        expect.objectContaining({ col: columns[3], value: "Vendor 1" }),
+      ]),
+    });
+    expect(clickData?.data).toHaveLength(columns.length);
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72932
Closes https://linear.app/metabase/issue/UXW-3909/sankey-click-filter-cannot-be-mapped-to-columns-other-than

### Description

Sankey clicks now expose all available row columns to dashboard click behavior instead of only source/target columns. Native-query edge clicks also return click data for parameter mapping while still avoiding native drill-through dimensions.

### How to verify

1. Create a SQL Sankey question with `source`, `target`, `value`, and an extra column such as `raw_vendor`. You can use this sql:
```
SELECT
  p.CATEGORY AS source,
  o.QUANTITY   AS target,
  COUNT(*)   AS flow_value,
  p.VENDOR   AS raw_vendor
FROM PRODUCTS p
INNER JOIN ORDERS o
WHERE 1 = 1
  [[ AND p.VENDOR = {{vendor_filter}} ]]
GROUP BY p.CATEGORY, o.QUANTITY, p.VENDOR
ORDER BY flow_value DESC
```
3. Put it on a dashboard and map a filter click behavior to the extra column.
4. Click a Sankey node or edge and confirm the dashboard filter updates from the extra column.

### Demo
https://www.loom.com/share/b246d034f84e4315a5ac20ff04f5b25e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)