### PR TITLE
Try excluding gson dep from other drivers

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -6,7 +6,8 @@
   com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"
                                        ;; lang3 is a dep in top-level deps.edn, so not actually used anyway; exclusion
                                        ;; here fixes security warnings about version used in JDBC driver
-                                       :exclusions  [org.apache.commons/commons-lang3]}
+                                       :exclusions  [org.apache.commons/commons-lang3
+                                                     com.google.code.gson/gson]}
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -14,7 +14,8 @@
                                                    ;; Azure-backed Snowflake stages, which Metabase never does
                                                    ;; (read-only SQL driver). Excluding the Netty transport removes
                                                    ;; the entire reactor-netty + transitive Netty 4.1.x chain.
-                                                   com.azure/azure-core-http-netty]}
+                                                   com.azure/azure-core-http-netty
+                                                   com.google.code.gson/gson]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73736

### Description

Try excluding the gson dep from other drivers. Databricks uses 2.8.9 which doesn't have the method that's throwing the exception. But it should've been getting overridden by the pinned versions. So this is a speculative fix. 

### How to verify

<details>

<summary>before</summary>

```
$ clojure -Stree | grep gson
com.google.code.gson/gson 2.12.1

$ cd modules/drivers/databricks/

$ clojure -Stree | grep gson
    . com.google.http-client/google-http-client-gson 1.43.3
  . com.google.http-client/google-http-client-gson 1.43.3
    . com.google.code.gson/gson 2.10.1 :newer-version
    X com.google.code.gson/gson 2.8.9 :older-version
  X com.google.code.gson/gson 2.8.9 :superseded

$ cd ../snowflake/

$ clojure -Stree | grep gson
    . com.google.http-client/google-http-client-gson 1.45.0
      . com.google.code.gson/gson 2.11.0
      X com.google.code.gson/gson 2.8.9 :older-version
    . com.google.http-client/google-http-client-gson 1.45.0
    . com.google.http-client/google-http-client-gson 1.45.0
    . com.google.code.gson/gson 2.11.0
    . com.google.code.gson/gson 2.11.0
```

</details>

<details>

<summary>after</summary>

```
$ clojure -Stree | grep gson
com.google.code.gson/gson 2.12.1

$ cd modules/drivers/databricks/

$ clojure -Stree | grep gson
    . com.google.http-client/google-http-client-gson 1.43.3
  . com.google.http-client/google-http-client-gson 1.43.3
    X com.google.code.gson/gson 2.10.1 :excluded
    X com.google.code.gson/gson 2.8.9 :excluded

$ cd ../snowflake/

$ clojure -Stree | grep gson
    . com.google.http-client/google-http-client-gson 1.45.0
      X com.google.code.gson/gson 2.11.0 :excluded
      X com.google.code.gson/gson 2.8.9 :excluded
    . com.google.http-client/google-http-client-gson 1.45.0
    . com.google.http-client/google-http-client-gson 1.45.0
    X com.google.code.gson/gson 2.11.0 :excluded
    . com.google.code.gson/gson 2.11.0
```

</details>

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
