### PR TITLE
Glob for driver plugin manifest file

### DIFF
--- a/bin/build/src/build_drivers/verify.clj
+++ b/bin/build/src/build_drivers/verify.clj
@@ -41,15 +41,25 @@
           (throw (ex-info (format "Driver verification failed: driver contains compiled Clojure core file %s" file)
                           {:file file})))))))
 
+(defn- find-plugin-manifest-entry
+  "Find a `metabase-plugin.yaml` entry in a JAR, checking both the root and `metabase/<driver>/` paths."
+  [^String jar-path]
+  (with-open [zip-file (ZipFile. jar-path)]
+    (first
+     (filter
+      (fn [^ZipEntry zip-entry]
+        (re-matches #"(metabase/[^/]+/)?metabase-plugin\.yaml" (str zip-entry)))
+      (enumeration-seq (.entries zip-file))))))
+
 (defn- verify-has-plugin-manifest [driver]
   (let [jar-filename (c/driver-jar-destination-path driver)]
     (u/step (format "Check %s contains metabase-plugin.yaml" jar-filename)
-      (if-let [manifest-entry (get-jar-entry jar-filename "metabase-plugin.yaml")]
+      (if-let [manifest-entry (find-plugin-manifest-entry jar-filename)]
         (with-open [zip-file (ZipFile. jar-filename)]
           (let [entry-is (.getInputStream zip-file manifest-entry)
                 yaml-str (slurp entry-is)
                 yml      (yaml/parse-string yaml-str)]
-            (u/announce "Plugin manifest found; validating it")
+            (u/announce "Plugin manifest found at %s; validating it" (str manifest-entry))
             (if-not (s/valid? ::lint-manifest-file/plugin-manifest yml)
               (do
                 ;; print a readable explanation of the spec error

--- a/bin/build/src/build_drivers/verify.clj
+++ b/bin/build/src/build_drivers/verify.clj
@@ -50,7 +50,8 @@
                        (re-matches #"(metabase/[^/]+/)?metabase-plugin\.yaml" (str zip-entry)))
                      (enumeration-seq (.entries zip-file)))]
       (when (> (count manifests) 1)
-        (throw (ex-info "Driver verification failed: multiple metabase-plugin.yaml files found in JAR")))
+        (throw (ex-info "Driver verification failed: multiple metabase-plugin.yaml files found in JAR"
+                        {:entries (map str manifests)})))
       (first manifests))))
 
 (defn- verify-has-plugin-manifest [driver]

--- a/bin/build/src/build_drivers/verify.clj
+++ b/bin/build/src/build_drivers/verify.clj
@@ -45,11 +45,13 @@
   "Find a `metabase-plugin.yaml` entry in a JAR, checking both the root and `metabase/<driver>/` paths."
   [^String jar-path]
   (with-open [zip-file (ZipFile. jar-path)]
-    (first
-     (filter
-      (fn [^ZipEntry zip-entry]
-        (re-matches #"(metabase/[^/]+/)?metabase-plugin\.yaml" (str zip-entry)))
-      (enumeration-seq (.entries zip-file))))))
+    (let [manifests (filter
+                     (fn [^ZipEntry zip-entry]
+                       (re-matches #"(metabase/[^/]+/)?metabase-plugin\.yaml" (str zip-entry)))
+                     (enumeration-seq (.entries zip-file)))]
+      (when (> (count manifests) 1)
+        (throw (ex-info "Driver verification failed: multiple metabase-plugin.yaml files found in JAR")))
+      (first manifests))))
 
 (defn- verify-has-plugin-manifest [driver]
   (let [jar-filename (c/driver-jar-destination-path driver)]

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -13,7 +13,7 @@
    [metabase.util.yaml :as yaml])
   (:import
    (java.io File)
-   (java.nio.file Files FileVisitOption Path Paths)))
+   (java.nio.file Files FileSystems FileVisitOption Path Paths)))
 
 (set! *warn-on-reflection* true)
 
@@ -71,8 +71,23 @@
 (defn- add-to-classpath! [^Path jar-path]
   (classloader/add-url-to-classpath! (-> jar-path .toUri .toURL)))
 
+(defn- slurp-plugin-manifest-from-archive
+  "Find and read `metabase-plugin.yaml` from a JAR archive. Searches both the JAR root and
+  `metabase/<driver>/metabase-plugin.yaml` to support both legacy and new driver resource layouts."
+  ^String [^Path jar-path]
+  (with-open [fs (FileSystems/newFileSystem jar-path (ClassLoader/getSystemClassLoader))]
+    (let [matcher (.getPathMatcher fs "glob:**/metabase-plugin.yaml")
+          root    (.getPath fs "/" (make-array String 0))]
+      (with-open [stream (Files/walk root 3 (make-array FileVisitOption 0))]
+        (when-let [^Path match (-> stream
+                                   (.filter (reify java.util.function.Predicate
+                                              (test [_ p] (.matches matcher ^Path p))))
+                                   (.findFirst)
+                                   (.orElse nil))]
+          (String. (Files/readAllBytes match)))))))
+
 (defn- plugin-info [^Path jar-path]
-  (some-> (u.files/slurp-file-from-archive jar-path "metabase-plugin.yaml")
+  (some-> (slurp-plugin-manifest-from-archive jar-path)
           yaml/parse-string))
 
 (defn- init-plugin-with-info!
@@ -140,7 +155,7 @@
     (load-plugin-manifest! manifest-path)))
 
 (defn- has-manifest? ^Boolean [^Path path]
-  (boolean (u.files/file-exists-in-archive? path "metabase-plugin.yaml")))
+  (boolean (slurp-plugin-manifest-from-archive path)))
 
 (defn- init-plugins! [paths]
   ;; sort paths so that ones that correspond to JARs with no plugin manifest (e.g. a dependency like the Oracle JDBC

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -82,17 +82,18 @@
         (let [all-manifests (-> stream
                                 (.filter (reify java.util.function.Predicate
                                            (test [_ p] (.matches all-matcher ^Path p))))
-                                (.collect (java.util.stream.Collectors/toList)))]
+                                (.collect (java.util.stream.Collectors/toList)))
+              nested-matcher (.getPathMatcher fs "glob:/metabase/*/metabase-plugin.yaml")
+              ^Path manifest (or (first (filter #(.matches nested-matcher ^Path %) all-manifests))
+                                 (first all-manifests))]
           (when (> (count all-manifests) 1)
-            (log/warnf "Found %d metabase-plugin.yaml files in %s: %s"
+            (log/warnf "Found %d metabase-plugin.yaml files in %s: %s — using %s"
                        (count all-manifests)
                        (.getFileName jar-path)
-                       (str/join ", " (map str all-manifests))))
-          (let [nested-matcher (.getPathMatcher fs "glob:/metabase/*/metabase-plugin.yaml")
-                ^Path manifest (or (first (filter #(.matches nested-matcher ^Path %) all-manifests))
-                                   (first all-manifests))]
-            (when manifest
-              (String. (Files/readAllBytes manifest)))))))))
+                       (str/join ", " (map str all-manifests))
+                       (str manifest)))
+          (when manifest
+            (String. (Files/readAllBytes manifest))))))))
 
 (defn- plugin-info [^Path jar-path]
   (some-> (slurp-plugin-manifest-from-archive jar-path)

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -72,19 +72,27 @@
   (classloader/add-url-to-classpath! (-> jar-path .toUri .toURL)))
 
 (defn- slurp-plugin-manifest-from-archive
-  "Find and read `metabase-plugin.yaml` from a JAR archive. Searches both the JAR root and
-  `metabase/<driver>/metabase-plugin.yaml` to support both legacy and new driver resource layouts."
+  "Find and read `metabase-plugin.yaml` from a JAR archive. Prefers `metabase/<driver>/metabase-plugin.yaml`
+  over a legacy root-level manifest. Logs a warning if multiple manifests are found."
   ^String [^Path jar-path]
   (with-open [fs (FileSystems/newFileSystem jar-path (ClassLoader/getSystemClassLoader))]
-    (let [matcher (.getPathMatcher fs "glob:**/metabase-plugin.yaml")
-          root    (.getPath fs "/" (make-array String 0))]
+    (let [all-matcher (.getPathMatcher fs "glob:**/metabase-plugin.yaml")
+          root        (.getPath fs "/" (make-array String 0))]
       (with-open [stream (Files/walk root 3 (make-array FileVisitOption 0))]
-        (when-let [^Path match (-> stream
-                                   (.filter (reify java.util.function.Predicate
-                                              (test [_ p] (.matches matcher ^Path p))))
-                                   (.findFirst)
-                                   (.orElse nil))]
-          (String. (Files/readAllBytes match)))))))
+        (let [all-manifests (-> stream
+                                (.filter (reify java.util.function.Predicate
+                                           (test [_ p] (.matches all-matcher ^Path p))))
+                                (.collect (java.util.stream.Collectors/toList)))]
+          (when (> (count all-manifests) 1)
+            (log/warnf "Found %d metabase-plugin.yaml files in %s: %s"
+                       (count all-manifests)
+                       (.getFileName jar-path)
+                       (str/join ", " (map str all-manifests))))
+          (let [nested-matcher (.getPathMatcher fs "glob:/metabase/*/metabase-plugin.yaml")
+                ^Path manifest (or (first (filter #(.matches nested-matcher ^Path %) all-manifests))
+                                   (first all-manifests))]
+            (when manifest
+              (String. (Files/readAllBytes manifest)))))))))
 
 (defn- plugin-info [^Path jar-path]
   (some-> (slurp-plugin-manifest-from-archive jar-path)


### PR DESCRIPTION
### Description

After the changes to put drivers on the class path, we moved the location of the plugin manifest. But some of the code to build drivers didn't take this into account and assumed it was still at the root. This change is to glob for the file so that we look both at the root and in the new location. 

### How to verify

1. Attempt to build an driver with `./bin/build-driver.sh {driver}`
2. See that it fails without these changes but succeeds with them. 

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
