### PR TITLE
Fix page crash when setting up sandboxing with a SQL question via the UI

### DIFF
--- a/frontend/src/metabase-types/api/group.ts
+++ b/frontend/src/metabase-types/api/group.ts
@@ -23,7 +23,7 @@ export type Member = {
 export type GroupInfo = {
   id: GroupId;
   name: string;
-  member_count: number;
+  member_count?: number;
   magic_group_type:
     | "all-internal-users"
     | "admin"

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -365,7 +365,7 @@ export const getDatabasesPermissionEditor = createSelector(
       title,
       breadcrumbs,
       description:
-        group != null
+        typeof group?.member_count === "number"
           ? ngettext(
               msgid`${group.member_count} person`,
               `${group.member_count} people`,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.unit.spec.tsx
@@ -1,10 +1,28 @@
+import { QueryStatus } from "@reduxjs/toolkit/query";
+
+import { createMockEntitiesState } from "__support__/store";
 import {
+  createMockAdminState,
+  createMockApiState,
+  createMockPermissionsState,
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import type { GroupsPermissions } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockGroup,
+  createMockSchema,
+  createMockTable,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
-import { getShouldShowTransformPermissions } from "./permission-editor";
+import { DataPermission, DataPermissionValue } from "../../types";
+
+import {
+  getDatabasesPermissionEditor,
+  getShouldShowTransformPermissions,
+} from "./permission-editor";
 
 describe("getShouldShowTransformPermissions", () => {
   describe("OSS version", () => {
@@ -92,5 +110,76 @@ describe("getShouldShowTransformPermissions", () => {
 
       expect(getShouldShowTransformPermissions(state)).toBe(false);
     });
+  });
+});
+
+describe("getDatabasesPermissionEditor", () => {
+  it("does not crash when the selected group has no member count (#74290)", () => {
+    const groupWithoutMemberCount = createMockGroup({
+      id: 1,
+      name: "All Users",
+      magic_group_type: "all-internal-users",
+    });
+    Reflect.deleteProperty(groupWithoutMemberCount, "member_count");
+
+    const permissions: GroupsPermissions = {
+      1: {
+        3: {
+          [DataPermission.CREATE_QUERIES]:
+            DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+          [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+        },
+      },
+    };
+
+    const state = createMockState({
+      admin: createMockAdminState({
+        permissions: createMockPermissionsState({
+          dataPermissions: permissions,
+          originalDataPermissions: permissions,
+        }),
+      }),
+      entities: createMockEntitiesState({
+        databases: [
+          createMockDatabase({
+            id: 3,
+            name: "Test Database",
+            tables: [
+              createMockTable({
+                id: 10,
+                db_id: 3,
+                display_name: "People",
+                schema: "public",
+              }),
+            ],
+          }),
+        ],
+        schemas: [createMockSchema({ id: "3:public", name: "public" })],
+      }),
+      "metabase-api": {
+        ...createMockApiState(),
+        queries: {
+          "listPermissionsGroups({})": {
+            status: QueryStatus.fulfilled,
+            data: [groupWithoutMemberCount],
+            error: undefined,
+            originalArgs: {},
+            requestId: "test-request-groups",
+            endpointName: "listPermissionsGroups",
+            startedTimeStamp: Date.now(),
+            fulfilledTimeStamp: Date.now(),
+          },
+        },
+      },
+    });
+
+    const editor = getDatabasesPermissionEditor(state, {
+      params: {
+        groupId: "1",
+        databaseId: "3",
+      },
+    });
+
+    expect(editor?.description).toBeNull();
   });
 });

--- a/frontend/src/metabase/admin/types.ts
+++ b/frontend/src/metabase/admin/types.ts
@@ -1,5 +1,5 @@
 export type MappingsType = Record<string, number[]>;
 export type GroupIds = number[];
 export type DeleteMappingModalValueType = "nothing" | "clear" | "delete";
-export type UserGroupType = { id: number; name: string; member_count: number };
+export type UserGroupType = { id: number; name: string; member_count?: number };
 export type UserGroupsType = UserGroupType[];


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74290
Closes https://linear.app/metabase/issue/UXW-4103/cannot-setup-sandboxing-with-a-sql-question-via-the-ui

### Description

When trying to setup a sandboxing rule with the UI and a SQL query, the UI crashes with an exception.

### How to verify

Please follow the [repro intructions](https://linear.app/metabase/issue/UXW-4103/cannot-setup-sandboxing-with-a-sql-question-via-the-ui#to-reproduce-2e577ba0) in the task description.

### Demo

No crash when configuring row and column security for table:
https://github.com/user-attachments/assets/93eec6fd-01b2-4ae5-bce1-282b07790735

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
