### PR TITLE
Fix impersonated model caching 

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -767,6 +767,34 @@
                                        "DROP ROLE IF EXISTS \"impersonation_role\";"]]
                       (jdbc/execute! spec [statement]))))))))))))
 
+(deftest native-model-persistence-works-when-impersonation-enabled-test
+  ;; Test explicitly with postgres since it supports persistence, impersonation, and impersonated native-query
+  ;; validation.
+  (mt/test-driver :postgres
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/dataset test-data
+        (mt/with-persistence-enabled! [persist-models!]
+          (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                         :attributes     {"impersonation_attr" "impersonation_role"}}
+            (request/as-admin
+              (mt/with-temp [:model/Card model {:type            :model
+                                                :database_id     (mt/id)
+                                                :query_type      :native
+                                                :dataset_query   (mt/native-query {:query "SELECT 1 AS id"})
+                                                :result_metadata [{:name      "id"
+                                                                   :base_type :type/Integer}]}]
+                (try
+                  (persist-models!)
+                  (catch Exception e
+                    (tap> e)
+                    (throw e)))
+                (is (=? {:state  "persisted"
+                         :active true
+                         :error  nil}
+                        (t2/select-one [:model/PersistedInfo :state :active :error]
+                                       :database_id (mt/id)
+                                       :card_id (:id model))))))))))))
+
 (deftest resilient-connection-options-test
   (testing "resilient connections have the correct role set"
     (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -783,11 +783,7 @@
                                                 :dataset_query   (mt/native-query {:query "SELECT 1 AS id"})
                                                 :result_metadata [{:name      "id"
                                                                    :base_type :type/Integer}]}]
-                (try
-                  (persist-models!)
-                  (catch Exception e
-                    (tap> e)
-                    (throw e)))
+                (persist-models!)
                 (is (=? {:state  "persisted"
                          :active true
                          :error  nil}

--- a/src/metabase/driver/connection.clj
+++ b/src/metabase/driver/connection.clj
@@ -69,7 +69,7 @@
    - `:default` — primary `:details`
    - `:write-data` — `:write-data-details` merged over `:details` (if configured)
 
-   Bind via [[with-write-connection]], not directly."
+   Bind via [[with-write-connection]] or [[with-default-connection]], not directly."
   :default)
 
 (defmacro with-write-connection
@@ -79,6 +79,14 @@
    into account (if configured) instead of only primary `:details`."
   [& body]
   `(binding [*connection-type* :write-data]
+     ~@body))
+
+(defmacro with-default-connection
+  "Establishes a default-connection context for body.
+
+   Use this to compile or execute a read query from inside a broader write-connection context."
+  [& body]
+  `(binding [*connection-type* :default]
      ~@body))
 
 (def ^:dynamic ^:private *suppress-resolution-telemetry*

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -6,6 +6,7 @@
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase.driver-api.core :as driver-api]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -67,7 +68,8 @@
 
 (defmethod ddl.i/refresh! :mysql
   [driver database definition dataset-query]
-  (let [{:keys [query params]} (driver-api/compile dataset-query)
+  (let [{:keys [query params]} (driver.conn/with-default-connection
+                                 (driver-api/compile dataset-query))
         db-spec (sql-jdbc.conn/db->pooled-connection-spec database)]
     (sql-jdbc.execute/do-with-connection-with-options
      driver

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -4,6 +4,7 @@
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase.driver-api.core :as driver-api]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.ddl :as sql.ddl]
@@ -36,7 +37,8 @@
 
 (defmethod ddl.i/refresh! :postgres
   [driver database definition dataset-query]
-  (let [{:keys [query params]} (driver-api/compile dataset-query)]
+  (let [{:keys [query params]} (driver.conn/with-default-connection
+                                 (driver-api/compile dataset-query))]
     (sql-jdbc.execute/do-with-connection-with-options
      driver
      database


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74289

### Description

Fixes impersonated model caching by wrapping the model query compilation in a non-write context so that we use the correct impersonation validation. 

When we refresh a cached model, it gets wrapped in a `write-data` connection-type context. We use this to determine if we should check for a single select statement, or a single write query. This meant when we tried to compile the actual model query, the impersonation validation was expecting a write command but got a select statement. The fix here is to wrap the model compilation in a non `write-data` connection-type context so that the impersonation validation checks for a single select statement instead of a single write statement. 

### How to verify

See steps in original issue and the unit test. It should work as expected now. 

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
