### PR TITLE
fix fe-builder in docker-compose

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -67,16 +67,21 @@ services:
   # Builds the frontend with hot reload. Mounts local dev so nothing else
   # needed.
   fe-builder:
-    # Reuses the repo's devcontainer image (JDK 21 + Node 22 + Bun + Clojure
+    # Reuses the repo's devcontainer image (JDK + Node + Bun + Clojure
     # CLI) so the FE/CLJS toolchain is maintained in exactly one place.
     build:
       context: ../.devcontainer
       dockerfile: Dockerfile
     container_name: fe-builder
     working_dir: /dev/metabase
+    # In hot mode rspack inlines an absolute publicPath of
+    # http://localhost:8080/ into index.html (see rspack.main.config.js), so
+    # the browser loads the bundle from the host's :8080 — it must be
+    # published, not just exposed on the docker network.
+    ports:
+      - "8080:8080"
     volumes:
       - ../:/dev/metabase
-      - ~/.npm:/root/.npm
       - ~/.bun/install/cache:/root/.bun/install/cache
     command:
       - /bin/sh

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -21,14 +21,9 @@ version: '3.1'
 # ;; connect (e.g. metabasedb_postgres_14_data:5432 vs. localhost:15432).
 # COMPOSE_PROFILES=postgresappdb,postgres14data,mysql57data,dev-app docker-compose --file dev/docker-compose.yml up
 # ;; All of the above, and builds the frontend, too. No need for `bun run build-hot` locally.
-# ;; NOTE: See comment below on fe-builder service. This isn't quite ready yet.
 # COMPOSE_PROFILES=postgresappdb,postgres14data,mysql57data,fe-builder,dev-app docker-compose --file dev/docker-compose.yml up
 #
 # TODOs:
-# - Get the fe-builder service working correctly. If anyone wants to see what it
-#   does, uncomment it and try
-#   COMPOSE_PROFILES=fe-builder docker-compose --file dev/docker-compose.yml up
-#   It will hang on step 4/5.
 # - Consider using swarm to declaratively scale up/down.
 services:
 
@@ -69,12 +64,14 @@ services:
     networks:
       - metabasenet
 
-# NOTE: This service isn't ready for prime time. It takes a LONG time to start
-#       up. I think there's some mounts to caches that are needed or something.
-#       Hopefully one of our node geniuses can figure it out.
-  # Just build the frontend. Mounts local dev so nothing else needed
+  # Builds the frontend with hot reload. Mounts local dev so nothing else
+  # needed.
   fe-builder:
-    image: node:22-bullseye
+    # Reuses the repo's devcontainer image (JDK 21 + Node 22 + Bun + Clojure
+    # CLI) so the FE/CLJS toolchain is maintained in exactly one place.
+    build:
+      context: ../.devcontainer
+      dockerfile: Dockerfile
     container_name: fe-builder
     working_dir: /dev/metabase
     volumes:
@@ -85,7 +82,6 @@ services:
       - /bin/sh
       - -c
       - |
-        npm install -g bun
         bun install
         bun run build-hot
     profiles:


### PR DESCRIPTION


### Description

The fe-builder in the docker-compose.yml never worked because it didn't include Java and the Clojure CLI so `shadow-cljs` failed. It also needed the port 8080 published. This PR uses the repo's devcontainer image which contains all required tools. And publishes 8080 on the fe-builder container.

### How to verify

COMPOSE_PROFILES=postgresappdb,dev-app,fe-builder docker compose -f dev/docker-compose.yml up

Verify front end becomes ready and the app is useable.
