### PR TITLE
Reserve reduced Y-axis tick count for minimum-height dashboard chart

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -63,6 +63,17 @@ import type { ShowWarning } from "../../types";
 import { getAxisTransforms } from "./transforms";
 import { getFormattingOptionsWithoutScaling } from "./util";
 
+// Default y-axis tick count when no user override is set. Matches echarts'
+// own default and keeps single- vs. multi-series charts consistent.
+const DEFAULT_Y_AXIS_TICK_COUNT = 5;
+
+// Reduced y-axis tick count used only when a dashboard chart is at the
+// minimum allowed grid height (see `card-size-defaults` in
+// `src/metabase/dashboards/constants.cljc`). At that size there is not
+// enough vertical room for the default tick count.
+const SMALL_CHART_Y_AXIS_TICK_COUNT = 2;
+const SMALL_CHART_GRID_HEIGHT_THRESHOLD = 3;
+
 const uniqueCards = (seriesModels: SeriesModel[]) =>
   _.uniq(seriesModels.map(({ cardId }) => cardId)).length;
 
@@ -561,9 +572,10 @@ export function getYAxisModel(
     splitNumber:
       settings["graph.y_axis.split_number"] > 0
         ? settings["graph.y_axis.split_number"]
-        : gridSize?.height && gridSize.height <= 5
-          ? 2 // Use fewer ticks for small dashboard charts
-          : 5, // Default to 5 ticks for consistent behavior between single and multiple series
+        : gridSize?.height &&
+            gridSize.height <= SMALL_CHART_GRID_HEIGHT_THRESHOLD
+          ? SMALL_CHART_Y_AXIS_TICK_COUNT
+          : DEFAULT_Y_AXIS_TICK_COUNT,
   };
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
@@ -1,8 +1,16 @@
 import dayjs from "dayjs";
 
 import type { RowValue } from "metabase-types/api";
+import {
+  createMockColumn,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
 
-import { computeSplit, getXAxisDateRangeFromSortedXAxisValues } from "./axis";
+import {
+  computeSplit,
+  getXAxisDateRangeFromSortedXAxisValues,
+  getYAxisModel,
+} from "./axis";
 import type { SeriesExtents } from "./types";
 
 describe("computeSplit", () => {
@@ -25,6 +33,61 @@ describe("computeSplit", () => {
     expect(computeSplit(extents).flat()).toHaveLength(
       Object.keys(extents).length,
     );
+  });
+});
+
+describe("getYAxisModel splitNumber (issue #69903)", () => {
+  const seriesKey = "count";
+  const column = createMockColumn({ name: seriesKey });
+  const settings = createMockVisualizationSettings();
+  const columnByDataKey = { [seriesKey]: column };
+
+  const getSplitNumber = (gridHeight: number | undefined) =>
+    getYAxisModel([seriesKey], [seriesKey], [], settings, columnByDataKey, {
+      gridSize:
+        gridHeight === undefined
+          ? undefined
+          : { width: 12, height: gridHeight },
+    })?.splitNumber;
+
+  it("uses the default tick count for medium-height dashboard charts (height 5)", () => {
+    // Regression: previously a height of 5 fell into the "small chart" branch
+    // and was forced to 2 ticks, producing excessive whitespace.
+    expect(getSplitNumber(5)).toBe(5);
+  });
+
+  it("uses the default tick count for height 4", () => {
+    expect(getSplitNumber(4)).toBe(5);
+  });
+
+  it("uses the default tick count for height 6 and above", () => {
+    expect(getSplitNumber(6)).toBe(5);
+    expect(getSplitNumber(10)).toBe(5);
+  });
+
+  it("uses fewer ticks for genuinely small charts (height <= 3)", () => {
+    expect(getSplitNumber(3)).toBe(2);
+    expect(getSplitNumber(2)).toBe(2);
+    expect(getSplitNumber(1)).toBe(2);
+  });
+
+  it("honors the user-configured split number when set", () => {
+    const customSettings = createMockVisualizationSettings({
+      "graph.y_axis.split_number": 7,
+    });
+    const result = getYAxisModel(
+      [seriesKey],
+      [seriesKey],
+      [],
+      customSettings,
+      columnByDataKey,
+      { gridSize: { width: 12, height: 5 } },
+    );
+    expect(result?.splitNumber).toBe(7);
+  });
+
+  it("uses the default tick count when no gridSize is provided", () => {
+    expect(getSplitNumber(undefined)).toBe(5);
   });
 });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69903
### Description

Fixes [UXW-3133](https://linear.app/metabase/issue/UXW-3133/y-axis-values-are-too-limiting-at-dashboard-level-especially-when-full).

A recent change forced cartesian charts on dashboards to render only 2 Y-axis ticks whenever their grid height was 5 rows or fewer, leaving a large empty band at the top of the plot area. Since the default chart height is 6 and the minimum is 3, almost every non-default-height card was hitting the reduced-tick path.

**Fix:** restrict the reduced tick count to charts actually at the minimum dashboard grid height. Charts at heights 4 and 5 fall back to the default tick count, recovering the pre-regression behavior.

### How to verify

- [ ] Add an Orders → Count by Created At: Month question to a dashboard, resize the card to height 5, and confirm the Y-axis shows roughly five evenly spaced labels instead of two.

### Demo

#### Before
<img width="2224" height="1108" alt="image" src="https://github.com/user-attachments/assets/7dd6fe62-6750-4b9c-9e99-444565b8a69c" />


#### After

<img width="2184" height="1096" alt="image" src="https://github.com/user-attachments/assets/a074655c-8939-4579-a2c4-6558baf19abd" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)