### PR TITLE
Skip milestone check for patch releases

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -184,9 +184,13 @@ jobs:
   manage-milestones:
     # Close the milestone we're about to ship and open the next one BEFORE building,
     # so any PRs that merge while the build is in flight are tagged with the next
-    # milestone (not the one about to be released). Gated on the preflight checks
-    # so a bad version/commit input doesn't rotate the milestone spuriously.
-    needs: [check-version, check-commit]
+    # milestone (not the one about to be released).
+    #
+    # Sequenced after trigger-milestone-check so that the check sees the milestone
+    # in its open state. milestone-check is informational and must never block, so
+    # we run regardless of its outcome; only preflight failures suppress this.
+    needs: [check-version, check-commit, trigger-milestone-check]
+    if: ${{ !cancelled() && needs.check-version.result == 'success' && needs.check-commit.result == 'success' }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -60,6 +60,11 @@ jobs:
               commitHash,
             });
 
+            if (issueCount === undefined) {
+              // checkMilestoneForRelease returns undefined for patches, which have nothing to check.
+              return;
+            }
+
             await sendMilestoneCheckMessage({
               channelName: process.env.SLACK_RELEASE_CHANNEL,
               issueCount,

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -145,6 +145,19 @@ jobs:
           || (echo "Commit not found in correct release branch" && exit 1)
         git checkout -
 
+  trigger-milestone-check:
+    # Posts a Slack FYI about issues that still need review for this release.
+    # Informational only — nothing depends on it, so it never blocks the release.
+    needs: [check-version, check-commit]
+    permissions:
+      contents: read
+      issues: read
+    uses: ./.github/workflows/release-milestone-check.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      commit: ${{ inputs.commit }}
+
   manage-milestones:
     # Close the milestone we're about to ship and open the next one BEFORE tagging,
     # so any PRs that merge while the release is in flight are tagged with the next
@@ -161,19 +174,6 @@ jobs:
     uses: ./.github/workflows/release-milestone-manage.yml
     with:
       version: ${{ inputs.version }}
-
-  trigger-milestone-check:
-    # Posts a Slack FYI about issues that still need review for this release.
-    # Informational only — nothing depends on it, so it never blocks the release.
-    needs: [check-version, check-commit]
-    permissions:
-      contents: read
-      issues: read
-    uses: ./.github/workflows/release-milestone-check.yml
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
-      commit: ${{ inputs.commit }}
 
   tag-uberjar-for-release:
     needs: [check-version, check-commit]

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -148,9 +148,13 @@ jobs:
   manage-milestones:
     # Close the milestone we're about to ship and open the next one BEFORE tagging,
     # so any PRs that merge while the release is in flight are tagged with the next
-    # milestone (not the one about to be released). Gated on the preflight checks
-    # so a bad version/commit input doesn't rotate the milestone spuriously.
-    needs: [check-version, check-commit]
+    # milestone (not the one about to be released).
+    #
+    # Sequenced after trigger-milestone-check so that the check sees the milestone
+    # in its open state. milestone-check is informational and must never block, so
+    # we run regardless of its outcome; only preflight failures suppress this.
+    needs: [check-version, check-commit, trigger-milestone-check]
+    if: ${{ !cancelled() && needs.check-version.result == 'success' && needs.check-commit.result == 'success' }}
     permissions:
       contents: read
       issues: write

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -20,6 +20,7 @@ import {
   getMajorVersion,
   getVersionFromReleaseBranch,
   ignorePatches,
+  isPatchVersion,
   versionSort,
 } from "./version-helpers";
 
@@ -300,6 +301,13 @@ export async function checkMilestoneForRelease({
   version,
   commitHash,
 }: GithubProps & { version: string, commitHash: string }) {
+  // Patches don't have their own milestones — they share the parent minor's.
+  // There's nothing to check pre-release; skip cleanly.
+  if (isPatchVersion(version)) {
+    console.log(`Skipping milestone check for patch version ${version}`);
+    return;
+  }
+
   const releaseMilestone = await findMilestone({ github, owner, repo, version });
 
   if (!releaseMilestone) {


### PR DESCRIPTION
`checkMilestoneForRelease` assumed an open milestone matching the version exists. Patches share the parent minor's milestone, so the lookup always threw "No open milestone found for v0.X.Y.Z" — newly visible after the auto-patch path started invoking this check via tag-for-release.

Return `undefined` from the helper for patch versions and skip the follow-up Slack message in the workflow.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR