### PR TITLE
[perf] Implement efficient insertion in add-pivot-grouping

### DIFF
--- a/src/metabase/query_processor/pivot/middleware.clj
+++ b/src/metabase/query_processor/pivot/middleware.clj
@@ -44,11 +44,7 @@
             rf            (rff metadata')
             group-bitmask (pivot.common/group-bitmask num-unremapped-breakouts unremapped-breakout-combination)
             xform         (map (fn [row]
-                                 (vec
-                                  (concat
-                                   (take num-remapped-breakouts row)
-                                   [group-bitmask]
-                                   (drop num-remapped-breakouts row)))))]
+                                 (perf/insert row num-remapped-breakouts group-bitmask)))]
         (xform rf)))))
 
 ;; this is mainly for documentation purposes

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -314,6 +314,28 @@
      (reduce (fn [res l] (reduce conj! res l)) res more)
      (persistent! res))))
 
+(defn insert
+  "Insert `el` at a position `pos` into a vector `v`. When position is equal to number of elements in `v`, insert at the
+  tail. Throws if position is negative or bigger than item count in `v`."
+  [v pos el]
+  (when-not (<= 0 pos (count v))
+    (throw (ex-info "Position should be in the range [0; N] of vector." {})))
+  (let [v (vec v)
+        n (count v)]
+    (if (= pos n)
+      (conj v el)
+      (let [i (volatile! -1)]
+        (persistent! (reduce (fn [acc x]
+                               (vswap! i inc)
+                               (conj! (cond-> acc
+                                        (= @i pos) (conj! el))
+                                      x))
+                             #?(:clj (if (<= n 32)
+                                       (small-transient (inc n) identity)
+                                       (transient []))
+                                :cljs (transient []))
+                             v))))))
+
 #?(:clj
    (defn transpose
      "Like `(apply mapv vector coll-of-colls)`, but more efficient."

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -318,6 +318,24 @@
      (reduce (fn [res l] (reduce conj! res l)) res more)
      (persistent! res))))
 
+(defn insert
+  "Insert `el` at a position `pos` into a vector `v`. When position is equal to number of elements in `v`, insert at the
+  tail."
+  [v pos el]
+  (let [v (vec v)
+        n (count v)]
+    (if (= pos n)
+      (conj v el)
+      (let [i (volatile! -1)]
+        (persistent! (reduce (fn [acc x]
+                               (vswap! i inc)
+                               (conj! (cond-> acc
+                                        (= @i pos) (conj! el))
+                                      x))
+                             (if (<= n 32)
+                               (small-transient (inc n) identity)
+                               (transient [])) v))))))
+
 #?(:clj
    (defn transpose
      "Like `(apply mapv vector coll-of-colls)`, but more efficient."

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -30,6 +30,28 @@
                                      (= r 2) vec)))))]
       (is (= (apply concat inputs) (apply perf/concat inputs))))))
 
+(deftest insert-test
+  (testing "basic insertion positions"
+    (is (= [0 1 2 3]    (perf/insert [1 2 3] 0 0)))
+    (is (= [1 2 99 3 4] (perf/insert [1 2 3 4] 2 99)))
+    (is (= [1 2 99 3]   (perf/insert [1 2 3] 2 99)))
+    (is (= [1 2 3 99]   (perf/insert [1 2 3] 3 99))))
+  (testing "empty and single-element vectors"
+    (is (= [42]    (perf/insert [] 0 42)))
+    (is (= [99 1]  (perf/insert [1] 0 99)))
+    (is (= [1 99]  (perf/insert [1] 1 99))))
+  (testing "accepts non-vector collection inputs"
+    (is (= [0 1 2 3]    (perf/insert '(1 2 3) 0 0)))
+    (is (= [0 1 99 2 3 4] (perf/insert (range 5) 2 99))))
+  (testing "works for long collections"
+    (is (= (concat [0] (range 50)) (perf/insert (range 50) 0 0)))
+    (is (= (concat (range 50) [0]) (perf/insert (range 50) 50 0)))
+    (is (= (concat (range 20) [0] (range 20 50)) (perf/insert (range 50) 20 0))))
+  (testing "throws on illegal inputs"
+    (is (thrown? #?(:clj Exception :cljs js/Error) (perf/insert [] 1 99)))
+    (is (thrown? #?(:clj Exception :cljs js/Error) (perf/insert [1 2 3] -1 99)))
+    (is (thrown? #?(:clj Exception :cljs js/Error) (perf/insert [1 2 3] 10 99)))))
+
 (defn- mapv-via-run! [f coll]
   (let [v (volatile! [])]
     (perf/run! #(vswap! v conj (f %)) coll)

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -30,6 +30,27 @@
                                      (= r 2) vec)))))]
       (is (= (apply concat inputs) (apply perf/concat inputs))))))
 
+(deftest insert-test
+  (testing "basic insertion positions"
+    (is (= [0 1 2 3]    (perf/insert [1 2 3] 0 0)))
+    (is (= [1 2 99 3 4] (perf/insert [1 2 3 4] 2 99)))
+    (is (= [1 2 99 3]   (perf/insert [1 2 3] 2 99)))
+    (is (= [1 2 3 99]   (perf/insert [1 2 3] 3 99))))
+
+  (testing "empty and single-element vectors"
+    (is (= [42]    (perf/insert [] 0 42)))
+    (is (= [99 1]  (perf/insert [1] 0 99)))
+    (is (= [1 99]  (perf/insert [1] 1 99))))
+
+  (testing "accepts non-vector collection inputs"
+    (is (= [0 1 2 3]    (perf/insert '(1 2 3) 0 0)))
+    (is (= [0 1 99 2 3 4] (perf/insert (range 5) 2 99))))
+
+  (testing "works for long collections"
+    (is (= (concat [0] (range 50)) (perf/insert (range 50) 0 0)))
+    (is (= (concat (range 50) [0]) (perf/insert (range 50) 50 0)))
+    (is (= (concat (range 20) [0] (range 20 50)) (perf/insert (range 50) 20 0)))))
+
 (defn- mapv-via-run! [f coll]
   (let [v (volatile! [])]
     (perf/run! #(vswap! v conj (f %)) coll)


### PR DESCRIPTION
Implement a more efficient `insert` function in `metabase.util.performance` namespace, and use it in `metabase.query-processor.pivot.middleware/add-pivot-grouping` instead of really wasteful concat method.

This reclaims 30% of allocations in my Canada Housing pivot benchmark: https://flamebin.dev/jCrcpd.