### PR TITLE
[perf] Don't perform redundant idempotent zone-id conversion in format-rows-xform

### DIFF
--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -84,7 +84,8 @@
                    ;; a column will have `converted_timezone` metadata if it is the result of `convert-timezone`
                    ;; expression in that case, we'll format the results with the target timezone.  Otherwise
                    ;; format it with results-timezone
-                   true (format-value (t/zone-id (or converted-timezone timezone-id)))))]
+                   true (format-value (or (some-> converted-timezone t/zone-id)
+                                          timezone-id))))]
     (fn
       ([]
        (rf))


### PR DESCRIPTION
Turned out, an innocently-looking `t/zone-id` invocation in `format-rows-xform` was inflating the memory allocations during rendering simple tables that contains timestamps by 5x: https://flamebin.dev/GQdJph. This small PR fixes that.