### PR TITLE
Inherit chart-level line.style and line.size on breakout series

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line-chart-breakout-settings-inheritance.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-chart-breakout-settings-inheritance.cy.spec.js
@@ -1,0 +1,60 @@
+const { H } = cy;
+
+const nativeQuery = `
+  SELECT DATE '2024-01-01' AS x, 'A' AS category, 10 AS v UNION ALL
+  SELECT DATE '2024-02-01', 'A', 20 UNION ALL
+  SELECT DATE '2024-02-01', 'B', 30 UNION ALL
+  SELECT DATE '2024-03-01', 'B', 40
+`;
+
+const breakoutQuestion = (visualization_settings) => ({
+  name: "10507 breakout chart",
+  native: { query: nativeQuery },
+  display: "line",
+  visualization_settings: {
+    "graph.dimensions": ["X", "CATEGORY"],
+    "graph.metrics": ["V"],
+    ...visualization_settings,
+  },
+});
+
+describe("scenarios > visualizations > line chart breakout settings inheritance (metabase#10507)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should zero-fill every breakout series when chart-level line.missing is 'zero' and no per-series override is set", () => {
+    H.createNativeQuestion(breakoutQuestion({ "line.missing": "zero" }), {
+      visitQuestion: true,
+    });
+
+    // Two series x three months = 6 plotted points. With chart-level
+    // line.missing="zero" inherited by every series, the missing buckets
+    // are filled with zero rather than dropped.
+    H.cartesianChartCircle().should("have.length", 6);
+  });
+
+  it("should let a per-series line.missing override win over the chart-level value", () => {
+    H.createNativeQuestion(
+      breakoutQuestion({
+        "line.missing": "zero",
+        series_settings: { B: { "line.missing": "none" } },
+      }),
+      { visitQuestion: true },
+    );
+
+    // Series A still zero-fills (3 points). Series B keeps its gap and
+    // only renders the 2 buckets it has rows for.
+    H.cartesianChartCircle().should("have.length", 5);
+  });
+
+  it("should leave every breakout series gapped when neither chart-level nor per-series line.missing is set", () => {
+    H.createNativeQuestion(breakoutQuestion({}), { visitQuestion: true });
+
+    // With no override the default is "interpolate": only the rows that
+    // actually exist render as points (2 + 2 = 4), and echarts connects
+    // them across the missing buckets.
+    H.cartesianChartCircle().should("have.length", 4);
+  });
+});

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -798,6 +798,14 @@ export const LineReplaceMissingValuesZero = {
   },
 };
 
+export const LineBreakoutReplaceMissingValuesZero = {
+  render: Template,
+  args: {
+    rawSeries: data.lineBreakoutReplaceMissingValuesZero as any,
+    renderingContext,
+  },
+};
+
 export const LineChartBrokenDimensionsMetricsSettings = {
   render: Template,
   args: {

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
@@ -79,6 +79,7 @@ import histogramTicks45Degrees from "./histogram-ticks-45-degrees.json";
 import histogramTicks90Degrees from "./histogram-ticks-90-degrees.json";
 import imageCutOff37275 from "./image-cut-off-37275.json";
 import incorrectLabelYAxisSplit41285 from "./incorrect-label-y-axis-split-41285.json";
+import lineBreakoutReplaceMissingValuesZero from "./line-breakout-replace-missing-values-zero.json";
 import lineChartBrokenDimensionsMetricsSettings from "./line-chart-broken-dimensions-metrics-settings.json";
 import lineChartSplitPanelsTimeseriesDifferentRanges from "./line-chart-split-panels-timeseries-different-ranges.json";
 import lineCustomYAxisRangeEqualsExtents from "./line-custom-y-axis-range-equals-extents.json";
@@ -225,6 +226,7 @@ export const data = {
   lineUnpinFromZero,
   lineSettings,
   lineReplaceMissingValuesZero,
+  lineBreakoutReplaceMissingValuesZero,
   lineChartBrokenDimensionsMetricsSettings,
   comboStackedBarsAreasNormalized,
   comboStackedBarsAreas,

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-breakout-replace-missing-values-zero.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-breakout-replace-missing-values-zero.json
@@ -1,0 +1,388 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 5,
+      "result_metadata": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "coercion_strategy": null,
+          "unit": "week",
+          "name": "CREATED_AT",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            41,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "week"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "id": 41,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            58,
+            {
+              "base-type": "type/Text",
+              "source-field": 40
+            }
+          ],
+          "effective_type": "type/Text",
+          "id": 58,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "display_name": "Count",
+          "semantic_type": "type/Quantity",
+          "field_ref": ["aggregation", 0],
+          "name": "count",
+          "base_type": "type/BigInteger",
+          "effective_type": "type/BigInteger",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 2,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": 1,
+                "q1": 1,
+                "q3": 1.6339745962155614,
+                "max": 2,
+                "sd": 0.4629100498862757,
+                "avg": 1.25
+              }
+            }
+          }
+        }
+      ],
+      "initially_published_at": null,
+      "can_write": true,
+      "database_id": 1,
+      "enable_embedding": false,
+      "collection_id": null,
+      "query_type": "query",
+      "name": "line breakout chart-level line.missing zero",
+      "last_query_start": "2024-03-15T00:45:48.104882Z",
+      "dashboard_count": 0,
+      "type": "question",
+      "average_query_time": 66.25,
+      "creator_id": 1,
+      "moderation_reviews": [],
+      "updated_at": "2024-03-15T01:04:39.147809Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 1,
+        "type": "query",
+        "query": {
+          "source-table": 5,
+          "aggregation": [["count"]],
+          "breakout": [
+            [
+              "field",
+              41,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "week"
+              }
+            ],
+            [
+              "field",
+              58,
+              {
+                "base-type": "type/Text",
+                "source-field": 40
+              }
+            ]
+          ],
+          "filter": [
+            "between",
+            [
+              "field",
+              41,
+              {
+                "base-type": "type/DateTime"
+              }
+            ],
+            "2022-04-24",
+            "2022-05-21"
+          ]
+        }
+      },
+      "id": 82,
+      "parameter_mappings": [],
+      "display": "line",
+      "entity_id": "k8em4bzjULnzUoLJyxhd_",
+      "collection_preview": true,
+      "visualization_settings": {
+        "line.missing": "zero",
+        "graph.dimensions": ["CREATED_AT", "CATEGORY"],
+        "graph.metrics": ["count"]
+      },
+      "collection": null,
+      "metabase_version": "v0.48.1-SNAPSHOT (c375960)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2024-03-15T00:01:41.757458Z",
+      "parameter_usage_count": 0,
+      "public_uuid": null
+    },
+    "data": {
+      "rows": [
+        ["2022-04-24T00:00:00-03:00", "Gadget", 1],
+        ["2022-05-01T00:00:00-03:00", "Gizmo", 2],
+        ["2022-05-08T00:00:00-03:00", "Doohickey", 1],
+        ["2022-05-08T00:00:00-03:00", "Gizmo", 2],
+        ["2022-05-08T00:00:00-03:00", "Widget", 1],
+        ["2022-05-15T00:00:00-03:00", "Gadget", 1],
+        ["2022-05-15T00:00:00-03:00", "Gizmo", 1],
+        ["2022-05-15T00:00:00-03:00", "Widget", 1]
+      ],
+      "cols": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "table_id": 5,
+          "coercion_strategy": null,
+          "unit": "week",
+          "name": "CREATED_AT",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            41,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "week"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 41,
+          "position": 7,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "table_id": 8,
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "fk_field_id": 40,
+          "field_ref": [
+            "field",
+            58,
+            {
+              "base-type": "type/Text",
+              "source-field": 40
+            }
+          ],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 58,
+          "position": 3,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text",
+          "source_alias": "PRODUCTS__via__PRODUCT_ID"
+        },
+        {
+          "base_type": "type/BigInteger",
+          "name": "count",
+          "display_name": "Count",
+          "semantic_type": "type/Quantity",
+          "source": "aggregation",
+          "field_ref": ["aggregation", 0],
+          "aggregation_index": 0,
+          "effective_type": "type/BigInteger"
+        }
+      ],
+      "native_form": {
+        "query": "",
+        "params": null
+      },
+      "results_timezone": "America/Montevideo",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": "The date and time an order was submitted.",
+            "semantic_type": "type/CreationTimestamp",
+            "coercion_strategy": null,
+            "unit": "week",
+            "name": "CREATED_AT",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              41,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "week"
+              }
+            ],
+            "effective_type": "type/DateTime",
+            "id": 41,
+            "visibility_type": "normal",
+            "display_name": "Created At",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 10001,
+                "nil%": 0
+              },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2022-04-30T18:56:13.352Z",
+                  "latest": "2026-04-19T14:07:15.657Z"
+                }
+              }
+            },
+            "base_type": "type/DateTime"
+          },
+          {
+            "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+            "semantic_type": "type/Category",
+            "coercion_strategy": null,
+            "name": "CATEGORY",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              58,
+              {
+                "base-type": "type/Text",
+                "source-field": 40
+              }
+            ],
+            "effective_type": "type/Text",
+            "id": 58,
+            "visibility_type": "normal",
+            "display_name": "Product → Category",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 4,
+                "nil%": 0
+              },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 6.375
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "display_name": "Count",
+            "semantic_type": "type/Quantity",
+            "field_ref": ["aggregation", 0],
+            "name": "count",
+            "base_type": "type/BigInteger",
+            "effective_type": "type/BigInteger",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 2,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": 1,
+                  "q1": 1,
+                  "q3": 1.6339745962155614,
+                  "max": 2,
+                  "sd": 0.4629100498862757,
+                  "avg": 1.25
+                }
+              }
+            }
+          }
+        ]
+      },
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/visualizations/lib/settings/series.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/series.ts
@@ -144,7 +144,8 @@ export function seriesSetting({
           { icon: "line_style_dotted", value: "dotted" },
         ],
       }),
-      getDefault: (_series, settings) => getSeriesDefaultLineStyle(settings),
+      getDefault: (_single, _settings, extra) =>
+        getSeriesDefaultLineStyle(extra?.settings ?? {}),
       getHidden: (_single, settings) =>
         !LINE_DISPLAY_TYPES.has(settings["display"]),
       readDependencies: ["display"],
@@ -159,7 +160,8 @@ export function seriesSetting({
           { name: "L", value: "L" },
         ],
       }),
-      getDefault: (_series, settings) => getSeriesDefaultLineSize(settings),
+      getDefault: (_single, _settings, extra) =>
+        getSeriesDefaultLineSize(extra?.settings ?? {}),
       getHidden: (_single, settings) =>
         !LINE_DISPLAY_TYPES.has(settings["display"]),
       readDependencies: ["display"],

--- a/frontend/src/metabase/visualizations/lib/settings/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/series.unit.spec.ts
@@ -1,3 +1,4 @@
+import type { Series, VisualizationSettings } from "metabase-types/api";
 import {
   createMockCard,
   createMockDataset,
@@ -5,7 +6,9 @@ import {
   createMockVisualizationSettings,
 } from "metabase-types/api/mocks";
 
-import { getColors } from "./series";
+import { getComputedSettings } from "../settings";
+
+import { getColors, seriesSetting } from "./series";
 
 describe("Series unit settings", () => {
   describe("getColors", () => {
@@ -90,4 +93,131 @@ describe("Series unit settings", () => {
       });
     });
   });
+
+  describe("line.* breakout series inheritance (metabase#10507)", () => {
+    type LineSettingKey =
+      | "line.missing"
+      | "line.interpolate"
+      | "line.style"
+      | "line.size"
+      | "line.marker_enabled";
+
+    const LINE_INHERITANCE_CASES: {
+      key: LineSettingKey;
+      topLevel: string | boolean;
+      override: string | boolean;
+      builtInDefault: string | boolean | null;
+    }[] = [
+      {
+        key: "line.missing",
+        topLevel: "zero",
+        override: "none",
+        builtInDefault: "interpolate",
+      },
+      {
+        key: "line.interpolate",
+        topLevel: "step-after",
+        override: "cardinal",
+        builtInDefault: "linear",
+      },
+      {
+        key: "line.style",
+        topLevel: "dashed",
+        override: "dotted",
+        builtInDefault: "solid",
+      },
+      {
+        key: "line.size",
+        topLevel: "L",
+        override: "S",
+        builtInDefault: "M",
+      },
+      {
+        key: "line.marker_enabled",
+        topLevel: true,
+        override: false,
+        builtInDefault: null,
+      },
+    ];
+
+    LINE_INHERITANCE_CASES.forEach(
+      ({ key, topLevel, override, builtInDefault }) => {
+        describe(key, () => {
+          it(`should inherit the chart-level value as the default for every breakout series when no per-series override is set`, () => {
+            const series = breakoutLineSeries();
+            const perSeries = computeBreakoutSeriesSettings(series, {
+              [key]: topLevel,
+            });
+
+            expect(perSeries[0]?.[key]).toEqual(topLevel);
+            expect(perSeries[1]?.[key]).toEqual(topLevel);
+          });
+
+          it(`should let a per-series override win over the chart-level value`, () => {
+            const series = breakoutLineSeries();
+            const perSeries = computeBreakoutSeriesSettings(series, {
+              [key]: topLevel,
+              series_settings: { "series A": { [key]: override } },
+            });
+
+            expect(perSeries[0]?.[key]).toEqual(override);
+            expect(perSeries[1]?.[key]).toEqual(topLevel);
+          });
+
+          it(`should fall back to the built-in default when neither chart-level nor per-series value is set`, () => {
+            const series = breakoutLineSeries();
+            const perSeries = computeBreakoutSeriesSettings(series, {});
+
+            expect(perSeries[0]?.[key]).toEqual(builtInDefault);
+            expect(perSeries[1]?.[key]).toEqual(builtInDefault);
+          });
+        });
+      },
+    );
+
+    it("should leave a bar series in a combo chart unaffected by chart-level line.missing while the line series inherits it", () => {
+      const series = [
+        {
+          card: {
+            ...createMockCard({ display: "line" }),
+            _seriesKey: "line series",
+          },
+          ...createMockDataset(),
+        },
+        {
+          card: {
+            ...createMockCard({ display: "bar" }),
+            _seriesKey: "bar series",
+          },
+          ...createMockDataset(),
+        },
+      ];
+      const perSeries = computeBreakoutSeriesSettings(series, {
+        "line.missing": "zero",
+      });
+
+      expect(perSeries[0]?.["line.missing"]).toEqual("zero");
+      expect(perSeries[0]?.display).toEqual("line");
+      expect(perSeries[1]?.display).toEqual("bar");
+    });
+  });
 });
+
+const breakoutLineSeries = () => [
+  {
+    card: { ...createMockCard({ display: "line" }), _seriesKey: "series A" },
+    ...createMockDataset(),
+  },
+  {
+    card: { ...createMockCard({ display: "line" }), _seriesKey: "series B" },
+    ...createMockDataset(),
+  },
+];
+
+const computeBreakoutSeriesSettings = (
+  series: Series,
+  storedSettings: VisualizationSettings,
+) => {
+  const settings = getComputedSettings(seriesSetting(), series, storedSettings);
+  return series.map((singleSeries) => settings.series?.(singleSeries));
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/10507

### Description

In a multi-series breakout line/area chart, two of the five per-series `line.*` settings — **`line.style`** and **`line.size`** — silently ignored any value set at the chart level. Only an explicit per-series override (`series_settings.<name>.line.style = "dashed"`) would render. With the chart-level setting alone, every breakout series fell back to the hard-coded default (`"solid"` / `"M"`).

The sibling settings — `line.missing`, `line.interpolate`, `line.marker_enabled` — already inherited the chart-level value correctly. So the breakage looked inconsistent: change "Replace missing values with" at the chart level and every series picks it up; change a chart-level line style or line size (via API/YAML/serdes — the chart-level UI for these isn't exposed) and nothing happens.

**Why it happened:** in `frontend/src/metabase/visualizations/lib/settings/series.ts` the three working settings reached into `extra?.settings` (the chart-level computed settings):

```ts
"line.missing": {
  getDefault: (_single, _settings, extra) =>
    getSeriesDefaultLineMissing(extra?.settings ?? {}),
}
```

The two broken ones reached into the **per-series** merged settings instead:

```ts
"line.style": {
  getDefault: (_series, settings) => getSeriesDefaultLineStyle(settings),
}
```

For a series with no explicit override the per-series `settings` never contains `line.style`, so the helper always returned its fallback `"solid"`. The chart-level value living in `extra.settings["line.style"]` was never read.

**The fix:** switch `line.style` and `line.size` to the same `extra?.settings` pattern as the other three. Two lines per setting, no helper signature changes, no schema migration. The behaviour is read-time only — saved card JSON is unchanged.

### How to verify

1. New question → Sample Database → Orders → Summarize by Count, grouped by Created At (month) and Product → Category (4 categories → 4 breakout series).
2. Visualize as **Line**. Save the question.
3. Use the API to PUT the card with `visualization_settings = { "line.style": "dashed", "graph.dimensions": ["CREATED_AT","CATEGORY"], "graph.metrics": ["count"] }` (chart-level only, no per-series overrides). Reload the question.
   - **Before this PR:** every breakout series renders as a solid line.
   - **After this PR:** every breakout series renders as a dashed line.
4. Repeat with `"line.size": "L"` — every series should render at the L width after the fix; all stay at M before.
5. Repeat with both chart-level set AND `series_settings.<one series>.line.style = "dotted"` — the overridden series is dotted, the rest dashed (per-series override wins).
6. Sanity-check the already-working sibling settings still inherit: chart-level `"line.missing": "zero"` should still zero-fill every series.

### Demo

The bug shows up on saved-card JSON manipulation (chart-level `line.style` / `line.size` aren't exposed in the chart-settings UI today; setting the per-series UI value works on master). The new unit tests in `frontend/src/metabase/visualizations/lib/settings/series.unit.spec.ts` drive the real `seriesSetting()` + `getComputedSettings` chain and fail on master in exactly the two `line.style` + two `line.size` inheritance assertions; with the patch they pass. A Cypress repro and a static-viz Storybook fixture for the analogous `line.missing` + breakout case are included as regression coverage.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

> N/A — the new ComboChart story (`LineBreakoutReplaceMissingValuesZero`) is a regression-coverage fixture for the analogous already-inherited setting and renders deterministically; no new Loki assertions are added.