### PR TITLE
Rewrite JUnit hook failures so Trunk attributes them to the original test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -158,6 +158,17 @@ jobs:
         # whether to fail or to pass the whole job, based on the quarantine list.
         continue-on-error: true
 
+      - name: Rewrite JUnit hook failures (dry-run)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [ -d ./target/junit ]; then
+            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+          else
+            echo "No ./target/junit directory; nothing to process."
+          fi
+
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -87,6 +87,17 @@ jobs:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: node e2e/runner/run_cypress_ci.js component
 
+      - name: Rewrite JUnit hook failures (dry-run)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [ -d ./target/junit ]; then
+            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+          else
+            echo "No ./target/junit directory; nothing to process."
+          fi
+
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -239,6 +250,17 @@ jobs:
         run: |
           node e2e/runner/run_cypress_ci.js component \
             --expose grepTags="-@skip-backward-compatibility"
+
+      - name: Rewrite JUnit hook failures (dry-run)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [ -d ./target/junit ]; then
+            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+          else
+            echo "No ./target/junit directory; nothing to process."
+          fi
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/bun.lock
+++ b/bun.lock
@@ -316,6 +316,8 @@
         "eslint-plugin-storybook": "9.1.17",
         "eslint-plugin-testing-library": "7.15.4",
         "eslint-plugin-ttag": "^1.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "fast-xml-parser": "^5.8.0",
         "fetch-mock": "^12.0.0",
         "get-nonce": "^1.0.1",
         "glob": "^7.1.1",
@@ -1214,6 +1216,8 @@
     "@nicolo-ribaudo/eslint-scope-5-internals": ["@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1", "", { "dependencies": { "eslint-scope": "5.1.1" } }, "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -3103,7 +3107,9 @@
 
     "fast-uri": ["fast-uri@3.0.1", "", {}, "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="],
 
-    "fast-xml-parser": ["fast-xml-parser@5.3.6", "", { "dependencies": { "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA=="],
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
 
     "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 
@@ -4259,6 +4265,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -5021,7 +5029,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
 
     "strtok3": ["strtok3@7.0.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^5.0.0" } }, "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ=="],
 
@@ -5446,6 +5454,8 @@
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
@@ -6676,6 +6686,8 @@
     "object.getownpropertydescriptors/es-abstract": ["es-abstract@1.22.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "arraybuffer.prototype.slice": "^1.0.3", "available-typed-arrays": "^1.0.6", "call-bind": "^1.0.7", "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.2", "es-to-primitive": "^1.2.1", "function.prototype.name": "^1.1.6", "get-intrinsic": "^1.2.4", "get-symbol-description": "^1.0.2", "globalthis": "^1.0.3", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2", "has-proto": "^1.0.1", "has-symbols": "^1.0.3", "hasown": "^2.0.1", "internal-slot": "^1.0.7", "is-array-buffer": "^3.0.4", "is-callable": "^1.2.7", "is-negative-zero": "^2.0.2", "is-regex": "^1.1.4", "is-shared-array-buffer": "^1.0.2", "is-string": "^1.0.7", "is-typed-array": "^1.1.13", "is-weakref": "^1.0.2", "object-inspect": "^1.13.1", "object-keys": "^1.1.1", "object.assign": "^4.1.5", "regexp.prototype.flags": "^1.5.2", "safe-array-concat": "^1.1.0", "safe-regex-test": "^1.0.3", "string.prototype.trim": "^1.2.8", "string.prototype.trimend": "^1.0.7", "string.prototype.trimstart": "^1.0.7", "typed-array-buffer": "^1.0.1", "typed-array-byte-length": "^1.0.0", "typed-array-byte-offset": "^1.0.0", "typed-array-length": "^1.0.4", "unbox-primitive": "^1.0.2", "which-typed-array": "^1.1.14" } }, "sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg=="],
 
     "openapi-sampler/@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "openapi-sampler/fast-xml-parser": ["fast-xml-parser@5.3.6", "", { "dependencies": { "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA=="],
 
     "openapi-typescript/@redocly/openapi-core": ["@redocly/openapi-core@1.34.5", "", { "dependencies": { "@redocly/ajv": "^8.11.2", "@redocly/config": "^0.22.0", "colorette": "^1.2.0", "https-proxy-agent": "^7.0.5", "js-levenshtein": "^1.1.6", "js-yaml": "^4.1.0", "minimatch": "^5.0.1", "pluralize": "^8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA=="],
 
@@ -8002,6 +8014,8 @@
     "object.getownpropertydescriptors/es-abstract/unbox-primitive": ["unbox-primitive@1.0.2", "", { "dependencies": { "call-bind": "^1.0.2", "has-bigints": "^1.0.2", "has-symbols": "^1.0.3", "which-boxed-primitive": "^1.0.2" } }, "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw=="],
 
     "object.getownpropertydescriptors/es-abstract/which-typed-array": ["which-typed-array@1.1.14", "", { "dependencies": { "available-typed-arrays": "^1.0.6", "call-bind": "^1.0.5", "for-each": "^0.3.3", "gopd": "^1.0.1", "has-tostringtag": "^1.0.1" } }, "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg=="],
+
+    "openapi-sampler/fast-xml-parser/strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
 
     "openapi-typescript/@redocly/openapi-core/@redocly/ajv": ["@redocly/ajv@8.11.3", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-4P3iZse91TkBiY+Dx5DUgxQ9GXkVJf++cmI0MOyLDxV9b5MUBI4II6ES8zA5JCbO72nKAJxWrw4PUPW+YP3ZDQ=="],
 

--- a/e2e/support/fix-junit-hooks.ts
+++ b/e2e/support/fix-junit-hooks.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env bun
+
+// Rewrite Cypress JUnit XML so hook failures are attributed to the
+// underlying test. When a `before each` / `before all` / `after each` /
+// `after all` hook throws, mocha-junit-reporter records the failing testcase
+// as `<suite> "before each" hook for "<test name>"`. That breaks downstream
+// Trunk that keys on the test name. This script parses the
+// XML and strips the hook label from `name` and `classname`, leaving the
+// failure body intact so the error is still preserved.
+
+import {
+  copyFileSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { Command } from "commander";
+import XMLBuilder from "fast-xml-builder";
+import { XMLParser } from "fast-xml-parser";
+
+type Options = {
+  dryRun?: boolean;
+  include: string[];
+};
+
+type Testcase = {
+  "@_name"?: string;
+  "@_classname"?: string;
+  [k: string]: unknown;
+};
+
+type Action =
+  | "rewrote"
+  | "dry-run"
+  | "no-hooks"
+  | "skipped-include"
+  | "skipped-no-spec";
+
+type Result = {
+  action: Action;
+  scanned: number;
+  rewritten: number;
+  specFile: string | null;
+};
+
+const program = new Command();
+program
+  .name("fix-junit-hooks")
+  .description(
+    "Rewrite Mocha/Cypress JUnit XML to attribute hook failures to the underlying test.",
+  )
+  .argument("<input-dir>", "directory of JUnit XML files to process")
+  .argument(
+    "[output-dir]",
+    "directory to write results to (defaults to input-dir, in place)",
+  )
+  .option("--dry-run", "log intended changes without writing rewritten XML")
+  .option(
+    "--include <substring>",
+    "only rewrite when the Root Suite's spec file path contains this substring (repeatable)",
+    (value: string, previous: string[]) => previous.concat([value]),
+    [] as string[],
+  )
+  .parse();
+
+const [inDir, outDir = inDir] = program.processedArgs as [string, string?];
+const { dryRun = false, include: includes } = program.opts<Options>();
+
+if (!statSync(inDir).isDirectory()) {
+  console.error(`error: <input-dir> must be a directory, got ${inDir}`);
+  process.exit(1);
+}
+if (inDir !== outDir) {
+  let outStat: ReturnType<typeof statSync> | null = null;
+  try {
+    outStat = statSync(outDir);
+  } catch {}
+  if (outStat && !outStat.isDirectory()) {
+    console.error(`error: <output-dir> must be a directory, got ${outDir}`);
+    process.exit(1);
+  }
+}
+
+const xmlOpts = {
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  cdataPropName: "__cdata",
+  preserveOrder: false,
+};
+const parser = new XMLParser(xmlOpts);
+const builder = new XMLBuilder({ ...xmlOpts, format: true });
+
+const HOOK_RE = /"(?:before|after) (?:each|all)" hook for "([^"]+)"/g;
+const fix = (s: string | undefined): string | undefined =>
+  typeof s === "string" ? s.replace(HOOK_RE, "$1") : s;
+
+function visitTestcases(node: unknown, fn: (tc: Testcase) => void): void {
+  if (Array.isArray(node)) {
+    node.forEach((n) => visitTestcases(n, fn));
+    return;
+  }
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  for (const [k, v] of Object.entries(node)) {
+    if (k === "testcase") {
+      (Array.isArray(v) ? v : [v]).forEach((tc: Testcase) => fn(tc));
+    } else {
+      visitTestcases(v, fn);
+    }
+  }
+}
+
+// mocha-junit-reporter records the spec path as `file=` on the Root Suite
+// testsuite; that's the only place it appears in the document.
+function findSpecFile(node: unknown): string | null {
+  if (Array.isArray(node)) {
+    for (const n of node) {
+      const f = findSpecFile(n);
+      if (f) {
+        return f;
+      }
+    }
+    return null;
+  }
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+  const file = (node as Record<string, unknown>)["@_file"];
+  if (typeof file === "string") {
+    return file;
+  }
+  for (const v of Object.values(node)) {
+    const f = findSpecFile(v);
+    if (f) {
+      return f;
+    }
+  }
+  return null;
+}
+
+function passthrough(input: string, output: string): void {
+  if (input !== output) {
+    copyFileSync(input, output);
+  }
+}
+
+function processFile(input: string, output: string): Result {
+  const tree = parser.parse(readFileSync(input, "utf8"));
+  const specFile = findSpecFile(tree);
+
+  if (includes.length) {
+    const matched = specFile && includes.some((s) => specFile.includes(s));
+    if (!matched) {
+      passthrough(input, output);
+      return {
+        action: specFile ? "skipped-include" : "skipped-no-spec",
+        scanned: 0,
+        rewritten: 0,
+        specFile,
+      };
+    }
+  }
+
+  let scanned = 0;
+  let rewritten = 0;
+  visitTestcases(tree, (tc) => {
+    scanned++;
+    const before = tc["@_name"];
+    tc["@_name"] = fix(tc["@_name"]);
+    tc["@_classname"] = fix(tc["@_classname"]);
+    if (tc["@_name"] !== before) {
+      rewritten++;
+    }
+  });
+
+  if (dryRun) {
+    passthrough(input, output);
+    return { action: "dry-run", scanned, rewritten, specFile };
+  }
+  if (rewritten === 0) {
+    passthrough(input, output);
+    return { action: "no-hooks", scanned, rewritten, specFile };
+  }
+  writeFileSync(output, builder.build(tree));
+  return { action: "rewrote", scanned, rewritten, specFile };
+}
+
+function summarize(path: string, r: Result): string {
+  switch (r.action) {
+    case "rewrote":
+      return `${path}: rewrote ${r.rewritten}/${r.scanned}`;
+    case "dry-run":
+      return `${path}: dry-run would rewrite ${r.rewritten}/${r.scanned}`;
+    case "no-hooks":
+      return `${path}: no hooks (0/${r.scanned})`;
+    case "skipped-include":
+      return `${path}: skipped (${r.specFile} did not match --include)`;
+    case "skipped-no-spec":
+      return `${path}: skipped (no Root Suite file= attribute)`;
+  }
+}
+
+const files = readdirSync(inDir)
+  .filter((f) => f.endsWith(".xml"))
+  .sort();
+
+let totalScanned = 0;
+let totalRewritten = 0;
+for (const f of files) {
+  const inP = join(inDir, f);
+  const outP = inDir === outDir ? inP : join(outDir, f);
+  const r = processFile(inP, outP);
+  console.error(summarize(inP, r));
+  totalScanned += r.scanned;
+  totalRewritten += r.rewritten;
+}
+console.error(
+  `total: ${totalRewritten}/${totalScanned} rewritten across ${files.length} files`,
+);

--- a/e2e/support/fix-junit-hooks.ts
+++ b/e2e/support/fix-junit-hooks.ts
@@ -39,11 +39,14 @@ type Action =
   | "skipped-include"
   | "skipped-no-spec";
 
+type Rewrite = { before: string; after: string };
+
 type Result = {
   action: Action;
   scanned: number;
   rewritten: number;
   specFile: string | null;
+  rewrites: Rewrite[];
 };
 
 const program = new Command();
@@ -161,47 +164,62 @@ function processFile(input: string, output: string): Result {
         scanned: 0,
         rewritten: 0,
         specFile,
+        rewrites: [],
       };
     }
   }
 
   let scanned = 0;
-  let rewritten = 0;
+  const rewrites: Rewrite[] = [];
   visitTestcases(tree, (tc) => {
     scanned++;
     const before = tc["@_name"];
     tc["@_name"] = fix(tc["@_name"]);
     tc["@_classname"] = fix(tc["@_classname"]);
-    if (tc["@_name"] !== before) {
-      rewritten++;
+    if (
+      tc["@_name"] !== before &&
+      before !== undefined &&
+      tc["@_name"] !== undefined
+    ) {
+      rewrites.push({ before, after: tc["@_name"] });
     }
   });
+  const rewritten = rewrites.length;
 
   if (dryRun) {
     passthrough(input, output);
-    return { action: "dry-run", scanned, rewritten, specFile };
+    return { action: "dry-run", scanned, rewritten, specFile, rewrites };
   }
   if (rewritten === 0) {
     passthrough(input, output);
-    return { action: "no-hooks", scanned, rewritten, specFile };
+    return { action: "no-hooks", scanned, rewritten, specFile, rewrites };
   }
   writeFileSync(output, builder.build(tree));
-  return { action: "rewrote", scanned, rewritten, specFile };
+  return { action: "rewrote", scanned, rewritten, specFile, rewrites };
 }
 
 function summarize(path: string, r: Result): string {
-  switch (r.action) {
-    case "rewrote":
-      return `${path}: rewrote ${r.rewritten}/${r.scanned}`;
-    case "dry-run":
-      return `${path}: dry-run would rewrite ${r.rewritten}/${r.scanned}`;
-    case "no-hooks":
-      return `${path}: no hooks (0/${r.scanned})`;
-    case "skipped-include":
-      return `${path}: skipped (${r.specFile} did not match --include)`;
-    case "skipped-no-spec":
-      return `${path}: skipped (no Root Suite file= attribute)`;
+  const head = (() => {
+    switch (r.action) {
+      case "rewrote":
+        return `${path}: rewrote ${r.rewritten}/${r.scanned}`;
+      case "dry-run":
+        return `${path}: dry-run would rewrite ${r.rewritten}/${r.scanned}`;
+      case "no-hooks":
+        return `${path}: no hooks (0/${r.scanned})`;
+      case "skipped-include":
+        return `${path}: skipped (${r.specFile} did not match --include)`;
+      case "skipped-no-spec":
+        return `${path}: skipped (no Root Suite file= attribute)`;
+    }
+  })();
+  if (r.rewrites.length === 0) {
+    return head;
   }
+  const detail = r.rewrites
+    .map(({ before, after }) => `  ${before} -> ${after}`)
+    .join("\n");
+  return `${head}\n${detail}`;
 }
 
 const files = readdirSync(inDir)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -18,6 +18,7 @@ frontend/test/          # Jest unit tests
 - **State**: Redux Toolkit
 - **Styling**: CSS Modules (preferred) > Emotion styled-components
 - **UI**: `metabase/ui` components built with Mantine v8
+- **Package manager**: Bun
 - **Build**: Rspack (primary), Webpack (legacy)
 - **Testing**: Jest + React Testing Library, Cypress
 

--- a/package.json
+++ b/package.json
@@ -322,6 +322,8 @@
     "eslint-plugin-storybook": "9.1.17",
     "eslint-plugin-testing-library": "7.15.4",
     "eslint-plugin-ttag": "^1.1.0",
+    "fast-xml-builder": "^1.2.0",
+    "fast-xml-parser": "^5.8.0",
     "fetch-mock": "^12.0.0",
     "get-nonce": "^1.0.1",
     "glob": "^7.1.1",


### PR DESCRIPTION
Contributes to [GDGT-2424](https://linear.app/metabase/issue/GDGT-2424/treat-beforeeach-failures-as-original-test-failures).

### Description

When an e2e test fails inside a Mocha hook (`beforeEach`, `before`, `afterEach`, `after`), `mocha-junit-reporter` records the failing testcase as `<suite> "before each" hook for "<test name>"` instead of attributing the failure to the underlying test. Trunk indexes that string as the test identity, so hook failures register as brand-new "tests" that immediately enter the "Broken" status with a single failed run and pollute the flake list.

This PR adds `e2e/support/fix-junit-hooks.ts`, a Bun script that reads a directory of JUnit XML files, strips the `"<hook>" hook for "<test name>"` wrapper from each `<testcase>`'s `name` and `classname` attributes, and writes the result back. The `<failure>` body (error message and stack trace) is left untouched, so developers can still tell immediately that the failure happened inside a hook — only the test identity changes.

The script is wired into `e2e-test.yml` and `embedding-sdk-component-tests.yml` as a step that runs after Cypress and before `upload-test-results`. **It runs with `--dry-run` for now**, so the workflow log will show which testcases _would_ be rewritten without modifying any XML — this is step 1 of a gradual rollout. Once the dry-run logs are cross-checked against Trunk, the next step is dropping `--dry-run` for a single spec via `--include 'documents/comments.cy.spec.ts'`, then expanding.

See the [this comment](https://linear.app/metabase/issue/GDGT-2426/investigate-whether-it-makes-sense-to-merge-beforeeach-hook-failures#comment-808e65f0) for full context and the cleanup plan for existing phantom records.

### How to verify

Since the script is in `--dry-run` mode, verification is observational, not behavioral:

1. After this PR's CI run, open the `e2e-tests` and `embedding-sdk-component-tests` job logs.
2. Find the `Rewrite JUnit hook failures (dry-run)` step.
3. Output should look like:
   ```
   target/junit/<hash>.xml: dry-run would rewrite N/M
   …
   total: K/L rewritten across N files
   ```

You can take a look of example run with rewrite [here](https://github.com/metabase/metabase/actions/runs/26047547177/job/76577280686)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR