### PR TITLE
fix(sdk-bundle): host style not respected when navigating between dashboards in InteractiveDashboard

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -641,18 +641,14 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       getSdkRoot().within(() => {
         cy.findByText("Dashboard A").should("be.visible");
 
-        // Pre-fix, navigating to another dashboard rendered a second nested
-        // SdkDashboardStyledWrapper inside the outer one (the navigation
-        // provider's wrapper plus SdkDashboard's own wrapper). The inner
-        // wrapper had no host style, so the dashboard chrome lost its
-        // height/scroll context and sticky filters broke. Asserting exactly
-        // one styled wrapper at every step pins that invariant.
+        // Pre-fix: nested wrapper dropped user height, broke sticky filters.
+        // Pin: exactly one styled wrapper at every step.
         cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
           "have.length",
           1,
         );
 
-        // Navigate to Dashboard B via custom click behavior.
+        cy.log("Navigate to Dashboard B via custom click behavior");
         H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
         cy.wait("@getDashboard");
         cy.findByText("Dashboard B").should("be.visible");

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -87,7 +87,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
                 row: 0,
                 col: 0,
                 size_x: 24,
-                size_y: 8,
+                size_y: 30,
                 parameter_mappings: [
                   {
                     parameter_id: DASHBOARD_B_FILTER.id,
@@ -624,7 +624,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       });
     });
 
-    it("should preserve user style on the navigated dashboard (EMB-1746)", () => {
+    it("should keep filters sticky on the navigated dashboard (EMB-1746)", () => {
       cy.get<number>("@dashboardAId").then((dashboardAId) => {
         mountSdkContent(
           <InteractiveDashboard
@@ -641,28 +641,27 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       getSdkRoot().within(() => {
         cy.findByText("Dashboard A").should("be.visible");
 
-        // Pre-fix: nested wrapper dropped user height, broke sticky filters.
-        // Pin: exactly one styled wrapper at every step.
-        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.length",
-          1,
-        );
-
         cy.log("Navigate to Dashboard B via custom click behavior");
         H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
         cy.wait("@getDashboard");
         cy.findByText("Dashboard B").should("be.visible");
-        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.length",
-          1,
-        );
+        H.filterWidget().should("be.visible");
 
-        cy.findByText("Back to Dashboard A").click();
-        cy.findByText("Dashboard A").should("be.visible");
-        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.length",
-          1,
-        );
+        // Pre-fix: nested wrapper dropped user height, so the scroll context
+        // was gone and the filter row scrolled off with the content.
+        cy.log("Scroll dashboard; filter row must stay pinned at wrapper top");
+        cy.findByTestId("sdk-dashboard-styled-wrapper").scrollTo("bottom");
+
+        cy.findByTestId("sdk-dashboard-styled-wrapper").then(($wrapper) => {
+          const wrapperTop = $wrapper[0].getBoundingClientRect().top;
+
+          H.filterWidget()
+            .should("be.visible")
+            .and(($filter) => {
+              const filterTop = $filter[0].getBoundingClientRect().top;
+              expect(filterTop).to.be.closeTo(wrapperTop, 20);
+            });
+        });
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -641,46 +641,31 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       getSdkRoot().within(() => {
         cy.findByText("Dashboard A").should("be.visible");
 
-        // Initial render: exactly one styled wrapper carrying the user height.
+        // Pre-fix, navigating to another dashboard rendered a second nested
+        // SdkDashboardStyledWrapper inside the outer one (the navigation
+        // provider's wrapper plus SdkDashboard's own wrapper). The inner
+        // wrapper had no host style, so the dashboard chrome lost its
+        // height/scroll context and sticky filters broke. Asserting exactly
+        // one styled wrapper at every step pins that invariant.
         cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
           "have.length",
           1,
-        );
-        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.css",
-          "height",
-          "400px",
         );
 
         // Navigate to Dashboard B via custom click behavior.
         H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
         cy.wait("@getDashboard");
         cy.findByText("Dashboard B").should("be.visible");
-
-        // After navigation: still exactly one styled wrapper, still carrying
-        // the user height. Pre-fix, the inner SdkDashboard rendered a second
-        // wrapper with no style, dropping height and breaking sticky filters.
         cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
           "have.length",
           1,
         );
-        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.css",
-          "height",
-          "400px",
-        );
 
-        // Back to Dashboard A: wrapper invariant still holds.
         cy.findByText("Back to Dashboard A").click();
         cy.findByText("Dashboard A").should("be.visible");
         cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
           "have.length",
           1,
-        );
-        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
-          "have.css",
-          "height",
-          "400px",
         );
       });
     });

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -623,6 +623,67 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
         cy.findByText(/Back to/).should("not.exist");
       });
     });
+
+    it("should preserve user style on the navigated dashboard (EMB-1746)", () => {
+      cy.get<number>("@dashboardAId").then((dashboardAId) => {
+        mountSdkContent(
+          <InteractiveDashboard
+            dashboardId={dashboardAId}
+            enableEntityNavigation
+            style={{ height: 400 }}
+          />,
+        );
+      });
+
+      cy.wait("@getDashboard");
+      cy.wait("@dashcardQuery");
+
+      getSdkRoot().within(() => {
+        cy.findByText("Dashboard A").should("be.visible");
+
+        // Initial render: exactly one styled wrapper carrying the user height.
+        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.length",
+          1,
+        );
+        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.css",
+          "height",
+          "400px",
+        );
+
+        // Navigate to Dashboard B via custom click behavior.
+        H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
+        cy.wait("@getDashboard");
+        cy.findByText("Dashboard B").should("be.visible");
+
+        // After navigation: still exactly one styled wrapper, still carrying
+        // the user height. Pre-fix, the inner SdkDashboard rendered a second
+        // wrapper with no style, dropping height and breaking sticky filters.
+        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.length",
+          1,
+        );
+        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.css",
+          "height",
+          "400px",
+        );
+
+        // Back to Dashboard A: wrapper invariant still holds.
+        cy.findByText("Back to Dashboard A").click();
+        cy.findByText("Dashboard A").should("be.visible");
+        cy.findAllByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.length",
+          1,
+        );
+        cy.findByTestId("sdk-dashboard-styled-wrapper").should(
+          "have.css",
+          "height",
+          "400px",
+        );
+      });
+    });
   });
 
   describe("same-dashboard navigation (EMB-1714)", () => {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -148,7 +148,7 @@ const SdkInternalNavigationProviderInner = ({
   const entryIndex = entryToRender ? stack.indexOf(entryToRender) : -1;
   // If the entry is the original entry, we just need to return the children.
   const entryIsOriginalEntity = stack.length === 0 || entryIndex === 0;
-  const isInsideNavigationStack = !entryIsOriginalEntity;
+  const hasNavigatedToEntity = !entryIsOriginalEntity;
 
   const value = useMemo(
     () => ({
@@ -162,9 +162,9 @@ const SdkInternalNavigationProviderInner = ({
       // the breadcrumbs.
       canGoBack: stack.filter((e) => e.type !== "metabase-browser").length > 1,
       initWithDashboard,
-      isInsideNavigationStack,
+      hasNavigatedToEntity,
     }),
-    [stack, push, pop, initWithDashboard, isInsideNavigationStack],
+    [stack, push, pop, initWithDashboard, hasNavigatedToEntity],
   );
 
   const shouldRenderBackButton = match(stack.at(-1)?.type ?? null)

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -137,6 +137,19 @@ const SdkInternalNavigationProviderInner = ({
     [stack.length],
   );
 
+  // "Virtual" entries are entries that are rendered by the previous entity (ie: drills, new question from dashboard)
+  // we don't have to render them, but we need them in the stack to make the back button work correctly
+  const nonVirtualEntries = useMemo(
+    () => stack.filter((entry) => !entry.virtual),
+    [stack],
+  );
+
+  const entryToRender = nonVirtualEntries.at(-1);
+  const entryIndex = entryToRender ? stack.indexOf(entryToRender) : -1;
+  // If the entry is the original entry, we just need to return the children.
+  const entryIsOriginalEntity = stack.length === 0 || entryIndex === 0;
+  const isInsideNavigationStack = !entryIsOriginalEntity;
+
   const value = useMemo(
     () => ({
       stack,
@@ -149,21 +162,10 @@ const SdkInternalNavigationProviderInner = ({
       // the breadcrumbs.
       canGoBack: stack.filter((e) => e.type !== "metabase-browser").length > 1,
       initWithDashboard,
+      isInsideNavigationStack,
     }),
-    [stack, push, pop, initWithDashboard],
+    [stack, push, pop, initWithDashboard, isInsideNavigationStack],
   );
-
-  // "Virtual" entries are entries that are rendered by the previous entity (ie: drills, new question from dashboard)
-  // we don't have to render them, but we need them in the stack to make the back button work correctly
-  const nonVirtualEntries = useMemo(
-    () => stack.filter((entry) => !entry.virtual),
-    [stack],
-  );
-
-  const entryToRender = nonVirtualEntries.at(-1);
-  const entryIndex = entryToRender ? stack.indexOf(entryToRender) : -1;
-  // If the entry is the original entry, we just need to return the children.
-  const entryIsOriginalEntity = stack.length === 0 || entryIndex === 0;
 
   const shouldRenderBackButton = match(stack.at(-1)?.type ?? null)
     .with(null, () => false)
@@ -182,8 +184,6 @@ const SdkInternalNavigationProviderInner = ({
     .with({ activeEntry: { type: "dashboard" } }, ({ activeEntry }) => (
       <InteractiveDashboardContent
         {...dashboardProps}
-        style={undefined}
-        className={undefined}
         dashboardId={activeEntry.id}
         initialParameters={activeEntry.parameters}
         enableEntityNavigation

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -67,6 +67,10 @@ export type SdkInternalNavigationContextValue = {
   canGoBack: boolean;
   previousEntry: SdkInternalNavigationEntry | undefined;
   initWithDashboard: (dashboard: { id: SdkDashboardId; name: string }) => void;
+  // True when nav stack has pushed beyond the original entity. SdkDashboard reads
+  // this to skip its own styled wrapper so the outer wrapper from the provider
+  // stays the sole styled container (height/sticky/scroll behavior preserved).
+  isInsideNavigationStack: boolean;
 };
 
 export const SdkInternalNavigationContext =

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -67,9 +67,11 @@ export type SdkInternalNavigationContextValue = {
   canGoBack: boolean;
   previousEntry: SdkInternalNavigationEntry | undefined;
   initWithDashboard: (dashboard: { id: SdkDashboardId; name: string }) => void;
-  // True when nav stack has pushed beyond the original entity. SdkDashboard reads
-  // this to skip its own styled wrapper so the outer wrapper from the provider
-  // stays the sole styled container (height/sticky/scroll behavior preserved).
+  /**
+   * True when nav stack has pushed beyond the original entity. SdkDashboard reads
+   * this to skip its own styled wrapper so the outer wrapper from the provider
+   * stays the sole styled container (height/sticky/scroll behavior preserved).
+   */
   isInsideNavigationStack: boolean;
 };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -72,7 +72,7 @@ export type SdkInternalNavigationContextValue = {
    * this to skip its own styled wrapper so the outer wrapper from the provider
    * stays the sole styled container (height/sticky/scroll behavior preserved).
    */
-  isInsideNavigationStack: boolean;
+  hasNavigatedToEntity: boolean;
 };
 
 export const SdkInternalNavigationContext =

--- a/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
@@ -112,6 +112,7 @@ function makeMockNavigation(
     currentEntry: undefined,
     previousEntry: undefined,
     initWithDashboard: jest.fn(),
+    isInsideNavigationStack: false,
     ...overrides,
   };
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
@@ -112,7 +112,7 @@ function makeMockNavigation(
     currentEntry: undefined,
     previousEntry: undefined,
     initWithDashboard: jest.fn(),
-    isInsideNavigationStack: false,
+    hasNavigatedToEntity: false,
     ...overrides,
   };
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -79,10 +79,7 @@ import type {
   SdkQuestionProps,
 } from "../SdkQuestion";
 
-import {
-  SdkDashboardStyledWrapper,
-  SdkDashboardStyledWrapperWithRef,
-} from "./SdkDashboardStyleWrapper";
+import { SdkDashboardStyledWrapper } from "./SdkDashboardStyleWrapper";
 import { SdkDashboardProvider } from "./context";
 import { useCommonDashboardParams } from "./use-common-dashboard-params";
 
@@ -538,10 +535,7 @@ const SdkDashboardInner = ({
       >
         {match({ finalRenderMode, isGuestEmbed })
           .with({ finalRenderMode: "question" }, () => (
-            <SdkDashboardStyledWrapperWithRef
-              className={className}
-              style={style}
-            >
+            <SdkDashboardStyledWrapper className={className} style={style}>
               <SdkAdHocQuestion
                 // `adhocQuestionUrl` would have value if renderMode is "question"
                 questionPath={adhocQuestionUrl!}
@@ -551,7 +545,7 @@ const SdkDashboardInner = ({
               >
                 {AdHocQuestionView && <AdHocQuestionView />}
               </SdkAdHocQuestion>
-            </SdkDashboardStyledWrapperWithRef>
+            </SdkDashboardStyledWrapper>
           ))
           .with({ finalRenderMode: "dashboard" }, () => (
             <SdkDashboardProvider
@@ -559,13 +553,10 @@ const SdkDashboardInner = ({
               onEditQuestion={onEditQuestion}
             >
               {children ?? (
-                <SdkDashboardStyledWrapperWithRef
-                  className={className}
-                  style={style}
-                >
+                <SdkDashboardStyledWrapper className={className} style={style}>
                   <Dashboard className={EmbedFrameS.EmbedFrame} />
                   <AutoRefreshController refreshPeriod={autoRefreshInterval} />
-                </SdkDashboardStyledWrapperWithRef>
+                </SdkDashboardStyledWrapper>
               )}
             </SdkDashboardProvider>
           ))

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -83,6 +83,25 @@ import { SdkDashboardStyledWrapper } from "./SdkDashboardStyleWrapper";
 import { SdkDashboardProvider } from "./context";
 import { useCommonDashboardParams } from "./use-common-dashboard-params";
 
+const MaybeStyledWrapper = ({
+  skip,
+  className,
+  style,
+  children,
+}: {
+  skip: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}) =>
+  skip ? (
+    <>{children}</>
+  ) : (
+    <SdkDashboardStyledWrapper className={className} style={style}>
+      {children}
+    </SdkDashboardStyledWrapper>
+  );
+
 /**
  * @interface
  * @inline
@@ -365,6 +384,11 @@ const SdkDashboardInner = ({
   const isDashboardDirty = useSelector(getIsDirty);
 
   const sdkNavigation = useSdkInternalNavigationOptional();
+  // When this SdkDashboard renders below a nav-stack push, the outer
+  // SdkInternalNavigationProvider already wraps with SdkDashboardStyledWrapper
+  // carrying user style/className. Skip our own wrapper to avoid double
+  // wrapping (which drops user height/sticky/scroll behavior).
+  const skipStyledWrapper = !!sdkNavigation?.isInsideNavigationStack;
 
   // Initialize navigation stack with dashboard entry when we have the name
   useEffect(() => {
@@ -416,17 +440,25 @@ const SdkDashboardInner = ({
 
   if (isLocaleLoading) {
     return (
-      <SdkDashboardStyledWrapper className={className} style={style}>
+      <MaybeStyledWrapper
+        skip={skipStyledWrapper}
+        className={className}
+        style={style}
+      >
         <SdkLoader />
-      </SdkDashboardStyledWrapper>
+      </MaybeStyledWrapper>
     );
   }
 
   if (tokenError) {
     return (
-      <SdkDashboardStyledWrapper className={className} style={style}>
+      <MaybeStyledWrapper
+        skip={skipStyledWrapper}
+        className={className}
+        style={style}
+      >
         <SdkError message={tokenError} />;
-      </SdkDashboardStyledWrapper>
+      </MaybeStyledWrapper>
     );
   }
 
@@ -436,9 +468,13 @@ const SdkDashboardInner = ({
 
   if (isStaticEmbeddingEntityLoadingError(errorPage, { isGuestEmbed })) {
     return (
-      <SdkDashboardStyledWrapper className={className} style={style}>
+      <MaybeStyledWrapper
+        skip={skipStyledWrapper}
+        className={className}
+        style={style}
+      >
         <SdkError message={errorPage.data ?? t`Something's gone wrong`} />
-      </SdkDashboardStyledWrapper>
+      </MaybeStyledWrapper>
     );
   }
 
@@ -449,19 +485,27 @@ const SdkDashboardInner = ({
 
   if (!dashboardId || isDashboardNotFound) {
     return (
-      <SdkDashboardStyledWrapper className={className} style={style}>
+      <MaybeStyledWrapper
+        skip={skipStyledWrapper}
+        className={className}
+        style={style}
+      >
         <DashboardNotFoundError id={dashboardId ?? ""} />
-      </SdkDashboardStyledWrapper>
+      </MaybeStyledWrapper>
     );
   }
 
   if (errorPage) {
     return (
-      <SdkDashboardStyledWrapper className={className} style={style}>
+      <MaybeStyledWrapper
+        skip={skipStyledWrapper}
+        className={className}
+        style={style}
+      >
         <SdkError
           message={errorPage.data?.message ?? t`Something's gone wrong`}
         />
-      </SdkDashboardStyledWrapper>
+      </MaybeStyledWrapper>
     );
   }
 
@@ -535,7 +579,11 @@ const SdkDashboardInner = ({
       >
         {match({ finalRenderMode, isGuestEmbed })
           .with({ finalRenderMode: "question" }, () => (
-            <SdkDashboardStyledWrapper className={className} style={style}>
+            <MaybeStyledWrapper
+              skip={skipStyledWrapper}
+              className={className}
+              style={style}
+            >
               <SdkAdHocQuestion
                 // `adhocQuestionUrl` would have value if renderMode is "question"
                 questionPath={adhocQuestionUrl!}
@@ -545,7 +593,7 @@ const SdkDashboardInner = ({
               >
                 {AdHocQuestionView && <AdHocQuestionView />}
               </SdkAdHocQuestion>
-            </SdkDashboardStyledWrapper>
+            </MaybeStyledWrapper>
           ))
           .with({ finalRenderMode: "dashboard" }, () => (
             <SdkDashboardProvider
@@ -553,20 +601,28 @@ const SdkDashboardInner = ({
               onEditQuestion={onEditQuestion}
             >
               {children ?? (
-                <SdkDashboardStyledWrapper className={className} style={style}>
+                <MaybeStyledWrapper
+                  skip={skipStyledWrapper}
+                  className={className}
+                  style={style}
+                >
                   <Dashboard className={EmbedFrameS.EmbedFrame} />
                   <AutoRefreshController refreshPeriod={autoRefreshInterval} />
-                </SdkDashboardStyledWrapper>
+                </MaybeStyledWrapper>
               )}
             </SdkDashboardProvider>
           ))
           .with({ finalRenderMode: "queryBuilder" }, ({ isGuestEmbed }) =>
             isGuestEmbed ? (
-              <SdkDashboardStyledWrapper className={className} style={style}>
+              <MaybeStyledWrapper
+                skip={skipStyledWrapper}
+                className={className}
+                style={style}
+              >
                 <SdkError
                   message={t`You can't save questions in Guest Embed mode`}
                 />
-              </SdkDashboardStyledWrapper>
+              </MaybeStyledWrapper>
             ) : (
               <DashboardQueryBuilder
                 onCreate={(question) => {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -388,7 +388,7 @@ const SdkDashboardInner = ({
   // SdkInternalNavigationProvider already wraps with SdkDashboardStyledWrapper
   // carrying user style/className. Skip our own wrapper to avoid double
   // wrapping (which drops user height/sticky/scroll behavior).
-  const skipStyledWrapper = !!sdkNavigation?.isInsideNavigationStack;
+  const skipStyledWrapper = !!sdkNavigation?.hasNavigatedToEntity;
 
   // Initialize navigation stack with dashboard entry when we have the name
   useEffect(() => {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -23,6 +23,7 @@ export const SdkDashboardStyledWrapper = ({
         CS.overflowAuto,
       )}
       style={style}
+      data-testid="sdk-dashboard-styled-wrapper"
     >
       {children}
     </Flex>

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -1,51 +1,30 @@
 import cx from "classnames";
-import { type PropsWithChildren, forwardRef } from "react";
+import type { PropsWithChildren } from "react";
 
 import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
 import CS from "metabase/css/core/index.css";
-import { useDashboardContext } from "metabase/dashboard/context";
 import { Flex } from "metabase/ui";
 
 import SdkDashboardStyleWrapperS from "./SdkDashboardStyleWrapper.module.css";
 
-export const SdkDashboardStyledWrapper = forwardRef(
-  function SdkDashboardStyledWrapperInner(
-    { className, style, children }: PropsWithChildren<CommonStylingProps>,
-    fullscreenRef: React.Ref<HTMLDivElement>,
-  ) {
-    return (
-      <Flex
-        direction="column"
-        justify="flex-start"
-        align="stretch"
-        className={cx(
-          className,
-          SdkDashboardStyleWrapperS.SdkDashboardStyleWrapper,
-          CS.overflowAuto,
-        )}
-        style={style}
-        ref={fullscreenRef}
-      >
-        {children}
-      </Flex>
-    );
-  },
-);
-
-export const SdkDashboardStyledWrapperWithRef = ({
+export const SdkDashboardStyledWrapper = ({
   className,
   style,
   children,
 }: PropsWithChildren<CommonStylingProps>) => {
-  const { fullscreenRef } = useDashboardContext();
-
   return (
-    <SdkDashboardStyledWrapper
-      className={className}
+    <Flex
+      direction="column"
+      justify="flex-start"
+      align="stretch"
+      className={cx(
+        className,
+        SdkDashboardStyleWrapperS.SdkDashboardStyleWrapper,
+        CS.overflowAuto,
+      )}
       style={style}
-      ref={fullscreenRef}
     >
       {children}
-    </SdkDashboardStyledWrapper>
+    </Flex>
   );
 };


### PR DESCRIPTION
closes EMB-1746
Closes https://github.com/metabase/metabase/issues/74312

### Description

Navigating from one dashboard to another inside `<InteractiveDashboard>` (via `enableEntityNavigation` + custom click behavior) caused the second dashboard to lose the host-provided `style` / `className` (e.g. `height: 100dvh`). Sticky filters stopped pinning and the layout reflowed full-width.

Root cause: `SdkInternalNavigationProvider` wraps navigated content in an outer `SdkDashboardStyledWrapper` carrying the host style, but `SdkDashboard` always renders its own `SdkDashboardStyledWrapper` inside. The provider intentionally forced the inner wrapper's `style`/`className` to `undefined` to avoid double padding/borders — which also stripped the height, leaving the inner wrapper without the scroll context the dashboard relies on for sticky pinning.

Fix: introduce `isInsideNavigationStack` on `SdkInternalNavigationContext`. When set, `SdkDashboard` skips its own styled wrapper so the outer provider wrapper stays the sole styled container. Drops the `style={undefined}` / `className={undefined}` overrides — no longer needed.

### How to verify

Manual repro from the ticket. Two conditions must hold or the regression is not observable:

- **Both the source and the destination dashboard need at least one filter widget at the top.** Otherwise there's no sticky element to pin.
- **Each dashboard's content height must exceed the `height` you set on `<InteractiveDashboard>`** (e.g. taller than `100dvh` if you set `style={{ height: "100dvh" }}`). Otherwise the wrapper never scrolls and the broken-vs-fixed scroll context is invisible.

Steps:

1. Sample SDK app:
   ```tsx
   <MetabaseProvider authConfig={config}>
     <InteractiveDashboard
       dashboardId="1"
       enableEntityNavigation
       style={{ height: "100dvh" }}
     />
   </MetabaseProvider>
   ```
2. Pick a source dashboard that has a filter widget AND enough cards to overflow `100dvh` (e.g. E-commerce Insights). Edit one of its cards, add a custom click behavior on a column → link to another dashboard that also has a filter widget and overflows `100dvh`.
3. Click the link. Scroll the destination dashboard.
4. Before: filter bar scrolls away with the content, layout is full-width.
   After: filter bar stays pinned at the top, layout matches the host `height: 100dvh` wrapper.

A new test has been added to `e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx`.

### Demo

#### After
<img width="1249" height="783" alt="image" src="https://github.com/user-attachments/assets/f2b3dadf-c61a-4cab-8a0f-e4e47530be74" />


#### Before
<img width="1262" height="779" alt="image" src="https://github.com/user-attachments/assets/510d7a5f-a160-489f-b1d3-a6d2a62e88aa" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)