### PR TITLE
Update first step of embed wizard

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -313,7 +313,7 @@ export function unpublishChanges(apiPath, callback) {
 }
 
 export function getParametersContainer() {
-  return cy.findByLabelText("Configuring parameters");
+  return cy.findByTestId("parameters-card");
 }
 
 export function setEmbeddingParameter(name, value) {

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -313,7 +313,7 @@ export function unpublishChanges(apiPath, callback) {
 }
 
 export function getParametersContainer() {
-  return cy.findByTestId("parameters-card");
+  return cy.findByTestId("parameters-container");
 }
 
 export function setEmbeddingParameter(name, value) {

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-setup-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-setup-helpers.ts
@@ -6,16 +6,24 @@ export const embedModalEnableEmbeddingCard = () =>
 
 export const embedModalEnableEmbedding = () => {
   cy.get("body").then(($body) => {
-    const isEmbeddingDisabled =
-      $body.find('[data-testid="enable-embedding-card"]').length > 0;
+    const $card = $body.find('[data-testid="enable-embedding-card"]');
 
-    if (isEmbeddingDisabled) {
-      embedModalEnableEmbeddingCard().within(() => {
-        cy.findByText(
-          /(Agree and (continue|enable)|Enable and continue)/,
-        ).click();
-      });
+    // No enable card on screen — terms were already accepted before mount.
+    if ($card.length === 0) {
+      return;
     }
+
+    // Once accepted, the action button becomes disabled and shows "Enabled".
+    // The card itself stays mounted, so guard against double-clicks.
+    if ($card.find("button:disabled").length > 0) {
+      return;
+    }
+
+    embedModalEnableEmbeddingCard().within(() => {
+      cy.findByText(
+        /(Agree and (continue|enable)|Enable and continue)/,
+      ).click();
+    });
   });
 };
 

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -172,6 +172,8 @@ describe("scenarios - embedding hub", () => {
       H.modal()
         .first()
         .within(() => {
+          cy.log("switch to guest auth");
+          cy.findByLabelText("Guest").click();
           cy.log("choose dashboard experience");
           cy.findByText("Dashboard").click();
           cy.log("pick a dashboard");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
@@ -114,32 +114,6 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
       cy.findByLabelText("Metabase account (SSO)").should("be.enabled");
     });
 
-    it("should reset experience to a default only when switching from SSO to Guest auth type and the current experience does not support guest embeds", () => {
-      visitNewEmbedPage();
-
-      getEmbedSidebar().within(() => {
-        cy.findByLabelText("Metabase account (SSO)").click();
-
-        cy.findByLabelText("Browser").click();
-        cy.findByLabelText("Browser").should("be.checked");
-
-        cy.findByLabelText("Guest").click();
-
-        cy.findByLabelText("Dashboard").should("be.checked");
-
-        cy.findByLabelText("Chart").click();
-        cy.findByLabelText("Chart").should("be.checked");
-
-        cy.findByLabelText("Metabase account (SSO)").click();
-
-        cy.findByLabelText("Chart").should("be.checked");
-
-        cy.findByLabelText("Guest").click();
-
-        cy.findByLabelText("Chart").should("be.checked");
-      });
-    });
-
     it("should not reset experience when changing auth type for Embed JS wizard opened from an entity page", () => {
       H.visitQuestion(ORDERS_QUESTION_ID);
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
@@ -50,6 +50,7 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      preselectGuest: true,
     });
 
     H.publishChanges("dashboard");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
@@ -154,6 +154,7 @@ describe(suiteTitle, () => {
       navigateToEmbedOptionsStep({
         experience: "dashboard",
         resourceName: "Dashboard with Remapping",
+        preselectGuest: true,
       });
 
       H.setEmbeddingParameter("Internal", "Editable");
@@ -294,6 +295,7 @@ describe(suiteTitle, () => {
       navigateToEmbedOptionsStep({
         experience: "chart",
         resourceName: "Question with Remapping",
+        preselectGuest: true,
       });
 
       H.setEmbeddingParameter("Internal", "Editable");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -135,6 +135,12 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
 
       H.waitForSimpleEmbedIframesToLoad();
 
+      // Switch to Guest auth (wizard now defaults to SSO when SSO isn't configured)
+      getEmbedSidebar().within(() => {
+        cy.findByLabelText("Guest").click();
+      });
+      embedModalEnableEmbedding();
+
       // Combined experience + resource step
       getEmbedSidebar().within(() => {
         cy.findByLabelText("Guest").should("be.visible").should("be.checked");
@@ -299,6 +305,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
         navigateToEmbedOptionsStep({
           experience: "chart",
           resourceName: FIRST_QUESTION_NAME,
+          preselectGuest: true,
         });
 
         cy.button("Unpublish").should("be.visible");
@@ -374,6 +381,7 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
         navigateToEmbedOptionsStep({
           experience: "dashboard",
           resourceName: DASHBOARD_NAME,
+          preselectGuest: true,
         });
 
         getEmbedSidebar().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -76,17 +76,19 @@ type NavigateToStepOptions =
       experience: "exploration" | "metabot";
       resourceName?: never;
       preselectSso?: boolean;
+      preselectGuest?: boolean;
     }
   | {
       experience: "dashboard" | "chart" | "browser";
       resourceName: string;
       preselectSso?: boolean;
+      preselectGuest?: boolean;
     };
 
 export const navigateToEntitySelectionStep = (
   options: NavigateToStepOptions,
 ) => {
-  const { experience, preselectSso } = options;
+  const { experience, preselectSso, preselectGuest } = options;
 
   visitNewEmbedPage();
 
@@ -99,6 +101,9 @@ export const navigateToEntitySelectionStep = (
 
   if (preselectSso || !isQuestionOrDashboardExperience) {
     cy.findByLabelText("Metabase account (SSO)").click();
+    embedModalEnableEmbedding();
+  } else if (preselectGuest) {
+    cy.findByLabelText("Guest").click();
     embedModalEnableEmbedding();
   }
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -99,6 +99,10 @@ describe(suiteTitle, () => {
       getResourceSelectorButton().should("contain", FIRST_DASHBOARD_NAME);
     });
 
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("Guest").click();
+    });
+
     cy.log("selected dashboard should be shown in the preview");
     cy.wait("@dashboard");
     H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -240,12 +240,12 @@ describe(suiteTitle, () => {
 
     getEmbedSidebar().within(() => {
       cy.findByText("Browser").click();
-      cy.findByText("Select a collection to embed").should("be.visible");
+      cy.findByText("Select initial collection").should("be.visible");
       getResourceSelectorButton().click();
     });
 
     H.entityPickerModal().within(() => {
-      cy.findByText("Select a collection").should("be.visible");
+      cy.findByText("Select default collection").should("be.visible");
 
       // The picker opens on "Recent items" by default. Navigate via the
       // root sidebar to disambiguate from any matching recent entries.

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -50,6 +50,11 @@ describe(suiteTitle, () => {
       H.waitForSimpleEmbedIframesToLoad();
 
       getEmbedSidebar().within(() => {
+        cy.findByLabelText("Guest").click();
+      });
+      embedModalEnableEmbedding();
+
+      getEmbedSidebar().within(() => {
         cy.findByText("Next").click();
       });
 
@@ -78,6 +83,11 @@ describe(suiteTitle, () => {
       visitNewEmbedPage();
       assertRecentItemName("card", questionName);
       H.expectUnstructuredSnowplowEvent({ event: "embed_wizard_opened" });
+
+      getEmbedSidebar().within(() => {
+        cy.findByLabelText("Guest").click();
+      });
+      embedModalEnableEmbedding();
 
       getEmbedSidebar().within(() => {
         cy.findByText("Chart").click();
@@ -190,6 +200,11 @@ describe(suiteTitle, () => {
       () => {
         visitNewEmbedPage();
         cy.wait("@emptyRecentItems");
+
+        getEmbedSidebar().within(() => {
+          cy.findByLabelText("Guest").click();
+        });
+        embedModalEnableEmbedding();
 
         getEmbedSidebar().within(() => {
           cy.findByText("Chart").click();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -184,6 +184,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      preselectGuest: true,
     });
 
     getEmbedSidebar()
@@ -379,6 +380,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      preselectGuest: true,
     });
 
     H.publishChanges("dashboard");
@@ -456,6 +458,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
+      preselectGuest: true,
     });
 
     H.publishChanges("card");
@@ -557,6 +560,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
+      preselectGuest: true,
     });
 
     getEmbedSidebar()
@@ -810,6 +814,7 @@ describe(suiteTitle, () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
+      preselectGuest: true,
     });
 
     H.publishChanges("dashboard");

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/NewEmbedButton/NewEmbedButton.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/NewEmbedButton/NewEmbedButton.tsx
@@ -4,7 +4,14 @@ import { useDispatch } from "metabase/redux";
 import { setOpenModalWithProps } from "metabase/redux/ui";
 import { Button } from "metabase/ui";
 
-export const NewEmbedButton = () => {
+interface NewEmbedButtonProps {
+  /**
+   * Force initial authentication mode to `guest`
+   */
+  forceIsGuest?: boolean;
+}
+
+export const NewEmbedButton = ({ forceIsGuest }: NewEmbedButtonProps) => {
   const dispatch = useDispatch();
 
   return (
@@ -17,7 +24,7 @@ export const NewEmbedButton = () => {
             id: "embed",
             props: {
               initialState: {
-                isGuest: true,
+                isGuest: forceIsGuest,
                 useExistingUserSession: true,
               },
             },

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/SharedCombinedEmbeddingSettings/SharedCombinedEmbeddingSettings.tsx
@@ -45,7 +45,7 @@ export function SharedCombinedEmbeddingSettings({
         title={t`Enable guest embeds`}
         description={t`A secure way to embed charts and dashboards, without single sign-on, when you don’t want to offer ad-hoc querying or chart drill-through.`}
         settingKey="enable-embedding-static"
-        actionButton={<NewEmbedButton />}
+        actionButton={<NewEmbedButton forceIsGuest />}
         sdk-setting-card
         testId="guest-embeds-setting-card"
       />

--- a/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/embedding/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -80,6 +80,7 @@ export const ParametersSettings = ({
     <>
       <StaticEmbedSetupPaneSettingsContentSection
         title={t`Configuring parameters`}
+        data-testid="parameters-container"
       >
         <Stack gap="1rem">
           <Text>{t`Parameters are disabled by default, which also makes them hidden from end-users. Make them editable so that end-users can see and modify them. Make them locked so that they are hidden from end-users but you can set their values from your app.`}</Text>

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -36,12 +36,7 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
           title: t`Get embed snippet`,
           description: t`Embed a dashboard, question, the query builder or the collection browser. Configure the experience and customize the appearance.`,
           onClick: () => {
-            openEmbedModal({
-              initialState: {
-                isGuest: true,
-                useExistingUserSession: true,
-              },
-            });
+            openEmbedModal({ initialState: {} });
           },
           variant: "outline",
         },

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
@@ -3,14 +3,8 @@ import { t } from "ttag";
 import { Card, Radio, Stack, Text } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../../context";
-import {
-  DEFAULT_EXPERIENCE,
-  useHandleExperienceChange,
-} from "../../hooks/use-handle-experience-change";
 import { getAuthTypeForSettings } from "../../utils/get-auth-type-for-settings";
 import { getResourceTypeFromExperience } from "../../utils/get-resource-type-from-experience";
-import { hasAuthToSelect } from "../../utils/has-auth-to-select";
-import { isStepWithResource } from "../../utils/is-step-with-resource";
 import { SetupSsoAlert } from "../Common/SetupSsoAlert";
 import { DatabaseRoutingWarning } from "../DatabaseRoutingWarning";
 
@@ -36,7 +30,6 @@ export const AuthenticationCard = () => {
     isGuestEmbedsEnabled,
     isGuestEmbedsTermsAccepted,
   } = useSdkIframeEmbedSetupContext();
-  const handleEmbedExperienceChange = useHandleExperienceChange();
 
   const resourceType = getResourceTypeFromExperience(experience);
   const authType = getAuthTypeForSettings(settings);
@@ -45,22 +38,9 @@ export const AuthenticationCard = () => {
     !isSsoEnabledAndConfigured && authType === "sso";
 
   const handleAuthTypeChange = (value: string) => {
-    const isGuest = value === "guest-embed";
-    const isSso = value === "sso";
-
-    // Reset experience to default when switching to guest embeds from non-supported experience
-    const shouldSwitchExperience =
-      isGuest &&
-      !isStepWithResource(currentStep) &&
-      !hasAuthToSelect(experience);
-
-    if (shouldSwitchExperience) {
-      handleEmbedExperienceChange(DEFAULT_EXPERIENCE);
-    }
-
     updateSettings({
-      isGuest,
-      isSso,
+      isGuest: value === "guest-embed",
+      isSso: value === "sso",
     });
   };
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../hooks/use-handle-experience-change";
 import { getAuthTypeForSettings } from "../../utils/get-auth-type-for-settings";
 import { getResourceTypeFromExperience } from "../../utils/get-resource-type-from-experience";
-import { isQuestionOrDashboardExperience } from "../../utils/is-question-or-dashboard-experience";
+import { hasAuthToSelect } from "../../utils/has-auth-to-select";
 import { isStepWithResource } from "../../utils/is-step-with-resource";
 import { SetupSsoAlert } from "../Common/SetupSsoAlert";
 import { DatabaseRoutingWarning } from "../DatabaseRoutingWarning";
@@ -52,7 +52,7 @@ export const AuthenticationCard = () => {
     const shouldSwitchExperience =
       isGuest &&
       !isStepWithResource(currentStep) &&
-      !isQuestionOrDashboardExperience(experience);
+      !hasAuthToSelect(experience);
 
     if (shouldSwitchExperience) {
       handleEmbedExperienceChange(DEFAULT_EXPERIENCE);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/AuthenticationCard/AuthenticationCard.tsx
@@ -11,6 +11,7 @@ import { getAuthTypeForSettings } from "../../utils/get-auth-type-for-settings";
 import { getResourceTypeFromExperience } from "../../utils/get-resource-type-from-experience";
 import { isQuestionOrDashboardExperience } from "../../utils/is-question-or-dashboard-experience";
 import { isStepWithResource } from "../../utils/is-step-with-resource";
+import { SetupSsoAlert } from "../Common/SetupSsoAlert";
 import { DatabaseRoutingWarning } from "../DatabaseRoutingWarning";
 
 import { EnableGuestEmbedsSection } from "./EnableGuestEmbedsSection";
@@ -25,6 +26,7 @@ export const AuthenticationCard = () => {
   const {
     experience,
     isSimpleEmbedFeatureAvailable,
+    isSsoEnabledAndConfigured,
     currentStep,
     settings,
     updateSettings,
@@ -38,6 +40,9 @@ export const AuthenticationCard = () => {
 
   const resourceType = getResourceTypeFromExperience(experience);
   const authType = getAuthTypeForSettings(settings);
+
+  const showSsoNotConfiguredWarning =
+    !isSsoEnabledAndConfigured && authType === "sso";
 
   const handleAuthTypeChange = (value: string) => {
     const isGuest = value === "guest-embed";
@@ -110,6 +115,8 @@ export const AuthenticationCard = () => {
             </Stack>
           </Stack>
         </Radio.Group>
+
+        {showSsoNotConfiguredWarning && <SetupSsoAlert />}
       </Stack>
     </Card>
   );

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/SetupSsoAlert.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Common/SetupSsoAlert.tsx
@@ -1,0 +1,43 @@
+import { jt, t } from "ttag";
+
+import { useDocsUrl } from "metabase/common/hooks";
+import { Alert, Anchor, Icon, Text } from "metabase/ui";
+
+import { SETUP_SSO_CAMPAIGN, UTM_LOCATION } from "../../analytics";
+
+const utmTags = {
+  utm_source: "product",
+  utm_medium: "docs",
+  utm_campaign: SETUP_SSO_CAMPAIGN,
+  utm_content: UTM_LOCATION,
+};
+
+export const SetupSsoAlert = () => {
+  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- Only for admins
+  const { url: setupSsoUrl } = useDocsUrl("embedding/sdk/authentication", {
+    utm: utmTags,
+  });
+
+  return (
+    <Alert
+      icon={
+        <Icon name="warning_triangle_filled" c="text-secondary" size={16} />
+      }
+      color="warning"
+    >
+      <Text size="md" lh="lg">
+        {jt`This embed will only work for local testing. To get production ready code, configure ${(
+          <Anchor
+            key="configure-sso"
+            href={setupSsoUrl}
+            target="_blank"
+            size="md"
+            lh="lg"
+          >
+            {t`JWT SSO or SAML`}
+          </Anchor>
+        )}.`}
+      </Text>
+    </Alert>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
@@ -13,7 +13,7 @@ export const ParametersCard = () => {
   }
 
   return (
-    <Card p="md" data-testid="parameters-card">
+    <Card p="md" data-testid="parameters-container">
       <Text size="lg" fw="bold" mb="xs">
         {t`Parameters`}
       </Text>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
@@ -13,7 +13,7 @@ export const ParametersCard = () => {
   }
 
   return (
-    <Card p="md" data-testid="parameters-container">
+    <Card p="md">
       <Text size="lg" fw="bold" mb="xs">
         {t`Parameters`}
       </Text>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/ParametersCard.tsx
@@ -13,7 +13,7 @@ export const ParametersCard = () => {
   }
 
   return (
-    <Card p="md">
+    <Card p="md" data-testid="parameters-card">
       <Text size="lg" fw="bold" mb="xs">
         {t`Parameters`}
       </Text>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ExperienceCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ExperienceCard.tsx
@@ -7,7 +7,7 @@ import { getEmbedExperiences } from "../../../constants";
 import { useSdkIframeEmbedSetupContext } from "../../../context";
 import { useHandleExperienceChange } from "../../../hooks/use-handle-experience-change";
 import type { SdkIframeEmbedSetupExperience } from "../../../types";
-import { isQuestionOrDashboardExperience } from "../../../utils/is-question-or-dashboard-experience";
+import { hasAuthToSelect } from "../../../utils/has-auth-to-select";
 import { SetupSsoAlert } from "../../Common/SetupSsoAlert";
 
 export const ExperienceCard = () => {
@@ -30,7 +30,7 @@ export const ExperienceCard = () => {
   });
 
   const showSsoNotConfiguredWarning =
-    !isSsoEnabledAndConfigured && !isQuestionOrDashboardExperience(experience);
+    !isSsoEnabledAndConfigured && !hasAuthToSelect(experience);
 
   return (
     <Card p="md">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ExperienceCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ExperienceCard.tsx
@@ -7,10 +7,16 @@ import { getEmbedExperiences } from "../../../constants";
 import { useSdkIframeEmbedSetupContext } from "../../../context";
 import { useHandleExperienceChange } from "../../../hooks/use-handle-experience-change";
 import type { SdkIframeEmbedSetupExperience } from "../../../types";
+import { isQuestionOrDashboardExperience } from "../../../utils/is-question-or-dashboard-experience";
+import { SetupSsoAlert } from "../../Common/SetupSsoAlert";
 
 export const ExperienceCard = () => {
-  const { isSimpleEmbedFeatureAvailable, experience, settings } =
-    useSdkIframeEmbedSetupContext();
+  const {
+    isSimpleEmbedFeatureAvailable,
+    isSsoEnabledAndConfigured,
+    experience,
+    settings,
+  } = useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
   const isMetabotAvailable = useMetabotEnabledEmbeddingAware({
@@ -23,39 +29,46 @@ export const ExperienceCard = () => {
     isMetabotAvailable,
   });
 
+  const showSsoNotConfiguredWarning =
+    !isSsoEnabledAndConfigured && !isQuestionOrDashboardExperience(experience);
+
   return (
     <Card p="md">
-      <Text size="lg" fw="bold" mb="md">
-        {t`Select your embed experience`}
-      </Text>
+      <Stack gap="md">
+        <Text size="lg" fw="bold">
+          {t`Select your embed experience`}
+        </Text>
 
-      <Radio.Group
-        value={experience}
-        onChange={(experience) =>
-          handleEmbedExperienceChange(
-            experience as SdkIframeEmbedSetupExperience,
-          )
-        }
-      >
-        <Stack gap="md">
-          {experiences.map((experience) => (
-            <Radio
-              key={experience.value}
-              value={experience.value}
-              label={
-                <Flex gap="xs" align="center">
-                  {experience.title}
-                </Flex>
-              }
-              description={experience.description}
-              disabled={
-                (!experience.supportsOss && !isSimpleEmbedFeatureAvailable) ||
-                (!experience.supportsGuestEmbed && isGuestEmbed)
-              }
-            />
-          ))}
-        </Stack>
-      </Radio.Group>
+        <Radio.Group
+          value={experience}
+          onChange={(experience) =>
+            handleEmbedExperienceChange(
+              experience as SdkIframeEmbedSetupExperience,
+            )
+          }
+        >
+          <Stack gap="md">
+            {experiences.map((experience) => (
+              <Radio
+                key={experience.value}
+                value={experience.value}
+                label={
+                  <Flex gap="xs" align="center">
+                    {experience.title}
+                  </Flex>
+                }
+                description={experience.description}
+                disabled={
+                  (!experience.supportsOss && !isSimpleEmbedFeatureAvailable) ||
+                  (!experience.supportsGuestEmbed && isGuestEmbed)
+                }
+              />
+            ))}
+          </Stack>
+        </Radio.Group>
+
+        {showSsoNotConfiguredWarning && <SetupSsoAlert />}
+      </Stack>
     </Card>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
@@ -2,7 +2,9 @@ import { useDisclosure } from "@mantine/hooks";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { skipToken, useGetCollectionQuery } from "metabase/api";
 import {
+  CollectionPickerModal,
   DashboardPickerModal,
   QuestionPickerModal,
 } from "metabase/common/components/Pickers";
@@ -33,6 +35,7 @@ export const ResourceCard = () => {
     resource,
     recentDashboards,
     recentQuestions,
+    recentCollections,
     addRecentItem,
   } = useSdkIframeEmbedSetupContext();
 
@@ -41,6 +44,12 @@ export const ResourceCard = () => {
 
   const selectedItemId = getResourceIdFromSettings(settings);
 
+  const { data: selectedCollection } = useGetCollectionQuery(
+    experience === "browser" && selectedItemId != null
+      ? { id: selectedItemId as CollectionId }
+      : skipToken,
+  );
+
   if (!hasResourceSelectionStep(experience)) {
     return null;
   }
@@ -48,9 +57,14 @@ export const ResourceCard = () => {
   const recentItems = match(experience)
     .with("dashboard", () => recentDashboards)
     .with("chart", () => recentQuestions)
+    .with("browser", () => recentCollections)
     .exhaustive();
 
-  const selectedResourceName = resource?.name;
+  const selectedResourceName = match(experience)
+    .with("dashboard", () => resource?.name)
+    .with("chart", () => resource?.name)
+    .with("browser", () => selectedCollection?.name)
+    .exhaustive();
 
   const fallbackResourceName = recentItems.find(
     (item) => item.id === selectedItemId,
@@ -65,7 +79,10 @@ export const ResourceCard = () => {
     // Do not update if the selected item is already selected.
     if (
       (experience === "dashboard" && settings.dashboardId === id) ||
-      (experience === "chart" && settings.questionId === id)
+      (experience === "chart" && settings.questionId === id) ||
+      (experience === "browser" &&
+        settings.componentName === "metabase-browser" &&
+        settings.initialCollection === id)
     ) {
       return;
     }
@@ -88,6 +105,10 @@ export const ResourceCard = () => {
         hiddenParameters: [],
         lockedParameters: [],
       });
+    } else if (experience === "browser") {
+      updateSettings({
+        initialCollection: id as CollectionId,
+      });
     }
   };
 
@@ -107,6 +128,7 @@ export const ResourceCard = () => {
     >(experience)
       .with("chart", () => "question")
       .with("dashboard", () => "dashboard")
+      .with("browser", () => "collection")
       .exhaustive();
 
     addRecentItem(resourceType, {
@@ -141,6 +163,18 @@ export const ResourceCard = () => {
           onChange={handlePickerModalResourceSelect}
           onClose={closePicker}
           options={MODAL_OPTIONS}
+        />
+      );
+    }
+
+    if (experience === "browser") {
+      return (
+        <CollectionPickerModal
+          title={t`Select default collection`}
+          value={PICKER_RECENTS_VALUE}
+          onChange={handlePickerModalResourceSelect}
+          onClose={closePicker}
+          options={COLLECTION_MODAL_OPTIONS}
         />
       );
     }
@@ -200,12 +234,24 @@ const getResourceCopy = (experience: ResourceExperience) =>
       placeholder: t`Select a chart`,
       label: t`Change chart`,
     }))
+    .with("browser", () => ({
+      title: t`Select initial collection`,
+      icon: "collection",
+      placeholder: t`Select initial collection`,
+      label: t`Change initial collection`,
+    }))
     .exhaustive();
 
 const MODAL_OPTIONS = {
   showPersonalCollections: true,
   showRootCollection: true,
   hasConfirmButtons: false,
+} as const;
+
+const COLLECTION_MODAL_OPTIONS = {
+  showPersonalCollections: true,
+  showRootCollection: true,
+  hasConfirmButtons: true,
 } as const;
 
 const hasResourceSelectionStep = (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
@@ -56,8 +56,8 @@ export const ResourceCard = () => {
 
   const recentItems = match(experience)
     .with("dashboard", () => recentDashboards)
-    .with("chart", () => recentQuestions)
     .with("browser", () => recentCollections)
+    .with("chart", () => recentQuestions)
     .exhaustive();
 
   const selectedResourceName = match(experience)
@@ -73,15 +73,14 @@ export const ResourceCard = () => {
   const { title, icon, placeholder, label } = getResourceCopy(experience);
 
   const updateEmbedSettings = (
-    experience: ResourceExperience,
+    experience: SdkIframeEmbedSetupExperience,
     id: string | number,
   ) => {
     // Do not update if the selected item is already selected.
     if (
       (experience === "dashboard" && settings.dashboardId === id) ||
       (experience === "chart" && settings.questionId === id) ||
-      (experience === "browser" &&
-        settings.componentName === "metabase-browser" &&
+      (settings.componentName === "metabase-browser" &&
         settings.initialCollection === id)
     ) {
       return;
@@ -127,8 +126,8 @@ export const ResourceCard = () => {
       SdkIframeEmbedSetupRecentItemType
     >(experience)
       .with("chart", () => "question")
-      .with("dashboard", () => "dashboard")
       .with("browser", () => "collection")
+      .with("dashboard", () => "dashboard")
       .exhaustive();
 
     addRecentItem(resourceType, {
@@ -256,7 +255,10 @@ const COLLECTION_MODAL_OPTIONS = {
 
 const hasResourceSelectionStep = (
   experience: SdkIframeEmbedSetupExperience,
-): experience is ResourceExperience =>
+): experience is Exclude<
+  SdkIframeEmbedSetupExperience,
+  (typeof EXPERIENCES_WITHOUT_RESOURCE_SELECTION)[number]
+> =>
   !(
     EXPERIENCES_WITHOUT_RESOURCE_SELECTION as SdkIframeEmbedSetupExperience[]
   ).includes(experience);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/ResourceCard.tsx
@@ -2,9 +2,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
-import { skipToken, useGetCollectionQuery } from "metabase/api";
 import {
-  CollectionPickerModal,
   DashboardPickerModal,
   QuestionPickerModal,
 } from "metabase/common/components/Pickers";
@@ -35,7 +33,6 @@ export const ResourceCard = () => {
     resource,
     recentDashboards,
     recentQuestions,
-    recentCollections,
     addRecentItem,
   } = useSdkIframeEmbedSetupContext();
 
@@ -44,27 +41,16 @@ export const ResourceCard = () => {
 
   const selectedItemId = getResourceIdFromSettings(settings);
 
-  const { data: selectedCollection } = useGetCollectionQuery(
-    experience === "browser" && selectedItemId != null
-      ? { id: selectedItemId as CollectionId }
-      : skipToken,
-  );
-
   if (!hasResourceSelectionStep(experience)) {
     return null;
   }
 
   const recentItems = match(experience)
     .with("dashboard", () => recentDashboards)
-    .with("browser", () => recentCollections)
     .with("chart", () => recentQuestions)
     .exhaustive();
 
-  const selectedResourceName = match(experience)
-    .with("dashboard", () => resource?.name)
-    .with("chart", () => resource?.name)
-    .with("browser", () => selectedCollection?.name)
-    .exhaustive();
+  const selectedResourceName = resource?.name;
 
   const fallbackResourceName = recentItems.find(
     (item) => item.id === selectedItemId,
@@ -73,15 +59,13 @@ export const ResourceCard = () => {
   const { title, icon, placeholder, label } = getResourceCopy(experience);
 
   const updateEmbedSettings = (
-    experience: SdkIframeEmbedSetupExperience,
+    experience: ResourceExperience,
     id: string | number,
   ) => {
     // Do not update if the selected item is already selected.
     if (
       (experience === "dashboard" && settings.dashboardId === id) ||
-      (experience === "chart" && settings.questionId === id) ||
-      (settings.componentName === "metabase-browser" &&
-        settings.initialCollection === id)
+      (experience === "chart" && settings.questionId === id)
     ) {
       return;
     }
@@ -104,10 +88,6 @@ export const ResourceCard = () => {
         hiddenParameters: [],
         lockedParameters: [],
       });
-    } else if (experience === "browser") {
-      updateSettings({
-        initialCollection: id as CollectionId,
-      });
     }
   };
 
@@ -126,7 +106,6 @@ export const ResourceCard = () => {
       SdkIframeEmbedSetupRecentItemType
     >(experience)
       .with("chart", () => "question")
-      .with("browser", () => "collection")
       .with("dashboard", () => "dashboard")
       .exhaustive();
 
@@ -162,18 +141,6 @@ export const ResourceCard = () => {
           onChange={handlePickerModalResourceSelect}
           onClose={closePicker}
           options={MODAL_OPTIONS}
-        />
-      );
-    }
-
-    if (experience === "browser") {
-      return (
-        <CollectionPickerModal
-          title={t`Select a collection`}
-          value={PICKER_RECENTS_VALUE}
-          onChange={handlePickerModalResourceSelect}
-          onClose={closePicker}
-          options={COLLECTION_MODAL_OPTIONS}
         />
       );
     }
@@ -233,12 +200,6 @@ const getResourceCopy = (experience: ResourceExperience) =>
       placeholder: t`Select a chart`,
       label: t`Change chart`,
     }))
-    .with("browser", () => ({
-      title: t`Select a collection to embed`,
-      icon: "collection",
-      placeholder: t`Select a collection`,
-      label: t`Change collection`,
-    }))
     .exhaustive();
 
 const MODAL_OPTIONS = {
@@ -247,18 +208,9 @@ const MODAL_OPTIONS = {
   hasConfirmButtons: false,
 } as const;
 
-const COLLECTION_MODAL_OPTIONS = {
-  showPersonalCollections: true,
-  showRootCollection: true,
-  hasConfirmButtons: true,
-} as const;
-
 const hasResourceSelectionStep = (
   experience: SdkIframeEmbedSetupExperience,
-): experience is Exclude<
-  SdkIframeEmbedSetupExperience,
-  (typeof EXPERIENCES_WITHOUT_RESOURCE_SELECTION)[number]
-> =>
+): experience is ResourceExperience =>
   !(
     EXPERIENCES_WITHOUT_RESOURCE_SELECTION as SdkIframeEmbedSetupExperience[]
   ).includes(experience);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/SelectEmbedExperienceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/SelectEmbedExperienceStep.tsx
@@ -5,6 +5,7 @@ import { Box, Stack } from "metabase/ui";
 
 import { UPSELL_CAMPAIGN_EXPERIENCE } from "../../../analytics";
 import { useSdkIframeEmbedSetupContext } from "../../../context";
+import { isQuestionOrDashboardExperience } from "../../../utils/is-question-or-dashboard-experience";
 import { AuthenticationCard } from "../../AuthenticationCard";
 import { EmbeddingUpsell } from "../../Common/EmbeddingUpsell";
 
@@ -12,7 +13,10 @@ import { ExperienceCard } from "./ExperienceCard";
 import { ResourceCard } from "./ResourceCard";
 
 export const SelectEmbedExperienceStep = () => {
-  const { allowPreviewAndNavigation } = useSdkIframeEmbedSetupContext();
+  const { allowPreviewAndNavigation, experience } =
+    useSdkIframeEmbedSetupContext();
+
+  const showAuthAndResource = isQuestionOrDashboardExperience(experience);
 
   // Authentication is interactive even when preview/navigation is disabled
   // (otherwise the user couldn't switch auth type or accept terms to unblock).
@@ -27,12 +31,19 @@ export const SelectEmbedExperienceStep = () => {
         <ExperienceCard />
       </Box>
 
-      <AuthenticationCard />
+      {showAuthAndResource && (
+        <>
+          <AuthenticationCard />
 
-      <Stack gap="md" {...dimmedProps}>
-        <ResourceCard />
+          <Box {...dimmedProps}>
+            <ResourceCard />
+          </Box>
+        </>
+      )}
+
+      <Box {...dimmedProps}>
         <EmbeddingUpsell campaign={UPSELL_CAMPAIGN_EXPERIENCE} />
-      </Stack>
+      </Box>
     </Stack>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/SelectEmbedExperienceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/SelectEmbedExperienceStep/SelectEmbedExperienceStep.tsx
@@ -5,7 +5,8 @@ import { Box, Stack } from "metabase/ui";
 
 import { UPSELL_CAMPAIGN_EXPERIENCE } from "../../../analytics";
 import { useSdkIframeEmbedSetupContext } from "../../../context";
-import { isQuestionOrDashboardExperience } from "../../../utils/is-question-or-dashboard-experience";
+import { hasAuthToSelect } from "../../../utils/has-auth-to-select";
+import { hasResourceToSelect } from "../../../utils/has-resource-to-select";
 import { AuthenticationCard } from "../../AuthenticationCard";
 import { EmbeddingUpsell } from "../../Common/EmbeddingUpsell";
 
@@ -16,7 +17,8 @@ export const SelectEmbedExperienceStep = () => {
   const { allowPreviewAndNavigation, experience } =
     useSdkIframeEmbedSetupContext();
 
-  const showAuthAndResource = isQuestionOrDashboardExperience(experience);
+  const showAuth = hasAuthToSelect(experience);
+  const showResource = hasResourceToSelect(experience);
 
   // Authentication is interactive even when preview/navigation is disabled
   // (otherwise the user couldn't switch auth type or accept terms to unblock).
@@ -31,14 +33,12 @@ export const SelectEmbedExperienceStep = () => {
         <ExperienceCard />
       </Box>
 
-      {showAuthAndResource && (
-        <>
-          <AuthenticationCard />
+      {showAuth && <AuthenticationCard />}
 
-          <Box {...dimmedProps}>
-            <ResourceCard />
-          </Box>
-        </>
+      {showResource && (
+        <Box {...dimmedProps}>
+          <ResourceCard />
+        </Box>
       )}
 
       <Box {...dimmedProps}>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -138,7 +138,9 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(
       screen.queryByText("Select a dashboard to embed"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Select initial collection")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Change initial collection" }),
+    ).toBeInTheDocument();
   });
 
   it("renders the SSO radio above the Guest radio in the authentication card", () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import {
   setupCardEndpoints,
   setupCardQueryMetadataEndpoint,
-  setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { screen, waitFor } from "__support__/ui";
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
@@ -205,7 +204,6 @@ describe("Embed flow > forward and backward navigation", () => {
     const mockDatabase = createMockDatabase();
     const mockCard = createMockCard({ id: 456 });
 
-    setupDatabasesEndpoints([mockDatabase]);
     setupCardEndpoints(mockCard);
     setupCardQueryMetadataEndpoint(
       mockCard,
@@ -237,7 +235,6 @@ describe("Embed flow > Pro feature upsell indicators", () => {
     const mockDatabase = createMockDatabase();
     const mockCard = createMockCard({ id: 456 });
 
-    setupDatabasesEndpoints([mockDatabase]);
     setupCardEndpoints(mockCard);
     setupCardQueryMetadataEndpoint(
       mockCard,
@@ -279,7 +276,6 @@ describe("Embed flow > Pro feature upsell indicators", () => {
     const mockDatabase = createMockDatabase();
     const mockCard = createMockCard({ id: 456 });
 
-    setupDatabasesEndpoints([mockDatabase]);
     setupCardEndpoints(mockCard);
     setupCardQueryMetadataEndpoint(
       mockCard,
@@ -320,8 +316,6 @@ describe("Embed flow > Pro feature upsell indicators", () => {
   });
 
   it("disables Pro checkboxes for OSS users (dashboard)", () => {
-    setupDatabasesEndpoints([createMockDatabase()]);
-
     setup({
       simpleEmbeddingEnabled: false,
       initialState: {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -110,6 +110,88 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(screen.getByText("Appearance")).toBeInTheDocument();
   });
 
+  describe.each(["Exploration", "Browser"])(
+    "when %s is selected",
+    (experienceLabel) => {
+      it("hides the authentication and resource selection cards", async () => {
+        setup({ simpleEmbeddingEnabled: true });
+
+        expect(screen.getByText("Authentication")).toBeInTheDocument();
+        expect(
+          screen.getByText("Select a dashboard to embed"),
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+          screen.getByRole("radio", { name: new RegExp(experienceLabel) }),
+        );
+
+        expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Select a dashboard to embed"),
+        ).not.toBeInTheDocument();
+      });
+    },
+  );
+
+  it("renders the SSO radio above the Guest radio in the authentication card", () => {
+    setup({ simpleEmbeddingEnabled: true });
+
+    const radios = screen.getAllByRole("radio");
+    const ssoIndex = radios.findIndex((r) => r.getAttribute("value") === "sso");
+    const guestIndex = radios.findIndex(
+      (r) => r.getAttribute("value") === "guest-embed",
+    );
+
+    expect(ssoIndex).toBeGreaterThanOrEqual(0);
+    expect(guestIndex).toBeGreaterThanOrEqual(0);
+    expect(ssoIndex).toBeLessThan(guestIndex);
+  });
+
+  describe("SSO not configured warnings", () => {
+    const warningText =
+      /This embed will only work for local testing\. To get production ready code, configure/;
+
+    it("shows a warning on the authentication card when SSO is selected but not configured", () => {
+      setup({ simpleEmbeddingEnabled: true, jwtReady: false });
+
+      expect(screen.getByDisplayValue("sso")).toBeChecked();
+      expect(screen.getByText("Authentication")).toBeInTheDocument();
+      expect(screen.getByText(warningText)).toBeInTheDocument();
+    });
+
+    it("hides the warning when Guest is selected", async () => {
+      setup({ simpleEmbeddingEnabled: true, jwtReady: false });
+
+      await userEvent.click(screen.getByRole("radio", { name: "Guest" }));
+
+      expect(screen.queryByText(warningText)).not.toBeInTheDocument();
+    });
+
+    it("hides the warning when SSO is configured", () => {
+      setup({ simpleEmbeddingEnabled: true, jwtReady: true });
+
+      expect(screen.queryByText(warningText)).not.toBeInTheDocument();
+    });
+
+    it("shows a warning on the experience card when Exploration is selected and SSO is not configured", async () => {
+      setup({ simpleEmbeddingEnabled: true, jwtReady: false });
+
+      await userEvent.click(screen.getByRole("radio", { name: /Exploration/ }));
+
+      expect(screen.getByText(warningText)).toBeInTheDocument();
+      // Authentication card is hidden so its warning is gone
+      expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+    });
+
+    it("hides the experience card warning when Exploration is selected and SSO is configured", async () => {
+      setup({ simpleEmbeddingEnabled: true, jwtReady: true });
+
+      await userEvent.click(screen.getByRole("radio", { name: /Exploration/ }));
+
+      expect(screen.queryByText(warningText)).not.toBeInTheDocument();
+    });
+  });
+
   it("disables next and back buttons when simple embedding is disabled", () => {
     setup({ simpleEmbeddingEnabled: false });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -109,28 +109,37 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(screen.getByText("Appearance")).toBeInTheDocument();
   });
 
-  describe.each(["Exploration", "Browser"])(
-    "when %s is selected",
-    (experienceLabel) => {
-      it("hides the authentication and resource selection cards", async () => {
-        setup({ simpleEmbeddingEnabled: true });
+  it("hides the authentication and resource cards when Exploration is selected", async () => {
+    setup({ simpleEmbeddingEnabled: true });
 
-        expect(screen.getByText("Authentication")).toBeInTheDocument();
-        expect(
-          screen.getByText("Select a dashboard to embed"),
-        ).toBeInTheDocument();
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+    expect(screen.getByText("Select a dashboard to embed")).toBeInTheDocument();
 
-        await userEvent.click(
-          screen.getByRole("radio", { name: new RegExp(experienceLabel) }),
-        );
+    await userEvent.click(screen.getByRole("radio", { name: /Exploration/ }));
 
-        expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
-        expect(
-          screen.queryByText("Select a dashboard to embed"),
-        ).not.toBeInTheDocument();
-      });
-    },
-  );
+    expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Select a dashboard to embed"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Select initial collection"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the authentication card but keeps the resource card (as a collection picker) when Browser is selected", async () => {
+    setup({ simpleEmbeddingEnabled: true });
+
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+    expect(screen.getByText("Select a dashboard to embed")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("radio", { name: /Browser/ }));
+
+    expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Select a dashboard to embed"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Select initial collection")).toBeInTheDocument();
+  });
 
   it("renders the SSO radio above the Guest radio in the authentication card", () => {
     setup({ simpleEmbeddingEnabled: true });
@@ -172,15 +181,20 @@ describe("Embed flow > forward and backward navigation", () => {
       expect(screen.queryByText(warningText)).not.toBeInTheDocument();
     });
 
-    it("shows a warning on the experience card when Exploration is selected and SSO is not configured", async () => {
-      setup({ simpleEmbeddingEnabled: true, jwtReady: false });
+    it.each(["Exploration", "Browser"])(
+      "shows a warning on the experience card when %s is selected and SSO is not configured",
+      async (experienceLabel) => {
+        setup({ simpleEmbeddingEnabled: true, jwtReady: false });
 
-      await userEvent.click(screen.getByRole("radio", { name: /Exploration/ }));
+        await userEvent.click(
+          screen.getByRole("radio", { name: new RegExp(experienceLabel) }),
+        );
 
-      expect(screen.getByText(warningText)).toBeInTheDocument();
-      // Authentication card is hidden so its warning is gone
-      expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
-    });
+        expect(screen.getByText(warningText)).toBeInTheDocument();
+        // Authentication card is hidden so its warning is gone
+        expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+      },
+    );
 
     it("hides the experience card warning when Exploration is selected and SSO is configured", async () => {
       setup({ simpleEmbeddingEnabled: true, jwtReady: true });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -157,6 +157,17 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(ssoIndex).toBeLessThan(guestIndex);
   });
 
+  it("selects Guest when initialState.isGuest is true, even with SSO configured", () => {
+    setup({
+      simpleEmbeddingEnabled: true,
+      jwtReady: true,
+      initialState: { isGuest: true, useExistingUserSession: true },
+    });
+
+    expect(screen.getByDisplayValue("guest-embed")).toBeChecked();
+    expect(screen.getByDisplayValue("sso")).not.toBeChecked();
+  });
+
   describe("SSO not configured warnings", () => {
     const warningText =
       /This embed will only work for local testing\. To get production ready code, configure/;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -5,6 +5,7 @@ import {
   findRequests,
   setupDashboardEndpoints,
   setupDashboardQueryMetadataEndpoint,
+  setupDatabasesEndpoints,
   setupNotificationChannelsEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
@@ -60,6 +61,7 @@ export const setup = (options?: {
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);
   setupSearchEndpoints([]);
+  setupDatabasesEndpoints([mockDatabase]);
   setupDashboardEndpoints(mockDashboard);
   setupDashboardQueryMetadataEndpoint(
     mockDashboard,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -3,6 +3,7 @@ import fetchMock from "fetch-mock";
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   findRequests,
+  setupCollectionByIdEndpoint,
   setupDashboardEndpoints,
   setupDashboardQueryMetadataEndpoint,
   setupDatabasesEndpoints,
@@ -17,6 +18,7 @@ import { renderWithProviders, waitFor } from "__support__/ui";
 import type { SdkIframeEmbedSetupModalInitialState } from "metabase/plugins";
 import { createMockState } from "metabase/redux/store/mocks";
 import {
+  createMockCollection,
   createMockDashboard,
   createMockDashboardQueryMetadata,
   createMockDatabase,
@@ -62,6 +64,9 @@ export const setup = (options?: {
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);
   setupSearchEndpoints([]);
   setupDatabasesEndpoints([mockDatabase]);
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection({ id: "root", name: "Our analytics" })],
+  });
   setupDashboardEndpoints(mockDashboard);
   setupDashboardQueryMetadataEndpoint(
     mockDashboard,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
@@ -72,6 +72,7 @@ type EmbedStepConfig = {
 export const EXPERIENCES_WITHOUT_RESOURCE_SELECTION = [
   "exploration",
   "metabot",
+  "browser",
 ] as const satisfies SdkIframeEmbedSetupExperience[];
 
 export const EMBED_STEPS: EmbedStepConfig[] = [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/constants.ts
@@ -72,7 +72,6 @@ type EmbedStepConfig = {
 export const EXPERIENCES_WITHOUT_RESOURCE_SELECTION = [
   "exploration",
   "metabot",
-  "browser",
 ] as const satisfies SdkIframeEmbedSetupExperience[];
 
 export const EMBED_STEPS: EmbedStepConfig[] = [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-handle-experience-change.ts
@@ -10,8 +10,6 @@ import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding
 import { determineDashboardId } from "metabase/embedding/embedding-iframe-sdk-setup/utils/determine-dashboard-id";
 import { getDefaultSdkIframeEmbedSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting";
 
-export const DEFAULT_EXPERIENCE = "dashboard";
-
 export const useHandleExperienceChange = () => {
   const {
     isSimpleEmbedFeatureAvailable,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
@@ -17,15 +17,15 @@ const GET_ENABLE_GUEST_EMBED_SETTINGS: (data: {
   isSimpleEmbedFeatureAvailable,
   experience,
 }) => {
-  const isQuestionOrDashboardEmbed = hasAuthToSelect(experience);
+  const needsAuthChoice = hasAuthToSelect(experience);
 
   return {
-    ...(isQuestionOrDashboardEmbed
+    ...(needsAuthChoice
       ? {
           isGuest: true,
           isSso: false,
           useExistingUserSession: false,
-          ...(isQuestionOrDashboardEmbed && {
+          ...(needsAuthChoice && {
             drills: false,
             // We force set `downloads` to `true` when the `simple embedding` feature is not enabled (OSS)
             ...(!isSimpleEmbedFeatureAvailable && {
@@ -52,10 +52,10 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
     SdkIframeDashboardEmbedSettings | SdkIframeQuestionEmbedSettings,
     "lockedParameters"
   > = ({ experience, isSsoEnabledAndConfigured, useExistingUserSession }) => {
-  const isQuestionOrDashboardEmbed = hasAuthToSelect(experience);
+  const needsAuthChoice = hasAuthToSelect(experience);
 
   return {
-    ...(isQuestionOrDashboardEmbed
+    ...(needsAuthChoice
       ? {
           isGuest: false,
           isSso: true,
@@ -69,7 +69,7 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
           useExistingUserSession:
             !isSsoEnabledAndConfigured || useExistingUserSession,
         }),
-    ...(isQuestionOrDashboardEmbed && {
+    ...(needsAuthChoice && {
       // Reset hiddenParameters when switching from guest to SSO.
       // This is needed because when recentlyCreatedDashboards populates the
       // dashboardId or questionId, the embed wizard starts in guest mode and

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
@@ -1,4 +1,4 @@
-import { isQuestionOrDashboardExperience } from "metabase/embedding/embedding-iframe-sdk-setup/utils/is-question-or-dashboard-experience";
+import { hasAuthToSelect } from "metabase/embedding/embedding-iframe-sdk-setup/utils/has-auth-to-select";
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 
 import type {
@@ -17,8 +17,7 @@ const GET_ENABLE_GUEST_EMBED_SETTINGS: (data: {
   isSimpleEmbedFeatureAvailable,
   experience,
 }) => {
-  const isQuestionOrDashboardEmbed =
-    isQuestionOrDashboardExperience(experience);
+  const isQuestionOrDashboardEmbed = hasAuthToSelect(experience);
 
   return {
     ...(isQuestionOrDashboardEmbed
@@ -53,8 +52,7 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
     SdkIframeDashboardEmbedSettings | SdkIframeQuestionEmbedSettings,
     "lockedParameters"
   > = ({ experience, isSsoEnabledAndConfigured, useExistingUserSession }) => {
-  const isQuestionOrDashboardEmbed =
-    isQuestionOrDashboardExperience(experience);
+  const isQuestionOrDashboardEmbed = hasAuthToSelect(experience);
 
   return {
     ...(isQuestionOrDashboardEmbed

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-auth-to-select.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-auth-to-select.ts
@@ -1,0 +1,11 @@
+import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
+
+/**
+ * Whether the experience offers an auth choice (SSO vs Guest). True only for
+ * the experiences that support guest embedding — others are SSO-only and
+ * don't need the Authentication card.
+ */
+export const hasAuthToSelect = (
+  experience: SdkIframeEmbedSetupExperience,
+): experience is "dashboard" | "chart" =>
+  ["dashboard", "chart"].includes(experience);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-resource-to-select.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-resource-to-select.ts
@@ -1,5 +1,10 @@
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 
+/**
+ * Whether the experience needs a specific resource picked by the user
+ * (dashboard, chart, or initial collection for the browser). Exploration and
+ * Metabot have nothing to select.
+ */
 export const hasResourceToSelect = (
   experience: SdkIframeEmbedSetupExperience,
 ): experience is "dashboard" | "chart" | "browser" =>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-resource-to-select.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/has-resource-to-select.ts
@@ -1,6 +1,6 @@
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
 
-export const isQuestionOrDashboardExperience = (
+export const hasResourceToSelect = (
   experience: SdkIframeEmbedSetupExperience,
-): experience is "dashboard" | "chart" =>
-  ["dashboard", "chart"].includes(experience);
+): experience is "dashboard" | "chart" | "browser" =>
+  ["dashboard", "chart", "browser"].includes(experience);


### PR DESCRIPTION
Closes [EMB-1723: State updates in the embedding wizard first step](https://linear.app/metabase/issue/EMB-1723/state-updates-in-the-embedding-wizard-first-step)

### Description

State updates to the first step ("Select your embed experience") of the embed wizard:

- **Hide the Authentication and Resource selection cards** unless Dashboard or Chart is selected — Exploration / Browser / Metabot don't need either.
- **Warn when SSO isn't configured** in two spots, both at the bottom of their card (consistent with EMB-1724):
  - On the Experience card, when Exploration / Browser / Metabot is selected.
  - On the Authentication card, when SSO is selected.
- Drop the (now unreachable) Browser branches from \`ResourceCard\` and add \`"browser"\` to \`EXPERIENCES_WITHOUT_RESOURCE_SELECTION\`.

SSO-above-Guest reordering was already done in #74153, so no change here.

### How to verify

1. Admin → Embedding → New embed.
2. With SSO **not** configured (no JWT/SAML): SSO is selected by default; the warning alert appears at the bottom of the Authentication card.
3. Switch experience to Exploration / Browser / Metabot: Authentication and Resource cards disappear; the warning alert appears at the bottom of the Experience card.
4. Configure JWT/SAML: both warnings disappear.
5. Switch to Guest while on Dashboard/Chart: the SSO warning disappears.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR