### PR TITLE
Surface computed version on release-auto runs

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -124,8 +124,26 @@ jobs:
             }).catch(console.error);
 
             core.setOutput('should_release', 'false');
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Auto-${{ inputs.kind }} release for v${{ inputs.version }}"
+            echo ""
+            if [[ "${{ steps.compute.outputs.should_release }}" == "true" ]]; then
+              echo "**Releasing:** \`${{ steps.compute.outputs.version }}\`"
+              echo ""
+              echo "**Commit:** [\`${{ steps.compute.outputs.commit }}\`](https://github.com/${{ github.repository }}/commit/${{ steps.compute.outputs.commit }})"
+            else
+              echo "_Skipped — see logs for the reason._"
+            fi
+            echo ""
+            echo "**Triggered by:** @${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   trigger-release:
+    name: Release ${{ needs.prepare.outputs.version }}
     needs: prepare
     if: ${{ needs.prepare.outputs.should_release == 'true' }}
     permissions:


### PR DESCRIPTION
Resolves DEV-1997

## Summary

> [!NOTE]
> This falls into the "nice-to-have" category.

Add a step summary to the prepare job listing the computed version, commit, and actor (or a skip note) so a run is self-describing from the GitHub Actions UI. Name the trigger-release job after the version too, so the child-job label reads "Release v0.61.1.4" instead of the default.


