### PR TITLE
fix: unnecessary scrollbar in sources used

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataSourcePills.tsx
@@ -154,7 +154,7 @@ const SourceItem = ({
         to={to}
         href={to}
       >
-        <Flex direction="column" gap="0.25rem" miw={0} maw="100%">
+        <Flex direction="column" miw={0} maw="100%">
           <Flex gap="sm" align="center" miw={0} maw="100%">
             <Icon
               name={iconName}
@@ -171,7 +171,7 @@ const SourceItem = ({
                 overflow: "hidden",
                 fontSize: "0.75rem",
                 fontWeight: 700,
-                lineHeight: 1,
+                lineHeight: 1.5,
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap",
               }}
@@ -204,9 +204,9 @@ const SourceItem = ({
                     miw={0}
                     c="text-secondary"
                     style={{
-                      overflowX: "hidden",
+                      overflow: "hidden",
                       fontSize: "0.75rem",
-                      lineHeight: 1,
+                      lineHeight: 1.5,
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
                     }}


### PR DESCRIPTION
Closes [BOT-1528: Library view shows an unnecessary scrollbar](https://linear.app/metabase/issue/BOT-1528/library-view-shows-an-unnecessary-scrollbar)

### Description

There was a scrollbar inside the location of the used source.

### How to verify

1. Send a message to Metabot.
2. See the sources used.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
