### PR TITLE
Fix permissions save action when a database was deleted recently

### DIFF
--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -16,19 +16,37 @@ export function getModifiedGroupsPermissionsGraphParts(
   allGroupIds: string[],
   externallyModifiedGroupIds: string[],
 ) {
-  const dataPermissionsModifiedGroupIds = allGroupIds.filter((groupId) => {
-    return !_.isEqual(
-      dataPermissions[groupId],
-      originalDataPermissions[groupId],
-    );
-  });
+  const externallyModifiedGroupIdsSet = new Set(externallyModifiedGroupIds);
+  const dataPermissionsModifiedGroups = Object.fromEntries(
+    allGroupIds
+      .map((groupId) => {
+        const groupPermissions = dataPermissions[groupId];
 
-  const allModifiedGroupIds = _.uniq([
-    ...dataPermissionsModifiedGroupIds,
-    ...externallyModifiedGroupIds,
-  ]);
+        if (externallyModifiedGroupIdsSet.has(groupId)) {
+          return [groupId, groupPermissions];
+        }
 
-  return _.pick(dataPermissions, allModifiedGroupIds);
+        const modifiedDatabasePermissions = Object.fromEntries(
+          Object.entries(groupPermissions ?? {}).filter(
+            ([databaseIdString, value]) => {
+              const databaseId = Number(databaseIdString);
+
+              return !_.isEqual(
+                value,
+                originalDataPermissions[groupId]?.[databaseId],
+              );
+            },
+          ),
+        );
+
+        return [groupId, modifiedDatabasePermissions];
+      })
+      .filter(([_groupId, groupPermissions]) => {
+        return !_.isEmpty(groupPermissions);
+      }),
+  );
+
+  return dataPermissionsModifiedGroups;
 }
 
 export function mergeGroupsPermissionsUpdates(

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -15,36 +15,38 @@ export function getModifiedGroupsPermissionsGraphParts(
   originalDataPermissions: GroupsPermissions,
   allGroupIds: string[],
   externallyModifiedGroupIds: string[],
-) {
+): GroupsPermissions {
   const externallyModifiedGroupIdsSet = new Set(externallyModifiedGroupIds);
-  const dataPermissionsModifiedGroups = Object.fromEntries(
-    allGroupIds
-      .map((groupId) => {
-        const groupPermissions = dataPermissions[groupId];
+  const dataPermissionsModifiedGroups: GroupsPermissions = {};
 
-        if (externallyModifiedGroupIdsSet.has(groupId)) {
-          return [groupId, groupPermissions];
-        }
+  for (const groupId of allGroupIds) {
+    const groupPermissions = dataPermissions[groupId];
 
-        const modifiedDatabasePermissions = Object.fromEntries(
-          Object.entries(groupPermissions ?? {}).filter(
-            ([databaseIdString, value]) => {
-              const databaseId = Number(databaseIdString);
+    if (externallyModifiedGroupIdsSet.has(groupId)) {
+      if (!_.isEmpty(groupPermissions)) {
+        dataPermissionsModifiedGroups[groupId] = groupPermissions;
+      }
 
-              return !_.isEqual(
-                value,
-                originalDataPermissions[groupId]?.[databaseId],
-              );
-            },
-          ),
-        );
+      continue;
+    }
 
-        return [groupId, modifiedDatabasePermissions];
-      })
-      .filter(([_groupId, groupPermissions]) => {
-        return !_.isEmpty(groupPermissions);
-      }),
-  );
+    const originalGroupPermissions = originalDataPermissions[groupId];
+    const modifiedDatabasePermissions: GroupsPermissions[string] = {};
+
+    for (const [databaseIdString, value] of Object.entries(
+      groupPermissions ?? {},
+    )) {
+      const databaseId = Number(databaseIdString);
+
+      if (!_.isEqual(value, originalGroupPermissions?.[databaseId])) {
+        modifiedDatabasePermissions[databaseId] = value;
+      }
+    }
+
+    if (!_.isEmpty(modifiedDatabasePermissions)) {
+      dataPermissionsModifiedGroups[groupId] = modifiedDatabasePermissions;
+    }
+  }
 
   return dataPermissionsModifiedGroups;
 }

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
@@ -36,6 +36,29 @@ describe("getModifiedGroupsPermissionsGraphParts", () => {
     });
   });
 
+  it("should only include databases with updated data permissions", async () => {
+    const update = getModifiedGroupsPermissionsGraphParts(
+      {
+        "1": {
+          "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO },
+          "2": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+        },
+      },
+      {
+        "1": {
+          "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+          "2": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+        },
+      },
+      ["1"],
+      [],
+    );
+
+    expect(update).toEqual({
+      "1": { "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO } },
+    });
+  });
+
   it("should include groups that have been externally modified", async () => {
     const externalUpdate = getModifiedGroupsPermissionsGraphParts(
       {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68793
Closes https://linear.app/metabase/issue/UXW-2869/editing-group-permissions-fails-after-deleting-a-database-in-the-same

### Description

Only send changed database permissions for modified groups. This prevents a stale deleted database entry in the in-memory permissions graph from being submitted with an unrelated group permission edit.

### How to verify

1. Open Admin > Permissions > Data > Groups > Data Analysts.
2. Delete a database in Admin > Databases without reloading the page.
3. Return to Data Analysts permissions, change a permission for another database, and save.
4. Confirm the save succeeds without a `data_permissions.db_id` foreign key error.

### Demo
https://www.loom.com/share/1e1d4a686968439c9b08019fd1792dc0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
