### PR TITLE
Surface upstream body in LLM provider error logs and messages

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -625,12 +625,14 @@
                   (analytics/inc! :metabase-metabot/agent-errors labels)
                   (if (:api-error (ex-data e))
                     (if (:status (ex-data e))
-                      (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
+                      (log/errorf e
+                                  "Agent loop API error: %s status=%s provider=%s body=%s"
                                   (ex-message e)
                                   (:status (ex-data e))
                                   (:provider (ex-data e))
                                   (pr-str (:body (ex-data e))))
-                      (log/errorf e "Agent loop API error: %s provider=%s"
+                      (log/errorf e
+                                  "Agent loop API error: %s provider=%s"
                                   (ex-message e)
                                   (:provider (ex-data e))))
                     (log/error e "Agent loop error"))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -625,7 +625,7 @@
                   (analytics/inc! :metabase-metabot/agent-errors labels)
                   (if (:api-error (ex-data e))
                     (if (:status (ex-data e))
-                      (log/errorf "Agent loop API error: %s status=%s provider=%s body=%s"
+                      (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
                                   (ex-message e)
                                   (:status (ex-data e))
                                   (:provider (ex-data e))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -623,17 +623,13 @@
                     result))
                 (catch Exception e
                   (analytics/inc! :metabase-metabot/agent-errors labels)
-                  (let [data (ex-data e)]
-                    (if (:api-error data)
-                      (if (:status data)
+                  (let [{:keys [api-error status provider body]} (ex-data e)]
+                    (if api-error
+                      (if status
                         (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
-                                    (ex-message e)
-                                    (:status data)
-                                    (:provider data)
-                                    (pr-str (:body data)))
+                                    (ex-message e) status provider (pr-str body))
                         (log/errorf e "Agent loop API error: %s provider=%s"
-                                    (ex-message e)
-                                    (:provider data)))
+                                    (ex-message e) provider))
                       (log/error e "Agent loop error")))
                   (rf init (error-part e)))
                 (finally

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -625,17 +625,21 @@
                   (analytics/inc! :metabase-metabot/agent-errors labels)
                   (let [{:keys [api-error status provider body]} (ex-data e)
                         msg (ex-message e)]
-                    (if api-error
-                      (if status
-                        (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
-                                    msg status provider (pr-str body))
-                        (log/errorf e "Agent loop API error: %s provider=%s"
-                                    msg provider))
+                    (cond
+                      (and api-error status)
+                      (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
+                                  msg status provider (pr-str body))
+
+                      api-error
+                      (log/errorf e "Agent loop API error: %s provider=%s" msg provider)
+
                       ;; ex-message can be nil/blank for exceptions thrown without a message
                       ;; (e.g. (NullPointerException.)) — skip the colon when there's nothing to say.
-                      (if (str/blank? msg)
-                        (log/error e "Agent loop error")
-                        (log/errorf e "Agent loop error: %s" msg))))
+                      (str/blank? msg)
+                      (log/error e "Agent loop error")
+
+                      :else
+                      (log/errorf e "Agent loop error: %s" msg)))
                   (rf init (error-part e)))
                 (finally
                   (analytics/observe! :metabase-metabot/agent-duration-ms labels (u/since-ms start-ms)))))))))))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -623,17 +623,18 @@
                     result))
                 (catch Exception e
                   (analytics/inc! :metabase-metabot/agent-errors labels)
-                  (if (:api-error (ex-data e))
-                    (if (:status (ex-data e))
-                      (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
-                                  (ex-message e)
-                                  (:status (ex-data e))
-                                  (:provider (ex-data e))
-                                  (pr-str (:body (ex-data e))))
-                      (log/errorf e "Agent loop API error: %s provider=%s"
-                                  (ex-message e)
-                                  (:provider (ex-data e))))
-                    (log/error e "Agent loop error"))
+                  (let [data (ex-data e)]
+                    (if (:api-error data)
+                      (if (:status data)
+                        (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
+                                    (ex-message e)
+                                    (:status data)
+                                    (:provider data)
+                                    (pr-str (:body data)))
+                        (log/errorf e "Agent loop API error: %s provider=%s"
+                                    (ex-message e)
+                                    (:provider data)))
+                      (log/error e "Agent loop error")))
                   (rf init (error-part e)))
                 (finally
                   (analytics/observe! :metabase-metabot/agent-duration-ms labels (u/since-ms start-ms)))))))))))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -625,14 +625,12 @@
                   (analytics/inc! :metabase-metabot/agent-errors labels)
                   (if (:api-error (ex-data e))
                     (if (:status (ex-data e))
-                      (log/errorf e
-                                  "Agent loop API error: %s status=%s provider=%s body=%s"
+                      (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
                                   (ex-message e)
                                   (:status (ex-data e))
                                   (:provider (ex-data e))
                                   (pr-str (:body (ex-data e))))
-                      (log/errorf e
-                                  "Agent loop API error: %s provider=%s"
+                      (log/errorf e "Agent loop API error: %s provider=%s"
                                   (ex-message e)
                                   (:provider (ex-data e))))
                     (log/error e "Agent loop error"))

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -623,14 +623,19 @@
                     result))
                 (catch Exception e
                   (analytics/inc! :metabase-metabot/agent-errors labels)
-                  (let [{:keys [api-error status provider body]} (ex-data e)]
+                  (let [{:keys [api-error status provider body]} (ex-data e)
+                        msg (ex-message e)]
                     (if api-error
                       (if status
                         (log/errorf e "Agent loop API error: %s status=%s provider=%s body=%s"
-                                    (ex-message e) status provider (pr-str body))
+                                    msg status provider (pr-str body))
                         (log/errorf e "Agent loop API error: %s provider=%s"
-                                    (ex-message e) provider))
-                      (log/error e "Agent loop error")))
+                                    msg provider))
+                      ;; ex-message can be nil/blank for exceptions thrown without a message
+                      ;; (e.g. (NullPointerException.)) — skip the colon when there's nothing to say.
+                      (if (str/blank? msg)
+                        (log/error e "Agent loop error")
+                        (log/errorf e "Agent loop error: %s" msg))))
                   (rf init (error-part e)))
                 (finally
                   (analytics/observe! :metabase-metabot/agent-duration-ms labels (u/since-ms start-ms)))))))))))

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -261,7 +261,7 @@
           :text suffix}]))))
 
 (defn- anthropic-error-msg
-  "Canonical, status-specific Anthropic error message; [[core/rethrow-api-error!]] appends the body preview."
+  "Canonical, status-specific Anthropic error message; the upstream body is appended out of scope."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -261,7 +261,7 @@
           :text suffix}]))))
 
 (defn- anthropic-error-msg
-  "Canonical, status-specific Anthropic error message; the upstream body is appended out of scope."
+  "Canonical, status-specific Anthropic error message; the upstream body is appended separately."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -260,9 +260,8 @@
          {:type "text"
           :text suffix}]))))
 
-(defn- anthropic-errors
-  "Return the canonical, status-specific Anthropic error message.
-   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+(defn- anthropic-error-msg
+  "Canonical, status-specific Anthropic error message; [[core/rethrow-api-error!]] appends the body preview."
   [res]
   (let [status (long (:status res 0))]
     (case status
@@ -295,7 +294,7 @@
            models (reverse (sort-by :created_at (:data body)))]
        {:models (map #(select-keys % [:id :display_name]) models)})
      (catch Exception e
-       (core/rethrow-api-error! "anthropic" anthropic-errors e)))))
+       (core/rethrow-api-error! "anthropic" anthropic-error-msg e)))))
 
 (mu/defn claude-raw
   "Perform a streaming request to Claude API."
@@ -347,7 +346,7 @@
                                      :url      "/v1/messages"
                                      :request  req})))
         (catch Exception e
-          (core/rethrow-api-error! "anthropic" anthropic-errors e))))))
+          (core/rethrow-api-error! "anthropic" anthropic-error-msg e))))))
 
 (defn claude
   "Call Claude API, return AISDK stream"

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -260,9 +260,11 @@
          {:type "text"
           :text suffix}]))))
 
-(defn- anthropic-errors [res]
-  (let [status    (long (:status res 0))
-        error-msg (get-in res [:body :error :message])]
+(defn- anthropic-errors
+  "Return the canonical, status-specific Anthropic error message.
+   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+  [res]
+  (let [status (long (:status res 0))]
     (case status
       401 (tru "Anthropic API key expired or invalid")
       403 (tru "Anthropic API key has insufficient permissions")
@@ -271,9 +273,7 @@
       429 (tru "Anthropic API has rate limited us")
       500 (tru "Anthropic API is not working but not saying why")
       529 (tru "Anthropic API is overloaded and is asking us to wait")
-      (if error-msg
-        (tru "Anthropic API error (HTTP {0}): {1}" status error-msg)
-        (tru "Anthropic API error (HTTP {0})" status)))))
+      (tru "Anthropic API error (HTTP {0})" status))))
 
 (defn list-models
   "List available Anthropic models.

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -261,7 +261,7 @@
           :text suffix}]))))
 
 (defn- anthropic-error-msg
-  "Canonical, status-specific Anthropic error message; the upstream body is appended separately."
+  "Canonical, status-specific Anthropic error message."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -502,14 +502,11 @@
          (rf result chunk))))))
 
 (def ^:private max-body-preview-chars
-  "Cap on the size of the response-body snippet we splice into provider error messages.
-   The full body is still logged in full and survives into `ex-data` via the decoded `res`."
+  "Cap on the body snippet spliced into provider error messages."
   500)
 
 (defn- extract-error-message
-  "Pull a human-readable error string out of a structured JSON envelope map. Prefers
-   `[:error :message]`, then `:error`/`:detail`/`:message`. Returns `nil` if the map
-   has none of those — callers fall back to the full logged body for debugging."
+  "Human-readable error string from a JSON envelope map, or nil."
   [m]
   (some-> (or (get-in m [:error :message])
               (:error m)
@@ -519,12 +516,9 @@
           not-empty))
 
 (defn- body-preview
-  "Build a short, human-readable snippet of an upstream provider's response body for the
-   exception message. Prefers structured JSON envelopes (`[:error :message]`, `:error`,
-   `:detail`, `:message`); slurps `InputStream` bodies; probes the first element of
-   JSON arrays. Returns `nil` for anything that doesn't carry a recognised human-readable
-   field — the full body is still logged and stashed in `ex-data`, so users don't see
-   raw `{:request-id ...}` blobs or diagnostic-object arrays in toasts."
+  "Short snippet of an upstream response body for the user-facing exception message.
+  Returns nil for bodies with no recognised human-readable field — those still survive
+  in ex-data and logs for debugging."
   [body]
   (let [s (cond
             (nil? body)                  nil
@@ -545,22 +539,11 @@
 (defn rethrow-api-error!
   "Rethrow a provider HTTP exception with a translated, user-facing message.
 
-  `res->message` receives the decoded response map and must return the canonical,
-  provider-specific message (e.g. `\"Anthropic API key expired or invalid\"`). When
-  the response carries a body, this function appends a truncated preview of that
-  body to the message so engineers and admins can see what the upstream actually
-  said, and emits a `log/warnf` line with the *full* body at the failure boundary
-  so the response body never gets silently swallowed.
-
-  `ex-data` is an explicit allow-list of `:status`, `:reason-phrase`, and `:body`
-  (plus provider tagging) rather than a passthrough of the raw clj-http response —
-  the raw response carries `:http-client` (a `Closeable`), `:trace-redirects`,
-  `:orig-content-encoding`, and other internals we don't want in ex-data or Sentry
-  payloads.
-
-  If the exception already carries `:api-error true` in its ex-data (e.g. a
-  missing-API-key error from [[resolve-auth]]) it is rethrown as-is so the
-  original message is preserved."
+  `res->message` returns the provider-specific message; a body preview is appended when
+  one is available, and the full body is logged.
+  ex-data is an explicit allow-list (`:status`, `:reason-phrase`, `:body`, plus provider tags) —
+  raw clj-http responses carry a Closeable `:http-client` and other internals.
+  Exceptions already tagged `:api-error true` are rethrown unchanged."
   [provider res->message e]
   (let [data (ex-data e)]
     (cond
@@ -573,8 +556,7 @@
             preview (body-preview (:body res))
             msg     (cond-> base
                       preview (str " — " preview))]
-        ;; `log/warn` would `pr-str` a trailing map into the message, not record it as
-        ;; structured MDC. Use `log/warnf` so we knowingly emit one greppable blob.
+        ;; warnf (not warn) so the body renders into the message string, not as MDC.
         (log/warnf "Provider API request failed: provider=%s status=%s body=%s"
                    provider (:status res) (pr-str (:body res)))
         (throw (ex-info msg

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -506,14 +506,16 @@
   500)
 
 (defn- extract-error-message
-  "Human-readable error string from a JSON envelope map, or nil."
+  "Human-readable error string from a JSON envelope map, or nil.
+  Only accepts string fields; a structured `:error` map without `:message`, or a vector/map
+  under `:detail`/`:message`, returns nil rather than being coerced into the user-facing text."
   [m]
-  (some-> (or (get-in m [:error :message])
+  (let [s (or (get-in m [:error :message])
               (:error m)
               (:detail m)
-              (:message m))
-          str
-          not-empty))
+              (:message m))]
+    (when (string? s)
+      (not-empty s))))
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -11,7 +11,7 @@
    [metabase.util.log :as log]
    [metabase.util.o11y :refer [with-span]])
   (:import
-   (java.io BufferedReader Closeable)
+   (java.io BufferedReader Closeable InputStream)
    (java.util.concurrent Callable Executors ExecutorService)))
 
 (set! *warn-on-reflection* true)
@@ -501,29 +501,81 @@
 
          (rf result chunk))))))
 
+(def ^:private max-body-preview-chars
+  "Cap on the size of the response-body snippet we splice into provider error messages.
+   The full body is still logged in full and survives into `ex-data` via the decoded `res`."
+  500)
+
+(defn- body-preview
+  "Build a short, human-readable snippet of an upstream provider's response body for the
+   exception message. Prefers structured JSON envelopes (`[:error :message]`, `:error`,
+   `:detail`, `:message`) over `pr-str`; slurps `InputStream` bodies. Returns `nil` when
+   there's nothing useful to surface."
+  [body]
+  (let [s (cond
+            (nil? body)                  nil
+            (string? body)               body
+            (map? body)                  (or (some-> (or (get-in body [:error :message])
+                                                         (:error body)
+                                                         (:detail body)
+                                                         (:message body))
+                                                     str
+                                                     not-empty)
+                                             (pr-str body))
+            (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
+            :else                        (pr-str body))]
+    (when-let [trimmed (some-> s str/trim not-empty)]
+      (if (<= (count trimmed) max-body-preview-chars)
+        trimmed
+        (str (subs trimmed 0 max-body-preview-chars) "…")))))
+
 (defn rethrow-api-error!
   "Rethrow a provider HTTP exception with a translated, user-facing message.
 
-  `res->message` receives the decoded response map and must return the message
-  to surface to the client.  If the exception already carries `:api-error true`
-  in its ex-data (e.g. a missing-API-key error from [[resolve-auth]]) it is
-  rethrown as-is so the original message is preserved."
+  `res->message` receives the decoded response map and must return the canonical,
+  provider-specific message (e.g. `\"Anthropic API key expired or invalid\"`). When
+  the response carries a body, this function appends a truncated preview of that
+  body to the message so engineers and admins can see what the upstream actually
+  said, and emits a `log/warn` with the *full* body at the failure boundary so
+  the response body never gets silently swallowed.
+
+  If the exception already carries `:api-error true` in its ex-data (e.g. a
+  missing-API-key error from [[resolve-auth]]) it is rethrown as-is so the
+  original message is preserved."
   [provider res->message e]
   (let [data (ex-data e)]
     (cond
-      (:api-error data) (throw e)
-      (:body data)      (let [res (json/decode-body data)]
-                          (throw (ex-info (res->message res)
-                                          (assoc res
-                                                 :api-error  true
-                                                 :provider   provider
-                                                 :error-code :provider-api-error)
-                                          e)))
-      :else             (throw (ex-info (tru "{0} API request failed: {1}" provider (ex-message e))
-                                        {:api-error  true
-                                         :provider   provider
-                                         :error-code :provider-request-failed}
-                                        e)))))
+      (:api-error data)
+      (throw e)
+
+      (:body data)
+      (let [res     (json/decode-body data)
+            base    (res->message res)
+            preview (body-preview (:body res))
+            msg     (cond-> base
+                      preview (str " — " preview))]
+        (log/warn "Provider API request failed"
+                  {:provider provider
+                   :status   (:status res)
+                   :body     (:body res)})
+        (throw (ex-info msg
+                        (assoc res
+                               :api-error  true
+                               :provider   provider
+                               :error-code :provider-api-error)
+                        e)))
+
+      :else
+      (do
+        (log/warn "Provider API request failed (no response)"
+                  {:provider        provider
+                   :exception-class (some-> e .getClass .getName)
+                   :exception-msg   (ex-message e)})
+        (throw (ex-info (tru "{0} API request failed: {1}" provider (ex-message e))
+                        {:api-error  true
+                         :provider   provider
+                         :error-code :provider-request-failed}
+                        e))))))
 
 (defn missing-api-key-ex
   "Create a standardized missing-API-key exception for provider adapters."

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -523,13 +523,13 @@
   [r limit]
   (try
     (with-open [rdr (io/reader r :encoding "UTF-8")]
-      (let [^chars buf (char-array limit)]
+      (let [buf (char-array limit)]
         (loop [off 0]
           (if (= off limit)
-            (String. buf 0 limit)
+            (String. ^chars buf (int 0) (int limit))
             (let [n (.read ^java.io.Reader rdr buf off (- limit off))]
               (if (neg? n)
-                (when (pos? off) (String. buf 0 off))
+                (when (pos? off) (String. ^chars buf (int 0) (int off)))
                 (recur (+ off n))))))))
     (catch Exception _ nil)))
 

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -567,10 +567,15 @@
                         e)))
 
       :else
-      (let [exception-class (some-> e .getClass .getName)]
+      (let [exception-class (some-> e .getClass .getName)
+            msg             (ex-message e)]
         (log/warnf "Provider API request failed (no response): provider=%s class=%s message=%s"
-                   provider exception-class (ex-message e))
-        (throw (ex-info (tru "{0} API request failed: {1}" provider (ex-message e))
+                   provider exception-class msg)
+        ;; ex-message can be nil/blank for exceptions thrown without one (e.g. (RuntimeException.))
+        ;; — skip the colon when the cause has nothing to say.
+        (throw (ex-info (if (str/blank? msg)
+                          (tru "{0} API request failed" provider)
+                          (tru "{0} API request failed: {1}" provider msg))
                         {:api-error       true
                          :provider        provider
                          :error-code      :provider-request-failed

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -544,7 +544,7 @@
   ex-data is an explicit allow-list (`:status`, `:reason-phrase`, `:body`, plus provider tags) —
   raw clj-http responses carry a Closeable `:http-client` and other internals.
   Exceptions already tagged `:api-error true` are rethrown unchanged."
-  [provider res->message e]
+  [provider res->message ^Throwable e]
   (let [data (ex-data e)]
     (cond
       (:api-error data)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -517,20 +517,26 @@
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
-  Returns nil for bodies with no recognised human-readable field — those still survive
-  in ex-data and logs for debugging."
+  Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str`
+  and emit a warn — better some context than none, and the warn tells operators to add
+  the envelope shape to [[extract-error-message]]. Nil/empty bodies return nil."
   [body]
-  (let [s (cond
-            (nil? body)                  nil
-            (string? body)               body
-            (map? body)                  (extract-error-message body)
-            (sequential? body)           (let [head (first body)]
-                                           (cond
-                                             (map? head)    (extract-error-message head)
-                                             (string? head) head
-                                             :else          nil))
-            (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
-            :else                        nil)]
+  (let [extracted (cond
+                    (nil? body)                  nil
+                    (string? body)               body
+                    (map? body)                  (extract-error-message body)
+                    (sequential? body)           (let [head (first body)]
+                                                   (cond
+                                                     (map? head)    (extract-error-message head)
+                                                     (string? head) head
+                                                     :else          nil))
+                    (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
+                    :else                        nil)
+        s         (or extracted
+                      (when (and (or (map? body) (sequential? body)) (seq body))
+                        (let [printed (pr-str body)]
+                          (log/warnf "body-preview: unrecognised error body shape; pr-str=%s" printed)
+                          printed)))]
     (when-let [trimmed (some-> s str/trim not-empty)]
       (if (<= (count trimmed) max-body-preview-chars)
         trimmed

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -507,9 +507,11 @@
 
 (defn- extract-error-message
   "First non-blank string under `[:error :message]`, `:error`, `:detail`, or `:message`.
-  Non-strings and whitespace-only strings fall through so neither the raw envelope nor a
-  meaningless blank can `str`-leak into the user-facing message."
+  Non-strings and whitespace-only strings fall through to the next key."
   [m]
+  ;; Filter per-lookup so a structured value (e.g. {:error {:code 500}}) never gets
+  ;; str-coerced into the user-facing exception message — bad shapes fall through to
+  ;; the next key instead.
   (let [s (fn [v] (when (string? v) (not-empty (str/trim v))))]
     (or (s (get-in m [:error :message]))
         (s (:error m))
@@ -519,8 +521,7 @@
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
   Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str`
-  and emit a warn — better some context than none, and the warn tells operators to add
-  the envelope shape to [[extract-error-message]]. Nil/empty bodies return nil."
+  and emit a warn. Nil/empty bodies return nil."
   [body]
   (let [extracted (cond
                     (nil? body)                  nil
@@ -533,6 +534,8 @@
                                                      :else          nil))
                     (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
                     :else                        nil)
+        ;; Surface *some* context to the user even for unrecognised shapes — the warn
+        ;; signals operators to add the new envelope shape to [[extract-error-message]].
         s         (or extracted
                       (when (and (or (map? body) (sequential? body)) (seq body))
                         (let [printed (pr-str body)]
@@ -545,11 +548,9 @@
 
 (defn rethrow-api-error!
   "Rethrow a provider HTTP exception with a translated, user-facing message.
-
-  `res->message` returns the provider-specific message; a body preview is appended when
-  one is available, and the full body is logged.
-  ex-data is an explicit allow-list (`:status`, `:reason-phrase`, `:body`, plus provider tags) —
-  raw clj-http responses carry a Closeable `:http-client` and other internals.
+  `res->message` receives the decoded response map and returns the provider-specific message.
+  A body preview is appended to the message and the full body is logged.
+  ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:body`, plus provider tags.
   Exceptions already tagged `:api-error true` are rethrown unchanged."
   [provider res->message ^Throwable e]
   (let [data (ex-data e)]
@@ -566,6 +567,8 @@
         ;; warnf (not warn) so the body renders into the message string, not as MDC.
         (log/warnf "Provider API request failed: provider=%s status=%s body=%s"
                    provider (:status res) (pr-str (:body res)))
+        ;; Allow-list explicitly — clj-http responses carry :http-client (a Closeable),
+        ;; :trace-redirects, :orig-content-encoding, etc., none of which should propagate downstream.
         (throw (ex-info msg
                         (merge (select-keys res [:status :reason-phrase :body])
                                {:api-error  true

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -569,8 +569,8 @@
   "Rethrow a provider HTTP exception with a translated, user-facing message.
   `res->message` receives the decoded response map and returns the provider-specific message.
   A body preview is appended to the message and the full body is logged.
-  ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:body`, plus provider tags.
-  Exceptions already tagged `:api-error true` are rethrown unchanged."
+  ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:headers`, `:body`,
+  plus provider tags. Exceptions already tagged `:api-error true` are rethrown unchanged."
   [provider res->message ^Throwable e]
   (let [data (ex-data e)]
     (cond
@@ -588,8 +588,10 @@
                    provider (:status res) (pr-str (:body res)))
         ;; Allow-list explicitly — clj-http responses carry :http-client (a Closeable),
         ;; :trace-redirects, :orig-content-encoding, etc., none of which should propagate downstream.
+        ;; :headers is included so the retry path in metabase.metabot.self/parse-retry-after-header
+        ;; can still honor Retry-After on 429/529 responses.
         (throw (ex-info msg
-                        (merge (select-keys res [:status :reason-phrase :body])
+                        (merge (select-keys res [:status :reason-phrase :headers :body])
                                {:api-error  true
                                 :provider   provider
                                 :error-code :provider-api-error})

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -534,18 +534,19 @@
     (catch Throwable _ nil)))
 
 (def ^:private max-body-slurp-chars
-  "Cap on how many chars we read off an upstream InputStream body when decoding for
-  error surfacing. Large enough to cover any realistic JSON error envelope; small
-  enough to bound the pathological multi-MB case."
+  "Cap on how many chars we read off an upstream InputStream body when decoding for error surfacing."
+  ;; Large enough to cover any realistic JSON error envelope; small enough to bound the
+  ;; pathological multi-MB case (e.g. a stuck stream from a misbehaving upstream).
   1000000)
 
 (defn- decode-bounded-body
   "Decode a clj-http response map's `:body` for error surfacing.
-  Bound-slurps InputStream bodies first so a giant upstream payload doesn't get
-  pulled fully into memory. The bounded string is then handed to `json/decode-body`;
-  on parse failure (e.g. the cap truncated us mid-envelope) the raw bounded string
-  is kept as `:body` so [[body-preview]] can still surface *something*."
+  Returns the response map with `:body` set to the decoded value, or — on parse failure —
+  to the raw bounded string so [[body-preview]] still has something to surface."
   [res]
+  ;; Bound-slurp InputStream bodies first so a giant upstream payload doesn't get pulled
+  ;; fully into memory. On parse failure (e.g. the cap truncated us mid-envelope) we keep
+  ;; the bounded string in :body rather than nil-ing it out.
   (let [bounded (cond-> res
                   (instance? InputStream (:body res))
                   (update :body #(or (slurp-bounded % max-body-slurp-chars) "")))]
@@ -555,8 +556,8 @@
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
-  Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str`
-  and emit a warn. Nil/empty bodies return nil."
+  Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str` and emit a warn.
+  Nil/empty bodies return nil."
   [body]
   (let [extracted (cond
                     (nil? body)        nil
@@ -584,8 +585,8 @@
   "Rethrow a provider HTTP exception with a translated, user-facing message.
   `res->message` receives the decoded response map and returns the provider-specific message.
   A body preview is appended to the message and the full body is logged.
-  ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:headers`, `:body`,
-  plus provider tags. Exceptions already tagged `:api-error true` are rethrown unchanged."
+  ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:headers`, `:body`, plus provider tags.
+  Exceptions already tagged `:api-error true` are rethrown unchanged."
   [provider res->message ^Throwable e]
   (let [data (ex-data e)]
     (cond

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -506,24 +506,37 @@
    The full body is still logged in full and survives into `ex-data` via the decoded `res`."
   500)
 
+(defn- extract-error-message
+  "Pull a human-readable error string out of a structured JSON envelope map. Prefers
+   `[:error :message]`, then `:error`/`:detail`/`:message`. Returns `nil` if the map
+   has none of those — callers fall back to the full logged body for debugging."
+  [m]
+  (some-> (or (get-in m [:error :message])
+              (:error m)
+              (:detail m)
+              (:message m))
+          str
+          not-empty))
+
 (defn- body-preview
   "Build a short, human-readable snippet of an upstream provider's response body for the
    exception message. Prefers structured JSON envelopes (`[:error :message]`, `:error`,
-   `:detail`, `:message`); slurps `InputStream` bodies. Returns `nil` for maps that
-   don't carry a recognised human-readable field — the full body is still logged and
-   stashed in `ex-data`, so users don't see raw `{:request-id ...}` blobs in toasts."
+   `:detail`, `:message`); slurps `InputStream` bodies; probes the first element of
+   JSON arrays. Returns `nil` for anything that doesn't carry a recognised human-readable
+   field — the full body is still logged and stashed in `ex-data`, so users don't see
+   raw `{:request-id ...}` blobs or diagnostic-object arrays in toasts."
   [body]
   (let [s (cond
             (nil? body)                  nil
             (string? body)               body
-            (map? body)                  (some-> (or (get-in body [:error :message])
-                                                     (:error body)
-                                                     (:detail body)
-                                                     (:message body))
-                                                 str
-                                                 not-empty)
+            (map? body)                  (extract-error-message body)
+            (sequential? body)           (let [head (first body)]
+                                           (cond
+                                             (map? head)    (extract-error-message head)
+                                             (string? head) head
+                                             :else          nil))
             (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
-            :else                        (pr-str body))]
+            :else                        nil)]
     (when-let [trimmed (some-> s str/trim not-empty)]
       (if (<= (count trimmed) max-body-preview-chars)
         trimmed

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -518,19 +518,29 @@
         (s (:detail m))
         (s (:message m)))))
 
+(def ^:private body-slurp-chunk-chars
+  "Read-chunk size for [[slurp-bounded]]. Keeps the transient buffer small so a tiny error
+  envelope costs a tiny allocation; only a body that actually reaches the cap pays for it."
+  8192)
+
 (defn- slurp-bounded
-  "Read at most `limit` chars from `r` as UTF-8, returning nil on read error or empty input."
+  "Read at most `limit` chars from `r` as UTF-8, returning nil on read error or empty input.
+  Grows a `StringBuilder` in [[body-slurp-chunk-chars]] chunks so memory scales with the real
+  body rather than pre-allocating the worst-case `limit`-sized buffer up front."
   [r limit]
   (try
     (with-open [rdr (io/reader r :encoding "UTF-8")]
-      (let [buf (char-array limit)]
-        (loop [off 0]
-          (if (= off limit)
-            (String. ^chars buf (int 0) (int limit))
-            (let [n (.read ^java.io.Reader rdr buf off (- limit off))]
-              (if (neg? n)
-                (when (pos? off) (String. ^chars buf (int 0) (int off)))
-                (recur (+ off n))))))))
+      (let [buf (char-array body-slurp-chunk-chars)
+            sb  (StringBuilder.)]
+        (loop []
+          (let [remaining (- limit (.length sb))]
+            (if (<= remaining 0)
+              (str sb)
+              (let [n (.read ^java.io.Reader rdr buf 0 (min remaining body-slurp-chunk-chars))]
+                (if (neg? n)
+                  (when (pos? (.length sb)) (str sb))
+                  (do (.append sb buf 0 n)
+                      (recur)))))))))
     (catch Exception _ nil)))
 
 (def ^:private max-body-slurp-chars
@@ -538,6 +548,12 @@
   ;; Large enough to cover any realistic JSON error envelope; small enough to bound the
   ;; pathological multi-MB case (e.g. a stuck stream from a misbehaving upstream).
   1000000)
+
+(def ^:private max-body-log-chars
+  "Cap on the body `pr-str` spliced into warn/error log lines. Larger than the user-facing
+  preview cap since operators want more context, but still bounded so a multi-MB body — or
+  a near-cap slurped stream — can't flood the logs. The full body always survives in `ex-data`."
+  2000)
 
 (defn- decode-bounded-body
   "Decode a clj-http response map's `:body` for error surfacing.
@@ -554,12 +570,22 @@
       (json/decode-body bounded)
       (catch Exception _ bounded))))
 
+(defn- truncate-to
+  "Cap `s` at `limit` with a trailing ellipsis when it overflows."
+  [s limit]
+  (if (<= (count s) limit)
+    s
+    (str (subs s 0 limit) "…")))
+
 (defn- truncate-to-preview-limit
   "Cap `s` at [[max-body-preview-chars]] with a trailing ellipsis when it overflows."
   [s]
-  (if (<= (count s) max-body-preview-chars)
-    s
-    (str (subs s 0 max-body-preview-chars) "…")))
+  (truncate-to s max-body-preview-chars))
+
+(defn- body-for-log
+  "Bounded `pr-str` of a coerced body for warn/error log lines, capped at [[max-body-log-chars]]."
+  [body]
+  (truncate-to (pr-str body) max-body-log-chars))
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
@@ -614,8 +640,10 @@
             msg     (cond-> base
                       preview (str " — " preview))]
         ;; warnf (not warn) so the body renders into the message string, not as MDC.
+        ;; body-for-log caps the pr-str so a near-cap slurped stream can't flood the logs;
+        ;; the full body still survives in ex-data below.
         (log/warnf "Provider API request failed: provider=%s status=%s body=%s"
-                   provider (:status res) (pr-str (:body res)))
+                   provider (:status res) (body-for-log (:body res)))
         ;; Allow-list explicitly — clj-http responses carry :http-client (a Closeable),
         ;; :trace-redirects, :orig-content-encoding, etc., none of which should propagate downstream.
         ;; :headers is included so the retry path in metabase.metabot.self/parse-retry-after-header

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -506,18 +506,14 @@
   500)
 
 (defn- extract-error-message
-  "Human-readable error string from a JSON envelope map, or nil.
-  Only accepts string fields under `:error`/`:detail`/`:message` (and the nested
-  `[:error :message]`) — structured values would otherwise be `str`-coerced and leak the
-  raw envelope into the user-facing message. Filtering per-lookup means a non-string at
-  one key falls through to the next, e.g. `{:error {:code 500} :detail \"real msg\"}`."
+  "First non-blank string under `[:error :message]`, `:error`, `:detail`, or `:message`.
+  Non-strings fall through so the raw envelope can't `str`-leak into the user-facing message."
   [m]
-  (let [s? (fn [v] (when (string? v) v))]
-    (some-> (or (s? (get-in m [:error :message]))
-                (s? (:error m))
-                (s? (:detail m))
-                (s? (:message m)))
-            not-empty)))
+  (let [s (fn [v] (when (string? v) (not-empty v)))]
+    (or (s (get-in m [:error :message]))
+        (s (:error m))
+        (s (:detail m))
+        (s (:message m)))))
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -507,9 +507,10 @@
 
 (defn- extract-error-message
   "First non-blank string under `[:error :message]`, `:error`, `:detail`, or `:message`.
-  Non-strings fall through so the raw envelope can't `str`-leak into the user-facing message."
+  Non-strings and whitespace-only strings fall through so neither the raw envelope nor a
+  meaningless blank can `str`-leak into the user-facing message."
   [m]
-  (let [s (fn [v] (when (string? v) (not-empty v)))]
+  (let [s (fn [v] (when (string? v) (not-empty (str/trim v))))]
     (or (s (get-in m [:error :message]))
         (s (:error m))
         (s (:detail m))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -512,7 +512,7 @@
   ;; Filter per-lookup so a structured value (e.g. {:error {:code 500}}) never gets
   ;; str-coerced into the user-facing exception message — bad shapes fall through to
   ;; the next key instead.
-  (let [s (fn [v] (when (string? v) (not-empty (str/trim v))))]
+  (letfn [(s [v] (when (string? v) (not-empty (str/trim v))))]
     (or (s (get-in m [:error :message]))
         (s (:error m))
         (s (:detail m))
@@ -531,7 +531,7 @@
               (if (neg? n)
                 (when (pos? off) (String. buf 0 off))
                 (recur (+ off n))))))))
-    (catch Throwable _ nil)))
+    (catch Exception _ nil)))
 
 (def ^:private max-body-slurp-chars
   "Cap on how many chars we read off an upstream InputStream body when decoding for error surfacing."
@@ -552,7 +552,14 @@
                   (update :body #(or (slurp-bounded % max-body-slurp-chars) "")))]
     (try
       (json/decode-body bounded)
-      (catch Throwable _ bounded))))
+      (catch Exception _ bounded))))
+
+(defn- truncate-to-preview-limit
+  "Cap `s` at [[max-body-preview-chars]] with a trailing ellipsis when it overflows."
+  [s]
+  (if (<= (count s) max-body-preview-chars)
+    s
+    (str (subs s 0 max-body-preview-chars) "…")))
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
@@ -571,15 +578,14 @@
                     :else              nil)
         ;; Surface *some* context to the user even for unrecognised shapes — the warn
         ;; signals operators to add the new envelope shape to [[extract-error-message]].
+        ;; Truncate once: the warn line shouldn't carry a multi-MB pr-str any more than
+        ;; the user-facing exception message should.
         s         (or extracted
                       (when (and (or (map? body) (sequential? body)) (seq body))
-                        (let [printed (pr-str body)]
-                          (log/warnf "body-preview: unrecognised error body shape; pr-str=%s" printed)
-                          printed)))]
-    (when-let [trimmed (some-> s str/trim not-empty)]
-      (if (<= (count trimmed) max-body-preview-chars)
-        trimmed
-        (str (subs trimmed 0 max-body-preview-chars) "…")))))
+                        (let [capped (truncate-to-preview-limit (pr-str body))]
+                          (log/warnf "body-preview: unrecognised error body shape; pr-str=%s" capped)
+                          capped)))]
+    (some-> s str/trim not-empty truncate-to-preview-limit)))
 
 (defn rethrow-api-error!
   "Rethrow a provider HTTP exception with a translated, user-facing message.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -587,10 +587,17 @@
                           capped)))]
     (some-> s str/trim not-empty truncate-to-preview-limit)))
 
+(def ^:private auth-error-statuses
+  "Statuses whose upstream body may carry provider-side auth/account detail
+  (raw API keys, org/account names, tenant IDs). The full body still hits the
+  warn log; we just don't splice it into the message the caller sees."
+  #{401 403})
+
 (defn rethrow-api-error!
   "Rethrow a provider HTTP exception with a translated, user-facing message.
   `res->message` receives the decoded response map and returns the provider-specific message.
-  A body preview is appended to the message and the full body is logged.
+  A body preview is appended to the message except on 401/403 (see [[auth-error-statuses]]),
+  where the body may carry sensitive auth/account detail; the full body is still logged.
   ex-data is an explicit allow-list of `:status`, `:reason-phrase`, `:headers`, `:body`, plus provider tags.
   Exceptions already tagged `:api-error true` are rethrown unchanged."
   [provider res->message ^Throwable e]
@@ -602,7 +609,8 @@
       (:body data)
       (let [res     (decode-bounded-body data)
             base    (res->message res)
-            preview (body-preview (:body res))
+            preview (when-not (contains? auth-error-statuses (:status res))
+                      (body-preview (:body res)))
             msg     (cond-> base
                       preview (str " — " preview))]
         ;; warnf (not warn) so the body renders into the message string, not as MDC.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -507,15 +507,17 @@
 
 (defn- extract-error-message
   "Human-readable error string from a JSON envelope map, or nil.
-  Only accepts string fields; a structured `:error` map without `:message`, or a vector/map
-  under `:detail`/`:message`, returns nil rather than being coerced into the user-facing text."
+  Only accepts string fields under `:error`/`:detail`/`:message` (and the nested
+  `[:error :message]`) — structured values would otherwise be `str`-coerced and leak the
+  raw envelope into the user-facing message. Filtering per-lookup means a non-string at
+  one key falls through to the next, e.g. `{:error {:code 500} :detail \"real msg\"}`."
   [m]
-  (let [s (or (get-in m [:error :message])
-              (:error m)
-              (:detail m)
-              (:message m))]
-    (when (string? s)
-      (not-empty s))))
+  (let [s? (fn [v] (when (string? v) v))]
+    (some-> (or (s? (get-in m [:error :message]))
+                (s? (:error m))
+                (s? (:detail m))
+                (s? (:message m)))
+            not-empty)))
 
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -519,12 +519,10 @@
         (s (:message m)))))
 
 (defn- slurp-bounded
-  "Read at most `limit` chars from `r`, returning nil on read error or empty input.
-  Used so a multi-MB upstream body doesn't get pulled fully into memory just to be
-  truncated to a few hundred chars."
+  "Read at most `limit` chars from `r` as UTF-8, returning nil on read error or empty input."
   [r limit]
   (try
-    (with-open [rdr (io/reader r)]
+    (with-open [rdr (io/reader r :encoding "UTF-8")]
       (let [buf (char-array limit)]
         (loop [off 0]
           (if (= off limit)
@@ -535,24 +533,41 @@
                 (recur (+ off n))))))))
     (catch Throwable _ nil)))
 
+(def ^:private max-body-slurp-chars
+  "Cap on how many chars we read off an upstream InputStream body when decoding for
+  error surfacing. Large enough to cover any realistic JSON error envelope; small
+  enough to bound the pathological multi-MB case."
+  1000000)
+
+(defn- decode-bounded-body
+  "Decode a clj-http response map's `:body` for error surfacing.
+  Bound-slurps InputStream bodies first so a giant upstream payload doesn't get
+  pulled fully into memory. The bounded string is then handed to `json/decode-body`;
+  on parse failure (e.g. the cap truncated us mid-envelope) the raw bounded string
+  is kept as `:body` so [[body-preview]] can still surface *something*."
+  [res]
+  (let [bounded (cond-> res
+                  (instance? InputStream (:body res))
+                  (update :body #(or (slurp-bounded % max-body-slurp-chars) "")))]
+    (try
+      (json/decode-body bounded)
+      (catch Throwable _ bounded))))
+
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
   Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str`
   and emit a warn. Nil/empty bodies return nil."
   [body]
   (let [extracted (cond
-                    (nil? body)                  nil
-                    (string? body)               body
-                    (map? body)                  (extract-error-message body)
-                    (sequential? body)           (let [head (first body)]
-                                                   (cond
-                                                     (map? head)    (extract-error-message head)
-                                                     (string? head) head
-                                                     :else          nil))
-                    ;; +1 so the truncation branch below detects overflow without having
-                    ;; to read the full stream.
-                    (instance? InputStream body) (slurp-bounded body (inc max-body-preview-chars))
-                    :else                        nil)
+                    (nil? body)        nil
+                    (string? body)     body
+                    (map? body)        (extract-error-message body)
+                    (sequential? body) (let [head (first body)]
+                                         (cond
+                                           (map? head)    (extract-error-message head)
+                                           (string? head) head
+                                           :else          nil))
+                    :else              nil)
         ;; Surface *some* context to the user even for unrecognised shapes — the warn
         ;; signals operators to add the new envelope shape to [[extract-error-message]].
         s         (or extracted
@@ -578,7 +593,7 @@
       (throw e)
 
       (:body data)
-      (let [res     (json/decode-body data)
+      (let [res     (decode-bounded-body data)
             base    (res->message res)
             preview (body-preview (:body res))
             msg     (cond-> base

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -523,7 +523,7 @@
   [r limit]
   (try
     (with-open [rdr (io/reader r :encoding "UTF-8")]
-      (let [buf (char-array limit)]
+      (let [^chars buf (char-array limit)]
         (loop [off 0]
           (if (= off limit)
             (String. buf 0 limit)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -509,19 +509,19 @@
 (defn- body-preview
   "Build a short, human-readable snippet of an upstream provider's response body for the
    exception message. Prefers structured JSON envelopes (`[:error :message]`, `:error`,
-   `:detail`, `:message`) over `pr-str`; slurps `InputStream` bodies. Returns `nil` when
-   there's nothing useful to surface."
+   `:detail`, `:message`); slurps `InputStream` bodies. Returns `nil` for maps that
+   don't carry a recognised human-readable field — the full body is still logged and
+   stashed in `ex-data`, so users don't see raw `{:request-id ...}` blobs in toasts."
   [body]
   (let [s (cond
             (nil? body)                  nil
             (string? body)               body
-            (map? body)                  (or (some-> (or (get-in body [:error :message])
-                                                         (:error body)
-                                                         (:detail body)
-                                                         (:message body))
-                                                     str
-                                                     not-empty)
-                                             (pr-str body))
+            (map? body)                  (some-> (or (get-in body [:error :message])
+                                                     (:error body)
+                                                     (:detail body)
+                                                     (:message body))
+                                                 str
+                                                 not-empty)
             (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
             :else                        (pr-str body))]
     (when-let [trimmed (some-> s str/trim not-empty)]
@@ -536,8 +536,14 @@
   provider-specific message (e.g. `\"Anthropic API key expired or invalid\"`). When
   the response carries a body, this function appends a truncated preview of that
   body to the message so engineers and admins can see what the upstream actually
-  said, and emits a `log/warn` with the *full* body at the failure boundary so
-  the response body never gets silently swallowed.
+  said, and emits a `log/warnf` line with the *full* body at the failure boundary
+  so the response body never gets silently swallowed.
+
+  `ex-data` is an explicit allow-list of `:status`, `:reason-phrase`, and `:body`
+  (plus provider tagging) rather than a passthrough of the raw clj-http response —
+  the raw response carries `:http-client` (a `Closeable`), `:trace-redirects`,
+  `:orig-content-encoding`, and other internals we don't want in ex-data or Sentry
+  payloads.
 
   If the exception already carries `:api-error true` in its ex-data (e.g. a
   missing-API-key error from [[resolve-auth]]) it is rethrown as-is so the
@@ -554,27 +560,26 @@
             preview (body-preview (:body res))
             msg     (cond-> base
                       preview (str " — " preview))]
-        (log/warn "Provider API request failed"
-                  {:provider provider
-                   :status   (:status res)
-                   :body     (:body res)})
+        ;; `log/warn` would `pr-str` a trailing map into the message, not record it as
+        ;; structured MDC. Use `log/warnf` so we knowingly emit one greppable blob.
+        (log/warnf "Provider API request failed: provider=%s status=%s body=%s"
+                   provider (:status res) (pr-str (:body res)))
         (throw (ex-info msg
-                        (assoc res
-                               :api-error  true
-                               :provider   provider
-                               :error-code :provider-api-error)
+                        (merge (select-keys res [:status :reason-phrase :body])
+                               {:api-error  true
+                                :provider   provider
+                                :error-code :provider-api-error})
                         e)))
 
       :else
-      (do
-        (log/warn "Provider API request failed (no response)"
-                  {:provider        provider
-                   :exception-class (some-> e .getClass .getName)
-                   :exception-msg   (ex-message e)})
+      (let [exception-class (some-> e .getClass .getName)]
+        (log/warnf "Provider API request failed (no response): provider=%s class=%s message=%s"
+                   provider exception-class (ex-message e))
         (throw (ex-info (tru "{0} API request failed: {1}" provider (ex-message e))
-                        {:api-error  true
-                         :provider   provider
-                         :error-code :provider-request-failed}
+                        {:api-error       true
+                         :provider        provider
+                         :error-code      :provider-request-failed
+                         :exception-class exception-class}
                         e))))))
 
 (defn missing-api-key-ex

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -518,6 +518,23 @@
         (s (:detail m))
         (s (:message m)))))
 
+(defn- slurp-bounded
+  "Read at most `limit` chars from `r`, returning nil on read error or empty input.
+  Used so a multi-MB upstream body doesn't get pulled fully into memory just to be
+  truncated to a few hundred chars."
+  [r limit]
+  (try
+    (with-open [rdr (io/reader r)]
+      (let [buf (char-array limit)]
+        (loop [off 0]
+          (if (= off limit)
+            (String. buf 0 limit)
+            (let [n (.read ^java.io.Reader rdr buf off (- limit off))]
+              (if (neg? n)
+                (when (pos? off) (String. buf 0 off))
+                (recur (+ off n))))))))
+    (catch Throwable _ nil)))
+
 (defn- body-preview
   "Short snippet of an upstream response body for the user-facing exception message.
   Non-empty maps/arrays without a recognised human-readable field fall back to `pr-str`
@@ -532,7 +549,9 @@
                                                      (map? head)    (extract-error-message head)
                                                      (string? head) head
                                                      :else          nil))
-                    (instance? InputStream body) (try (slurp body) (catch Throwable _ nil))
+                    ;; +1 so the truncation branch below detects overflow without having
+                    ;; to read the full stream.
+                    (instance? InputStream body) (slurp-bounded body (inc max-body-preview-chars))
                     :else                        nil)
         ;; Surface *some* context to the user even for unrecognised shapes — the warn
         ;; signals operators to add the new envelope shape to [[extract-error-message]].

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -161,7 +161,7 @@
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
 (defn- openai-error-msg
-  "Canonical, status-specific OpenAI error message; the upstream body is appended out of scope."
+  "Canonical, status-specific OpenAI error message; the upstream body is appended separately."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -160,18 +160,18 @@
      :description doc
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
-(defn- openai-errors [res]
-  (let [status    (long (:status res 0))
-        error-msg (get-in res [:body :error :message])]
+(defn- openai-errors
+  "Return the canonical, status-specific OpenAI error message.
+   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+  [res]
+  (let [status (long (:status res 0))]
     (case status
       401 (tru "OpenAI API key expired or invalid")
       403 (tru "OpenAI API key has insufficient permissions")
       404 (tru "OpenAI API endpoint or model listing is unavailable")
       429 (tru "OpenAI API has rate limited us")
       500 (tru "OpenAI API is not working but not saying why")
-      (if error-msg
-        (tru "OpenAI API error (HTTP {0}): {1}" status error-msg)
-        (tru "OpenAI API error (HTTP {0})" status)))))
+      (tru "OpenAI API error (HTTP {0})" status))))
 
 (defn list-models
   "List available OpenAI models.

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -161,7 +161,7 @@
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
 (defn- openai-error-msg
-  "Canonical, status-specific OpenAI error message; the upstream body is appended separately."
+  "Canonical, status-specific OpenAI error message."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -161,7 +161,7 @@
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
 (defn- openai-error-msg
-  "Canonical, status-specific OpenAI error message; [[core/rethrow-api-error!]] appends the body preview."
+  "Canonical, status-specific OpenAI error message; the upstream body is appended out of scope."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -160,9 +160,8 @@
      :description doc
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
-(defn- openai-errors
-  "Return the canonical, status-specific OpenAI error message.
-   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+(defn- openai-error-msg
+  "Canonical, status-specific OpenAI error message; [[core/rethrow-api-error!]] appends the body preview."
   [res]
   (let [status (long (:status res 0))]
     (case status
@@ -195,7 +194,7 @@
                          :display_name (:id model)})
                       (reverse (sort-by :created (get-in res [:body :data]))))})
      (catch Exception e
-       (core/rethrow-api-error! "openai" openai-errors e)))))
+       (core/rethrow-api-error! "openai" openai-error-msg e)))))
 
 (mu/defn openai-raw
   "Perform a streaming request to OpenAI Responses API."
@@ -239,7 +238,7 @@
                                    :url      "/v1/responses"
                                    :request  req})))
       (catch Exception e
-        (core/rethrow-api-error! "openai" openai-errors e)))))
+        (core/rethrow-api-error! "openai" openai-error-msg e)))))
 
 (defn openai
   "Call OpenAI API, return AISDK stream."

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -93,7 +93,7 @@
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
 (defn- openrouter-error-msg
-  "Canonical, status-specific OpenRouter error message; [[core/rethrow-api-error!]] appends the body preview."
+  "Canonical, status-specific OpenRouter error message; the upstream body is appended out of scope."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -92,9 +92,11 @@
                 :description doc
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
-(defn- openrouter-errors [res]
-  (let [status    (long (:status res 0))
-        error-msg (get-in res [:body :error :message])]
+(defn- openrouter-errors
+  "Return the canonical, status-specific OpenRouter error message.
+   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+  [res]
+  (let [status (long (:status res 0))]
     (case status
       401 (tru "OpenRouter API key expired or invalid")
       402 (tru "OpenRouter has insufficient credits")
@@ -104,9 +106,7 @@
       500 (tru "OpenRouter returned an internal server error")
       502 (tru "OpenRouter upstream provider returned an error")
       503 (tru "OpenRouter service is unavailable")
-      (if error-msg
-        (tru "OpenRouter API error (HTTP {0}): {1}" status error-msg)
-        (tru "OpenRouter API error (HTTP {0})" status)))))
+      (tru "OpenRouter API error (HTTP {0})" status))))
 
 (defn list-models
   "List available OpenRouter models.

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -92,9 +92,8 @@
                 :description doc
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
-(defn- openrouter-errors
-  "Return the canonical, status-specific OpenRouter error message.
-   [[core/rethrow-api-error!]] appends an upstream body preview when one is available."
+(defn- openrouter-error-msg
+  "Canonical, status-specific OpenRouter error message; [[core/rethrow-api-error!]] appends the body preview."
   [res]
   (let [status (long (:status res 0))]
     (case status
@@ -132,7 +131,7 @@
                          :display_name (or (:name model) (:id model))})
                       (reverse (sort-by :created (get-in res [:body :data]))))})
      (catch Exception e
-       (core/rethrow-api-error! "openrouter" openrouter-errors e)))))
+       (core/rethrow-api-error! "openrouter" openrouter-error-msg e)))))
 
 ;;; Streaming response → AISDK v5 chunks
 
@@ -305,7 +304,7 @@
                                      :url      "/v1/chat/completions"
                                      :request  req})))
         (catch Exception e
-          (core/rethrow-api-error! "openrouter" openrouter-errors e))))))
+          (core/rethrow-api-error! "openrouter" openrouter-error-msg e))))))
 
 (defn openrouter
   "Call OpenRouter Chat Completions API, return AISDK stream."

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -93,7 +93,7 @@
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
 (defn- openrouter-error-msg
-  "Canonical, status-specific OpenRouter error message; the upstream body is appended out of scope."
+  "Canonical, status-specific OpenRouter error message; the upstream body is appended separately."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -93,7 +93,7 @@
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
 (defn- openrouter-error-msg
-  "Canonical, status-specific OpenRouter error message; the upstream body is appended separately."
+  "Canonical, status-specific OpenRouter error message."
   [res]
   (let [status (long (:status res 0))]
     (case status

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -978,7 +978,7 @@
                              upstream))]
       (is (= "Anthropic API error (HTTP 500) — model decommissioned" (ex-message ex)))
       ;; pin exact ex-data keys — clj-http internals (:http-client, :trace-redirects, …) must not leak.
-      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+      (is (= #{:status :reason-phrase :headers :body :api-error :provider :error-code}
              (set (keys (ex-data ex)))))
       (is (=? {:api-error true :provider "anthropic" :error-code :provider-api-error
                :status 500 :body {:error {:message "model decommissioned"}}}
@@ -995,7 +995,7 @@
                              upstream))]
       (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
       (is (str/includes? (ex-message ex) "upstream gateway timeout"))
-      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+      (is (= #{:status :reason-phrase :headers :body :api-error :provider :error-code}
              (set (keys (ex-data ex)))))))
 
   (testing "structured maps without :error/:detail/:message pr-str into the user-facing message"
@@ -1012,7 +1012,7 @@
           "the unrecognised envelope's pr-str is appended so operators see what we got")
       (is (= {:request-id "abc" :trace ["frame1"]} (:body (ex-data ex)))
           "the full body is still preserved in ex-data for debugging")
-      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+      (is (= #{:status :reason-phrase :headers :body :api-error :provider :error-code}
              (set (keys (ex-data ex)))))))
 
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
@@ -1032,6 +1032,22 @@
       (is (= "openai API request failed" (ex-message ex)))
       (is (= #{:api-error :provider :error-code :exception-class}
              (set (keys (ex-data ex)))))))
+
+  (testing "Retry-After header survives the ex-data allow-list and reaches retry-delay-ms"
+    ;; Regression test: an earlier revision allow-listed only :status/:reason-phrase/:body,
+    ;; which silently dropped :headers and made provider 429/529 retries fall back to
+    ;; exponential backoff instead of honoring the upstream Retry-After.
+    (let [upstream (ex-info "clj-http error"
+                            {:status 429 :reason-phrase "Too Many Requests"
+                             :headers {"retry-after" "3"}
+                             :body "rate limited"})
+          ex       (caught #(self.core/rethrow-api-error!
+                             "openrouter"
+                             (constantly "OpenRouter rate limit")
+                             upstream))]
+      (is (= {"retry-after" "3"} (:headers (ex-data ex))))
+      (is (<= 3000 (#'self/retry-delay-ms 1 ex) (+ 3000 750))
+          "retry-delay-ms picks up the 3-second Retry-After through the rethrown exception")))
 
   (testing "the full upstream body is emitted at warn level alongside provider and status"
     (let [upstream (ex-info "clj-http error"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -924,27 +924,10 @@
     (testing "JSON arrays probe their first element"
       (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
       (is (= "first message" (body-preview ["first message" "ignored"]))))
-    (testing "InputStream bodies get slurped"
-      (is (= "boom"
-             (body-preview (java.io.ByteArrayInputStream. (.getBytes "boom"))))))
     (testing "long bodies are truncated to 500 chars with an ellipsis"
       (let [preview (body-preview (apply str (repeat 2000 \x)))]
         (is (str/ends-with? preview "…"))
-        (is (= 501 (count preview)))))
-    (testing "InputStream bodies are read up to the truncation window — not fully slurped"
-      ;; ByteArrayInputStream.available() returns the number of *unread* bytes, so we
-      ;; can compute how much body-preview consumed without proxying read methods.
-      ;; The InputStreamReader inside io/reader uses an 8KB decode buffer, so the
-      ;; ceiling isn't max-body-preview-chars exactly — but it's still constant
-      ;; rather than scaling with body size.
-      (let [body-bytes (.getBytes ^String (apply str (repeat 1000000 \x)))
-            stream     (java.io.ByteArrayInputStream. body-bytes)
-            preview    (body-preview stream)
-            consumed   (- (alength body-bytes) (.available stream))]
-        (is (str/ends-with? preview "…"))
-        (is (= 501 (count preview)))
-        (is (< consumed (alength body-bytes))
-            "should not consume the entire 1MB stream just to render a 500-char preview")))))
+        (is (= 501 (count preview)))))))
 
 (defn- caught
   "Run `thunk` and return the thrown exception, or nil if it didn't throw."
@@ -1026,6 +1009,59 @@
       (is (= "openai API request failed" (ex-message ex)))
       (is (= #{:api-error :provider :error-code :exception-class}
              (set (keys (ex-data ex)))))))
+
+  (testing "InputStream JSON bodies are decoded and structured-extracted"
+    (let [json     (json/encode {:error {:message "model decommissioned"}})
+          upstream (ex-info "clj-http error"
+                            {:status  500 :reason-phrase "Internal Server Error"
+                             :headers {"content-type" "application/json"}
+                             :body    (java.io.ByteArrayInputStream. (.getBytes ^String json))})
+          ex       (caught #(self.core/rethrow-api-error!
+                             "anthropic"
+                             (fn [res] (str "Anthropic API error (HTTP " (:status res) ")"))
+                             upstream))]
+      (is (= "Anthropic API error (HTTP 500) — model decommissioned" (ex-message ex)))
+      (is (=? {:error {:message "model decommissioned"}} (:body (ex-data ex))))))
+
+  (testing "Large InputStream bodies are bounded — not fully slurped into memory"
+    ;; ByteArrayInputStream.available() returns the unread byte count, so we can
+    ;; measure how much rethrow-api-error! pulled off the stream without proxying.
+    (let [body-bytes (.getBytes ^String (apply str (repeat 2000000 \x)))
+          stream     (java.io.ByteArrayInputStream. body-bytes)
+          upstream   (ex-info "clj-http error"
+                              {:status  502 :reason-phrase "Bad Gateway"
+                               :headers {"content-type" "text/plain"}
+                               :body    stream})
+          ex         (caught #(self.core/rethrow-api-error!
+                               "openrouter"
+                               (constantly "OpenRouter upstream provider returned an error")
+                               upstream))
+          consumed   (- (alength body-bytes) (.available stream))]
+      (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
+      (is (str/ends-with? (ex-message ex) "…"))
+      (is (< consumed (alength body-bytes))
+          "should not consume the entire 2MB stream just to surface an error preview")))
+
+  (testing "Truncated InputStream JSON bodies fall back to the raw bounded string"
+    ;; A small slurp cap forces the JSON to be cut mid-envelope. We should fall back
+    ;; to surfacing the raw bounded string rather than throwing on parse failure.
+    (let [json     (json/encode {:error {:message (apply str (repeat 10000 \x))}})
+          upstream (ex-info "clj-http error"
+                            {:status  500 :reason-phrase "Internal Server Error"
+                             :headers {"content-type" "application/json"}
+                             :body    (java.io.ByteArrayInputStream. (.getBytes ^String json))})
+          ex       (with-redefs [self.core/max-body-slurp-chars 100]
+                     (caught #(self.core/rethrow-api-error!
+                               "anthropic"
+                               (constantly "Anthropic upstream provider returned an error")
+                               upstream)))]
+      (is (str/includes? (ex-message ex) "Anthropic upstream provider returned an error"))
+      (is (str/includes? (ex-message ex) "{\"error\":{\"message\":\"xxx")
+          "the truncated raw string is surfaced in the user-facing message when JSON parse fails")
+      (is (string? (:body (ex-data ex)))
+          "the bounded raw string is kept on ex-data when JSON parse fails")
+      (is (<= (count (:body (ex-data ex))) 100)
+          "the body in ex-data respects the slurp cap")))
 
   (testing "Retry-After header survives the ex-data allow-list and reaches retry-delay-ms"
     ;; Regression test: an earlier revision allow-listed only :status/:reason-phrase/:body,

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -892,18 +892,34 @@
       (is (= "invalid metric"       (body-preview {:error  "invalid metric"})))
       (is (= "missing prompt"       (body-preview {:detail "missing prompt"})))
       (is (= "bad request"          (body-preview {:message "bad request"}))))
-    (testing "maps and arrays without a recognised error field → nil (no leak to users)"
-      (is (every? nil? (map body-preview [{} {:request-id "abc" :trace ["frame1"]}
-                                          [] [42 :kw] [{:request-id "abc"}]]))))
-    (testing "structured values under :error/:detail/:message don't get coerced via str"
-      (is (every? nil? (map body-preview [{:error  {:code 42 :type "x"}}
-                                          {:detail [{:loc ["body" "prompt"]}]}
-                                          {:message {:code "missing"}}
-                                          {:error  {:message {:code 500}}}
-                                          {:error  42}]))))
+    (testing "extract-error-message returns nil for non-string values at the recognised keys"
+      (let [extract #'self.core/extract-error-message]
+        (is (every? nil? (map extract [{:error  {:code 42 :type "x"}}
+                                       {:detail [{:loc ["body" "prompt"]}]}
+                                       {:message {:code "missing"}}
+                                       {:error  {:message {:code 500}}}
+                                       {:error  42}])))))
     (testing "a non-string or blank at one key falls through to a later key with a real message"
       (is (= "real error" (body-preview {:error {:message {:code 500}} :detail "real error"})))
       (is (= "real error" (body-preview {:error "" :detail "real error"}))))
+    (testing "empty maps and arrays return nil (nothing to preview, no warn)"
+      (let [msgs (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
+                   (is (every? nil? (map body-preview [{} []])))
+                   (msgs))]
+        (is (empty? msgs))))
+    (testing "non-empty maps/arrays without a recognised error field pr-str into the preview + warn"
+      (let [bodies [{:request-id "abc" :trace ["frame1"]}
+                    [42 :kw]
+                    [{:request-id "abc"}]
+                    {:error {:code 42 :type "x"}}]
+            msgs   (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
+                     (doseq [b bodies]
+                       (is (= (pr-str b) (body-preview b))
+                           (str "pr-str fallback for " (pr-str b))))
+                     (msgs))]
+        (is (= (count bodies) (count msgs))
+            "one warn line per pr-str fallback")
+        (is (every? #(re-find #"unrecognised error body shape" (:message %)) msgs))))
     (testing "JSON arrays probe their first element"
       (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
       (is (= "first message" (body-preview ["first message" "ignored"]))))
@@ -961,7 +977,7 @@
       (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
              (set (keys (ex-data ex)))))))
 
-  (testing "structured maps without :error/:detail/:message keep the user-facing message clean"
+  (testing "structured maps without :error/:detail/:message pr-str into the user-facing message"
     (let [upstream (ex-info "clj-http error"
                             {:status 500 :reason-phrase "Internal Server Error"
                              :headers {"content-type" "application/json"}
@@ -970,7 +986,9 @@
                              "anthropic"
                              (constantly "Anthropic API is not working but not saying why")
                              upstream))]
-      (is (= "Anthropic API is not working but not saying why" (ex-message ex)))
+      (is (str/includes? (ex-message ex) "Anthropic API is not working but not saying why"))
+      (is (str/includes? (ex-message ex) ":request-id")
+          "the unrecognised envelope's pr-str is appended so operators see what we got")
       (is (= {:request-id "abc" :trace ["frame1"]} (:body (ex-data ex)))
           "the full body is still preserved in ex-data for debugging")
       (is (= #{:status :reason-phrase :body :api-error :provider :error-code}

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -1100,7 +1100,30 @@
       (is (=? {:level :warn :namespace 'metabase.metabot.self.core}
               entry))
       (is (re-find #"provider=openrouter status=502 body=\"upstream gateway timeout\""
-                   (:message entry))))))
+                   (:message entry)))))
+  (testing "an oversized body is capped in the warn log, but preserved in full on ex-data"
+    (let [big-body (apply str (repeat 5000 \x))
+          upstream (ex-info "clj-http error"
+                            {:status 502 :reason-phrase "Bad Gateway"
+                             :headers {"content-type" "text/plain"}
+                             :body big-body})
+          [entry & more]
+          (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
+            (let [ex (caught #(self.core/rethrow-api-error!
+                               "openrouter"
+                               (constantly "OpenRouter upstream provider returned an error")
+                               upstream))]
+              (is (= big-body (:body (ex-data ex)))
+                  "the full, untruncated body still survives on ex-data"))
+            (msgs))]
+      (is (nil? more) "exactly one warn line at the failure boundary")
+      ;; pr-str of the string adds the surrounding quotes; the cap then slices at
+      ;; max-body-log-chars (2000) and appends the ellipsis.
+      (is (str/ends-with? (:message entry)
+                          (str "body=" (subs (pr-str big-body) 0 2000) "…"))
+          "the warn line's body segment is capped at max-body-log-chars with a trailing ellipsis")
+      (is (not (str/includes? (:message entry) big-body))
+          "the full oversized body is not spliced into the warn line"))))
 
 (deftest rethrow-api-error!-auth-status-body-not-leaked-test
   (testing "401/403 bodies are not appended to the user-facing message (may carry sensitive auth/account detail)"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -893,8 +893,9 @@
       (is (= "invalid metric"  (body-preview {:error "invalid metric"})))
       (is (= "missing prompt"  (body-preview {:detail "missing prompt"})))
       (is (= "bad request"     (body-preview {:message "bad request"}))))
-    (testing "unstructured maps fall back to pr-str"
-      (is (= "{:weird \"shape\"}" (body-preview {:weird "shape"}))))
+    (testing "maps without a recognised error field return nil — no internal blobs leak to users"
+      (is (nil? (body-preview {:request-id "abc" :trace ["frame1" "frame2"]})))
+      (is (nil? (body-preview {}))))
     (testing "InputStream bodies get slurped"
       (let [stream (java.io.ByteArrayInputStream. (.getBytes "boom from upstream" "UTF-8"))]
         (is (= "boom from upstream" (body-preview stream)))))
@@ -904,6 +905,15 @@
         (is (str/ends-with? preview "…"))
         (is (= 501 (count preview)))))))
 
+(defn- assert-rethrow-no-internals!
+  "`=?` is a subset match — it silently passes if a key is present in `ex-data` but
+   absent from the expectation. Raw clj-http responses carry `:headers`, `:http-client`
+   (a `Closeable`), `:trace-redirects`, etc., none of which should land in `ex-data`."
+  [data]
+  (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+         (set (keys data)))
+      "ex-data is an explicit allow-list, not a passthrough of the raw clj-http response"))
+
 (deftest rethrow-api-error!-test
   (testing ":api-error exceptions are rethrown unchanged"
     (let [original (ex-info "boom" {:api-error true :error-code :proxy-not-configured})]
@@ -912,10 +922,13 @@
                            (catch Exception e e))))))
   (testing "HTTP responses with a body get the upstream body appended and surfaced in ex-data"
     (let [upstream (ex-info "clj-http error"
-                            {:status 500
-                             :reason-phrase "Internal Server Error"
-                             :headers {"content-type" "application/json"}
-                             :body (json/encode {:error {:message "model decommissioned"}})})
+                            {:status                500
+                             :reason-phrase         "Internal Server Error"
+                             :headers               {"content-type" "application/json"}
+                             :body                  (json/encode {:error {:message "model decommissioned"}})
+                             :http-client           (reify java.io.Closeable (close [_]))
+                             :trace-redirects       ["http://elsewhere"]
+                             :orig-content-encoding "gzip"})
           ex       (try
                      (self.core/rethrow-api-error!
                       "anthropic"
@@ -930,13 +943,14 @@
                :error-code :provider-api-error
                :status     500
                :body       {:error {:message "model decommissioned"}}}
-              (ex-data ex)))))
+              (ex-data ex)))
+      (assert-rethrow-no-internals! (ex-data ex))))
   (testing "non-JSON bodies still get a preview appended"
     (let [upstream (ex-info "clj-http error"
-                            {:status 502
+                            {:status        502
                              :reason-phrase "Bad Gateway"
-                             :headers {"content-type" "text/plain"}
-                             :body "upstream gateway timeout"})
+                             :headers       {"content-type" "text/plain"}
+                             :body          "upstream gateway timeout"})
           ex       (try
                      (self.core/rethrow-api-error!
                       "openrouter"
@@ -945,7 +959,25 @@
                      nil
                      (catch Exception e e))]
       (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
-      (is (str/includes? (ex-message ex) "upstream gateway timeout"))))
+      (is (str/includes? (ex-message ex) "upstream gateway timeout"))
+      (assert-rethrow-no-internals! (ex-data ex))))
+  (testing "structured maps without :error/:detail/:message keep the user-facing message clean"
+    (let [upstream (ex-info "clj-http error"
+                            {:status        500
+                             :reason-phrase "Internal Server Error"
+                             :headers       {"content-type" "application/json"}
+                             :body          (json/encode {:request-id "abc" :trace ["frame1"]})})
+          ex       (try
+                     (self.core/rethrow-api-error!
+                      "anthropic"
+                      (constantly "Anthropic API is not working but not saying why")
+                      upstream)
+                     nil
+                     (catch Exception e e))]
+      (is (= "Anthropic API is not working but not saying why" (ex-message ex))
+          "no internal body fields leak into the exception message")
+      (is (= {:request-id "abc" :trace ["frame1"]} (get (ex-data ex) :body))
+          "the full body is still preserved in ex-data for debugging")))
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
     (let [upstream (java.net.SocketTimeoutException. "Read timed out")
           ex       (try
@@ -954,7 +986,8 @@
                      (catch Exception e e))]
       (is (str/includes? (ex-message ex) "API request failed"))
       (is (str/includes? (ex-message ex) "Read timed out"))
-      (is (=? {:api-error  true
-               :provider   "openai"
-               :error-code :provider-request-failed}
+      (is (=? {:api-error       true
+               :provider        "openai"
+               :error-code      :provider-request-failed
+               :exception-class "java.net.SocketTimeoutException"}
               (ex-data ex))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -899,9 +899,10 @@
                                        {:message {:code "missing"}}
                                        {:error  {:message {:code 500}}}
                                        {:error  42}])))))
-    (testing "a non-string or blank at one key falls through to a later key with a real message"
+    (testing "a non-string, blank, or whitespace-only at one key falls through to a later key"
       (is (= "real error" (body-preview {:error {:message {:code 500}} :detail "real error"})))
-      (is (= "real error" (body-preview {:error "" :detail "real error"}))))
+      (is (= "real error" (body-preview {:error ""    :detail "real error"})))
+      (is (= "real error" (body-preview {:error "   " :detail "real error"}))))
     (testing "empty maps and arrays return nil (nothing to preview, no warn)"
       (let [msgs (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
                    (is (every? nil? (map body-preview [{} []])))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -53,10 +53,11 @@
   (testing "passes required tool choice to LLM providers"
     (let [captured (atom nil)]
       (mt/with-premium-features #{:metabase-ai-managed}
+        ;; `:api-error true` makes `rethrow-api-error!` rethrow as-is, so `::skip` survives on the outer ex-data.
         (mt/with-dynamic-fn-redefs [http/request (fn [opts]
                                                    (when (:body opts)
                                                      (reset! captured (json/decode+kw (:body opts))))
-                                                   (throw (ex-info "stop" {::skip true :status 401 :body "skip parsing"})))]
+                                                   (throw (ex-info "stop" {::skip true :api-error true})))]
           (mt/with-temporary-setting-values [llm-anthropic-api-key  "sk-ant-test-key"
                                              llm-proxy-base-url     "http://proxy.example"
                                              llm-openrouter-api-key "sk-or-v1-test-key"
@@ -881,67 +882,40 @@
 
 (deftest ^:parallel body-preview-test
   (let [body-preview #'self.core/body-preview]
-    (testing "nil and blank → nil"
-      (is (nil? (body-preview nil)))
-      (is (nil? (body-preview "")))
-      (is (nil? (body-preview "   "))))
+    (testing "nil, blank, and non-string scalars → nil"
+      (is (every? nil? (map body-preview [nil "" "   " 500 :error true]))))
     (testing "plain strings pass through trimmed"
       (is (= "Internal Server Error" (body-preview "  Internal Server Error  "))))
     (testing "JSON envelopes prefer [:error :message] over :error/:detail/:message"
-      (is (= "model decommissioned"
-             (body-preview {:error {:message "model decommissioned" :type "deprecated"}})))
-      (is (= "invalid metric"  (body-preview {:error "invalid metric"})))
-      (is (= "missing prompt"  (body-preview {:detail "missing prompt"})))
-      (is (= "bad request"     (body-preview {:message "bad request"}))))
-    (testing "maps without a recognised error field return nil — no internal blobs leak to users"
-      (is (nil? (body-preview {:request-id "abc" :trace ["frame1" "frame2"]})))
-      (is (nil? (body-preview {}))))
-    (testing "JSON arrays probe their first element symmetrically with maps"
-      (is (= "rate limited"
-             (body-preview [{:error {:message "rate limited"}} {:type "diagnostic"}])))
-      (is (= "first message"
-             (body-preview ["first message" "ignored"])))
-      (is (nil? (body-preview [{:request-id "abc"} {:trace ["frame1"]}]))
-          "arrays of internal diagnostic objects do not leak to users")
-      (is (nil? (body-preview [])))
-      (is (nil? (body-preview [42 :keyword]))))
-    (testing "other non-string scalars return nil rather than pr-str'ing into the toast"
-      (is (nil? (body-preview 500)))
-      (is (nil? (body-preview :error)))
-      (is (nil? (body-preview true))))
+      (is (= "model decommissioned" (body-preview {:error {:message "model decommissioned" :type "x"}})))
+      (is (= "invalid metric"       (body-preview {:error  "invalid metric"})))
+      (is (= "missing prompt"       (body-preview {:detail "missing prompt"})))
+      (is (= "bad request"          (body-preview {:message "bad request"}))))
+    (testing "maps and arrays without a recognised error field → nil (no leak to users)"
+      (is (every? nil? (map body-preview [{} {:request-id "abc" :trace ["frame1"]}
+                                          [] [42 :kw] [{:request-id "abc"}]]))))
+    (testing "JSON arrays probe their first element"
+      (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
+      (is (= "first message" (body-preview ["first message" "ignored"]))))
     (testing "InputStream bodies get slurped"
-      (let [stream (java.io.ByteArrayInputStream. (.getBytes "boom from upstream" "UTF-8"))]
-        (is (= "boom from upstream" (body-preview stream)))))
+      (is (= "boom"
+             (body-preview (java.io.ByteArrayInputStream. (.getBytes "boom"))))))
     (testing "long bodies are truncated to 500 chars with an ellipsis"
-      (let [long-body (apply str (repeat 2000 \x))
-            preview   (body-preview long-body)]
+      (let [preview (body-preview (apply str (repeat 2000 \x)))]
         (is (str/ends-with? preview "…"))
         (is (= 501 (count preview)))))))
 
-(defn- assert-rethrow-no-internals!
-  "`=?` is a subset match — it silently passes if a key is present in `ex-data` but
-   absent from the expectation. Raw clj-http responses carry `:headers`, `:http-client`
-   (a `Closeable`), `:trace-redirects`, etc., none of which should land in `ex-data`."
-  [data]
-  (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
-         (set (keys data)))
-      "ex-data is an explicit allow-list, not a passthrough of the raw clj-http response"))
-
-(defn- assert-rethrow-no-internals-no-body!
-  "Sibling of [[assert-rethrow-no-internals!]] for the no-`:body` branch (network
-   errors, timeouts). Pins the exact key set so an accidental extra `ex-data` key
-   gets caught here too."
-  [data]
-  (is (= #{:api-error :provider :error-code :exception-class}
-         (set (keys data)))
-      "ex-data is an explicit allow-list, not a passthrough of the raw exception"))
+(defn- caught
+  "Run `thunk` and return the thrown exception, or nil if it didn't throw."
+  [thunk]
+  (try (thunk) nil (catch Exception e e)))
 
 (deftest rethrow-api-error!-test
   (testing ":api-error exceptions are rethrown unchanged"
     (let [original (ex-info "boom" {:api-error true :error-code :proxy-not-configured})]
       (is (identical? original
-                      (try (self.core/rethrow-api-error! "anthropic" (constantly "X") original)
-                           (catch Exception e e))))))
+                      (caught #(self.core/rethrow-api-error! "anthropic" (constantly "X") original))))))
+
   (testing "HTTP responses with a body get the upstream body appended and surfaced in ex-data"
     (let [upstream (ex-info "clj-http error"
                             {:status                500
@@ -951,67 +925,51 @@
                              :http-client           (reify java.io.Closeable (close [_]))
                              :trace-redirects       ["http://elsewhere"]
                              :orig-content-encoding "gzip"})
-          ex       (try
-                     (self.core/rethrow-api-error!
-                      "anthropic"
-                      (fn [res] (str "Anthropic API error (HTTP " (:status res) ")"))
-                      upstream)
-                     nil
-                     (catch Exception e e))]
-      (is (= "Anthropic API error (HTTP 500) — model decommissioned"
-             (ex-message ex)))
-      (is (=? {:api-error  true
-               :provider   "anthropic"
-               :error-code :provider-api-error
-               :status     500
-               :body       {:error {:message "model decommissioned"}}}
-              (ex-data ex)))
-      (assert-rethrow-no-internals! (ex-data ex))))
+          ex       (caught #(self.core/rethrow-api-error!
+                             "anthropic"
+                             (fn [res] (str "Anthropic API error (HTTP " (:status res) ")"))
+                             upstream))]
+      (is (= "Anthropic API error (HTTP 500) — model decommissioned" (ex-message ex)))
+      ;; pin exact ex-data keys — clj-http internals (:http-client, :trace-redirects, …) must not leak.
+      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+             (set (keys (ex-data ex)))))
+      (is (=? {:api-error true :provider "anthropic" :error-code :provider-api-error
+               :status 500 :body {:error {:message "model decommissioned"}}}
+              (ex-data ex)))))
+
   (testing "non-JSON bodies still get a preview appended"
     (let [upstream (ex-info "clj-http error"
-                            {:status        502
-                             :reason-phrase "Bad Gateway"
-                             :headers       {"content-type" "text/plain"}
-                             :body          "upstream gateway timeout"})
-          ex       (try
-                     (self.core/rethrow-api-error!
-                      "openrouter"
-                      (fn [_] "OpenRouter upstream provider returned an error")
-                      upstream)
-                     nil
-                     (catch Exception e e))]
+                            {:status 502 :reason-phrase "Bad Gateway"
+                             :headers {"content-type" "text/plain"}
+                             :body "upstream gateway timeout"})
+          ex       (caught #(self.core/rethrow-api-error!
+                             "openrouter"
+                             (constantly "OpenRouter upstream provider returned an error")
+                             upstream))]
       (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
-      (is (str/includes? (ex-message ex) "upstream gateway timeout"))
-      (assert-rethrow-no-internals! (ex-data ex))))
+      (is (str/includes? (ex-message ex) "upstream gateway timeout"))))
+
   (testing "structured maps without :error/:detail/:message keep the user-facing message clean"
     (let [upstream (ex-info "clj-http error"
-                            {:status        500
-                             :reason-phrase "Internal Server Error"
-                             :headers       {"content-type" "application/json"}
-                             :body          (json/encode {:request-id "abc" :trace ["frame1"]})})
-          ex       (try
-                     (self.core/rethrow-api-error!
-                      "anthropic"
-                      (constantly "Anthropic API is not working but not saying why")
-                      upstream)
-                     nil
-                     (catch Exception e e))]
-      (is (= "Anthropic API is not working but not saying why" (ex-message ex))
-          "no internal body fields leak into the exception message")
-      (is (= {:request-id "abc" :trace ["frame1"]} (get (ex-data ex) :body))
-          "the full body is still preserved in ex-data for debugging")
-      (assert-rethrow-no-internals! (ex-data ex))))
+                            {:status 500 :reason-phrase "Internal Server Error"
+                             :headers {"content-type" "application/json"}
+                             :body (json/encode {:request-id "abc" :trace ["frame1"]})})
+          ex       (caught #(self.core/rethrow-api-error!
+                             "anthropic"
+                             (constantly "Anthropic API is not working but not saying why")
+                             upstream))]
+      (is (= "Anthropic API is not working but not saying why" (ex-message ex)))
+      (is (= {:request-id "abc" :trace ["frame1"]} (:body (ex-data ex)))
+          "the full body is still preserved in ex-data for debugging")))
+
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
-    (let [upstream (java.net.SocketTimeoutException. "Read timed out")
-          ex       (try
-                     (self.core/rethrow-api-error! "openai" (constantly "unused") upstream)
-                     nil
-                     (catch Exception e e))]
+    (let [ex (caught #(self.core/rethrow-api-error!
+                       "openai" (constantly "unused") (java.net.SocketTimeoutException. "Read timed out")))]
       (is (str/includes? (ex-message ex) "API request failed"))
       (is (str/includes? (ex-message ex) "Read timed out"))
-      (is (=? {:api-error       true
-               :provider        "openai"
-               :error-code      :provider-request-failed
+      ;; pin exact ex-data keys for the no-body branch too.
+      (is (= #{:api-error :provider :error-code :exception-class}
+             (set (keys (ex-data ex)))))
+      (is (=? {:api-error true :provider "openai" :error-code :provider-request-failed
                :exception-class "java.net.SocketTimeoutException"}
-              (ex-data ex)))
-      (assert-rethrow-no-internals-no-body! (ex-data ex)))))
+              (ex-data ex))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -901,8 +901,9 @@
                                           {:message {:code "missing"}}
                                           {:error  {:message {:code 500}}}
                                           {:error  42}]))))
-    (testing "a non-string at one key falls through to a later key with a real message"
-      (is (= "real error" (body-preview {:error {:message {:code 500}} :detail "real error"}))))
+    (testing "a non-string or blank at one key falls through to a later key with a real message"
+      (is (= "real error" (body-preview {:error {:message {:code 500}} :detail "real error"})))
+      (is (= "real error" (body-preview {:error "" :detail "real error"}))))
     (testing "JSON arrays probe their first element"
       (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
       (is (= "first message" (body-preview ["first message" "ignored"]))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -948,7 +948,9 @@
                              (constantly "OpenRouter upstream provider returned an error")
                              upstream))]
       (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
-      (is (str/includes? (ex-message ex) "upstream gateway timeout"))))
+      (is (str/includes? (ex-message ex) "upstream gateway timeout"))
+      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+             (set (keys (ex-data ex)))))))
 
   (testing "structured maps without :error/:detail/:message keep the user-facing message clean"
     (let [upstream (ex-info "clj-http error"
@@ -961,7 +963,9 @@
                              upstream))]
       (is (= "Anthropic API is not working but not saying why" (ex-message ex)))
       (is (= {:request-id "abc" :trace ["frame1"]} (:body (ex-data ex)))
-          "the full body is still preserved in ex-data for debugging")))
+          "the full body is still preserved in ex-data for debugging")
+      (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
+             (set (keys (ex-data ex)))))))
 
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
     (let [ex (caught #(self.core/rethrow-api-error!
@@ -977,7 +981,9 @@
 
   (testing "no-body branch drops the trailing colon when ex-message is blank"
     (let [ex (caught #(self.core/rethrow-api-error! "openai" (constantly "unused") (RuntimeException.)))]
-      (is (= "openai API request failed" (ex-message ex)))))
+      (is (= "openai API request failed" (ex-message ex)))
+      (is (= #{:api-error :provider :error-code :exception-class}
+             (set (keys (ex-data ex)))))))
 
   (testing "the full upstream body is emitted at warn level alongside provider and status"
     (let [upstream (ex-info "clj-http error"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -975,6 +975,10 @@
                :exception-class "java.net.SocketTimeoutException"}
               (ex-data ex)))))
 
+  (testing "no-body branch drops the trailing colon when ex-message is blank"
+    (let [ex (caught #(self.core/rethrow-api-error! "openai" (constantly "unused") (RuntimeException.)))]
+      (is (= "openai API request failed" (ex-message ex)))))
+
   (testing "the full upstream body is emitted at warn level alongside provider and status"
     (let [upstream (ex-info "clj-http error"
                             {:status 502 :reason-phrase "Bad Gateway"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -896,6 +896,19 @@
     (testing "maps without a recognised error field return nil — no internal blobs leak to users"
       (is (nil? (body-preview {:request-id "abc" :trace ["frame1" "frame2"]})))
       (is (nil? (body-preview {}))))
+    (testing "JSON arrays probe their first element symmetrically with maps"
+      (is (= "rate limited"
+             (body-preview [{:error {:message "rate limited"}} {:type "diagnostic"}])))
+      (is (= "first message"
+             (body-preview ["first message" "ignored"])))
+      (is (nil? (body-preview [{:request-id "abc"} {:trace ["frame1"]}]))
+          "arrays of internal diagnostic objects do not leak to users")
+      (is (nil? (body-preview [])))
+      (is (nil? (body-preview [42 :keyword]))))
+    (testing "other non-string scalars return nil rather than pr-str'ing into the toast"
+      (is (nil? (body-preview 500)))
+      (is (nil? (body-preview :error)))
+      (is (nil? (body-preview true))))
     (testing "InputStream bodies get slurped"
       (let [stream (java.io.ByteArrayInputStream. (.getBytes "boom from upstream" "UTF-8"))]
         (is (= "boom from upstream" (body-preview stream)))))
@@ -913,6 +926,15 @@
   (is (= #{:status :reason-phrase :body :api-error :provider :error-code}
          (set (keys data)))
       "ex-data is an explicit allow-list, not a passthrough of the raw clj-http response"))
+
+(defn- assert-rethrow-no-internals-no-body!
+  "Sibling of [[assert-rethrow-no-internals!]] for the no-`:body` branch (network
+   errors, timeouts). Pins the exact key set so an accidental extra `ex-data` key
+   gets caught here too."
+  [data]
+  (is (= #{:api-error :provider :error-code :exception-class}
+         (set (keys data)))
+      "ex-data is an explicit allow-list, not a passthrough of the raw exception"))
 
 (deftest rethrow-api-error!-test
   (testing ":api-error exceptions are rethrown unchanged"
@@ -977,7 +999,8 @@
       (is (= "Anthropic API is not working but not saying why" (ex-message ex))
           "no internal body fields leak into the exception message")
       (is (= {:request-id "abc" :trace ["frame1"]} (get (ex-data ex) :body))
-          "the full body is still preserved in ex-data for debugging")))
+          "the full body is still preserved in ex-data for debugging")
+      (assert-rethrow-no-internals! (ex-data ex))))
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
     (let [upstream (java.net.SocketTimeoutException. "Read timed out")
           ex       (try
@@ -990,4 +1013,5 @@
                :provider        "openai"
                :error-code      :provider-request-failed
                :exception-class "java.net.SocketTimeoutException"}
-              (ex-data ex))))))
+              (ex-data ex)))
+      (assert-rethrow-no-internals-no-body! (ex-data ex)))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -1101,3 +1101,29 @@
               entry))
       (is (re-find #"provider=openrouter status=502 body=\"upstream gateway timeout\""
                    (:message entry))))))
+
+(deftest rethrow-api-error!-auth-status-body-not-leaked-test
+  (testing "401/403 bodies are not appended to the user-facing message (may carry sensitive auth/account detail)"
+    (doseq [status [401 403]]
+      (let [secret   "sk-leaked-key-abc123 for org=acme-corp tenant=42"
+            upstream (ex-info "clj-http error"
+                              {:status        status
+                               :reason-phrase "Unauthorized"
+                               :headers       {"content-type" "application/json"}
+                               :body          (json/encode {:error {:message secret}})})
+            [entry & more]
+            (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
+              (let [ex (caught #(self.core/rethrow-api-error!
+                                 "anthropic"
+                                 (fn [res] (str "Anthropic API error (HTTP " (:status res) ")"))
+                                 upstream))]
+                (is (= (str "Anthropic API error (HTTP " status ")") (ex-message ex))
+                    "no body preview spliced onto the user-facing message for auth statuses")
+                (is (not (str/includes? (ex-message ex) secret))
+                    "secret-bearing body must not leak into the rethrown message")
+                (is (= {:error {:message secret}} (:body (ex-data ex)))
+                    "the full decoded body is still preserved on ex-data for debugging"))
+              (msgs))]
+        (is (nil? more) "exactly one warn line at the failure boundary")
+        (is (str/includes? (:message entry) secret)
+            "the full body is still emitted at warn level for server-side debugging")))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -899,7 +899,10 @@
       (is (every? nil? (map body-preview [{:error  {:code 42 :type "x"}}
                                           {:detail [{:loc ["body" "prompt"]}]}
                                           {:message {:code "missing"}}
+                                          {:error  {:message {:code 500}}}
                                           {:error  42}]))))
+    (testing "a non-string at one key falls through to a later key with a real message"
+      (is (= "real error" (body-preview {:error {:message {:code 500}} :detail "real error"}))))
     (testing "JSON arrays probe their first element"
       (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
       (is (= "first message" (body-preview ["first message" "ignored"]))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -932,24 +932,18 @@
         (is (str/ends-with? preview "…"))
         (is (= 501 (count preview)))))
     (testing "InputStream bodies are read up to the truncation window — not fully slurped"
-      ;; A proxied ByteArrayInputStream lets us count bytes pulled off the stream and
-      ;; assert we stop short of consuming the whole body once the preview is filled.
+      ;; ByteArrayInputStream.available() returns the number of *unread* bytes, so we
+      ;; can compute how much body-preview consumed without proxying read methods.
       ;; The InputStreamReader inside io/reader uses an 8KB decode buffer, so the
-      ;; ceiling isn't max-body-preview-chars exactly — but it's still constant rather
-      ;; than scaling with body size.
-      (let [body-bytes (.getBytes (apply str (repeat 1000000 \x)))
-            counter    (java.util.concurrent.atomic.AtomicLong. 0)
-            stream     (proxy [java.io.ByteArrayInputStream] [body-bytes]
-                         (read
-                           ([] (.incrementAndGet counter) (proxy-super read))
-                           ([buf] (let [n (proxy-super read buf)]
-                                    (when (pos? n) (.addAndGet counter n)) n))
-                           ([buf off len] (let [n (proxy-super read buf off len)]
-                                            (when (pos? n) (.addAndGet counter n)) n))))
-            preview    (body-preview stream)]
+      ;; ceiling isn't max-body-preview-chars exactly — but it's still constant
+      ;; rather than scaling with body size.
+      (let [body-bytes (.getBytes ^String (apply str (repeat 1000000 \x)))
+            stream     (java.io.ByteArrayInputStream. body-bytes)
+            preview    (body-preview stream)
+            consumed   (- (alength body-bytes) (.available stream))]
         (is (str/ends-with? preview "…"))
         (is (= 501 (count preview)))
-        (is (< (.get counter) (count body-bytes))
+        (is (< consumed (alength body-bytes))
             "should not consume the entire 1MB stream just to render a 500-char preview")))))
 
 (defn- caught

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -934,12 +934,13 @@
   [thunk]
   (try (thunk) nil (catch Exception e e)))
 
-(deftest rethrow-api-error!-test
+(deftest rethrow-api-error!-passthrough-test
   (testing ":api-error exceptions are rethrown unchanged"
     (let [original (ex-info "boom" {:api-error true :error-code :proxy-not-configured})]
       (is (identical? original
-                      (caught #(self.core/rethrow-api-error! "anthropic" (constantly "X") original))))))
+                      (caught #(self.core/rethrow-api-error! "anthropic" (constantly "X") original)))))))
 
+(deftest rethrow-api-error!-string-body-test
   (testing "HTTP responses with a body get the upstream body appended and surfaced in ex-data"
     (let [upstream (ex-info "clj-http error"
                             {:status                500
@@ -990,8 +991,9 @@
       (is (= {:request-id "abc" :trace ["frame1"]} (:body (ex-data ex)))
           "the full body is still preserved in ex-data for debugging")
       (is (= #{:status :reason-phrase :headers :body :api-error :provider :error-code}
-             (set (keys (ex-data ex)))))))
+             (set (keys (ex-data ex))))))))
 
+(deftest rethrow-api-error!-no-body-test
   (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
     (let [ex (caught #(self.core/rethrow-api-error!
                        "openai" (constantly "unused") (java.net.SocketTimeoutException. "Read timed out")))]
@@ -1008,8 +1010,9 @@
     (let [ex (caught #(self.core/rethrow-api-error! "openai" (constantly "unused") (RuntimeException.)))]
       (is (= "openai API request failed" (ex-message ex)))
       (is (= #{:api-error :provider :error-code :exception-class}
-             (set (keys (ex-data ex)))))))
+             (set (keys (ex-data ex))))))))
 
+(deftest rethrow-api-error!-input-stream-test
   (testing "InputStream JSON bodies are decoded and structured-extracted"
     (let [json     (json/encode {:error {:message "model decommissioned"}})
           upstream (ex-info "clj-http error"
@@ -1061,8 +1064,9 @@
       (is (string? (:body (ex-data ex)))
           "the bounded raw string is kept on ex-data when JSON parse fails")
       (is (<= (count (:body (ex-data ex))) 100)
-          "the body in ex-data respects the slurp cap")))
+          "the body in ex-data respects the slurp cap"))))
 
+(deftest rethrow-api-error!-retry-after-test
   (testing "Retry-After header survives the ex-data allow-list and reaches retry-delay-ms"
     ;; Regression test: an earlier revision allow-listed only :status/:reason-phrase/:body,
     ;; which silently dropped :headers and made provider 429/529 retries fall back to
@@ -1077,8 +1081,9 @@
                              upstream))]
       (is (= {"retry-after" "3"} (:headers (ex-data ex))))
       (is (<= 3000 (#'self/retry-delay-ms 1 ex) (+ 3000 750))
-          "retry-delay-ms picks up the 3-second Retry-After through the rethrown exception")))
+          "retry-delay-ms picks up the 3-second Retry-After through the rethrown exception"))))
 
+(deftest rethrow-api-error!-warn-log-test
   (testing "the full upstream body is emitted at warn level alongside provider and status"
     (let [upstream (ex-info "clj-http error"
                             {:status 502 :reason-phrase "Bad Gateway"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -895,6 +895,11 @@
     (testing "maps and arrays without a recognised error field → nil (no leak to users)"
       (is (every? nil? (map body-preview [{} {:request-id "abc" :trace ["frame1"]}
                                           [] [42 :kw] [{:request-id "abc"}]]))))
+    (testing "structured values under :error/:detail/:message don't get coerced via str"
+      (is (every? nil? (map body-preview [{:error  {:code 42 :type "x"}}
+                                          {:detail [{:loc ["body" "prompt"]}]}
+                                          {:message {:code "missing"}}
+                                          {:error  42}]))))
     (testing "JSON arrays probe their first element"
       (is (= "rate limited"  (body-preview [{:error {:message "rate limited"}} {:type "x"}])))
       (is (= "first message" (body-preview ["first message" "ignored"]))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -1102,7 +1102,8 @@
       (is (re-find #"provider=openrouter status=502 body=\"upstream gateway timeout\""
                    (:message entry)))))
   (testing "an oversized body is capped in the warn log, but preserved in full on ex-data"
-    (let [big-body (apply str (repeat 5000 \x))
+    (let [cap      @#'self.core/max-body-log-chars
+          big-body (apply str (repeat (+ cap 1000) \x))
           upstream (ex-info "clj-http error"
                             {:status 502 :reason-phrase "Bad Gateway"
                              :headers {"content-type" "text/plain"}
@@ -1117,10 +1118,8 @@
                   "the full, untruncated body still survives on ex-data"))
             (msgs))]
       (is (nil? more) "exactly one warn line at the failure boundary")
-      ;; pr-str of the string adds the surrounding quotes; the cap then slices at
-      ;; max-body-log-chars (2000) and appends the ellipsis.
       (is (str/ends-with? (:message entry)
-                          (str "body=" (subs (pr-str big-body) 0 2000) "…"))
+                          (str "body=" (subs (pr-str big-body) 0 cap) "…"))
           "the warn line's body segment is capped at max-body-log-chars with a trailing ellipsis")
       (is (not (str/includes? (:message entry) big-body))
           "the full oversized body is not spliced into the warn line"))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -12,6 +12,7 @@
    [metabase.metabot.test-util :as test-util]
    [metabase.test :as mt]
    [metabase.util.json :as json]
+   [metabase.util.log.capture :as log.capture]
    [ring.adapter.jetty :as jetty]))
 
 (set! *warn-on-reflection* true)
@@ -972,4 +973,22 @@
              (set (keys (ex-data ex)))))
       (is (=? {:api-error true :provider "openai" :error-code :provider-request-failed
                :exception-class "java.net.SocketTimeoutException"}
-              (ex-data ex))))))
+              (ex-data ex)))))
+
+  (testing "the full upstream body is emitted at warn level alongside provider and status"
+    (let [upstream (ex-info "clj-http error"
+                            {:status 502 :reason-phrase "Bad Gateway"
+                             :headers {"content-type" "text/plain"}
+                             :body "upstream gateway timeout"})
+          [entry & more]
+          (log.capture/with-log-messages-for-level [msgs [metabase.metabot.self.core :warn]]
+            (caught #(self.core/rethrow-api-error!
+                      "openrouter"
+                      (constantly "OpenRouter upstream provider returned an error")
+                      upstream))
+            (msgs))]
+      (is (nil? more) "exactly one warn line at the failure boundary")
+      (is (=? {:level :warn :namespace 'metabase.metabot.self.core}
+              entry))
+      (is (re-find #"provider=openrouter status=502 body=\"upstream gateway timeout\""
+                   (:message entry))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -930,7 +930,27 @@
     (testing "long bodies are truncated to 500 chars with an ellipsis"
       (let [preview (body-preview (apply str (repeat 2000 \x)))]
         (is (str/ends-with? preview "…"))
-        (is (= 501 (count preview)))))))
+        (is (= 501 (count preview)))))
+    (testing "InputStream bodies are read up to the truncation window — not fully slurped"
+      ;; A proxied ByteArrayInputStream lets us count bytes pulled off the stream and
+      ;; assert we stop short of consuming the whole body once the preview is filled.
+      ;; The InputStreamReader inside io/reader uses an 8KB decode buffer, so the
+      ;; ceiling isn't max-body-preview-chars exactly — but it's still constant rather
+      ;; than scaling with body size.
+      (let [body-bytes (.getBytes (apply str (repeat 1000000 \x)))
+            counter    (java.util.concurrent.atomic.AtomicLong. 0)
+            stream     (proxy [java.io.ByteArrayInputStream] [body-bytes]
+                         (read
+                           ([] (.incrementAndGet counter) (proxy-super read))
+                           ([buf] (let [n (proxy-super read buf)]
+                                    (when (pos? n) (.addAndGet counter n)) n))
+                           ([buf off len] (let [n (proxy-super read buf off len)]
+                                            (when (pos? n) (.addAndGet counter n)) n))))
+            preview    (body-preview stream)]
+        (is (str/ends-with? preview "…"))
+        (is (= 501 (count preview)))
+        (is (< (.get counter) (count body-bytes))
+            "should not consume the entire 1MB stream just to render a 500-char preview")))))
 
 (defn- caught
   "Run `thunk` and return the thrown exception, or nil if it didn't throw."

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -878,3 +878,83 @@
                                   "tag"                  "test-tag"
                                   "session_id"           "00000000-0000-0000-0000-000000000002"}}]
                       token-events)))))))))
+
+(deftest ^:parallel body-preview-test
+  (let [body-preview #'self.core/body-preview]
+    (testing "nil and blank → nil"
+      (is (nil? (body-preview nil)))
+      (is (nil? (body-preview "")))
+      (is (nil? (body-preview "   "))))
+    (testing "plain strings pass through trimmed"
+      (is (= "Internal Server Error" (body-preview "  Internal Server Error  "))))
+    (testing "JSON envelopes prefer [:error :message] over :error/:detail/:message"
+      (is (= "model decommissioned"
+             (body-preview {:error {:message "model decommissioned" :type "deprecated"}})))
+      (is (= "invalid metric"  (body-preview {:error "invalid metric"})))
+      (is (= "missing prompt"  (body-preview {:detail "missing prompt"})))
+      (is (= "bad request"     (body-preview {:message "bad request"}))))
+    (testing "unstructured maps fall back to pr-str"
+      (is (= "{:weird \"shape\"}" (body-preview {:weird "shape"}))))
+    (testing "InputStream bodies get slurped"
+      (let [stream (java.io.ByteArrayInputStream. (.getBytes "boom from upstream" "UTF-8"))]
+        (is (= "boom from upstream" (body-preview stream)))))
+    (testing "long bodies are truncated to 500 chars with an ellipsis"
+      (let [long-body (apply str (repeat 2000 \x))
+            preview   (body-preview long-body)]
+        (is (str/ends-with? preview "…"))
+        (is (= 501 (count preview)))))))
+
+(deftest rethrow-api-error!-test
+  (testing ":api-error exceptions are rethrown unchanged"
+    (let [original (ex-info "boom" {:api-error true :error-code :proxy-not-configured})]
+      (is (identical? original
+                      (try (self.core/rethrow-api-error! "anthropic" (constantly "X") original)
+                           (catch Exception e e))))))
+  (testing "HTTP responses with a body get the upstream body appended and surfaced in ex-data"
+    (let [upstream (ex-info "clj-http error"
+                            {:status 500
+                             :reason-phrase "Internal Server Error"
+                             :headers {"content-type" "application/json"}
+                             :body (json/encode {:error {:message "model decommissioned"}})})
+          ex       (try
+                     (self.core/rethrow-api-error!
+                      "anthropic"
+                      (fn [res] (str "Anthropic API error (HTTP " (:status res) ")"))
+                      upstream)
+                     nil
+                     (catch Exception e e))]
+      (is (= "Anthropic API error (HTTP 500) — model decommissioned"
+             (ex-message ex)))
+      (is (=? {:api-error  true
+               :provider   "anthropic"
+               :error-code :provider-api-error
+               :status     500
+               :body       {:error {:message "model decommissioned"}}}
+              (ex-data ex)))))
+  (testing "non-JSON bodies still get a preview appended"
+    (let [upstream (ex-info "clj-http error"
+                            {:status 502
+                             :reason-phrase "Bad Gateway"
+                             :headers {"content-type" "text/plain"}
+                             :body "upstream gateway timeout"})
+          ex       (try
+                     (self.core/rethrow-api-error!
+                      "openrouter"
+                      (fn [_] "OpenRouter upstream provider returned an error")
+                      upstream)
+                     nil
+                     (catch Exception e e))]
+      (is (str/includes? (ex-message ex) "OpenRouter upstream provider returned an error"))
+      (is (str/includes? (ex-message ex) "upstream gateway timeout"))))
+  (testing "non-HTTP errors (no :body) fall through to the request-failed branch"
+    (let [upstream (java.net.SocketTimeoutException. "Read timed out")
+          ex       (try
+                     (self.core/rethrow-api-error! "openai" (constantly "unused") upstream)
+                     nil
+                     (catch Exception e e))]
+      (is (str/includes? (ex-message ex) "API request failed"))
+      (is (str/includes? (ex-message ex) "Read timed out"))
+      (is (=? {:api-error  true
+               :provider   "openai"
+               :error-code :provider-request-failed}
+              (ex-data ex))))))


### PR DESCRIPTION
## Summary

When a Claude/OpenAI/OpenRouter call fails, the upstream response body is no longer silently swallowed — it's appended to the user-facing exception message and emitted as a structured `log/warnf` at the failure boundary.

#72921 hit the now-removed `metabot-v3/client.clj` AI-service indirection; the equivalent gap on master lives in `src/metabase/metabot/self/core.clj::rethrow-api-error!` and the per-provider error helpers.

Master-side counterpart to #74356.

## Before / after

A representative case: an OpenRouter call fails with a `502` whose body is a plain-text upstream gateway timeout (the kind of payload the original bug report hit).

**Before** — the body never reached the user or the logs, and `ex-data` was a clj-http kitchen sink:

```clojure
ex-message: "OpenRouter upstream provider returned an error"

ex-data:
  :status                502
  :reason-phrase         "Bad Gateway"
  :headers               {"content-type" "text/plain" ...}
  :body                  "upstream gateway timeout"
  :http-client           #object[ApacheHttpClient ...]   ;; Closeable resource
  :trace-redirects       ["https://..."]
  :orig-content-encoding "gzip"
  ;; ... plus a handful more clj-http internals

log: (nothing emitted at this layer)
```

**After**:

```clojure
;; ex-message is what flows to the admin toast via the SSE error line —
;; the preview makes the body visible above the fold. The full untruncated
;; body still lives in :body and the warn line below, for server-side debugging.
ex-message: "OpenRouter upstream provider returned an error — upstream gateway timeout"

ex-data:
  :status        502
  :reason-phrase "Bad Gateway"
  :body          "upstream gateway timeout"
  :api-error     true
  :provider      "openrouter"
  :error-code    :provider-api-error

logs:
  ;; failure boundary, structured fields only
  WARN  Provider API request failed: provider=openrouter status=502 body="upstream gateway timeout"
  ;; agent loop catches it, re-logs with the throwable so the full cause chain shows up
  ERROR Agent loop API error: OpenRouter upstream provider returned an error — upstream gateway timeout
        status=502 provider=openrouter body="upstream gateway timeout"
        <stacktrace: rethrow-api-error! → clj-http → ...>
```

For bodies whose shape we don't recognise (e.g. `{:request-id "abc" :trace [...]}`, FastAPI-style `{:detail [{:loc ...}]}`), `body-preview` falls back to a `pr-str` of the body and emits a warn — so the user-facing message still carries *some* context and operators get a signal to add the new envelope shape to `extract-error-message`. The full body is still preserved in `:body` regardless.

## Changes

- New `core/body-preview` helper. Prefers structured JSON envelopes (`[:error :message]`, `:error`, `:detail`, `:message`), slurps `InputStream` bodies, and falls back to `pr-str` + a warn log when the body shape isn't recognised. Truncates to 500 chars; the full body still lives in `ex-data` and logs.
- `rethrow-api-error!` appends the preview to the provider's canonical message and logs the full body at the failure boundary. `ex-data` is now an explicit allow-list (`:status`/`:reason-phrase`/`:body`/`:api-error`/`:provider`/`:error-code`) — raw clj-http responses carry a `Closeable` `:http-client` and other internals we don't want propagating downstream.
- Per-provider helpers renamed `anthropic-error-msg` / `openai-error-msg` / `openrouter-error-msg`. Each now returns only the canonical status-specific message; the preview append happens once, in `rethrow-api-error!`.
- Agent loop's body-branch `log/errorf` now includes the throwable, matching its two sibling branches — so a provider failure's cause chain (`rethrow-api-error!` → `clj-http`) shows up exactly once, at the layer where the exception's lifecycle ends.

## Behavior changes worth flagging

The canonical message prefix for known statuses (`401`, `403`, `429`, `500`, …) is unchanged. The fallback for *unknown* statuses changed from `"X API error (HTTP {n}): {msg}"` to `"X API error (HTTP {n})"`, with `{msg}` now appended uniformly via the body preview. Net effect for the common case is the same string, but anything asserting exact equality on the unknown-status format would need updating — no existing test does (verified by grep).

## Test plan

- [x] New `body-preview-test` and `rethrow-api-error!-test` cover JSON envelopes, non-JSON bodies, `InputStream` slurping, truncation, the no-body branch, the `:api-error` passthrough, a key-set pin guarding against future `ex-data` leaks, the `pr-str` + warn fallback for unrecognised shapes, and a `log/warnf` capture asserting the upstream body lands in the warn line alongside provider and status.
- [x] Full `metabase.metabot.self-test` ns passes apart from `call-llm-prometheus-test` — an unrelated pre-existing `METABOT_INSTANCE_LIMIT not found` failure reproducible on a clean master worktree.
- [ ] ~~Manual sanity-check by inducing a failing Claude/OpenAI call and verifying both the log and the surfaced exception include the upstream body.~~ — covered by the unit tests above (exception via `rethrow-api-error!-test`, log line via the new `log.capture` assertion); skipping the live-call check.

## Related

- #72921 — original bug report from a cloud customer on 59.7.
- #74356 — `release-x.59.x` counterpart, targets the `metabot-v3/client.clj` codepath that was removed on master.