### PR TITLE
Lift Athena duplicate-column test out of IAM-gated parent (GHY-3273)

### DIFF
--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -296,21 +296,27 @@
                              (let [metadata (.getMetaData conn)]
                                (#'athena/get-columns metadata catalog (:schema table) (:name table))))))))
             (testing "`describe-table` returns the fields anyway"
-              (is (not-empty (:fields (driver/describe-table :athena db table)))))
-            (testing "`describe-table-fields` uses DESCRIBE if the JDBC driver returns duplicate column names (#58441)"
-              (let [get-columns-called (volatile! false)]
-                (with-redefs [athena/get-columns (fn [& _]
-                                                   (vreset! get-columns-called true)
-                                                   [{:column_name "c" :type_name "bigint"}
-                                                    {:column_name "c" :type_name "string"}])]
-                  (is (= #{{:database-position 0, :name "id", :database-type "int", :base-type :type/Integer}
-                           {:database-position 1, :name "name", :database-type "string", :base-type :type/Text}
-                           {:database-position 2, :name "code", :database-type "string", :base-type :type/Text}
-                           {:database-position 3, :name "latitude", :database-type "double", :base-type :type/Float}
-                           {:database-position 4, :name "longitude", :database-type "double", :base-type :type/Float}
-                           {:database-position 5, :name "municipality_id", :database-type "int", :base-type :type/Integer}}
-                         (:fields (driver/describe-table :athena db table))))
-                  (is (true? @get-columns-called)))))))))))
+              (is (not-empty (:fields (driver/describe-table :athena db table)))))))))))
+
+(deftest describe-table-falls-back-to-describe-on-duplicate-jdbc-columns-test
+  (testing "`describe-table-fields` uses DESCRIBE if the JDBC driver returns duplicate column names (#58441, GHY-3273)"
+    (mt/test-driver :athena
+      (mt/dataset airports
+        (let [db                 (mt/db)
+              table              (t2/select-one :model/Table :db_id (:id db) :name "airport")
+              get-columns-called (volatile! false)]
+          (with-redefs [athena/get-columns (fn [& _]
+                                             (vreset! get-columns-called true)
+                                             [{:column_name "c" :type_name "bigint"}
+                                              {:column_name "c" :type_name "string"}])]
+            (is (= #{{:database-position 0, :name "id", :database-type "int", :base-type :type/Integer}
+                     {:database-position 1, :name "name", :database-type "string", :base-type :type/Text}
+                     {:database-position 2, :name "code", :database-type "string", :base-type :type/Text}
+                     {:database-position 3, :name "latitude", :database-type "double", :base-type :type/Float}
+                     {:database-position 4, :name "longitude", :database-type "double", :base-type :type/Float}
+                     {:database-position 5, :name "municipality_id", :database-type "int", :base-type :type/Integer}}
+                   (:fields (driver/describe-table :athena db table))))
+            (is (true? @get-columns-called))))))))
 
 (deftest column-name-with-question-mark-test
   (testing "Column name with a question mark in it should be compiled correctly (#44915)"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #54559
Closes GHY-3273

## Summary

Pulled out a reproduction test to make it test the bug in more circumstances, not just when the other conditions don't error before it. Those conditions would error when certain env vars were not set.

Verified locally:
- New test passes against the live Athena instance.
- New test fails when I forced the pre-fix `describe-table-fields` (no duplicate detection) — confirming it actually catches the regression.
