### PR TITLE
Check for VolumeOperationAllowedLocalPaths connecting to databricks.

### DIFF
--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -73,6 +73,9 @@
 
 (defmethod driver/can-connect? :databricks
   [driver details]
+  (when-let [opts (not-empty (:additional-options details))]
+    (when (re-find #"VolumeOperationAllowedLocalPaths" opts)
+      (throw (Exception. "Potentially dangerous keys in connection details"))))
   (sql-jdbc.conn/with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
     (and (catalog-present? jdbc-spec (:catalog details))
          (sql-jdbc.conn/can-connect-with-spec? jdbc-spec))))

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -66,6 +66,12 @@
     ((get-method sql-jdbc.sync/database-type->base-type :hive-like)
      driver database-type)))
 
+(defmethod driver/validate-db-details! :databricks
+  [_driver details]
+  (when-let [opts (not-empty (:additional-options details))]
+    (when (re-find #"(?i)VolumeOperationAllowedLocalPaths" opts)
+      (throw (Exception. "Potentially dangerous keys in connection details")))))
+
 (defn- catalog-present?
   [jdbc-spec catalog]
   (let [sql "select 0 from `system`.`information_schema`.`catalogs` where catalog_name = ?"]
@@ -73,9 +79,7 @@
 
 (defmethod driver/can-connect? :databricks
   [driver details]
-  (when-let [opts (not-empty (:additional-options details))]
-    (when (re-find #"VolumeOperationAllowedLocalPaths" opts)
-      (throw (Exception. "Potentially dangerous keys in connection details"))))
+  (driver/validate-db-details! driver details)
   (sql-jdbc.conn/with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
     (and (catalog-present? jdbc-spec (:catalog details))
          (sql-jdbc.conn/can-connect-with-spec? jdbc-spec))))

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -474,7 +474,10 @@
     (testing "Can connect returns true for catalog that is present on the instance"
       (is (true? (driver/can-connect? :databricks (:details (mt/db))))))
     (testing "Can connect returns false for catalog that is NOT present on the instance (#49444)"
-      (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))))
+      (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))
+    (testing "Disallows unsafe connection parameters"
+      (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db))
+                                                          :additional-options "VolumeOperationAllowedLocalPaths=/etc/hosts")))))))
 
 (deftest can-connect-using-m2m-test
   (mt/test-driver

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -476,8 +476,9 @@
     (testing "Can connect returns false for catalog that is NOT present on the instance (#49444)"
       (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))
     (testing "Disallows unsafe connection parameters"
-      (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db))
-                                                          :additional-options "VolumeOperationAllowedLocalPaths=/etc/hosts")))))))
+      (is (thrown-with-msg? Exception #"Potentially dangerous keys"
+                            (driver/can-connect? :databricks (assoc (:details (mt/db))
+                                                                    :additional-options "VolumeOperationAllowedLocalPaths=/etc/hosts")))))))
 
 (deftest can-connect-using-m2m-test
   (mt/test-driver

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -18,6 +18,7 @@
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (defn- maybe-qualify-schema
@@ -476,9 +477,15 @@
     (testing "Can connect returns false for catalog that is NOT present on the instance (#49444)"
       (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))
     (testing "Disallows unsafe connection parameters"
-      (is (thrown-with-msg? Exception #"Potentially dangerous keys"
-                            (driver/can-connect? :databricks (assoc (:details (mt/db))
-                                                                    :additional-options "VolumeOperationAllowedLocalPaths=/etc/hosts")))))))
+      (let [details (assoc (:details (mt/db)) :additional-options "VolumeOperationAllowedLocalPaths=/etc/hosts")]
+        (is (thrown-with-msg? Exception #"Potentially dangerous keys"
+                              (driver/can-connect? :databricks details)))
+        (is (thrown-with-msg? Exception #"Potentially dangerous keys"
+                              (driver/can-connect? :databricks (update details
+                                                                       :additional-options
+                                                                       u/lower-case-en))))
+        (is (thrown-with-msg? Exception #"Potentially dangerous keys"
+                              (driver/validate-db-details! :databricks details)))))))
 
 (deftest can-connect-using-m2m-test
   (mt/test-driver


### PR DESCRIPTION
### Description

These settings shouldn't be allowed; there's no legitimate use case for them.

In https://github.com/metabase/metabase/pull/74343 there was a new `validate-db-details` method introduced, but there has been some discussion about whether that was the right approach. Perhaps this change should go in that method instead.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
