### PR TITLE
fix: escape HTML in HighlightExpression to prevent XSS

### DIFF
--- a/frontend/src/metabase/querying/components/expressions/HighlightExpression/util.unit.spec.ts
+++ b/frontend/src/metabase/querying/components/expressions/HighlightExpression/util.unit.spec.ts
@@ -14,4 +14,10 @@ describe("highlight", () => {
       '<span class="variableName">if</span><span class="paren">(</span><span class="processingInstruction">[User Id]</span> <span class="compareOperator">></span> <span class="number">10</span>, <span class="string">"YES"</span>, <span class="number">42</span> <span class="arithmeticOperator">+</span> <span class="number">1e7</span><span class="paren">)</span>',
     );
   });
+
+  it("should escape HTML special characters in expression text", () => {
+    const html = highlight(`[<script>alert(1)</script>]`);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
 });

--- a/frontend/src/metabase/querying/components/expressions/HighlightExpression/utils.ts
+++ b/frontend/src/metabase/querying/components/expressions/HighlightExpression/utils.ts
@@ -9,16 +9,25 @@ const highlighter: Highlighter = {
 
 type HTML = string;
 
+function escapeHTML(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 export function highlight(code: string): HTML {
   const tree = parser.parse(code);
 
   let res = "";
 
   function emit(text: string, className: string) {
+    const escaped = escapeHTML(text);
     if (className) {
-      res += `<span class="${className}">${text}</span>`;
+      res += `<span class="${className}">${escaped}</span>`;
     } else {
-      res += text;
+      res += escaped;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[74389]

### Description

In HighlightExpression/utils.ts, the highlight() function inserted text directly through emit() without HTML escaping, and the result was rendered using dangerouslySetInnerHTML.

If database column names or expressions contain HTML special characters such as <, >, &, or ", they may be interpreted as actual HTML instead of plain text. A malicious column name (e.g. <script>alert(1)</script>) could therefore lead to an XSS vulnerability.

To fix this, an escapeHTML() function was added and applied before every text insertion inside emit().

### How to verify

1. Create a table in the database with a column name containing HTML special characters (e.g. amount<script>alert(1)</script>).
2. Sync the table in Metabase.
3. Reference the column in a Custom Expression.
4. Confirm that the Expression preview renders the value as literal text rather than interpreting it as HTML.

### Demo

  N/A

### Checklist

- [ ]  Tests have been added/updated to cover changes in this PR
