### PR TITLE
Clarify empty preview state in embed wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -23,6 +23,7 @@ import {
   Image,
   Modal,
   Stack,
+  Text,
 } from "metabase/ui";
 import type { SettingKey } from "metabase-types/api";
 
@@ -146,7 +147,17 @@ export const SdkIframeEmbedSetupContent = () => {
           ) : (
             <Card h="100%">
               <Flex h="100%" align="center" justify="center">
-                <Image w={120} h={120} src={noResultsSource} alt="No results" />
+                <Stack align="center" gap="md">
+                  <Image
+                    w={120}
+                    h={120}
+                    src={noResultsSource}
+                    alt="No results"
+                  />
+                  <Text c="text-secondary">
+                    {t`Preview will appear when you select what to embed`}
+                  </Text>
+                </Stack>
               </Flex>
             </Card>
           )}


### PR DESCRIPTION
Closes [EMB-1726: Clarify that until selection of a resource, the preview is an example](https://linear.app/metabase/issue/EMB-1726/clarify-that-until-selection-of-a-resource-the-preview-is-an-example)

> [!NOTE]
> Stacked on top of #74346 — review/merge that one first.

### Description

In the embed wizard, the preview panel shows a boat illustration when no
resource is selected (or when preview is gated by terms / feature flags).
The illustration alone doesn't explain why the preview isn't showing.

This adds a clarifying line below the illustration:
**"Preview will appear when you select what to embed"**, so users understand
the placeholder is waiting on a resource selection from the first step.

<img width="1604" height="1037" alt="image" src="https://github.com/user-attachments/assets/088d7b0e-45cf-467b-91ce-a226878d2f62" />


### How to verify

1. Admin → Embedding → New embed.
2. Pick the Chart experience while no question has ever been opened (or
   archive the preselected dashboard/question): the preview panel shows the
   boat illustration with the new copy underneath.
3. Select a resource from the picker: the placeholder is replaced by the
   actual embed preview.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR