### PR TITLE
Enable save toggle in the embed wizard for Metabot

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -774,6 +774,31 @@ describe(suiteTitle, () => {
     });
   });
 
+  it("toggles save button for metabot", () => {
+    navigateToEmbedOptionsStep({ experience: "metabot" });
+
+    getEmbedSidebar()
+      .findByLabelText("Allow people to save new questions")
+      .should("not.be.checked");
+
+    cy.log("turn on save option");
+    getEmbedSidebar()
+      .findByLabelText("Allow people to save new questions")
+      .click()
+      .should("be.checked");
+
+    cy.log("snippet should be updated");
+    getEmbedSidebar().findByText("Get code").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_options_completed",
+      event_detail:
+        "settings=custom,experience=metabot,authType=sso,isSaveEnabled=true,theme=default",
+    });
+
+    codeBlock().should("contain", 'is-save-enabled="true"');
+  });
+
   it("can toggle read-only setting for browser", () => {
     navigateToEmbedOptionsStep({
       experience: "browser",
@@ -969,7 +994,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,authType=sso,layout=stacked,theme=default",
+        "settings=custom,experience=metabot,authType=sso,isSaveEnabled=false,layout=stacked,theme=default",
     });
 
     getEmbedSidebar().findByText("Back").click();
@@ -985,7 +1010,7 @@ describe(suiteTitle, () => {
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_options_completed",
       event_detail:
-        "settings=custom,experience=metabot,authType=sso,layout=sidebar,theme=default",
+        "settings=custom,experience=metabot,authType=sso,isSaveEnabled=false,layout=sidebar,theme=default",
     });
   });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/BehaviorCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/BehaviorCard.tsx
@@ -49,6 +49,17 @@ export const BehaviorCard = () => {
           />
         ),
       )
+      .with({ componentName: "metabase-metabot" }, (settings) => (
+        <Checkbox
+          label={t`Allow people to save new questions`}
+          checked={settings.isSaveEnabled}
+          onChange={(e) =>
+            updateSettings({
+              isSaveEnabled: e.target.checked,
+            } satisfies Partial<typeof settings>)
+          }
+        />
+      ))
       .with(
         { componentName: "metabase-question", questionId: P.nonNullable },
         (settings) => (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -392,3 +392,34 @@ describe("Embed flow > Pro feature upsell indicators", () => {
     PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = () => false;
   });
 });
+
+describe("Embed flow > Metabot", () => {
+  beforeEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = () => false;
+  });
+
+  it("toggles the save option for Metabot", async () => {
+    setup({
+      simpleEmbeddingEnabled: true,
+      metabotEnabled: true,
+    });
+
+    // Switch to Metabot experience
+    await userEvent.click(screen.getByRole("radio", { name: /Metabot/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    const saveCheckbox = await screen.findByRole("checkbox", {
+      name: "Allow people to save new questions",
+    });
+
+    expect(saveCheckbox).toBeEnabled();
+    expect(saveCheckbox).not.toBeChecked();
+
+    await userEvent.click(saveCheckbox);
+    expect(saveCheckbox).toBeChecked();
+  });
+});

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -35,6 +35,7 @@ export const setup = (options?: {
   jwtReady?: boolean;
   initialState?: SdkIframeEmbedSetupModalInitialState;
   hasEmailSetup?: boolean;
+  metabotEnabled?: boolean;
 }) => {
   const { enterprisePlugins } = options ?? {};
 
@@ -59,6 +60,8 @@ export const setup = (options?: {
     "jwt-enabled": options?.jwtReady ?? false,
     "jwt-configured": options?.jwtReady ?? false,
     "jwt-enabled-and-configured": options?.jwtReady ?? false,
+    "embedded-metabot-enabled?": options?.metabotEnabled ?? false,
+    "llm-metabot-configured?": options?.metabotEnabled ?? false,
   });
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.ts
@@ -87,6 +87,7 @@ export const getDefaultSdkIframeEmbedSettings = ({
       "metabot",
       (): MetabotEmbedOptions => ({
         componentName: "metabase-metabot",
+        isSaveEnabled: false,
       }),
     )
     .exhaustive();

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-default-sdk-iframe-embed-setting.unit.spec.ts
@@ -59,7 +59,7 @@ describe("getDefaultSdkIframeEmbedSettings", () => {
     {
       experience: "metabot",
       componentName: "metabase-metabot",
-      expectedProps: {},
+      expectedProps: { isSaveEnabled: false },
     },
   ])(
     "$experience experience",


### PR DESCRIPTION
Closes [Enable save in the embedding wizard](https://linear.app/metabase/issue/EMB-1742/enable-save-in-the-embedding-wizard)

> [!NOTE]
> Stacked on top of #74346 — review/merge that one first.

### Description

Surfaces the existing `isSaveEnabled` Metabot option in the embedding wizard's Behavior card, mirroring the toggle we already expose for the Exploration and Chart experiences. The metabot default now sets `isSaveEnabled: false` for parity with the other experiences.

### How to verify

To exercise this you need AI enabled. Easiest way: configure Claude in **Admin → AI** (Anthropic API key — dev key in 1Password — and pick a Claude model).

1. Go to **Admin → Embedding** and open the embed wizard.
2. Pick the **Metabot** experience and click **Next**.
3. Confirm the **Behavior** card now shows an `Allow people to save new questions` checkbox, unchecked by default.
4. Toggle it on — the generated snippet on the **Get code** step should now contain `is-save-enabled="true"`.
5. (Optional) Trigger a question via Metabot in the preview iframe and verify the **Save** button appears once the checkbox is on.

### Demo

<img width="1607" height="1039" alt="image" src="https://github.com/user-attachments/assets/51f90a41-c735-4dcc-840b-15a3317ff94b" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass stress testing