### PR TITLE
fix(bigquery): support Workload Identity Federation credential configs in BigQuery driver

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
@@ -8,7 +8,7 @@
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
-   (com.google.auth.oauth2 ServiceAccountCredentials)
+   (com.google.auth.oauth2 GoogleCredentials ServiceAccountCredentials)
    (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
@@ -22,29 +22,34 @@
   "UTC")
 
 (mu/defn service-account-json->service-account-credential
-  "Returns a `ServiceAccountCredentials` (not scoped) for the given `service-account-json` (String)."
+  "Returns a `GoogleCredentials` (not scoped) for the given `service-account-json` (String).
+  Supports both traditional service account key JSON and Workload Identity Federation (WIF)
+  credential configuration files (e.g. IdentityPoolCredentials for AWS IRSA / OIDC)."
   {:added "0.42.0"}
-  ^ServiceAccountCredentials [^String service-account-json :- :string]
-  (ServiceAccountCredentials/fromStream (ByteArrayInputStream. (.getBytes service-account-json))))
+  ^GoogleCredentials [^String service-account-json :- :string]
+  (GoogleCredentials/fromStream (ByteArrayInputStream. (.getBytes service-account-json))))
 
 (def ^:private RequiredDetails
   [:map [:service-account-json :string]])
 
 (mu/defn database-details->service-account-credential
-  "Returns a `ServiceAccountCredentials` (not scoped) for the given `db-details`, which is based upon the value
-  associated to its `service-account-json` key (a String)."
+  "Returns a `GoogleCredentials` (not scoped) for the given `db-details`, which is based upon the value
+  associated to its `service-account-json` key (a String).
+  Supports both traditional service account key JSON and Workload Identity Federation (WIF)
+  credential configuration files."
   {:added "0.42.0"}
-  ^ServiceAccountCredentials [{:keys [^String service-account-json] :as db-details} :- RequiredDetails]
+  ^GoogleCredentials [{:keys [^String service-account-json] :as db-details} :- RequiredDetails]
   {:pre [(map? db-details) (seq service-account-json)]}
   (service-account-json->service-account-credential service-account-json))
 
 (mu/defn database-details->credential-project-id
-  "Uses the given DB `details` credentials to determine the embedded project-id.  This is basically an
-  inferred/calculated key (not something the user will ever\n  set directly), since it's simply encoded within the
-  `service-account-json` payload."
+  "Uses the given DB `details` credentials to determine the embedded project-id.
+  Returns nil for non-ServiceAccountCredentials (e.g. WIF credentials), in which case
+  the user-supplied project-id from database details will be used instead."
   [details :- RequiredDetails]
-  (-> (database-details->service-account-credential details)
-      .getProjectId))
+  (let [creds (database-details->service-account-credential details)]
+    (when (instance? ServiceAccountCredentials creds)
+      (.getProjectId ^ServiceAccountCredentials creds))))
 
 (mu/defn populate-project-id-from-credentials!
   "Update the given `database` details blob to include the credentials' project-id as a separate entry (under a
@@ -57,7 +62,8 @@
   details change (i.e. the service account), just calculate it once per change (when the DB is updated, or upon first
   query for a new Database), and store it back to the app DB.
 
-  Returns the calculated project-id (see [[database-details->credential-project-id]]) String from the credentials."
+  Returns the calculated project-id (see [[database-details->credential-project-id]]) String from the credentials,
+  or nil for WIF credentials (where the project-id is supplied explicitly by the user)."
   {:added "0.42.0"}
   ^String [database :- [:map [:details RequiredDetails]]]
   ;; :project-id-from-credentials is a database-level cache managed by this driver. We store and read it from
@@ -69,7 +75,7 @@
       (let [write-proj-id (driver.conn/with-write-connection
                             (database-details->credential-project-id
                              (driver.conn/effective-details database)))]
-        (when (not= creds-proj-id write-proj-id)
+        (when (and creds-proj-id write-proj-id (not= creds-proj-id write-proj-id))
           (log/warnf (str "Database %d: read and write service accounts belong to different GCP projects "
                           "(%s vs %s). The cached project-id-from-credentials uses the read SA's project; "
                           "query qualification may be incorrect for write connections.")


### PR DESCRIPTION
## Summary

Fixes #74400

Replaces `ServiceAccountCredentials/fromStream` with `GoogleCredentials/fromStream` in the BigQuery driver so that **Workload Identity Federation (WIF) credential configuration files** are accepted alongside traditional service account key JSON.

## Changes

**`modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj`**

- Import `GoogleCredentials` in addition to `ServiceAccountCredentials`
- `service-account-json->service-account-credential`: use `GoogleCredentials/fromStream` (handles all credential types) instead of `ServiceAccountCredentials/fromStream` (SA key only)
- `database-details->service-account-credential`: return type updated to `GoogleCredentials`
- `database-details->credential-project-id`: guard with `instance? ServiceAccountCredentials` check — WIF credentials (`IdentityPoolCredentials`) have no embedded project-id, so return `nil` and let the user-supplied `project-id` from database details be used instead

## Why

`GoogleCredentials/fromStream` is the generic factory in `google-auth-library` that correctly dispatches to the right credential type based on the JSON content:
- `service_account` → `ServiceAccountCredentials`  
- `external_account` → `IdentityPoolCredentials` (WIF)
- `impersonated_service_account` → `ImpersonatedCredentials`

The previous code hardcoded `ServiceAccountCredentials/fromStream`, which throws a `ClassCastException` when the JSON contains a WIF config.

## Test Plan

- [ ] Existing BigQuery tests pass (SA key JSON still works)
- [ ] New: connect BigQuery using a WIF `external_account` credential config — no `ClassCastException`, connection succeeds
- [ ] `database-details->credential-project-id` returns `nil` for WIF creds (project-id from user input is used)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)