### PR TITLE
Defensively support double-encoded search index rows

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -708,7 +708,12 @@
 (defn- decode-legacy-input
   "Decode `row`s `:legacy_input` JSONB PGobject into a Clojure map."
   [row]
-  (update row :legacy_input decode-pgobject))
+  ;; BOT-1543: some existing rows have legacy_input stored as a JSON string rather than a JSON
+  ;; object, so one decode yields a string; decode once more in that case.
+  (update row :legacy_input
+          (fn [pgo]
+            (let [decoded (decode-pgobject pgo)]
+              (cond-> decoded (string? decoded) json/decode+kw)))))
 
 ;; Search-models whose `mi/can-read?` is a pure function of `:collection_id`, which is
 ;; already denormalized on the index row. Values are the Toucan model whose `can-read?`

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -12,7 +12,9 @@
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u])
+  (:import
+   (org.postgresql.util PGobject)))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -558,6 +560,17 @@
     (testing "MySQL-style integer booleans are converted correctly"
       (is (false? (#'semantic.index/to-boolean 0)))
       (is (true? (#'semantic.index/to-boolean 1))))))
+
+(deftest decode-legacy-input-test
+  (letfn [(pgo [s] (doto (PGobject.) (.setType "jsonb") (.setValue s)))]
+    (testing "JSONB object value decodes to a map"
+      (is (= {:legacy_input {:name "Top 10" :model "card"}}
+             (#'semantic.index/decode-legacy-input
+              {:legacy_input (pgo "{\"name\":\"Top 10\",\"model\":\"card\"}")}))))
+    (testing "BOT-1543: JSONB string value (double-encoded) is decoded again"
+      (is (= {:legacy_input {:name "Pro" :model "collection"}}
+             (#'semantic.index/decode-legacy-input
+              {:legacy_input (pgo "\"{\\\"name\\\":\\\"Pro\\\",\\\"model\\\":\\\"collection\\\"}\"")}))))))
 
 (deftest doc->db-record-boolean-conversion-test
   (testing "doc->db-record properly converts boolean fields using to-boolean"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -16,6 +16,8 @@
   (:import
    (org.postgresql.util PGobject)))
 
+(set! *warn-on-reflection* true)
+
 (use-fixtures :once #'semantic.tu/once-fixture)
 
 (deftest create-index-table!-test


### PR DESCRIPTION
See https://linear.app/metabase/issue/BOT-1543

In the distant past we used to double-encode this JSON field, and then parse it twice as well.

Then we fixed that, but unfortunately the semantic search db can hold onto some very old rows.

These rows would then parse to a string instead of a map, and cause a crash that stripped _all_ semantic matches from our search results, essentially degrading to regular keyword search.

This PR adds defensive code to detect and handle such obsolete rows. 

Fixing the rows themselves is left out of scope for now, this is intended as a hotfix only.