### PR TITLE
Distinguish empty Metabot prompt regeneration from errors

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -36358,7 +36358,7 @@
       "post" : {
         "operationId" : "post-api-metabot-metabot-id-prompt-suggestions-regenerate",
         "summary" : "POST /api/metabot/metabot/{id}/prompt-suggestions/regenerate",
-        "description" : "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.",
+        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].\n   The managed-free-limit case surfaces as a 402, not a union variant.",
         "parameters" : [ {
           "in" : "path",
           "name" : "id",

--- a/docs/api.json
+++ b/docs/api.json
@@ -14048,6 +14048,59 @@
           "required" : [ "enabled" ]
         }
       },
+      "metabase.workspaces.core.table-namespace" : {
+        "description" : "A `{:db ?, :schema ?}` namespace map. Either or both keys may be present\n   depending on the driver's `qualified-name-components`; at least one must\n   populate. Empty-string `\"\"` is reserved for the storage layer; the atom\n   carries `nil`/missing for absent slots.",
+        "type" : "object",
+        "properties" : {
+          "db" : {
+            "oneOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "null"
+            } ]
+          },
+          "schema" : {
+            "oneOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "null"
+            } ]
+          }
+        }
+      },
+      "metabase.workspaces.core.workspace-database-config" : {
+        "description" : "Per-database workspace config: `:input_schemas` is a vector of driver-opaque\n   schema names (the source schemas the workspace reads from) — may be empty\n   on drivers with no schema layer (e.g. MySQL), where the bound DB itself acts\n   as the implicit input namespace; `:output` is a single namespace map (the\n   workspace's isolation schema, expanded with the warehouse catalog at boot).",
+        "type" : "object",
+        "properties" : {
+          "input_schemas" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "output" : {
+            "$ref" : "#/components/schemas/metabase.workspaces.core.table-namespace"
+          }
+        },
+        "required" : [ "input_schemas", "output" ]
+      },
+      "metabase.workspaces.core.workspace-instance-config" : {
+        "description" : "The shape stored in the EE `instance-workspace` setting after the `:workspace`\n   config.yml loader has resolved database names to ids. Database keys are integer\n   ids (post-resolution); the wire format with name keys lives in\n   `metabase-enterprise.advanced-config.file.workspace`.",
+        "type" : "object",
+        "properties" : {
+          "databases" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/metabase.workspaces.core.workspace-database-config"
+            }
+          },
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        },
+        "required" : [ "name", "databases" ]
+      },
       "metabase.xrays.api.automagic-dashboards.base-64-encoded-json" : {
         "description" : "form-encoded base-64-encoded JSON"
       },
@@ -23612,6 +23665,55 @@
         "tags" : [ "/api/ee/action-v2" ]
       }
     },
+    "/api/ee/advanced-config" : {
+      "post" : {
+        "operationId" : "post-api-ee-advanced-config",
+        "summary" : "POST /api/ee/advanced-config",
+        "description" : "Apply an uploaded `config.yml` to this instance. Runs the same per-section\n  initializers (`settings`, `databases`, `users`, `api-keys`, `workspace`, ...)\n  the boot-time loader runs. Superuser-only.\n\n  Unlike the boot-time loader, `{{env VAR}}` templates are NOT expanded — the\n  file's values are inserted verbatim, so an admin's upload can't read\n  server-side environment variables it didn't intend to.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "null"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "config" : {
+                    "type" : "object",
+                    "properties" : {
+                      "filename" : {
+                        "type" : "string"
+                      },
+                      "tempfile" : { }
+                    },
+                    "required" : [ "filename", "tempfile" ]
+                  }
+                },
+                "required" : [ "config" ]
+              }
+            }
+          }
+        },
+        "tags" : [ "/api/ee/advanced-config" ]
+      }
+    },
     "/api/ee/advanced-permissions/application/graph" : {
       "get" : {
         "operationId" : "get-api-ee-advanced-permissions-application-graph",
@@ -29931,7 +30033,7 @@
       "post" : {
         "operationId" : "post-api-ee-security-center-test-notification",
         "summary" : "POST /api/ee/security-center/test-notification",
-        "description" : "Send a test notification through the configured Security Center channels.",
+        "description" : "Send a test notification through the given Security Center channels.\n\n   The request body lets callers pass the unsaved notification config from the\n   dialog so the test reflects current form state, not the persisted settings.\n   Both fields are optional; when omitted, the saved setting is used.",
         "parameters" : [ ],
         "responses" : {
           "2XX" : {
@@ -29955,6 +30057,34 @@
           },
           "5XX" : {
             "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "email_recipients" : {
+                    "oneOf" : [ {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/metabase.notification.models.NotificationRecipient"
+                      }
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "slack_channel" : {
+                    "oneOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  }
+                }
+              }
+            }
           }
         },
         "tags" : [ "/api/ee/security-center" ]
@@ -31381,7 +31511,7 @@
       "get" : {
         "operationId" : "get-api-ee-workspace-instance-current",
         "summary" : "GET /api/ee/workspace-instance/current",
-        "description" : "Read-only summary of the workspace loaded on this instance.\n\n  Reads from the in-process atom populated at boot by the `:workspace` section of\n  `config.yml`. Returns `nil` when no workspace was loaded — i.e. this is a manager-only\n  instance, or no `config.yml` was present at boot.",
+        "description" : "Read-only summary of the workspace loaded on this instance, wrapped in a\n  `{:data ...}` envelope.\n\n  Reads from the `instance-workspace` setting populated at boot by the `:workspace`\n  section of `config.yml`, or at runtime by `POST /current`. `:data` is `null`\n  when no workspace was loaded — i.e. this is a manager-only instance, or no\n  `config.yml` was present at boot and `POST /current` hasn't been called.\n  The envelope avoids an empty JSON body for the `nil` case.",
         "parameters" : [ ],
         "responses" : {
           "2XX" : {
@@ -31389,52 +31519,158 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "oneOf" : [ {
-                    "type" : "object",
-                    "properties" : {
-                      "databases" : {
+                  "type" : "object",
+                  "properties" : {
+                    "data" : {
+                      "oneOf" : [ {
                         "type" : "object",
-                        "additionalProperties" : {
-                          "type" : "object",
-                          "properties" : {
-                            "input_schemas" : {
-                              "type" : "array",
-                              "items" : {
-                                "type" : "string"
-                              }
-                            },
-                            "output" : {
+                        "properties" : {
+                          "databases" : {
+                            "type" : "object",
+                            "additionalProperties" : {
                               "type" : "object",
                               "properties" : {
-                                "db" : {
-                                  "oneOf" : [ {
+                                "input_schemas" : {
+                                  "type" : "array",
+                                  "items" : {
                                     "type" : "string"
-                                  }, {
-                                    "type" : "null"
-                                  } ]
+                                  }
                                 },
-                                "schema" : {
-                                  "oneOf" : [ {
-                                    "type" : "string"
-                                  }, {
-                                    "type" : "null"
-                                  } ]
+                                "output" : {
+                                  "type" : "object",
+                                  "properties" : {
+                                    "db" : {
+                                      "oneOf" : [ {
+                                        "type" : "string"
+                                      }, {
+                                        "type" : "null"
+                                      } ]
+                                    },
+                                    "schema" : {
+                                      "oneOf" : [ {
+                                        "type" : "string"
+                                      }, {
+                                        "type" : "null"
+                                      } ]
+                                    }
+                                  }
                                 }
-                              }
+                              },
+                              "required" : [ "input_schemas", "output" ]
                             }
                           },
-                          "required" : [ "input_schemas", "output" ]
-                        }
-                      },
-                      "name" : {
-                        "type" : "string",
-                        "minLength" : 1
+                          "name" : {
+                            "type" : "string",
+                            "minLength" : 1
+                          }
+                        },
+                        "required" : [ "name", "databases" ]
+                      }, {
+                        "type" : "null"
+                      } ]
+                    }
+                  },
+                  "required" : [ "data" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/ee/workspace-instance" ]
+      },
+      "post" : {
+        "operationId" : "post-api-ee-workspace-instance-current",
+        "summary" : "POST /api/ee/workspace-instance/current",
+        "description" : "Install a workspace config on this instance at runtime. Accepts the same shape\n  `GET /current` returns and persists it via the `instance-workspace` setting so\n  it survives restarts. Use this on a running instance to enter workspace mode\n  without restarting from `config.yml`.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "databases" : {
+                      "type" : "object",
+                      "additionalProperties" : {
+                        "type" : "object",
+                        "properties" : {
+                          "input_schemas" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string"
+                            }
+                          },
+                          "output" : {
+                            "type" : "object",
+                            "properties" : {
+                              "db" : {
+                                "oneOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "null"
+                                } ]
+                              },
+                              "schema" : {
+                                "oneOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "null"
+                                } ]
+                              }
+                            }
+                          }
+                        },
+                        "required" : [ "input_schemas", "output" ]
                       }
                     },
-                    "required" : [ "name", "databases" ]
-                  }, {
-                    "type" : "null"
-                  } ]
+                    "name" : {
+                      "type" : "string",
+                      "minLength" : 1
+                    }
+                  },
+                  "required" : [ "name", "databases" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/metabase.workspaces.core.workspace-instance-config"
+              }
+            }
+          }
+        },
+        "tags" : [ "/api/ee/workspace-instance" ]
+      },
+      "delete" : {
+        "operationId" : "delete-api-ee-workspace-instance-current",
+        "summary" : "DELETE /api/ee/workspace-instance/current",
+        "description" : "Clear the workspace config on this instance. After this returns, the instance\n  is no longer in workspace mode and `GET /current` returns `nil`. Also drops\n  every `TableRemapping` row, since stale mappings from the prior workspace\n  would otherwise keep rewriting queries on the now-unmanaged databases.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "null"
                 }
               }
             }
@@ -36370,7 +36606,45 @@
         } ],
         "responses" : {
           "2XX" : {
-            "description" : "Successful response"
+            "description" : "Successful response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "prompt_count" : {
+                        "type" : "integer",
+                        "minimum" : 1
+                      },
+                      "status" : {
+                        "const" : "generated"
+                      }
+                    },
+                    "required" : [ "status", "prompt_count" ],
+                    "additionalProperties" : false
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "status" : {
+                        "const" : "no-library-content"
+                      }
+                    },
+                    "required" : [ "status" ],
+                    "additionalProperties" : false
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "status" : {
+                        "const" : "ai-produced-no-prompts"
+                      }
+                    },
+                    "required" : [ "status" ],
+                    "additionalProperties" : false
+                  } ]
+                }
+              }
+            }
           },
           "4XX" : {
             "description" : "Client error response"

--- a/docs/api.json
+++ b/docs/api.json
@@ -36358,7 +36358,7 @@
       "post" : {
         "operationId" : "post-api-metabot-metabot-id-prompt-suggestions-regenerate",
         "summary" : "POST /api/metabot/metabot/{id}/prompt-suggestions/regenerate",
-        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].\n   The managed-free-limit case surfaces as a 402, not a union variant.",
+        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   The response `:status` is `:generated` (with a `:prompt_count`) when prompts were created,\n   `:no-library-content` when the Metabot has no models or metrics to summarize, or\n   `:ai-produced-no-prompts` when generation produced nothing.\n   Returns a 402 if the instance has reached its managed-AI usage limit.",
         "parameters" : [ {
           "in" : "path",
           "name" : "id",

--- a/docs/api.json
+++ b/docs/api.json
@@ -14048,59 +14048,6 @@
           "required" : [ "enabled" ]
         }
       },
-      "metabase.workspaces.core.table-namespace" : {
-        "description" : "A `{:db ?, :schema ?}` namespace map. Either or both keys may be present\n   depending on the driver's `qualified-name-components`; at least one must\n   populate. Empty-string `\"\"` is reserved for the storage layer; the atom\n   carries `nil`/missing for absent slots.",
-        "type" : "object",
-        "properties" : {
-          "db" : {
-            "oneOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "null"
-            } ]
-          },
-          "schema" : {
-            "oneOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "null"
-            } ]
-          }
-        }
-      },
-      "metabase.workspaces.core.workspace-database-config" : {
-        "description" : "Per-database workspace config: `:input_schemas` is a vector of driver-opaque\n   schema names (the source schemas the workspace reads from) — may be empty\n   on drivers with no schema layer (e.g. MySQL), where the bound DB itself acts\n   as the implicit input namespace; `:output` is a single namespace map (the\n   workspace's isolation schema, expanded with the warehouse catalog at boot).",
-        "type" : "object",
-        "properties" : {
-          "input_schemas" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "output" : {
-            "$ref" : "#/components/schemas/metabase.workspaces.core.table-namespace"
-          }
-        },
-        "required" : [ "input_schemas", "output" ]
-      },
-      "metabase.workspaces.core.workspace-instance-config" : {
-        "description" : "The shape stored in the EE `instance-workspace` setting after the `:workspace`\n   config.yml loader has resolved database names to ids. Database keys are integer\n   ids (post-resolution); the wire format with name keys lives in\n   `metabase-enterprise.advanced-config.file.workspace`.",
-        "type" : "object",
-        "properties" : {
-          "databases" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "$ref" : "#/components/schemas/metabase.workspaces.core.workspace-database-config"
-            }
-          },
-          "name" : {
-            "type" : "string",
-            "minLength" : 1
-          }
-        },
-        "required" : [ "name", "databases" ]
-      },
       "metabase.xrays.api.automagic-dashboards.base-64-encoded-json" : {
         "description" : "form-encoded base-64-encoded JSON"
       },
@@ -23665,55 +23612,6 @@
         "tags" : [ "/api/ee/action-v2" ]
       }
     },
-    "/api/ee/advanced-config" : {
-      "post" : {
-        "operationId" : "post-api-ee-advanced-config",
-        "summary" : "POST /api/ee/advanced-config",
-        "description" : "Apply an uploaded `config.yml` to this instance. Runs the same per-section\n  initializers (`settings`, `databases`, `users`, `api-keys`, `workspace`, ...)\n  the boot-time loader runs. Superuser-only.\n\n  Unlike the boot-time loader, `{{env VAR}}` templates are NOT expanded — the\n  file's values are inserted verbatim, so an admin's upload can't read\n  server-side environment variables it didn't intend to.",
-        "parameters" : [ ],
-        "responses" : {
-          "2XX" : {
-            "description" : "Successful response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "null"
-                }
-              }
-            }
-          },
-          "4XX" : {
-            "description" : "Client error response"
-          },
-          "5XX" : {
-            "description" : "Server error response"
-          }
-        },
-        "requestBody" : {
-          "content" : {
-            "multipart/form-data" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "config" : {
-                    "type" : "object",
-                    "properties" : {
-                      "filename" : {
-                        "type" : "string"
-                      },
-                      "tempfile" : { }
-                    },
-                    "required" : [ "filename", "tempfile" ]
-                  }
-                },
-                "required" : [ "config" ]
-              }
-            }
-          }
-        },
-        "tags" : [ "/api/ee/advanced-config" ]
-      }
-    },
     "/api/ee/advanced-permissions/application/graph" : {
       "get" : {
         "operationId" : "get-api-ee-advanced-permissions-application-graph",
@@ -30033,7 +29931,7 @@
       "post" : {
         "operationId" : "post-api-ee-security-center-test-notification",
         "summary" : "POST /api/ee/security-center/test-notification",
-        "description" : "Send a test notification through the given Security Center channels.\n\n   The request body lets callers pass the unsaved notification config from the\n   dialog so the test reflects current form state, not the persisted settings.\n   Both fields are optional; when omitted, the saved setting is used.",
+        "description" : "Send a test notification through the configured Security Center channels.",
         "parameters" : [ ],
         "responses" : {
           "2XX" : {
@@ -30057,34 +29955,6 @@
           },
           "5XX" : {
             "description" : "Server error response"
-          }
-        },
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "email_recipients" : {
-                    "oneOf" : [ {
-                      "type" : "array",
-                      "items" : {
-                        "$ref" : "#/components/schemas/metabase.notification.models.NotificationRecipient"
-                      }
-                    }, {
-                      "type" : "null"
-                    } ]
-                  },
-                  "slack_channel" : {
-                    "oneOf" : [ {
-                      "type" : "string"
-                    }, {
-                      "type" : "null"
-                    } ]
-                  }
-                }
-              }
-            }
           }
         },
         "tags" : [ "/api/ee/security-center" ]
@@ -31511,7 +31381,7 @@
       "get" : {
         "operationId" : "get-api-ee-workspace-instance-current",
         "summary" : "GET /api/ee/workspace-instance/current",
-        "description" : "Read-only summary of the workspace loaded on this instance, wrapped in a\n  `{:data ...}` envelope.\n\n  Reads from the `instance-workspace` setting populated at boot by the `:workspace`\n  section of `config.yml`, or at runtime by `POST /current`. `:data` is `null`\n  when no workspace was loaded — i.e. this is a manager-only instance, or no\n  `config.yml` was present at boot and `POST /current` hasn't been called.\n  The envelope avoids an empty JSON body for the `nil` case.",
+        "description" : "Read-only summary of the workspace loaded on this instance.\n\n  Reads from the in-process atom populated at boot by the `:workspace` section of\n  `config.yml`. Returns `nil` when no workspace was loaded — i.e. this is a manager-only\n  instance, or no `config.yml` was present at boot.",
         "parameters" : [ ],
         "responses" : {
           "2XX" : {
@@ -31519,158 +31389,52 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "object",
-                  "properties" : {
-                    "data" : {
-                      "oneOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "databases" : {
                         "type" : "object",
-                        "properties" : {
-                          "databases" : {
-                            "type" : "object",
-                            "additionalProperties" : {
+                        "additionalProperties" : {
+                          "type" : "object",
+                          "properties" : {
+                            "input_schemas" : {
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string"
+                              }
+                            },
+                            "output" : {
                               "type" : "object",
                               "properties" : {
-                                "input_schemas" : {
-                                  "type" : "array",
-                                  "items" : {
+                                "db" : {
+                                  "oneOf" : [ {
                                     "type" : "string"
-                                  }
+                                  }, {
+                                    "type" : "null"
+                                  } ]
                                 },
-                                "output" : {
-                                  "type" : "object",
-                                  "properties" : {
-                                    "db" : {
-                                      "oneOf" : [ {
-                                        "type" : "string"
-                                      }, {
-                                        "type" : "null"
-                                      } ]
-                                    },
-                                    "schema" : {
-                                      "oneOf" : [ {
-                                        "type" : "string"
-                                      }, {
-                                        "type" : "null"
-                                      } ]
-                                    }
-                                  }
+                                "schema" : {
+                                  "oneOf" : [ {
+                                    "type" : "string"
+                                  }, {
+                                    "type" : "null"
+                                  } ]
                                 }
-                              },
-                              "required" : [ "input_schemas", "output" ]
-                            }
-                          },
-                          "name" : {
-                            "type" : "string",
-                            "minLength" : 1
-                          }
-                        },
-                        "required" : [ "name", "databases" ]
-                      }, {
-                        "type" : "null"
-                      } ]
-                    }
-                  },
-                  "required" : [ "data" ]
-                }
-              }
-            }
-          },
-          "4XX" : {
-            "description" : "Client error response"
-          },
-          "5XX" : {
-            "description" : "Server error response"
-          }
-        },
-        "tags" : [ "/api/ee/workspace-instance" ]
-      },
-      "post" : {
-        "operationId" : "post-api-ee-workspace-instance-current",
-        "summary" : "POST /api/ee/workspace-instance/current",
-        "description" : "Install a workspace config on this instance at runtime. Accepts the same shape\n  `GET /current` returns and persists it via the `instance-workspace` setting so\n  it survives restarts. Use this on a running instance to enter workspace mode\n  without restarting from `config.yml`.",
-        "parameters" : [ ],
-        "responses" : {
-          "2XX" : {
-            "description" : "Successful response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "object",
-                  "properties" : {
-                    "databases" : {
-                      "type" : "object",
-                      "additionalProperties" : {
-                        "type" : "object",
-                        "properties" : {
-                          "input_schemas" : {
-                            "type" : "array",
-                            "items" : {
-                              "type" : "string"
-                            }
-                          },
-                          "output" : {
-                            "type" : "object",
-                            "properties" : {
-                              "db" : {
-                                "oneOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "null"
-                                } ]
-                              },
-                              "schema" : {
-                                "oneOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "null"
-                                } ]
                               }
                             }
-                          }
-                        },
-                        "required" : [ "input_schemas", "output" ]
+                          },
+                          "required" : [ "input_schemas", "output" ]
+                        }
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "minLength" : 1
                       }
                     },
-                    "name" : {
-                      "type" : "string",
-                      "minLength" : 1
-                    }
-                  },
-                  "required" : [ "name", "databases" ]
-                }
-              }
-            }
-          },
-          "4XX" : {
-            "description" : "Client error response"
-          },
-          "5XX" : {
-            "description" : "Server error response"
-          }
-        },
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/metabase.workspaces.core.workspace-instance-config"
-              }
-            }
-          }
-        },
-        "tags" : [ "/api/ee/workspace-instance" ]
-      },
-      "delete" : {
-        "operationId" : "delete-api-ee-workspace-instance-current",
-        "summary" : "DELETE /api/ee/workspace-instance/current",
-        "description" : "Clear the workspace config on this instance. After this returns, the instance\n  is no longer in workspace mode and `GET /current` returns `nil`. Also drops\n  every `TableRemapping` row, since stale mappings from the prior workspace\n  would otherwise keep rewriting queries on the now-unmanaged databases.",
-        "parameters" : [ ],
-        "responses" : {
-          "2XX" : {
-            "description" : "Successful response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "null"
+                    "required" : [ "name", "databases" ]
+                  }, {
+                    "type" : "null"
+                  } ]
                 }
               }
             }
@@ -36606,45 +36370,45 @@
         } ],
         "responses" : {
           "2XX" : {
-            "description" : "Successful response",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "oneOf" : [ {
-                    "type" : "object",
+                    "additionalProperties" : false,
                     "properties" : {
                       "prompt_count" : {
-                        "type" : "integer",
-                        "minimum" : 1
+                        "minimum" : 1,
+                        "type" : "integer"
                       },
                       "status" : {
                         "const" : "generated"
                       }
                     },
                     "required" : [ "status", "prompt_count" ],
-                    "additionalProperties" : false
+                    "type" : "object"
                   }, {
-                    "type" : "object",
+                    "additionalProperties" : false,
                     "properties" : {
                       "status" : {
                         "const" : "no-library-content"
                       }
                     },
                     "required" : [ "status" ],
-                    "additionalProperties" : false
+                    "type" : "object"
                   }, {
-                    "type" : "object",
+                    "additionalProperties" : false,
                     "properties" : {
                       "status" : {
                         "const" : "ai-produced-no-prompts"
                       }
                     },
                     "required" : [ "status" ],
-                    "additionalProperties" : false
+                    "type" : "object"
                   } ]
                 }
               }
-            }
+            },
+            "description" : "Successful response"
           },
           "4XX" : {
             "description" : "Client error response"

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -246,6 +246,12 @@ export type DeleteSuggestedMetabotPromptRequest = {
   prompt_id: SuggestedMetabotPrompt["id"];
 };
 
+export type RegenerateSuggestedMetabotPromptsResponse =
+  | { status: "generated"; prompt_count: number }
+  | { status: "no-library-content" }
+  | { status: "ai-produced-no-prompts" }
+  | { status: "managed-free-limit-reached" };
+
 export const METABOT_ISSUE_TYPE_VALUES = [
   "ui-bug",
   "took-incorrect-actions",

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -249,8 +249,7 @@ export type DeleteSuggestedMetabotPromptRequest = {
 export type RegenerateSuggestedMetabotPromptsResponse =
   | { status: "generated"; prompt_count: number }
   | { status: "no-library-content" }
-  | { status: "ai-produced-no-prompts" }
-  | { status: "managed-free-limit-reached" };
+  | { status: "ai-produced-no-prompts" };
 
 export const METABOT_ISSUE_TYPE_VALUES = [
   "ui-bug",

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
@@ -84,17 +84,13 @@ export const MetabotPromptSuggestionPane = ({
       .with({ status: "generated" }, () => undefined)
       .with({ status: "no-library-content" }, () => {
         sendToast({
-          // translators: shown when an admin clicks "Regenerate suggested prompts"
-          // but the Metabot has no models or metrics for the AI to summarize.
-          message: t`No models or metrics to summarize — add some to this Metabot's collection first.`,
+          message: t`Add some models or metrics to this Metabot's collection to generate prompts.`,
           icon: "info",
         });
       })
       .with({ status: "ai-produced-no-prompts" }, () => {
         sendToast({
-          // translators: shown when an admin clicks "Regenerate suggested prompts"
-          // and the AI ran successfully but returned no suggested prompts.
-          message: t`The AI didn't generate any prompts this time. Try again in a moment.`,
+          message: t`Metabot couldn't come up with any prompts. Try again in a moment.`,
           icon: "info",
         });
       })

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
@@ -1,5 +1,6 @@
 import { useClipboard } from "@mantine/hooks";
 import { useMemo } from "react";
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
@@ -79,28 +80,25 @@ export const MetabotPromptSuggestionPane = ({
       return;
     }
     setPage(0);
-    switch (data.status) {
-      case "generated":
-        return;
-      case "no-library-content":
+    match(data)
+      .with({ status: "generated" }, () => undefined)
+      .with({ status: "no-library-content" }, () => {
         sendToast({
-          message: t`No models or metrics to summarise — add some to this Metabot's collection first.`,
+          // translators: shown when an admin clicks "Regenerate suggested prompts"
+          // but the Metabot has no models or metrics for the AI to summarize.
+          message: t`No models or metrics to summarize — add some to this Metabot's collection first.`,
           icon: "info",
         });
-        return;
-      case "ai-produced-no-prompts":
+      })
+      .with({ status: "ai-produced-no-prompts" }, () => {
         sendToast({
+          // translators: shown when an admin clicks "Regenerate suggested prompts"
+          // and the AI ran successfully but returned no suggested prompts.
           message: t`The AI didn't generate any prompts this time. Try again in a moment.`,
           icon: "info",
         });
-        return;
-      case "managed-free-limit-reached":
-        sendToast({
-          message: t`Your managed AI usage limit has been reached.`,
-          icon: "warning",
-        });
-        return;
-    }
+      })
+      .exhaustive();
   };
 
   const prompts = useMemo(() => data?.prompts ?? [], [data?.prompts]);

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
@@ -73,14 +73,33 @@ export const MetabotPromptSuggestionPane = ({
   };
 
   const handleRegeneratePrompts = async () => {
-    const { error } = await regeneratePrompts(metabot.id);
-    if (error) {
-      sendToast({
-        message: t`Error regenerate prompts`,
-        icon: "warning",
-      });
-    } else {
-      setPage(0);
+    const { data, error } = await regeneratePrompts(metabot.id);
+    if (error || !data) {
+      sendToast({ message: t`Error regenerating prompts`, icon: "warning" });
+      return;
+    }
+    setPage(0);
+    switch (data.status) {
+      case "generated":
+        return;
+      case "no-library-content":
+        sendToast({
+          message: t`No models or metrics to summarise — add some to this Metabot's collection first.`,
+          icon: "info",
+        });
+        return;
+      case "ai-produced-no-prompts":
+        sendToast({
+          message: t`The AI didn't generate any prompts this time. Try again in a moment.`,
+          icon: "info",
+        });
+        return;
+      case "managed-free-limit-reached":
+        sendToast({
+          message: t`Your managed AI usage limit has been reached.`,
+          icon: "warning",
+        });
+        return;
     }
   };
 

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -309,12 +309,15 @@ describe("suggested prompts", () => {
     it("does not show a toast on the happy path", async () => {
       await setupForRegenerate({ status: "generated", prompt_count: 3 });
       await clickRegenerate();
-      // Give any toast a chance to render, then assert none of the empty-state copy is visible.
-      await waitFor(() => {
-        expect(
-          screen.queryByText(/No models or metrics to summarize/),
-        ).not.toBeInTheDocument();
+      // Anchor on the mutation actually settling — the button's loading text ("Regenerating ...")
+      // is replaced by the idle text only after `isRegenerating` flips back to false, which is
+      // the same render where any empty-state toast would have appeared if the switch was wrong.
+      await screen.findByRole("button", {
+        name: "Regenerate suggested prompts",
       });
+      expect(
+        screen.queryByText(/No models or metrics to summarize/),
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByText(/AI didn't generate any prompts/),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -8,8 +8,12 @@ import {
   setupRemoveMetabotPromptSuggestionEndpoint,
 } from "__support__/server-mocks/metabot";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { UndoListing } from "metabase/common/components/UndoListing";
 import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
-import type { SuggestedMetabotPrompt } from "metabase-types/api";
+import type {
+  RegenerateSuggestedMetabotPromptsResponse,
+  SuggestedMetabotPrompt,
+} from "metabase-types/api";
 
 import { MetabotPromptSuggestionPane } from "./MetabotAdminSuggestedPrompts";
 import { mockSuggestedPrompts } from "./test-utils";
@@ -59,10 +63,13 @@ const setup = async (opts?: SetupOpts) => {
     : paginationContext;
 
   const TestComponent = () => (
-    <MetabotPromptSuggestionPane
-      metabot={{ id: metabotId, collection_id: null }}
-      pageSize={pageSize}
-    />
+    <>
+      <MetabotPromptSuggestionPane
+        metabot={{ id: metabotId, collection_id: null }}
+        pageSize={pageSize}
+      />
+      <UndoListing />
+    </>
   );
 
   renderWithProviders(<Route path="/" component={TestComponent} />, {
@@ -253,5 +260,64 @@ describe("suggested prompts", () => {
     expect(loadingRow).toBeInTheDocument();
 
     expect(await screen.findByText(firstPrompt.prompt)).toBeInTheDocument();
+  });
+
+  describe("regenerate empty-state toasts", () => {
+    const clickRegenerate = async () =>
+      userEvent.click(
+        await screen.findByRole("button", {
+          name: /Regenerate suggested prompts/,
+        }),
+      );
+
+    const setupForRegenerate = async (
+      body: RegenerateSuggestedMetabotPromptsResponse,
+    ) => {
+      const { metabotId } = await setup();
+      setupMetabotPromptSuggestionsEndpoint({
+        metabotId,
+        prompts: defaultMetabotMockedPrompts,
+        paginationContext: {
+          offset: 0,
+          limit: 3,
+          total: defaultMetabotMockedPrompts.length,
+        },
+      });
+      setupRegenerateMetabotPromptSuggestionsEndpoint(
+        metabotId,
+        undefined,
+        body,
+      );
+    };
+
+    it("shows the no-library-content toast", async () => {
+      await setupForRegenerate({ status: "no-library-content" });
+      await clickRegenerate();
+      expect(
+        await screen.findByText(/No models or metrics to summarize/),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the ai-produced-no-prompts toast", async () => {
+      await setupForRegenerate({ status: "ai-produced-no-prompts" });
+      await clickRegenerate();
+      expect(
+        await screen.findByText(/AI didn't generate any prompts/),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show a toast on the happy path", async () => {
+      await setupForRegenerate({ status: "generated", prompt_count: 3 });
+      await clickRegenerate();
+      // Give any toast a chance to render, then assert none of the empty-state copy is visible.
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/No models or metrics to summarize/),
+        ).not.toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText(/AI didn't generate any prompts/),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -1,4 +1,5 @@
 import _userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
 import {
@@ -35,10 +36,18 @@ const prevPage = async () =>
 const nextPage = async () =>
   userEvent.click(await screen.findByLabelText("chevronright icon"));
 
+const clickRegenerate = async () =>
+  userEvent.click(
+    await screen.findByRole("button", {
+      name: /Regenerate suggested prompts/,
+    }),
+  );
+
 type SetupOpts = {
   metabotId?: number;
   pageSize?: number;
   mockInitialPage?: boolean;
+  regenerateBody?: RegenerateSuggestedMetabotPromptsResponse;
 };
 
 const setup = async (opts?: SetupOpts) => {
@@ -46,6 +55,7 @@ const setup = async (opts?: SetupOpts) => {
     metabotId = FIXED_METABOT_IDS.DEFAULT,
     pageSize = 3,
     mockInitialPage = true,
+    regenerateBody,
   } = opts ?? {};
 
   const paginationContext = {
@@ -61,6 +71,19 @@ const setup = async (opts?: SetupOpts) => {
         paginationContext,
       })
     : paginationContext;
+
+  if (regenerateBody) {
+    setupMetabotPromptSuggestionsEndpoint({
+      metabotId,
+      prompts: defaultMetabotMockedPrompts,
+      paginationContext,
+    });
+    setupRegenerateMetabotPromptSuggestionsEndpoint(
+      metabotId,
+      undefined,
+      regenerateBody,
+    );
+  }
 
   const TestComponent = () => (
     <>
@@ -263,63 +286,39 @@ describe("suggested prompts", () => {
   });
 
   describe("regenerate empty-state toasts", () => {
-    const clickRegenerate = async () =>
-      userEvent.click(
-        await screen.findByRole("button", {
-          name: /Regenerate suggested prompts/,
-        }),
-      );
-
-    const setupForRegenerate = async (
-      body: RegenerateSuggestedMetabotPromptsResponse,
-    ) => {
-      const { metabotId } = await setup();
-      setupMetabotPromptSuggestionsEndpoint({
-        metabotId,
-        prompts: defaultMetabotMockedPrompts,
-        paginationContext: {
-          offset: 0,
-          limit: 3,
-          total: defaultMetabotMockedPrompts.length,
-        },
-      });
-      setupRegenerateMetabotPromptSuggestionsEndpoint(
-        metabotId,
-        undefined,
-        body,
-      );
-    };
-
     it("shows the no-library-content toast", async () => {
-      await setupForRegenerate({ status: "no-library-content" });
+      await setup({ regenerateBody: { status: "no-library-content" } });
       await clickRegenerate();
       expect(
-        await screen.findByText(/No models or metrics to summarize/),
+        await screen.findByText(/Add some models or metrics/),
       ).toBeInTheDocument();
     });
 
     it("shows the ai-produced-no-prompts toast", async () => {
-      await setupForRegenerate({ status: "ai-produced-no-prompts" });
+      await setup({ regenerateBody: { status: "ai-produced-no-prompts" } });
       await clickRegenerate();
       expect(
-        await screen.findByText(/AI didn't generate any prompts/),
+        await screen.findByText(/Metabot couldn't come up with any prompts/),
       ).toBeInTheDocument();
     });
 
     it("does not show a toast on the happy path", async () => {
-      await setupForRegenerate({ status: "generated", prompt_count: 3 });
+      await setup({
+        regenerateBody: { status: "generated", prompt_count: 3 },
+      });
       await clickRegenerate();
-      // Anchor on the mutation actually settling — the button's loading text ("Regenerating ...")
-      // is replaced by the idle text only after `isRegenerating` flips back to false, which is
-      // the same render where any empty-state toast would have appeared if the switch was wrong.
-      await screen.findByRole("button", {
-        name: "Regenerate suggested prompts",
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called(
+            `path:/api/metabot/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions/regenerate`,
+          ),
+        ).toBe(true);
       });
       expect(
-        screen.queryByText(/No models or metrics to summarize/),
+        screen.queryByText(/Add some models or metrics/),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByText(/AI didn't generate any prompts/),
+        screen.queryByText(/Metabot couldn't come up with any prompts/),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/api/metabot.ts
+++ b/frontend/src/metabase/api/metabot.ts
@@ -9,6 +9,7 @@ import type {
   MetabotSettingsResponse,
   MetabotSlackSettings,
   MetabotSourceFeedback,
+  RegenerateSuggestedMetabotPromptsResponse,
   SuggestedMetabotPromptsRequest,
   SuggestedMetabotPromptsResponse,
   UpdateMetabotSettingsRequest,
@@ -97,7 +98,10 @@ export const metabotApi = Api.injectEndpoints({
           idTag("metabot-prompt-suggestions", metabot_id),
         ]),
     }),
-    regenerateSuggestedMetabotPrompts: builder.mutation<void, MetabotId>({
+    regenerateSuggestedMetabotPrompts: builder.mutation<
+      RegenerateSuggestedMetabotPromptsResponse,
+      MetabotId
+    >({
       query: (metabot_id) => ({
         method: "POST",
         url: `/api/metabot/metabot/${metabot_id}/prompt-suggestions/regenerate`,

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -12,6 +12,7 @@ import type {
   MetabotSettingsResponse,
   MetabotTenantLimit,
   PurchaseCloudAddOnRequest,
+  RegenerateSuggestedMetabotPromptsResponse,
   SuggestedMetabotPrompt,
   SuggestedMetabotPromptsResponse,
   UpdateMetabotSettingsRequest,
@@ -106,10 +107,14 @@ export function setupRemoveMetabotPromptSuggestionEndpoint(
 export function setupRegenerateMetabotPromptSuggestionsEndpoint(
   metabotId: MetabotId,
   options?: UserRouteConfig,
+  body: RegenerateSuggestedMetabotPromptsResponse = {
+    status: "generated",
+    prompt_count: 1,
+  },
 ) {
   fetchMock.post(
     `path:/api/metabot/metabot/${metabotId}/prompt-suggestions/regenerate`,
-    { status: 200, body: { status: "generated", prompt_count: 1 } },
+    { status: 200, body },
     options,
   );
 }

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -109,7 +109,7 @@ export function setupRegenerateMetabotPromptSuggestionsEndpoint(
 ) {
   fetchMock.post(
     `path:/api/metabot/metabot/${metabotId}/prompt-suggestions/regenerate`,
-    { status: 204 },
+    { status: 200, body: { status: "generated", prompt_count: 1 } },
     options,
   );
 }

--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -36112,7 +36112,7 @@
     },
     "/api/metabot/metabot/{id}/prompt-suggestions/regenerate" : {
       "post" : {
-        "description" : "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.",
+        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].\n   The managed-free-limit case surfaces as a 402, not a union variant.",
         "operationId" : "post-api-metabot-metabot-id-prompt-suggestions-regenerate",
         "parameters" : [ {
           "in" : "path",

--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -36125,6 +36125,44 @@
         } ],
         "responses" : {
           "2XX" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "oneOf" : [ {
+                    "additionalProperties" : false,
+                    "properties" : {
+                      "prompt_count" : {
+                        "minimum" : 1,
+                        "type" : "integer"
+                      },
+                      "status" : {
+                        "const" : "generated"
+                      }
+                    },
+                    "required" : [ "status", "prompt_count" ],
+                    "type" : "object"
+                  }, {
+                    "additionalProperties" : false,
+                    "properties" : {
+                      "status" : {
+                        "const" : "no-library-content"
+                      }
+                    },
+                    "required" : [ "status" ],
+                    "type" : "object"
+                  }, {
+                    "additionalProperties" : false,
+                    "properties" : {
+                      "status" : {
+                        "const" : "ai-produced-no-prompts"
+                      }
+                    },
+                    "required" : [ "status" ],
+                    "type" : "object"
+                  } ]
+                }
+              }
+            },
             "description" : "Successful response"
           },
           "4XX" : {

--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -36112,7 +36112,7 @@
     },
     "/api/metabot/metabot/{id}/prompt-suggestions/regenerate" : {
       "post" : {
-        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].\n   The managed-free-limit case surfaces as a 402, not a union variant.",
+        "description" : "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.\n   The response `:status` is `:generated` (with a `:prompt_count`) when prompts were created,\n   `:no-library-content` when the Metabot has no models or metrics to summarize, or\n   `:ai-produced-no-prompts` when generation produced nothing.\n   Returns a 402 if the instance has reached its managed-AI usage limit.",
         "operationId" : "post-api-metabot-metabot-id-prompt-suggestions-regenerate",
         "parameters" : [ {
           "in" : "path",

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -70,11 +70,13 @@
 
 (api.macros/defendpoint :post "/:id/prompt-suggestions/regenerate"
   :- [:multi {:dispatch :status}
-      [:generated              [:map
-                                [:status [:= :generated]]
-                                [:prompt_count nat-int?]]]
-      [:no-library-content     [:map [:status [:= :no-library-content]]]]
-      [:ai-produced-no-prompts [:map [:status [:= :ai-produced-no-prompts]]]]]
+      [:generated              [:map {:closed true}
+                                [:status       [:= :generated]]
+                                ;; `:generated` is only returned when total > 0 — see
+                                ;; [[metabot.suggested-prompts/generate-sample-prompts]].
+                                [:prompt_count pos-int?]]]
+      [:no-library-content     [:map {:closed true} [:status [:= :no-library-content]]]]
+      [:ai-produced-no-prompts [:map {:closed true} [:status [:= :ai-produced-no-prompts]]]]]
   "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.
    Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].
    The managed-free-limit case surfaces as a 402, not a union variant."

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -61,20 +61,25 @@
           (metabot.suggested-prompts/generate-sample-prompts id)))
       (t2/select-one :model/Metabot :id id))))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:id/prompt-suggestions/regenerate"
-  "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones."
+  :- [:map
+      [:status :keyword]
+      [:reason       {:optional true} :keyword]
+      [:prompt-count {:optional true} nat-int?]]
+  "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.
+
+   Returns a map describing the outcome so the UI can distinguish a successful regeneration
+   from the various 'no error, but nothing produced' cases — e.g. the metabot has no models or
+   metrics in its library yet, or the LLM returned no questions for the inputs we supplied.
+
+   Response shape: see [[metabase.metabot.suggested-prompts/generate-sample-prompts]]."
   [{:keys [id]} :- [:map [:id pos-int?]]]
   (api/check-superuser)
   (t2/with-transaction [_conn]
     (api/check-404 (t2/exists? :model/Metabot :id id))
     (metabot.usage/check-metabase-managed-free-limit!)
     (metabot.suggested-prompts/delete-all-metabot-prompts id)
-    (metabot.suggested-prompts/generate-sample-prompts id))
-  api/generic-204-no-content)
+    (metabot.suggested-prompts/generate-sample-prompts id)))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -80,8 +80,10 @@
       [:no-library-content     [:map {:closed true} [:status [:= :no-library-content]]]]
       [:ai-produced-no-prompts [:map {:closed true} [:status [:= :ai-produced-no-prompts]]]]]
   "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.
-   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].
-   The managed-free-limit case surfaces as a 402, not a union variant."
+   The response `:status` is `:generated` (with a `:prompt_count`) when prompts were created,
+   `:no-library-content` when the Metabot has no models or metrics to summarize, or
+   `:ai-produced-no-prompts` when generation produced nothing.
+   Returns a 402 if the instance has reached its managed-AI usage limit."
   [{:keys [id]} :- [:map [:id pos-int?]]]
   (api/check-superuser)
   (t2/with-transaction [_conn]

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -75,17 +75,9 @@
                                 [:prompt_count nat-int?]]]
       [:no-library-content     [:map [:status [:= :no-library-content]]]]
       [:ai-produced-no-prompts [:map [:status [:= :ai-produced-no-prompts]]]]]
-  "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.
-
-   Returns a single-tag discriminated union so the UI can `switch` on `:status` to distinguish a
-   successful regeneration from the various 'no error, but nothing produced' cases.
-
-   The managed-free-limit case isn't in the union: both this endpoint and
-   [[metabot.suggested-prompts/generate-sample-prompts]] throw a 402 via
-   [[metabot.usage/check-metabase-managed-free-limit!]], so the locked state always surfaces as
-   a 402 error rather than a 200 with a status — no TOCTOU race between checks.
-
-   Response shape: see [[metabase.metabot.suggested-prompts/generate-sample-prompts]]."
+  "Remove any existing prompt suggestions for the Metabot with `id` and generate new ones.
+   Returns a discriminated union on `:status`; see [[metabot.suggested-prompts/generate-sample-prompts]].
+   The managed-free-limit case surfaces as a 402, not a union variant."
   [{:keys [id]} :- [:map [:id pos-int?]]]
   (api/check-superuser)
   (t2/with-transaction [_conn]

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -57,12 +57,14 @@
       (when (not= old-vals metabot-updates)
         (t2/update! :model/Metabot id metabot-updates)
         (when-not (metabot.usage/managed-free-limit-reached?)
-          (metabot.suggested-prompts/delete-all-metabot-prompts id)
+          ;; Delete + regenerate atomically so a raced managed-AI lock (the 402 swallowed below) or
+          ;; any other failure rolls back the delete instead of leaving the Metabot with zero
+          ;; prompts. The 402 still triggers the rollback because it escapes the transaction body
+          ;; before we catch it. Swallowing it keeps a settings-only PUT from failing on a race.
           (try
-            (metabot.suggested-prompts/generate-sample-prompts id)
-            ;; Best-effort: if the managed-AI lock kicks in between the pre-check above and the
-            ;; canonical check inside `generate-sample-prompts`, swallow the 402 so a PUT to
-            ;; update Metabot settings doesn't fail just because prompt regeneration was raced.
+            (t2/with-transaction [_conn]
+              (metabot.suggested-prompts/delete-all-metabot-prompts id)
+              (metabot.suggested-prompts/generate-sample-prompts id))
             (catch clojure.lang.ExceptionInfo e
               (when-not (= "metabase_ai_managed_locked" (:error-code (ex-data e)))
                 (throw e))))))

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -58,7 +58,14 @@
         (t2/update! :model/Metabot id metabot-updates)
         (when-not (metabot.usage/managed-free-limit-reached?)
           (metabot.suggested-prompts/delete-all-metabot-prompts id)
-          (metabot.suggested-prompts/generate-sample-prompts id)))
+          (try
+            (metabot.suggested-prompts/generate-sample-prompts id)
+            ;; Best-effort: if the managed-AI lock kicks in between the pre-check above and the
+            ;; canonical check inside `generate-sample-prompts`, swallow the 402 so a PUT to
+            ;; update Metabot settings doesn't fail just because prompt regeneration was raced.
+            (catch clojure.lang.ExceptionInfo e
+              (when-not (= "metabase_ai_managed_locked" (:error-code (ex-data e)))
+                (throw e))))))
       (t2/select-one :model/Metabot :id id))))
 
 (api.macros/defendpoint :post "/:id/prompt-suggestions/regenerate"
@@ -73,8 +80,10 @@
    Returns a single-tag discriminated union so the UI can `switch` on `:status` to distinguish a
    successful regeneration from the various 'no error, but nothing produced' cases.
 
-   The managed-free-limit case isn't in the union: [[metabot.usage/check-metabase-managed-free-limit!]]
-   throws a 402 before we ever call into [[metabot.suggested-prompts/generate-sample-prompts]].
+   The managed-free-limit case isn't in the union: both this endpoint and
+   [[metabot.suggested-prompts/generate-sample-prompts]] throw a 402 via
+   [[metabot.usage/check-metabase-managed-free-limit!]], so the locked state always surfaces as
+   a 402 error rather than a 200 with a status — no TOCTOU race between checks.
 
    Response shape: see [[metabase.metabot.suggested-prompts/generate-sample-prompts]]."
   [{:keys [id]} :- [:map [:id pos-int?]]]

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -63,16 +63,18 @@
 
 (api.macros/defendpoint :post "/:id/prompt-suggestions/regenerate"
   :- [:multi {:dispatch :status}
-      [:generated                  [:map
-                                    [:status [:= :generated]]
-                                    [:prompt_count nat-int?]]]
-      [:no-library-content         [:map [:status [:= :no-library-content]]]]
-      [:ai-produced-no-prompts     [:map [:status [:= :ai-produced-no-prompts]]]]
-      [:managed-free-limit-reached [:map [:status [:= :managed-free-limit-reached]]]]]
+      [:generated              [:map
+                                [:status [:= :generated]]
+                                [:prompt_count nat-int?]]]
+      [:no-library-content     [:map [:status [:= :no-library-content]]]]
+      [:ai-produced-no-prompts [:map [:status [:= :ai-produced-no-prompts]]]]]
   "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.
 
    Returns a single-tag discriminated union so the UI can `switch` on `:status` to distinguish a
    successful regeneration from the various 'no error, but nothing produced' cases.
+
+   The managed-free-limit case isn't in the union: [[metabot.usage/check-metabase-managed-free-limit!]]
+   throws a 402 before we ever call into [[metabot.suggested-prompts/generate-sample-prompts]].
 
    Response shape: see [[metabase.metabot.suggested-prompts/generate-sample-prompts]]."
   [{:keys [id]} :- [:map [:id pos-int?]]]

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -62,15 +62,17 @@
       (t2/select-one :model/Metabot :id id))))
 
 (api.macros/defendpoint :post "/:id/prompt-suggestions/regenerate"
-  :- [:map
-      [:status :keyword]
-      [:reason       {:optional true} :keyword]
-      [:prompt-count {:optional true} nat-int?]]
+  :- [:multi {:dispatch :status}
+      [:generated                  [:map
+                                    [:status [:= :generated]]
+                                    [:prompt_count nat-int?]]]
+      [:no-library-content         [:map [:status [:= :no-library-content]]]]
+      [:ai-produced-no-prompts     [:map [:status [:= :ai-produced-no-prompts]]]]
+      [:managed-free-limit-reached [:map [:status [:= :managed-free-limit-reached]]]]]
   "Remove any existing prompt suggestions for the Metabot instance with `id` and generate new ones.
 
-   Returns a map describing the outcome so the UI can distinguish a successful regeneration
-   from the various 'no error, but nothing produced' cases — e.g. the metabot has no models or
-   metrics in its library yet, or the LLM returned no questions for the inputs we supplied.
+   Returns a single-tag discriminated union so the UI can `switch` on `:status` to distinguish a
+   successful regeneration from the various 'no error, but nothing produced' cases.
 
    Response shape: see [[metabase.metabot.suggested-prompts/generate-sample-prompts]]."
   [{:keys [id]} :- [:map [:id pos-int?]]]

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -54,7 +54,7 @@
    single discriminator so the frontend can switch on one field:
 
      {:status :generated :prompt_count N}        ; happy path
-     {:status :no-library-content}               ; metabot has no models/metrics to summarise
+     {:status :no-library-content}               ; metabot has no models/metrics to summarize
      {:status :ai-produced-no-prompts}           ; LLM returned 0 questions for the inputs
      {:status :managed-free-limit-reached}       ; managed AI usage cap hit
 
@@ -84,7 +84,7 @@
               model-inputs  (map model-input models)]
           (if (and (empty? metric-inputs) (empty? model-inputs))
             (do
-              (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarise."
+              (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarize."
                         {:metabot-id metabot-id})
               {:status :no-library-content})
             (let [{:keys [table_questions metric_questions]}
@@ -94,8 +94,9 @@
                                          :model      (:type origin)
                                          :card_id    (:id origin)}]
                                (map #(assoc base :prompt %) questions)))
-                  metric-prompts (mapcat ->prompt metric_questions metrics)
-                  model-prompts  (mapcat ->prompt table_questions models)
+                  ;; Realize into vectors so we don't redo `->prompt` work when counting and inserting.
+                  metric-prompts (vec (mapcat ->prompt metric_questions metrics))
+                  model-prompts  (vec (mapcat ->prompt table_questions models))
                   total          (+ (count metric-prompts) (count model-prompts))]
               (when (seq metric-prompts)
                 (t2/insert! :model/MetabotPrompt metric-prompts))

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -50,12 +50,13 @@
   "Generate suggested prompts for the Metabot instance with `metabot-id`.
 
    Returns a map describing the outcome so callers can distinguish success from
-   the various 'no error, but nothing produced' cases:
+   the various 'no error, but nothing produced' cases. The `:status` key is a
+   single discriminator so the frontend can switch on one field:
 
-     {:status :generated :prompt-count N}            ; happy path
-     {:status :empty :reason :no-library-content}    ; metabot has no models/metrics to summarise
-     {:status :empty :reason :ai-produced-no-prompts} ; LLM returned 0 questions for the inputs
-     {:status :empty :reason :managed-free-limit-reached}  ; managed AI usage cap hit
+     {:status :generated :prompt_count N}        ; happy path
+     {:status :no-library-content}               ; metabot has no models/metrics to summarise
+     {:status :ai-produced-no-prompts}           ; LLM returned 0 questions for the inputs
+     {:status :managed-free-limit-reached}       ; managed AI usage cap hit
 
    Skips the LLM call entirely on the `:no-library-content` and `:managed-free-limit-reached`
    branches so we don't burn tokens (or AI-service round-trips) generating nothing."
@@ -64,7 +65,7 @@
     (do
       (log/info "Skipping suggested prompt generation because the managed AI free limit has been reached."
                 {:metabot-id metabot-id})
-      {:status :empty :reason :managed-free-limit-reached})
+      {:status :managed-free-limit-reached})
     (let [opts (merge default-opts opts)]
       (lib-be/with-metadata-provider-cache
         (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
@@ -85,7 +86,7 @@
             (do
               (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarise."
                         {:metabot-id metabot-id})
-              {:status :empty :reason :no-library-content})
+              {:status :no-library-content})
             (let [{:keys [table_questions metric_questions]}
                   (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
                   ->prompt (fn [{:keys [questions]} {::keys [origin]}]
@@ -101,8 +102,8 @@
               (when (seq model-prompts)
                 (t2/insert! :model/MetabotPrompt model-prompts))
               (if (zero? total)
-                {:status :empty :reason :ai-produced-no-prompts}
-                {:status :generated :prompt-count total}))))))))
+                {:status :ai-produced-no-prompts}
+                {:status :generated :prompt_count total}))))))))
 
 (defn delete-all-metabot-prompts
   "Drop suggested prompts for instance of Metabot."

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -56,55 +56,53 @@
      {:status :generated :prompt_count N}        ; happy path
      {:status :no-library-content}               ; metabot has no models/metrics to summarize
      {:status :ai-produced-no-prompts}           ; LLM returned 0 questions for the inputs
-     {:status :managed-free-limit-reached}       ; managed AI usage cap hit
 
-   Skips the LLM call entirely on the `:no-library-content` and `:managed-free-limit-reached`
-   branches so we don't burn tokens (or AI-service round-trips) generating nothing."
+   Throws a 402 via [[metabot.usage/check-metabase-managed-free-limit!]] when the managed AI
+   usage cap is hit — making the return type a closed union so the regenerate endpoint can
+   declare an exact response schema. Callers that want best-effort behavior (e.g. PUT /:id)
+   pre-guard with [[metabot.usage/managed-free-limit-reached?]] and catch the 402 to handle
+   the rare TOCTOU race where the limit flips between the pre-check and here."
   [metabot-id & {:as opts}]
-  (if (metabot.usage/managed-free-limit-reached?)
-    (do
-      (log/info "Skipping suggested prompt generation because the managed AI free limit has been reached."
-                {:metabot-id metabot-id})
-      {:status :managed-free-limit-reached})
-    (let [opts (merge default-opts opts)]
-      (lib-be/with-metadata-provider-cache
-        (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
-                                                   (sort-by :view_count >)
-                                                   (group-by :type))
-              ;; Limit to 5 metrics and 5 models
-              limited-cards (concat (take 5 metrics) (take 5 models))
-              {metrics :metric, models :model}
-              (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
-                         detail (map (fn [detail card] (assoc detail ::origin card))
-                                     (metabot.tools.entity-details/cards-details card-type database-id group-cards nil)
-                                     group-cards)]
-                     detail)
-                   (group-by :type))
-              metric-inputs (map metric-input metrics)
-              model-inputs  (map model-input models)]
-          (if (and (empty? metric-inputs) (empty? model-inputs))
-            (do
-              (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarize."
-                        {:metabot-id metabot-id})
-              {:status :no-library-content})
-            (let [{:keys [table_questions metric_questions]}
-                  (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
-                  ->prompt (fn [{:keys [questions]} {::keys [origin]}]
-                             (let [base {:metabot_id metabot-id
-                                         :model      (:type origin)
-                                         :card_id    (:id origin)}]
-                               (map #(assoc base :prompt %) questions)))
-                  ;; Realize into vectors so we don't redo `->prompt` work when counting and inserting.
-                  metric-prompts (vec (mapcat ->prompt metric_questions metrics))
-                  model-prompts  (vec (mapcat ->prompt table_questions models))
-                  total          (+ (count metric-prompts) (count model-prompts))]
-              (when (seq metric-prompts)
-                (t2/insert! :model/MetabotPrompt metric-prompts))
-              (when (seq model-prompts)
-                (t2/insert! :model/MetabotPrompt model-prompts))
-              (if (zero? total)
-                {:status :ai-produced-no-prompts}
-                {:status :generated :prompt_count total}))))))))
+  (metabot.usage/check-metabase-managed-free-limit!)
+  (let [opts (merge default-opts opts)]
+    (lib-be/with-metadata-provider-cache
+      (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
+                                                 (sort-by :view_count >)
+                                                 (group-by :type))
+            ;; Limit to 5 metrics and 5 models
+            limited-cards (concat (take 5 metrics) (take 5 models))
+            {metrics :metric, models :model}
+            (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
+                       detail (map (fn [detail card] (assoc detail ::origin card))
+                                   (metabot.tools.entity-details/cards-details card-type database-id group-cards nil)
+                                   group-cards)]
+                   detail)
+                 (group-by :type))
+            metric-inputs (map metric-input metrics)
+            model-inputs  (map model-input models)]
+        (if (and (empty? metric-inputs) (empty? model-inputs))
+          (do
+            (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarize."
+                      {:metabot-id metabot-id})
+            {:status :no-library-content})
+          (let [{:keys [table_questions metric_questions]}
+                (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
+                ->prompt (fn [{:keys [questions]} {::keys [origin]}]
+                           (let [base {:metabot_id metabot-id
+                                       :model      (:type origin)
+                                       :card_id    (:id origin)}]
+                             (map #(assoc base :prompt %) questions)))
+                ;; Realize into vectors so we don't redo `->prompt` work when counting and inserting.
+                metric-prompts (vec (mapcat ->prompt metric_questions metrics))
+                model-prompts  (vec (mapcat ->prompt table_questions models))
+                total          (+ (count metric-prompts) (count model-prompts))]
+            (when (seq metric-prompts)
+              (t2/insert! :model/MetabotPrompt metric-prompts))
+            (when (seq model-prompts)
+              (t2/insert! :model/MetabotPrompt model-prompts))
+            (if (zero? total)
+              {:status :ai-produced-no-prompts}
+              {:status :generated :prompt_count total})))))))
 
 (defn delete-all-metabot-prompts
   "Drop suggested prompts for instance of Metabot."

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -47,11 +47,24 @@
     result))
 
 (defn generate-sample-prompts
-  "Generate suggested prompts for instance of Metabot."
+  "Generate suggested prompts for the Metabot instance with `metabot-id`.
+
+   Returns a map describing the outcome so callers can distinguish success from
+   the various 'no error, but nothing produced' cases:
+
+     {:status :generated :prompt-count N}            ; happy path
+     {:status :empty :reason :no-library-content}    ; metabot has no models/metrics to summarise
+     {:status :empty :reason :ai-produced-no-prompts} ; LLM returned 0 questions for the inputs
+     {:status :empty :reason :managed-free-limit-reached}  ; managed AI usage cap hit
+
+   Skips the LLM call entirely on the `:no-library-content` and `:managed-free-limit-reached`
+   branches so we don't burn tokens (or AI-service round-trips) generating nothing."
   [metabot-id & {:as opts}]
   (if (metabot.usage/managed-free-limit-reached?)
-    (log/info "Skipping suggested prompt generation because the managed AI free limit has been reached."
-              {:metabot-id metabot-id})
+    (do
+      (log/info "Skipping suggested prompt generation because the managed AI free limit has been reached."
+                {:metabot-id metabot-id})
+      {:status :empty :reason :managed-free-limit-reached})
     (let [opts (merge default-opts opts)]
       (lib-be/with-metadata-provider-cache
         (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
@@ -67,20 +80,29 @@
                      detail)
                    (group-by :type))
               metric-inputs (map metric-input metrics)
-              model-inputs (map model-input models)
-              {:keys [table_questions metric_questions]}
-              (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
-              ->prompt (fn [{:keys [questions]} {::keys [origin]}]
-                         (let [base {:metabot_id metabot-id
-                                     :model      (:type origin)
-                                     :card_id    (:id origin)}]
-                           (map #(assoc base :prompt %) questions)))
-              metric-prompts (mapcat ->prompt metric_questions metrics)
-              model-prompts (mapcat ->prompt table_questions models)]
-          (when (seq metric-prompts)
-            (t2/insert! :model/MetabotPrompt metric-prompts))
-          (when (seq model-prompts)
-            (t2/insert! :model/MetabotPrompt model-prompts)))))))
+              model-inputs  (map model-input models)]
+          (if (and (empty? metric-inputs) (empty? model-inputs))
+            (do
+              (log/info "Skipping suggested prompt generation: metabot has no models or metrics to summarise."
+                        {:metabot-id metabot-id})
+              {:status :empty :reason :no-library-content})
+            (let [{:keys [table_questions metric_questions]}
+                  (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
+                  ->prompt (fn [{:keys [questions]} {::keys [origin]}]
+                             (let [base {:metabot_id metabot-id
+                                         :model      (:type origin)
+                                         :card_id    (:id origin)}]
+                               (map #(assoc base :prompt %) questions)))
+                  metric-prompts (mapcat ->prompt metric_questions metrics)
+                  model-prompts  (mapcat ->prompt table_questions models)
+                  total          (+ (count metric-prompts) (count model-prompts))]
+              (when (seq metric-prompts)
+                (t2/insert! :model/MetabotPrompt metric-prompts))
+              (when (seq model-prompts)
+                (t2/insert! :model/MetabotPrompt model-prompts))
+              (if (zero? total)
+                {:status :empty :reason :ai-produced-no-prompts}
+                {:status :generated :prompt-count total}))))))))
 
 (defn delete-all-metabot-prompts
   "Drop suggested prompts for instance of Metabot."

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -47,21 +47,15 @@
     result))
 
 (defn generate-sample-prompts
-  "Generate suggested prompts for the Metabot instance with `metabot-id`.
-
-   Returns a map describing the outcome so callers can distinguish success from
-   the various 'no error, but nothing produced' cases. The `:status` key is a
-   single discriminator so the frontend can switch on one field:
+  "Generate suggested prompts for the Metabot with `metabot-id`. Returns one of:
 
      {:status :generated :prompt_count N}        ; happy path
      {:status :no-library-content}               ; metabot has no models/metrics to summarize
      {:status :ai-produced-no-prompts}           ; LLM returned 0 questions for the inputs
 
-   Throws a 402 via [[metabot.usage/check-metabase-managed-free-limit!]] when the managed AI
-   usage cap is hit — making the return type a closed union so the regenerate endpoint can
-   declare an exact response schema. Callers that want best-effort behavior (e.g. PUT /:id)
-   pre-guard with [[metabot.usage/managed-free-limit-reached?]] and catch the 402 to handle
-   the rare TOCTOU race where the limit flips between the pre-check and here."
+   Throws a 402 via [[metabot.usage/check-metabase-managed-free-limit!]] when the managed AI cap is hit.
+   Best-effort callers (e.g. PUT /:id) pre-guard with [[metabot.usage/managed-free-limit-reached?]]
+   and catch the 402 to handle the rare TOCTOU race where the limit flips between the two checks."
   [metabot-id & {:as opts}]
   (metabot.usage/check-metabase-managed-free-limit!)
   (let [opts (merge default-opts opts)]

--- a/src/metabase/metabot/task/suggested_prompts_generator.clj
+++ b/src/metabase/metabot/task/suggested_prompts_generator.clj
@@ -5,6 +5,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.request.core :as request]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
@@ -21,8 +22,16 @@
 
 (defn- maybe-generate-suggested-prompts! []
   (try
-    (if-not (metabot.config/any-metabot-enabled?)
+    (cond
+      (not (metabot.config/any-metabot-enabled?))
       (log/info "Metabot is disabled. Skipping suggested prompt generation.")
+
+      ;; Pre-check so a locked managed-AI instance logs a clean info-level skip instead of bubbling
+      ;; the 402 from `generate-sample-prompts` up into the catch as a noisy startup error.
+      (metabot.usage/managed-free-limit-reached?)
+      (log/info "Managed AI free limit reached. Skipping suggested prompt generation.")
+
+      :else
       ;; Run as admin since this is a system task generating prompts for all content in scope.
       ;; Users will only see prompts for content they have access to (filtered at query time).
       (request/as-admin

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -69,8 +69,10 @@
           (testing "should generate prompt suggestions for metabot"
             (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
               ;; Trigger prompt generation by calling the regenerate endpoint
-              (mt/user-http-request :crowberto :post 204
-                                    (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+              (is (=? {:status       "generated"
+                       :prompt-count (reduce + (map count (vals prompts)))}
+                      (mt/user-http-request :crowberto :post 200
+                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
             (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
                                            :metabot_id metabot-id
                                            {:join     [[:report_card :card] [:= :card.id :card_id]]
@@ -143,7 +145,9 @@
                     (is (= remaining-prompt-ids (current-prompt-ids))))
                   (testing "admin users are allowed"
                     (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-                      (mt/user-http-request :crowberto :post 204 url)))))
+                      (is (=? {:status "generated" :prompt-count pos-int?}
+                              (mt/user-http-request :crowberto :post 200 url)))))))
+
               (let [new-prompt-ids (current-prompt-ids)]
                 (is (= (count all-prompt-ids) (count new-prompt-ids)))
                 (is (empty? (set/intersection all-prompt-ids new-prompt-ids)))
@@ -318,6 +322,39 @@
                      (:message response))))
             (is (= #{prompt-id}
                    (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))
+
+(deftest metabot-prompt-regenerate-empty-states-test
+  (testing "POST /prompt-suggestions/regenerate returns a structured outcome so the UI can"
+    (testing "distinguish a metabot whose library has no models or metrics from a real error"
+      (mt/with-temp [:model/Collection {collection-id :id} {:name "Empty Library"}
+                     :model/Metabot    {metabot-id :id}    {:name          "Empty metabot"
+                                                            :collection_id collection-id}]
+        ;; No cards in the collection — the LLM should never be called.
+        (with-redefs [metabot.example-question-generator/generate-example-questions
+                      (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
+          (is (= {:status "empty" :reason "no-library-content"}
+                 (mt/user-http-request :crowberto :post 200
+                                       (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))))
+    (testing "distinguish 'LLM produced nothing' from 'LLM errored'"
+      (mt/dataset test-data
+        (let [model-query {:type :query :database (mt/id) :query {:source-table (mt/id :products)}}]
+          (mt/with-temp [:model/Collection {collection-id :id} {:name "Library with a model"}
+                         :model/Card       {card-id :id}       {:name          "Products model"
+                                                                :type          :model
+                                                                :dataset_query model-query
+                                                                :collection_id collection-id}
+                         :model/Metabot    {metabot-id :id}    {:name          "Productive metabot"
+                                                                :collection_id collection-id}]
+            (with-redefs [metabot.example-question-generator/generate-example-questions
+                          (constantly {:table_questions  [{:questions []}]
+                                       :metric_questions []})]
+              (is (= {:status "empty" :reason "ai-produced-no-prompts"}
+                     (mt/user-http-request :crowberto :post 200
+                                           (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))))
+              (is (empty? (t2/select :model/MetabotPrompt :metabot_id metabot-id))
+                  "no prompts should be persisted when the LLM returned none")
+              ;; Reference the bound card so kondo doesn't flag it as unused.
+              (is (pos-int? card-id)))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -8,6 +8,7 @@
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.premium-features.core :as premium-features]
@@ -299,6 +300,33 @@
               (is (nil? (:collection_id response)))
               (is (= #{prompt-id}
                      (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
+
+(deftest metabot-put-swallows-managed-locked-toctou-from-generate-sample-prompts-test
+  (testing "if the managed-AI lock flips between the pre-check and `generate-sample-prompts`,
+            the PUT still succeeds (best-effort regeneration) — the 402 is swallowed."
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                   :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                    :collection_id collection-id}]
+      (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                    metabot.suggested-prompts/generate-sample-prompts
+                    (fn [& _]
+                      (throw (ex-info "locked" {:status-code 402
+                                                :error-code  "metabase_ai_managed_locked"})))]
+        (let [response (mt/user-http-request :crowberto :put 200
+                                             (format "metabot/metabot/%d" metabot-id)
+                                             {:collection_id nil})]
+          (is (nil? (:collection_id response))))))
+    (testing "non-locked ex-info from generate-sample-prompts still propagates"
+      (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                     :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                      :collection_id collection-id}]
+        (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                      metabot.suggested-prompts/generate-sample-prompts
+                      (fn [& _]
+                        (throw (ex-info "boom" {:status-code 500})))]
+          (mt/user-http-request :crowberto :put 500
+                                (format "metabot/metabot/%d" metabot-id)
+                                {:collection_id nil}))))))
 
 (deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -67,20 +67,26 @@
                                                        :tables :table_questions})))]
           ;; --------------------------- Generating sample prompts ---------------------------
           (testing "should generate prompt suggestions for metabot"
-            (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-              ;; Trigger prompt generation by calling the regenerate endpoint
-              (is (=? {:status       "generated"
-                       :prompt_count (reduce + (map count (vals prompts)))}
-                      (mt/user-http-request :crowberto :post 200
-                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
-            (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
+            (let [response (with-redefs [metabot.example-question-generator/generate-example-questions
+                                         prompt-generator]
+                             ;; Trigger prompt generation by calling the regenerate endpoint
+                             (mt/user-http-request
+                              :crowberto :post 200
+                              (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+                  added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
                                            :metabot_id metabot-id
                                            {:join     [[:report_card :card] [:= :card.id :card_id]]
                                             :order-by [:metabot_prompt.id]})]
+              (is (=? {:status       "generated"
+                       :prompt_count (reduce + (map count (vals prompts)))}
+                      response))
               ;; Verify prompts were added to the database
               (is (= prompts
                      (-> (group-by :model_name added-prompts)
-                         (update-vals #(map :prompt %)))))))
+                         (update-vals #(map :prompt %)))))
+              ;; And that :prompt_count in the response matches the actual DB row count, not
+              ;; just the count the mock declared it would generate.
+              (is (= (:prompt_count response) (count added-prompts)))))
           ;; --------------------------- Querying sample prompts ---------------------------
           (let [expected-prompts (into #{} (mapcat val) prompts)
                 all-prompts (mt/user-http-request :rasta :get 200

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -312,11 +312,11 @@
                                                          :prompt "existing prompt"
                                                          :model :model
                                                          :card_id card-id}]
-      (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
-                    metabot.suggested-prompts/generate-sample-prompts
-                    (fn [& _]
-                      (throw (ex-info "locked" {:status-code 402
-                                                :error-code  "metabase_ai_managed_locked"})))]
+      (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                                  metabot.suggested-prompts/generate-sample-prompts
+                                  (fn [& _]
+                                    (throw (ex-info "locked" {:status-code 402
+                                                              :error-code  "metabase_ai_managed_locked"})))]
         (let [response (mt/user-http-request :crowberto :put 200
                                              (format "metabot/metabot/%d" metabot-id)
                                              {:collection_id nil})]
@@ -333,10 +333,10 @@
                                                          :prompt "existing prompt"
                                                          :model :model
                                                          :card_id card-id}]
-      (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
-                    metabot.suggested-prompts/generate-sample-prompts
-                    (fn [& _]
-                      (throw (ex-info "boom" {:status-code 500})))]
+      (mt/with-dynamic-fn-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                                  metabot.suggested-prompts/generate-sample-prompts
+                                  (fn [& _]
+                                    (throw (ex-info "boom" {:status-code 500})))]
         (mt/user-http-request :crowberto :put 500
                               (format "metabot/metabot/%d" metabot-id)
                               {:collection_id nil})
@@ -379,8 +379,8 @@
                      :model/Metabot    {metabot-id :id}    {:name          "Empty metabot"
                                                             :collection_id collection-id}]
         ;; No cards in the collection — the LLM should never be called.
-        (with-redefs [metabot.example-question-generator/generate-example-questions
-                      (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
+        (mt/with-dynamic-fn-redefs [metabot.example-question-generator/generate-example-questions
+                                    (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
           (is (= {:status "no-library-content"}
                  (mt/user-http-request :crowberto :post 200
                                        (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))))
@@ -394,9 +394,9 @@
                                                                 :collection_id collection-id}
                          :model/Metabot    {metabot-id :id}    {:name          "Productive metabot"
                                                                 :collection_id collection-id}]
-            (with-redefs [metabot.example-question-generator/generate-example-questions
-                          (constantly {:table_questions  [{:questions []}]
-                                       :metric_questions []})]
+            (mt/with-dynamic-fn-redefs [metabot.example-question-generator/generate-example-questions
+                                        (constantly {:table_questions  [{:questions []}]
+                                                     :metric_questions []})]
               (is (= {:status "ai-produced-no-prompts"}
                      (mt/user-http-request :crowberto :post 200
                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -303,10 +303,16 @@
 
 (deftest metabot-put-swallows-managed-locked-toctou-from-generate-sample-prompts-test
   (testing "if the managed-AI lock flips between the pre-check and `generate-sample-prompts`,
-            the PUT still succeeds (best-effort regeneration) — the 402 is swallowed."
+            the PUT still succeeds (best-effort regeneration) — the 402 is swallowed, and the
+            delete is rolled back with it so existing prompts are preserved."
     (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
                    :model/Metabot {metabot-id :id} {:name "Test Metabot"
-                                                    :collection_id collection-id}]
+                                                    :collection_id collection-id}
+                   :model/Card {card-id :id} {:name "Test Model Card" :type :model}
+                   :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                         :prompt "existing prompt"
+                                                         :model :model
+                                                         :card_id card-id}]
       (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
                     metabot.suggested-prompts/generate-sample-prompts
                     (fn [& _]
@@ -315,18 +321,28 @@
         (let [response (mt/user-http-request :crowberto :put 200
                                              (format "metabot/metabot/%d" metabot-id)
                                              {:collection_id nil})]
-          (is (nil? (:collection_id response))))))
-    (testing "non-locked ex-info from generate-sample-prompts still propagates"
-      (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
-                     :model/Metabot {metabot-id :id} {:name "Test Metabot"
-                                                      :collection_id collection-id}]
-        (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
-                      metabot.suggested-prompts/generate-sample-prompts
-                      (fn [& _]
-                        (throw (ex-info "boom" {:status-code 500})))]
-          (mt/user-http-request :crowberto :put 500
-                                (format "metabot/metabot/%d" metabot-id)
-                                {:collection_id nil}))))))
+          (is (nil? (:collection_id response)))
+          (is (= #{prompt-id}
+                 (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))
+  (testing "non-locked ex-info from generate-sample-prompts still propagates, and the delete is
+            rolled back so existing prompts survive"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                   :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                    :collection_id collection-id}
+                   :model/Card {card-id :id} {:name "Test Model Card" :type :model}
+                   :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                         :prompt "existing prompt"
+                                                         :model :model
+                                                         :card_id card-id}]
+      (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                    metabot.suggested-prompts/generate-sample-prompts
+                    (fn [& _]
+                      (throw (ex-info "boom" {:status-code 500})))]
+        (mt/user-http-request :crowberto :put 500
+                              (format "metabot/metabot/%d" metabot-id)
+                              {:collection_id nil})
+        (is (= #{prompt-id}
+               (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))
 
 (deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -154,7 +154,6 @@
                     (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
                       (is (=? {:status "generated" :prompt_count pos-int?}
                               (mt/user-http-request :crowberto :post 200 url)))))))
-
               (let [new-prompt-ids (current-prompt-ids)]
                 (is (= (count all-prompt-ids) (count new-prompt-ids)))
                 (is (empty? (set/intersection all-prompt-ids new-prompt-ids)))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -70,7 +70,7 @@
             (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
               ;; Trigger prompt generation by calling the regenerate endpoint
               (is (=? {:status       "generated"
-                       :prompt-count (reduce + (map count (vals prompts)))}
+                       :prompt_count (reduce + (map count (vals prompts)))}
                       (mt/user-http-request :crowberto :post 200
                                             (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
             (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
@@ -145,7 +145,7 @@
                     (is (= remaining-prompt-ids (current-prompt-ids))))
                   (testing "admin users are allowed"
                     (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-                      (is (=? {:status "generated" :prompt-count pos-int?}
+                      (is (=? {:status "generated" :prompt_count pos-int?}
                               (mt/user-http-request :crowberto :post 200 url)))))))
 
               (let [new-prompt-ids (current-prompt-ids)]
@@ -332,7 +332,7 @@
         ;; No cards in the collection — the LLM should never be called.
         (with-redefs [metabot.example-question-generator/generate-example-questions
                       (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
-          (is (= {:status "empty" :reason "no-library-content"}
+          (is (= {:status "no-library-content"}
                  (mt/user-http-request :crowberto :post 200
                                        (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))))
     (testing "distinguish 'LLM produced nothing' from 'LLM errored'"
@@ -348,7 +348,7 @@
             (with-redefs [metabot.example-question-generator/generate-example-questions
                           (constantly {:table_questions  [{:questions []}]
                                        :metric_questions []})]
-              (is (= {:status "empty" :reason "ai-produced-no-prompts"}
+              (is (= {:status "ai-produced-no-prompts"}
                      (mt/user-http-request :crowberto :post 200
                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))))
               (is (empty? (t2/select :model/MetabotPrompt :metabot_id metabot-id))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -8,6 +8,7 @@
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.premium-features.core :as premium-features]
@@ -313,6 +314,33 @@
               (is (nil? (:collection_id response)))
               (is (= #{prompt-id}
                      (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
+
+(deftest metabot-put-swallows-managed-locked-toctou-from-generate-sample-prompts-test
+  (testing "if the managed-AI lock flips between the pre-check and `generate-sample-prompts`,
+            the PUT still succeeds (best-effort regeneration) — the 402 is swallowed."
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                   :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                    :collection_id collection-id}]
+      (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                    metabot.suggested-prompts/generate-sample-prompts
+                    (fn [& _]
+                      (throw (ex-info "locked" {:status-code 402
+                                                :error-code  "metabase_ai_managed_locked"})))]
+        (let [response (mt/user-http-request :crowberto :put 200
+                                             (format "metabot/metabot/%d" metabot-id)
+                                             {:collection_id nil})]
+          (is (nil? (:collection_id response))))))
+    (testing "non-locked ex-info from generate-sample-prompts still propagates"
+      (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                     :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                      :collection_id collection-id}]
+        (with-redefs [metabot.usage/managed-free-limit-reached? (constantly false)
+                      metabot.suggested-prompts/generate-sample-prompts
+                      (fn [& _]
+                        (throw (ex-info "boom" {:status-code 500})))]
+          (mt/user-http-request :crowberto :put 500
+                                (format "metabot/metabot/%d" metabot-id)
+                                {:collection_id nil}))))))
 
 (deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -69,8 +69,10 @@
           (testing "should generate prompt suggestions for metabot"
             (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
                         ;; Trigger prompt generation by calling the regenerate endpoint
-              (mt/user-http-request :crowberto :post 204
-                                    (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+              (is (=? {:status       "generated"
+                       :prompt-count (reduce + (map count (vals prompts)))}
+                      (mt/user-http-request :crowberto :post 200
+                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
             (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
                                            :metabot_id metabot-id
                                            {:join     [[:report_card :card] [:= :card.id :card_id]]
@@ -145,7 +147,8 @@
                     (is (= remaining-prompt-ids (current-prompt-ids))))
                   (testing "admin users are allowed"
                     (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-                      (mt/user-http-request :crowberto :post 204 url)))))
+                      (is (=? {:status "generated" :prompt-count pos-int?}
+                              (mt/user-http-request :crowberto :post 200 url)))))))
 
               (let [new-prompt-ids (current-prompt-ids)]
                 (is (= (count all-prompt-ids) (count new-prompt-ids)))
@@ -333,6 +336,39 @@
                      (:message response))))
             (is (= #{prompt-id}
                    (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))
+
+(deftest metabot-prompt-regenerate-empty-states-test
+  (testing "POST /prompt-suggestions/regenerate returns a structured outcome so the UI can"
+    (testing "distinguish a metabot whose library has no models or metrics from a real error"
+      (mt/with-temp [:model/Collection {collection-id :id} {:name "Empty Library"}
+                     :model/Metabot    {metabot-id :id}    {:name          "Empty metabot"
+                                                            :collection_id collection-id}]
+        ;; No cards in the collection — the LLM should never be called.
+        (with-redefs [metabot.example-question-generator/generate-example-questions
+                      (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
+          (is (= {:status "empty" :reason "no-library-content"}
+                 (mt/user-http-request :crowberto :post 200
+                                       (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))))
+    (testing "distinguish 'LLM produced nothing' from 'LLM errored'"
+      (mt/dataset test-data
+        (let [model-query {:type :query :database (mt/id) :query {:source-table (mt/id :products)}}]
+          (mt/with-temp [:model/Collection {collection-id :id} {:name "Library with a model"}
+                         :model/Card       {card-id :id}       {:name          "Products model"
+                                                                :type          :model
+                                                                :dataset_query model-query
+                                                                :collection_id collection-id}
+                         :model/Metabot    {metabot-id :id}    {:name          "Productive metabot"
+                                                                :collection_id collection-id}]
+            (with-redefs [metabot.example-question-generator/generate-example-questions
+                          (constantly {:table_questions  [{:questions []}]
+                                       :metric_questions []})]
+              (is (= {:status "empty" :reason "ai-produced-no-prompts"}
+                     (mt/user-http-request :crowberto :post 200
+                                           (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))))
+              (is (empty? (t2/select :model/MetabotPrompt :metabot_id metabot-id))
+                  "no prompts should be persisted when the LLM returned none")
+              ;; Reference the bound card so kondo doesn't flag it as unused.
+              (is (pos-int? card-id)))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -70,7 +70,7 @@
             (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
                         ;; Trigger prompt generation by calling the regenerate endpoint
               (is (=? {:status       "generated"
-                       :prompt-count (reduce + (map count (vals prompts)))}
+                       :prompt_count (reduce + (map count (vals prompts)))}
                       (mt/user-http-request :crowberto :post 200
                                             (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
             (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
@@ -147,7 +147,7 @@
                     (is (= remaining-prompt-ids (current-prompt-ids))))
                   (testing "admin users are allowed"
                     (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-                      (is (=? {:status "generated" :prompt-count pos-int?}
+                      (is (=? {:status "generated" :prompt_count pos-int?}
                               (mt/user-http-request :crowberto :post 200 url)))))))
 
               (let [new-prompt-ids (current-prompt-ids)]
@@ -346,7 +346,7 @@
         ;; No cards in the collection — the LLM should never be called.
         (with-redefs [metabot.example-question-generator/generate-example-questions
                       (fn [& _] (throw (ex-info "LLM should not be called for an empty library" {})))]
-          (is (= {:status "empty" :reason "no-library-content"}
+          (is (= {:status "no-library-content"}
                  (mt/user-http-request :crowberto :post 200
                                        (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))))
     (testing "distinguish 'LLM produced nothing' from 'LLM errored'"
@@ -362,7 +362,7 @@
             (with-redefs [metabot.example-question-generator/generate-example-questions
                           (constantly {:table_questions  [{:questions []}]
                                        :metric_questions []})]
-              (is (= {:status "empty" :reason "ai-produced-no-prompts"}
+              (is (= {:status "ai-produced-no-prompts"}
                      (mt/user-http-request :crowberto :post 200
                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))))
               (is (empty? (t2/select :model/MetabotPrompt :metabot_id metabot-id))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -67,20 +67,26 @@
                                                        :tables :table_questions})))]
                     ;; --------------------------- Generating sample prompts ---------------------------
           (testing "should generate prompt suggestions for metabot"
-            (with-redefs [metabot.example-question-generator/generate-example-questions prompt-generator]
-                        ;; Trigger prompt generation by calling the regenerate endpoint
-              (is (=? {:status       "generated"
-                       :prompt_count (reduce + (map count (vals prompts)))}
-                      (mt/user-http-request :crowberto :post 200
-                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
-            (let [added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
+            (let [response (with-redefs [metabot.example-question-generator/generate-example-questions
+                                         prompt-generator]
+                             ;; Trigger prompt generation by calling the regenerate endpoint
+                             (mt/user-http-request
+                              :crowberto :post 200
+                              (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+                  added-prompts (t2/select [:model/MetabotPrompt [:card.name :model_name] :prompt]
                                            :metabot_id metabot-id
                                            {:join     [[:report_card :card] [:= :card.id :card_id]]
                                             :order-by [:metabot_prompt.id]})]
+              (is (=? {:status       "generated"
+                       :prompt_count (reduce + (map count (vals prompts)))}
+                      response))
                         ;; Verify prompts were added to the database
               (is (= prompts
                      (-> (group-by :model_name added-prompts)
-                         (update-vals #(map :prompt %)))))))
+                         (update-vals #(map :prompt %)))))
+                        ;; And that :prompt_count in the response matches the actual DB row count, not
+                        ;; just the count the mock declared it would generate.
+              (is (= (:prompt_count response) (count added-prompts)))))
                     ;; --------------------------- Querying sample prompts ---------------------------
           (let [expected-prompts (into #{} (mapcat val) prompts)
                 all-prompts (mt/user-http-request :rasta :get 200

--- a/test/metabase/metabot/native_generation_integration_test.clj
+++ b/test/metabase/metabot/native_generation_integration_test.clj
@@ -47,8 +47,10 @@
               native-mock (make-native-prompt-generator prompts-by-name)]
           (testing "regenerate endpoint works with native path"
             (with-redefs [native-generator/generate-example-questions native-mock]
-              (mt/user-http-request :crowberto :post 204
-                                    (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+              (is (=? {:status "generated" :prompt_count 10}
+                      (mt/user-http-request :crowberto :post 200
+                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
+
             (let [prompts (t2/select [:model/MetabotPrompt :prompt :model [:card.name :model_name]]
                                      :metabot_id metabot-id
                                      {:join     [[:report_card :card] [:= :card.id :card_id]]
@@ -61,8 +63,9 @@
           (testing "native path prompts are replaced on re-regenerate"
             (let [old-ids (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)]
               (with-redefs [native-generator/generate-example-questions native-mock]
-                (mt/user-http-request :crowberto :post 204
-                                      (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+                (is (=? {:status "generated" :prompt_count 10}
+                        (mt/user-http-request :crowberto :post 200
+                                              (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
               (let [new-ids (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)]
                 (is (= 10 (count new-ids)))
                 (is (empty? (set/intersection old-ids new-ids)))))))))))

--- a/test/metabase/metabot/native_generation_integration_test.clj
+++ b/test/metabase/metabot/native_generation_integration_test.clj
@@ -50,7 +50,6 @@
               (is (=? {:status "generated" :prompt_count 10}
                       (mt/user-http-request :crowberto :post 200
                                             (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
-
             (let [prompts (t2/select [:model/MetabotPrompt :prompt :model [:card.name :model_name]]
                                      :metabot_id metabot-id
                                      {:join     [[:report_card :card] [:= :card.id :card_id]]

--- a/test/metabase/metabot/native_generation_integration_test.clj
+++ b/test/metabase/metabot/native_generation_integration_test.clj
@@ -49,8 +49,9 @@
 
           (testing "regenerate endpoint works with native path"
             (with-redefs [native-generator/generate-example-questions native-mock]
-              (mt/user-http-request :crowberto :post 204
-                                    (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+              (is (=? {:status "generated" :prompt_count 10}
+                      (mt/user-http-request :crowberto :post 200
+                                            (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
 
             (let [prompts (t2/select [:model/MetabotPrompt :prompt :model [:card.name :model_name]]
                                      :metabot_id metabot-id
@@ -65,8 +66,9 @@
           (testing "native path prompts are replaced on re-regenerate"
             (let [old-ids (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)]
               (with-redefs [native-generator/generate-example-questions native-mock]
-                (mt/user-http-request :crowberto :post 204
-                                      (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))
+                (is (=? {:status "generated" :prompt_count 10}
+                        (mt/user-http-request :crowberto :post 200
+                                              (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id)))))
               (let [new-ids (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)]
                 (is (= 10 (count new-ids)))
                 (is (empty? (set/intersection old-ids new-ids)))))))))))


### PR DESCRIPTION
## Summary

Companion to #74356 / #74359 (which surfaced the upstream body on LLM errors). When the admin clicks _Regenerate suggested prompts_ today, three very different outcomes look the same to the UI: the LLM crashed, the metabot's library is empty (no models or metrics to summarise), or the LLM ran fine but returned no questions. All three previously returned `204 No Content` and the admin saw a silent success.

This PR makes `metabase.metabot.suggested-prompts/generate-sample-prompts` return a structured outcome and lifts it through to the API response so the UI can tell them apart:

```clj
{:status :generated :prompt_count N}     ; happy path, N is pos-int
{:status :no-library-content}            ; nothing to summarise
{:status :ai-produced-no-prompts}        ; LLM returned 0 questions
```

A 4th outcome — managed AI usage cap — surfaces as a **402 error**, not a union variant. The endpoint guards with `check-metabase-managed-free-limit!` before doing any work, so a locked instance always sees the 402; the union remains a closed three-variant discriminated map.

The `:no-library-content` branch skips the LLM call entirely — no token spend, no AI-service round-trip for inputs that can't possibly yield anything. Other errors (HTTP 5xx, network, etc.) continue to surface as thrown exceptions and turn into 4xx/5xx responses, so `:empty` and `:error` are cleanly separated for the FE.

## Contract change

`POST /api/metabot/metabot/:id/prompt-suggestions/regenerate` now returns `200 OK` with the structured body in place of `204 No Content`. The response schema is declared as a `[:multi {:dispatch :status} ...]` with `{:closed true}` on each variant so the OpenAPI docs and the upcoming TypeScript signature generation pick it up automatically. The committed specs (`resources/openapi/openapi.json`, `docs/api.json`) are regenerated to match the endpoint's current docstring.

Behaviours unchanged:
- The free-trial token-cap gate (`check-metabase-managed-free-limit!`) still throws `402` before the work starts.
- `PUT /metabot/:id` still calls `generate-sample-prompts` on config change; it pre-guards with `managed-free-limit-reached?` and runs delete + regenerate inside a `t2/with-transaction`. A swallowed TOCTOU 402 — or any other regeneration failure — rolls back the delete, so existing prompts survive instead of being wiped. The 402 is still swallowed (PUT stays `200`) so a Metabot settings update doesn't fail just because prompt regeneration was raced; any other error propagates as before, but with the delete rolled back.
- The startup `SuggestedPromptsGenerator` Quartz job pre-guards on `managed-free-limit-reached?` for the same reason — a locked instance logs a clean info-level skip instead of erroring out at startup.

## Frontend

The admin panel's regenerate button now branches on `:status` to render an empty-state hint for `:no-library-content` and `:ai-produced-no-prompts`, instead of the previous silent success toast.

## Backports

Targets master (v62). Has the `backport` label — backports cut from here.

## Test plan

- [x] `metabot-prompt-regenerate-empty-states-test` (new) — covers `:no-library-content` (LLM is not even called) and `:ai-produced-no-prompts` (LLM returns 0 questions, no prompts persisted).
- [x] `sample-prompts-e2e-test` updated — asserts the new `{:status :generated :prompt_count N}` body on the happy path.
- [x] `metabot-put-swallows-managed-locked-toctou-from-generate-sample-prompts-test` — seeds an existing `MetabotPrompt` and asserts it survives both the swallowed-402 path (PUT `200`) and a propagated non-locked error (PUT `500`), covering the transaction rollback.
- [x] `metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test` unchanged behaviour: still `402`.
- [x] `metabot-put-skips-prompt-regeneration-when-managed-provider-is-locked-test` unchanged behaviour.
- [x] `metabot-prompt-regeneration-on-config-change-test` unchanged behaviour.
- [ ] Manual: click _Regenerate suggested prompts_ against a metabot with an empty collection; confirm the response carries `:no-library-content` and the FE renders the empty-state hint.
