### PR TITLE
Fix double vertical scrollbar in popovers with AccordionList

### DIFF
--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
@@ -1,8 +1,11 @@
+:global(.mb-mantine-Popover-dropdown):has(> .accordionListRoot) {
+  display: flex;
+  flex-direction: column;
+}
+
 .accordionListRoot {
   outline: none;
   overflow: auto;
-  max-width: inherit;
-  max-height: inherit;
 }
 
 .hasSearch {

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
@@ -12,10 +12,17 @@
    *  onto a child element instead.
    */
   overflow: visible;
+  /* Reset box-sizing to content-box so when .dropdownContent inherits max-height, it
+    won't include border. Othherwise, it will make .dropdownContent overflow .dropdown
+    by 2px pixel.
+  */
+  box-sizing: content-box;
 }
 
 .dropdownContent {
   overflow: auto;
+  display: flex;
+  flex-direction: column;
   max-width: inherit;
   max-height: inherit;
 }

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
@@ -13,8 +13,8 @@
    */
   overflow: visible;
   /* Reset box-sizing to content-box so when .dropdownContent inherits max-height, it
-    won't include border. Othherwise, it will make .dropdownContent overflow .dropdown
-    by 2px pixel.
+    won't include border. Otherwise, it will make .dropdownContent overflow .dropdown
+    by 2px.
   */
   box-sizing: content-box;
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74394
Closes [GDGT-2430](https://linear.app/metabase/issue/GDGT-2430), https://github.com/metabase/metabase/issues/74394
can be related to https://github.com/metabase/metabase/issues/48016

### Description

Previously, when an `AccordionList` was rendered inside a Mantine popover, the accordion inherited `max-height` directly from the popover. The popover has a 1px border, and because `box-sizing: border-box` (the default) includes the border in `max-height`, the accordion's inherited `max-height` referred to the popover's full box rather than its content area. The accordion sat inside that content area (2px shorter), so it overflowed by 2px and produced a **second scrollbar** alongside its own — the double-scrollbar bug from the issue.

Switched the approach to make the popover a flex column container with the accordion as a flex item. The accordion now fills the popover's content box exactly, regardless of border width, with no `max-height: inherit` math required.

To keep the surface change small, this is **scoped to popovers that actually contain the accordion** rather than applied to all popovers. `AccordionList.module.css` uses `:global(.mb-mantine-Popover-dropdown):has(> .accordionListRoot)` to flip just those popovers to flex-column.

`ClausePopover` is a special case: it wraps content in a `Box` (`.dropdownContent`), so the accordion isn't a direct child of the popover and the `:has` rule doesn't reach it. Since `ClausePopover` is used in only a handful of clause-editing steps, its `.dropdownContent` is updated directly to `display: flex; flex-direction: column` and tested manually across those callers (Filter, Summarize, Sort, group-by, etc.) — no double scrollbars, no layout regressions in non-accordion popovers.

### How to verify

1. Open https://stats.metabase.com/model/6141-dashboard from the bug report.
2. Click "Filter". With a viewport short enough that the column list overflows, there should be **a single scrollbar** on the list — not two side-by-side.
3. Scroll inside the list: the search bar at the top should stay sticky.
