### PR TITLE
Prepare the MCP for ChatGPT app

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -178,6 +178,7 @@
      clojure.core.async/take!
      clojure.core.async/to-chan!
      clojure.core.async/to-chan!!
+     metabase.api.macros.defendpoint.tools-manifest/assert-optional-fields-nullable!
      metabase.channel.core/send!
      metabase.warehouses.models.database/assert-not-h2!
      metabase.driver.sql-jdbc.execute/execute-prepared-statement!

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1933,6 +1933,7 @@
   {:team "UX West"
    :api  #{metabase.server.core
            metabase.server.init
+           metabase.server.middleware.security
            metabase.server.middleware.session
            metabase.server.settings
            metabase.server.streaming-response} ; TODO -- too many API namespaces

--- a/resources/metabase/agent_api/construct_query.md
+++ b/resources/metabase/agent_api/construct_query.md
@@ -8,15 +8,15 @@ Construct a Metabase MBQL query from a structured program. The body is the progr
 
 The `prompt` field is optional for Agent API callers. MCP clients should include it whenever they have the user's message; pass the original message as-is and do not summarize, rewrite, or infer a different prompt.
 
-In MCP, this returns `{"query_handle": "<uuid>"}` — pass the handle to `execute_query` or `visualize_query` as `query_handle`. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
+In MCP, this returns `{"query_handle": "<uuid>", "widgetSessionId": "<id>"}` — pass `query_handle` to `execute_query` or `visualize_query`. In the case of ChatGPT (which rotates MCP sessions between tool calls), also pass `widgetSessionId` to the follow-up tool so the handle resolves against the original session; other MCP clients can omit it. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
 
 IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). Do not invent IDs. The backend repairs minor mistakes (aliases, casing, over-wrapping) before validation, but the canonical names below always work.
 
 ## Workflow
 
 1. Use `search` and the entity-detail tools (`get_table`, `get_metric`) to find the table/metric/model and its fields.
-2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. In MCP, you get back `{"query_handle": "<uuid>"}`.
-3. Pass that handle to `execute_query` or `visualize_query` as `query_handle`.
+2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. In MCP, you get back `{"query_handle": "<uuid>", "widgetSessionId": "<id>"}`.
+3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call. In ChatGPT, also pass `widgetSessionId`; other clients can omit it.
 
 Never embed IDs you did not read from a metadata endpoint — invented IDs will fail at execution.
 

--- a/resources/metabase/agent_api/construct_query.md
+++ b/resources/metabase/agent_api/construct_query.md
@@ -8,7 +8,7 @@ Construct a Metabase MBQL query from a structured program. The body is the progr
 
 The `prompt` field is optional for Agent API callers. MCP clients should include it whenever they have the user's message; pass the original message as-is and do not summarize, rewrite, or infer a different prompt.
 
-In MCP, this returns `{"query_handle": "<uuid>"}` — pass it as `query_handle` to the follow-up `execute_query` or `visualize_query` call. Handles are scoped to the calling user; the server prefers the calling MCP session before falling back across the user's other sessions, so harnesses that rotate MCP session ids between tool calls still resolve. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
+In MCP, this returns `{"query_handle": "<uuid>"}` — pass `query_handle` to `execute_query` or `visualize_query`. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
 
 IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). Do not invent IDs. The backend repairs minor mistakes (aliases, casing, over-wrapping) before validation, but the canonical names below always work.
 

--- a/resources/metabase/agent_api/construct_query.md
+++ b/resources/metabase/agent_api/construct_query.md
@@ -8,15 +8,15 @@ Construct a Metabase MBQL query from a structured program. The body is the progr
 
 The `prompt` field is optional for Agent API callers. MCP clients should include it whenever they have the user's message; pass the original message as-is and do not summarize, rewrite, or infer a different prompt.
 
-In MCP, this returns `{"query_handle": "<uuid>", "widgetSessionId": "<id>"}` — pass `query_handle` to `execute_query` or `visualize_query`. In the case of ChatGPT (which rotates MCP sessions between tool calls), also pass `widgetSessionId` to the follow-up tool so the handle resolves against the original session; other MCP clients can omit it. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
+In MCP, this returns `{"query_handle": "<uuid>"}` — pass it as `query_handle` to the follow-up `execute_query` or `visualize_query` call. Handles are scoped to the calling user; the server prefers the calling MCP session before falling back across the user's other sessions, so harnesses that rotate MCP session ids between tool calls still resolve. The HTTP Agent API response contains `{"query": "<base64>"}` and echoes `prompt` only when supplied.
 
 IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). Do not invent IDs. The backend repairs minor mistakes (aliases, casing, over-wrapping) before validation, but the canonical names below always work.
 
 ## Workflow
 
 1. Use `search` and the entity-detail tools (`get_table`, `get_metric`) to find the table/metric/model and its fields.
-2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. In MCP, you get back `{"query_handle": "<uuid>", "widgetSessionId": "<id>"}`.
-3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call. In ChatGPT, also pass `widgetSessionId`; other clients can omit it.
+2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. In MCP, you get back `{"query_handle": "<uuid>"}`.
+3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call.
 
 Never embed IDs you did not read from a metadata endpoint — invented IDs will fail at execution.
 

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -537,31 +537,6 @@
    "- A `metric` source already provides its own aggregation and time dimension. Add only the additional breakouts/filters you need.\n"
    "- When the user asks for an exact year (e.g. 2024), use `[\"=\", [\"field\", year_field], 2024]` or a `between` with explicit dates — not relative filters like `time-interval`.\n"))
 
-(def ^:private construct-query-tool-input-malli
-  "Malli schema for the construct_query tool's MCP input.
-  Deliberately flatter than `::construct-query-request` — the operator/ref grammar
-  is conveyed through the tool description and the construct-query.md MCP resource,
-  not the schema. Server-side wire validation still goes through `::construct-query-request`."
-  [:map
-   [:source
-    {:tool/description "Database entity to query."}
-    [:map
-     [:type {:tool/description "Entity kind."}
-      [:enum "table" "card" "dataset" "metric"]]
-     [:id ms/PositiveInt]]]
-   [:operations
-    {:tool/description (str "Array of operator tuples like [\"filter\", clause] or "
-                            "[\"aggregate\", agg-clause]. See metabase://docs/construct-query.md "
-                            "for the full grammar.")}
-    [:sequential
-     [:sequential
-      {:tool/description (str "First element is the operator string; remaining "
-                              "elements are operator-specific arguments (scalars, "
-                              "references, or nested arrays).")}
-      :any]]]
-   [:prompt {:optional true}
-    [:maybe ConstructQueryPrompt]]])
-
 (defn- evaluate-program-to-live-query
   "Resolve a program's source entity, evaluate the program via agent-lib, and return
   the live lib query (with lib metadata attached)."
@@ -591,7 +566,6 @@
   {:scope metabot/agent-query-construct
    :tool  {:name "construct_query"
            :description construct-query-tool-description
-           :input-schema construct-query-tool-input-malli
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params
@@ -790,13 +764,6 @@
                              "instead. "
                              "Pass `query_handle` (preferred) from construct_query rather than constructing the "
                              "base64 query yourself.")
-           :input-schema [:map
-                          [:query {:optional true
-                                   :tool/description "Base64-encoded MBQL query. Use `query_handle` instead when available."}
-                           [:maybe ms/NonBlankString]]
-                          [:query_handle {:optional true
-                                          :tool/description "Handle returned by construct_query — preferred over raw `query`."}
-                           [:maybe ms/UUIDString]]]
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -397,7 +397,7 @@
   capturing the user's original intent when a caller has one."
   (mut/merge agent-lib/program-schema
              [:map
-              [:prompt {:optional true} ConstructQueryPrompt]]))
+              [:prompt {:optional true} [:maybe ConstructQueryPrompt]]]))
 
 (mr/def ::construct-query-response
   "Response containing a base64-encoded MBQL query and, when supplied, the original prompt for use with /v1/execute."

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -567,6 +567,19 @@
    [:prompt {:optional true}
     [:maybe ConstructQueryPrompt]]])
 
+(def ^:private construct-query-tool-output-malli
+  "LLM-facing Malli schema for the construct_query *tool* output. Differs from
+  `::construct-query-response` because `make-store-construct-query-result`
+  body-transforms the endpoint's `{:query, :prompt?}` response into
+  `{:query_handle, :widgetSessionId?}` before the MCP client sees it."
+  [:map
+   [:query_handle
+    {:tool/description "Opaque UUID handle for the stored query. Pass as `query_handle` to `execute_query` or `visualize_query`."}
+    ms/NonBlankString]
+   [:widgetSessionId {:optional true
+                      :tool/description "Session id under which the handle is stored. In the case of ChatGPT, pass it to the follow-up tool as `widgetSessionId`; other clients can ignore it."}
+    [:maybe ms/NonBlankString]]])
+
 (defn- evaluate-program-to-live-query
   "Resolve a program's source entity, evaluate the program via agent-lib, and return
   the live lib query (with lib metadata attached)."
@@ -597,6 +610,7 @@
    :tool  {:name "construct_query"
            :description construct-query-tool-description
            :input-schema construct-query-tool-input-malli
+           :output-schema construct-query-tool-output-malli
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -537,6 +537,36 @@
    "- A `metric` source already provides its own aggregation and time dimension. Add only the additional breakouts/filters you need.\n"
    "- When the user asks for an exact year (e.g. 2024), use `[\"=\", [\"field\", year_field], 2024]` or a `between` with explicit dates — not relative filters like `time-interval`.\n"))
 
+(def ^:private construct-query-tool-input-malli
+  "LLM-facing Malli schema for the construct_query tool input. Deliberately
+  flatter than `::construct-query-request` — the operator/ref grammar is
+  conveyed through the tool description and the construct-query.md MCP
+  resource, not the schema. Server-side wire validation still goes through
+  `::construct-query-request`.
+
+  Driving the tool schema from Malli rather than hand-written JSON avoids
+  duplication and ensures the standard tools-manifest pipeline (ref inlining,
+  `:tool/description` lifting, strict transform) is applied uniformly."
+  [:map
+   [:source
+    {:tool/description "Database entity to query."}
+    [:map
+     [:type {:tool/description "Entity kind."}
+      [:enum "table" "card" "dataset" "metric"]]
+     [:id ms/PositiveInt]]]
+   [:operations
+    {:tool/description (str "Array of operator tuples like [\"filter\", clause] or "
+                            "[\"aggregate\", agg-clause]. See metabase://docs/construct-query.md "
+                            "for the full grammar.")}
+    [:sequential
+     [:sequential
+      {:tool/description (str "First element is the operator string; remaining "
+                              "elements are operator-specific arguments (scalars, "
+                              "references, or nested arrays).")}
+      :any]]]
+   [:prompt {:optional true}
+    [:maybe ConstructQueryPrompt]]])
+
 (defn- evaluate-program-to-live-query
   "Resolve a program's source entity, evaluate the program via agent-lib, and return
   the live lib query (with lib metadata attached)."
@@ -566,6 +596,7 @@
   {:scope metabot/agent-query-construct
    :tool  {:name "construct_query"
            :description construct-query-tool-description
+           :input-schema construct-query-tool-input-malli
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -538,15 +538,10 @@
    "- When the user asks for an exact year (e.g. 2024), use `[\"=\", [\"field\", year_field], 2024]` or a `between` with explicit dates — not relative filters like `time-interval`.\n"))
 
 (def ^:private construct-query-tool-input-malli
-  "LLM-facing Malli schema for the construct_query tool input. Deliberately
-  flatter than `::construct-query-request` — the operator/ref grammar is
-  conveyed through the tool description and the construct-query.md MCP
-  resource, not the schema. Server-side wire validation still goes through
-  `::construct-query-request`.
-
-  Driving the tool schema from Malli rather than hand-written JSON avoids
-  duplication and ensures the standard tools-manifest pipeline (ref inlining,
-  `:tool/description` lifting, strict transform) is applied uniformly."
+  "Malli schema for the construct_query tool's MCP input.
+  Deliberately flatter than `::construct-query-request` — the operator/ref grammar
+  is conveyed through the tool description and the construct-query.md MCP resource,
+  not the schema. Server-side wire validation still goes through `::construct-query-request`."
   [:map
    [:source
     {:tool/description "Database entity to query."}
@@ -566,18 +561,6 @@
       :any]]]
    [:prompt {:optional true}
     [:maybe ConstructQueryPrompt]]])
-
-(def construct-query-tool-output-malli
-  "LLM-facing Malli schema for the construct_query *tool* output. Differs from
-  `::construct-query-response` because `make-store-construct-query-result`
-  body-transforms the endpoint's `{:query, :prompt?}` response into
-  `{:query_handle}` before the MCP client sees it. Exposed (not private) so the
-  MCP body transformer can validate against the same schema at runtime — keeping
-  the published outputSchema and the actual emitted shape from drifting apart."
-  [:map
-   [:query_handle
-    {:tool/description "Opaque UUID handle for the stored query. Pass as `query_handle` to `execute_query` or `visualize_query`."}
-    ms/UUIDString]])
 
 (defn- evaluate-program-to-live-query
   "Resolve a program's source entity, evaluate the program via agent-lib, and return
@@ -609,7 +592,6 @@
    :tool  {:name "construct_query"
            :description construct-query-tool-description
            :input-schema construct-query-tool-input-malli
-           :output-schema construct-query-tool-output-malli
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -419,10 +419,8 @@
   (str
    "Construct a Metabase MBQL query from a structured program. The body structure is:\n"
    "`{\"source\": {...}, \"operations\": [...]}`\n"
-   "For MCP calls, include `\"prompt\": \"<user's exact original message>\"` whenever you have the user's "
-   "message; do not summarize or modify it.\n"
-   "Returns `{\"query_handle\": \"<uuid>\"}` — pass it as `query_handle` to the follow-up `execute_query` "
-   "or `visualize_query` call.\n"
+   "For MCP calls, include `\"prompt\": \"<user's exact original message>\"` whenever you have the user's message; do not summarize or modify it.\n"
+   "Returns `{\"query_handle\": \"<uuid>\"}` — pass `query_handle` to `execute_query` or `visualize_query`.\n"
    "For the full reference, read the `metabase://docs/construct-query.md` MCP resource.\n"
    "\n"
    "IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). "
@@ -431,8 +429,7 @@
    "\n"
    "## Workflow\n"
    "1. Use `search_entities` / entity-detail tools to find the table/metric/model and its fields.\n"
-   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. "
-   "You get back `{\"query_handle\": \"<uuid>\"}`.\n"
+   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. You get back `{\"query_handle\": \"<uuid>\"}`.\n"
    "3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call.\n"
    "Never embed IDs you did not read from a metadata endpoint — invented IDs will fail at execution.\n"
    "\n"
@@ -808,7 +805,9 @@
                              "row count, and execution time. Use this when the user explicitly asks for raw data, "
                              "rows, columns, counts, metadata, or programmatic query results. If the user asks to "
                              "show, display, visualize, plot, chart, or present the result, use visualize_query "
-                             "instead. Pass `query_handle` from the construct_query response.")
+                             "instead. "
+                             "Pass `query_handle` (preferred) from construct_query rather than constructing the "
+                             "base64 query yourself.")
            :input-schema [:map
                           [:query {:optional true
                                    :tool/description "Base64-encoded MBQL query. Use `query_handle` instead when available."}

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -419,8 +419,10 @@
   (str
    "Construct a Metabase MBQL query from a structured program. The body structure is:\n"
    "`{\"source\": {...}, \"operations\": [...]}`\n"
-   "For MCP calls, include `\"prompt\": \"<user's exact original message>\"` whenever you have the user's message; do not summarize or modify it.\n"
-   "Returns `{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}` — pass `query_handle` to `execute_query` or `visualize_query`. In the case of ChatGPT (which rotates MCP sessions between tool calls), also pass `widgetSessionId` to the follow-up tool so the handle resolves against the original session; other MCP clients can ignore it.\n"
+   "For MCP calls, include `\"prompt\": \"<user's exact original message>\"` whenever you have the user's "
+   "message; do not summarize or modify it.\n"
+   "Returns `{\"query_handle\": \"<uuid>\"}` — pass it as `query_handle` to the follow-up `execute_query` "
+   "or `visualize_query` call.\n"
    "For the full reference, read the `metabase://docs/construct-query.md` MCP resource.\n"
    "\n"
    "IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). "
@@ -429,8 +431,9 @@
    "\n"
    "## Workflow\n"
    "1. Use `search_entities` / entity-detail tools to find the table/metric/model and its fields.\n"
-   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. You get back `{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}`.\n"
-   "3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call. In ChatGPT, also pass `widgetSessionId`; other clients can omit it.\n"
+   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. "
+   "You get back `{\"query_handle\": \"<uuid>\"}`.\n"
+   "3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call.\n"
    "Never embed IDs you did not read from a metadata endpoint — invented IDs will fail at execution.\n"
    "\n"
    "## Source\n"
@@ -567,18 +570,17 @@
    [:prompt {:optional true}
     [:maybe ConstructQueryPrompt]]])
 
-(def ^:private construct-query-tool-output-malli
+(def construct-query-tool-output-malli
   "LLM-facing Malli schema for the construct_query *tool* output. Differs from
   `::construct-query-response` because `make-store-construct-query-result`
   body-transforms the endpoint's `{:query, :prompt?}` response into
-  `{:query_handle, :widgetSessionId?}` before the MCP client sees it."
+  `{:query_handle}` before the MCP client sees it. Exposed (not private) so the
+  MCP body transformer can validate against the same schema at runtime — keeping
+  the published outputSchema and the actual emitted shape from drifting apart."
   [:map
    [:query_handle
     {:tool/description "Opaque UUID handle for the stored query. Pass as `query_handle` to `execute_query` or `visualize_query`."}
-    ms/NonBlankString]
-   [:widgetSessionId {:optional true
-                      :tool/description "Session id under which the handle is stored. In the case of ChatGPT, pass it to the follow-up tool as `widgetSessionId`; other clients can ignore it."}
-    [:maybe ms/NonBlankString]]])
+    ms/UUIDString]])
 
 (defn- evaluate-program-to-live-query
   "Resolve a program's source entity, evaluate the program via agent-lib, and return
@@ -806,21 +808,14 @@
                              "row count, and execution time. Use this when the user explicitly asks for raw data, "
                              "rows, columns, counts, metadata, or programmatic query results. If the user asks to "
                              "show, display, visualize, plot, chart, or present the result, use visualize_query "
-                             "instead. "
-                             "Pass `query_handle` (preferred) from construct_query rather than constructing the "
-                             "base64 query yourself. In the case of ChatGPT, also pass `widgetSessionId` from "
-                             "the construct_query response so the handle resolves against the original session; "
-                             "other MCP clients can ignore it.")
+                             "instead. Pass `query_handle` from the construct_query response.")
            :input-schema [:map
                           [:query {:optional true
                                    :tool/description "Base64-encoded MBQL query. Use `query_handle` instead when available."}
                            [:maybe ms/NonBlankString]]
                           [:query_handle {:optional true
                                           :tool/description "Handle returned by construct_query — preferred over raw `query`."}
-                           [:maybe ms/NonBlankString]]
-                          [:widgetSessionId {:optional true
-                                             :tool/description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}
-                           [:maybe ms/NonBlankString]]]
+                           [:maybe ms/UUIDString]]]
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -420,7 +420,7 @@
    "Construct a Metabase MBQL query from a structured program. The body structure is:\n"
    "`{\"source\": {...}, \"operations\": [...]}`\n"
    "For MCP calls, include `\"prompt\": \"<user's exact original message>\"` whenever you have the user's message; do not summarize or modify it.\n"
-   "Returns `{\"query_handle\": \"<uuid>\"}` — pass it as `query_handle` to `execute_query` or `visualize_query`.\n"
+   "Returns `{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}` — pass `query_handle` to `execute_query` or `visualize_query`. In the case of ChatGPT (which rotates MCP sessions between tool calls), also pass `widgetSessionId` to the follow-up tool so the handle resolves against the original session; other MCP clients can ignore it.\n"
    "For the full reference, read the `metabase://docs/construct-query.md` MCP resource.\n"
    "\n"
    "IMPORTANT: field IDs must come from entity-detail endpoints (`/v1/table/{id}`, `/v1/metric/{id}`). "
@@ -429,8 +429,8 @@
    "\n"
    "## Workflow\n"
    "1. Use `search_entities` / entity-detail tools to find the table/metric/model and its fields.\n"
-   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. You get back `{\"query_handle\": \"<uuid>\"}`.\n"
-   "3. Pass that handle to `execute_query` or `visualize_query` as `query_handle`.\n"
+   "2. Call `construct_query` with the program. Include the user's original `prompt` whenever available. You get back `{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}`.\n"
+   "3. Pass `query_handle` to the follow-up `execute_query` or `visualize_query` call. In ChatGPT, also pass `widgetSessionId`; other clients can omit it.\n"
    "Never embed IDs you did not read from a metadata endpoint — invented IDs will fail at execution.\n"
    "\n"
    "## Source\n"
@@ -792,7 +792,21 @@
                              "row count, and execution time. Use this when the user explicitly asks for raw data, "
                              "rows, columns, counts, metadata, or programmatic query results. If the user asks to "
                              "show, display, visualize, plot, chart, or present the result, use visualize_query "
-                             "instead.")
+                             "instead. "
+                             "Pass `query_handle` (preferred) from construct_query rather than constructing the "
+                             "base64 query yourself. In the case of ChatGPT, also pass `widgetSessionId` from "
+                             "the construct_query response so the handle resolves against the original session; "
+                             "other MCP clients can ignore it.")
+           :input-schema [:map
+                          [:query {:optional true
+                                   :tool/description "Base64-encoded MBQL query. Use `query_handle` instead when available."}
+                           [:maybe ms/NonBlankString]]
+                          [:query_handle {:optional true
+                                          :tool/description "Handle returned by construct_query — preferred over raw `query`."}
+                           [:maybe ms/NonBlankString]]
+                          [:widgetSessionId {:optional true
+                                             :tool/description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}
+                           [:maybe ms/NonBlankString]]]
            :annotations {:read-only? true :idempotent? true}}}
   [_route-params
    _query-params

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -174,6 +174,16 @@
                   :idempotentHint  true}
     {}))
 
+(def ^:private required-hint-defaults
+  "Always-present hints on every tool's MCP annotations. Used as fallbacks when
+  neither HTTP-method defaults nor explicit metadata set them. Some clients
+  (e.g. ChatGPT Apps SDK) reject tools that omit these. `openWorldHint: false`
+  reflects that Metabase tools operate on the user's own instance — they don't
+  reach external entities."
+  {:readOnlyHint    false
+   :destructiveHint false
+   :openWorldHint   false})
+
 (defn infer-annotations
   "Compute MCP ToolAnnotations from HTTP method defaults merged with explicit `:annotations`.
    Returns `{:annotations <merged> :redundant <pairs> :contradictory? <bool>}`. Callers should
@@ -199,9 +209,11 @@
                                       (when-let [mcp-key (annotation-key-mapping k)]
                                         (when (= v (get method-defaults mcp-key))
                                           [k v]))))
-                              explicit-annotations)]
-    (cond-> {:annotations (cond-> merged
-                            read-only? (dissoc :destructiveHint))
+                              explicit-annotations)
+        annotations     (merge required-hint-defaults
+                               (cond-> merged
+                                 read-only? (dissoc :destructiveHint)))]
+    (cond-> {:annotations annotations
              :redundant   redundant}
       (and read-only? (true? (:destructiveHint merged)))
       (assoc :contradictory? true))))

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -160,31 +160,23 @@
    :open-world?  :openWorldHint})
 
 (defn- method-default-annotations
-  "Default MCP ToolAnnotations for an HTTP method.
-   Returns the trio `readOnlyHint` / `destructiveHint` / `openWorldHint` for every method
-   so the published manifest always carries them — some MCP clients (e.g. the ChatGPT
-   Apps SDK) reject tools that omit those keys.
-   POST defaults to non-destructive; opt in with `:destructive? true` on the tool metadata."
+  "Default MCP ToolAnnotations for an HTTP method."
   [method]
-  (case method
-    (:get :head) {:readOnlyHint    true
-                  :destructiveHint false
-                  :idempotentHint  true
-                  :openWorldHint   false}
-    :post        {:readOnlyHint    false
-                  :destructiveHint false
-                  :openWorldHint   false}
-    :put         {:readOnlyHint    false
-                  :destructiveHint false
-                  :idempotentHint  true
-                  :openWorldHint   false}
-    :delete      {:readOnlyHint    false
-                  :destructiveHint true
-                  :idempotentHint  true
-                  :openWorldHint   false}
-    {:readOnlyHint    false
-     :destructiveHint false
-     :openWorldHint   false}))
+  ;; `readOnlyHint`, `destructiveHint`, and `openWorldHint` are always present —
+  ;; some MCP clients (e.g. the ChatGPT Apps SDK) reject tools that omit them.
+  ;; `openWorldHint` signals whether a tool reaches arbitrary external entities
+  ;; (e.g. a web-search tool) — false here because every Metabase tool stays
+  ;; within the user's own instance.
+  (merge {:readOnlyHint    false
+          :destructiveHint false
+          :openWorldHint   false}
+         (case method
+           (:get :head) {:readOnlyHint   true
+                         :idempotentHint true}
+           :put         {:idempotentHint true}
+           :delete      {:destructiveHint true
+                         :idempotentHint  true}
+           {})))
 
 (defn infer-annotations
   "Compute MCP ToolAnnotations from HTTP method defaults merged with explicit `:annotations`.
@@ -224,77 +216,28 @@
       (when (:properties jss)
         (select-keys jss [:properties :required])))))
 
-(defn- nullable-schema
-  "Return a JSON Schema that accepts `nil` in addition to `schema`.
-  OpenAI's strict tool schema validation expects every property to be listed in
-  `required`; nullable properties are how we preserve optional API inputs in the
-  exported MCP schema without changing the endpoint contract."
-  [schema]
-  (cond
-    (= "null" (:type schema))
-    schema
-
-    (string? (:type schema))
-    (update schema :type (fn [type] [type "null"]))
-
-    (vector? (:type schema))
-    (update schema :type (fn [types] (vec (distinct (conj types "null")))))
-
-    (contains? schema :oneOf)
-    (update schema :oneOf (fn [schemas] (vec (distinct (conj schemas {:type "null"})))))
-
-    (contains? schema :anyOf)
-    (update schema :anyOf (fn [schemas] (vec (distinct (conj schemas {:type "null"})))))
-
-    :else
-    {:anyOf [schema {:type "null"}]}))
-
 (defn strict-tool-input-schema
   "Make an MCP inputSchema compatible with stricter LLM clients.
 
   MCP allows normal JSON Schema optional object properties.
   OpenAI's strict tool schema validation is narrower: every object property must be
-  required, and optional values should be modeled as nullable instead."
+  listed in `:required`. The Malli source already models nullability via `[:maybe ...]`
+  (see [[assert-optional-fields-nullable!]]), so this only needs to widen
+  `:required` and close the object — property types are left alone."
   [schema]
   (letfn [(strict-schema [schema]
             (let [schema (cond-> schema
-                           (:properties schema)
-                           (update :properties update-vals strict-schema)
-
-                           (:items schema)
-                           (update :items strict-schema)
-
-                           (:oneOf schema)
-                           (update :oneOf #(mapv strict-schema %))
-
-                           (:anyOf schema)
-                           (update :anyOf #(mapv strict-schema %))
-
-                           (:allOf schema)
-                           (update :allOf #(mapv strict-schema %)))]
+                           (:properties schema) (update :properties update-vals strict-schema)
+                           (:items schema)      (update :items strict-schema)
+                           (:oneOf schema)      (update :oneOf #(mapv strict-schema %))
+                           (:anyOf schema)      (update :anyOf #(mapv strict-schema %))
+                           (:allOf schema)      (update :allOf #(mapv strict-schema %)))]
               (if (and (= "object" (:type schema)) (seq (:properties schema)))
-                (let [property-names      (vec (keys (:properties schema)))
-                      required-property?  (set (:required schema))
-                      nullable-properties (remove required-property? property-names)]
-                  (-> schema
-                      (assoc :required property-names
-                             :additionalProperties false)
-                      (update :properties
-                              (fn [properties]
-                                (reduce (fn [properties property-name]
-                                          (update properties property-name nullable-schema))
-                                        properties
-                                        nullable-properties)))))
+                (assoc schema
+                       :required (vec (keys (:properties schema)))
+                       :additionalProperties false)
                 schema)))]
     (strict-schema schema)))
-
-(defn- map-entries
-  "Return malli `:map` entry seqs for the schema, or nil if it isn't a map after deref.
-   Each entry has shape `[key props value-schema]`."
-  [schema]
-  (let [walked (mc/deref-all schema)]
-    (when (= :map (mc/type walked))
-      (mc/children walked))))
 
 (defn- nullable-malli?
   "True when `schema` accepts `nil` (e.g. `[:maybe X]`, `:any`, `:nil`)."
@@ -302,20 +245,25 @@
   (try (mr/validate schema nil) (catch Throwable _ false)))
 
 (defn- assert-optional-fields-nullable!
-  "Throw if any top-level optional field on `malli-schema` rejects an explicit null.
-   The strict-tool transform rewrites optional fields to nullable JSON Schema for OpenAI
-   clients, so a Malli-only-optional field would publish a schema that allows null and
-   then reject the same payload at validation time.
+  "Throw if any optional field reachable from `malli-schema` rejects an explicit null.
+   The strict-tool transform forces every property into `:required`, so an optional
+   field that isn't `[:maybe ...]` would publish a schema that allows null but be
+   rejected by Malli validation at the endpoint.
    The fix is at the schema definition: pair `:optional true` with `[:maybe ...]`."
   [malli-schema tool-name]
   (when malli-schema
-    (doseq [[k props value-schema] (map-entries (mr/resolve-schema malli-schema))
-            :when (and (true? (:optional props))
-                       (not (nullable-malli? value-schema)))]
-      (throw (ex-info (str "Tool " tool-name " input has optional non-nullable field "
-                           (pr-str k) ". Mark it `[:maybe ...]` so Malli accepts explicit "
-                           "nulls — strict JSON Schema rewrites optional fields to nullable.")
-                      {:tool tool-name :field k})))))
+    (mc/walk
+     (mr/resolve-schema malli-schema)
+     (fn [schema _path children _opts]
+       (when (= :map (mc/type schema))
+         (doseq [[k props value-schema] children
+                 :when (and (true? (:optional props))
+                            (not (nullable-malli? value-schema)))]
+           (throw (ex-info (str "Tool " tool-name " input has optional non-nullable field "
+                                (pr-str k) ". Mark it `[:maybe ...]` so the published JSON "
+                                "Schema is already nullable and Malli accepts explicit nulls.")
+                           {:tool tool-name :field k}))))
+       schema))))
 
 (defn- merge-input-schemas
   "Merge route, query, and body param schemas into a single inputSchema object.
@@ -349,16 +297,16 @@
   1. `:input-schema` on the tool metadata as a Malli schema.
   2. Implicit — derived from the endpoint's route/query/body Malli.
 
-  Both paths run through the strict transform.
-  When `:input-schema` is explicit, [[assert-optional-fields-nullable!]] runs first —
-  optional fields must be modeled as `[:maybe ...]` so the strict transform's
-  null-rewrite doesn't publish a schema that the runtime then rejects."
+  Either path is linted by [[assert-optional-fields-nullable!]]: every optional
+  field must be `[:maybe ...]` so the published JSON Schema is already nullable,
+  letting the strict transform leave property types alone."
   [tool-name form]
-  (let [explicit (get-in form [:metadata :tool :input-schema])]
-    (if explicit
-      (do (assert-optional-fields-nullable! explicit tool-name)
-          (-> explicit malli->json-schema strict-tool-input-schema))
-      (some-> (merge-input-schemas form) strict-tool-input-schema))))
+  (if-let [explicit (get-in form [:metadata :tool :input-schema])]
+    (do (assert-optional-fields-nullable! explicit tool-name)
+        (-> explicit malli->json-schema strict-tool-input-schema))
+    (do (doseq [k [:route :query :body]]
+          (assert-optional-fields-nullable! (get-in form [:params k :schema]) tool-name))
+        (some-> (merge-input-schemas form) strict-tool-input-schema))))
 
 (defn- response-schema->json-schema
   "Convert an endpoint's response schema to JSON Schema for the tools manifest."

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -243,9 +243,11 @@
 
 (defn assert-optional-fields-nullable!
   "Throw if any optional field reachable from `malli-schema` rejects an explicit null.
-   The strict-tool transform forces every property into `:required`, so an optional field that isn't
-   `[:maybe ...]` would publish a schema that allows null but be rejected by Malli validation at the endpoint.
-   The fix is at the schema definition: pair `:optional true` with `[:maybe ...]`."
+   The strict-tool transform forces every property into `:required` (it does not widen property types),
+   so the only way for a strict MCP client to express \"no value\" is by sending null. If the Malli source
+   marks a field `:optional true` without `[:maybe ...]`, the published JSON Schema is required-and-non-
+   nullable — the `:optional` marker has no observable effect and the contract drifts from what the
+   schema says. The fix is at the schema definition: pair `:optional true` with `[:maybe ...]`."
   [malli-schema tool-name]
   (when malli-schema
     (mc/walk
@@ -257,7 +259,8 @@
                             (not (nullable-malli? value-schema)))]
            (throw (ex-info (str "Tool " tool-name " input has optional non-nullable field "
                                 (pr-str k) ". Mark it `[:maybe ...]` so the published JSON "
-                                "Schema is already nullable and Malli accepts explicit nulls.")
+                                "Schema is nullable; otherwise `:optional` has no observable effect "
+                                "under the strict-tool transform.")
                            {:tool tool-name :field k}))))
        schema))))
 

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -7,7 +7,7 @@
   - `name`, `description` — tool identity
   - `endpoint` — HTTP method + path
   - `inputSchema` — merged route + query + body parameters
-  - `outputSchema` — from the response schema, or an explicit `:output-schema` on the tool metadata
+  - `outputSchema` — derived from the endpoint's response schema
   - `annotations` — MCP ToolAnnotations (readOnlyHint, destructiveHint, etc.)"
   (:require
    [clojure.string :as str]
@@ -160,38 +160,38 @@
    :open-world?  :openWorldHint})
 
 (defn- method-default-annotations
-  "Infer default MCP ToolAnnotations from HTTP method. POST defaults to non-destructive — opt
-   in with `:destructive? true` for endpoints that actually destroy data."
+  "Default MCP ToolAnnotations for an HTTP method.
+   Returns the trio `readOnlyHint` / `destructiveHint` / `openWorldHint` for every method
+   so the published manifest always carries them — some MCP clients (e.g. the ChatGPT
+   Apps SDK) reject tools that omit those keys.
+   POST defaults to non-destructive; opt in with `:destructive? true` on the tool metadata."
   [method]
   (case method
     (:get :head) {:readOnlyHint    true
-                  :idempotentHint  true}
-    :post        {:destructiveHint false}
-    :put         {:destructiveHint false
-                  :idempotentHint  true}
-    :delete      {:destructiveHint true
-                  :idempotentHint  true}
-    {}))
-
-(def ^:private required-hint-defaults
-  "Always-present hints on every tool's MCP annotations. Used as fallbacks when
-  neither HTTP-method defaults nor explicit metadata set them. Some clients
-  (e.g. ChatGPT Apps SDK) reject tools that omit these. `openWorldHint: false`
-  reflects that Metabase tools operate on the user's own instance — they don't
-  reach external entities."
-  {:readOnlyHint    false
-   :destructiveHint false
-   :openWorldHint   false})
+                  :destructiveHint false
+                  :idempotentHint  true
+                  :openWorldHint   false}
+    :post        {:readOnlyHint    false
+                  :destructiveHint false
+                  :openWorldHint   false}
+    :put         {:readOnlyHint    false
+                  :destructiveHint false
+                  :idempotentHint  true
+                  :openWorldHint   false}
+    :delete      {:readOnlyHint    false
+                  :destructiveHint true
+                  :idempotentHint  true
+                  :openWorldHint   false}
+    {:readOnlyHint    false
+     :destructiveHint false
+     :openWorldHint   false}))
 
 (defn infer-annotations
   "Compute MCP ToolAnnotations from HTTP method defaults merged with explicit `:annotations`.
-   Returns `{:annotations <merged> :redundant <pairs> :contradictory? <bool>}`. Callers should
-   reject `:redundant` entries (explicit declarations must add information beyond the
-   HTTP-method default) and `:contradictory?` (a tool can't be both read-only and destructive).
-
-   `destructiveHint` is dropped from `:annotations` when `readOnlyHint` is true since per the
-   MCP spec it's only meaningful for non-read-only tools — but if both were `true` before the
-   drop, the result is flagged `:contradictory?` rather than silently coalesced."
+   Returns `{:annotations <merged> :redundant <pairs> :contradictory? <bool>}`.
+   Callers should reject `:redundant` entries (explicit declarations must add information
+   beyond the HTTP-method default) and `:contradictory?` (a tool can't be both read-only and
+   destructive)."
   [method explicit-annotations]
   (let [method-defaults (method-default-annotations method)
         explicit        (into {}
@@ -209,9 +209,7 @@
                                         (when (= v (get method-defaults mcp-key))
                                           [k v]))))
                               explicit-annotations)
-        annotations     (merge required-hint-defaults
-                               (cond-> merged
-                                 read-only? (dissoc :destructiveHint)))]
+        annotations     merged]
     (cond-> {:annotations annotations
              :redundant   redundant}
       (and read-only? (true? (:destructiveHint merged)))
@@ -254,9 +252,9 @@
 (defn strict-tool-input-schema
   "Make an MCP inputSchema compatible with stricter LLM clients.
 
-  MCP allows normal JSON Schema optional object properties. OpenAI's strict tool
-  schema validation is narrower: every object property must be required, and
-  optional values should be modeled as nullable instead."
+  MCP allows normal JSON Schema optional object properties.
+  OpenAI's strict tool schema validation is narrower: every object property must be
+  required, and optional values should be modeled as nullable instead."
   [schema]
   (letfn [(strict-schema [schema]
             (let [schema (cond-> schema
@@ -299,18 +297,16 @@
       (mc/children walked))))
 
 (defn- nullable-malli?
-  "True when `schema` accepts `nil`. Mirrors Malli's runtime check: `[:maybe X]`,
-   `:any`, `:nil`, and a few other shapes pass."
+  "True when `schema` accepts `nil` (e.g. `[:maybe X]`, `:any`, `:nil`)."
   [schema]
   (try (mr/validate schema nil) (catch Throwable _ false)))
 
 (defn- assert-optional-fields-nullable!
-  "Throw if any top-level optional field on `malli-schema` rejects an explicit
-   null. The strict-tool transform rewrites optional fields to nullable JSON
-   Schema for OpenAI clients, so a Malli-only-optional field would publish a
-   schema that allows `null` and then reject the same payload at validation
-   time. The fix is at the schema definition: pair `:optional true` with
-   `[:maybe ...]`."
+  "Throw if any top-level optional field on `malli-schema` rejects an explicit null.
+   The strict-tool transform rewrites optional fields to nullable JSON Schema for OpenAI
+   clients, so a Malli-only-optional field would publish a schema that allows null and
+   then reject the same payload at validation time.
+   The fix is at the schema definition: pair `:optional true` with `[:maybe ...]`."
   [malli-schema tool-name]
   (when malli-schema
     (doseq [[k props value-schema] (map-entries (mr/resolve-schema malli-schema))
@@ -347,20 +343,16 @@
                                            (seq all-req) (assoc :required all-req)))))
 
 (defn- tool-input-schema
-  "Resolve a tool's MCP `inputSchema`. Two sources, in priority order:
+  "Resolve a tool's MCP `inputSchema`.
 
-  1. `:input-schema` set on the tool metadata as a Malli schema — passed through
-     `malli->json-schema` (which inlines refs, flattens root-level composites, and
-     respects per-leaf `:json-schema` properties for things like `:format \"uuid\"`)
-     and then the strict transform.
-  2. Implicit — derived from the endpoint's route/query/body Malli via
-     `merge-input-schemas`, then run through the strict transform.
+  Sources, in priority order:
+  1. `:input-schema` on the tool metadata as a Malli schema.
+  2. Implicit — derived from the endpoint's route/query/body Malli.
 
-  When `:input-schema` is an explicit Malli schema we also enforce that every
-  optional field is nullable — the strict transform rewrites optional fields to
-  nullable JSON Schema, and a Malli-only-optional field would publish a schema
-  that allows null and reject the same payload at runtime. See
-  [[assert-optional-fields-nullable!]]."
+  Both paths run through the strict transform.
+  When `:input-schema` is explicit, [[assert-optional-fields-nullable!]] runs first —
+  optional fields must be modeled as `[:maybe ...]` so the strict transform's
+  null-rewrite doesn't publish a schema that the runtime then rejects."
   [tool-name form]
   (let [explicit (get-in form [:metadata :tool :input-schema])]
     (if explicit
@@ -378,21 +370,12 @@
       (malli->json-schema content))))
 
 (defn- tool-output-schema
-  "Resolve a tool's MCP `outputSchema`. Two sources, in priority order:
-
-  1. `:output-schema` on the tool metadata as a Malli schema — passed through
-     `malli->json-schema` (no strict transform: the server emits exact shapes
-     and we don't want all-required/nullable rewriting on outputs).
-  2. Implicit — derived from the endpoint's response schema.
-
-  An override is only appropriate when an MCP body transform reshapes the
-  endpoint's response on the way out (e.g. `make-store-construct-query-result`
-  swaps `:query` for `:query_handle`); the transformer is then responsible for
-  matching this shape and should validate against the same schema at runtime."
+  "Derive a tool's MCP `outputSchema` from the endpoint's `:response-schema`.
+  No strict transform — outputs aren't constrained by OpenAI's strict-tool rules.
+  Layers above (e.g. `metabase.mcp.tools`) may patch this for tools whose MCP
+  body transform reshapes the endpoint response."
   [form]
-  (if-let [explicit (get-in form [:metadata :tool :output-schema])]
-    (malli->json-schema explicit)
-    (response-schema->json-schema (:response-schema form))))
+  (response-schema->json-schema (:response-schema form)))
 
 (defn- route-path->endpoint-path
   "Convert Clout-style route path (`:id`) to curly-brace path (`{id}`)."

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -8,7 +8,7 @@
   - `endpoint` — HTTP method + path
   - `inputSchema` — merged route + query + body parameters
   - `outputSchema` — from the endpoint's response schema, or an explicit
-    `:output-schema` (Malli vector / JSON Schema map) on the tool metadata
+    `:output-schema` on the tool metadata
   - `annotations` — MCP ToolAnnotations (readOnlyHint, destructiveHint, etc.)"
   (:require
    [clojure.string :as str]

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -164,11 +164,11 @@
   [method]
   ;; `readOnlyHint`, `destructiveHint`, and `openWorldHint` are always present —
   ;; some MCP clients (e.g. the ChatGPT Apps SDK) reject tools that omit them.
-  ;; `openWorldHint` signals whether a tool reaches arbitrary external entities
-  ;; (e.g. a web-search tool) — false here because every Metabase tool stays
-  ;; within the user's own instance.
   (merge {:readOnlyHint    false
           :destructiveHint false
+          ;; `openWorldHint` signals whether a tool reaches arbitrary external
+          ;; entities (e.g. a web-search tool) — false here because every
+          ;; Metabase tool stays within the user's own instance.
           :openWorldHint   false}
          (case method
            (:get :head) {:readOnlyHint   true
@@ -220,10 +220,9 @@
   "Make an MCP inputSchema compatible with stricter LLM clients.
 
   MCP allows normal JSON Schema optional object properties.
-  OpenAI's strict tool schema validation is narrower: every object property must be
-  listed in `:required`. The Malli source already models nullability via `[:maybe ...]`
-  (see [[assert-optional-fields-nullable!]]), so this only needs to widen
-  `:required` and close the object — property types are left alone."
+  OpenAI's strict tool schema validation is narrower: every object property must be listed in `:required`.
+  The Malli source already models nullability via `[:maybe ...]` (see [[assert-optional-fields-nullable!]]),
+  so this only needs to widen `:required` and close the object — property types are left alone."
   [schema]
   (letfn [(strict-schema [schema]
             (let [schema (cond-> schema
@@ -244,11 +243,10 @@
   [schema]
   (try (mr/validate schema nil) (catch Throwable _ false)))
 
-(defn- assert-optional-fields-nullable!
+(defn assert-optional-fields-nullable!
   "Throw if any optional field reachable from `malli-schema` rejects an explicit null.
-   The strict-tool transform forces every property into `:required`, so an optional
-   field that isn't `[:maybe ...]` would publish a schema that allows null but be
-   rejected by Malli validation at the endpoint.
+   The strict-tool transform forces every property into `:required`, so an optional field that isn't
+   `[:maybe ...]` would publish a schema that allows null but be rejected by Malli validation at the endpoint.
    The fix is at the schema definition: pair `:optional true` with `[:maybe ...]`."
   [malli-schema tool-name]
   (when malli-schema
@@ -291,22 +289,15 @@
                                            (seq all-req) (assoc :required all-req)))))
 
 (defn- tool-input-schema
-  "Resolve a tool's MCP `inputSchema`.
-
-  Sources, in priority order:
-  1. `:input-schema` on the tool metadata as a Malli schema.
-  2. Implicit — derived from the endpoint's route/query/body Malli.
-
-  Either path is linted by [[assert-optional-fields-nullable!]]: every optional
-  field must be `[:maybe ...]` so the published JSON Schema is already nullable,
-  letting the strict transform leave property types alone."
+  "Derive a tool's MCP `inputSchema` from the endpoint's route/query/body Malli.
+  Linted by [[assert-optional-fields-nullable!]]: every optional field must be `[:maybe ...]` so the
+  published JSON Schema is already nullable, letting the strict transform leave property types alone.
+  Layers above (e.g. `metabase.mcp.tools`) may patch this for tools whose MCP input shape differs from
+  the endpoint's wire shape."
   [tool-name form]
-  (if-let [explicit (get-in form [:metadata :tool :input-schema])]
-    (do (assert-optional-fields-nullable! explicit tool-name)
-        (-> explicit malli->json-schema strict-tool-input-schema))
-    (do (doseq [k [:route :query :body]]
-          (assert-optional-fields-nullable! (get-in form [:params k :schema]) tool-name))
-        (some-> (merge-input-schemas form) strict-tool-input-schema))))
+  (doseq [k [:route :query :body]]
+    (assert-optional-fields-nullable! (get-in form [:params k :schema]) tool-name))
+  (some-> (merge-input-schemas form) strict-tool-input-schema))
 
 (defn- response-schema->json-schema
   "Convert an endpoint's response schema to JSON Schema for the tools manifest."
@@ -320,8 +311,8 @@
 (defn- tool-output-schema
   "Derive a tool's MCP `outputSchema` from the endpoint's `:response-schema`.
   No strict transform — outputs aren't constrained by OpenAI's strict-tool rules.
-  Layers above (e.g. `metabase.mcp.tools`) may patch this for tools whose MCP
-  body transform reshapes the endpoint response."
+  Layers above (e.g. `metabase.mcp.tools`) may patch this for tools whose MCP body transform
+  reshapes the endpoint response."
   [form]
   (response-schema->json-schema (:response-schema form)))
 

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -162,13 +162,12 @@
 (defn- method-default-annotations
   "Default MCP ToolAnnotations for an HTTP method."
   [method]
-  ;; `readOnlyHint`, `destructiveHint`, and `openWorldHint` are always present —
-  ;; some MCP clients (e.g. the ChatGPT Apps SDK) reject tools that omit them.
+  ;; `readOnlyHint`, `destructiveHint`, and `openWorldHint` are always present — some MCP clients
+  ;; (e.g. the ChatGPT Apps SDK) reject tools that omit them.
   (merge {:readOnlyHint    false
           :destructiveHint false
-          ;; `openWorldHint` signals whether a tool reaches arbitrary external
-          ;; entities (e.g. a web-search tool) — false here because every
-          ;; Metabase tool stays within the user's own instance.
+          ;; `openWorldHint` signals whether a tool reaches arbitrary external entities (e.g. a
+          ;; web-search tool) — false because Metabase tools stay within the user's own instance.
           :openWorldHint   false}
          (case method
            (:get :head) {:readOnlyHint   true
@@ -181,9 +180,8 @@
 (defn infer-annotations
   "Compute MCP ToolAnnotations from HTTP method defaults merged with explicit `:annotations`.
    Returns `{:annotations <merged> :redundant <pairs> :contradictory? <bool>}`.
-   Callers should reject `:redundant` entries (explicit declarations must add information
-   beyond the HTTP-method default) and `:contradictory?` (a tool can't be both read-only and
-   destructive)."
+   Callers should reject `:redundant` entries (explicit declarations must add information beyond
+   the HTTP-method default) and `:contradictory?` (a tool can't be both read-only and destructive)."
   [method explicit-annotations]
   (let [method-defaults (method-default-annotations method)
         explicit        (into {}

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -7,7 +7,8 @@
   - `name`, `description` — tool identity
   - `endpoint` — HTTP method + path
   - `inputSchema` — merged route + query + body parameters
-  - `responseSchema` — from the endpoint's response schema
+  - `outputSchema` — from the endpoint's response schema, or an explicit
+    `:output-schema` (Malli vector / JSON Schema map) on the tool metadata
   - `annotations` — MCP ToolAnnotations (readOnlyHint, destructiveHint, etc.)"
   (:require
    [clojure.string :as str]
@@ -328,6 +329,22 @@
                        response-schema)]
       (malli->json-schema content))))
 
+(defn- tool-output-schema
+  "Resolve a tool's MCP `outputSchema`. Three sources, in priority order:
+
+  1. `:output-schema` on the tool metadata as a Malli vector — passed through
+     the standard `malli->json-schema` pipeline (no strict transform — server
+     emits exact shapes; we don't want all-required/nullable rewriting on
+     outputs).
+  2. `:output-schema` as a JSON Schema map — used verbatim (escape hatch).
+  3. Implicit — derived from the endpoint's response schema."
+  [form]
+  (let [explicit (get-in form [:metadata :tool :output-schema])]
+    (cond
+      (vector? explicit) (malli->json-schema explicit)
+      (map? explicit)    explicit
+      :else              (response-schema->json-schema (:response-schema form)))))
+
 (defn- route-path->endpoint-path
   "Convert Clout-style route path (`:id`) to curly-brace path (`{id}`)."
   [path]
@@ -371,7 +388,7 @@
                            (:docstr form))
         full-path      (str prefix (route-path->endpoint-path route-path))
         input-schema   (tool-input-schema form)
-        resp-schema    (response-schema->json-schema (:response-schema form))
+        output-schema  (tool-output-schema form)
         inferred       (infer-annotations method (:annotations tool-md))
         annotations    (:annotations inferred)
         _              (when (:contradictory? inferred)
@@ -392,7 +409,7 @@
              :endpoint    {:method (u/upper-case-en (name method))
                            :path   full-path}}
       input-schema      (assoc :inputSchema input-schema)
-      resp-schema       (assoc :responseSchema resp-schema)
+      output-schema     (assoc :outputSchema output-schema)
       (seq annotations) (assoc :annotations annotations)
       task-support      (assoc :execution {:taskSupport (name task-support)})
       (string? scope)   (assoc :scope scope))))

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -214,6 +214,70 @@
       (when (:properties jss)
         (select-keys jss [:properties :required])))))
 
+(defn- nullable-schema
+  "Return a JSON Schema that accepts `nil` in addition to `schema`.
+  OpenAI's strict tool schema validation expects every property to be listed in
+  `required`; nullable properties are how we preserve optional API inputs in the
+  exported MCP schema without changing the endpoint contract."
+  [schema]
+  (cond
+    (= "null" (:type schema))
+    schema
+
+    (string? (:type schema))
+    (update schema :type (fn [type] [type "null"]))
+
+    (vector? (:type schema))
+    (update schema :type (fn [types] (vec (distinct (conj types "null")))))
+
+    (contains? schema :oneOf)
+    (update schema :oneOf (fn [schemas] (vec (distinct (conj schemas {:type "null"})))))
+
+    (contains? schema :anyOf)
+    (update schema :anyOf (fn [schemas] (vec (distinct (conj schemas {:type "null"})))))
+
+    :else
+    {:anyOf [schema {:type "null"}]}))
+
+(defn- strict-tool-input-schema
+  "Make an MCP inputSchema compatible with stricter LLM clients.
+
+  MCP allows normal JSON Schema optional object properties. OpenAI's strict tool
+  schema validation is narrower: every object property must be required, and
+  optional values should be modeled as nullable instead."
+  [schema]
+  (letfn [(strict-schema [schema]
+            (let [schema (cond-> schema
+                           (:properties schema)
+                           (update :properties update-vals strict-schema)
+
+                           (:items schema)
+                           (update :items strict-schema)
+
+                           (:oneOf schema)
+                           (update :oneOf #(mapv strict-schema %))
+
+                           (:anyOf schema)
+                           (update :anyOf #(mapv strict-schema %))
+
+                           (:allOf schema)
+                           (update :allOf #(mapv strict-schema %)))]
+              (if (and (= "object" (:type schema)) (seq (:properties schema)))
+                (let [property-names      (vec (keys (:properties schema)))
+                      required-property?  (set (:required schema))
+                      nullable-properties (remove required-property? property-names)]
+                  (-> schema
+                      (assoc :required property-names
+                             :additionalProperties false)
+                      (update :properties
+                              (fn [properties]
+                                (reduce (fn [properties property-name]
+                                          (update properties property-name nullable-schema))
+                                        properties
+                                        nullable-properties)))))
+                schema)))]
+    (strict-schema schema)))
+
 (defn- merge-input-schemas
   "Merge route, query, and body param schemas into a single inputSchema object.
   Route params are always required. For body schemas that aren't simple maps (e.g. `:or`),
@@ -238,6 +302,22 @@
       (and body-full (empty? all-props)) body-full
       (seq all-props)                    (cond-> {:type "object" :properties all-props}
                                            (seq all-req) (assoc :required all-req)))))
+
+(defn- tool-input-schema
+  "Resolve a tool's MCP `inputSchema`. Three sources, in priority order:
+
+  1. `:input-schema` set on the tool metadata as a Malli vector — passed through
+     the standard `malli->json-schema` pipeline and the strict transform.
+  2. `:input-schema` set as a JSON Schema map — used verbatim (escape hatch for
+     hand-tuned schemas).
+  3. Implicit — derived from the endpoint's body Malli via `merge-input-schemas`,
+     then run through the strict transform."
+  [form]
+  (let [explicit (get-in form [:metadata :tool :input-schema])]
+    (cond
+      (vector? explicit) (-> explicit malli->json-schema strict-tool-input-schema)
+      (map? explicit)    explicit
+      :else              (some-> (merge-input-schemas form) strict-tool-input-schema))))
 
 (defn- response-schema->json-schema
   "Convert an endpoint's response schema to JSON Schema for the tools manifest."
@@ -290,7 +370,7 @@
         description    (or (:description tool-md)
                            (:docstr form))
         full-path      (str prefix (route-path->endpoint-path route-path))
-        input-schema   (merge-input-schemas form)
+        input-schema   (tool-input-schema form)
         resp-schema    (response-schema->json-schema (:response-schema form))
         inferred       (infer-annotations method (:annotations tool-md))
         annotations    (:annotations inferred)

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -7,8 +7,7 @@
   - `name`, `description` — tool identity
   - `endpoint` — HTTP method + path
   - `inputSchema` — merged route + query + body parameters
-  - `outputSchema` — from the endpoint's response schema, or an explicit
-    `:output-schema` on the tool metadata
+  - `outputSchema` — from the response schema, or an explicit `:output-schema` on the tool metadata
   - `annotations` — MCP ToolAnnotations (readOnlyHint, destructiveHint, etc.)"
   (:require
    [clojure.string :as str]
@@ -252,7 +251,7 @@
     :else
     {:anyOf [schema {:type "null"}]}))
 
-(defn- strict-tool-input-schema
+(defn strict-tool-input-schema
   "Make an MCP inputSchema compatible with stricter LLM clients.
 
   MCP allows normal JSON Schema optional object properties. OpenAI's strict tool
@@ -291,6 +290,37 @@
                 schema)))]
     (strict-schema schema)))
 
+(defn- map-entries
+  "Return malli `:map` entry seqs for the schema, or nil if it isn't a map after deref.
+   Each entry has shape `[key props value-schema]`."
+  [schema]
+  (let [walked (mc/deref-all schema)]
+    (when (= :map (mc/type walked))
+      (mc/children walked))))
+
+(defn- nullable-malli?
+  "True when `schema` accepts `nil`. Mirrors Malli's runtime check: `[:maybe X]`,
+   `:any`, `:nil`, and a few other shapes pass."
+  [schema]
+  (try (mr/validate schema nil) (catch Throwable _ false)))
+
+(defn- assert-optional-fields-nullable!
+  "Throw if any top-level optional field on `malli-schema` rejects an explicit
+   null. The strict-tool transform rewrites optional fields to nullable JSON
+   Schema for OpenAI clients, so a Malli-only-optional field would publish a
+   schema that allows `null` and then reject the same payload at validation
+   time. The fix is at the schema definition: pair `:optional true` with
+   `[:maybe ...]`."
+  [malli-schema tool-name]
+  (when malli-schema
+    (doseq [[k props value-schema] (map-entries (mr/resolve-schema malli-schema))
+            :when (and (true? (:optional props))
+                       (not (nullable-malli? value-schema)))]
+      (throw (ex-info (str "Tool " tool-name " input has optional non-nullable field "
+                           (pr-str k) ". Mark it `[:maybe ...]` so Malli accepts explicit "
+                           "nulls — strict JSON Schema rewrites optional fields to nullable.")
+                      {:tool tool-name :field k})))))
+
 (defn- merge-input-schemas
   "Merge route, query, and body param schemas into a single inputSchema object.
   Route params are always required. For body schemas that aren't simple maps (e.g. `:or`),
@@ -317,20 +347,26 @@
                                            (seq all-req) (assoc :required all-req)))))
 
 (defn- tool-input-schema
-  "Resolve a tool's MCP `inputSchema`. Three sources, in priority order:
+  "Resolve a tool's MCP `inputSchema`. Two sources, in priority order:
 
-  1. `:input-schema` set on the tool metadata as a Malli vector — passed through
-     the standard `malli->json-schema` pipeline and the strict transform.
-  2. `:input-schema` set as a JSON Schema map — used verbatim (escape hatch for
-     hand-tuned schemas).
-  3. Implicit — derived from the endpoint's body Malli via `merge-input-schemas`,
-     then run through the strict transform."
-  [form]
+  1. `:input-schema` set on the tool metadata as a Malli schema — passed through
+     `malli->json-schema` (which inlines refs, flattens root-level composites, and
+     respects per-leaf `:json-schema` properties for things like `:format \"uuid\"`)
+     and then the strict transform.
+  2. Implicit — derived from the endpoint's route/query/body Malli via
+     `merge-input-schemas`, then run through the strict transform.
+
+  When `:input-schema` is an explicit Malli schema we also enforce that every
+  optional field is nullable — the strict transform rewrites optional fields to
+  nullable JSON Schema, and a Malli-only-optional field would publish a schema
+  that allows null and reject the same payload at runtime. See
+  [[assert-optional-fields-nullable!]]."
+  [tool-name form]
   (let [explicit (get-in form [:metadata :tool :input-schema])]
-    (cond
-      (vector? explicit) (-> explicit malli->json-schema strict-tool-input-schema)
-      (map? explicit)    explicit
-      :else              (some-> (merge-input-schemas form) strict-tool-input-schema))))
+    (if explicit
+      (do (assert-optional-fields-nullable! explicit tool-name)
+          (-> explicit malli->json-schema strict-tool-input-schema))
+      (some-> (merge-input-schemas form) strict-tool-input-schema))))
 
 (defn- response-schema->json-schema
   "Convert an endpoint's response schema to JSON Schema for the tools manifest."
@@ -342,20 +378,21 @@
       (malli->json-schema content))))
 
 (defn- tool-output-schema
-  "Resolve a tool's MCP `outputSchema`. Three sources, in priority order:
+  "Resolve a tool's MCP `outputSchema`. Two sources, in priority order:
 
-  1. `:output-schema` on the tool metadata as a Malli vector — passed through
-     the standard `malli->json-schema` pipeline (no strict transform — server
-     emits exact shapes; we don't want all-required/nullable rewriting on
-     outputs).
-  2. `:output-schema` as a JSON Schema map — used verbatim (escape hatch).
-  3. Implicit — derived from the endpoint's response schema."
+  1. `:output-schema` on the tool metadata as a Malli schema — passed through
+     `malli->json-schema` (no strict transform: the server emits exact shapes
+     and we don't want all-required/nullable rewriting on outputs).
+  2. Implicit — derived from the endpoint's response schema.
+
+  An override is only appropriate when an MCP body transform reshapes the
+  endpoint's response on the way out (e.g. `make-store-construct-query-result`
+  swaps `:query` for `:query_handle`); the transformer is then responsible for
+  matching this shape and should validate against the same schema at runtime."
   [form]
-  (let [explicit (get-in form [:metadata :tool :output-schema])]
-    (cond
-      (vector? explicit) (malli->json-schema explicit)
-      (map? explicit)    explicit
-      :else              (response-schema->json-schema (:response-schema form)))))
+  (if-let [explicit (get-in form [:metadata :tool :output-schema])]
+    (malli->json-schema explicit)
+    (response-schema->json-schema (:response-schema form))))
 
 (defn- route-path->endpoint-path
   "Convert Clout-style route path (`:id`) to curly-brace path (`{id}`)."
@@ -399,7 +436,7 @@
         description    (or (:description tool-md)
                            (:docstr form))
         full-path      (str prefix (route-path->endpoint-path route-path))
-        input-schema   (tool-input-schema form)
+        input-schema   (tool-input-schema tool-name form)
         output-schema  (tool-output-schema form)
         inferred       (infer-annotations method (:annotations tool-md))
         annotations    (:annotations inferred)

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -155,9 +155,11 @@
 (defn- normalize-domain
   "Extract and lowercase the domain from a URL or Host-style header value.
    Bracketed IPv6 forms (`[::1]:3000`) and ports are handled correctly.
-   Returns nil for unparsable input."
+   Returns nil for unparsable input.
+   Uses `try-parse-url` (the silent variant) — `Origin`/`Host` are client-controlled,
+   so malformed inputs are expected and shouldn't spam the error logs."
   [url]
-  (some-> url str mw.security/parse-url :domain u/lower-case-en))
+  (some-> url str mw.security/try-parse-url :domain u/lower-case-en))
 
 (defn- same-origin-host? [origin host]
   (let [origin-domain (normalize-domain origin)]
@@ -167,8 +169,7 @@
   (boolean
    (or (mcp/sandbox-origin? origin)
        (when-let [approved-origins (not-empty (mcp/cors-origins))]
-          ;; `parse-url` returns nil for a malformed origin - we treat that as non-approved.
-         (when-let [origin-url (mw.security/parse-url origin)]
+         (when-let [origin-url (mw.security/try-parse-url origin)]
            (some (fn [approved-origin]
                    (and (mw.security/approved-domain? (:domain origin-url) (:domain approved-origin))
                         (mw.security/approved-protocol? (:protocol origin-url) (:protocol approved-origin))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -25,7 +25,6 @@
    [throttle.core :as throttle])
   (:import
    (java.io BufferedWriter OutputStreamWriter)
-   (java.net URI)
    (java.nio.charset StandardCharsets)))
 
 (set! *warn-on-reflection* true)
@@ -154,11 +153,13 @@
 
 (defn- same-origin-host?
   [origin host]
-  (try
-    (let [origin-host  (.getHost (URI. origin))
-          request-host (first (str/split (str host) #":"))]
-      (= origin-host request-host))
-    (catch Exception _ false)))
+  (let [origin-url (mw.security/parse-url origin)
+        host-url   (mw.security/parse-url (str host))]
+    (boolean
+     (and origin-url
+          host-url
+          (= (str/lower-case (:domain origin-url))
+             (str/lower-case (:domain host-url)))))))
 
 (defn- approved-mcp-origin?
   [origin]

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -152,24 +152,23 @@
 
 ;;; ------------------------------------------------- Validation --------------------------------------------------
 
-(defn- same-origin-host?
-  [origin host]
-  (let [origin-url (mw.security/parse-url origin)
-        host-url   (mw.security/parse-url (str host))]
-    (boolean
-     (and origin-url
-          host-url
-          (= (u/lower-case-en (:domain origin-url))
-             (u/lower-case-en (:domain host-url)))))))
+(defn- normalize-domain
+  "Extract and lowercase the domain from a URL or Host-style header value. Uses
+   `mw.security/parse-url` so bracketed IPv6 forms (`[::1]:3000`) and ports are
+   handled correctly. Returns nil for unparsable input."
+  [url]
+  (some-> url str mw.security/parse-url :domain u/lower-case-en))
 
-(defn- approved-mcp-origin?
-  [origin]
-  (or (mcp/sandbox-origin? origin)
-      (when-let [approved-origins (not-empty (mcp/cors-origins))]
-        ;; `parse-url` returns nil for malformed Origin values — treat those as
-        ;; not approved rather than passing nil down to `approved-domain?` et al.
-        (when-let [origin-url (mw.security/parse-url origin)]
-          (boolean
+(defn- same-origin-host? [origin host]
+  (let [origin-domain (normalize-domain origin)]
+    (and (some? origin-domain) (= origin-domain (normalize-domain host)))))
+
+(defn- approved-mcp-origin? [origin]
+  (boolean
+   (or (mcp/sandbox-origin? origin)
+       (when-let [approved-origins (not-empty (mcp/cors-origins))]
+          ;; `parse-url` returns nil for a malformed origin - we treat that as non-approved.
+         (when-let [origin-url (mw.security/parse-url origin)]
            (some (fn [approved-origin]
                    (and (mw.security/approved-domain? (:domain origin-url) (:domain approved-origin))
                         (mw.security/approved-protocol? (:protocol origin-url) (:protocol approved-origin))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -164,7 +164,9 @@
   [origin]
   (or (mcp/sandbox-origin? origin)
       (when-let [approved-origins (not-empty (mcp/cors-origins))]
-        (let [origin-url (mw.security/parse-url origin)]
+        ;; `parse-url` returns nil for malformed Origin values — treat those as
+        ;; not approved rather than passing nil down to `approved-domain?` et al.
+        (when-let [origin-url (mw.security/parse-url origin)]
           (boolean
            (some (fn [approved-origin]
                    (and (mw.security/approved-domain? (:domain origin-url) (:domain approved-origin))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -153,9 +153,9 @@
 ;;; ------------------------------------------------- Validation --------------------------------------------------
 
 (defn- normalize-domain
-  "Extract and lowercase the domain from a URL or Host-style header value. Uses
-   `mw.security/parse-url` so bracketed IPv6 forms (`[::1]:3000`) and ports are
-   handled correctly. Returns nil for unparsable input."
+  "Extract and lowercase the domain from a URL or Host-style header value.
+   Bracketed IPv6 forms (`[::1]:3000`) and ports are handled correctly.
+   Returns nil for unparsable input."
   [url]
   (some-> url str mw.security/parse-url :domain u/lower-case-en))
 
@@ -178,8 +178,8 @@
 (defn- validate-origin
   "Validate the Origin header to prevent DNS rebinding attacks (MCP spec requirement).
    Returns a 403 response if Origin is present and is neither same-host nor an
-   explicitly configured MCP app origin. Non-browser clients that omit the Origin
-   header are allowed through."
+   explicitly configured MCP app origin.
+   Non-browser clients that omit the Origin header are allowed through."
   [request]
   (when-let [origin (get-in request [:headers "origin"])]
     (let [host (get-in request [:headers "host"])]

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -165,15 +165,17 @@
     (and (some? origin-domain) (= origin-domain (normalize-domain host)))))
 
 (defn- approved-mcp-origin? [origin]
+  ;; Pre-lowercase both inputs so DNS hostname matching is case-insensitive (per RFC) and so mixed-case
+  ;; schemes still match `try-parse-url`'s lowercase-only `https?|app|capacitor` regex.
   (boolean
    (or (mcp/sandbox-origin? origin)
        (when-let [approved-origins (not-empty (mcp/cors-origins))]
-         (when-let [origin-url (mw.security/try-parse-url origin)]
+         (when-let [origin-url (mw.security/try-parse-url (u/lower-case-en origin))]
            (some (fn [approved-origin]
                    (and (mw.security/approved-domain? (:domain origin-url) (:domain approved-origin))
                         (mw.security/approved-protocol? (:protocol origin-url) (:protocol approved-origin))
                         (mw.security/approved-port? (:port origin-url) (:port approved-origin))))
-                 (mw.security/parse-approved-origins approved-origins)))))))
+                 (mw.security/parse-approved-origins (u/lower-case-en approved-origins))))))))
 
 (defn- validate-origin
   "Validate the Origin header to prevent DNS rebinding attacks (MCP spec requirement).

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -154,10 +154,9 @@
 
 (defn- normalize-domain
   "Extract and lowercase the domain from a URL or Host-style header value.
-   Bracketed IPv6 forms (`[::1]:3000`) and ports are handled correctly.
-   Returns nil for unparsable input.
-   Uses `try-parse-url` (the silent variant) — `Origin`/`Host` are client-controlled,
-   so malformed inputs are expected and shouldn't spam the error logs."
+   Bracketed IPv6 forms (`[::1]:3000`) and ports are handled correctly. Returns nil for unparsable input.
+   Uses `try-parse-url` (the silent variant) — `Origin`/`Host` are client-controlled, so malformed inputs
+   are expected and shouldn't spam the error logs."
   [url]
   (some-> url str mw.security/try-parse-url :domain u/lower-case-en))
 
@@ -178,9 +177,8 @@
 
 (defn- validate-origin
   "Validate the Origin header to prevent DNS rebinding attacks (MCP spec requirement).
-   Returns a 403 response if Origin is present and is neither same-host nor an
-   explicitly configured MCP app origin.
-   Non-browser clients that omit the Origin header are allowed through."
+   Returns a 403 response if Origin is present and is neither same-host nor an explicitly configured
+   MCP app origin. Non-browser clients that omit the Origin header are allowed through."
   [request]
   (when-let [origin (get-in request [:headers "origin"])]
     (let [host (get-in request [:headers "host"])]

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -19,6 +19,7 @@
    [metabase.server.middleware.security :as mw.security]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.system.core :as system]
+   [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [oidc-provider.store :as oidc.store]
@@ -158,8 +159,8 @@
     (boolean
      (and origin-url
           host-url
-          (= (str/lower-case (:domain origin-url))
-             (str/lower-case (:domain host-url)))))))
+          (= (u/lower-case-en (:domain origin-url))
+             (u/lower-case-en (:domain host-url)))))))
 
 (defn- approved-mcp-origin?
   [origin]

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -9,12 +9,14 @@
    [metabase.api.common :as api]
    [metabase.api.macros.scope :as scope]
    [metabase.api.open-api :as open-api]
+   [metabase.mcp.core :as mcp]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.mcp.session :as mcp.session]
    [metabase.mcp.tools :as mcp.tools]
    [metabase.mcp.validation :as mcp.validation]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.request.core :as request]
+   [metabase.server.middleware.security :as mw.security]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.system.core :as system]
    [metabase.util.json :as json]
@@ -150,18 +152,36 @@
 
 ;;; ------------------------------------------------- Validation --------------------------------------------------
 
+(defn- same-origin-host?
+  [origin host]
+  (try
+    (let [origin-host  (.getHost (URI. origin))
+          request-host (first (str/split (str host) #":"))]
+      (= origin-host request-host))
+    (catch Exception _ false)))
+
+(defn- approved-mcp-origin?
+  [origin]
+  (or (mcp/sandbox-origin? origin)
+      (when-let [approved-origins (not-empty (mcp/cors-origins))]
+        (let [origin-url (mw.security/parse-url origin)]
+          (boolean
+           (some (fn [approved-origin]
+                   (and (mw.security/approved-domain? (:domain origin-url) (:domain approved-origin))
+                        (mw.security/approved-protocol? (:protocol origin-url) (:protocol approved-origin))
+                        (mw.security/approved-port? (:port origin-url) (:port approved-origin))))
+                 (mw.security/parse-approved-origins approved-origins)))))))
+
 (defn- validate-origin
   "Validate the Origin header to prevent DNS rebinding attacks (MCP spec requirement).
-   Returns a 403 response if Origin is present and doesn't match the request's Host header.
-   Non-browser clients that omit the Origin header are allowed through."
+   Returns a 403 response if Origin is present and is neither same-host nor an
+   explicitly configured MCP app origin. Non-browser clients that omit the Origin
+   header are allowed through."
   [request]
   (when-let [origin (get-in request [:headers "origin"])]
     (let [host (get-in request [:headers "host"])]
-      (when-not (try
-                  (let [origin-host (.getHost (URI. origin))
-                        request-host (first (str/split (str host) #":"))]
-                    (= origin-host request-host))
-                  (catch Exception _ false))
+      (when-not (or (same-origin-host? origin host)
+                    (approved-mcp-origin? origin))
         (json-response 403 (jsonrpc-error nil -32600 "Origin not allowed"))))))
 
 (defn- require-valid-session

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -10,10 +10,12 @@
    nil scope is treated as internal-only."
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [metabase.api.common :as api]
    [metabase.api.macros.defendpoint.tools-manifest :as tools-manifest]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
+   [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
@@ -85,6 +87,16 @@
          :uri->resource (sorted-map)
          :tools         (sorted-map)}))
 
+(defn- chatgpt-client?
+  "True when the in-flight request's User-Agent identifies the ChatGPT MCP/Apps
+   client. ChatGPT empirically sends `openai-mcp/...`; Claude rejects
+   `_meta.ui.domain` unless it's a Claude-issued subdomain, so we gate the field
+   on this check."
+  []
+  (boolean (some-> (request/current-request)
+                   (get-in [:headers "user-agent"])
+                   (str/includes? "openai-mcp"))))
+
 (defn- site-origin
   "Origin (scheme://host[:port]) extracted from `site-url`, dropping any path segment.
    ChatGPT's MCP host treats `_meta.ui.domain` and the CSP domain lists as origins, so an instance
@@ -103,7 +115,10 @@
    to pick a sandbox configuration:
 
    - `prefersBorder`    — presentation hint asking the host to draw a frame border
-   - `domain`           — the origin the iframe content is anchored at
+   - `domain`           — origin the iframe content is anchored at. ChatGPT-only:
+                          Claude validates this against its own namespace
+                          (`*.claudemcpcontent.com`) and rejects anything else,
+                          so we emit it only for ChatGPT (gated by [[chatgpt-client?]]).
    - `csp.connectDomains`  — hosts the iframe may XHR/fetch/WebSocket to
                               (the embedded SDK calls back to this Metabase instance)
    - `csp.resourceDomains` — hosts the iframe may load scripts/styles/images from
@@ -116,6 +131,7 @@
     {:ui (cond-> {:csp {:connectDomains  [url]
                         :resourceDomains [url]}}
            (contains? resource :prefersBorder)
+           (chatgpt-client?) (assoc :domain url)
            (assoc :prefersBorder (:prefersBorder resource)))}))
 
 (mu/defn register-resource!

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -10,6 +10,7 @@
    nil scope is treated as internal-only."
   (:require
    [clojure.java.io :as io]
+   [metabase.api.common :as api]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
    [metabase.system.core :as system]
@@ -255,8 +256,9 @@
   :response-fn (fn [arguments {:keys [session-id]}]
                  (let [query             (:query arguments)
                        handle            (:query_handle arguments)
-                       widget-session-id (:widgetSessionId arguments)
-                       lookup-session-id (or widget-session-id session-id)
+                       verified-widget   (mcp.session/verified-widget-session-id
+                                          (:widgetSessionId arguments) api/*current-user-id*)
+                       lookup-session-id (or verified-widget session-id)
                        resolved          (some->> handle (mcp.session/resolve-query-handle lookup-session-id))
                        encoded           (or query (:encoded_query resolved))
                        prompt            (:prompt resolved)]
@@ -307,8 +309,9 @@
                  :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
-                   (let [widget-session-id (:widgetSessionId arguments)
-                         lookup-session-id (or widget-session-id session-id)]
+                   (let [verified-widget   (mcp.session/verified-widget-session-id
+                                            (:widgetSessionId arguments) api/*current-user-id*)
+                         lookup-session-id (or verified-widget session-id)]
                      (if-let [encoded (mcp.session/read-handle lookup-session-id handle)]
                        (cond-> {:content           [{:type "text" :text "Rendering drill-through visualization..."}]
                                 :structuredContent (cond-> {:query encoded}

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -95,8 +95,8 @@
    - `csp.resourceDomains` — hosts the iframe may load scripts/styles/images from
                               (the SDK bundle is served from this Metabase instance)
 
-   `frameDomains` is intentionally omitted — we don't nest iframes inside the visualization, and
-   leaving it out narrows the CSP for security review."
+   `frameDomains` is intentionally omitted — we don't nest iframes inside the visualization, and leaving
+   it out narrows the CSP for security review."
   [resource]
   (let [url (system/site-url)]
     {:ui (cond-> {:csp {:connectDomains  [url]

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -100,14 +100,16 @@
 (defn- site-origin
   "Origin (scheme://host[:port]) extracted from `site-url`, dropping any path segment.
    ChatGPT's MCP host treats `_meta.ui.domain` and the CSP domain lists as origins, so an instance
-   hosted under a subpath would otherwise leak the path and fail validation."
+   hosted under a subpath would otherwise leak the path and fail validation. Returns nil when
+   `site-url` is unset — callers degrade gracefully rather than NPE on a misconfigured instance."
   []
-  (let [^URI uri (URI. (system/site-url))
-        scheme   (.getScheme uri)
-        host     (.getHost uri)
-        port     (.getPort uri)]
-    (cond-> (str scheme "://" host)
-      (not (neg? port)) (str ":" port))))
+  (when-let [url (system/site-url)]
+    (let [^URI uri (URI. url)
+          scheme   (.getScheme uri)
+          host     (.getHost uri)
+          port     (.getPort uri)]
+      (cond-> (str scheme "://" host)
+        (not (neg? port)) (str ":" port)))))
 
 (defn- ui-meta
   "MCP `_meta.ui` block returned alongside UI resources.
@@ -131,8 +133,10 @@
     {:ui (cond-> {:csp {:connectDomains  [url]
                         :resourceDomains [url]}}
            (contains? resource :prefersBorder)
-           (chatgpt-client?) (assoc :domain url)
-           (assoc :prefersBorder (:prefersBorder resource)))}))
+           (assoc :prefersBorder (:prefersBorder resource))
+
+           (chatgpt-client?)
+           (assoc :domain url))}))
 
 (mu/defn register-resource!
   "Register an MCP resource. Overwrites any existing entry with the same `:uri`."

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -84,9 +84,9 @@
          :tools         (sorted-map)}))
 
 (defn- ui-meta
-  "MCP `_meta.ui` block returned alongside UI resources. Hosts that render the
-   resource in a sandboxed iframe (notably ChatGPT's MCP app surface) use this to
-   pick a sandbox configuration:
+  "MCP `_meta.ui` block returned alongside UI resources.
+   Hosts that render the resource in a sandboxed iframe (notably ChatGPT's MCP app
+   surface) use this to pick a sandbox configuration:
 
    - `prefersBorder`    — presentation hint asking the host to draw a frame border
    - `domain`           — the origin the iframe content is anchored at
@@ -134,9 +134,7 @@
     resource))
 
 (defn- malli->ui-input-schema
-  "Convert a Malli schema for a UI-tool input into the published JSON Schema.
-   Runs through the same pipeline as defendpoint tools (`malli->json-schema` +
-   strict transform) so behavior is consistent across all MCP tools."
+  "Convert a Malli schema for a UI-tool input into the published JSON Schema."
   [schema]
   (-> schema tools-manifest/malli->json-schema tools-manifest/strict-tool-input-schema))
 
@@ -147,9 +145,7 @@
   (tools-manifest/malli->json-schema schema))
 
 (mu/defn- register-ui-tool!
-  "Register a UI tool. `inputSchema` and `outputSchema` are Malli schemas; the
-   JSON Schemas exported to MCP clients are derived from them via the same
-   pipeline used for defendpoint tools."
+  "Register a UI tool. `inputSchema` and `outputSchema` are Malli schemas (not JSON Schema)."
   [resource-key :- :keyword
    tool         :- [:map
                     [:name :string]

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -229,34 +229,45 @@
                     "`Show me orders by month`, `Display revenue by region`, or "
                     "`Visualize active users over time`. This renders the final answer in the UI. "
                     "Do not call execute_query after visualize_query; showing the visualization "
-                    "is enough.")
+                    "is enough. "
+                    "In the case of ChatGPT (which rotates MCP sessions between tool calls), "
+                    "pass the `widgetSessionId` returned by the prior construct_query response so "
+                    "the handle resolves against the original session; other MCP clients can omit it.")
   ;; Both fields are optional rather than expressing "at least one of" via a top-level `anyOf`.
   ;; This is because some MCP clients, e.g. the MCP inspector (mcpjam) rejects top-level combinators.
   ;; The response-fn enforces the at-least-one contract at runtime.
   :inputSchema {:type       "object"
-                :properties {:query        {:type "string" :minLength 1
-                                            :description "Base64-encoded MBQL query (use query_handle instead when available)"}
-                             :query_handle {:type "string" :format "uuid"
-                                            :description "Handle returned by construct_query; preferred over raw query"}}}
+                :properties {:query           {:type "string" :minLength 1
+                                               :description "Base64-encoded MBQL query (use query_handle instead when available)"}
+                             :query_handle    {:type "string" :format "uuid"
+                                               :description "Handle returned by construct_query; preferred over raw query"}
+                             :widgetSessionId {:type "string"
+                                               :description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}}
   :response-fn (fn [arguments {:keys [session-id]}]
-                 (let [query   (:query arguments)
-                       handle  (:query_handle arguments)
-                       resolved (some->> handle (mcp.session/resolve-query-handle session-id))
-                       encoded (or query (:encoded_query resolved))
-                       prompt  (:prompt resolved)]
+                 (let [query             (:query arguments)
+                       handle            (:query_handle arguments)
+                       widget-session-id (:widgetSessionId arguments)
+                       lookup-session-id (or widget-session-id session-id)
+                       resolved          (some->> handle (mcp.session/resolve-query-handle lookup-session-id))
+                       encoded           (or query (:encoded_query resolved))
+                       prompt            (:prompt resolved)]
                    (cond
                      (and (nil? query) (nil? handle))
                      {:content [{:type "text" :text "Provide either 'query' or 'query_handle'."}]
                       :isError true}
 
                      encoded
-                     {:content           [{:type "text" :text (str "Visualizing query in the interactive UI. "
-                                                                   "Do not call execute_query after this; "
-                                                                   "the visualization is the final result.")}]
-                      ;; If visualize_query was called with a handle, use the stored prompt so the iframe can
-                      ;; include the user's original request when submitting visualization feedback.
-                      :structuredContent (cond-> {:query encoded}
-                                           prompt (assoc :prompt prompt))}
+                     (cond-> {:content           [{:type "text" :text (str "Visualizing query in the interactive UI. "
+                                                                           "Do not call execute_query after this; "
+                                                                           "the visualization is the final result.")}]
+                              ;; If visualize_query was called with a handle, use the stored prompt so the iframe can
+                              ;; include the user's original request when submitting visualization feedback.
+                              ;; Re-emit `lookup-session-id` (not the current rotating MCP session id) so
+                              ;; the LLM keeps threading the same stable id across all follow-ups.
+                              :structuredContent (cond-> {:query encoded}
+                                                   prompt            (assoc :prompt prompt)
+                                                   lookup-session-id (assoc :widgetSessionId lookup-session-id))}
+                       lookup-session-id (assoc :_meta {"openai/widgetSessionId" lookup-session-id}))
 
                      :else
                      {:content [{:type "text" :text "Query handle not found. Try running construct_query again."}]
@@ -269,17 +280,26 @@
                     "Use this tool, not execute_query, when the user asks to show the result and "
                     "their message includes a `handle` UUID. This is the exact follow-up for the "
                     "phrase `Show me the result`. Do not execute the query yourself; pass the "
-                    "`handle` UUID as the `handle` argument.")
+                    "`handle` UUID as the `handle` argument. "
+                    "In the case of ChatGPT (which rotates MCP sessions between tool calls), "
+                    "pass `widgetSessionId` from a prior tool response so the handle resolves "
+                    "against the original session; other MCP clients can omit it.")
   :inputSchema {:type       "object"
-                :properties {:handle {:type "string" :format "uuid"
-                                      :description "Handle UUID from the user's drill-through message."}}
+                :properties {:handle          {:type "string" :format "uuid"
+                                               :description "Handle UUID from the user's drill-through message."}
+                             :widgetSessionId {:type "string"
+                                               :description "Session id from a prior tool response. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}
                 :required   ["handle"]}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
-                   (if-let [encoded (mcp.session/read-handle session-id handle)]
-                     {:content          [{:type "text" :text "Rendering drill-through visualization..."}]
-                      :structuredContent {:query encoded}}
-                     {:content [{:type "text" :text "No drill-through found for that handle."}]
-                      :isError true})
+                   (let [widget-session-id (:widgetSessionId arguments)
+                         lookup-session-id (or widget-session-id session-id)]
+                     (if-let [encoded (mcp.session/read-handle lookup-session-id handle)]
+                       (cond-> {:content           [{:type "text" :text "Rendering drill-through visualization..."}]
+                                :structuredContent (cond-> {:query encoded}
+                                                     lookup-session-id (assoc :widgetSessionId lookup-session-id))}
+                         lookup-session-id (assoc :_meta {"openai/widgetSessionId" lookup-session-id}))
+                       {:content [{:type "text" :text "No drill-through found for that handle."}]
+                        :isError true}))
                    {:content [{:type "text" :text "No drill-through found for that handle."}]
                     :isError true}))})

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -85,8 +85,8 @@
 
 (defn- ui-meta
   "MCP `_meta.ui` block returned alongside UI resources.
-   Hosts that render the resource in a sandboxed iframe (notably ChatGPT's MCP app
-   surface) use this to pick a sandbox configuration:
+   Hosts that render the resource in a sandboxed iframe (notably ChatGPT's MCP app surface) use this
+   to pick a sandbox configuration:
 
    - `prefersBorder`    — presentation hint asking the host to draw a frame border
    - `domain`           — the origin the iframe content is anchored at
@@ -95,8 +95,8 @@
    - `csp.resourceDomains` — hosts the iframe may load scripts/styles/images from
                               (the SDK bundle is served from this Metabase instance)
 
-   `frameDomains` is intentionally omitted — we don't nest iframes inside the
-   visualization, and leaving it out narrows the CSP for security review."
+   `frameDomains` is intentionally omitted — we don't nest iframes inside the visualization, and
+   leaving it out narrows the CSP for security review."
   [resource]
   (let [url (system/site-url)]
     {:ui (cond-> {:csp {:connectDomains  [url]

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -11,11 +11,13 @@
   (:require
    [clojure.java.io :as io]
    [metabase.api.common :as api]
+   [metabase.api.macros.defendpoint.tools-manifest :as tools-manifest]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
    [metabase.system.core :as system]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
    [stencil.core :as stencil]))
 
 (set! *warn-on-reflection* true)
@@ -81,7 +83,21 @@
          :uri->resource (sorted-map)
          :tools         (sorted-map)}))
 
-(defn- ui-meta [resource]
+(defn- ui-meta
+  "MCP `_meta.ui` block returned alongside UI resources. Hosts that render the
+   resource in a sandboxed iframe (notably ChatGPT's MCP app surface) use this to
+   pick a sandbox configuration:
+
+   - `prefersBorder`    — presentation hint asking the host to draw a frame border
+   - `domain`           — the origin the iframe content is anchored at
+   - `csp.connectDomains`  — hosts the iframe may XHR/fetch/WebSocket to
+                              (the embedded SDK calls back to this Metabase instance)
+   - `csp.resourceDomains` — hosts the iframe may load scripts/styles/images from
+                              (the SDK bundle is served from this Metabase instance)
+
+   `frameDomains` is intentionally omitted — we don't nest iframes inside the
+   visualization, and leaving it out narrows the CSP for security review."
+  [resource]
   (let [url (system/site-url)]
     {:ui (cond-> {:csp {:connectDomains  [url]
                         :resourceDomains [url]}}
@@ -117,18 +133,37 @@
                          (assoc-in [:uri->resource uri] resource)))
     resource))
 
+(defn- malli->ui-input-schema
+  "Convert a Malli schema for a UI-tool input into the published JSON Schema.
+   Runs through the same pipeline as defendpoint tools (`malli->json-schema` +
+   strict transform) so behavior is consistent across all MCP tools."
+  [schema]
+  (-> schema tools-manifest/malli->json-schema tools-manifest/strict-tool-input-schema))
+
+(defn- malli->ui-output-schema
+  "Convert a Malli schema for a UI-tool output into the published JSON Schema.
+   No strict transform — outputs aren't constrained by OpenAI's strict-tool rules."
+  [schema]
+  (tools-manifest/malli->json-schema schema))
+
 (mu/defn- register-ui-tool!
+  "Register a UI tool. `inputSchema` and `outputSchema` are Malli schemas; the
+   JSON Schemas exported to MCP clients are derived from them via the same
+   pipeline used for defendpoint tools."
   [resource-key :- :keyword
    tool         :- [:map
                     [:name :string]
                     [:description :string]
-                    [:inputSchema :map]
-                    [:outputSchema {:optional true} :map]
-                    [:annotations {:optional true} :map]
+                    [:inputSchema  :any]
+                    [:outputSchema {:optional true} :any]
+                    [:annotations  {:optional true} :map]
                     [:response-fn fn?]]]
   (if-let [uri (get-in @registry [:key->uri resource-key])]
     (let [scope (get-in @registry [:uri->resource uri :scope])
-          tool  (assoc tool :scope scope :_meta {:ui {:resourceUri uri}})]
+          tool  (-> tool
+                    (update :inputSchema  malli->ui-input-schema)
+                    (cond-> (:outputSchema tool) (update :outputSchema malli->ui-output-schema))
+                    (assoc :scope scope :_meta {:ui {:resourceUri uri}}))]
       (swap! registry assoc-in [:tools (:name tool)] tool)
       tool)
     (throw (ex-info "Unknown resource" {:resource-key resource-key}))))
@@ -231,59 +266,49 @@
                     "`Show me orders by month`, `Display revenue by region`, or "
                     "`Visualize active users over time`. This renders the final answer in the UI. "
                     "Do not call execute_query after visualize_query; showing the visualization "
-                    "is enough. "
-                    "In the case of ChatGPT (which rotates MCP sessions between tool calls), "
-                    "pass the `widgetSessionId` returned by the prior construct_query response so "
-                    "the handle resolves against the original session; other MCP clients can omit it.")
+                    "is enough.")
   ;; Both fields are optional rather than expressing "at least one of" via a top-level `anyOf`.
   ;; This is because some MCP clients, e.g. the MCP inspector (mcpjam) rejects top-level combinators.
   ;; The response-fn enforces the at-least-one contract at runtime.
-  :inputSchema  {:type       "object"
-                 :properties {:query           {:type "string" :minLength 1
-                                                :description "Base64-encoded MBQL query (use query_handle instead when available)"}
-                              :query_handle    {:type "string" :format "uuid"
-                                                :description "Handle returned by construct_query; preferred over raw query"}
-                              :widgetSessionId {:type "string" :format "uuid"
-                                                :description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}}
-  :outputSchema {:type       "object"
-                 :properties {:query           {:type        "string"
-                                                :description "Base64-encoded MBQL query that the visualization is rendering."}
-                              :prompt          {:type        "string"
-                                                :description "User's original request, when stored alongside the handle."}
-                              :widgetSessionId {:type        "string" :format "uuid"
-                                                :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
-                 :required   ["query"]}
+  :inputSchema
+  [:map
+   [:query        {:optional true
+                   :description "Base64-encoded MBQL query (use query_handle instead when available)"}
+    [:maybe ms/NonBlankString]]
+   [:query_handle {:optional true
+                   :description "Handle returned by construct_query; preferred over raw query"}
+    [:maybe ms/UUIDString]]]
+  :outputSchema
+  [:map
+   [:query  {:description "Base64-encoded MBQL query that the visualization is rendering."}
+    :string]
+   [:prompt {:optional true
+             :description "User's original request, when stored alongside the handle."}
+    [:maybe :string]]]
   :annotations {:readOnlyHint    true
                 :destructiveHint false
                 :idempotentHint  true
                 :openWorldHint   false}
   :response-fn (fn [arguments {:keys [session-id]}]
-                 (let [query             (:query arguments)
-                       handle            (:query_handle arguments)
-                       widget-id         (:widgetSessionId arguments)
-                       lookup-session-id (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
-                                           widget-id
-                                           session-id)
-                       resolved          (some->> handle (mcp.session/resolve-query-handle lookup-session-id))
-                       encoded           (or query (:encoded_query resolved))
-                       prompt            (:prompt resolved)]
+                 (let [query    (:query arguments)
+                       handle   (:query_handle arguments)
+                       resolved (some->> handle (mcp.session/resolve-query-handle
+                                                 session-id api/*current-user-id*))
+                       encoded  (or query (:encoded_query resolved))
+                       prompt   (:prompt resolved)]
                    (cond
                      (and (nil? query) (nil? handle))
                      {:content [{:type "text" :text "Provide either 'query' or 'query_handle'."}]
                       :isError true}
 
                      encoded
-                     (cond-> {:content           [{:type "text" :text (str "Visualizing query in the interactive UI. "
-                                                                           "Do not call execute_query after this; "
-                                                                           "the visualization is the final result.")}]
-                              ;; If visualize_query was called with a handle, use the stored prompt so the iframe can
-                              ;; include the user's original request when submitting visualization feedback.
-                              ;; Re-emit `lookup-session-id` (not the current rotating MCP session id) so
-                              ;; the LLM keeps threading the same stable id across all follow-ups.
-                              :structuredContent (cond-> {:query encoded}
-                                                   prompt            (assoc :prompt prompt)
-                                                   lookup-session-id (assoc :widgetSessionId lookup-session-id))}
-                       lookup-session-id (assoc :_meta {"openai/widgetSessionId" lookup-session-id}))
+                     {:content           [{:type "text" :text (str "Visualizing query in the interactive UI. "
+                                                                   "Do not call execute_query after this; "
+                                                                   "the visualization is the final result.")}]
+                      ;; If visualize_query was called with a handle, use the stored prompt so the iframe can
+                      ;; include the user's original request when submitting visualization feedback.
+                      :structuredContent (cond-> {:query encoded}
+                                           prompt (assoc :prompt prompt))}
 
                      :else
                      {:content [{:type "text" :text "Query handle not found. Try running construct_query again."}]
@@ -296,38 +321,25 @@
                     "Use this tool, not execute_query, when the user asks to show the result and "
                     "their message includes a `handle` UUID. This is the exact follow-up for the "
                     "phrase `Show me the result`. Do not execute the query yourself; pass the "
-                    "`handle` UUID as the `handle` argument. "
-                    "In the case of ChatGPT (which rotates MCP sessions between tool calls), "
-                    "pass `widgetSessionId` from a prior tool response so the handle resolves "
-                    "against the original session; other MCP clients can omit it.")
-  :inputSchema  {:type       "object"
-                 :properties {:handle          {:type "string" :format "uuid"
-                                                :description "Handle UUID from the user's drill-through message."}
-                              :widgetSessionId {:type "string" :format "uuid"
-                                                :description "Session id from a prior tool response. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}
-                 :required   ["handle"]}
-  :outputSchema {:type       "object"
-                 :properties {:query           {:type        "string"
-                                                :description "Base64-encoded MBQL query bound to the drill-through handle."}
-                              :widgetSessionId {:type        "string" :format "uuid"
-                                                :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
-                 :required   ["query"]}
+                    "`handle` UUID as the `handle` argument.")
+  :inputSchema
+  [:map
+   [:handle {:description "Handle UUID from the user's drill-through message."}
+    ms/UUIDString]]
+  :outputSchema
+  [:map
+   [:query {:description "Base64-encoded MBQL query bound to the drill-through handle."}
+    :string]]
   :annotations {:readOnlyHint    true
                 :destructiveHint false
                 :idempotentHint  true
                 :openWorldHint   false}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
-                   (let [widget-id         (:widgetSessionId arguments)
-                         lookup-session-id (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
-                                             widget-id
-                                             session-id)]
-                     (if-let [encoded (mcp.session/read-handle lookup-session-id handle)]
-                       (cond-> {:content           [{:type "text" :text "Rendering drill-through visualization..."}]
-                                :structuredContent (cond-> {:query encoded}
-                                                     lookup-session-id (assoc :widgetSessionId lookup-session-id))}
-                         lookup-session-id (assoc :_meta {"openai/widgetSessionId" lookup-session-id}))
-                       {:content [{:type "text" :text "No drill-through found for that handle."}]
-                        :isError true}))
+                   (if-let [encoded (mcp.session/read-handle session-id api/*current-user-id* handle)]
+                     {:content           [{:type "text" :text "Rendering drill-through visualization..."}]
+                      :structuredContent {:query encoded}}
+                     {:content [{:type "text" :text "No drill-through found for that handle."}]
+                      :isError true})
                    {:content [{:type "text" :text "No drill-through found for that handle."}]
                     :isError true}))})

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -256,9 +256,10 @@
   :response-fn (fn [arguments {:keys [session-id]}]
                  (let [query             (:query arguments)
                        handle            (:query_handle arguments)
-                       verified-widget   (mcp.session/verified-widget-session-id
-                                          (:widgetSessionId arguments) api/*current-user-id*)
-                       lookup-session-id (or verified-widget session-id)
+                       widget-id         (:widgetSessionId arguments)
+                       lookup-session-id (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
+                                           widget-id
+                                           session-id)
                        resolved          (some->> handle (mcp.session/resolve-query-handle lookup-session-id))
                        encoded           (or query (:encoded_query resolved))
                        prompt            (:prompt resolved)]
@@ -309,9 +310,10 @@
                  :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
-                   (let [verified-widget   (mcp.session/verified-widget-session-id
-                                            (:widgetSessionId arguments) api/*current-user-id*)
-                         lookup-session-id (or verified-widget session-id)]
+                   (let [widget-id         (:widgetSessionId arguments)
+                         lookup-session-id (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
+                                             widget-id
+                                             session-id)]
                      (if-let [encoded (mcp.session/read-handle lookup-session-id handle)]
                        (cond-> {:content           [{:type "text" :text "Rendering drill-through visualization..."}]
                                 :structuredContent (cond-> {:query encoded}

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -125,6 +125,7 @@
                     [:description :string]
                     [:inputSchema :map]
                     [:outputSchema {:optional true} :map]
+                    [:annotations {:optional true} :map]
                     [:response-fn fn?]]]
   (if-let [uri (get-in @registry [:key->uri resource-key])]
     (let [scope (get-in @registry [:uri->resource uri :scope])
@@ -253,6 +254,10 @@
                               :widgetSessionId {:type        "string" :format "uuid"
                                                 :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
                  :required   ["query"]}
+  :annotations {:readOnlyHint    true
+                :destructiveHint false
+                :idempotentHint  true
+                :openWorldHint   false}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (let [query             (:query arguments)
                        handle            (:query_handle arguments)
@@ -308,6 +313,10 @@
                               :widgetSessionId {:type        "string" :format "uuid"
                                                 :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
                  :required   ["query"]}
+  :annotations {:readOnlyHint    true
+                :destructiveHint false
+                :idempotentHint  true
+                :openWorldHint   false}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
                    (let [widget-id         (:widgetSessionId arguments)

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -243,14 +243,14 @@
                                                 :description "Base64-encoded MBQL query (use query_handle instead when available)"}
                               :query_handle    {:type "string" :format "uuid"
                                                 :description "Handle returned by construct_query; preferred over raw query"}
-                              :widgetSessionId {:type "string"
+                              :widgetSessionId {:type "string" :format "uuid"
                                                 :description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}}
   :outputSchema {:type       "object"
                  :properties {:query           {:type        "string"
                                                 :description "Base64-encoded MBQL query that the visualization is rendering."}
                               :prompt          {:type        "string"
                                                 :description "User's original request, when stored alongside the handle."}
-                              :widgetSessionId {:type        "string"
+                              :widgetSessionId {:type        "string" :format "uuid"
                                                 :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
                  :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]
@@ -298,13 +298,13 @@
   :inputSchema  {:type       "object"
                  :properties {:handle          {:type "string" :format "uuid"
                                                 :description "Handle UUID from the user's drill-through message."}
-                              :widgetSessionId {:type "string"
+                              :widgetSessionId {:type "string" :format "uuid"
                                                 :description "Session id from a prior tool response. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}
                  :required   ["handle"]}
   :outputSchema {:type       "object"
                  :properties {:query           {:type        "string"
                                                 :description "Base64-encoded MBQL query bound to the drill-through handle."}
-                              :widgetSessionId {:type        "string"
+                              :widgetSessionId {:type        "string" :format "uuid"
                                                 :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
                  :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -84,8 +84,7 @@
 (defn- ui-meta [resource]
   (let [url (system/site-url)]
     {:ui (cond-> {:csp {:connectDomains  [url]
-                        :resourceDomains [url]
-                        :frameDomains    [url]}}
+                        :resourceDomains [url]}}
            (contains? resource :prefersBorder)
            (assoc :prefersBorder (:prefersBorder resource)))}))
 

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -18,7 +18,9 @@
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [stencil.core :as stencil]))
+   [stencil.core :as stencil])
+  (:import
+   (java.net URI)))
 
 (set! *warn-on-reflection* true)
 
@@ -83,6 +85,18 @@
          :uri->resource (sorted-map)
          :tools         (sorted-map)}))
 
+(defn- site-origin
+  "Origin (scheme://host[:port]) extracted from `site-url`, dropping any path segment.
+   ChatGPT's MCP host treats `_meta.ui.domain` and the CSP domain lists as origins, so an instance
+   hosted under a subpath would otherwise leak the path and fail validation."
+  []
+  (let [^URI uri (URI. (system/site-url))
+        scheme   (.getScheme uri)
+        host     (.getHost uri)
+        port     (.getPort uri)]
+    (cond-> (str scheme "://" host)
+      (not (neg? port)) (str ":" port))))
+
 (defn- ui-meta
   "MCP `_meta.ui` block returned alongside UI resources.
    Hosts that render the resource in a sandboxed iframe (notably ChatGPT's MCP app surface) use this
@@ -98,7 +112,7 @@
    `frameDomains` is intentionally omitted — we don't nest iframes inside the visualization, and leaving
    it out narrows the CSP for security review."
   [resource]
-  (let [url (system/site-url)]
+  (let [url (site-origin)]
     {:ui (cond-> {:csp {:connectDomains  [url]
                         :resourceDomains [url]}}
            (contains? resource :prefersBorder)

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -123,6 +123,7 @@
                     [:name :string]
                     [:description :string]
                     [:inputSchema :map]
+                    [:outputSchema {:optional true} :map]
                     [:response-fn fn?]]]
   (if-let [uri (get-in @registry [:key->uri resource-key])]
     (let [scope (get-in @registry [:uri->resource uri :scope])
@@ -236,13 +237,21 @@
   ;; Both fields are optional rather than expressing "at least one of" via a top-level `anyOf`.
   ;; This is because some MCP clients, e.g. the MCP inspector (mcpjam) rejects top-level combinators.
   ;; The response-fn enforces the at-least-one contract at runtime.
-  :inputSchema {:type       "object"
-                :properties {:query           {:type "string" :minLength 1
-                                               :description "Base64-encoded MBQL query (use query_handle instead when available)"}
-                             :query_handle    {:type "string" :format "uuid"
-                                               :description "Handle returned by construct_query; preferred over raw query"}
-                             :widgetSessionId {:type "string"
-                                               :description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}}
+  :inputSchema  {:type       "object"
+                 :properties {:query           {:type "string" :minLength 1
+                                                :description "Base64-encoded MBQL query (use query_handle instead when available)"}
+                              :query_handle    {:type "string" :format "uuid"
+                                                :description "Handle returned by construct_query; preferred over raw query"}
+                              :widgetSessionId {:type "string"
+                                                :description "Session id returned by construct_query. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}}
+  :outputSchema {:type       "object"
+                 :properties {:query           {:type        "string"
+                                                :description "Base64-encoded MBQL query that the visualization is rendering."}
+                              :prompt          {:type        "string"
+                                                :description "User's original request, when stored alongside the handle."}
+                              :widgetSessionId {:type        "string"
+                                                :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
+                 :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (let [query             (:query arguments)
                        handle            (:query_handle arguments)
@@ -284,12 +293,18 @@
                     "In the case of ChatGPT (which rotates MCP sessions between tool calls), "
                     "pass `widgetSessionId` from a prior tool response so the handle resolves "
                     "against the original session; other MCP clients can omit it.")
-  :inputSchema {:type       "object"
-                :properties {:handle          {:type "string" :format "uuid"
-                                               :description "Handle UUID from the user's drill-through message."}
-                             :widgetSessionId {:type "string"
-                                               :description "Session id from a prior tool response. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}
-                :required   ["handle"]}
+  :inputSchema  {:type       "object"
+                 :properties {:handle          {:type "string" :format "uuid"
+                                                :description "Handle UUID from the user's drill-through message."}
+                              :widgetSessionId {:type "string"
+                                                :description "Session id from a prior tool response. In the case of ChatGPT, pass it so the handle resolves across rotating MCP sessions; other clients can omit it."}}
+                 :required   ["handle"]}
+  :outputSchema {:type       "object"
+                 :properties {:query           {:type        "string"
+                                                :description "Base64-encoded MBQL query bound to the drill-through handle."}
+                              :widgetSessionId {:type        "string"
+                                                :description "Session id under which the handle resolved — re-emitted so ChatGPT can thread it to subsequent calls."}}
+                 :required   ["query"]}
   :response-fn (fn [arguments {:keys [session-id]}]
                  (if-let [handle (:handle arguments)]
                    (let [widget-session-id (:widgetSessionId arguments)

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -151,18 +151,17 @@
 (defn store-handle!
   "Insert a new handle row binding `encoded-query` to the calling user, and return the handle UUID.
 
-   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and reads can
-   prefer the calling session before falling back across the user's other sessions (see
-   [[resolve-query-handle]]).
+   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and reads can prefer
+   the calling session before falling back across the user's other sessions (see [[resolve-query-handle]]).
 
-   `prompt` is optional, but should be supplied for construct_query handles so visualize_query can
-   later return both the query and original user prompt to the MCP iframe for feedback submission."
+   `prompt` is optional, but should be supplied for construct_query handles so visualize_query can later
+   return both the query and original user prompt to the MCP iframe for feedback submission."
   ([mcp-session-id user-id encoded-query]
    (store-handle! mcp-session-id user-id encoded-query nil))
   ([mcp-session-id user-id encoded-query prompt]
-   ;; Materializing a core_session here serves two purposes: its FK is what
-   ;; makes handles cascade-delete when the session row is reaped, and its
-   ;; user_id is what find-handle-row filters on for cross-session ownership.
+   ;; Materializing a core_session here serves two purposes: its FK is what makes handles
+   ;; cascade-delete when the session row is reaped, and its user_id is what find-handle-row
+   ;; filters on for cross-session ownership.
    (let [core-session-id (:id (get-or-create-embedding-session! mcp-session-id user-id))
          handle-id       (str (UUID/randomUUID))]
      (t2/insert! :model/McpQueryHandle
@@ -175,9 +174,8 @@
 
 (defn- find-handle-row
   "Look up the handle row owned by `user-id`.
-   Prefers a row stored under the calling `mcp-session-id` and falls back to any other session
-   owned by the same user — the fallback covers harnesses (e.g. ChatGPT) that rotate MCP sessions
-   between tool calls."
+   Prefers a row stored under the calling `mcp-session-id` and falls back to any other session owned
+   by the same user — the fallback covers harnesses (e.g. ChatGPT) that rotate MCP sessions between calls."
   [mcp-session-id user-id handle-id]
   (when (and user-id handle-id)
     ;; Single round-trip: join `mcp_query_handle` to `core_session` and filter on

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -20,6 +20,7 @@
    [metabase.mcp.models.mcp-query-handle]
    [metabase.mcp.settings :as mcp.settings]
    [metabase.session.core :as session]
+   [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    (java.nio ByteBuffer)
@@ -148,41 +149,72 @@
 ;; encoded query.
 
 (defn store-handle!
-  "Insert a new handle row binding `encoded-query` to the MCP session, and return
+  "Insert a new handle row binding `encoded-query` to the calling user, and return
    the freshly minted handle UUID.
 
-   When `user-id` is non-nil, materializes the backing `core_session` so cleanup
-   happens via cascade when the session row is reaped. When nil — e.g. agent flows
-   that don't render an iframe — the row is stored without a `core_session_id` and
-   relies on explicit `delete!` for cleanup.
+   `mcp-session-id` is recorded so that an explicit DELETE /api/mcp can sweep the
+   session's handles, and so reads can prefer the calling session before falling
+   back across the user's other sessions (see [[resolve-query-handle]]). The
+   materialized `core_session` row anchors the FK cascade — handles cascade-delete
+   when their session row is reaped — and carries the `user_id`, which is what
+   we filter on to scope cross-session lookups to the calling user.
 
    `prompt` is optional, but should be supplied for construct_query handles so
    visualize_query can later return both the query and original user prompt to
    the MCP iframe for feedback submission."
-  ([session-id user-id encoded-query]
-   (store-handle! session-id user-id encoded-query nil))
-  ([session-id user-id encoded-query prompt]
-   (let [core-session-id (when user-id
-                           (:id (get-or-create-embedding-session! session-id user-id)))
+  ([mcp-session-id user-id encoded-query]
+   (store-handle! mcp-session-id user-id encoded-query nil))
+  ([mcp-session-id user-id encoded-query prompt]
+   (let [core-session-id (:id (get-or-create-embedding-session! mcp-session-id user-id))
          handle-id       (str (UUID/randomUUID))]
      (t2/insert! :model/McpQueryHandle
                  (cond-> {:id              handle-id
-                          :mcp_session_id  session-id
+                          :mcp_session_id  mcp-session-id
                           :core_session_id core-session-id
                           :encoded_query   encoded-query}
                    prompt (assoc :prompt prompt)))
      handle-id)))
 
+(defn- handle-belongs-to-user?
+  "True when `handle-row`'s `core_session_id` resolves to a `core_session` row
+   owned by `user-id`. We never store handles without a `core_session_id`, so a
+   missing or mismatched session means the handle is not the caller's."
+  [handle-row user-id]
+  (when-let [core-session-id (:core_session_id handle-row)]
+    (= user-id (t2/select-one-fn :user_id :core_session :id core-session-id))))
+
+(defn- find-handle-row
+  "Look up the handle row, scoping to handles owned by `user-id` via their
+   `core_session`. Prefers a row stored under the calling `mcp-session-id` and
+   falls back to any other session owned by the same user — that fallback covers
+   harnesses (e.g. ChatGPT) that rotate MCP sessions between tool calls. The
+   handle id is globally unique, and the `core_session` ownership check scopes
+   the lookup to the calling user."
+  [mcp-session-id user-id handle-id]
+  (when (and user-id handle-id)
+    (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id)]
+      (cond
+        (not (handle-belongs-to-user? row user-id)) nil
+        (= mcp-session-id (:mcp_session_id row))    row
+        :else                                       (do (log/debugf
+                                                         "MCP handle %s resolved across sessions for user %s"
+                                                         handle-id user-id)
+                                                        row)))))
+
 (defn read-handle
-  "Return the encoded query for `handle-id` in `session-id`, or nil if no row exists."
-  [session-id handle-id]
-  (t2/select-one-fn :encoded_query :model/McpQueryHandle :id handle-id, :mcp_session_id session-id))
+  "Return the encoded query for `handle-id` owned by `user-id`, or nil if no row
+   exists. Prefers a row stored under `mcp-session-id` but falls back across the
+   user's other sessions; ownership is enforced via the handle's `core_session`."
+  [mcp-session-id user-id handle-id]
+  (:encoded_query (find-handle-row mcp-session-id user-id handle-id)))
 
 (defn resolve-query-handle
-  "Return {:encoded_query ... :prompt ...} for `handle-id`, or nil if not found.
-   Used by visualize_query and execute_query to resolve construct_query handles."
-  [session-id handle-id]
-  (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id, :mcp_session_id session-id)]
+  "Return {:encoded_query ... :prompt ...} for `handle-id` owned by `user-id`, or
+   nil if not found. Used by visualize_query and execute_query to resolve
+   construct_query handles; the lookup prefers `mcp-session-id` and falls back
+   across the user's other sessions."
+  [mcp-session-id user-id handle-id]
+  (when-let [row (find-handle-row mcp-session-id user-id handle-id)]
     (select-keys row [:encoded_query :prompt])))
 
 (defn delete!

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -185,6 +185,17 @@
   (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id, :mcp_session_id session-id)]
     (select-keys row [:encoded_query :prompt])))
 
+(defn verified-widget-session-id
+  "Return `widget-session-id` only if it has a backing `core_session` row owned by
+  `user-id`, otherwise nil. Used to gate the LLM-supplied widgetSessionId override
+  before it's accepted as a handle-lookup key."
+  [widget-session-id user-id]
+  (when (and widget-session-id user-id)
+    (let [key-hashed (session/hash-session-key (derive-embedding-session-key widget-session-id))
+          owner      (t2/select-one-fn :user_id :core_session :key_hashed key-hashed)]
+      (when (= owner user-id)
+        widget-session-id))))
+
 (defn delete!
   "Delete the `core_session` backing this MCP session (if one was ever created)
    and any associated query handles. Scoped to `user-id` so that one user cannot

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -151,8 +151,9 @@
 (defn store-handle!
   "Insert a new handle row binding `encoded-query` to the calling user, and return the handle UUID.
 
-   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and reads can prefer
-   the calling session before falling back across the user's other sessions (see [[resolve-query-handle]]).
+   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and so reads can log
+   when a handle is resolved across sessions (see [[find-handle-row]]) — the read path itself is purely
+   user-scoped, since handle UUIDs are globally unique.
 
    `prompt` is optional, but should be supplied for construct_query handles so visualize_query can later
    return both the query and original user prompt to the MCP iframe for feedback submission."
@@ -173,9 +174,11 @@
      handle-id)))
 
 (defn- find-handle-row
-  "Look up the handle row owned by `user-id`.
-   Prefers a row stored under the calling `mcp-session-id` and falls back to any other session owned
-   by the same user — the fallback covers harnesses (e.g. ChatGPT) that rotate MCP sessions between calls."
+  "Look up the handle row by `handle-id`, scoped to `user-id`.
+   Handle ids are globally unique UUIDs, so the join's `WHERE mqh.id = handle-id` returns at most one
+   row by definition — no ordering or session-preference logic is needed. `mcp-session-id` is recorded
+   on the row only so harnesses that rotate MCP sessions between calls (e.g. ChatGPT) can be logged as
+   cross-session resolutions for telemetry."
   [mcp-session-id user-id handle-id]
   (when (and user-id handle-id)
     ;; Single round-trip: join `mcp_query_handle` to `core_session` and filter on
@@ -194,13 +197,13 @@
 
 (defn read-handle
   "Return the encoded query for `handle-id` owned by `user-id`, or nil if no row exists.
-   Falls back across the user's other sessions when no row matches `mcp-session-id`."
+   Lookup is user-scoped — see [[find-handle-row]] for how `mcp-session-id` is used."
   [mcp-session-id user-id handle-id]
   (:encoded_query (find-handle-row mcp-session-id user-id handle-id)))
 
 (defn resolve-query-handle
   "Return {:encoded_query ... :prompt ...} for `handle-id` owned by `user-id`, or nil.
-   Falls back across the user's other sessions when no row matches `mcp-session-id`."
+   Lookup is user-scoped — see [[find-handle-row]] for how `mcp-session-id` is used."
   [mcp-session-id user-id handle-id]
   (when-let [row (find-handle-row mcp-session-id user-id handle-id)]
     (select-keys row [:encoded_query :prompt])))

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -149,16 +149,14 @@
 ;; encoded query.
 
 (defn store-handle!
-  "Insert a new handle row binding `encoded-query` to the calling user, and return
-   the freshly minted handle UUID.
+  "Insert a new handle row binding `encoded-query` to the calling user, and return the handle UUID.
 
-   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles
-   and reads can prefer the calling session before falling back across the user's
-   other sessions (see [[resolve-query-handle]]).
+   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and reads can
+   prefer the calling session before falling back across the user's other sessions (see
+   [[resolve-query-handle]]).
 
-   `prompt` is optional, but should be supplied for construct_query handles so
-   visualize_query can later return both the query and original user prompt to
-   the MCP iframe for feedback submission."
+   `prompt` is optional, but should be supplied for construct_query handles so visualize_query can
+   later return both the query and original user prompt to the MCP iframe for feedback submission."
   ([mcp-session-id user-id encoded-query]
    (store-handle! mcp-session-id user-id encoded-query nil))
   ([mcp-session-id user-id encoded-query prompt]
@@ -176,13 +174,14 @@
      handle-id)))
 
 (defn- find-handle-row
-  "Look up the handle row owned by `user-id` in a single query, by joining
-   `mcp_query_handle` to `core_session` and filtering on `core_session.user_id`.
-   Prefers a row stored under the calling `mcp-session-id` and falls back to any
-   other session owned by the same user — the fallback covers harnesses (e.g.
-   ChatGPT) that rotate MCP sessions between tool calls."
+  "Look up the handle row owned by `user-id`.
+   Prefers a row stored under the calling `mcp-session-id` and falls back to any other session
+   owned by the same user — the fallback covers harnesses (e.g. ChatGPT) that rotate MCP sessions
+   between tool calls."
   [mcp-session-id user-id handle-id]
   (when (and user-id handle-id)
+    ;; Single round-trip: join `mcp_query_handle` to `core_session` and filter on
+    ;; `core_session.user_id`, so ownership is enforced in the WHERE clause.
     (let [row (t2/select-one :model/McpQueryHandle
                              {:select [:mqh.*]
                               :from   [[:mcp_query_handle :mqh]]

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -152,12 +152,9 @@
   "Insert a new handle row binding `encoded-query` to the calling user, and return
    the freshly minted handle UUID.
 
-   `mcp-session-id` is recorded so that an explicit DELETE /api/mcp can sweep the
-   session's handles, and so reads can prefer the calling session before falling
-   back across the user's other sessions (see [[resolve-query-handle]]). The
-   materialized `core_session` row anchors the FK cascade — handles cascade-delete
-   when their session row is reaped — and carries the `user_id`, which is what
-   we filter on to scope cross-session lookups to the calling user.
+   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles
+   and reads can prefer the calling session before falling back across the user's
+   other sessions (see [[resolve-query-handle]]).
 
    `prompt` is optional, but should be supplied for construct_query handles so
    visualize_query can later return both the query and original user prompt to
@@ -165,6 +162,9 @@
   ([mcp-session-id user-id encoded-query]
    (store-handle! mcp-session-id user-id encoded-query nil))
   ([mcp-session-id user-id encoded-query prompt]
+   ;; Materializing a core_session here serves two purposes: its FK is what
+   ;; makes handles cascade-delete when the session row is reaped, and its
+   ;; user_id is what find-handle-row filters on for cross-session ownership.
    (let [core-session-id (:id (get-or-create-embedding-session! mcp-session-id user-id))
          handle-id       (str (UUID/randomUUID))]
      (t2/insert! :model/McpQueryHandle
@@ -176,22 +176,21 @@
      handle-id)))
 
 (defn- handle-belongs-to-user?
-  "True when `handle-row`'s `core_session_id` resolves to a `core_session` row
-   owned by `user-id`. We never store handles without a `core_session_id`, so a
-   missing or mismatched session means the handle is not the caller's."
+  "True when `handle-row` belongs to `user-id` via its `core_session_id`.
+   Handles without a `core_session_id` are treated as not the caller's."
   [handle-row user-id]
   (when-let [core-session-id (:core_session_id handle-row)]
     (= user-id (t2/select-one-fn :user_id :core_session :id core-session-id))))
 
 (defn- find-handle-row
-  "Look up the handle row, scoping to handles owned by `user-id` via their
-   `core_session`. Prefers a row stored under the calling `mcp-session-id` and
-   falls back to any other session owned by the same user — that fallback covers
-   harnesses (e.g. ChatGPT) that rotate MCP sessions between tool calls. The
-   handle id is globally unique, and the `core_session` ownership check scopes
-   the lookup to the calling user."
+  "Look up the handle row owned by `user-id`.
+   Prefers a row stored under the calling `mcp-session-id` and falls back to any
+   other session owned by the same user — that fallback covers harnesses (e.g.
+   ChatGPT) that rotate MCP sessions between tool calls."
   [mcp-session-id user-id handle-id]
   (when (and user-id handle-id)
+    ;; Global id-only lookup is safe: handle ids are globally unique and the
+    ;; ownership check on the next line rejects rows that aren't the caller's.
     (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id)]
       (cond
         (not (handle-belongs-to-user? row user-id)) nil
@@ -202,17 +201,14 @@
                                                         row)))))
 
 (defn read-handle
-  "Return the encoded query for `handle-id` owned by `user-id`, or nil if no row
-   exists. Prefers a row stored under `mcp-session-id` but falls back across the
-   user's other sessions; ownership is enforced via the handle's `core_session`."
+  "Return the encoded query for `handle-id` owned by `user-id`, or nil if no row exists.
+   Falls back across the user's other sessions when no row matches `mcp-session-id`."
   [mcp-session-id user-id handle-id]
   (:encoded_query (find-handle-row mcp-session-id user-id handle-id)))
 
 (defn resolve-query-handle
-  "Return {:encoded_query ... :prompt ...} for `handle-id` owned by `user-id`, or
-   nil if not found. Used by visualize_query and execute_query to resolve
-   construct_query handles; the lookup prefers `mcp-session-id` and falls back
-   across the user's other sessions."
+  "Return {:encoded_query ... :prompt ...} for `handle-id` owned by `user-id`, or nil.
+   Falls back across the user's other sessions when no row matches `mcp-session-id`."
   [mcp-session-id user-id handle-id]
   (when-let [row (find-handle-row mcp-session-id user-id handle-id)]
     (select-keys row [:encoded_query :prompt])))

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -186,11 +186,10 @@
     (select-keys row [:encoded_query :prompt])))
 
 (defn verified-widget-session-id
-  "Return `widget-session-id` only if it has a backing `core_session` row owned by
-  `user-id`, otherwise nil. Used to gate the LLM-supplied widgetSessionId override
-  before it's accepted as a handle-lookup key."
+  "Return `widget-session-id` only if it looks like a UUID AND has a backing
+  `core_session` row owned by `user-id`, otherwise nil."
   [widget-session-id user-id]
-  (when (and widget-session-id user-id)
+  (when (and user-id (valid-id? widget-session-id))
     (let [key-hashed (session/hash-session-key (derive-embedding-session-key widget-session-id))
           owner      (t2/select-one-fn :user_id :core_session :key_hashed key-hashed)]
       (when (= owner user-id)

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -175,30 +175,25 @@
                    prompt (assoc :prompt prompt)))
      handle-id)))
 
-(defn- handle-belongs-to-user?
-  "True when `handle-row` belongs to `user-id` via its `core_session_id`.
-   Handles without a `core_session_id` are treated as not the caller's."
-  [handle-row user-id]
-  (when-let [core-session-id (:core_session_id handle-row)]
-    (= user-id (t2/select-one-fn :user_id :core_session :id core-session-id))))
-
 (defn- find-handle-row
-  "Look up the handle row owned by `user-id`.
+  "Look up the handle row owned by `user-id` in a single query, by joining
+   `mcp_query_handle` to `core_session` and filtering on `core_session.user_id`.
    Prefers a row stored under the calling `mcp-session-id` and falls back to any
-   other session owned by the same user — that fallback covers harnesses (e.g.
+   other session owned by the same user — the fallback covers harnesses (e.g.
    ChatGPT) that rotate MCP sessions between tool calls."
   [mcp-session-id user-id handle-id]
   (when (and user-id handle-id)
-    ;; Global id-only lookup is safe: handle ids are globally unique and the
-    ;; ownership check on the next line rejects rows that aren't the caller's.
-    (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id)]
-      (cond
-        (not (handle-belongs-to-user? row user-id)) nil
-        (= mcp-session-id (:mcp_session_id row))    row
-        :else                                       (do (log/debugf
-                                                         "MCP handle %s resolved across sessions for user %s"
-                                                         handle-id user-id)
-                                                        row)))))
+    (let [row (t2/select-one :model/McpQueryHandle
+                             {:select [:mqh.*]
+                              :from   [[:mcp_query_handle :mqh]]
+                              :join   [[:core_session :cs] [:= :cs.id :mqh.core_session_id]]
+                              :where  [:and
+                                       [:= :mqh.id handle-id]
+                                       [:= :cs.user_id user-id]]})]
+      (when (and row (not= mcp-session-id (:mcp_session_id row)))
+        (log/debugf "MCP handle %s resolved across sessions for user %s"
+                    handle-id user-id))
+      row)))
 
 (defn read-handle
   "Return the encoded query for `handle-id` owned by `user-id`, or nil if no row exists.

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -185,16 +185,6 @@
   (when-let [row (t2/select-one :model/McpQueryHandle :id handle-id, :mcp_session_id session-id)]
     (select-keys row [:encoded_query :prompt])))
 
-(defn verified-widget-session-id
-  "Return `widget-session-id` only if it looks like a UUID AND has a backing
-  `core_session` row owned by `user-id`, otherwise nil."
-  [widget-session-id user-id]
-  (when (and user-id (valid-id? widget-session-id))
-    (let [key-hashed (session/hash-session-key (derive-embedding-session-key widget-session-id))
-          owner      (t2/select-one-fn :user_id :core_session :key_hashed key-hashed)]
-      (when (= owner user-id)
-        widget-session-id))))
-
 (defn delete!
   "Delete the `core_session` backing this MCP session (if one was ever created)
    and any associated query handles. Scoped to `user-id` so that one user cannot

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -108,33 +108,50 @@
    If :query_handle is present, look it up and replace with :query.
    If :query is itself a UUID (the LLM passed the handle in the wrong field), resolve
    it too — but log a warning so we can track how often this antipattern fires.
+   When the caller provides :widgetSessionId (in the case of ChatGPT, the
+   thread-stable id used to correlate tool calls across rotating MCP sessions),
+   it takes precedence over the current request's MCP session id for handle
+   lookup. Other MCP clients (Claude Desktop, Cursor, …) have stable per-thread
+   sessions and don't need to pass it — the fallback uses the current session id.
    Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
   [session-id tool-name arguments]
-  (cond
-    (:query_handle arguments)
-    (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle session-id (:query_handle arguments))]
-      (-> arguments (dissoc :query_handle) (assoc :query encoded_query))
-      ::handle-not-found)
+  (let [lookup-session-id (or (:widgetSessionId arguments) session-id)]
+    (cond
+      (:query_handle arguments)
+      (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query_handle arguments))]
+        (-> arguments (dissoc :query_handle :widgetSessionId) (assoc :query encoded_query))
+        ::handle-not-found)
 
-    (mcp.session/valid-id? (:query arguments))
-    (do (log/warnf "MCP tool %s: agent passed a UUID handle in :query; resolving as :query_handle"
-                   tool-name)
-        (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle session-id (:query arguments))]
-          (assoc arguments :query encoded_query)
-          ::handle-not-found))
+      (mcp.session/valid-id? (:query arguments))
+      (do (log/warnf "MCP tool %s: agent passed a UUID handle in :query; resolving as :query_handle"
+                     tool-name)
+          (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query arguments))]
+            (-> arguments (dissoc :widgetSessionId) (assoc :query encoded_query))
+            ::handle-not-found))
 
-    :else
-    arguments))
+      :else
+      (dissoc arguments :widgetSessionId))))
 
 (defn- make-store-construct-query-result
   "Build a body-transform fn for construct_query. Stores the base64 payload server-side
    under the calling MCP session and returns {:query_handle uuid} instead of {:query base64},
    so the LLM carries a short opaque UUID rather than the full base64 string.
-   Also stores the optional prompt with the handle, used for submitting feedback on visualizations."
+   Also stores the optional prompt with the handle, used for submitting feedback on visualizations.
+
+   Returns a wrapped shape `{:body … :_meta …}` so the caller can lift `:_meta`
+   onto the MCP tool-call response. The MCP `_meta.openai/widgetSessionId` is
+   the runtime channel ChatGPT uses to correlate tool calls within one chat
+   thread (other MCP clients ignore it); the `:widgetSessionId` field in the
+   structured content is the LLM-visible fallback the model is instructed to
+   pass forward when ChatGPT rotates sessions between tool calls."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]
-      {:query_handle (mcp.session/store-handle! session-id user-id encoded (:prompt body))}
+      (let [handle (mcp.session/store-handle! session-id user-id encoded (:prompt body))]
+        {:body  (cond-> {:query_handle handle}
+                  session-id (assoc :widgetSessionId session-id))
+         :_meta (when session-id
+                  {"openai/widgetSessionId" session-id})})
       body)))
 
 ;; Tools that accept :query_handle as an alternative to a raw base64 :query string.
@@ -211,8 +228,19 @@
         response
 
         (= 200 (:status response))
-        (text-content (cond-> (:body response)
-                        body-transform-fn (body-transform-fn)))
+        (let [body     (cond-> (:body response)
+                         body-transform-fn (body-transform-fn))
+              ;; body-transform-fns can return a wrapped shape
+              ;; `{:body … :_meta …}` to attach an `_meta` block to the MCP
+              ;; tool-call response (used by construct_query for
+              ;; `openai/widgetSessionId`). Detected by *both* keys being
+              ;; present so legitimate bodies that happen to have a `:body`
+              ;; field aren't mis-unwrapped.
+              wrapped? (and (map? body) (contains? body :body) (contains? body :_meta))
+              mcp-body (if wrapped? (:body body) body)
+              mcp-meta (when wrapped? (not-empty (:_meta body)))]
+          (cond-> (text-content mcp-body)
+            mcp-meta (assoc :_meta mcp-meta)))
 
         :else
         (error-content (extract-error-message response))))))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -112,9 +112,10 @@
    for lookup (ChatGPT's thread-continuity hack — see `make-store-construct-query-result`).
    Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
   [session-id tool-name arguments]
-  (let [verified-widget    (mcp.session/verified-widget-session-id
-                            (:widgetSessionId arguments) api/*current-user-id*)
-        lookup-session-id  (or verified-widget session-id)]
+  (let [widget-id          (:widgetSessionId arguments)
+        lookup-session-id  (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
+                             widget-id
+                             session-id)]
     (cond
       (:query_handle arguments)
       (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query_handle arguments))]

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -96,7 +96,9 @@
   (-> malli tools-manifest/malli->json-schema tools-manifest/strict-tool-input-schema))
 
 (defn- apply-schema-overrides
-  "Replace `:inputSchema`/`:outputSchema` on tools whose MCP-visible shape differs from the wire shape."
+  "Replace `:inputSchema`/`:outputSchema` on tools whose MCP-visible shape differs from the wire shape.
+   The `overrides-cover-known-tools-test` test asserts every key here matches a real tool name; a
+   misspelled or drifted key would otherwise silently no-op and leave the wire shape published."
   [tools]
   (mapv (fn [{tool-name :name :as tool}]
           (cond-> tool

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -26,10 +26,10 @@
 
 ;;; ---------------------------- MCP schema overrides -------------------------------
 ;;
-;; A few tools have an MCP-visible input or output shape that differs from the wire
-;; shape declared on the defendpoint. Owning the override here keeps `agent-api`
-;; ignorant of MCP: the endpoint describes its own wire schema, and this layer patches
-;; the manifest to publish the MCP-visible shape.
+;; A few tools have an MCP-visible input or output shape that differs from the wire shape declared
+;; on the defendpoint. Owning the override here keeps `agent-api` ignorant of MCP: the endpoint
+;; describes its own wire schema, and this layer patches the manifest to publish the MCP-visible
+;; shape.
 
 (def ^:private construct-query-mcp-input-malli
   "MCP-visible input for `construct_query`.
@@ -221,14 +221,14 @@
 
 (defn- make-store-construct-query-result
   "Build a body-transform fn for construct_query.
-   The fn stores the base64 payload server-side under the calling user (with the current MCP session
-   id recorded for cleanup) and returns {:query_handle uuid} instead of {:query base64}, so the LLM
-   carries a short opaque UUID rather than the full base64 string.
+   The fn stores the base64 payload server-side under the calling user (with the current MCP session id
+   recorded for cleanup) and returns {:query_handle uuid} instead of {:query base64}, so the LLM carries
+   a short opaque UUID rather than the full base64 string.
    The optional prompt is stored with the handle for later feedback submission.
 
-   The fn validates its emitted shape against `construct-query-mcp-output-malli` — the same schema
-   the manifest publishes as the tool's outputSchema — keeping the published schema and the actual
-   emitted body in lockstep."
+   The fn validates its emitted shape against `construct-query-mcp-output-malli` — the same schema the
+   manifest publishes as the tool's outputSchema — keeping the published schema and the actual emitted
+   body in lockstep."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -142,8 +142,8 @@
         tools))
 
 (defn- generate-manifest
-  "Generate tools manifest from agent API endpoint metadata, then patch input/output schemas for
-  tools whose MCP-visible shape differs from the wire shape."
+  "Generate tools manifest from agent API endpoint metadata, then patch input/output schemas for tools
+  whose MCP-visible shape differs from the wire shape."
   []
   (-> (tools-manifest/generate-tools-manifest
        {'metabase.agent-api.api "/api/agent"})
@@ -283,8 +283,8 @@
 
 (defn- text-content
   "Wrap a value as an MCP tool-call result.
-   Map/sequential values are surfaced as `structuredContent` — MCP spec requires this for any tool
-   that declares an `outputSchema`.
+   Map/sequential values are surfaced as `structuredContent` — MCP spec requires this for any tool that
+   declares an `outputSchema`.
    The `content` array carries a text serialization for clients that don't consume structuredContent."
   [v]
   (cond-> {:content [{:type "text" :text (if (string? v) v (json/encode v))}]}
@@ -399,6 +399,31 @@
     (invoke-agent-api method api-path token-scopes remaining-args
                       :body-transform-fn body-transform-fn)))
 
+;; --- Design note: centralized null-stripping at the MCP boundary --------------------------------
+;; The MCP inputSchema we publish makes every optional field required-and-nullable, because strict
+;; MCP clients (notably ChatGPT) cannot represent absent fields — they always send every property
+;; the schema declares, with `null` for the ones the agent doesn't want to populate. We strip
+;; those nulls here so each downstream tool handler can use ordinary Clojure idioms (destructure
+;; `:or` defaults, `(when foo …)`, etc.) and treat missing and null identically.
+;;
+;; The alternative is per-tool auditing: every endpoint handler would need to coerce nil into the
+;; right default, and every wire schema's dispatch logic would need to tolerate explicit nulls. We
+;; chose centralization because (a) it's the layer that creates the strict-validator artifact, and
+;; (b) the codex review found that `query`'s `:multi` dispatch on `:continuation_token` already
+;; mishandled a client-sent `null`, so per-tool handling is easy to miss.
+;;
+;; TRADE-OFF: as a consequence, a top-level `null` argument is indistinguishable from omitted at
+;; the MCP boundary. If we ever expose a tool whose semantics genuinely require `null` to mean
+;; something different from "missing" (e.g. \"clear this field\" semantics), it must either model
+;; the distinction with a sentinel value (`{:clear true}`) or do the bespoke handling before this
+;; normalization runs (e.g. as a pre-processing step inside `call-tool`).
+(defn- drop-nil-args
+  "Strip nil-valued top-level keys from MCP tool arguments.
+   Nested values are left alone — the strict-tool transform only rewrites top-level properties."
+  [arguments]
+  (when arguments
+    (into {} (remove (comp nil? val)) arguments)))
+
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.
    `token-scopes` from the original MCP session are propagated to the synthetic
@@ -407,20 +432,21 @@
    as opts in case a tool needs to scope reads to the calling MCP session.
    Returns MCP content on success, or error content on failure."
   [token-scopes session-id tool-name arguments]
-  (if-let [ui-tool (some #(when (= tool-name (:name %)) %) (mcp.resources/list-ui-tools))]
-    (if-not (mcp.scope/matches? token-scopes (:scope ui-tool))
-      (error-content (str "Insufficient scope to call tool: " tool-name))
-      ((:response-fn ui-tool) arguments {:session-id session-id}))
-    (if-let [tool-def (get (tool-index) tool-name)]
-      (if-not (mcp.scope/matches? token-scopes (:scope tool-def))
+  (let [arguments (drop-nil-args arguments)]
+    (if-let [ui-tool (some #(when (= tool-name (:name %)) %) (mcp.resources/list-ui-tools))]
+      (if-not (mcp.scope/matches? token-scopes (:scope ui-tool))
         (error-content (str "Insufficient scope to call tool: " tool-name))
-        (let [arguments (if (tools-accepting-query-handle tool-name)
-                          (resolve-query-arg session-id tool-name arguments)
-                          arguments)]
-          (if (= arguments ::handle-not-found)
-            (error-content "Query handle not found. The query may have expired — try running construct_query again.")
-            (try
-              (dispatch-via-agent-api tool-def arguments token-scopes session-id)
-              (catch Exception e
-                (error-content (or (ex-message e) "Internal error")))))))
-      (error-content (str "Unknown tool: " tool-name)))))
+        ((:response-fn ui-tool) arguments {:session-id session-id}))
+      (if-let [tool-def (get (tool-index) tool-name)]
+        (if-not (mcp.scope/matches? token-scopes (:scope tool-def))
+          (error-content (str "Insufficient scope to call tool: " tool-name))
+          (let [arguments (if (tools-accepting-query-handle tool-name)
+                            (resolve-query-arg session-id tool-name arguments)
+                            arguments)]
+            (if (= arguments ::handle-not-found)
+              (error-content "Query handle not found. The query may have expired — try running construct_query again.")
+              (try
+                (dispatch-via-agent-api tool-def arguments token-scopes session-id)
+                (catch Exception e
+                  (error-content (or (ex-message e) "Internal error")))))))
+        (error-content (str "Unknown tool: " tool-name))))))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -31,27 +31,39 @@
 ;; describes its own wire schema, and this layer patches the manifest to publish the MCP-visible
 ;; shape.
 
+;; Shared sub-shapes for the program-shaped tools (`construct_query`, `query`). Extracted so the two
+;; tools can't drift on what a program looks like to the LLM — both reuse the same `:source` map and
+;; the same flattened `:operations` (`[:sequential [:sequential :any]]`, no tuple-of-anys, no `:and`).
+;; The wire schemas under `agent_api` use the precise tuple/composite grammar; this layer publishes
+;; the permissive variant strict MCP clients (ChatGPT) accept.
+
+(def ^:private program-source-malli
+  [:map
+   [:type {:tool/description "Entity kind."}
+    [:enum "table" "card" "dataset" "metric"]]
+   [:id ms/PositiveInt]])
+
+(def ^:private program-operations-malli
+  [:sequential
+   [:sequential
+    {:tool/description (str "First element is the operator string; remaining "
+                            "elements are operator-specific arguments (scalars, "
+                            "references, or nested arrays).")}
+    :any]])
+
+(def ^:private operations-description
+  (str "Array of operator tuples like [\"filter\", clause] or [\"aggregate\", agg-clause]. "
+       "See metabase://docs/construct-query.md for the full grammar."))
+
 (def ^:private construct-query-mcp-input-malli
   "MCP-visible input for `construct_query`.
   Deliberately flatter than the wire schema — the operator/ref grammar is conveyed through the tool
   description and the construct-query.md MCP resource, not the schema."
   [:map
-   [:source
-    {:tool/description "Database entity to query."}
-    [:map
-     [:type {:tool/description "Entity kind."}
-      [:enum "table" "card" "dataset" "metric"]]
-     [:id ms/PositiveInt]]]
-   [:operations
-    {:tool/description (str "Array of operator tuples like [\"filter\", clause] or "
-                            "[\"aggregate\", agg-clause]. See metabase://docs/construct-query.md "
-                            "for the full grammar.")}
-    [:sequential
-     [:sequential
-      {:tool/description (str "First element is the operator string; remaining "
-                              "elements are operator-specific arguments (scalars, "
-                              "references, or nested arrays).")}
-      :any]]]
+   [:source     {:tool/description "Database entity to query."}
+    program-source-malli]
+   [:operations {:tool/description operations-description}
+    program-operations-malli]
    ;; Length bounds + description go on the inner `:string` so they end up on the JSON Schema branch
    ;; (and not as an `:allOf`, which ChatGPT's strict validator rejects).
    [:prompt {:optional true}
@@ -59,6 +71,25 @@
                       :max               10000
                       :tool/description  (str "The user's exact original message, when available. "
                                               "Pass it as-is without summarizing or rewriting.")}]]]])
+
+(def ^:private query-mcp-input-malli
+  "MCP-visible input for `query`. The wire body is a `:multi` whose `:program` branch references
+  agent-lib tuple/composite schemas — those emit `prefixItems`/`allOf` JSON Schema constructs that
+  strict MCP clients (ChatGPT) reject. This override publishes the same flattened program shape used
+  by `construct_query`, plus the `:continuation_token` alternative for pagination."
+  [:map
+   [:source             {:optional true
+                         :tool/description (str "Database entity to query. Omit when paginating via "
+                                                "`continuation_token`.")}
+    [:maybe program-source-malli]]
+   [:operations         {:optional true
+                         :tool/description operations-description}
+    [:maybe program-operations-malli]]
+   [:continuation_token {:optional true
+                         :tool/description (str "Token returned by a previous `query` response — pass "
+                                                "it back to fetch the next page. Mutually exclusive "
+                                                "with `source`/`operations`.")}
+    [:maybe ms/NonBlankString]]])
 
 (def ^:private execute-query-mcp-input-malli
   "MCP-visible input for `execute_query`.
@@ -85,6 +116,7 @@
 (def ^:private mcp-input-overrides
   "tool-name → Malli schema. Replaces the manifest's derived `:inputSchema`."
   {"construct_query" construct-query-mcp-input-malli
+   "query"           query-mcp-input-malli
    "execute_query"   execute-query-mcp-input-malli})
 
 (def ^:private mcp-output-overrides

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -159,9 +159,13 @@
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
-  "Wrap a value as MCP text content."
+  "Wrap a value as an MCP tool-call result. Map/sequential values are surfaced
+  as `structuredContent` — MCP spec requires this for any tool that declares an
+  `outputSchema`. The `content` array carries a text serialization for clients
+  that don't consume structuredContent."
   [v]
-  {:content [{:type "text" :text (if (string? v) v (json/encode v))}]})
+  (cond-> {:content [{:type "text" :text (if (string? v) v (json/encode v))}]}
+    (or (map? v) (sequential? v)) (assoc :structuredContent v)))
 
 (defn- error-content
   "Wrap an error message as MCP error content."

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -46,7 +46,7 @@
     (into []
           (comp (filter #(mcp.scope/matches? token-scopes (:scope %)))
                 (map (fn [tool]
-                       (select-keys tool [:name :title :description :inputSchema :annotations :_meta]))))
+                       (select-keys tool [:name :title :description :inputSchema :outputSchema :annotations :_meta]))))
           (concat tools (mcp.resources/list-ui-tools)))))
 
 (defn- build-tool-index

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -24,44 +24,96 @@
 
 (set! *warn-on-reflection* true)
 
-;;; ---------------------------- MCP outputSchema overrides -------------------------------
+;;; ---------------------------- MCP schema overrides -------------------------------
 ;;
-;; A few tools body-transform the endpoint response on the MCP boundary (see
-;; `make-store-construct-query-result`), so the MCP-visible shape differs from the
-;; endpoint's `:response-schema`. Owning the override here keeps `agent-api` ignorant
-;; of MCP: the endpoint describes the wire shape, and this layer publishes the shape
-;; MCP clients actually see. The body-transform validates against the same Malli
-;; schema so the published manifest and the emitted body can't drift apart.
+;; A few tools have an MCP-visible input or output shape that differs from the wire
+;; shape declared on the defendpoint. Owning the override here keeps `agent-api`
+;; ignorant of MCP: the endpoint describes its own wire schema, and this layer patches
+;; the manifest to publish the MCP-visible shape.
+
+(def ^:private construct-query-mcp-input-malli
+  "MCP-visible input for `construct_query`.
+  Deliberately flatter than the wire schema — the operator/ref grammar is conveyed through the tool
+  description and the construct-query.md MCP resource, not the schema."
+  [:map
+   [:source
+    {:tool/description "Database entity to query."}
+    [:map
+     [:type {:tool/description "Entity kind."}
+      [:enum "table" "card" "dataset" "metric"]]
+     [:id ms/PositiveInt]]]
+   [:operations
+    {:tool/description (str "Array of operator tuples like [\"filter\", clause] or "
+                            "[\"aggregate\", agg-clause]. See metabase://docs/construct-query.md "
+                            "for the full grammar.")}
+    [:sequential
+     [:sequential
+      {:tool/description (str "First element is the operator string; remaining "
+                              "elements are operator-specific arguments (scalars, "
+                              "references, or nested arrays).")}
+      :any]]]
+   ;; Length bounds + description go on the inner `:string` so they end up on the JSON Schema branch
+   ;; (and not as an `:allOf`, which ChatGPT's strict validator rejects).
+   [:prompt {:optional true}
+    [:maybe [:string {:min               1
+                      :max               10000
+                      :tool/description  (str "The user's exact original message, when available. "
+                                              "Pass it as-is without summarizing or rewriting.")}]]]])
+
+(def ^:private execute-query-mcp-input-malli
+  "MCP-visible input for `execute_query`.
+  The wire endpoint requires `:query`; the MCP tool also accepts `:query_handle`, resolved by
+  [[resolve-query-arg]] before dispatch."
+  [:map
+   [:query {:optional true
+            :tool/description "Base64-encoded MBQL query. Use `query_handle` instead when available."}
+    [:maybe ms/NonBlankString]]
+   [:query_handle {:optional true
+                   :tool/description "Handle returned by construct_query — preferred over raw `query`."}
+    [:maybe ms/UUIDString]]])
 
 (def ^:private construct-query-mcp-output-malli
   "MCP-visible output of `construct_query`.
-   The agent_api endpoint returns `{:query base64}`; the MCP body transform stores
-   that and emits `{:query_handle}`."
+   The agent_api endpoint returns `{:query base64}`; the MCP body transform stores that and emits
+   `{:query_handle}`."
   [:map
    [:query_handle
-    {:tool/description "Opaque UUID handle for the stored query. Pass as `query_handle` to `execute_query` or `visualize_query`."}
+    {:tool/description (str "Opaque UUID handle for the stored query. "
+                            "Pass as `query_handle` to `execute_query` or `visualize_query`.")}
     ms/UUIDString]])
 
+(def ^:private mcp-input-overrides
+  "tool-name → Malli schema. Replaces the manifest's derived `:inputSchema`."
+  {"construct_query" construct-query-mcp-input-malli
+   "execute_query"   execute-query-mcp-input-malli})
+
 (def ^:private mcp-output-overrides
-  "tool-name → Malli schema. Applied to the tools-manifest output before publishing."
+  "tool-name → Malli schema. Replaces the manifest's derived `:outputSchema`."
   {"construct_query" construct-query-mcp-output-malli})
 
-(defn- apply-output-overrides
-  "Replace `:outputSchema` on tools that body-transform their endpoint response."
+(defn- override->input-json-schema [malli tool-name]
+  (tools-manifest/assert-optional-fields-nullable! malli tool-name)
+  (-> malli tools-manifest/malli->json-schema tools-manifest/strict-tool-input-schema))
+
+(defn- apply-schema-overrides
+  "Replace `:inputSchema`/`:outputSchema` on tools whose MCP-visible shape differs from the wire shape."
   [tools]
-  (mapv (fn [tool]
-          (if-let [override (mcp-output-overrides (:name tool))]
-            (assoc tool :outputSchema (tools-manifest/malli->json-schema override))
-            tool))
+  (mapv (fn [{tool-name :name :as tool}]
+          (cond-> tool
+            (mcp-input-overrides tool-name)
+            (assoc :inputSchema (override->input-json-schema (mcp-input-overrides tool-name) tool-name))
+
+            (mcp-output-overrides tool-name)
+            (assoc :outputSchema (tools-manifest/malli->json-schema (mcp-output-overrides tool-name)))))
         tools))
 
 (defn- generate-manifest
-  "Generate tools manifest from agent API endpoint metadata, then patch outputSchemas
-  for tools whose MCP body transform reshapes the endpoint response."
+  "Generate tools manifest from agent API endpoint metadata, then patch input/output schemas for
+  tools whose MCP-visible shape differs from the wire shape."
   []
   (-> (tools-manifest/generate-tools-manifest
        {'metabase.agent-api.api "/api/agent"})
-      (update :tools apply-output-overrides)))
+      (update :tools apply-schema-overrides)))
 
 (def ^:private manifest-delay
   (delay (generate-manifest)))
@@ -169,15 +221,14 @@
 
 (defn- make-store-construct-query-result
   "Build a body-transform fn for construct_query.
-   The fn stores the base64 payload server-side under the calling user (with the
-   current MCP session id recorded for cleanup) and returns {:query_handle uuid}
-   instead of {:query base64}, so the LLM carries a short opaque UUID rather than
-   the full base64 string.
+   The fn stores the base64 payload server-side under the calling user (with the current MCP session
+   id recorded for cleanup) and returns {:query_handle uuid} instead of {:query base64}, so the LLM
+   carries a short opaque UUID rather than the full base64 string.
    The optional prompt is stored with the handle for later feedback submission.
 
-   The fn validates its emitted shape against `construct-query-mcp-output-malli` —
-   the same schema the manifest publishes as the tool's outputSchema — keeping the
-   published schema and the actual emitted body in lockstep."
+   The fn validates its emitted shape against `construct-query-mcp-output-malli` — the same schema
+   the manifest publishes as the tool's outputSchema — keeping the published schema and the actual
+   emitted body in lockstep."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]
@@ -198,10 +249,9 @@
 
 (defn- text-content
   "Wrap a value as an MCP tool-call result.
-   Map/sequential values are surfaced as `structuredContent` — MCP spec requires this
-   for any tool that declares an `outputSchema`.
-   The `content` array carries a text serialization for clients that don't consume
-   structuredContent."
+   Map/sequential values are surfaced as `structuredContent` — MCP spec requires this for any tool
+   that declares an `outputSchema`.
+   The `content` array carries a text serialization for clients that don't consume structuredContent."
   [v]
   (cond-> {:content [{:type "text" :text (if (string? v) v (json/encode v))}]}
     (or (map? v) (sequential? v)) (assoc :structuredContent v)))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -15,7 +15,8 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli.registry :as mr])
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms])
   (:import
    (java.io ByteArrayOutputStream)
    (java.net URLEncoder)
@@ -23,11 +24,44 @@
 
 (set! *warn-on-reflection* true)
 
+;;; ---------------------------- MCP outputSchema overrides -------------------------------
+;;
+;; A few tools body-transform the endpoint response on the MCP boundary (see
+;; `make-store-construct-query-result`), so the MCP-visible shape differs from the
+;; endpoint's `:response-schema`. Owning the override here keeps `agent-api` ignorant
+;; of MCP: the endpoint describes the wire shape, and this layer publishes the shape
+;; MCP clients actually see. The body-transform validates against the same Malli
+;; schema so the published manifest and the emitted body can't drift apart.
+
+(def ^:private construct-query-mcp-output-malli
+  "MCP-visible output of `construct_query`.
+   The agent_api endpoint returns `{:query base64}`; the MCP body transform stores
+   that and emits `{:query_handle}`."
+  [:map
+   [:query_handle
+    {:tool/description "Opaque UUID handle for the stored query. Pass as `query_handle` to `execute_query` or `visualize_query`."}
+    ms/UUIDString]])
+
+(def ^:private mcp-output-overrides
+  "tool-name → Malli schema. Applied to the tools-manifest output before publishing."
+  {"construct_query" construct-query-mcp-output-malli})
+
+(defn- apply-output-overrides
+  "Replace `:outputSchema` on tools that body-transform their endpoint response."
+  [tools]
+  (mapv (fn [tool]
+          (if-let [override (mcp-output-overrides (:name tool))]
+            (assoc tool :outputSchema (tools-manifest/malli->json-schema override))
+            tool))
+        tools))
+
 (defn- generate-manifest
-  "Generate tools manifest from agent API endpoint metadata."
+  "Generate tools manifest from agent API endpoint metadata, then patch outputSchemas
+  for tools whose MCP body transform reshapes the endpoint response."
   []
-  (tools-manifest/generate-tools-manifest
-   {'metabase.agent-api.api "/api/agent"}))
+  (-> (tools-manifest/generate-tools-manifest
+       {'metabase.agent-api.api "/api/agent"})
+      (update :tools apply-output-overrides)))
 
 (def ^:private manifest-delay
   (delay (generate-manifest)))
@@ -108,10 +142,7 @@
   "Resolve the query argument for tools that accept a handle.
    If :query_handle is present, look it up and replace with :query.
    If :query is itself a UUID (the LLM passed the handle in the wrong field), resolve
-   it too — but log a warning so we can track how often this antipattern fires.
-   Handles are scoped to the calling user; [[mcp.session/resolve-query-handle]]
-   prefers the current MCP session before falling back across the user's other
-   sessions, so harnesses that rotate session ids between calls still resolve.
+   it too (and log a warning).
    Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
   [session-id tool-name arguments]
   (let [user-id api/*current-user-id*]
@@ -134,18 +165,19 @@
       arguments)))
 
 (def ^:private construct-query-output-validator
-  (mr/validator agent-api/construct-query-tool-output-malli))
+  (mr/validator construct-query-mcp-output-malli))
 
 (defn- make-store-construct-query-result
-  "Build a body-transform fn for construct_query. Stores the base64 payload server-side
-   under the calling user (with the current MCP session id recorded for cleanup) and
-   returns {:query_handle uuid} instead of {:query base64}, so the LLM carries a short
-   opaque UUID rather than the full base64 string. Also stores the optional prompt
-   with the handle, used for submitting feedback on visualizations.
+  "Build a body-transform fn for construct_query.
+   The fn stores the base64 payload server-side under the calling user (with the
+   current MCP session id recorded for cleanup) and returns {:query_handle uuid}
+   instead of {:query base64}, so the LLM carries a short opaque UUID rather than
+   the full base64 string.
+   The optional prompt is stored with the handle for later feedback submission.
 
-   Validates the emitted shape against `agent-api/construct-query-tool-output-malli`
-   — the same schema the manifest publishes as the tool's outputSchema — so the
-   published schema and the actual emitted body stay in lockstep."
+   The fn validates its emitted shape against `construct-query-mcp-output-malli` —
+   the same schema the manifest publishes as the tool's outputSchema — keeping the
+   published schema and the actual emitted body in lockstep."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]
@@ -165,10 +197,11 @@
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
-  "Wrap a value as an MCP tool-call result. Map/sequential values are surfaced
-  as `structuredContent` — MCP spec requires this for any tool that declares an
-  `outputSchema`. The `content` array carries a text serialization for clients
-  that don't consume structuredContent."
+  "Wrap a value as an MCP tool-call result.
+   Map/sequential values are surfaced as `structuredContent` — MCP spec requires this
+   for any tool that declares an `outputSchema`.
+   The `content` array carries a text serialization for clients that don't consume
+   structuredContent."
   [v]
   (cond-> {:content [{:type "text" :text (if (string? v) v (json/encode v))}]}
     (or (map? v) (sequential? v)) (assoc :structuredContent v)))

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -108,14 +108,13 @@
    If :query_handle is present, look it up and replace with :query.
    If :query is itself a UUID (the LLM passed the handle in the wrong field), resolve
    it too — but log a warning so we can track how often this antipattern fires.
-   When the caller provides :widgetSessionId (in the case of ChatGPT, the
-   thread-stable id used to correlate tool calls across rotating MCP sessions),
-   it takes precedence over the current request's MCP session id for handle
-   lookup. Other MCP clients (Claude Desktop, Cursor, …) have stable per-thread
-   sessions and don't need to pass it — the fallback uses the current session id.
+   :widgetSessionId, when provided, overrides the current request's session id
+   for lookup (ChatGPT's thread-continuity hack — see `make-store-construct-query-result`).
    Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
   [session-id tool-name arguments]
-  (let [lookup-session-id (or (:widgetSessionId arguments) session-id)]
+  (let [verified-widget    (mcp.session/verified-widget-session-id
+                            (:widgetSessionId arguments) api/*current-user-id*)
+        lookup-session-id  (or verified-widget session-id)]
     (cond
       (:query_handle arguments)
       (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query_handle arguments))]
@@ -138,12 +137,10 @@
    so the LLM carries a short opaque UUID rather than the full base64 string.
    Also stores the optional prompt with the handle, used for submitting feedback on visualizations.
 
-   Returns a wrapped shape `{:body … :_meta …}` so the caller can lift `:_meta`
-   onto the MCP tool-call response. The MCP `_meta.openai/widgetSessionId` is
-   the runtime channel ChatGPT uses to correlate tool calls within one chat
-   thread (other MCP clients ignore it); the `:widgetSessionId` field in the
-   structured content is the LLM-visible fallback the model is instructed to
-   pass forward when ChatGPT rotates sessions between tool calls."
+   Returns `{:body … :_meta …}` so the caller can lift `:_meta` onto the MCP
+   tool-call response. Both `_meta.openai/widgetSessionId` and the
+   `:widgetSessionId` field in `structuredContent` carry the session id forward
+   so ChatGPT can correlate handles across its rotated MCP sessions."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -14,7 +14,8 @@
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
    [metabase.util.json :as json]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.malli.registry :as mr])
   (:import
    (java.io ByteArrayOutputStream)
    (java.net URLEncoder)
@@ -108,48 +109,53 @@
    If :query_handle is present, look it up and replace with :query.
    If :query is itself a UUID (the LLM passed the handle in the wrong field), resolve
    it too — but log a warning so we can track how often this antipattern fires.
-   :widgetSessionId, when provided, overrides the current request's session id
-   for lookup (ChatGPT's thread-continuity hack — see `make-store-construct-query-result`).
+   Handles are scoped to the calling user; [[mcp.session/resolve-query-handle]]
+   prefers the current MCP session before falling back across the user's other
+   sessions, so harnesses that rotate session ids between calls still resolve.
    Returns updated arguments, or ::handle-not-found if the handle doesn't exist."
   [session-id tool-name arguments]
-  (let [widget-id          (:widgetSessionId arguments)
-        lookup-session-id  (if (and widget-id (mcp.session/owned-by-user? widget-id api/*current-user-id*))
-                             widget-id
-                             session-id)]
+  (let [user-id api/*current-user-id*]
     (cond
       (:query_handle arguments)
-      (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query_handle arguments))]
-        (-> arguments (dissoc :query_handle :widgetSessionId) (assoc :query encoded_query))
+      (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle
+                                        session-id user-id (:query_handle arguments))]
+        (-> arguments (dissoc :query_handle) (assoc :query encoded_query))
         ::handle-not-found)
 
       (mcp.session/valid-id? (:query arguments))
       (do (log/warnf "MCP tool %s: agent passed a UUID handle in :query; resolving as :query_handle"
                      tool-name)
-          (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle lookup-session-id (:query arguments))]
-            (-> arguments (dissoc :widgetSessionId) (assoc :query encoded_query))
+          (if-let [{:keys [encoded_query]} (mcp.session/resolve-query-handle
+                                            session-id user-id (:query arguments))]
+            (assoc arguments :query encoded_query)
             ::handle-not-found))
 
       :else
-      (dissoc arguments :widgetSessionId))))
+      arguments)))
+
+(def ^:private construct-query-output-validator
+  (mr/validator agent-api/construct-query-tool-output-malli))
 
 (defn- make-store-construct-query-result
   "Build a body-transform fn for construct_query. Stores the base64 payload server-side
-   under the calling MCP session and returns {:query_handle uuid} instead of {:query base64},
-   so the LLM carries a short opaque UUID rather than the full base64 string.
-   Also stores the optional prompt with the handle, used for submitting feedback on visualizations.
+   under the calling user (with the current MCP session id recorded for cleanup) and
+   returns {:query_handle uuid} instead of {:query base64}, so the LLM carries a short
+   opaque UUID rather than the full base64 string. Also stores the optional prompt
+   with the handle, used for submitting feedback on visualizations.
 
-   Returns `{:body … :_meta …}` so the caller can lift `:_meta` onto the MCP
-   tool-call response. Both `_meta.openai/widgetSessionId` and the
-   `:widgetSessionId` field in `structuredContent` carry the session id forward
-   so ChatGPT can correlate handles across its rotated MCP sessions."
+   Validates the emitted shape against `agent-api/construct-query-tool-output-malli`
+   — the same schema the manifest publishes as the tool's outputSchema — so the
+   published schema and the actual emitted body stay in lockstep."
   [session-id user-id]
   (fn [body]
     (if-let [encoded (:query body)]
-      (let [handle (mcp.session/store-handle! session-id user-id encoded (:prompt body))]
-        {:body  (cond-> {:query_handle handle}
-                  session-id (assoc :widgetSessionId session-id))
-         :_meta (when session-id
-                  {"openai/widgetSessionId" session-id})})
+      (let [handle   (mcp.session/store-handle! session-id user-id encoded (:prompt body))
+            new-body {:query_handle handle}]
+        (when-not (construct-query-output-validator new-body)
+          (throw (ex-info (str "construct_query body transform produced a shape that doesn't "
+                               "match the declared outputSchema")
+                          {:body new-body})))
+        new-body)
       body)))
 
 ;; Tools that accept :query_handle as an alternative to a raw base64 :query string.
@@ -230,19 +236,8 @@
         response
 
         (= 200 (:status response))
-        (let [body     (cond-> (:body response)
-                         body-transform-fn (body-transform-fn))
-              ;; body-transform-fns can return a wrapped shape
-              ;; `{:body … :_meta …}` to attach an `_meta` block to the MCP
-              ;; tool-call response (used by construct_query for
-              ;; `openai/widgetSessionId`). Detected by *both* keys being
-              ;; present so legitimate bodies that happen to have a `:body`
-              ;; field aren't mis-unwrapped.
-              wrapped? (and (map? body) (contains? body :body) (contains? body :_meta))
-              mcp-body (if wrapped? (:body body) body)
-              mcp-meta (when wrapped? (not-empty (:_meta body)))]
-          (cond-> (text-content mcp-body)
-            mcp-meta (assoc :_meta mcp-meta)))
+        (text-content (cond-> (:body response)
+                        body-transform-fn (body-transform-fn)))
 
         :else
         (error-content (extract-error-message response))))))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -60,20 +60,27 @@
   the original request was HTTPS; if sent in response to an HTTP request, this is simply ignored)"
   {"Strict-Transport-Security" "max-age=31536000"})
 
-(defn parse-url
-  "Returns an object with protocol, domain and port for the given url"
+(defn try-parse-url
+  "Like `parse-url` but returns nil silently on unparsable input. Use this when
+   the caller is parsing client-controlled data (e.g. `Origin`/`Host` headers)
+   where bad input is expected and shouldn't fill the error logs."
   [url]
   (if (= url "*")
     {:protocol nil :domain "*" :port "*"}
     ;; Pattern supports both regular hostnames/IPv4 and bracketed IPv6 addresses like [::1]
     (let [pattern #"^(?:(https?|app|capacitor)://)?(\[[^\]]+\]|[^:/]+)(?::(\d+|\*))?$"
-          matches (re-matches pattern url)]
-      (if-not matches
-        (do (log/errorf "Invalid URL: %s" url) nil)
-        (let [[_ protocol domain port] matches]
-          {:protocol protocol
-           :domain domain
-           :port port})))))
+          [_ protocol domain port] (re-matches pattern url)]
+      (when domain
+        {:protocol protocol :domain domain :port port}))))
+
+(defn parse-url
+  "Returns an object with protocol, domain and port for the given url. Logs an
+   error when the input doesn't parse — appropriate for server-side config (where
+   bad input indicates a misconfiguration). For client-controlled input prefer
+   [[try-parse-url]]."
+  [url]
+  (or (try-parse-url url)
+      (do (log/errorf "Invalid URL: %s" url) nil)))
 
 (defn- add-wildcard-entries
   "Adds a wildcard prefix `.*` to the domain part of the given `domain-or-url` string.

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -61,9 +61,9 @@
   {"Strict-Transport-Security" "max-age=31536000"})
 
 (defn try-parse-url
-  "Like `parse-url` but returns nil silently on unparsable input. Use this when
-   the caller is parsing client-controlled data (e.g. `Origin`/`Host` headers)
-   where bad input is expected and shouldn't fill the error logs."
+  "Like `parse-url` but returns nil silently on unparsable input. Use this when the caller is parsing
+   client-controlled data (e.g. `Origin`/`Host` headers) where bad input is expected and shouldn't
+   fill the error logs."
   [url]
   (if (= url "*")
     {:protocol nil :domain "*" :port "*"}
@@ -74,10 +74,9 @@
         {:protocol protocol :domain domain :port port}))))
 
 (defn parse-url
-  "Returns an object with protocol, domain and port for the given url. Logs an
-   error when the input doesn't parse — appropriate for server-side config (where
-   bad input indicates a misconfiguration). For client-controlled input prefer
-   [[try-parse-url]]."
+  "Returns an object with protocol, domain and port for the given url. Logs an error when the input
+   doesn't parse — appropriate for server-side config (where bad input indicates a misconfiguration).
+   For client-controlled input prefer [[try-parse-url]]."
   [url]
   (or (try-parse-url url)
       (do (log/errorf "Invalid URL: %s" url) nil)))

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -233,9 +233,9 @@
                                :properties {:id {:type "integer"}}
                                :required   [:id]
                                :additionalProperties false}
-              :responseSchema {:type       "object"
-                               :properties {:name {:type "string"}}
-                               :required   [:name]}
+              :outputSchema {:type       "object"
+                             :properties {:name {:type "string"}}
+                             :required   [:name]}
               :annotations    {:readOnlyHint   true
                                :idempotentHint true}}
              result))))
@@ -456,9 +456,9 @@
                                                 :description "Maximum number of results to return"}}
                            :required   [:q :limit]
                            :additionalProperties false}
-          :responseSchema {:type       "object"
-                           :properties {:results {:type "array" :items {:type "string"}}}
-                           :required   [:results]}}
+          :outputSchema {:type       "object"
+                         :properties {:results {:type "array" :items {:type "string"}}}
+                         :required   [:results]}}
          (test-tool "test_search"))))
 
 (deftest ^:parallel generate-tools-manifest-post-with-task-support-test
@@ -472,11 +472,11 @@
                                         :action {:type "string"}}
                            :required   [:id :action]
                            :additionalProperties false}
-          :responseSchema {:type       "object"
-                           :properties {:id     {:type "integer"}
-                                        :status {:type "string"
-                                                 :enum ["active" "inactive" "pending"]}}
-                           :required   [:id :status]}
+          :outputSchema {:type       "object"
+                         :properties {:id     {:type "integer"}
+                                      :status {:type "string"
+                                               :enum ["active" "inactive" "pending"]}}
+                         :required   [:id :status]}
           :execution      {:taskSupport "parallel"}}
          (test-tool "test_resource_action"))))
 

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -8,37 +8,44 @@
 
 (deftest ^:parallel infer-annotations-test
   (testing "GET defaults"
-    (is (= {:annotations {:readOnlyHint true :idempotentHint true}
+    (is (= {:annotations {:readOnlyHint true :idempotentHint true :destructiveHint false :openWorldHint false}
             :redundant   {}}
            (tools-manifest/infer-annotations :get nil))))
   (testing "DELETE defaults"
-    (is (= {:annotations {:destructiveHint true :idempotentHint true}
+    (is (= {:annotations {:destructiveHint true :idempotentHint true :readOnlyHint false :openWorldHint false}
             :redundant   {}}
            (tools-manifest/infer-annotations :delete nil))))
   (testing "PUT defaults"
-    (is (= {:annotations {:destructiveHint false :idempotentHint true}
+    (is (= {:annotations {:destructiveHint false :idempotentHint true :readOnlyHint false :openWorldHint false}
             :redundant   {}}
            (tools-manifest/infer-annotations :put nil))))
   (testing "POST defaults to non-destructive (opt in with :destructive? true)"
-    (is (= {:annotations {:destructiveHint false} :redundant {}}
+    (is (= {:annotations {:destructiveHint false :readOnlyHint false :openWorldHint false}
+            :redundant   {}}
            (tools-manifest/infer-annotations :post nil)))
     (is (= {:destructive? false}
            (:redundant (tools-manifest/infer-annotations :post {:destructive? false})))))
-  (testing "destructiveHint is dropped from output when readOnlyHint is true (per MCP spec it's only meaningful for non-read-only tools)"
-    (is (= {:readOnlyHint true}
+  (testing "destructiveHint is dropped from output when readOnlyHint is true (per MCP spec it's only meaningful for non-read-only tools), then re-added as false by the required-hint defaults"
+    (is (= {:readOnlyHint true :destructiveHint false :openWorldHint false}
            (:annotations (tools-manifest/infer-annotations :post {:read-only? true})))))
   (testing "Flags :contradictory? when readOnlyHint and destructiveHint would both be true before the cleanup"
     (is (true? (:contradictory? (tools-manifest/infer-annotations :get {:destructive? true}))))
     (is (true? (:contradictory? (tools-manifest/infer-annotations :delete {:read-only? true})))))
   (testing "Explicit annotations are merged on top of method defaults"
-    (is (= {:annotations {:readOnlyHint true :idempotentHint true}
+    (is (= {:annotations {:readOnlyHint true :idempotentHint true :destructiveHint false :openWorldHint false}
             :redundant   {}}
            (tools-manifest/infer-annotations :post {:read-only? true :idempotent? true}))))
   (testing "Reports redundant pairs that match what we'd already infer (using developer-facing keys)"
     (is (= {:read-only? true}
            (:redundant (tools-manifest/infer-annotations :get {:read-only? true}))))
     (is (= {:destructive? false}
-           (:redundant (tools-manifest/infer-annotations :put {:destructive? false}))))))
+           (:redundant (tools-manifest/infer-annotations :put {:destructive? false})))))
+  (testing "readOnlyHint, destructiveHint, openWorldHint are always present (some MCP clients reject tools without them)"
+    (doseq [method [:get :post :put :delete :head]]
+      (let [ann (:annotations (tools-manifest/infer-annotations method nil))]
+        (is (contains? ann :readOnlyHint)    (str method " missing :readOnlyHint"))
+        (is (contains? ann :destructiveHint) (str method " missing :destructiveHint"))
+        (is (contains? ann :openWorldHint)   (str method " missing :openWorldHint"))))))
 
 (deftest ^:parallel prefer-tool-descriptions-test
   (testing "tool/description replaces description in JSON schema output"
@@ -236,8 +243,10 @@
               :outputSchema {:type       "object"
                              :properties {:name {:type "string"}}
                              :required   [:name]}
-              :annotations    {:readOnlyHint   true
-                               :idempotentHint true}}
+              :annotations    {:readOnlyHint    true
+                               :idempotentHint  true
+                               :destructiveHint false
+                               :openWorldHint   false}}
              result))))
 
   (testing "Scope is included when metadata has :scope"
@@ -412,7 +421,7 @@
   (is (= {:name           "test_get_thing"
           :title          "Test Get Thing"
           :description    "A test endpoint for tools manifest generation."
-          :annotations    {:readOnlyHint true :idempotentHint true}
+          :annotations    {:readOnlyHint true :idempotentHint true :destructiveHint false :openWorldHint false}
           :endpoint       {:method "GET" :path "/api/test/v1/test/{id}"}
           :inputSchema    {:type       "object"
                            :properties {:id {:type "integer"}}
@@ -424,7 +433,7 @@
   (is (= {:name           "test_action"
           :title          "Test Action"
           :description    "A test POST action."
-          :annotations    {:readOnlyHint true}
+          :annotations    {:readOnlyHint true :destructiveHint false :openWorldHint false}
           :endpoint       {:method "POST" :path "/api/test/v1/test-action"}
           :inputSchema    {:type       "object"
                            :properties {:name {:type "string"}}
@@ -436,7 +445,7 @@
   (is (= {:name           "delete_test"
           :title          "Delete Test"
           :description    "Delete a test resource."
-          :annotations    {:destructiveHint true :idempotentHint true}
+          :annotations    {:destructiveHint true :idempotentHint true :readOnlyHint false :openWorldHint false}
           :endpoint       {:method "DELETE" :path "/api/test/v1/test/{id}"}
           :inputSchema    {:type       "object"
                            :properties {:id {:type "integer"}}
@@ -448,7 +457,7 @@
   (is (= {:name           "test_search"
           :title          "Test Search"
           :description    "Search for things."
-          :annotations    {:readOnlyHint true :idempotentHint true}
+          :annotations    {:readOnlyHint true :idempotentHint true :destructiveHint false :openWorldHint false}
           :endpoint       {:method "GET" :path "/api/test/v1/test-search"}
           :inputSchema    {:type       "object"
                            :properties {:q     {:type "string"}
@@ -465,7 +474,7 @@
   (is (= {:name           "test_resource_action"
           :title          "Test Resource Action"
           :description    "Perform an action on a resource."
-          :annotations    {:readOnlyHint true}
+          :annotations    {:readOnlyHint true :destructiveHint false :openWorldHint false}
           :endpoint       {:method "POST" :path "/api/test/v1/test-resource/{id}/action"}
           :inputSchema    {:type       "object"
                            :properties {:id     {:type "integer"}
@@ -484,7 +493,7 @@
   (is (= {:name           "test_resource"
           :title          "Test Resource"
           :description    "Update a test resource."
-          :annotations    {:destructiveHint false :idempotentHint true}
+          :annotations    {:destructiveHint false :idempotentHint true :readOnlyHint false :openWorldHint false}
           :endpoint       {:method "PUT" :path "/api/test/v1/test-resource/{id}"}
           :inputSchema    {:type       "object"
                            :properties {:id      {:type "integer"}

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -231,7 +231,8 @@
               :endpoint       {:method "GET" :path "/api/agent/v1/table/{id}"}
               :inputSchema    {:type       "object"
                                :properties {:id {:type "integer"}}
-                               :required   [:id]}
+                               :required   [:id]
+                               :additionalProperties false}
               :responseSchema {:type       "object"
                                :properties {:name {:type "string"}}
                                :required   [:name]}
@@ -415,7 +416,8 @@
           :endpoint       {:method "GET" :path "/api/test/v1/test/{id}"}
           :inputSchema    {:type       "object"
                            :properties {:id {:type "integer"}}
-                           :required   [:id]}}
+                           :required   [:id]
+                           :additionalProperties false}}
          (test-tool "test_get_thing"))))
 
 (deftest ^:parallel generate-tools-manifest-post-with-annotation-override-test
@@ -426,7 +428,8 @@
           :endpoint       {:method "POST" :path "/api/test/v1/test-action"}
           :inputSchema    {:type       "object"
                            :properties {:name {:type "string"}}
-                           :required   [:name]}}
+                           :required   [:name]
+                           :additionalProperties false}}
          (test-tool "test_action"))))
 
 (deftest ^:parallel generate-tools-manifest-delete-test
@@ -437,7 +440,8 @@
           :endpoint       {:method "DELETE" :path "/api/test/v1/test/{id}"}
           :inputSchema    {:type       "object"
                            :properties {:id {:type "integer"}}
-                           :required   [:id]}}
+                           :required   [:id]
+                           :additionalProperties false}}
          (test-tool "delete_test"))))
 
 (deftest ^:parallel generate-tools-manifest-get-with-query-params-test
@@ -448,9 +452,10 @@
           :endpoint       {:method "GET" :path "/api/test/v1/test-search"}
           :inputSchema    {:type       "object"
                            :properties {:q     {:type "string"}
-                                        :limit {:type        "integer"
+                                        :limit {:type        ["integer" "null"]
                                                 :description "Maximum number of results to return"}}
-                           :required   [:q]}
+                           :required   [:q :limit]
+                           :additionalProperties false}
           :responseSchema {:type       "object"
                            :properties {:results {:type "array" :items {:type "string"}}}
                            :required   [:results]}}
@@ -465,7 +470,8 @@
           :inputSchema    {:type       "object"
                            :properties {:id     {:type "integer"}
                                         :action {:type "string"}}
-                           :required   [:id :action]}
+                           :required   [:id :action]
+                           :additionalProperties false}
           :responseSchema {:type       "object"
                            :properties {:id     {:type "integer"}
                                         :status {:type "string"
@@ -484,5 +490,6 @@
                            :properties {:id      {:type "integer"}
                                         :dry-run {:oneOf [{:type "boolean"} {:type "null"}]}
                                         :name    {:type "string"}}
-                           :required   [:id :name]}}
+                           :required   [:id :dry-run :name]
+                           :additionalProperties false}}
          (test-tool "test_resource"))))

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -6,6 +6,38 @@
    [metabase.util.malli.registry :as mr])
   (:import (clojure.lang ExceptionInfo)))
 
+(deftest ^:parallel assert-optional-fields-nullable!-test
+  (testing "no throw when every :optional field is also nullable via [:maybe ...]"
+    (is (some? (tools-manifest/assert-optional-fields-nullable!
+                [:map [:foo {:optional true} [:maybe :string]]] "ok-tool"))))
+  (testing "no throw when there are no :optional fields"
+    (is (some? (tools-manifest/assert-optional-fields-nullable!
+                [:map [:foo :string] [:bar :int]] "no-optional-tool")))
+    (is (nil? (tools-manifest/assert-optional-fields-nullable! nil "nil-schema-tool"))))
+  (testing "throws when an :optional field rejects nil"
+    (let [ex (try (tools-manifest/assert-optional-fields-nullable!
+                   [:map [:foo {:optional true} :string]] "bad-tool")
+                  (catch ExceptionInfo e e))]
+      (is (instance? ExceptionInfo ex))
+      (is (= "bad-tool" (-> ex ex-data :tool)))
+      (is (= :foo (-> ex ex-data :field)))))
+  (testing "walks composites — `:or` of maps catches the offender inside a branch"
+    (let [schema [:or
+                  [:map [:foo :string]]
+                  [:map [:bar {:optional true} :int]]]
+          ex    (try (tools-manifest/assert-optional-fields-nullable! schema "or-tool")
+                     (catch ExceptionInfo e e))]
+      (is (instance? ExceptionInfo ex))
+      (is (= :bar (-> ex ex-data :field)))))
+  (testing "walks into nested map properties"
+    (let [schema [:map
+                  [:outer [:map
+                           [:inner {:optional true} :int]]]]
+          ex    (try (tools-manifest/assert-optional-fields-nullable! schema "nested-tool")
+                     (catch ExceptionInfo e e))]
+      (is (instance? ExceptionInfo ex))
+      (is (= :inner (-> ex ex-data :field))))))
+
 (deftest ^:parallel infer-annotations-test
   (testing "GET defaults"
     (is (= {:annotations {:readOnlyHint true :idempotentHint true :destructiveHint false :openWorldHint false}
@@ -25,7 +57,7 @@
            (tools-manifest/infer-annotations :post nil)))
     (is (= {:destructive? false}
            (:redundant (tools-manifest/infer-annotations :post {:destructive? false})))))
-  (testing "destructiveHint is dropped from output when readOnlyHint is true (per MCP spec it's only meaningful for non-read-only tools), then re-added as false by the required-hint defaults"
+  (testing "POST's method defaults carry destructiveHint false / openWorldHint false; explicit :read-only? true is merged on top"
     (is (= {:readOnlyHint true :destructiveHint false :openWorldHint false}
            (:annotations (tools-manifest/infer-annotations :post {:read-only? true})))))
   (testing "Flags :contradictory? when readOnlyHint and destructiveHint would both be true before the cleanup"

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -341,8 +341,8 @@
    {:keys [q limit]} :- [:map
                          [:q :string]
                          [:limit {:optional true}
-                          [:int {:description      "Max results"
-                                 :tool/description "Maximum number of results to return"}]]]]
+                          [:maybe [:int {:description      "Max results"
+                                         :tool/description "Maximum number of results to return"}]]]]]
   {:results []})
 
 ;; 5. POST with route + body params, task-support, and registered schema in response
@@ -461,8 +461,9 @@
           :endpoint       {:method "GET" :path "/api/test/v1/test-search"}
           :inputSchema    {:type       "object"
                            :properties {:q     {:type "string"}
-                                        :limit {:type        ["integer" "null"]
-                                                :description "Maximum number of results to return"}}
+                                        :limit {:oneOf [{:type        "integer"
+                                                         :description "Maximum number of results to return"}
+                                                        {:type "null"}]}}
                            :required   [:q :limit]
                            :additionalProperties false}
           :outputSchema {:type       "object"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -231,6 +231,17 @@
     "search"
     "visualize_query"})
 
+(deftest tools-list-all-tools-declare-required-hints-test
+  (testing "every tool advertises readOnlyHint, destructiveHint, openWorldHint (some MCP clients reject tools that omit them)"
+    (let [[session-id _] (initialize!)
+          response       (mcp-request (jsonrpc-request "tools/list") {"mcp-session-id" session-id})
+          tools          (get-in response [:body :result :tools])]
+      (is (seq tools) "tools/list should return at least one tool")
+      (doseq [{:keys [name annotations]} tools]
+        (is (contains? annotations :readOnlyHint)    (str name " missing :readOnlyHint"))
+        (is (contains? annotations :destructiveHint) (str name " missing :destructiveHint"))
+        (is (contains? annotations :openWorldHint)   (str name " missing :openWorldHint"))))))
+
 (deftest tools-list-test
   (testing "tools/list returns the agent and UI tools"
     (let [[session-id _] (initialize!)

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -294,7 +294,7 @@
                                  "")
                              "exact original message"))
           (is (str/includes? reference "MCP clients should include it whenever they have the user's message"))
-          (is (str/includes? reference "{\"query_handle\": \"<uuid>\"}")))))))
+          (is (str/includes? reference "{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}")))))))
 
 (deftest ping-test
   (testing "ping returns empty result"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -130,7 +130,7 @@
       (is (= 403 (:status response)))
       (is (= "Origin not allowed" (get-in response [:body :error :message])))))
   (testing "cross-origin browser requests are accepted for configured MCP client origins"
-    (mt/with-temporary-setting-values [mcp-apps-cors-custom-origins "http://127.0.0.1:6274"]
+    (mt/with-temporary-setting-values [mcp.settings/mcp-apps-cors-custom-origins "http://127.0.0.1:6274"]
       (let [response (mcp-request (jsonrpc-request "initialize")
                                   {"host"   "mbtest.poom.dev"
                                    "origin" "http://127.0.0.1:6274"})]

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -280,6 +280,25 @@
       (is (= "ORDERS" (-> result :structuredContent :name))
           "structuredContent should mirror the endpoint response shape"))))
 
+(deftest tools-list-strict-shape-test
+  (testing "no tool's inputSchema uses JSON-Schema constructs that ChatGPT's strict MCP validator rejects"
+    ;; Pins the strict-shape guarantee across the whole exposed tool surface. `construct_query` had
+    ;; this asserted before; broadening it to every tool catches drift in any wire schema (e.g.
+    ;; `query`'s `:multi` body referencing agent-lib `:tuple` schemas) that would silently leak
+    ;; `:allOf`/`:prefixItems`/`items:false` constructs into a tool that worked before the regression.
+    (let [[session-id _] (initialize!)
+          response       (mcp-request (jsonrpc-request "tools/list") {"mcp-session-id" session-id})
+          tools          (get-in response [:body :result :tools])]
+      (is (pos? (count tools)))
+      (doseq [{:keys [name inputSchema]} tools]
+        (let [schema-keys (atom #{})]
+          (walk/postwalk (fn [x] (when (map? x) (swap! schema-keys into (keys x))) x) inputSchema)
+          (is (empty? (select-keys (frequencies @schema-keys) [:allOf :prefixItems]))
+              (str "Tool " name " inputSchema contains :allOf or :prefixItems"))
+          (is (not (some #(false? (:items %))
+                         (->> (tree-seq coll? seq inputSchema) (filter map?))))
+              (str "Tool " name " inputSchema contains `items: false` (tuple closure)")))))))
+
 (deftest tools-list-test
   (testing "tools/list returns the agent and UI tools"
     (let [[session-id _] (initialize!)

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -766,6 +766,27 @@
 
 ;;; --------------------------------------- widgetSessionId cross-session handle resolution -------------------------------------
 
+(deftest tools-expose-output-schema-test
+  (testing "MCP tools/list declares outputSchema for tools that emit structuredContent"
+    (let [[session-id _] (initialize!)
+          response       (mcp-request (jsonrpc-request "tools/list") {"mcp-session-id" session-id})
+          tools          (get-in response [:body :result :tools])
+          tools-by-name  (into {} (map (juxt :name identity)) tools)]
+      (testing "construct_query advertises {query_handle, widgetSessionId} as its output"
+        (let [output-schema (get-in tools-by-name ["construct_query" :outputSchema])
+              prop-names    (set (map name (keys (:properties output-schema))))]
+          (is (= "object" (:type output-schema)))
+          (is (contains? prop-names "query_handle"))
+          (is (contains? prop-names "widgetSessionId"))))
+      (testing "visualize_query advertises its structuredContent shape"
+        (let [output-schema (get-in tools-by-name ["visualize_query" :outputSchema])]
+          (is (= "object" (:type output-schema)))
+          (is (contains? (set (map name (keys (:properties output-schema)))) "query"))))
+      (testing "render_drill_through advertises its structuredContent shape"
+        (let [output-schema (get-in tools-by-name ["render_drill_through" :outputSchema])]
+          (is (= "object" (:type output-schema)))
+          (is (contains? (set (map name (keys (:properties output-schema)))) "query")))))))
+
 (deftest construct-query-returns-widget-session-id-test
   (testing "construct_query echoes the calling MCP session id as widgetSessionId for cross-session handoff"
     (let [[session-id _] (initialize!)

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -353,7 +353,7 @@
                                  "")
                              "exact original message"))
           (is (str/includes? reference "MCP clients should include it whenever they have the user's message"))
-          (is (str/includes? reference "{\"query_handle\": \"<uuid>\", \"widgetSessionId\": \"<id>\"}")))))))
+          (is (str/includes? reference "{\"query_handle\": \"<uuid>\"}")))))))
 
 (deftest ping-test
   (testing "ping returns empty result"
@@ -676,6 +676,7 @@
                   question-data  (call-tool session-id "create_question"
                                             {:name  "Smoke Question"
                                              :query (mcp.session/read-handle session-id
+                                                                             (mt/user->id :crowberto)
                                                                              (:query_handle construct-data))})
                   _              (reset! question-id (:id question-data))
                   dash-data      (call-tool session-id "create_dashboard"
@@ -739,21 +740,7 @@
               (mcp-request (jsonrpc-request "tools/call"
                                             {:name      "render_drill_through"
                                              :arguments {:handle (str (random-uuid))}})
-                           {"mcp-session-id" session-id})))))
-
-  (testing "render_drill_through does not resolve a handle from another session"
-    (let [user-id             (mt/user->id :crowberto)
-          [owner-session _]   (initialize!)
-          [attacker-session _] (initialize!)
-          handle              (mt/with-current-user user-id
-                                (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
-      (is (=? {:status 200
-               :body   {:result {:isError true
-                                 :content [{:text #(str/includes? % "No drill-through found")}]}}}
-              (mcp-request (jsonrpc-request "tools/call"
-                                            {:name      "render_drill_through"
-                                             :arguments {:handle handle}})
-                           {"mcp-session-id" attacker-session}))))))
+                           {"mcp-session-id" session-id}))))))
 
 (deftest tools-call-visualize-query-test
   (testing "visualize_query echoes the inline query"
@@ -810,39 +797,9 @@
               (mcp-request (jsonrpc-request "tools/call"
                                             {:name      "visualize_query"
                                              :arguments {:query_handle (str (random-uuid))}})
-                           {"mcp-session-id" session-id})))))
+                           {"mcp-session-id" session-id}))))))
 
-  (testing "visualize_query does not resolve a query_handle from another session"
-    (let [user-id             (mt/user->id :crowberto)
-          [owner-session _]   (initialize!)
-          [attacker-session _] (initialize!)
-          handle              (mt/with-current-user user-id
-                                (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
-      (is (=? {:status 200
-               :body   {:result {:isError true
-                                 :content [{:text #(str/includes? % "Query handle not found")}]}}}
-              (mcp-request (jsonrpc-request "tools/call"
-                                            {:name      "visualize_query"
-                                             :arguments {:query_handle handle}})
-                           {"mcp-session-id" attacker-session})))))
-
-  (testing "execute_query does not resolve a query_handle from another session"
-    (let [[owner-session _]    (initialize!)
-          [attacker-session _] (initialize!)
-          construct-data       (call-tool owner-session "construct_query"
-                                          {:source     {:type "table" :id (mt/id :orders)}
-                                           :operations [["limit" 5]]
-                                           :prompt     "show 5 orders"})
-          response             (mcp-request (jsonrpc-request "tools/call"
-                                                             {:name      "execute_query"
-                                                              :arguments {:query_handle (:query_handle construct-data)}})
-                                            {"mcp-session-id" attacker-session})]
-      (is (=? {:status 200
-               :body   {:result {:isError true
-                                 :content [{:text #(str/includes? % "Query handle not found")}]}}}
-              response)))))
-
-;;; --------------------------------------- widgetSessionId cross-session handle resolution -------------------------------------
+;;; --------------------------------------- cross-session handle resolution -------------------------------------
 
 (deftest tools-expose-output-schema-test
   (testing "MCP tools/list declares outputSchema for tools that emit structuredContent"
@@ -850,12 +807,13 @@
           response       (mcp-request (jsonrpc-request "tools/list") {"mcp-session-id" session-id})
           tools          (get-in response [:body :result :tools])
           tools-by-name  (into {} (map (juxt :name identity)) tools)]
-      (testing "construct_query advertises {query_handle, widgetSessionId} as its output"
+      (testing "construct_query advertises {query_handle} as its output"
         (let [output-schema (get-in tools-by-name ["construct_query" :outputSchema])
               prop-names    (set (map name (keys (:properties output-schema))))]
           (is (= "object" (:type output-schema)))
           (is (contains? prop-names "query_handle"))
-          (is (contains? prop-names "widgetSessionId"))))
+          (is (not (contains? prop-names "widgetSessionId"))
+              "widgetSessionId was retired in favour of cross-session per-user lookup")))
       (testing "visualize_query advertises its structuredContent shape"
         (let [output-schema (get-in tools-by-name ["visualize_query" :outputSchema])]
           (is (= "object" (:type output-schema)))
@@ -865,45 +823,32 @@
           (is (= "object" (:type output-schema)))
           (is (contains? (set (map name (keys (:properties output-schema)))) "query")))))))
 
-(deftest construct-query-returns-widget-session-id-test
-  (testing "construct_query echoes the calling MCP session id as widgetSessionId for cross-session handoff"
+(deftest construct-query-returns-bare-handle-test
+  (testing "construct_query returns just `{:query_handle uuid}` — no widget session plumbing"
     (let [[session-id _] (initialize!)
           construct-data (call-tool session-id "construct_query"
                                     {:source     {:type "table" :id (mt/id :orders)}
                                      :operations [["limit" 5]]
-                                     :prompt     "show 5 orders"})
-          response       (mcp-request (jsonrpc-request "tools/call"
-                                                       {:name      "construct_query"
-                                                        :arguments {:source     {:type "table" :id (mt/id :orders)}
-                                                                    :operations [["limit" 5]]
-                                                                    :prompt     "show 5 orders"}})
-                                      {"mcp-session-id" session-id})]
-      ;; Structured content (LLM-visible) carries `widgetSessionId` so the model
-      ;; can thread it forward in tool-call arguments.
-      (is (= session-id (:widgetSessionId construct-data)))
-      ;; The MCP `_meta.openai/widgetSessionId` is the OpenAI-runtime channel
-      ;; that ChatGPT correlates tool calls by.
-      (is (= session-id (get-in response [:body :result :_meta :openai/widgetSessionId]))))))
+                                     :prompt     "show 5 orders"})]
+      (is (some? (parse-uuid (:query_handle construct-data))))
+      (is (not (contains? construct-data :widgetSessionId))))))
 
-(deftest visualize-query-resolves-via-widget-session-id-test
-  (testing "visualize_query resolves a handle from another session when widgetSessionId points back to the original session"
+(deftest visualize-query-resolves-via-cross-session-fallback-test
+  (testing "visualize_query resolves a handle stored in another session of the same user — no widgetSessionId needed"
     (let [user-id             (mt/user->id :crowberto)
           [owner-session _]   (initialize!)
           [rotated-session _] (initialize!)
           handle              (mt/with-current-user user-id
                                 (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
       (is (=? {:status 200
-               :body   {:result {:structuredContent {:query            "ZW5jb2RlZA=="
-                                                     :widgetSessionId  owner-session}
-                                 :_meta             {:openai/widgetSessionId owner-session}}}}
+               :body   {:result {:structuredContent {:query "ZW5jb2RlZA=="}}}}
               (mcp-request (jsonrpc-request "tools/call"
                                             {:name      "visualize_query"
-                                             :arguments {:query_handle    handle
-                                                         :widgetSessionId owner-session}})
+                                             :arguments {:query_handle handle}})
                            {"mcp-session-id" rotated-session}))))))
 
-(deftest execute-query-resolves-via-widget-session-id-test
-  (testing "execute_query resolves a handle from another session when widgetSessionId points back to the original session"
+(deftest execute-query-resolves-via-cross-session-fallback-test
+  (testing "execute_query resolves a handle stored in another session of the same user — no widgetSessionId needed"
     (let [[owner-session _]   (initialize!)
           [rotated-session _] (initialize!)
           construct-data      (call-tool owner-session "construct_query"
@@ -912,31 +857,27 @@
                                           :prompt     "show 5 orders"})
           response            (mcp-request (jsonrpc-request "tools/call"
                                                             {:name      "execute_query"
-                                                             :arguments {:query_handle    (:query_handle construct-data)
-                                                                         :widgetSessionId owner-session}})
+                                                             :arguments {:query_handle (:query_handle construct-data)}})
                                            {"mcp-session-id" rotated-session})]
       (is (= 200 (:status response)))
       (is (not (get-in response [:body :result :isError]))))))
 
-(deftest render-drill-through-resolves-via-widget-session-id-test
-  (testing "render_drill_through resolves a handle from another session when widgetSessionId points back to the original session"
+(deftest render-drill-through-resolves-via-cross-session-fallback-test
+  (testing "render_drill_through resolves a handle stored in another session of the same user"
     (let [user-id             (mt/user->id :crowberto)
           [owner-session _]   (initialize!)
           [rotated-session _] (initialize!)
           handle              (mt/with-current-user user-id
                                 (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
       (is (=? {:status 200
-               :body   {:result {:structuredContent {:query            "ZW5jb2RlZA=="
-                                                     :widgetSessionId  owner-session}
-                                 :_meta             {:openai/widgetSessionId owner-session}}}}
+               :body   {:result {:structuredContent {:query "ZW5jb2RlZA=="}}}}
               (mcp-request (jsonrpc-request "tools/call"
                                             {:name      "render_drill_through"
-                                             :arguments {:handle          handle
-                                                         :widgetSessionId owner-session}})
+                                             :arguments {:handle handle}})
                            {"mcp-session-id" rotated-session}))))))
 
-(deftest visualize-query-rejects-cross-user-widget-session-id-test
-  (testing "visualize_query refuses to resolve another user's handle even when widgetSessionId points at the owner's session"
+(deftest visualize-query-refuses-cross-user-handle-test
+  (testing "visualize_query refuses to resolve another user's handle"
     (let [owner-id              (mt/user->id :crowberto)
           [owner-session _]     (initialize!)                     ;; crowberto
           ;; Fresh UUID-shaped sentinel for the stored payload so the leak
@@ -948,8 +889,7 @@
           response              (mcp-request-as :rasta
                                                 (jsonrpc-request "tools/call"
                                                                  {:name      "visualize_query"
-                                                                  :arguments {:query_handle    handle
-                                                                              :widgetSessionId owner-session}})
+                                                                  :arguments {:query_handle handle}})
                                                 {"mcp-session-id" attacker-session})]
       (testing "the response is an error, NOT crowberto's encoded query"
         (is (=? {:status 200
@@ -958,7 +898,7 @@
                 response))
         (is (not= encoded-payload
                   (get-in response [:body :result :structuredContent :query]))
-            "widgetSessionId must not bypass user scoping")))))
+            "cross-user handle resolution must fail")))))
 
 ;;; --------------------------------------------- OAuth Bearer Auth -------------------------------------------------
 

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -45,6 +45,14 @@
                                 {:request-options {:headers extra-headers}}
                                 body)))
 
+(defn- mcp-request-as
+  "Like `mcp-request` but authenticates as the given test username."
+  [username body extra-headers]
+  (client/client-full-response (test.users/username->token username)
+                               :post "mcp"
+                               {:request-options {:headers extra-headers}}
+                               body))
+
 (defn- mcp-request-unauthenticated
   "Make an unauthenticated POST request to /api/mcp."
   ([body]
@@ -95,6 +103,16 @@
     ;; Complete the handshake so the session is marked initialized
     (mcp-request (jsonrpc-notification "notifications/initialized")
                  {"mcp-session-id" session-id})
+    [session-id response]))
+
+(defn- initialize-as!
+  "Like `initialize!` but authenticates as the given test username."
+  [username]
+  (let [response   (mcp-request-as username (jsonrpc-request "initialize") {})
+        session-id (get-in response [:headers "Mcp-Session-Id"])]
+    (mcp-request-as username
+                    (jsonrpc-notification "notifications/initialized")
+                    {"mcp-session-id" session-id})
     [session-id response]))
 
 (defn- call-tool
@@ -857,6 +875,31 @@
                                              :arguments {:handle          handle
                                                          :widgetSessionId owner-session}})
                            {"mcp-session-id" rotated-session}))))))
+
+(deftest visualize-query-rejects-cross-user-widget-session-id-test
+  (testing "visualize_query refuses to resolve another user's handle even when widgetSessionId points at the owner's session"
+    (let [owner-id              (mt/user->id :crowberto)
+          [owner-session _]     (initialize!)                     ;; crowberto
+          ;; Fresh UUID-shaped sentinel for the stored payload so the leak
+          ;; assertion below can't accidentally match against any other test fixture.
+          encoded-payload       (str (random-uuid))
+          handle                (mt/with-current-user owner-id
+                                  (mcp.session/store-handle! owner-session owner-id encoded-payload))
+          [attacker-session _]  (initialize-as! :rasta)
+          response              (mcp-request-as :rasta
+                                                (jsonrpc-request "tools/call"
+                                                                 {:name      "visualize_query"
+                                                                  :arguments {:query_handle    handle
+                                                                              :widgetSessionId owner-session}})
+                                                {"mcp-session-id" attacker-session})]
+      (testing "the response is an error, NOT crowberto's encoded query"
+        (is (=? {:status 200
+                 :body   {:result {:isError true
+                                   :content [{:text #(str/includes? % "Query handle not found")}]}}}
+                response))
+        (is (not= encoded-payload
+                  (get-in response [:body :result :structuredContent :query]))
+            "widgetSessionId must not bypass user scoping")))))
 
 ;;; --------------------------------------------- OAuth Bearer Auth -------------------------------------------------
 

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -598,7 +598,8 @@
                   ;; can clean up even if a later step throws.
                   question-data  (call-tool session-id "create_question"
                                             {:name  "Smoke Question"
-                                             :query (mcp.session/read-handle session-id (:query_handle construct-data))})
+                                             :query (mcp.session/read-handle session-id
+                                                                             (:query_handle construct-data))})
                   _              (reset! question-id (:id question-data))
                   dash-data      (call-tool session-id "create_dashboard"
                                             {:name "Smoke Dashboard"})]

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [clojure.walk :as walk]
    [metabase.agent-api.settings :as agent-api.settings]
    [metabase.api.macros.scope :as scope]
    [metabase.lib.core :as lib]
@@ -121,6 +122,21 @@
       (is (= 401 (:status response)))
       (is (= -32603 (get-in response [:body :error :code]))))))
 
+(deftest origin-validation-test
+  (testing "cross-origin browser requests are rejected when the origin is not configured"
+    (let [response (mcp-request (jsonrpc-request "initialize")
+                                {"host"   "mbtest.poom.dev"
+                                 "origin" "http://127.0.0.1:6274"})]
+      (is (= 403 (:status response)))
+      (is (= "Origin not allowed" (get-in response [:body :error :message])))))
+  (testing "cross-origin browser requests are accepted for configured MCP client origins"
+    (mt/with-temporary-setting-values [mcp-apps-cors-custom-origins "http://127.0.0.1:6274"]
+      (let [response (mcp-request (jsonrpc-request "initialize")
+                                  {"host"   "mbtest.poom.dev"
+                                   "origin" "http://127.0.0.1:6274"})]
+        (is (= 200 (:status response)))
+        (is (some? (get-in response [:headers "Mcp-Session-Id"])))))))
+
 (deftest mcp-enabled-setting-test
   (testing "external MCP requests return 403 when disabled"
     (mt/with-temporary-setting-values [mcp.settings/mcp-enabled? false]
@@ -220,17 +236,45 @@
           (is (= "string" (get-in (array-branch (property-schema "search" "term_queries")) [:items :type])))
           (is (contains? (leaf-types (property-schema "search" "semantic_queries")) "array"))
           (is (= "string" (get-in (array-branch (property-schema "search" "semantic_queries")) [:items :type])))))
-      (testing "construct_query exposes the optional user prompt"
+      (testing "construct_query exposes the nullable user prompt"
         (let [tools-by-name          (into {} (map (juxt :name identity)) tools)
               construct-query-tool   (get tools-by-name "construct_query")
               construct-query-schema (:inputSchema construct-query-tool)
               prompt-schema          (or (get-in construct-query-schema [:properties "prompt"])
                                          (get-in construct-query-schema [:properties :prompt]))
               required-fields        (set (:required construct-query-schema))
+              schema-keys            (atom #{})
               reference              (slurp (io/resource "metabase/agent_api/construct_query.md"))]
+          (walk/postwalk (fn [x]
+                           (when (map? x)
+                             (swap! schema-keys into (keys x)))
+                           x)
+                         construct-query-schema)
           (is (str/includes? (:description construct-query-tool) "include `\"prompt\""))
-          (is (not (contains? required-fields "prompt")))
-          (is (str/includes? (:description prompt-schema) "exact original message"))
+          ;; Strict-tool-input-schema forces every property into :required and
+          ;; converts previously-optional ones (like :prompt) to nullable unions.
+          (is (or (contains? required-fields "prompt")
+                  (contains? required-fields :prompt)))
+          (is (= false (:additionalProperties construct-query-schema)))
+          ;; Prompt is nullable. Either a `:type` union (hand-written form) or an
+          ;; `:anyOf`/`:oneOf` with a {:type "null"} branch (Malli `[:maybe …]`).
+          (is (or (= ["string" "null"] (:type prompt-schema))
+                  (= #{"string" "null"} (set (:type prompt-schema)))
+                  (some #(= "null" (:type %)) (:anyOf prompt-schema))
+                  (some #(= "null" (:type %)) (:oneOf prompt-schema))))
+          ;; ChatGPT's MCP validator rejects exactly these JSON-Schema constructs.
+          ;; `:oneOf`/`:minLength`/`:maxLength` are accepted by ChatGPT and not asserted against.
+          (is (empty? (select-keys (frequencies @schema-keys)
+                                   [:allOf :prefixItems])))
+          ;; `items: false` (tuple closure) must not appear either.
+          (is (not (some #(false? (:items %))
+                         (->> (tree-seq coll? seq construct-query-schema)
+                              (filter map?)))))
+          (is (str/includes? (or (:description prompt-schema)
+                                 (some :description (:anyOf prompt-schema))
+                                 (some :description (:oneOf prompt-schema))
+                                 "")
+                             "exact original message"))
           (is (str/includes? reference "MCP clients should include it whenever they have the user's message"))
           (is (str/includes? reference "{\"query_handle\": \"<uuid>\"}")))))))
 

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -169,7 +169,14 @@
     (let [response (mcp-request (jsonrpc-request "initialize")
                                 {"host"   "Example.com"
                                  "origin" "https://example.COM"})]
-      (is (= 200 (:status response))))))
+      (is (= 200 (:status response)))))
+  (testing "approved MCP origins match the Origin header case-insensitively"
+    (mt/with-temporary-setting-values [mcp.settings/mcp-apps-cors-custom-origins "https://Example.COM"]
+      (let [response (mcp-request (jsonrpc-request "initialize")
+                                  {"host"   "mbtest.poom.dev"
+                                   "origin" "HTTPS://example.com"})]
+        (is (= 200 (:status response)))
+        (is (some? (get-in response [:headers "Mcp-Session-Id"])))))))
 
 (deftest mcp-enabled-setting-test
   (testing "external MCP requests return 403 when disabled"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -153,7 +153,17 @@
                                   {"host"   "mbtest.poom.dev"
                                    "origin" "http://127.0.0.1:6274"})]
         (is (= 200 (:status response)))
-        (is (some? (get-in response [:headers "Mcp-Session-Id"])))))))
+        (is (some? (get-in response [:headers "Mcp-Session-Id"]))))))
+  (testing "same-origin requests with bracketed IPv6 hosts are accepted"
+    (let [response (mcp-request (jsonrpc-request "initialize")
+                                {"host"   "[::1]:3000"
+                                 "origin" "http://[::1]:3000"})]
+      (is (= 200 (:status response)))))
+  (testing "same-origin requests with mixed-case host/origin are accepted"
+    (let [response (mcp-request (jsonrpc-request "initialize")
+                                {"host"   "Example.com"
+                                 "origin" "https://example.COM"})]
+      (is (= 200 (:status response))))))
 
 (deftest mcp-enabled-setting-test
   (testing "external MCP requests return 403 when disabled"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -118,7 +118,10 @@
 (defn- call-tool
   "Call an MCP tool within an initialized session. Returns the parsed MCP result
    content (the JSON-decoded text from the first content block).
-   Records test failures if the response status is not 200 or the tool returns an error."
+   Records test failures if the response status is not 200 or the tool returns an error.
+   Also enforces the MCP spec contract: every successful tool result with content
+   must include `structuredContent` (because every tool in our manifest declares
+   `outputSchema`, and the spec mandates structuredContent for those)."
   [session-id tool-name arguments]
   (let [response (mcp-request (jsonrpc-request "tools/call"
                                                {:name tool-name :arguments arguments})
@@ -129,6 +132,9 @@
     (is (not (:isError result))
         (str "Tool " tool-name " error: " (some-> result :content first :text)))
     (when-not (:isError result)
+      (is (contains? result :structuredContent)
+          (str "Tool " tool-name " declared an outputSchema in tools/list but did "
+               "not return structuredContent — MCP spec violation."))
       (json/decode+kw (:text (first (:content result)))))))
 
 ;;; ---------------------------------------------------- Tests -----------------------------------------------------
@@ -241,6 +247,38 @@
         (is (contains? annotations :readOnlyHint)    (str name " missing :readOnlyHint"))
         (is (contains? annotations :destructiveHint) (str name " missing :destructiveHint"))
         (is (contains? annotations :openWorldHint)   (str name " missing :openWorldHint"))))))
+
+(deftest text-content-includes-structured-content-for-maps-test
+  (testing "text-content emits structuredContent for map values — MCP spec requires it for tools with outputSchema"
+    (let [text-content (var-get #'mcp.tools/text-content)]
+      (testing "map → both content and structuredContent"
+        (let [result (text-content {:foo "bar"})]
+          (is (= {:foo "bar"} (:structuredContent result)))
+          (is (= "{\"foo\":\"bar\"}" (-> result :content first :text)))))
+      (testing "sequential → structuredContent is the collection"
+        (is (= [1 2 3] (:structuredContent (text-content [1 2 3])))))
+      (testing "string → no structuredContent (nothing to structure)"
+        (let [result (text-content "ok")]
+          (is (not (contains? result :structuredContent)))
+          (is (= "ok" (-> result :content first :text))))))))
+
+(deftest tool-result-emits-structured-content-test
+  (testing "tools that declare outputSchema emit structuredContent — guards the regression where Claude Desktop got 500s because we declared outputSchema without matching structuredContent"
+    (let [[session-id _] (initialize!)
+          response       (mcp-request (jsonrpc-request "tools/call"
+                                                       {:name      "get_table"
+                                                        :arguments {:id (mt/id :orders)}})
+                                      {"mcp-session-id" session-id})
+          result         (get-in response [:body :result])]
+      (is (= 200 (:status response)))
+      (is (not (:isError result))
+          (str "get_table should succeed: " (some-> result :content first :text)))
+      (is (contains? result :structuredContent)
+          "get_table declares outputSchema → MUST emit structuredContent")
+      (is (map? (:structuredContent result))
+          "structuredContent should be the parsed response object, not a string")
+      (is (= "ORDERS" (-> result :structuredContent :name))
+          "structuredContent should mirror the endpoint response shape"))))
 
 (deftest tools-list-test
   (testing "tools/list returns the agent and UI tools"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -764,6 +764,78 @@
                                  :content [{:text #(str/includes? % "Query handle not found")}]}}}
               response)))))
 
+;;; --------------------------------------- widgetSessionId cross-session handle resolution -------------------------------------
+
+(deftest construct-query-returns-widget-session-id-test
+  (testing "construct_query echoes the calling MCP session id as widgetSessionId for cross-session handoff"
+    (let [[session-id _] (initialize!)
+          construct-data (call-tool session-id "construct_query"
+                                    {:source     {:type "table" :id (mt/id :orders)}
+                                     :operations [["limit" 5]]
+                                     :prompt     "show 5 orders"})
+          response       (mcp-request (jsonrpc-request "tools/call"
+                                                       {:name      "construct_query"
+                                                        :arguments {:source     {:type "table" :id (mt/id :orders)}
+                                                                    :operations [["limit" 5]]
+                                                                    :prompt     "show 5 orders"}})
+                                      {"mcp-session-id" session-id})]
+      ;; Structured content (LLM-visible) carries `widgetSessionId` so the model
+      ;; can thread it forward in tool-call arguments.
+      (is (= session-id (:widgetSessionId construct-data)))
+      ;; The MCP `_meta.openai/widgetSessionId` is the OpenAI-runtime channel
+      ;; that ChatGPT correlates tool calls by.
+      (is (= session-id (get-in response [:body :result :_meta :openai/widgetSessionId]))))))
+
+(deftest visualize-query-resolves-via-widget-session-id-test
+  (testing "visualize_query resolves a handle from another session when widgetSessionId points back to the original session"
+    (let [user-id             (mt/user->id :crowberto)
+          [owner-session _]   (initialize!)
+          [rotated-session _] (initialize!)
+          handle              (mt/with-current-user user-id
+                                (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
+      (is (=? {:status 200
+               :body   {:result {:structuredContent {:query            "ZW5jb2RlZA=="
+                                                     :widgetSessionId  owner-session}
+                                 :_meta             {:openai/widgetSessionId owner-session}}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "visualize_query"
+                                             :arguments {:query_handle    handle
+                                                         :widgetSessionId owner-session}})
+                           {"mcp-session-id" rotated-session}))))))
+
+(deftest execute-query-resolves-via-widget-session-id-test
+  (testing "execute_query resolves a handle from another session when widgetSessionId points back to the original session"
+    (let [[owner-session _]   (initialize!)
+          [rotated-session _] (initialize!)
+          construct-data      (call-tool owner-session "construct_query"
+                                         {:source     {:type "table" :id (mt/id :orders)}
+                                          :operations [["limit" 5]]
+                                          :prompt     "show 5 orders"})
+          response            (mcp-request (jsonrpc-request "tools/call"
+                                                            {:name      "execute_query"
+                                                             :arguments {:query_handle    (:query_handle construct-data)
+                                                                         :widgetSessionId owner-session}})
+                                           {"mcp-session-id" rotated-session})]
+      (is (= 200 (:status response)))
+      (is (not (get-in response [:body :result :isError]))))))
+
+(deftest render-drill-through-resolves-via-widget-session-id-test
+  (testing "render_drill_through resolves a handle from another session when widgetSessionId points back to the original session"
+    (let [user-id             (mt/user->id :crowberto)
+          [owner-session _]   (initialize!)
+          [rotated-session _] (initialize!)
+          handle              (mt/with-current-user user-id
+                                (mcp.session/store-handle! owner-session user-id "ZW5jb2RlZA=="))]
+      (is (=? {:status 200
+               :body   {:result {:structuredContent {:query            "ZW5jb2RlZA=="
+                                                     :widgetSessionId  owner-session}
+                                 :_meta             {:openai/widgetSessionId owner-session}}}}
+              (mcp-request (jsonrpc-request "tools/call"
+                                            {:name      "render_drill_through"
+                                             :arguments {:handle          handle
+                                                         :widgetSessionId owner-session}})
+                           {"mcp-session-id" rotated-session}))))))
+
 ;;; --------------------------------------------- OAuth Bearer Auth -------------------------------------------------
 
 (deftest unauthenticated-returns-401-test

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
-   [metabase.mcp.resources :as mcp.resources]))
+   [metabase.mcp.resources :as mcp.resources]
+   [metabase.system.core :as system]))
 
 (set! *warn-on-reflection* true)
 
@@ -87,3 +88,19 @@
               (mcp.resources/read-resource "ui://metabase/visualize-query.html"
                                            #{"agent:visualize"}
                                            {}))))))
+
+(deftest builtin-visualize-query-ui-resource-metadata-test
+  (testing "the visualize_query UI resource includes ChatGPT Apps metadata"
+    (let [site-url "https://metabase.example.com"
+          uri      "ui://metabase/visualize-query.html"]
+      (with-redefs [system/site-url (constantly site-url)]
+        (mcp.resources/with-fallback-template
+          (is (=? {:status   :ok
+                   :contents [{:uri      uri
+                               :mimeType "text/html;profile=mcp-app"
+                               :_meta    {:ui {:prefersBorder true
+                                               :domain        site-url
+                                               :csp           {:connectDomains  [site-url]
+                                                               :resourceDomains [site-url]
+                                                               :frameDomains    [site-url]}}}}]}
+                  (mcp.resources/read-resource uri #{"agent:visualize"} {}))))))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -90,8 +90,11 @@
                                            {}))))))
 
 (deftest builtin-visualize-query-ui-resource-metadata-test
-  (testing "the visualize_query UI resource includes ChatGPT Apps metadata"
-    (let [site-url "https://metabase.example.com"
+  (testing "the visualize_query UI resource publishes bare origins in its ChatGPT Apps metadata"
+    ;; site-url is set with a subpath to confirm `_meta.ui.domain` and the CSP domain lists strip the
+    ;; path — ChatGPT's MCP host treats those fields as origins and would otherwise reject the value.
+    (let [site-url "https://metabase.example.com/sub/path"
+          origin   "https://metabase.example.com"
           uri      "ui://metabase/visualize-query.html"]
       (with-redefs [system/site-url (constantly site-url)]
         (mcp.resources/with-fallback-template
@@ -99,7 +102,7 @@
                    :contents [{:uri      uri
                                :mimeType "text/html;profile=mcp-app"
                                :_meta    {:ui {:prefersBorder true
-                                               :domain        site-url
-                                               :csp           {:connectDomains  [site-url]
-                                                               :resourceDomains [site-url]}}}}]}
+                                               :domain        origin
+                                               :csp           {:connectDomains  [origin]
+                                                               :resourceDomains [origin]}}}}]}
                   (mcp.resources/read-resource uri #{"agent:visualize"} {}))))))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
    [metabase.mcp.resources :as mcp.resources]
+   [metabase.request.core :as request]
    [metabase.system.core :as system]))
 
 (set! *warn-on-reflection* true)
@@ -90,19 +91,37 @@
                                            {}))))))
 
 (deftest builtin-visualize-query-ui-resource-metadata-test
-  (testing "the visualize_query UI resource publishes bare origins in its ChatGPT Apps metadata"
+  (testing "the visualize_query UI resource publishes bare origins; :domain is gated on the ChatGPT client"
     ;; site-url is set with a subpath to confirm `_meta.ui.domain` and the CSP domain lists strip the
     ;; path — ChatGPT's MCP host treats those fields as origins and would otherwise reject the value.
+    ;; `:domain` itself is only emitted for ChatGPT — Claude validates it against its own
+    ;; `*.claudemcpcontent.com` namespace and rejects anything else, so the field is suppressed for
+    ;; non-ChatGPT clients (detected via the in-flight request's User-Agent header).
     (let [site-url "https://metabase.example.com/sub/path"
           origin   "https://metabase.example.com"
-          uri      "ui://metabase/visualize-query.html"]
+          uri      "ui://metabase/visualize-query.html"
+          read-ui  (fn []
+                     (mcp.resources/with-fallback-template
+                       (mcp.resources/read-resource uri #{"agent:visualize"} {})))]
       (with-redefs [system/site-url (constantly site-url)]
-        (mcp.resources/with-fallback-template
-          (is (=? {:status   :ok
-                   :contents [{:uri      uri
-                               :mimeType "text/html;profile=mcp-app"
-                               :_meta    {:ui {:prefersBorder true
-                                               :domain        origin
-                                               :csp           {:connectDomains  [origin]
-                                                               :resourceDomains [origin]}}}}]}
-                  (mcp.resources/read-resource uri #{"agent:visualize"} {}))))))))
+        (testing "no request bound → CSP origins still emitted, :domain suppressed"
+          (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
+            (is (=? {:prefersBorder true
+                     :csp           {:connectDomains  [origin]
+                                     :resourceDomains [origin]}}
+                    ui-meta))
+            (is (not (contains? ui-meta :domain)))))
+        (testing "non-ChatGPT User-Agent → :domain suppressed"
+          (request/with-current-request {:headers {"user-agent" "claude-ai/0.1.0"}}
+            (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
+              (is (not (contains? ui-meta :domain))))))
+        (testing "ChatGPT User-Agent (`openai-mcp/...`) → :domain = origin"
+          (request/with-current-request {:headers {"user-agent" "openai-mcp/1.0.0 (ChatGPT)"}}
+            (is (=? {:status   :ok
+                     :contents [{:uri      uri
+                                 :mimeType "text/html;profile=mcp-app"
+                                 :_meta    {:ui {:prefersBorder true
+                                                 :domain        origin
+                                                 :csp           {:connectDomains  [origin]
+                                                                 :resourceDomains [origin]}}}}]}
+                    (read-ui)))))))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -101,6 +101,5 @@
                                :_meta    {:ui {:prefersBorder true
                                                :domain        site-url
                                                :csp           {:connectDomains  [site-url]
-                                                               :resourceDomains [site-url]
-                                                               :frameDomains    [site-url]}}}}]}
+                                                               :resourceDomains [site-url]}}}}]}
                   (mcp.resources/read-resource uri #{"agent:visualize"} {}))))))))

--- a/test/metabase/mcp/session_test.clj
+++ b/test/metabase/mcp/session_test.clj
@@ -104,28 +104,45 @@
       (is (some? (parse-uuid h1)) "store-handle! must return a UUID string")
       (is (some? (parse-uuid h2)))
       (is (not= h1 h2) "successive calls must produce distinct handles")
-      (is (= "first"  (mcp.session/read-handle session-id h1)))
-      (is (= "second" (mcp.session/read-handle session-id h2)))
-      (is (nil? (mcp.session/read-handle session-id (str (random-uuid))))
+      (is (= "first"  (mcp.session/read-handle session-id user-id h1)))
+      (is (= "second" (mcp.session/read-handle session-id user-id h2)))
+      (is (nil? (mcp.session/read-handle session-id user-id (str (random-uuid))))
           "read-handle returns nil for unknown handles"))))
 
-(deftest read-handle-is-scoped-to-session-test
-  (testing "read-handle does not resolve handles from another MCP session"
-    (let [user-id         (mt/user->id :crowberto)
-          owner-session   (mcp.session/create! user-id)
-          other-session   (mcp.session/create! user-id)
-          handle          (mcp.session/store-handle! owner-session user-id "payload")]
-      (is (= "payload" (mcp.session/read-handle owner-session handle)))
-      (is (nil? (mcp.session/read-handle other-session handle))))))
+(deftest read-handle-falls-back-across-the-users-sessions-test
+  (testing "read-handle resolves a handle stored in one session when called from another session of the same user"
+    (let [user-id        (mt/user->id :crowberto)
+          owner-session  (mcp.session/create! user-id)
+          rotated-session (mcp.session/create! user-id)
+          handle         (mcp.session/store-handle! owner-session user-id "payload")]
+      (testing "same session → resolves"
+        (is (= "payload" (mcp.session/read-handle owner-session user-id handle))))
+      (testing "different session, same user → still resolves (cross-session fallback)"
+        (is (= "payload" (mcp.session/read-handle rotated-session user-id handle))))))
+
+  (testing "read-handle refuses to resolve handles owned by a different user"
+    (let [owner-id    (mt/user->id :crowberto)
+          attacker-id (mt/user->id :rasta)
+          session-id  (mcp.session/create! owner-id)
+          handle      (mcp.session/store-handle! session-id owner-id "payload")]
+      (is (nil? (mcp.session/read-handle session-id attacker-id handle))))))
+
+(deftest resolve-query-handle-returns-encoded-query-and-prompt-test
+  (testing "resolve-query-handle returns the stored query and prompt"
+    (let [user-id    (mt/user->id :crowberto)
+          session-id (mcp.session/create! user-id)
+          handle     (mcp.session/store-handle! session-id user-id "encoded" "what was my question")]
+      (is (= {:encoded_query "encoded" :prompt "what was my question"}
+             (mcp.session/resolve-query-handle session-id user-id handle))))))
 
 (deftest store-handle-cascades-with-core-session-test
   (testing "deleting the backing core_session cascades to its handles"
     (let [user-id    (mt/user->id :crowberto)
           session-id (mcp.session/create! user-id)
           handle     (mcp.session/store-handle! session-id user-id "payload")]
-      (is (= "payload" (mcp.session/read-handle session-id handle)))
+      (is (= "payload" (mcp.session/read-handle session-id user-id handle)))
       (t2/delete! :core_session :key_hashed (derived-hash session-id))
-      (is (nil? (mcp.session/read-handle session-id handle))
+      (is (nil? (mcp.session/read-handle session-id user-id handle))
           "cascade should reap the handle when the core_session row goes"))))
 
 (deftest delete-removes-handles-test
@@ -134,7 +151,7 @@
           session-id (mcp.session/create! user-id)
           handle     (mcp.session/store-handle! session-id user-id "payload")
           _          (mcp.session/delete! session-id user-id)]
-      (is (nil? (mcp.session/read-handle session-id handle))))))
+      (is (nil? (mcp.session/read-handle session-id user-id handle))))))
 
 (deftest session-does-not-fire-login-event-test
   (testing "Creating a core_session via get-or-create-session-key! does not publish :event/user-login"

--- a/test/metabase/mcp/session_test.clj
+++ b/test/metabase/mcp/session_test.clj
@@ -118,6 +118,25 @@
       (is (= "payload" (mcp.session/read-handle owner-session handle)))
       (is (nil? (mcp.session/read-handle other-session handle))))))
 
+(deftest verified-widget-session-id-test
+  (testing "verified-widget-session-id returns the id only when core_session ownership matches"
+    (let [owner-id    (mt/user->id :crowberto)
+          attacker-id (mt/user->id :rasta)
+          session-id  (mcp.session/create! owner-id)
+          ;; `create!` only mints a UUID — the backing `core_session` row is
+          ;; materialized lazily. Storing a handle triggers
+          ;; `get-or-create-embedding-session!` and gives us a row to look up.
+          _           (mcp.session/store-handle! session-id owner-id "seed")]
+      (testing "matching user → trusted"
+        (is (= session-id (mcp.session/verified-widget-session-id session-id owner-id))))
+      (testing "non-matching user → nil"
+        (is (nil? (mcp.session/verified-widget-session-id session-id attacker-id))))
+      (testing "unknown session id → nil"
+        (is (nil? (mcp.session/verified-widget-session-id (str (random-uuid)) owner-id))))
+      (testing "nil inputs → nil"
+        (is (nil? (mcp.session/verified-widget-session-id nil owner-id)))
+        (is (nil? (mcp.session/verified-widget-session-id session-id nil)))))))
+
 (deftest store-handle-cascades-with-core-session-test
   (testing "deleting the backing core_session cascades to its handles"
     (let [user-id    (mt/user->id :crowberto)

--- a/test/metabase/mcp/session_test.clj
+++ b/test/metabase/mcp/session_test.clj
@@ -118,25 +118,6 @@
       (is (= "payload" (mcp.session/read-handle owner-session handle)))
       (is (nil? (mcp.session/read-handle other-session handle))))))
 
-(deftest verified-widget-session-id-test
-  (testing "verified-widget-session-id returns the id only when core_session ownership matches"
-    (let [owner-id    (mt/user->id :crowberto)
-          attacker-id (mt/user->id :rasta)
-          session-id  (mcp.session/create! owner-id)
-          ;; `create!` only mints a UUID — the backing `core_session` row is
-          ;; materialized lazily. Storing a handle triggers
-          ;; `get-or-create-embedding-session!` and gives us a row to look up.
-          _           (mcp.session/store-handle! session-id owner-id "seed")]
-      (testing "matching user → trusted"
-        (is (= session-id (mcp.session/verified-widget-session-id session-id owner-id))))
-      (testing "non-matching user → nil"
-        (is (nil? (mcp.session/verified-widget-session-id session-id attacker-id))))
-      (testing "unknown session id → nil"
-        (is (nil? (mcp.session/verified-widget-session-id (str (random-uuid)) owner-id))))
-      (testing "nil inputs → nil"
-        (is (nil? (mcp.session/verified-widget-session-id nil owner-id)))
-        (is (nil? (mcp.session/verified-widget-session-id session-id nil)))))))
-
 (deftest store-handle-cascades-with-core-session-test
   (testing "deleting the backing core_session cascades to its handles"
     (let [user-id    (mt/user->id :crowberto)

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -4,6 +4,23 @@
    [clojure.test :refer :all]
    [metabase.mcp.tools]))
 
+(deftest ^:parallel drop-nil-args-test
+  (testing "strips nil-valued top-level keys so 'missing' and 'explicit nil' are equivalent at the MCP boundary"
+    (let [drop-nil-args (var-get #'metabase.mcp.tools/drop-nil-args)]
+      (testing "removes top-level nils"
+        (is (= {:id 42 :flag false}
+               (drop-nil-args {:id 42 :flag false :extra nil}))))
+      (testing "keeps non-nil falsey values"
+        (is (= {:flag false :count 0 :text ""}
+               (drop-nil-args {:flag false :count 0 :text ""}))))
+      (testing "preserves nested nils (only top-level is rewritten)"
+        (is (= {:source {:type "table" :id nil}}
+               (drop-nil-args {:source {:type "table" :id nil} :continuation_token nil}))))
+      (testing "nil argument → nil"
+        (is (nil? (drop-nil-args nil))))
+      (testing "empty map stays empty"
+        (is (= {} (drop-nil-args {})))))))
+
 (deftest ^:parallel overrides-cover-known-tools-test
   (testing "every key in `mcp-input-overrides` / `mcp-output-overrides` matches a real tool"
     ;; Catches the silent-no-op failure mode if a tool gets renamed or an override key is misspelled:

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -1,4 +1,20 @@
 (ns metabase.mcp.tools-test
   "scope-matches? tests moved to [[metabase.mcp.scope-test]]."
   (:require
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [metabase.mcp.tools]))
+
+(deftest ^:parallel overrides-cover-known-tools-test
+  (testing "every key in `mcp-input-overrides` / `mcp-output-overrides` matches a real tool"
+    ;; Catches the silent-no-op failure mode if a tool gets renamed or an override key is misspelled:
+    ;; the override would otherwise be dropped on the floor and the wire-shape schema would be published
+    ;; in place of the intended MCP shape. Lives as a test (not a runtime check at manifest generation)
+    ;; so prod startup isn't burdened with a check that only catches developer mistakes.
+    (let [manifest-fn (#'metabase.mcp.tools/manifest)
+          tool-names  (into #{} (map :name) (:tools manifest-fn))]
+      (doseq [[label override-map-var] [["mcp-input-overrides"  #'metabase.mcp.tools/mcp-input-overrides]
+                                        ["mcp-output-overrides" #'metabase.mcp.tools/mcp-output-overrides]]]
+        (testing label
+          (let [unknown (remove tool-names (keys @override-map-var))]
+            (is (empty? unknown)
+                (str label " has keys that don't match any tool name: " (vec unknown)))))))))


### PR DESCRIPTION
Prepare the MCP for ChatGPT app publishing:
- adjust mali scheme to pass validation
- ~~handle widgetSessionId according to https://community.openai.com/t/connector-tool-calls-generating-fresh-mcp-session-each-invocation/1364975/12~~ drop widgetSessionId; handle lookups now fall back across the user's other sessions
- adds output schemas as ChatGPT warns if output schemas are not set
- adjust csp for UI resources (this should not be backported)

We must backport (probably manually?) the first 2 items to v61 and v60

How to test:
- @heypoom knows how to test it in ChatGPT/other agents
- i will also test it in ChatGPT/other agents

When i will do backports, we have to test it explicitly on v61 to ensure it properly works without UI templates

<img width="964" height="1174" alt="image" src="https://github.com/user-attachments/assets/200825b4-3ff1-463e-b339-0c58e07ed0fc" />

<img width="1434" height="1348" alt="image" src="https://github.com/user-attachments/assets/f629ceac-5b3f-44f6-82eb-b54180e969d0" />