### PR TITLE
Fix dark-mode document print contrast via CSS token overrides

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -550,6 +550,40 @@ describe("documents", () => {
         });
       });
 
+      it("should swap document text/border tokens to light-theme values when printing in dark mode (metabase#68323)", () => {
+        cy.request("PUT", "/api/setting/color-scheme", { value: "dark" });
+        H.visitDocument("@documentId");
+        cy.get('html[data-mantine-color-scheme="dark"]').should("exist");
+
+        const editorSelector = '[data-testid="document-content"] .ProseMirror';
+
+        cy.get(editorSelector).should(
+          "have.css",
+          "color",
+          "rgba(255, 255, 255, 0.95)",
+        );
+
+        cy.then(() =>
+          Cypress.automation("remote:debugger:protocol", {
+            command: "Emulation.setEmulatedMedia",
+            params: { media: "print" },
+          }),
+        );
+
+        cy.get(editorSelector).should(
+          "have.css",
+          "color",
+          "rgba(7, 23, 34, 0.84)",
+        );
+
+        cy.then(() =>
+          Cypress.automation("remote:debugger:protocol", {
+            command: "Emulation.setEmulatedMedia",
+            params: { media: "" },
+          }),
+        );
+      });
+
       it("should handle undo/redo properly, resetting the history whenever a different document is viewed", () => {
         H.visitDocument("@documentId");
         H.getDocumentCard("Orders").should("exist");

--- a/frontend/src/metabase/documents/components/DocumentPage.module.css
+++ b/frontend/src/metabase/documents/components/DocumentPage.module.css
@@ -47,6 +47,46 @@
     }
   }
 
+  /* Browsers strip dark backgrounds when printing, leaving dark-mode
+     light text unreadable on white paper. Repoint the document's text
+     and border tokens at their light-theme equivalents so the printed
+     output stays readable.
+
+     Mantine emits each theme color as a chain of aliases: the `c="..."`
+     prop on a parent resolves to `--mantine-color-<key>-text`, while a
+     `<Text>` element's own default color resolves to
+     `--mantine-color-<key>-filled`. Both have to be flipped to keep
+     header text, metadata, and inline icons readable.
+
+     The dark theme has no `border-inverse` token, but
+     `--mb-color-text-secondary-opaque` resolves to the same `orion[20]`
+     value that the light theme uses for `border`, so reuse it.
+     (metabase#68323) */
+  :global(html[data-mantine-color-scheme="dark"]) .documentContainer {
+    --mb-color-text-primary: var(--mb-color-text-primary-inverse);
+    --mb-color-text-secondary: var(--mb-color-text-secondary-inverse);
+    --mb-color-text-tertiary: var(--mb-color-text-tertiary-inverse);
+    --mantine-color-text-primary-text: var(
+      --mantine-color-text-primary-inverse-text
+    );
+    --mantine-color-text-secondary-text: var(
+      --mantine-color-text-secondary-inverse-text
+    );
+    --mantine-color-text-tertiary-text: var(
+      --mantine-color-text-tertiary-inverse-text
+    );
+    --mantine-color-text-primary-filled: var(
+      --mantine-color-text-primary-inverse-filled
+    );
+    --mantine-color-text-secondary-filled: var(
+      --mantine-color-text-secondary-inverse-filled
+    );
+    --mantine-color-text-tertiary-filled: var(
+      --mantine-color-text-tertiary-inverse-filled
+    );
+    --mb-color-border: var(--mb-color-text-secondary-opaque);
+  }
+
   .documentContainer {
     position: absolute;
     visibility: visible;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68323
Approach A: scoped `@media print` rule on `.documentContainer` that repoints `--mb-color-text-*` and Mantine's `--mantine-color-text-*-{text,filled}` aliases to their `*-inverse` equivalents in dark mode. Also borrows `text-secondary-opaque` for --`mb-color-border `since no border-inverse token exists.

**Pros**: pure CSS, no React/runtime cost, no flash, scoped to documents. 

**Cons**: enumerates one token chain at a time - future components that introduce new Mantine variable consumers in the document tree need their own overrides added here.

Closes [UXW-2758: Printing documents when using dark mode results in low contrast pdf](https://linear.app/metabase/issue/UXW-2758/printing-documents-when-using-dark-mode-results-in-low-contrast-pdf)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
