### PR TITLE
Fix dark-mode document print contrast by flipping scheme on beforeprint

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -550,6 +550,37 @@ describe("documents", () => {
         });
       });
 
+      it("should flip the page to light mode while printing in dark mode (metabase#68323)", () => {
+        cy.request("PUT", "/api/setting/color-scheme", { value: "dark" });
+        H.visitDocument("@documentId");
+
+        cy.get('html[data-mantine-color-scheme="dark"]').should("exist");
+
+        const editorSelector = '[data-testid="document-content"] .ProseMirror';
+        cy.get(editorSelector).should(
+          "have.css",
+          "color",
+          "rgba(255, 255, 255, 0.95)",
+        );
+
+        cy.window().then((win) => {
+          win.dispatchEvent(new Event("beforeprint"));
+        });
+
+        cy.get('html[data-mantine-color-scheme="light"]').should("exist");
+        cy.get(editorSelector).should(
+          "have.css",
+          "color",
+          "rgba(7, 23, 34, 0.84)",
+        );
+
+        cy.window().then((win) => {
+          win.dispatchEvent(new Event("afterprint"));
+        });
+
+        cy.get('html[data-mantine-color-scheme="dark"]').should("exist");
+      });
+
       it("should handle undo/redo properly, resetting the history whenever a different document is viewed", () => {
         H.visitDocument("@documentId");
         H.getDocumentCard("Orders").should("exist");

--- a/frontend/src/metabase/AppColorSchemeProvider.tsx
+++ b/frontend/src/metabase/AppColorSchemeProvider.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
 import { useMedia } from "react-use";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
@@ -40,6 +41,7 @@ export function AppColorSchemeProvider({
   const [colorScheme, setColorScheme] = useState<ColorScheme>(
     defaultColorScheme || "auto",
   );
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
     // NOTE: The `defaultColorScheme` prop may change in cases where the
@@ -52,7 +54,28 @@ export function AppColorSchemeProvider({
     setColorScheme(defaultColorScheme);
   }, [defaultColorScheme]);
 
+  useEffect(() => {
+    // Flip to light synchronously so the print snapshot is readable;
+    // browsers strip dark backgrounds via `print-color-adjust: economy`.
+    const onBeforePrint = () => {
+      flushSync(() => setIsPrinting(true));
+    };
+    const onAfterPrint = () => {
+      setIsPrinting(false);
+    };
+    window.addEventListener("beforeprint", onBeforePrint);
+    window.addEventListener("afterprint", onAfterPrint);
+    return () => {
+      window.removeEventListener("beforeprint", onBeforePrint);
+      window.removeEventListener("afterprint", onAfterPrint);
+    };
+  }, []);
+
   const resolvedColorScheme = useMemo(() => {
+    // Print wins over every other preference — paper is light.
+    if (isPrinting) {
+      return "light";
+    }
     if (forceColorScheme) {
       return forceColorScheme;
     }
@@ -60,7 +83,7 @@ export function AppColorSchemeProvider({
       return "light";
     }
     return colorScheme === "auto" ? systemColorScheme : colorScheme;
-  }, [colorScheme, forceColorScheme, systemColorScheme]);
+  }, [colorScheme, forceColorScheme, isPrinting, systemColorScheme]);
 
   const handleColorSchemeUpdate = useCallback(
     (value: ColorScheme) => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68323

### Description

Solution: `AppColorSchemeProvider` listens for the window `beforeprint` and `afterprint` events. On `beforeprint` it calls `flushSync` to synchronously force `resolvedColorScheme` to "light"; the entire MantineProvider re-renders before the browser captures the DOM for printing, so every CSS variable consumer flips at once. The original scheme is restored on `afterprint`.

Pros: one place, no per-token enumeration; works for any page that prints (dashboards, questions, documents) and for both window.print() and the browser's native cmd+P.
Cons: full theme re-render on print (chart recomputes, brief flash on screen during the print dialog), tied to React rendering order - needs flushSync to commit before the print snapshot.

Closes [UXW-2758: Printing documents when using dark mode results in low contrast pdf](https://linear.app/metabase/issue/UXW-2758/printing-documents-when-using-dark-mode-results-in-low-contrast-pdf)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
