### PR TITLE
Don't strip values from impersonation validation

### DIFF
--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -537,14 +537,13 @@
   "Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
    and returns the query reconstructed from the parsed AST."
   [dialect sql stmt-type]
-  (let [sql (strip-large-values sql)]
-    (-> (with-open [^Closeable ctx (python.pool/python-context)]
-          (with-python-timeout ctx default-timeout-ms
-            (-> ^Value (common/eval-python ctx "sql_tools.is_single_stmt_of_type")
-                (.execute ^Value (object-array [sql stmt-type dialect]))
-                .asString)))
-        json/decode+kw
-        (perf/update-keys (comp keyword u/->kebab-case-en)))))
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          (-> ^Value (common/eval-python ctx "sql_tools.is_single_stmt_of_type")
+              (.execute ^Value (object-array [sql stmt-type dialect]))
+              .asString)))
+      json/decode+kw
+      (perf/update-keys (comp keyword u/->kebab-case-en))))
 
 (comment
   (referenced-tables "postgres" "select * from transactions")

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -537,13 +537,19 @@
   "Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
    and returns the query reconstructed from the parsed AST."
   [dialect sql stmt-type]
-  (-> (with-open [^Closeable ctx (python.pool/python-context)]
-        (with-python-timeout ctx default-timeout-ms
-          (-> ^Value (common/eval-python ctx "sql_tools.is_single_stmt_of_type")
-              (.execute ^Value (object-array [sql stmt-type dialect]))
-              .asString)))
-      json/decode+kw
-      (perf/update-keys (comp keyword u/->kebab-case-en))))
+  (let [stripped-sql (strip-large-values sql)
+        result (-> (with-open [^Closeable ctx (python.pool/python-context)]
+                     (with-python-timeout ctx default-timeout-ms
+                       (-> ^Value (common/eval-python ctx "sql_tools.is_single_stmt_of_type")
+                           (.execute ^Value (object-array [stripped-sql stmt-type dialect]))
+                           .asString)))
+                   json/decode+kw
+                   (perf/update-keys (comp keyword u/->kebab-case-en)))]
+    ;; The `:sql` in the `result` is the reconstructed SQL from the SQLGlot parser.
+    ;; We generally want to use the reconstructed SQL, but if the original SQL had its values stripped (to avoid GraalPy OOM)
+    ;; then we need to return the original SQL to preserve the values. (#74284)
+    (cond-> result
+      (not= sql stripped-sql) (assoc :sql sql))))
 
 (comment
   (referenced-tables "postgres" "select * from transactions")

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -234,5 +234,10 @@
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"
     (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]
-      (is (= {:is-single-stmt? true, :sql values-query}
-             (sql-tools/is-single-stmt-of-type? :postgres values-query "read"))))))
+      (are [sql is-single-stmt?] (= {:is-single-stmt? is-single-stmt? :sql sql}
+                                    (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+        values-query true
+        (str "SELECT 1; " values-query) false
+        (str "SET ROLE none; " values-query) false
+        (str values-query "; SELECT 1") false
+        (str values-query "; SET ROLE none") false))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -230,3 +230,9 @@
         "SELECT * FROM foo INTERSECT ALL SELECT * FROM bar EXCEPT ALL SELECT * FROM baz"
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
+
+(deftest ^:parallel is-single-stmt-of-type-not-stripped-test
+  (testing "we don't strip value clauses for impersonation validation (#74284)"
+    (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]
+      (is (= {:is-single-stmt? true, :sql values-query}
+             (sql-tools/is-single-stmt-of-type? :postgres values-query "read"))))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -232,7 +232,7 @@
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
 
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
-  (testing "we don't strip value clauses for impersonation validation (#74284)"
+  (testing "we don't remove value clauses when validating impersonated queries (#74284)"
     (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]
       (is (= {:is-single-stmt? true, :sql values-query}
              (sql-tools/is-single-stmt-of-type? :postgres values-query "read"))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74284

### Description

Changes were made in https://github.com/metabase/metabase/pull/73314 to strip queries with > 100 value clauses to prevent graalvm ooms. This broke impersonation for queries with > 100 value clauses as we execute the query reconstructed by the sqlglot parser, which now had its value clauses stripped. The change in this PR is to not strip the value clauses when validating impersonated queries. 

### How to verify

See the original issue or the `values-query` in the unit test. You should be able to execute this query on an impersonated database and get the expected results. 

### Demo

https://github.com/user-attachments/assets/584a8849-db27-4db1-a9ce-dd3e1a5d1b05

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
