### PR TITLE
Uxw 3359 visualizer breaks internal dimension remapping for integer

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
@@ -174,7 +174,7 @@ export const ColumnsList = (props: ColumnListProps) => {
                     return null;
                   }
 
-                  // Hide remapped display companions; extractRemappedColumns pairs them at render time.
+                  // Hide remapped display columns; extractRemappedColumns pairs them at render time.
                   if (column.remapped_from != null) {
                     return null;
                   }

--- a/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
@@ -174,6 +174,11 @@ export const ColumnsList = (props: ColumnListProps) => {
                     return null;
                   }
 
+                  // Hide remapped display companions; extractRemappedColumns pairs them at render time.
+                  if (column.remapped_from != null) {
+                    return null;
+                  }
+
                   const columnReference = referencedColumns.find((ref) =>
                     isReferenceToColumn(column, source.id, ref),
                   );

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/HorizontalWell/CartesianHorizontallWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/HorizontalWell/CartesianHorizontallWell.tsx
@@ -16,7 +16,7 @@ import {
   getVisualizerRawSettings,
 } from "metabase/visualizer/selectors";
 import { removeColumn } from "metabase/visualizer/visualizer.slice";
-import { isDate, isString } from "metabase-lib/v1/types/utils/isa";
+import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type { DatasetColumn } from "metabase-types/api";
 
 import { WellItem } from "../WellItem";
@@ -49,15 +49,15 @@ export function CartesianHorizontalWell({ style, ...props }: FlexProps) {
 
     const dimensions: DatasetColumn[] = [];
     const timeDimensions = allDimensions.filter(isDate);
-    const categoryDimensions = allDimensions.filter(isString);
+    // Non-temporal = category-like (string, integer-Category, binned numeric, etc.).
+    const categoryDimensions = allDimensions.filter((col) => !isDate(col));
 
-    // Show only one dimension for multiseries charts,
-    // as they have to be added/removed together, not individually
+    // Only one temporal x-axis is allowed; category dims can span multiple per-series slots.
     if (timeDimensions.length > 0) {
       dimensions.push(timeDimensions[0]);
     }
     if (categoryDimensions.length > 0) {
-      dimensions.push(...categoryDimensions); //.push(categoryDimensions[0]);
+      dimensions.push(...categoryDimensions);
     }
 
     return dimensions;

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -85,9 +85,7 @@ export function copyColumn(
   return copy;
 }
 
-// `copyColumn` renames columns to `COLUMN_N` but leaves `remapped_from`/`remapped_to`
-// pointing at the original names. Without this rewrite, `extractRemappedColumns` fails
-// to pair a dimension with its display-value companion and falls back to raw IDs.
+// Point remapped_from/to at the renamed COLUMN_N so extractRemappedColumns can pair them.
 export function rewriteRemappedReferences(
   column: DatasetColumn,
   oldToNew: Map<string, string>,

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -85,6 +85,32 @@ export function copyColumn(
   return copy;
 }
 
+// `copyColumn` renames columns to `COLUMN_N` but leaves `remapped_from`/`remapped_to`
+// pointing at the original names. Without this rewrite, `extractRemappedColumns` fails
+// to pair a dimension with its display-value companion and falls back to raw IDs.
+export function rewriteRemappedReferences(
+  column: DatasetColumn,
+  oldToNew: Map<string, string>,
+): DatasetColumn {
+  const remapped_from =
+    column.remapped_from != null
+      ? oldToNew.get(column.remapped_from)
+      : column.remapped_from;
+  const remapped_to =
+    column.remapped_to != null
+      ? oldToNew.get(column.remapped_to)
+      : column.remapped_to;
+
+  if (
+    remapped_from === column.remapped_from &&
+    remapped_to === column.remapped_to
+  ) {
+    return column;
+  }
+
+  return { ...column, remapped_from, remapped_to };
+}
+
 export function addColumnMapping(
   mapping: VisualizerColumnValueSource[] | undefined,
   source: VisualizerColumnValueSource,

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -94,9 +94,7 @@ function pickColumns(
         settings["graph.dimensions"]?.includes(name) ||
         tooltipColumns.includes(name));
 
-    // Keep a column whose `remapped_from` points at a selected dimension so the
-    // server-injected display-value companion (e.g. integer-Category remapping) is
-    // not silently dropped.
+    // Keep the display-value companion of any selected dim.
     return originalColumns.filter(
       (col) => isSelected(col.name) || isSelected(col.remapped_from),
     );

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -94,7 +94,7 @@ function pickColumns(
         settings["graph.dimensions"]?.includes(name) ||
         tooltipColumns.includes(name));
 
-    // Keep the display-value companion of any selected dim.
+    // Keep the display-value column paired with any selected dim.
     return originalColumns.filter(
       (col) => isSelected(col.name) || isSelected(col.remapped_from),
     );
@@ -184,9 +184,9 @@ export function getInitialStateForCardDataSource(
     columnsToRefs[column.name] = columnRef.name;
   });
 
-  const renames = new Map(Object.entries(columnsToRefs));
+  const columnRenames = new Map(Object.entries(columnsToRefs));
   state.columns = state.columns.map((col) =>
-    rewriteRemappedReferences(col, renames),
+    rewriteRemappedReferences(col, columnRenames),
   );
 
   const entries = getColumnVizSettings(state.display!)

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -27,6 +27,7 @@ import {
   copyColumn,
   createVisualizerColumnReference,
   extractReferencedColumns,
+  rewriteRemappedReferences,
 } from "./column";
 import {
   DEFAULT_VISUALIZER_DISPLAY,
@@ -87,13 +88,18 @@ function pickColumns(
       getColumnNameFromKey,
     );
 
-    return originalColumns.filter((col) => {
-      return (
-        settings["graph.metrics"]?.includes(col.name) ||
-        settings["graph.dimensions"]?.includes(col.name) ||
-        tooltipColumns.includes(col.name)
-      );
-    });
+    const isSelected = (name?: string) =>
+      name != null &&
+      (settings["graph.metrics"]?.includes(name) ||
+        settings["graph.dimensions"]?.includes(name) ||
+        tooltipColumns.includes(name));
+
+    // Keep a column whose `remapped_from` points at a selected dimension so the
+    // server-injected display-value companion (e.g. integer-Category remapping) is
+    // not silently dropped.
+    return originalColumns.filter(
+      (col) => isSelected(col.name) || isSelected(col.remapped_from),
+    );
   }
 
   return originalColumns;
@@ -179,6 +185,11 @@ export function getInitialStateForCardDataSource(
     state.columnValuesMapping[columnRef.name] = [columnRef];
     columnsToRefs[column.name] = columnRef.name;
   });
+
+  const renames = new Map(Object.entries(columnsToRefs));
+  state.columns = state.columns.map((col) =>
+    rewriteRemappedReferences(col, renames),
+  );
 
   const entries = getColumnVizSettings(state.display!)
     .map((setting) => {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -297,6 +297,75 @@ describe("getInitialStateForCardDataSource", () => {
     });
   });
 
+  it("should keep remapped display companion columns and rewrite references (UXW-3359)", () => {
+    const dataset = createMockDataset({
+      data: createMockDatasetData({
+        cols: [
+          createMockColumn({
+            name: "buyingstatus",
+            base_type: "type/Integer",
+            effective_type: "type/Integer",
+            semantic_type: "type/Category",
+            remapped_to: "buyingstatus_display",
+          }),
+          createMockColumn({
+            name: "buyingstatus_display",
+            base_type: "type/Text",
+            effective_type: "type/Text",
+            remapped_from: "buyingstatus",
+          }),
+          createMockColumn({
+            name: "count",
+            base_type: "type/BigInteger",
+            effective_type: "type/BigInteger",
+            semantic_type: "type/Quantity",
+          }),
+        ],
+      }),
+    });
+
+    const card = createMockCard({
+      display: "bar",
+      name: "Remapped",
+      description: null,
+      visualization_settings: {
+        "graph.dimensions": ["buyingstatus"],
+        "graph.metrics": ["count"],
+      },
+    });
+
+    const state = getInitialStateForCardDataSource(card, dataset);
+
+    // Companion display column is included in the mapping.
+    expect(state.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        { name: "COLUMN_1", originalName: "buyingstatus", sourceId: "card:1" },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "buyingstatus_display",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_3: [
+        { name: "COLUMN_3", originalName: "count", sourceId: "card:1" },
+      ],
+    });
+
+    // Remap references now point at the renamed COLUMN_N rather than original names.
+    const baseCol = state.columns.find((c) => c.name === "COLUMN_1");
+    const displayCol = state.columns.find((c) => c.name === "COLUMN_2");
+    expect(baseCol?.remapped_to).toBe("COLUMN_2");
+    expect(displayCol?.remapped_from).toBe("COLUMN_1");
+
+    // Settings only mention the user-selected dimension/metric (not the companion).
+    expect(state.settings).toEqual({
+      "graph.dimensions": ["COLUMN_1"],
+      "graph.metrics": ["COLUMN_3"],
+    });
+  });
+
   it.each<CardDisplayType>(["scalar", "gauge"])(
     "should return scalar funnel initial state if the original card is a %s",
     (vizType) => {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -297,7 +297,7 @@ describe("getInitialStateForCardDataSource", () => {
     });
   });
 
-  it("should keep remapped display companion columns and rewrite references (UXW-3359)", () => {
+  it("should keep remapped display columns and rewrite references (UXW-3359)", () => {
     const dataset = createMockDataset({
       data: createMockDatasetData({
         cols: [

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -336,7 +336,6 @@ describe("getInitialStateForCardDataSource", () => {
 
     const state = getInitialStateForCardDataSource(card, dataset);
 
-    // Companion display column is included in the mapping.
     expect(state.columnValuesMapping).toEqual({
       COLUMN_1: [
         { name: "COLUMN_1", originalName: "buyingstatus", sourceId: "card:1" },
@@ -353,13 +352,11 @@ describe("getInitialStateForCardDataSource", () => {
       ],
     });
 
-    // Remap references now point at the renamed COLUMN_N rather than original names.
     const baseCol = state.columns.find((c) => c.name === "COLUMN_1");
     const displayCol = state.columns.find((c) => c.name === "COLUMN_2");
     expect(baseCol?.remapped_to).toBe("COLUMN_2");
     expect(displayCol?.remapped_from).toBe("COLUMN_1");
 
-    // Settings only mention the user-selected dimension/metric (not the companion).
     expect(state.settings).toEqual({
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_3"],

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -13,6 +13,7 @@ import {
   copyColumn,
   createVisualizerColumnReference,
   extractReferencedColumns,
+  rewriteRemappedReferences,
 } from "./column";
 import { createDataSource } from "./data-source";
 import { updateVizSettingsWithRefs } from "./update-viz-settings-with-refs";
@@ -66,6 +67,8 @@ function processColumnsForDataSource(
 ): ColumnInfo[] {
   const columnInfos: ColumnInfo[] = [];
 
+  const firstNewIndex = state.columns.length;
+
   columns.forEach((column) => {
     const columnRef = createVisualizerColumnReference(
       dataSource,
@@ -88,6 +91,16 @@ function processColumnsForDataSource(
       column: processedColumn,
     });
   });
+
+  const renames = new Map(
+    columnInfos.map(({ columnRef }) => [
+      columnRef.originalName,
+      columnRef.name,
+    ]),
+  );
+  for (let i = firstNewIndex; i < state.columns.length; i++) {
+    state.columns[i] = rewriteRemappedReferences(state.columns[i], renames);
+  }
 
   return columnInfos;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -92,14 +92,17 @@ function processColumnsForDataSource(
     });
   });
 
-  const renames = new Map(
+  const columnRenames = new Map(
     columnInfos.map(({ columnRef }) => [
       columnRef.originalName,
       columnRef.name,
     ]),
   );
   for (let i = firstNewIndex; i < state.columns.length; i++) {
-    state.columns[i] = rewriteRemappedReferences(state.columns[i], renames);
+    state.columns[i] = rewriteRemappedReferences(
+      state.columns[i],
+      columnRenames,
+    );
   }
 
   return columnInfos;

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
@@ -12,7 +12,7 @@ import {
   isScalarFunnel,
 } from "../visualizations/funnel";
 
-import { copyColumn } from "./column";
+import { copyColumn, rewriteRemappedReferences } from "./column";
 
 /**
  * Creates visualization columns for a visualizer entity.
@@ -45,6 +45,23 @@ export const getVisualizationColumns = (
     ];
   }
 
+  // Build per-source rename maps so we can rewrite `remapped_from`/`remapped_to`
+  // (which `copyColumn` leaves pointing at original names) without leaking
+  // names across data sources.
+  const renamesBySource = new Map<
+    VisualizerDataSourceId,
+    Map<string, string>
+  >();
+  Object.values(columnValuesMapping).forEach((mappings) =>
+    mappings.forEach((mapping) => {
+      if (typeof mapping !== "string") {
+        const existing = renamesBySource.get(mapping.sourceId) ?? new Map();
+        existing.set(mapping.originalName, mapping.name);
+        renamesBySource.set(mapping.sourceId, existing);
+      }
+    }),
+  );
+
   const visualizationColumns: DatasetColumn[] = [];
   // For all other chart types, create visualization columns from column mappings
   Object.entries(columnValuesMapping).forEach(
@@ -63,11 +80,16 @@ export const getVisualizationColumns = (
             return;
           }
 
-          const visualizationColumn = copyColumn(
-            columnMapping.name,
-            datasetColumn,
-            dataSource.name,
-            visualizationColumns,
+          const renames =
+            renamesBySource.get(columnMapping.sourceId) ?? new Map();
+          const visualizationColumn = rewriteRemappedReferences(
+            copyColumn(
+              columnMapping.name,
+              datasetColumn,
+              dataSource.name,
+              visualizationColumns,
+            ),
+            renames,
           );
 
           visualizationColumns.push(visualizationColumn);

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
@@ -46,16 +46,17 @@ export const getVisualizationColumns = (
   }
 
   // Per-source rename maps so remapped_from/to rewrites don't leak across sources.
-  const renamesBySource = new Map<
+  const columnRenamesBySource = new Map<
     VisualizerDataSourceId,
     Map<string, string>
   >();
   Object.values(columnValuesMapping).forEach((mappings) =>
     mappings.forEach((mapping) => {
       if (typeof mapping !== "string") {
-        const existing = renamesBySource.get(mapping.sourceId) ?? new Map();
+        const existing =
+          columnRenamesBySource.get(mapping.sourceId) ?? new Map();
         existing.set(mapping.originalName, mapping.name);
-        renamesBySource.set(mapping.sourceId, existing);
+        columnRenamesBySource.set(mapping.sourceId, existing);
       }
     }),
   );
@@ -78,8 +79,8 @@ export const getVisualizationColumns = (
             return;
           }
 
-          const renames =
-            renamesBySource.get(columnMapping.sourceId) ?? new Map();
+          const columnRenames =
+            columnRenamesBySource.get(columnMapping.sourceId) ?? new Map();
           const visualizationColumn = rewriteRemappedReferences(
             copyColumn(
               columnMapping.name,
@@ -87,7 +88,7 @@ export const getVisualizationColumns = (
               dataSource.name,
               visualizationColumns,
             ),
-            renames,
+            columnRenames,
           );
 
           visualizationColumns.push(visualizationColumn);

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
@@ -45,9 +45,7 @@ export const getVisualizationColumns = (
     ];
   }
 
-  // Build per-source rename maps so we can rewrite `remapped_from`/`remapped_to`
-  // (which `copyColumn` leaves pointing at original names) without leaking
-  // names across data sources.
+  // Per-source rename maps so remapped_from/to rewrites don't leak across sources.
   const renamesBySource = new Map<
     VisualizerDataSourceId,
     Map<string, string>

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
@@ -159,6 +159,140 @@ describe("getVisualizationColumns", () => {
       ]);
     });
 
+    it("should rewrite remapped_from/remapped_to to the renamed COLUMN_N (UXW-3359)", () => {
+      const visualizerEntity: VisualizerVizDefinition = {
+        display: "bar",
+        settings: {},
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              name: "COLUMN_1",
+              originalName: "buyingstatus",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_2: [
+            {
+              name: "COLUMN_2",
+              originalName: "buyingstatus_display",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_3: [
+            {
+              name: "COLUMN_3",
+              originalName: "count",
+              sourceId: "card:1",
+            },
+          ],
+        },
+      };
+
+      const dataSource: VisualizerDataSource = {
+        id: "card:1",
+        sourceId: 1,
+        name: "Source 1",
+        type: "card",
+      };
+
+      const buyingStatusColumn = createMockColumn({
+        name: "buyingstatus",
+        base_type: "type/Integer",
+        effective_type: "type/Integer",
+        semantic_type: "type/Category",
+        remapped_to: "buyingstatus_display",
+      });
+      const buyingStatusDisplayColumn = createMockColumn({
+        name: "buyingstatus_display",
+        base_type: "type/Text",
+        effective_type: "type/Text",
+        remapped_from: "buyingstatus",
+      });
+      const countColumn = createMockColumn({
+        name: "count",
+        base_type: "type/BigInteger",
+      });
+
+      const dataset: Dataset = createMockDataset({
+        data: createMockDatasetData({
+          cols: [buyingStatusColumn, buyingStatusDisplayColumn, countColumn],
+        }),
+      });
+
+      const columns = getVisualizationColumns(
+        visualizerEntity,
+        { "card:1": dataset },
+        [dataSource],
+      );
+
+      const base = columns.find((c) => c.name === "COLUMN_1");
+      const display = columns.find((c) => c.name === "COLUMN_2");
+
+      expect(base?.remapped_to).toBe("COLUMN_2");
+      expect(display?.remapped_from).toBe("COLUMN_1");
+    });
+
+    it("should scope rewrites to the same data source", () => {
+      const visualizerEntity: VisualizerVizDefinition = {
+        display: "bar",
+        settings: {},
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              name: "COLUMN_1",
+              originalName: "buyingstatus",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_2: [
+            {
+              name: "COLUMN_2",
+              originalName: "buyingstatus",
+              sourceId: "card:2",
+            },
+          ],
+        },
+      };
+
+      const dataSource1: VisualizerDataSource = {
+        id: "card:1",
+        sourceId: 1,
+        name: "Source 1",
+        type: "card",
+      };
+      const dataSource2: VisualizerDataSource = {
+        id: "card:2",
+        sourceId: 2,
+        name: "Source 2",
+        type: "card",
+      };
+
+      const colWithRemap = createMockColumn({
+        name: "buyingstatus",
+        remapped_to: "buyingstatus_display",
+      });
+      const colWithoutRemap = createMockColumn({ name: "buyingstatus" });
+
+      const datasets = {
+        "card:1": createMockDataset({
+          data: createMockDatasetData({ cols: [colWithRemap] }),
+        }),
+        "card:2": createMockDataset({
+          data: createMockDatasetData({ cols: [colWithoutRemap] }),
+        }),
+      };
+
+      const columns = getVisualizationColumns(visualizerEntity, datasets, [
+        dataSource1,
+        dataSource2,
+      ]);
+
+      // card:1's column has remapped_to pointing at a name not in card:1's renames →
+      // gets cleared (undefined), not silently mapped via card:2's COLUMN_2.
+      const fromCard1 = columns.find((c) => c.name === "COLUMN_1");
+      expect(fromCard1?.remapped_to).toBeUndefined();
+    });
+
     it("should ignore missing dataset column or data source", () => {
       const visualizerEntity: VisualizerVizDefinition = {
         display: "bar",

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
@@ -287,8 +287,7 @@ describe("getVisualizationColumns", () => {
         dataSource2,
       ]);
 
-      // card:1's column has remapped_to pointing at a name not in card:1's renames →
-      // gets cleared (undefined), not silently mapped via card:2's COLUMN_2.
+      // remapped_to gets cleared, not silently mapped to card:2's COLUMN_2.
       const fromCard1 = columns.find((c) => c.name === "COLUMN_1");
       expect(fromCard1?.remapped_to).toBeUndefined();
     });

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -16,6 +16,7 @@ import {
   createVisualizerColumnReference,
   extractReferencedColumns,
   isDraggedColumnItem,
+  rewriteRemappedReferences,
   shouldSplitVisualizerSeries,
   updateVizSettingsWithRefs,
 } from "metabase/visualizer/utils";
@@ -83,6 +84,10 @@ export const cartesianDropHandler = (
         columnRef,
         dataSource,
       );
+      const dataset = datasetMap[dataSource.id];
+      if (dataset) {
+        attachRemappedCompanion(state, columnRef, column, dataset, dataSource);
+      }
       maybeImportDimensionsFromOtherDataSources(
         state,
         settings,
@@ -399,9 +404,10 @@ function removeDimensionFromMultiSeriesChart(
     state.settings["graph.dimensions"] = originalDimensions.filter(
       (name) => !isDate(dimensionColumnMap[name]),
     );
-  } else if (isString(column)) {
-    state.settings["graph.dimensions"] = originalDimensions.filter(
-      (name) => !isString(dimensionColumnMap[name]),
+  } else {
+    // Non-date dim: clear all non-date dims (string, integer-Category, binned numeric, etc.).
+    state.settings["graph.dimensions"] = originalDimensions.filter((name) =>
+      isDate(dimensionColumnMap[name]),
     );
   }
 
@@ -409,10 +415,58 @@ function removeDimensionFromMultiSeriesChart(
     (name) => !state.settings["graph.dimensions"]?.includes(name),
   );
 
-  removedColumns.forEach((name) => {
+  // Strip orphan companions too, or stale remapped_from refs misalign render-time rows.
+  const removedNameSet = new Set(removedColumns);
+  const orphanedCompanions = state.columns
+    .filter(
+      (col) =>
+        col.remapped_from != null && removedNameSet.has(col.remapped_from),
+    )
+    .map((col) => col.name);
+
+  [...removedColumns, ...orphanedCompanions].forEach((name) => {
     state.columns = state.columns.filter((col) => col.name !== name);
     delete state.columnValuesMapping[name];
   });
+}
+
+// Silently attach a base dim's display-value companion (in state.columns/columnValuesMapping
+// but not graph.dimensions) and point both cols' remapped refs at the new COLUMN_N names.
+export function attachRemappedCompanion(
+  state:
+    | Draft<VisualizerVizDefinitionWithColumns>
+    | VisualizerVizDefinitionWithColumns,
+  baseColRef: VisualizerColumnReference,
+  originalBaseCol: DatasetColumn,
+  dataset: Dataset,
+  dataSource: VisualizerDataSource,
+) {
+  const companionCol = dataset.data.cols.find(
+    (col) => col.remapped_from === originalBaseCol.name,
+  );
+  if (!companionCol) {
+    return;
+  }
+
+  const companionRef = createVisualizerColumnReference(
+    dataSource,
+    companionCol,
+    extractReferencedColumns(state.columnValuesMapping),
+  );
+  state.columns.push(
+    copyColumn(companionRef.name, companionCol, dataSource.name, state.columns),
+  );
+  state.columnValuesMapping[companionRef.name] = [companionRef];
+
+  const renames = new Map([
+    [originalBaseCol.name, baseColRef.name],
+    [companionCol.name, companionRef.name],
+  ]);
+  state.columns = state.columns.map((col) =>
+    col.name === baseColRef.name || col.name === companionRef.name
+      ? rewriteRemappedReferences(col, renames)
+      : col,
+  );
 }
 
 export function maybeImportDimensionsFromOtherDataSources(
@@ -450,6 +504,13 @@ export function maybeImportDimensionsFromOtherDataSources(
         settings,
         matchingDimension,
         columnRef,
+        dataSource,
+      );
+      attachRemappedCompanion(
+        state,
+        columnRef,
+        matchingDimension,
+        dataset,
         dataSource,
       );
     }
@@ -504,14 +565,13 @@ export function combineWithCartesianChart(
   const { data } = dataset;
 
   const metrics = data.cols.filter((col) => isMetric(col));
-  // Display-value companion columns (server-injected from internal dimension
-  // remapping) are dimension-typed but should never appear in graph.dimensions —
-  // they're paired with their base column by `extractRemappedColumns` instead.
+  // Display-value companions are attached separately below, not as graph.dimensions slots.
   const dimensions = data.cols.filter(
     (col) => isDimension(col) && !isMetric(col) && col.remapped_from == null,
   );
 
   const columnsToRefs: Record<string, string> = {};
+  const firstNewIndex = state.columns.length;
 
   metrics.forEach((column) => {
     const isCompatible = !!findColumnSlotForCartesianChart({
@@ -564,11 +624,8 @@ export function combineWithCartesianChart(
     }
   });
 
-  // Attach display-value companion columns silently — they need to live in
-  // `columnValuesMapping`/`state.columns` so `extractRemappedColumns` can pair
-  // them with their base dimension, but they must NOT be added to
-  // graph.dimensions (which would otherwise give this card an extra x-axis slot
-  // and prevent merging with cards from other data sources).
+  // Silent companion attach: in columnValuesMapping/state.columns, NOT graph.dimensions
+  // (extra dim slots break cross-source axis merging).
   data.cols
     .filter(
       (col) =>
@@ -586,6 +643,12 @@ export function combineWithCartesianChart(
       state.columnValuesMapping[columnRef.name] = [columnRef];
       columnsToRefs[column.name] = columnRef.name;
     });
+
+  // Point remapped_from/to at the new COLUMN_N names so extractRemappedColumns can pair them.
+  const renames = new Map(Object.entries(columnsToRefs));
+  for (let i = firstNewIndex; i < state.columns.length; i++) {
+    state.columns[i] = rewriteRemappedReferences(state.columns[i], renames);
+  }
 
   if (vizSettings && vizSettings.column_settings) {
     const remappedSettings = updateVizSettingsWithRefs(

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -504,8 +504,11 @@ export function combineWithCartesianChart(
   const { data } = dataset;
 
   const metrics = data.cols.filter((col) => isMetric(col));
+  // Display-value companion columns (server-injected from internal dimension
+  // remapping) are dimension-typed but should never appear in graph.dimensions —
+  // they're paired with their base column by `extractRemappedColumns` instead.
   const dimensions = data.cols.filter(
-    (col) => isDimension(col) && !isMetric(col),
+    (col) => isDimension(col) && !isMetric(col) && col.remapped_from == null,
   );
 
   const columnsToRefs: Record<string, string> = {};
@@ -560,6 +563,29 @@ export function combineWithCartesianChart(
       columnsToRefs[column.name] = columnRef.name;
     }
   });
+
+  // Attach display-value companion columns silently — they need to live in
+  // `columnValuesMapping`/`state.columns` so `extractRemappedColumns` can pair
+  // them with their base dimension, but they must NOT be added to
+  // graph.dimensions (which would otherwise give this card an extra x-axis slot
+  // and prevent merging with cards from other data sources).
+  data.cols
+    .filter(
+      (col) =>
+        col.remapped_from != null && columnsToRefs[col.remapped_from] != null,
+    )
+    .forEach((column) => {
+      const columnRef = createVisualizerColumnReference(
+        dataSource,
+        column,
+        extractReferencedColumns(state.columnValuesMapping),
+      );
+      state.columns.push(
+        copyColumn(columnRef.name, column, dataSource.name, state.columns),
+      );
+      state.columnValuesMapping[columnRef.name] = [columnRef];
+      columnsToRefs[column.name] = columnRef.name;
+    });
 
   if (vizSettings && vizSettings.column_settings) {
     const remappedSettings = updateVizSettingsWithRefs(

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -86,7 +86,13 @@ export const cartesianDropHandler = (
       );
       const dataset = datasetMap[dataSource.id];
       if (dataset) {
-        attachRemappedCompanion(state, columnRef, column, dataset, dataSource);
+        attachRemappedDisplayColumn(
+          state,
+          columnRef,
+          column,
+          dataset,
+          dataSource,
+        );
       }
       maybeImportDimensionsFromOtherDataSources(
         state,
@@ -415,24 +421,24 @@ function removeDimensionFromMultiSeriesChart(
     (name) => !state.settings["graph.dimensions"]?.includes(name),
   );
 
-  // Strip orphan companions too, or stale remapped_from refs misalign render-time rows.
+  // Strip orphan display columns too, or stale remapped_from refs misalign render-time rows.
   const removedNameSet = new Set(removedColumns);
-  const orphanedCompanions = state.columns
+  const orphanedDisplayCols = state.columns
     .filter(
       (col) =>
         col.remapped_from != null && removedNameSet.has(col.remapped_from),
     )
     .map((col) => col.name);
 
-  [...removedColumns, ...orphanedCompanions].forEach((name) => {
+  [...removedColumns, ...orphanedDisplayCols].forEach((name) => {
     state.columns = state.columns.filter((col) => col.name !== name);
     delete state.columnValuesMapping[name];
   });
 }
 
-// Silently attach a base dim's display-value companion (in state.columns/columnValuesMapping
+// Silently attach a base dim's display-value column (in state.columns/columnValuesMapping
 // but not graph.dimensions) and point both cols' remapped refs at the new COLUMN_N names.
-export function attachRemappedCompanion(
+export function attachRemappedDisplayColumn(
   state:
     | Draft<VisualizerVizDefinitionWithColumns>
     | VisualizerVizDefinitionWithColumns,
@@ -441,30 +447,30 @@ export function attachRemappedCompanion(
   dataset: Dataset,
   dataSource: VisualizerDataSource,
 ) {
-  const companionCol = dataset.data.cols.find(
+  const displayCol = dataset.data.cols.find(
     (col) => col.remapped_from === originalBaseCol.name,
   );
-  if (!companionCol) {
+  if (!displayCol) {
     return;
   }
 
-  const companionRef = createVisualizerColumnReference(
+  const displayRef = createVisualizerColumnReference(
     dataSource,
-    companionCol,
+    displayCol,
     extractReferencedColumns(state.columnValuesMapping),
   );
   state.columns.push(
-    copyColumn(companionRef.name, companionCol, dataSource.name, state.columns),
+    copyColumn(displayRef.name, displayCol, dataSource.name, state.columns),
   );
-  state.columnValuesMapping[companionRef.name] = [companionRef];
+  state.columnValuesMapping[displayRef.name] = [displayRef];
 
-  const renames = new Map([
+  const columnRenames = new Map([
     [originalBaseCol.name, baseColRef.name],
-    [companionCol.name, companionRef.name],
+    [displayCol.name, displayRef.name],
   ]);
   state.columns = state.columns.map((col) =>
-    col.name === baseColRef.name || col.name === companionRef.name
-      ? rewriteRemappedReferences(col, renames)
+    col.name === baseColRef.name || col.name === displayRef.name
+      ? rewriteRemappedReferences(col, columnRenames)
       : col,
   );
 }
@@ -506,7 +512,7 @@ export function maybeImportDimensionsFromOtherDataSources(
         columnRef,
         dataSource,
       );
-      attachRemappedCompanion(
+      attachRemappedDisplayColumn(
         state,
         columnRef,
         matchingDimension,
@@ -565,7 +571,7 @@ export function combineWithCartesianChart(
   const { data } = dataset;
 
   const metrics = data.cols.filter((col) => isMetric(col));
-  // Display-value companions are attached separately below, not as graph.dimensions slots.
+  // Display-value columns are attached separately below, not as graph.dimensions slots.
   const dimensions = data.cols.filter(
     (col) => isDimension(col) && !isMetric(col) && col.remapped_from == null,
   );
@@ -624,7 +630,7 @@ export function combineWithCartesianChart(
     }
   });
 
-  // Silent companion attach: in columnValuesMapping/state.columns, NOT graph.dimensions
+  // Silent display-column attach: in columnValuesMapping/state.columns, NOT graph.dimensions
   // (extra dim slots break cross-source axis merging).
   data.cols
     .filter(
@@ -645,9 +651,12 @@ export function combineWithCartesianChart(
     });
 
   // Point remapped_from/to at the new COLUMN_N names so extractRemappedColumns can pair them.
-  const renames = new Map(Object.entries(columnsToRefs));
+  const columnRenames = new Map(Object.entries(columnsToRefs));
   for (let i = firstNewIndex; i < state.columns.length; i++) {
-    state.columns[i] = rewriteRemappedReferences(state.columns[i], renames);
+    state.columns[i] = rewriteRemappedReferences(
+      state.columns[i],
+      columnRenames,
+    );
   }
 
   if (vizSettings && vizSettings.column_settings) {

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1012,7 +1012,7 @@ describe("cartesian", () => {
       });
     });
 
-    it("should attach remapped display companions silently without adding them to graph.dimensions (UXW-3359)", () => {
+    it("should attach remapped display columns silently without adding them to graph.dimensions (UXW-3359)", () => {
       const settings = createMockVisualizationSettings({
         "graph.metrics": ["COLUMN_2"],
         "graph.dimensions": ["COLUMN_1"],
@@ -1098,7 +1098,7 @@ describe("cartesian", () => {
         "COLUMN_5",
       ]);
 
-      // Text companion lives in columnValuesMapping but NOT graph.dimensions.
+      // Text display column lives in columnValuesMapping but NOT graph.dimensions.
       expect(nextState.settings["graph.dimensions"]).not.toContain("COLUMN_6");
       expect(nextState.columnValuesMapping).toMatchObject({
         COLUMN_6: [

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1061,8 +1061,7 @@ describe("cartesian", () => {
         base_type: "type/Integer",
         effective_type: "type/Integer",
         semantic_type: "type/Category",
-        // Group-by dimension — `source: "breakout"` ensures isMetric() returns false
-        // so the integer column is treated as a dimension, mirroring real query output.
+        // source: "breakout" makes isMetric() false so the int col is a dimension.
         source: "breakout",
         remapped_to: "rating_display",
       });
@@ -1089,9 +1088,7 @@ describe("cartesian", () => {
         createDataSource("card", 2, "Card 2"),
       );
 
-      // Card 2's base dimension and metric are added as new slots. Metrics are
-      // processed first, then dimensions, so the new metric gets COLUMN_4 and
-      // the new dimension gets COLUMN_5.
+      // Metrics processed before dims → new metric is COLUMN_4, new dim is COLUMN_5.
       expect(nextState.settings["graph.metrics"]).toEqual([
         "COLUMN_2",
         "COLUMN_4",
@@ -1101,9 +1098,7 @@ describe("cartesian", () => {
         "COLUMN_5",
       ]);
 
-      // …but the display companion is NOT in graph.dimensions even though it's
-      // a text dimension. It still lives in columnValuesMapping so
-      // extractRemappedColumns can pair it with its base column.
+      // Text companion lives in columnValuesMapping but NOT graph.dimensions.
       expect(nextState.settings["graph.dimensions"]).not.toContain("COLUMN_6");
       expect(nextState.columnValuesMapping).toMatchObject({
         COLUMN_6: [

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1012,6 +1012,111 @@ describe("cartesian", () => {
       });
     });
 
+    it("should attach remapped display companions silently without adding them to graph.dimensions (UXW-3359)", () => {
+      const settings = createMockVisualizationSettings({
+        "graph.metrics": ["COLUMN_2"],
+        "graph.dimensions": ["COLUMN_1"],
+      });
+      const state: VisualizerVizDefinitionWithColumns = {
+        display: "bar",
+        columns: [
+          createMockColumn({
+            name: "COLUMN_1",
+            display_name: "Rating",
+            base_type: "type/Integer",
+            effective_type: "type/Integer",
+            semantic_type: "type/Category",
+            remapped_to: "COLUMN_3",
+          }),
+          createMockNumericColumn({ name: "COLUMN_2", display_name: "Count" }),
+          createMockColumn({
+            name: "COLUMN_3",
+            display_name: "Rating",
+            base_type: "type/Text",
+            effective_type: "type/Text",
+            remapped_from: "COLUMN_1",
+          }),
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "rating" },
+          ],
+          COLUMN_2: [
+            { sourceId: "card:1", name: "COLUMN_2", originalName: "count" },
+          ],
+          COLUMN_3: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_3",
+              originalName: "rating_display",
+            },
+          ],
+        },
+        settings,
+      };
+
+      const newRatingInt = createMockColumn({
+        name: "rating",
+        display_name: "Rating",
+        base_type: "type/Integer",
+        effective_type: "type/Integer",
+        semantic_type: "type/Category",
+        // Group-by dimension — `source: "breakout"` ensures isMetric() returns false
+        // so the integer column is treated as a dimension, mirroring real query output.
+        source: "breakout",
+        remapped_to: "rating_display",
+      });
+      const newRatingDisplay = createMockColumn({
+        name: "rating_display",
+        display_name: "Rating",
+        base_type: "type/Text",
+        effective_type: "type/Text",
+        source: "breakout",
+        remapped_from: "rating",
+      });
+      const newCount = createMockNumericColumn({
+        name: "count",
+        display_name: "Count",
+      });
+
+      const nextState = _.clone(state);
+      combineWithCartesianChart(
+        nextState,
+        settings,
+        createMockDataset({
+          data: { cols: [newRatingInt, newRatingDisplay, newCount] },
+        }),
+        createDataSource("card", 2, "Card 2"),
+      );
+
+      // Card 2's base dimension and metric are added as new slots. Metrics are
+      // processed first, then dimensions, so the new metric gets COLUMN_4 and
+      // the new dimension gets COLUMN_5.
+      expect(nextState.settings["graph.metrics"]).toEqual([
+        "COLUMN_2",
+        "COLUMN_4",
+      ]);
+      expect(nextState.settings["graph.dimensions"]).toEqual([
+        "COLUMN_1",
+        "COLUMN_5",
+      ]);
+
+      // …but the display companion is NOT in graph.dimensions even though it's
+      // a text dimension. It still lives in columnValuesMapping so
+      // extractRemappedColumns can pair it with its base column.
+      expect(nextState.settings["graph.dimensions"]).not.toContain("COLUMN_6");
+      expect(nextState.columnValuesMapping).toMatchObject({
+        COLUMN_6: [
+          {
+            sourceId: "card:2",
+            name: "COLUMN_6",
+            originalName: "rating_display",
+          },
+        ],
+      });
+      expect(nextState.columns.map((col) => col.name)).toContain("COLUMN_6");
+    });
+
     describe("dimension sorting based on x-axis scale", () => {
       it("should prioritize date dimensions when x-axis scale is timeseries", () => {
         const settings = createMockVisualizationSettings({

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -50,7 +50,7 @@ import {
 import { getUpdatedSettingsForDisplay } from "./utils/get-updated-settings-for-display";
 import {
   addColumnToCartesianChart,
-  attachRemappedCompanion,
+  attachRemappedDisplayColumn,
   cartesianDropHandler,
   combineWithCartesianChart,
   maybeImportDimensionsFromOtherDataSources,
@@ -414,8 +414,8 @@ const visualizerSlice = createSlice({
         const isDimension = dimension.includes(column.name);
 
         if (isDimension) {
-          // Re-attach companion so remapping survives remove + re-add.
-          attachRemappedCompanion(
+          // Re-attach display column so remapping survives remove + re-add.
+          attachRemappedDisplayColumn(
             state,
             columnRef,
             originalColumn,

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -50,6 +50,7 @@ import {
 import { getUpdatedSettingsForDisplay } from "./utils/get-updated-settings-for-display";
 import {
   addColumnToCartesianChart,
+  attachRemappedCompanion,
   cartesianDropHandler,
   combineWithCartesianChart,
   maybeImportDimensionsFromOtherDataSources,
@@ -411,6 +412,17 @@ const visualizerSlice = createSlice({
 
         const dimension = state.settings["graph.dimensions"] ?? [];
         const isDimension = dimension.includes(column.name);
+
+        if (isDimension) {
+          // Re-attach companion so remapping survives remove + re-add.
+          attachRemappedCompanion(
+            state,
+            columnRef,
+            originalColumn,
+            dataset as Dataset,
+            dataSource,
+          );
+        }
 
         if (isDimension && column.id) {
           const datasetMap = _.omit(state.datasets, dataSource.id) as Record<


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71223
### Description

Updates the Visualizer to handle questions with remapped columns and non string category columns better

### How to verify
#### Setup
1. Go to Admin -> Table Metadata
2. From the sample database, go to reviews, and set up custom mapping for Rating
3. Create 2 questions where the dimension is the Rating: Auto binned. You should set up the axis to use Ordinal values
4. Add one of the questions to a dashboard, then on that new Dashcard, click "visualize another way

#### What's changed
1. You should not see the remap column in the data manager
2. Remapped values should appear on the x axis of the visualizer preview
3. You should be able to add the second question to the preview
4. Adding and removing all the columns should work as expected, and when re-adding, column remapping should not get dropped.

### Demo

https://www.loom.com/share/16657c3d7d5d455aaec8f8f692f00419

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
