### PR TITLE
Use chr(92) over '\' to work around sql-formatter bug for oracle

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -813,3 +813,7 @@
                   (update :update pos?)
                   (update :insert pos?)
                   (update :delete pos?))))))
+
+(defmethod sql.qp/transform-literal-like-pattern-honeysql :oracle
+  [_driver like-rhs-honeysql]
+  [:escape like-rhs-honeysql [:raw "CHR(92)"]])

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -763,3 +763,24 @@
                (mt/with-native-query-testing-context query
                  (is (= [[3 1]]
                         (mt/formatted-rows [int int] (qp/process-query query)))))))))))))
+
+(deftest ^:parallel two-contains-filters-formatted-correct-test
+  (testing "a query with two contains filters should be formatted correctly (#74086)"
+    (mt/test-driver :oracle
+      (let [mp         (mt/metadata-provider)
+            id-field   (lib.metadata/field mp (mt/id :people :id))
+            name-field (lib.metadata/field mp (mt/id :people :name))
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                      (lib/filter (lib/and
+                                   (lib/contains name-field "Alice")
+                                   (lib/contains name-field "ice")))
+                      (lib/with-fields [id-field name-field]))
+            result (qp/process-query query)
+            native-sql (-> result :data :native_form :query)
+            prettified-sql (driver/prettify-native-form driver/*driver* native-sql)
+            native-query (lib/native-query mp prettified-sql)]
+        (is (= "SELECT\n  *\nFROM\n  (\n    SELECT\n      \"mb_test\".\"test_data_people\".\"id\" \"id\",\n      \"mb_test\".\"test_data_people\".\"name\" \"name\"\n    FROM\n      \"mb_test\".\"test_data_people\"\n    WHERE\n      (\n        \"mb_test\".\"test_data_people\".\"name\" LIKE '%Alice%' ESCAPE CHR(92)\n      )\n      AND (\n        \"mb_test\".\"test_data_people\".\"name\" LIKE '%ice%' ESCAPE CHR(92)\n      )\n  )\nWHERE\n  rownum <= 1048575"
+               prettified-sql))
+        (is (= [[1345 "Alice Connelly"]]
+               (mt/formatted-rows [int str] result)
+               (mt/formatted-rows [int str] (qp/process-query native-query))))))))

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -643,7 +643,25 @@
                    (mt/run-mbql-query escaping_table
                      {:filter   [:contains $string1 lit]
                       :order-by [[:asc $id]]
-                      :limit    8})))))))))
+                      :limit    8}))))))
+      (testing "two literal contains filters"
+        (let [mp            (mt/metadata-provider)
+              id-field      (lib.metadata/field mp (mt/id :escaping_table :id))
+              string1-field (lib.metadata/field mp (mt/id :escaping_table :string1))
+              query         (-> (lib/query mp (lib.metadata/table mp (mt/id :escaping_table)))
+                                (lib/filter (lib/and
+                                             (lib/contains string1-field "\\")
+                                             (lib/contains string1-field "%")))
+                                (lib/order-by id-field)
+                                (lib/with-fields [id-field string1-field])
+                                (lib/limit 8))]
+          (is (= [[10 "_many%\\escapes"]
+                  [11 "more%___%esca\\pes%"]
+                  [12 "%backslash\\%before_percent_"]
+                  [13 "\\backslash\\_before%underscore\\"]]
+                 (mt/formatted-rows
+                  [int identity]
+                  (qp/process-query query)))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             NESTED AND/OR CLAUSES                                              |


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74086

### Description

There's a bug in https://github.com/vertical-blank/sql-formatter that doesn't work when there are multiple escapes for plsql dialects like oracle. Fix here is a workaround by using `CHR(92)` instead of `'\'`. 

### How to verify

See repro steps from original issue. The query preview should be correct (no extra spaces in second like statement), and when you convert to a native query it should execute successfully. 

### Demo

https://github.com/user-attachments/assets/b3f4dc8b-2ede-4a5e-b927-3621c6331ea1

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
