### PR TITLE
Pass dashboard Id to visualizer

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -59,6 +59,7 @@ const elements = [
   createElement({ type: "shared", name: "palette", enforceOutgoing: true }),
   createElement({ type: "shared", name: "querying" }),
   createElement({ type: "shared", name: "visualizations" }),
+  createElement({ type: "shared", name: "visualizer", enforceOutgoing: true }),
   createElement({ type: "shared", name: "account", enforceOutgoing: true }),
   createElement({ type: "shared", name: "archive", enforceOutgoing: true }),
   createElement({ type: "shared", name: "auth", enforceOutgoing: true }),

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -563,6 +563,7 @@ class DashboardGridInner extends Component<
         initialState={{ state: visualizerModalStatus.state }}
         saveLabel={t`Save`}
         allowSaveWhenPristine={allowSaveWhenPristine}
+        dashboardId={this.props.dashboard.id}
       />
     );
   }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -14,7 +14,7 @@ import { SelectList } from "metabase/common/components/SelectList";
 import type { BaseSelectListItemProps } from "metabase/common/components/SelectList/BaseSelectListItem";
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import { addCardWithVisualization } from "metabase/dashboard/actions";
-import { getSelectedTabId } from "metabase/dashboard/selectors";
+import { getDashboardId, getSelectedTabId } from "metabase/dashboard/selectors";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useGetIcon } from "metabase/hooks/use-icon";
 import { PLUGIN_MODERATION } from "metabase/plugins";
@@ -56,6 +56,7 @@ export function QuestionList({
   const isVisualizerModalOpen = !!visualizerModalCardId;
 
   const selectedTabId = useSelector(getSelectedTabId);
+  const dashboardId = useSelector(getDashboardId);
 
   useEffect(() => {
     setQueryOffset(0);
@@ -188,6 +189,7 @@ export function QuestionList({
       {isVisualizerModalOpen && (
         <VisualizerModalWithCardId
           cardId={visualizerModalCardId}
+          dashboardId={dashboardId ?? undefined}
           onSave={(visualization) => {
             dispatch(
               addCardWithVisualization({ visualization, tabId: selectedTabId }),

--- a/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
@@ -21,7 +21,7 @@ import {
   initializeVisualizer,
   removeDataSource,
 } from "metabase/visualizer/visualizer.slice";
-import type { VisualizerDataSource } from "metabase-types/api";
+import type { DashboardId, VisualizerDataSource } from "metabase-types/api";
 
 import {
   trackVisualizerAddMoreDataClicked,
@@ -32,7 +32,13 @@ import { ColumnsList } from "./ColumnsList/ColumnsList";
 import S from "./DataImporter.module.css";
 import { DatasetsList } from "./DatasetsList/DatasetsList";
 
-export const DataImporter = ({ className }: { className?: string }) => {
+export const DataImporter = ({
+  className,
+  dashboardId,
+}: {
+  className?: string;
+  dashboardId: DashboardId | undefined;
+}) => {
   const [search, setSearch] = useState("");
   const [showDatasets, handlers] = useDisclosure(false);
   const dispatch = useDispatch();
@@ -121,6 +127,7 @@ export const DataImporter = ({ className }: { className?: string }) => {
           search={debouncedSearch}
           setDataSourceCollapsed={setDataSourceCollapsed}
           muted={!showDatasets}
+          dashboardId={dashboardId}
         />
       </Flex>
       <Flex

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
-import { getDashboard } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/redux";
 import { Box, Flex, Skeleton } from "metabase/ui";
 import { isNotNull } from "metabase/utils/types";
@@ -56,6 +55,12 @@ interface DatasetsListProps {
    * so next time it is rendered, it will show the data immediately.
    */
   muted?: boolean;
+  /**
+   * The id of the dashboard the visualizer was opened from, or `undefined` when
+   * it wasn't opened from a dashboard. Used to filter out dashboard questions
+   * that belong to other dashboards.
+   */
+  dashboardId: DashboardId | undefined;
 }
 
 export function DatasetsList({
@@ -63,8 +68,8 @@ export function DatasetsList({
   setDataSourceCollapsed,
   style,
   muted,
+  dashboardId,
 }: DatasetsListProps) {
-  const dashboardId = useSelector(getDashboard)?.id;
   const dispatch = useDispatch();
   const dataSources = useSelector(getDataSources);
   const dataSourceIds = useMemo(

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -25,7 +25,7 @@ import {
   resetVisualizer,
   setDraggedItem,
 } from "metabase/visualizer/visualizer.slice";
-import type { VisualizerVizDefinition } from "metabase-types/api";
+import type { DashboardId, VisualizerVizDefinition } from "metabase-types/api";
 
 import { DataImporter } from "../DataImporter";
 import { DragOverlay as VisualizerDragOverlay } from "../DragOverlay";
@@ -66,11 +66,23 @@ interface VisualizerProps {
   onClose: () => void;
   saveLabel?: string;
   allowSaveWhenPristine?: boolean;
+  /**
+   * The id of the dashboard the visualizer was opened from, or `undefined` when
+   * it wasn't opened from a dashboard, so the data picker can filter out
+   * dashboard questions that belong to other dashboards.
+   */
+  dashboardId: DashboardId | undefined;
 }
 
 const VisualizerInner = (props: VisualizerProps) => {
-  const { className, onSave, saveLabel, allowSaveWhenPristine, onClose } =
-    props;
+  const {
+    className,
+    onSave,
+    saveLabel,
+    allowSaveWhenPristine,
+    onClose,
+    dashboardId,
+  } = props;
 
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
   const { isDataSidebarOpen, isVizSettingsSidebarOpen } = useVisualizerUi();
@@ -160,7 +172,10 @@ const VisualizerInner = (props: VisualizerProps) => {
       <Box className={classNames}>
         {/* left side bar */}
         <Box className={S.dataSidebar}>
-          <DataImporter className={S.dataSidebarContent} />
+          <DataImporter
+            className={S.dataSidebarContent}
+            dashboardId={dashboardId}
+          />
         </Box>
 
         {/* top header bar */}


### PR DESCRIPTION
Passes via props to avoid importing from Dashboard. Fixes 1 violation.

Allows us to enforce `visualizer` module