### PR TITLE
[Metabot] No feedback when no content is available to generate Metabot suggested prompts

### DIFF
--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.tsx
@@ -1,5 +1,6 @@
 import { useClipboard } from "@mantine/hooks";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { isMatching } from "ts-pattern";
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
@@ -42,14 +43,22 @@ export const MetabotPromptSuggestionPane = ({
   const { handleNextPage, handlePreviousPage, page, setPage } = usePagination();
   const offset = page * pageSize;
 
-  const { data, isLoading, error } = useGetSuggestedMetabotPromptsQuery({
-    metabot_id: metabot.id,
-    limit: pageSize,
-    offset,
-  });
+  const { data, isLoading, error, requestId, isFetching } =
+    useGetSuggestedMetabotPromptsQuery({
+      metabot_id: metabot.id,
+      limit: pageSize,
+      offset,
+    });
   const [deletePrompt] = useDeleteSuggestedMetabotPromptMutation();
   const [regeneratePrompts, { isLoading: isRegenerating }] =
     useRegenerateSuggestedMetabotPromptsMutation();
+
+  const [initRequestId, setInitRequestId] = useState("");
+  useEffect(() => {
+    if (requestId && !initRequestId) {
+      setInitRequestId(requestId);
+    }
+  }, [requestId, initRequestId]);
 
   const handleDeletePrompt = async (promptId: SuggestedMetabotPrompt["id"]) => {
     const { error } = await deletePrompt({
@@ -76,13 +85,28 @@ export const MetabotPromptSuggestionPane = ({
     const { error } = await regeneratePrompts(metabot.id);
     if (error) {
       sendToast({
-        message: t`Error regenerate prompts`,
+        message: t`Error regenerating prompts`,
         icon: "warning",
       });
     } else {
       setPage(0);
     }
   };
+
+  useEffect(
+    function warnNoPrompts() {
+      const isRefetch = requestId !== initRequestId;
+      const isSettled = !isFetching;
+      const hasNoPrompts = isMatching({ total: 0 }, data);
+      if (isRefetch && isSettled && hasNoPrompts) {
+        sendToast({
+          message: t`Collection contains no models or metrics to create prompts from.`,
+          icon: "warning",
+        });
+      }
+    },
+    [data, requestId, initRequestId, isFetching, sendToast],
+  );
 
   const prompts = useMemo(() => data?.prompts ?? [], [data?.prompts]);
   const total = data?.total ?? 0;

--- a/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -8,6 +8,9 @@ import {
   setupRemoveMetabotPromptSuggestionEndpoint,
 } from "__support__/server-mocks/metabot";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Api } from "metabase/api";
+import { idTag } from "metabase/api/tags";
+import { UndoListing } from "metabase/common/components/UndoListing";
 import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
 import type { SuggestedMetabotPrompt } from "metabase-types/api";
 
@@ -59,17 +62,23 @@ const setup = async (opts?: SetupOpts) => {
     : paginationContext;
 
   const TestComponent = () => (
-    <MetabotPromptSuggestionPane
-      metabot={{ id: metabotId, collection_id: null }}
-      pageSize={pageSize}
-    />
+    <>
+      <MetabotPromptSuggestionPane
+        metabot={{ id: metabotId, collection_id: null }}
+        pageSize={pageSize}
+      />
+      <UndoListing />
+    </>
   );
 
-  renderWithProviders(<Route path="/" component={TestComponent} />, {
-    withRouter: true,
-  });
+  const { store } = renderWithProviders(
+    <Route path="/" component={TestComponent} />,
+    {
+      withRouter: true,
+    },
+  );
 
-  return { metabotId, nextPaginationContext };
+  return { metabotId, nextPaginationContext, store };
 };
 
 describe("suggested prompts", () => {
@@ -206,6 +215,48 @@ describe("suggested prompts", () => {
 
     expect(await screen.findByText(secondPrompt.prompt)).toBeInTheDocument();
     expect(screen.queryByText(firstPrompt.prompt)).not.toBeInTheDocument();
+  });
+
+  it("should show a warning toast when regeneration produces no prompts", async () => {
+    const { metabotId } = await setup({ pageSize: 1, mockInitialPage: false });
+    setupMetabotPromptSuggestionsEndpoint({
+      metabotId,
+      prompts: [],
+      paginationContext: { offset: 0, limit: 1, total: 0 },
+    });
+    setupRegenerateMetabotPromptSuggestionsEndpoint(metabotId);
+
+    const regenerateButton = await screen.findByRole("button", {
+      name: /Regenerate suggested prompts/,
+    });
+    await userEvent.click(regenerateButton);
+
+    expect(
+      await screen.findByText(
+        /Collection contains no models or metrics to create prompts from/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should show a warning toast when the metabot's collection changes to one with no eligible content", async () => {
+    const { metabotId, store } = await setup({ pageSize: 1 });
+
+    await expectVisiblePrompts(defaultMetabotMockedPrompts.slice(0, 1));
+
+    setupMetabotPromptSuggestionsEndpoint({
+      metabotId,
+      prompts: [],
+      paginationContext: { offset: 0, limit: 1, total: 0 },
+    });
+    store.dispatch(
+      Api.util.invalidateTags([idTag("metabot-prompt-suggestions", metabotId)]),
+    );
+
+    expect(
+      await screen.findByText(
+        /Collection contains no models or metrics to create prompts from/,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("should allow the user to regenerate the prompts", async () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74360
[BOT-1533: No feedback when no content is available to generate Metabot suggested prompts](https://linear.app/metabase/issue/BOT-1533/no-feedback-when-no-content-is-available-to-generate-metabot-suggested)