### PR TITLE
test: re-enable iframe resize embedding test on v59

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1035,87 +1035,83 @@ describe("scenarios > embedding > dashboard appearance", () => {
     });
   });
 
-  it(
-    "should resize iframe to dashboard content size (metabase#47061)",
-    { tags: "@skip" },
-    () => {
-      const dashboardDetails = {
-        name: "dashboard name",
-        enable_embedding: true,
-      };
+  it("should resize iframe to dashboard content size (metabase#47061)", () => {
+    const dashboardDetails = {
+      name: "dashboard name",
+      enable_embedding: true,
+    };
 
-      const questionDetails = {
-        name: "Line chart",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            [
-              "field",
-              ORDERS.CREATED_AT,
-              { "base-type": "type/DateTime", "temporal-unit": "month" },
-            ],
+    const questionDetails = {
+      name: "Line chart",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            { "base-type": "type/DateTime", "temporal-unit": "month" },
           ],
-          limit: 5,
-        },
-        display: "bar",
-      };
-      H.createQuestion(questionDetails)
-        .then(({ body: { id: card_id } }) => {
-          H.createDashboardWithTabs({
-            ...dashboardDetails,
-            dashcards: [
-              {
-                id: -1,
-                card_id,
-                row: 0,
-                col: 0,
-                size_x: 8,
-                size_y: 20,
-              },
-            ],
-          });
-        })
-        .then((dashboard) => {
-          return H.getEmbeddedPageUrl({
-            resource: { dashboard: dashboard.id },
-            params: {},
-          });
-        })
-        .then((urlOptions) => {
-          const baseUrl = Cypress.config("baseUrl");
-          Cypress.config("baseUrl", null);
-          cy.visit(
-            `e2e/test/scenarios/embedding/embedding-dashboard.html?iframeUrl=${baseUrl + urlOptions.url}`,
-          );
+        ],
+        limit: 5,
+      },
+      display: "bar",
+    };
+    H.createQuestion(questionDetails)
+      .then(({ body: { id: card_id } }) => {
+        H.createDashboardWithTabs({
+          ...dashboardDetails,
+          dashcards: [
+            {
+              id: -1,
+              card_id,
+              row: 0,
+              col: 0,
+              size_x: 8,
+              size_y: 20,
+            },
+          ],
         });
-
-      H.getIframeBody().within(() => {
-        cy.findByText(questionDetails.name).should("exist");
-        cy.findByText("May 2025").should("exist");
-
-        // TODO: Enable this once we fix the flakiness https://app.trunk.io/metabase/flaky-tests/test/facb35f0-6d76-5e7d-b21c-40401bbc3ff6?repo=metabase%2Fmetabase
-        // (metabase#49537)
-        // chartPathWithFillColor("#509EE3").last().realHover();
-        // echartsTooltip().should("be.visible");
-        // assertEChartsTooltip({
-        //   header: "August 2025",
-        //   rows: [
-        //     {
-        //       name: "Count",
-        //       value: "79",
-        //       secondaryValue: "+23.44%",
-        //     },
-        //   ],
-        // });
+      })
+      .then((dashboard) => {
+        return H.getEmbeddedPageUrl({
+          resource: { dashboard: dashboard.id },
+          params: {},
+        });
+      })
+      .then((urlOptions) => {
+        const baseUrl = Cypress.config("baseUrl");
+        Cypress.config("baseUrl", null);
+        cy.visit(
+          `e2e/test/scenarios/embedding/embedding-dashboard.html?iframeUrl=${baseUrl + urlOptions.url}`,
+        );
       });
 
-      cy.get("#iframe").should(($iframe) => {
-        const [iframe] = $iframe;
-        expect(iframe.clientHeight).to.be.greaterThan(1000);
-      });
-    },
-  );
+    H.getIframeBody().within(() => {
+      cy.findByText(questionDetails.name).should("exist");
+      cy.findByText("April 2025").should("exist");
+
+      // TODO: Enable this once we fix the flakiness https://app.trunk.io/metabase/flaky-tests/test/facb35f0-6d76-5e7d-b21c-40401bbc3ff6?repo=metabase%2Fmetabase
+      // (metabase#49537)
+      // chartPathWithFillColor("#509EE3").last().realHover();
+      // echartsTooltip().should("be.visible");
+      // assertEChartsTooltip({
+      //   header: "August 2025",
+      //   rows: [
+      //     {
+      //       name: "Count",
+      //       value: "79",
+      //       secondaryValue: "+23.44%",
+      //     },
+      //   ],
+      // });
+    });
+
+    cy.get("#iframe").should(($iframe) => {
+      const [iframe] = $iframe;
+      expect(iframe.clientHeight).to.be.greaterThan(1000);
+    });
+  });
 
   it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
     cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {


### PR DESCRIPTION
Fixes EMB-1615

### Description

The v59 backport of the Sample Database date shift skipped this test with `@skip`. The backport ported the change as-is without retaining the correct month assertion — the first chart month is `April 2025`, not `May 2025`. This un-skips it and fixes the assertion.

Here's [the change on the original backport](https://github.com/metabase/metabase/pull/72973/changes#diff-12ae8f3df2081116deed9542b39fada02cf06b55fd0b1bba175fbd42f0660c28L1090-L1092) that skipped the test
<img width="1583" height="110" alt="image" src="https://github.com/user-attachments/assets/9243eee8-1809-4aa5-9f68-0cf17d9751b3" />


### How to verify

Run the spec on `release-x.59.x`. `should resize iframe to dashboard content size (metabase#47061)` should pass.

### Demo

<img width="2201" height="874" alt="Screenshot 2026-05-20 at 12 20 17 PM" src="https://github.com/user-attachments/assets/a55cfe29-5923-4fdc-9fbd-5e36b32b7649" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ This PR fixes the existing test
- [x] [Stress test run](https://github.com/metabase/metabase/actions/runs/26166917408/job/76973538154): 100/100. But note that [there was another 19/20 run here](https://github.com/metabase/metabase/actions/runs/26166428425). Since the 100/100 works, I'll just mark this is not flaky.