### PR TITLE
Fix brush date filter e2e assertion on v59

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -56,7 +56,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     );
 
     H.queryBuilderMain().within(() => {
-      H.echartsContainer().contains(/June \d{1,2}, 2025/); // more granular axis labels
+      H.echartsContainer().findByText("June 2025"); // more granular axis labels
 
       // confirm that product category is still broken out
       cy.findByLabelText("Legend").within(() => {


### PR DESCRIPTION
Closes [GDGT-2448](https://linear.app/metabase/issue/GDGT-2448)

### Description

The e2e test `should allow brush date filter` (`chart_drill.cy.spec.js`) fails deterministically on `release-x.59.x` while passing on v60, v61, and master. After brushing (zoom) on a month-bucketed timeseries, the test expects **day-level** x-axis labels (`/June \d{1,2}, 2025/`), but v59 renders **month-level** labels (`June 2025`).

The day-level behavior comes from #70814 "Time series axis label improvements" (backported to v60/v61 as #72450), which rewrote the timeseries tick/interval logic and updated this assertion from month to day. **That fix was never backported to v59.** The day-level assertion still reached v59 through the sample-DB date-shift backport (#72973), which imported the post-#70814 expectation without the corresponding code fix — so on v59 the test now demands labels the code cannot produce.

This PR reverts just the assertion to the month-level label v59 actually renders (`June 2025`, matching the `Month Year` format the same test already asserts for `July 2025` / `January 2026`). No product code changes.

### How to verify

See CI green on this PR.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR