### PR TITLE
Allow serialization to import transform tables after sync

### DIFF
--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -202,7 +202,9 @@
       (throw (ex-info "Cannot set data_authority back to unconfigured once it has been configured"
                       {:status-code 400})))
 
-    ;; Prevent changing data_source to/from metabase-transform
+    ;; Prevent changing data_source to/from metabase-transform.
+    ;; The "to metabase-transform" direction is allowed during deserialization so an existing synced table
+    ;; can be migrated to a transform-managed table via serdes.
     (when (contains? changes :data_source)
       (let [original-data-source (some-> (:data_source original-table) keyword)
             new-data-source      (some-> (:data_source changes) keyword)]
@@ -210,7 +212,8 @@
                    (not= new-data-source :metabase-transform))
           (throw (ex-info "Cannot change data_source from metabase-transform"
                           {:status-code 400})))
-        (when (and (not= original-data-source :metabase-transform)
+        (when (and (not mi/*deserializing?*)
+                   (not= original-data-source :metabase-transform)
                    (= new-data-source :metabase-transform))
           (throw (ex-info "Cannot set data_source to metabase-transform"
                           {:status-code 400})))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -517,7 +517,21 @@
         (is (= :ingested (t2/select-one-fn :data_source :model/Table :id table-id))))
       (testing "can also change it to nil"
         (is (some? (t2/update! :model/Table table-id {:data_source nil})))
-        (is (nil? (t2/select-one-fn :data_source :model/Table :id table-id)))))))
+        (is (nil? (t2/select-one-fn :data_source :model/Table :id table-id))))))
+
+  (testing "data_source guard is relaxed for nil -> metabase-transform during deserialization (GDGT-2445)"
+    (testing "can set data_source to metabase-transform on an existing synced table"
+      (mt/with-temp [:model/Table {table-id :id} {:data_source nil}]
+        (binding [mi/*deserializing?* true]
+          (is (some? (t2/update! :model/Table table-id {:data_source :metabase-transform}))))
+        (is (= :metabase-transform (t2/select-one-fn :data_source :model/Table :id table-id)))))
+    (testing "reverse direction stays blocked even during deserialization"
+      (mt/with-temp [:model/Table {table-id :id} {:data_source :metabase-transform}]
+        (binding [mi/*deserializing?* true]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Cannot change data_source from metabase-transform"
+               (t2/update! :model/Table table-id {:data_source nil}))))))))
 
 (deftest is-published-and-collection-id-test
   (testing "is_published defaults to false"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74442
Closes https://linear.app/metabase/issue/GDGT-2445/existing-database-tables-cannot-be-migrated-to-use-transforms-via