### PR TITLE
Fix conditional formatting colors for BigDecimal cells in email renderer

### DIFF
--- a/src/metabase/channel/render/js/color.clj
+++ b/src/metabase/channel/render/js/color.clj
@@ -32,6 +32,14 @@
                         [:name :string]]]]
    [:rows [:sequential [:sequential :any]]]])
 
+(defn- ->js-number
+  "Coerce BigDecimal/BigInteger to primitive double/long so Graal's JS context sees them as numbers, not host objects."
+  [v]
+  (cond
+    (instance? BigDecimal v) (.doubleValue ^BigDecimal v)
+    (instance? BigInteger v) (.longValue ^BigInteger v)
+    :else v))
+
 (defn- convert-bignumbers-by-column
   "Convert BigDecimal and BigInteger values to doubles/longs since Graal doesn't handle these"
   [data]
@@ -54,14 +62,7 @@
             (map-indexed
              (fn [idx item]
                (if (bignum-column-indices idx)
-                 (cond
-                   (instance? BigDecimal item)
-                   (.doubleValue ^BigDecimal item)
-
-                   (instance? BigInteger item)
-                   (.longValue ^BigInteger item)
-
-                   :else item)
+                 (->js-number item)
                  item))
              row)))
          data)))))
@@ -91,11 +92,11 @@
   ^String [color-selector cell-value column-name row-index]
   (let [cell-value (cond
                      (formatter/NumericWrapper? cell-value)
-                     (:num-value cell-value)
+                     (->js-number (:num-value cell-value))
 
                      (formatter/TextWrapper? cell-value)
                      (:original-value cell-value)
 
                      :else
-                     cell-value)]
+                     (->js-number cell-value))]
     (.asString (js.engine/execute-fn color-selector cell-value row-index column-name))))

--- a/src/metabase/channel/render/js/color.clj
+++ b/src/metabase/channel/render/js/color.clj
@@ -33,11 +33,19 @@
    [:rows [:sequential [:sequential :any]]]])
 
 (defn- ->js-number
-  "Coerce BigDecimal/BigInteger to primitive double/long so Graal's JS context sees them as numbers, not host objects."
+  "Coerce BigDecimal/BigInteger to primitive double/long so Graal's JS context sees them as numbers, not host objects.
+   Returns nil when the value would overflow — BigInteger too wide for long, or BigDecimal magnitude beyond Double's
+   finite range — since silently truncating would feed wrong values into gradient/comparison logic."
   [v]
   (cond
-    (instance? BigDecimal v) (.doubleValue ^BigDecimal v)
-    (instance? BigInteger v) (.longValue ^BigInteger v)
+    (instance? BigDecimal v)
+    (let [d (.doubleValue ^BigDecimal v)]
+      (when (Double/isFinite d) d))
+
+    (instance? BigInteger v)
+    (when (<= (.bitLength ^BigInteger v) 63)
+      (.longValue ^BigInteger v))
+
     :else v))
 
 (defn- convert-bignumbers-by-column

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -969,6 +969,25 @@
                    {:card     (mapcat :content card-header-els)
                     :dashcard (mapcat :content dash-header-els)}))))))))
 
+(deftest table-renders-range-conditional-formatting-on-decimal-columns
+  (testing "range/gradient formatting colors BigDecimal cells in the email renderer (GDGT-2412)"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card {card-id :id}
+                     {:display :table
+                      :dataset_query (mt/native-query
+                                      {:query "SELECT * FROM (VALUES (CAST(0.1 AS DECIMAL(10,4))), (0.5), (0.9)) t(pct)"})
+                      :visualization_settings
+                      {:table.column_formatting
+                       [{:columns ["PCT"]
+                         :type "range"
+                         :min_type "custom" :min_value 0
+                         :max_type "custom" :max_value 1
+                         :colors ["#ffffff" "#ff0000"]
+                         :id 0}]}}]
+        (mt/with-current-user (mt/user->id :rasta)
+          (let [cells (hik.s/select (hik.s/tag :td) (render.tu/render-card-as-hickory! card-id))]
+            (is (every? #(some-> % :attrs :style (str/includes? "background-color")) cells))))))))
+
 (deftest table-renders-respect-conditional-formatting
   (testing "Rendered Tables respect the conditional formatting on a card."
     (let [ids-to-colour [1 2 3 5 8 13]]

--- a/test/metabase/channel/render/js/color_test.clj
+++ b/test/metabase/channel/render/js/color_test.clj
@@ -8,6 +8,8 @@
   (:import
    [java.math BigDecimal BigInteger]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private red "#ff0000")
 (def ^:private green "#00ff00")
 

--- a/test/metabase/channel/render/js/color_test.clj
+++ b/test/metabase/channel/render/js/color_test.clj
@@ -122,7 +122,13 @@
                 result (convert-fn data)]
             (is (= [[123.456 789 "test"] [123.456 789 "another"]] result))
             (is (every? #(instance? Double (first %)) result))
-            (is (every? #(instance? Long (second %)) result))))))))
+            (is (every? #(instance? Long (second %)) result))))
+
+        (testing "values that overflow primitive ranges become nil rather than silently truncating"
+          (let [too-big-int (.shiftLeft (BigInteger. "1") 65) ; doesn't fit in long
+                too-big-dec (.scaleByPowerOfTen (BigDecimal. "1") 400)] ; beyond Double range
+            (is (= [[nil] [42]] (convert-fn [[too-big-int] [(BigInteger. "42")]])))
+            (is (= [[nil] [1.5]] (convert-fn [[too-big-dec] [(BigDecimal. "1.5")]])))))))))
 
 (deftest bigdecimal-cell-gets-range-color-test
   (testing "get-background-color applies range colors to BigDecimal cell values (GDGT-2412)"

--- a/test/metabase/channel/render/js/color_test.clj
+++ b/test/metabase/channel/render/js/color_test.clj
@@ -123,3 +123,20 @@
             (is (= [[123.456 789 "test"] [123.456 789 "another"]] result))
             (is (every? #(instance? Double (first %)) result))
             (is (every? #(instance? Long (second %)) result))))))))
+
+(deftest bigdecimal-cell-gets-range-color-test
+  (testing "get-background-color applies range colors to BigDecimal cell values (GDGT-2412)"
+    (let [viz      {:table.column_formatting
+                    [{:columns ["pct"] :type "range" :colors ["#ffffff" "#ff0000"]}]}
+          selector (js.color/make-color-selector
+                    {:cols [{:name "pct"}] :rows [[0.0] [0.5] [1.0]]}
+                    viz)
+          color-for (fn [n]
+                      (js.color/get-background-color
+                       selector
+                       (formatter/->NumericWrapper (str n) n)
+                       "pct"
+                       1))]
+      (is (= "rgba(255, 128, 128, 0.75)" (color-for 0.5)))
+      (is (= "rgba(255, 128, 128, 0.75)" (color-for (BigDecimal. "0.5"))))
+      (is (= "rgba(255, 0, 0, 0.75)" (color-for (BigInteger. "1")))))))

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -93,10 +93,10 @@
 
 (defn- img-node-with-svg?
   [loc]
-  (let [[tag {:keys [src]}] (zip/node loc)]
-    (and
-     (= tag :img)
-     (str/starts-with? src "<svg"))))
+  (let [[tag attrs] (zip/node loc)]
+    (and (= tag :img)
+         (map? attrs)
+         (some-> ^String (:src attrs) (str/starts-with? "<svg")))))
 
 (def ^:private parse-svg #'js.svg/parse-svg-string)
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73912
[GDGT-2412](https://linear.app/metabase/issue/GDGT-2412)

`get-background-color` was passing `BigDecimal` cell values straight to GraalJS, where they arrive as host objects and fail the JS-side `typeof === "number"` check, so range/gradient formatting on DECIMAL columns silently dropped the color. Coerce to primitive double/long at the per-cell site, same as `make-color-selector` already does on the row side.

## Repro

1. New native question on the H2 Sample Database:
   ```sql
   SELECT CAST(0.1 AS DECIMAL(10,4)) AS pct UNION ALL
   SELECT CAST(0.5 AS DECIMAL(10,4)) UNION ALL
   SELECT CAST(0.9 AS DECIMAL(10,4))
   ```
2. Switch viz to Table → Conditional formatting → add a Color range rule on `PCT` (white → red).
3. The UI shows the gradient. Send the question through an alert webhook (or email/Slack subscription).
4. Before this fix: the rendered image has no background colors. After: cells are colored.

Before
<img width="627" height="397" alt="Screenshot 2026-05-20 at 17 36 08" src="https://github.com/user-attachments/assets/aab95813-ba33-4e6d-a8d0-1ccd3b84506c" />


After
<img width="602" height="409" alt="Screenshot 2026-05-20 at 17 39 34" src="https://github.com/user-attachments/assets/6ae905de-35cd-4674-b634-c0b2a79f61e1" />


