### PR TITLE
fix: add metabase_version to serdes extract

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.collections.models.collection :as collection]
+   [metabase.config.core :as config]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -210,11 +211,22 @@
                    ;; extract all non-content entities like data model and settings if necessary
                    (eduction (map #(serdes/extract-all % opts)) cat (remove (set serdes.models/content) models))])))))
 
+(defn- needs-version?
+  "True for extracted entities that should carry a `:metabase_version` stamp."
+  [entity]
+  (and (not (instance? Exception entity))
+       (not= "Setting" (-> entity :serdes/meta last :model))))
+
+(defn- stamp-version [entity]
+  (if (needs-version? entity)
+    (assoc entity :metabase_version config/mb-version-string)
+    entity))
+
 (defn extract
   "Returns a reducible stream of entities to serialize"
   [opts]
   (serdes.backfill/backfill-ids!)
-  (extract-subtrees opts))
+  (eduction (map stamp-version) (extract-subtrees opts)))
 
 (comment
   (def nodes (let [colls (mapv vector (repeat "Collection") (collection-set-for-user nil))]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -102,12 +102,14 @@
       (serdes.backfill/has-entity-id? model))))
 
 (defn- warn-if-version-mismatch
-  "Checks if the version in the exported entity's serdes/meta differs from the current Metabase version.
-  Logs a warning if there is a mismatch."
+  "Checks if the version in the exported entity differs from the current Metabase version.
+  Logs a warning if there is a mismatch. Entities without a `:metabase_version` (eg. Settings,
+  which are bundled into settings.yaml without per-entity metadata) are skipped."
   [ingested path]
-  (when (or (nil? *warned-version-mismatch*) (not @*warned-version-mismatch*))
-    (let [current-version config/mb-version-string
-          exported-version (or (:metabase_version ingested) "UNKNOWN")]
+  (when (and (or (nil? *warned-version-mismatch*) (not @*warned-version-mismatch*))
+             (:metabase_version ingested))
+    (let [current-version  config/mb-version-string
+          exported-version (:metabase_version ingested)]
       (when (not= exported-version current-version)
         (log/warnf "Version mismatch loading %s: exported with: %s, current version: %s"
                    path

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -105,7 +105,8 @@
 (defn- clean-entity
   "Removes any comparison-confounding fields, like `:created_at`."
   [entity]
-  (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule))
+  (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule
+          :metabase_version))
 
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest e2e-storage-ingestion-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -12,6 +12,7 @@
    [metabase-enterprise.serialization.v2.round-trip-test :as round-trip-test]
    [metabase.actions.models :as action]
    [metabase.audit-app.core :as audit]
+   [metabase.config.core :as config]
    [metabase.core.core :as mbc]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -2937,3 +2938,20 @@
       (testing "all embedding themes are extracted"
         (is (= #{light-eid dark-eid}
                (ids-by-model "EmbeddingTheme" (extract/extract {}))))))))
+
+(deftest stamp-metabase-version-test
+  (testing "extract stamps :metabase_version on entities (so load can detect version mismatches)"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection {coll-id :id} {:name "My Collection"}
+                         :model/Card       _             {:name "My Card" :collection_id coll-id}]
+        (let [extracted (into [] (extract/extract {}))
+              by-model  (group-by (comp :model last :serdes/meta) extracted)]
+          (testing "Collections and Cards get the current Metabase version"
+            (doseq [m ["Collection" "Card"]
+                    entity (get by-model m)]
+              (is (= config/mb-version-string (:metabase_version entity))
+                  (str m " should be stamped with the current version"))))
+          (testing "Settings are not stamped — settings.yaml only persists :key and :value"
+            (doseq [setting (get by-model "Setting")]
+              (is (not (contains? setting :metabase_version))
+                  "Setting should not be stamped"))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1791,7 +1791,7 @@
         (is (= 4 (coll-count)))))))
 
 (deftest warn-if-version-mismatch-test
-  (ts/with-dbs [source-db dest-db dest-db2]
+  (ts/with-dbs [source-db dest-db dest-db2 dest-db3]
     (ts/with-db source-db
       (mt/with-temp [:model/Collection _ {:name "col-1"}]
         (let [extract (into [] (serdes.extract/extract {:no-settings true}))]
@@ -1807,7 +1807,14 @@
             (testing "No warnings when version in serdes/meta matches current version"
               (log.capture/with-log-messages-for-level [messages :warn]
                 (serdes.load/load-metabase! (ingestion-in-memory extract))
-                (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages)))))))))))))
+                (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages))))))))
+          (ts/with-db dest-db3
+            (testing "No warnings when entities have no :metabase_version (eg. legacy exports or Settings)"
+              (let [no-version-extract (map #(dissoc % :metabase_version) extract)]
+                (log.capture/with-log-messages-for-level [messages [metabase-enterprise.serialization.v2.load :warn]]
+                  (serdes.load/load-metabase! (ingestion-in-memory no-version-extract))
+                  (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages))))
+                      "Missing :metabase_version should be treated as unknown, not as a mismatch"))))))))))
 
 (deftest import-published-table-with-existing-database-test
   (testing "Importing a published table works when database already exists on target"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1805,7 +1805,7 @@
                       "Should log a version mismatch warning only once per load")))))
           (ts/with-db dest-db2
             (testing "No warnings when version in serdes/meta matches current version"
-              (log.capture/with-log-messages-for-level [messages :warn]
+              (log.capture/with-log-messages-for-level [messages [metabase-enterprise.serialization.v2.load :warn]]
                 (serdes.load/load-metabase! (ingestion-in-memory extract))
                 (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages))))))))
           (ts/with-db dest-db3

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -43,11 +43,11 @@
           (testing "the Collections properly exported"
             (let [yaml-parent (-> (yaml/from-file (io/file dump-dir "collections" "main"
                                                            "some_collection.yaml"))
-                                  (dissoc :serdes/meta)
+                                  (dissoc :serdes/meta :metabase_version)
                                   (update :created_at t/offset-date-time))
                   yaml-child  (-> (yaml/from-file (io/file dump-dir "collections" "main"
                                                            "some_collection" "child_collection.yaml"))
-                                  (dissoc :serdes/meta)
+                                  (dissoc :serdes/meta :metabase_version)
                                   (update :created_at t/offset-date-time))]
               (is (= (-> (into {} (t2/select-one :model/Collection :id (:id parent)))
                          (dissoc :id :location)
@@ -145,6 +145,7 @@
                                                 "databases"  "my_company_data"
                                                 "tables"     "customers"
                                                 "fields"     "company__SLASH__organization_website.yaml"))
+                       (dissoc :metabase_version)
                        (update :visibility_type keyword)
                        (update :base_type       keyword))))))))))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74444
Closes https://linear.app/metabase/issue/GDGT-2446/serialization-import-always-prints-version-mismatch-warning

There was an existing test that should've caught this, but it was broken and never captured the right logs.