### PR TITLE
Save x-ray dashboard in-place from embedding hub picker

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -27,7 +27,7 @@ describe("scenarios - embedding hub", () => {
         .should("exist");
     });
 
-    it('"Create a dashboard" card should show return toast after saving x-ray', () => {
+    it('"Create a dashboard" card should save the x-ray and show a success toast without leaving the guide', () => {
       cy.visit("/admin/embedding/setup-guide");
 
       cy.log("Find and click on 'Create a dashboard' card");
@@ -43,20 +43,13 @@ describe("scenarios - embedding hub", () => {
         H.pickEntity({ path: ["Databases", "Sample Database", "Accounts"] });
       });
 
-      cy.log("Should navigate to auto dashboard with from param");
-      cy.url().should("include", "/auto/dashboard/table/");
-      cy.url().should("include", "returnToEmbeddingSetupGuide=");
+      cy.log("Should show a success toast with a link to the new dashboard");
+      H.undoToast()
+        .findByText("Your dashboard was saved", { timeout: 30_000 })
+        .should("be.visible");
+      H.undoToast().findByText("See it").should("be.visible");
 
-      cy.log("Wait for x-ray dashboard to load and save it");
-      cy.findByRole("button", { name: "Save this", timeout: 30_000 }).click();
-
-      cy.log("Should show modal prompting to return to setup guide");
-      H.modal().within(() => {
-        cy.findByText("Dashboard saved!").should("be.visible");
-        cy.findByText("Return to the setup guide").click();
-      });
-
-      cy.log("Should navigate back to the setup guide");
+      cy.log("Should remain on the setup guide");
       cy.url().should("include", "/admin/embedding/setup-guide");
     });
 

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -18,8 +18,6 @@ import {
   useDashboardContext,
 } from "metabase/dashboard/context";
 import { useDashboardUrlQuery } from "metabase/dashboard/hooks";
-import { ReturnToSetupGuideModal } from "metabase/embedding/components/ReturnToSetupGuideModal";
-import { RETURN_TO_SETUP_GUIDE_PARAM } from "metabase/embedding/constants";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
@@ -51,10 +49,6 @@ const AutomaticDashboardAppInner = () => {
   const invalidateCollections = () => invalidateTags(null, ["collection"]);
 
   const [savedDashboardUrl, setSavedDashboardUrl] = useState<string>();
-  const [showReturnModal, setShowReturnModal] = useState(false);
-  const fromEmbeddingSetupGuide = new URLSearchParams(
-    window.location.search,
-  ).has(RETURN_TO_SETUP_GUIDE_PARAM);
 
   useEffect(() => {
     setSavedDashboardUrl(undefined);
@@ -91,9 +85,6 @@ const AutomaticDashboardAppInner = () => {
         }),
       );
       setSavedDashboardUrl(newDashboardUrl);
-      if (fromEmbeddingSetupGuide) {
-        setShowReturnModal(true);
-      }
     }
   };
 
@@ -218,14 +209,6 @@ const AutomaticDashboardAppInner = () => {
           </Box>
         )}
       </div>
-      {fromEmbeddingSetupGuide && (
-        <ReturnToSetupGuideModal
-          opened={showReturnModal}
-          onClose={() => setShowReturnModal(false)}
-          title={t`Dashboard saved!`}
-          message={t`Your dashboard has been saved. Return to the setup guide to continue.`}
-        />
-      )}
     </div>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -119,7 +119,6 @@ export const EmbeddingHub = () => {
       <EmbeddingHubXrayPickerModal
         opened={openedModal?.type === "xray-dashboard"}
         onClose={closeModal}
-        fromEmbeddingSetupGuide
       />
       {openedModal?.type === "user-strategy" && (
         <PLUGIN_TENANTS.EditUserStrategyModal onClose={closeModal} />

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -100,7 +100,7 @@ describe("EmbeddingHub", () => {
 
   it("creates and saves an x-ray dashboard when a table is picked", async () => {
     const xrayDashboard = createMockDashboard({
-      id: "/auto/dashboard/table/10" as unknown as number,
+      id: 10,
       name: "A look at Foo Bar Table",
     });
     const savedDashboard = createMockDashboard({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
-import { push } from "react-router-redux";
 
 import {
   setupCollectionByIdEndpoint,
@@ -20,21 +19,13 @@ import {
 import { createMockState } from "metabase/redux/store/mocks";
 import {
   createMockCollection,
+  createMockDashboard,
   createMockRecentTableDatabaseInfo,
   createMockRecentTableItem,
   createMockUser,
 } from "metabase-types/api/mocks";
 
-jest.mock("react-router-redux", () => ({
-  push: jest.fn(() => ({
-    type: "@@router/CALL_HISTORY_METHOD",
-    payload: { method: "push" },
-  })),
-}));
-
 import { EmbeddingHub } from "./EmbeddingHub";
-
-const mockPush = push as jest.MockedFunction<typeof push>;
 
 const setup = ({ isAdmin = true, checklist = {} } = {}) => {
   mockGetBoundingClientRect();
@@ -87,14 +78,13 @@ const setup = ({ isAdmin = true, checklist = {} } = {}) => {
     "data-isolation-strategy": null,
   });
 
-  return renderWithProviders(<EmbeddingHub />, { storeInitialState: state });
+  return renderWithProviders(<EmbeddingHub />, {
+    storeInitialState: state,
+    withUndos: true,
+  });
 };
 
 describe("EmbeddingHub", () => {
-  beforeEach(() => {
-    mockPush.mockClear();
-  });
-
   it("opens AddDataModal when 'Connect a database' is clicked", async () => {
     setup();
 
@@ -108,7 +98,19 @@ describe("EmbeddingHub", () => {
     });
   });
 
-  it("opens table picker when 'Create a dashboard' is clicked", async () => {
+  it("creates and saves an x-ray dashboard when a table is picked", async () => {
+    const xrayDashboard = createMockDashboard({
+      id: "/auto/dashboard/table/10" as unknown as number,
+      name: "A look at Foo Bar Table",
+    });
+    const savedDashboard = createMockDashboard({
+      id: 42,
+      name: "A look at Foo Bar Table",
+    });
+
+    fetchMock.get("path:/api/automagic-dashboards/table/10", xrayDashboard);
+    fetchMock.post("path:/api/dashboard/save", savedDashboard);
+
     setup();
 
     await userEvent.click(await screen.findByText("Create a dashboard"));
@@ -128,9 +130,34 @@ describe("EmbeddingHub", () => {
 
     await userEvent.click(within(dialog).getByText("Foo Bar Table"));
 
-    expect(mockPush).toHaveBeenCalledWith(
-      "/auto/dashboard/table/10?returnToEmbeddingSetupGuide=true",
-    );
+    expect(
+      await screen.findByText("Your dashboard was saved"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("See it")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("entity-picker-modal")).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast when x-ray dashboard creation fails", async () => {
+    fetchMock.get("path:/api/automagic-dashboards/table/10", 500);
+
+    setup();
+
+    await userEvent.click(await screen.findByText("Create a dashboard"));
+
+    const dialog = await screen.findByTestId("entity-picker-modal");
+
+    await userEvent.click(await screen.findByText("Recent items"));
+
+    expect(
+      await within(dialog).findByText("Foo Bar Table"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByText("Foo Bar Table"));
+
+    expect(
+      await screen.findByText("Failed to create dashboard"),
+    ).toBeInTheDocument();
   });
 
   it("shows success banner when first 3 steps are completed", async () => {

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubXrayPickerModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubXrayPickerModal.tsx
@@ -1,29 +1,77 @@
-import { push } from "react-router-redux";
+import cx from "classnames";
+import { dissoc } from "icepick";
 import { t } from "ttag";
 
+import { Api, dashboardApi } from "metabase/api";
+import { invalidateTags, listTag } from "metabase/api/tags";
+import { Link } from "metabase/common/components/Link";
 import { DataPickerModal } from "metabase/common/components/Pickers/DataPicker";
-import { RETURN_TO_SETUP_GUIDE_PARAM } from "metabase/embedding/constants";
+import { useToast } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/redux";
-import type { TableId } from "metabase-types/api";
+import { AutoApi } from "metabase/services";
+import * as Urls from "metabase/urls";
+import type { Dashboard, TableId } from "metabase-types/api";
 
 interface EmbeddingHubXrayPickerModalProps {
   opened: boolean;
   onClose: () => void;
-  fromEmbeddingSetupGuide?: boolean;
 }
 
 export const EmbeddingHubXrayPickerModal = ({
   opened,
   onClose,
-  fromEmbeddingSetupGuide,
 }: EmbeddingHubXrayPickerModalProps) => {
   const dispatch = useDispatch();
+  const [sendToast] = useToast();
 
-  function handleTableSelect(tableId: TableId) {
-    const params = fromEmbeddingSetupGuide
-      ? `?${RETURN_TO_SETUP_GUIDE_PARAM}=true`
-      : "";
-    dispatch(push(`/auto/dashboard/table/${tableId}${params}`));
+  async function handleTableSelect(tableId: TableId) {
+    onClose();
+
+    try {
+      const xrayDashboard: Dashboard = await AutoApi.dashboard({
+        subPath: `table/${tableId}`,
+      });
+
+      const { data: savedDashboard } = await dispatch(
+        dashboardApi.endpoints.saveDashboard.initiate(
+          dissoc(xrayDashboard, "id"),
+        ),
+      );
+
+      if (!savedDashboard) {
+        throw new Error("Failed to save x-ray dashboard");
+      }
+
+      dispatch(
+        Api.util.invalidateTags([
+          ...invalidateTags(null, ["collection"]),
+          listTag("embedding-hub-checklist"),
+        ]),
+      );
+
+      const savedDashboardUrl = Urls.dashboard(savedDashboard);
+      sendToast({
+        message: (
+          <div className={cx(CS.flex, CS.alignCenter)}>
+            {t`Your dashboard was saved`}
+            <Link
+              className={cx(CS.link, CS.textBold, CS.ml1)}
+              to={savedDashboardUrl}
+            >
+              {t`See it`}
+            </Link>
+          </div>
+        ),
+        icon: "dashboard",
+      });
+    } catch {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: t`Failed to create dashboard`,
+      });
+    }
   }
 
   if (!opened) {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/MetabaseAccountCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/MetabaseAccountCard.tsx
@@ -39,7 +39,7 @@ export const MetabaseAccountCard = () => {
 
   return (
     <Card p="md">
-      <Stack gap="md" p="xs">
+      <Stack gap="md">
         <Text size="lg" fw="bold">
           {
             // eslint-disable-next-line metabase/no-literal-metabase-strings -- Public Facing string


### PR DESCRIPTION
Closes [EMB-1725: "Create a dashboard" button should just create the x-ray and save it](https://linear.app/metabase/issue/EMB-1725/create-a-dashboard-button-should-just-create-the-x-ray-and-save-it)

### Description

In the embedding hub, picking a table from the "Create a dashboard" picker used to navigate the user to the live x-ray page (`/auto/dashboard/table/:id`), leaving them to save the dashboard themselves. This PR saves the x-ray dashboard in place: on table selection we fetch the x-ray, persist it via `saveDashboard`, then surface a toast with a "See it" link to the saved dashboard. The embedding-hub checklist cache is invalidated so the saved dashboard counts toward setup progress.

The `fromEmbeddingSetupGuide` / `RETURN_TO_SETUP_GUIDE_PARAM` flow on `AutomaticDashboardApp` is no longer needed and has been removed.

### How to verify

1. Open the embedding hub setup guide.
2. Click "Create a dashboard" and pick any table.
3. The modal closes and a toast appears: "Your dashboard was saved — See it".
4. Click "See it" → land on the saved dashboard (not the live x-ray URL).
5. The dashboard appears in the collection it was saved to.
6. The "Create a dashboard" checklist step is marked done.

### Demo

https://www.loom.com/share/6aa8668e59f0499290565fb47bde0929

### Checklist

- [x] Tests have been added/updated to cover changes in this PR