### PR TITLE
Fix excessive padding in embed wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabaseAccountSection.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/Authentication/MetabaseAccountSection.tsx
@@ -42,7 +42,7 @@ export const MetabaseAccountSection = () => {
   return (
     <>
       <Card p="md">
-        <Stack gap="md" p="xs">
+        <Stack gap="md">
           <Text size="lg" fw="bold">
             {
               // eslint-disable-next-line metabase/no-literal-metabase-strings -- Public Facing string


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74342
Closes [EMB-1750: Embed wizard SSO step 3 has extra padding](https://linear.app/metabase/issue/EMB-1750/embed-wizard-sso-step-3-has-extra-padding)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to the last step of the embedding wizard and look at the card title (assuming you've selected SSO).

### Demo

https://www.loom.com/share/4a5eb40e3fa44ef98ae99e9c6e301ba8

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
