### PR TITLE
feat: add card-row-diff alert type for watching new rows

### DIFF
--- a/frontend/src/metabase-types/api/mocks/notification.ts
+++ b/frontend/src/metabase-types/api/mocks/notification.ts
@@ -9,27 +9,53 @@ import { createMockUserInfo } from "metabase-types/api/mocks/user";
 
 export const createMockNotification = (
   opts?: Partial<Notification>,
-): Notification => ({
-  payload_id: 7,
-  payload: {
-    id: 7,
-    card_id: 1,
-    send_once: false,
-    send_condition: "has_result",
-    created_at: "2025-01-07T18:40:47.245205+03:00",
+): Notification =>
+  ({
+    payload_id: 7,
+    payload: {
+      id: 7,
+      card_id: 1,
+      send_once: false,
+      send_condition: "has_result",
+      created_at: "2025-01-07T18:40:47.245205+03:00",
+      updated_at: "2025-01-07T18:40:47.245205+03:00",
+    },
+    creator: createMockUserInfo({ ...opts?.creator }),
+    payload_type: "notification/card",
+    handlers: [createMockNotificationHandlerEmail()],
+    creator_id: 3,
+    subscriptions: [createMockNotificationCronSubscription()],
     updated_at: "2025-01-07T18:40:47.245205+03:00",
-  },
-  creator: createMockUserInfo({ ...opts?.creator }),
-  payload_type: "notification/card",
-  handlers: [createMockNotificationHandlerEmail()],
-  creator_id: 3,
-  subscriptions: [createMockNotificationCronSubscription()],
-  updated_at: "2025-01-07T18:40:47.245205+03:00",
-  active: true,
-  id: 10,
-  created_at: "2025-01-07T18:40:47.245205+03:00",
-  ...opts,
-});
+    active: true,
+    id: 10,
+    created_at: "2025-01-07T18:40:47.245205+03:00",
+    ...opts,
+  }) as Notification;
+
+export const createMockNotificationCardRowDiff = (
+  opts?: Partial<Notification>,
+): Notification =>
+  ({
+    payload_id: 8,
+    payload: {
+      id: 8,
+      card_id: 1,
+      send_mode: "per-row",
+      message_template: null,
+      created_at: "2025-01-07T18:40:47.245205+03:00",
+      updated_at: "2025-01-07T18:40:47.245205+03:00",
+    },
+    creator: createMockUserInfo({ ...opts?.creator }),
+    payload_type: "notification/card-row-diff",
+    handlers: [createMockNotificationHandlerEmail()],
+    creator_id: 3,
+    subscriptions: [createMockNotificationCronSubscription()],
+    updated_at: "2025-01-07T18:40:47.245205+03:00",
+    active: true,
+    id: 11,
+    created_at: "2025-01-07T18:40:47.245205+03:00",
+    ...opts,
+  }) as Notification;
 
 export const createMockNotificationHandlerEmail = (
   opts?: Partial<NotificationHandlerEmail>,

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -11,6 +11,8 @@ export type NotificationCardSendCondition =
   | "goal_below"
   | "has_result";
 
+export type NotificationCardRowDiffSendMode = "per-row" | "digest";
+
 //#region Payload union type
 type NotificationCardPayload = {
   payload_type: "notification/card";
@@ -27,7 +29,24 @@ type NotificationCardPayload = {
   payload_id?: number;
 };
 
-type NotificationPayload = NotificationCardPayload; // will be populated with more variants later on
+type NotificationCardRowDiffPayload = {
+  payload_type: "notification/card-row-diff";
+  payload: {
+    card_id: CardId;
+    card?: Card;
+    send_mode: NotificationCardRowDiffSendMode;
+    message_template?: string | null;
+
+    id?: number;
+    created_at?: string;
+    updated_at?: string;
+  };
+  payload_id?: number;
+};
+
+type NotificationPayload =
+  | NotificationCardPayload
+  | NotificationCardRowDiffPayload;
 
 //#endregion
 
@@ -138,19 +157,31 @@ export interface ListNotificationsRequest extends PaginationRequest {
   permission_group_id?: number;
 }
 
-export type CreateAlertNotificationRequest = NotificationCardPayload & {
-  handlers: NotificationHandler[];
-  subscriptions: NotificationCronSubscription[];
-};
+export type CreateAlertNotificationRequest =
+  | (NotificationCardPayload & {
+      handlers: NotificationHandler[];
+      subscriptions: NotificationCronSubscription[];
+    })
+  | (NotificationCardRowDiffPayload & {
+      handlers: NotificationHandler[];
+      subscriptions: NotificationCronSubscription[];
+    });
 
 export type CreateNotificationRequest = CreateAlertNotificationRequest; // will be populated with more variants later on
 
-export type UpdateAlertNotificationRequest = NotificationCardPayload & {
-  id: NotificationId;
-  active: boolean;
-  handlers: NotificationHandler[];
-  subscriptions: NotificationCronSubscription[];
-};
+export type UpdateAlertNotificationRequest =
+  | (NotificationCardPayload & {
+      id: NotificationId;
+      active: boolean;
+      handlers: NotificationHandler[];
+      subscriptions: NotificationCronSubscription[];
+    })
+  | (NotificationCardRowDiffPayload & {
+      id: NotificationId;
+      active: boolean;
+      handlers: NotificationHandler[];
+      subscriptions: NotificationCronSubscription[];
+    });
 
 export type UpdateNotificationRequest = UpdateAlertNotificationRequest; // will be populated with more variants later on
 

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
 import { isEqual } from "underscore";
@@ -30,14 +30,17 @@ import { useDispatch, useSelector } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
 import { canAccessSettings, getUser } from "metabase/selectors/user";
 import {
+  Badge,
   Button,
   Flex,
+  Group,
   Modal,
   Paper,
   Select,
   Stack,
   Switch,
   Text,
+  Textarea,
   rem,
 } from "metabase/ui";
 import { getResponseErrorMessage } from "metabase/utils/errors";
@@ -45,12 +48,14 @@ import type Question from "metabase-lib/v1/Question";
 import type {
   CreateAlertNotificationRequest,
   Notification,
+  NotificationCardRowDiffSendMode,
   NotificationCardSendCondition,
   NotificationCronSubscription,
   NotificationHandler,
   ScheduleType,
   UpdateAlertNotificationRequest,
 } from "metabase-types/api";
+import type { Field } from "metabase-types/api/field";
 
 import { ChannelSetupModal } from "../ChannelSetupModal";
 import { NotificationChannelsPicker } from "../components/NotificationChannelsPicker";
@@ -58,11 +63,17 @@ import { NotificationChannelsPicker } from "../components/NotificationChannelsPi
 import { AlertTriggerIcon } from "./AlertTriggerIcon";
 import { AlertModalSettingsBlock } from "./components/AlertModalSettingsBlock/AlertModalSettingsBlock";
 import { NotificationSchedule } from "./components/NotificationSchedule/NotificationSchedule";
-import type { NotificationTriggerOption } from "./types";
+import type {
+  NotificationTriggerOption,
+  NotificationTriggerValue,
+} from "./types";
 
 function getAlertTriggerOptionsMap(
   question: Question | undefined,
-): Record<NotificationCardSendCondition, NotificationTriggerOption> {
+): Record<
+  NotificationCardSendCondition | "watch_new_rows",
+  NotificationTriggerOption
+> {
   const isMetric = question?.type() === "metric";
   return {
     has_result: {
@@ -78,6 +89,10 @@ function getAlertTriggerOptionsMap(
     goal_below: {
       value: "goal_below" as const,
       label: t`When results go below the goal`,
+    },
+    watch_new_rows: {
+      value: "watch_new_rows" as const,
+      label: t`When new rows appear`,
     },
   };
 }
@@ -155,7 +170,10 @@ export const CreateOrEditQuestionAlertModal = ({
     CreateAlertNotificationRequest | UpdateAlertNotificationRequest | null
   >(null);
 
+  const templateTextareaRef = useRef<HTMLTextAreaElement>(null);
+
   const questionId = question?.id();
+  const resultColumns: Field[] = question?.card()?.result_metadata ?? [];
   const isEditMode = !!editingNotification;
   const subscription = notification?.subscriptions[0];
 
@@ -176,10 +194,11 @@ export const CreateOrEditQuestionAlertModal = ({
 
   const triggerOptions = useMemo(() => {
     const optionsMap = getAlertTriggerOptionsMap(question);
-    return getAlertTriggerOptions({
+    const conditionOptions = getAlertTriggerOptions({
       question,
       visualizationSettings,
     }).map((trigger) => optionsMap[trigger]);
+    return [...conditionOptions, optionsMap["watch_new_rows"]];
   }, [question, visualizationSettings]);
 
   const hasSingleTriggerOption = triggerOptions.length === 1;
@@ -303,6 +322,11 @@ export const CreateOrEditQuestionAlertModal = ({
     return null;
   }
 
+  const currentTriggerValue: NotificationTriggerValue =
+    notification.payload_type === "notification/card-row-diff"
+      ? "watch_new_rows"
+      : notification.payload.send_condition;
+
   const isValid = alertIsValid(notification, channelSpec);
   const hasChanges = !isEqual(editingNotification, notification);
   const hasError = errorCreating || errorUpdating;
@@ -353,17 +377,33 @@ export const CreateOrEditQuestionAlertModal = ({
               <Select
                 data-testid="alert-goal-select"
                 data={triggerOptions}
-                value={notification.payload.send_condition}
+                value={currentTriggerValue}
                 w={276}
-                onChange={(value) =>
-                  setNotification({
-                    ...notification,
-                    payload: {
-                      ...notification.payload,
-                      send_condition: value as NotificationCardSendCondition,
-                    },
-                  })
-                }
+                onChange={(value: string | null) => {
+                  if (!value) {
+                    return;
+                  }
+                  if (value === "watch_new_rows") {
+                    setNotification({
+                      ...notification,
+                      payload_type: "notification/card-row-diff",
+                      payload: {
+                        card_id: notification.payload.card_id,
+                        send_mode: "per-row",
+                      },
+                    });
+                  } else {
+                    setNotification({
+                      ...notification,
+                      payload_type: "notification/card",
+                      payload: {
+                        card_id: notification.payload.card_id,
+                        send_condition: value as NotificationCardSendCondition,
+                        send_once: false,
+                      },
+                    });
+                  }
+                }}
               />
             )}
           </Flex>
@@ -404,27 +444,127 @@ export const CreateOrEditQuestionAlertModal = ({
         )}
 
         <AlertModalSettingsBlock title={t`More options`}>
-          <Switch
-            label={t`Delete this Alert after it's triggered`}
-            styles={{
-              label: {
-                lineHeight: "1.5rem",
-              },
-            }}
-            labelPosition="right"
-            size="sm"
-            checked={notification.payload.send_once}
-            onChange={(e) =>
-              setNotification({
-                ...notification,
-                payload: {
-                  ...notification.payload,
-                  send_once: e.target.checked,
+          {notification.payload_type === "notification/card-row-diff" ? (
+            <Select
+              label={t`Delivery format`}
+              data={[
+                { value: "per-row", label: t`One message per new row` },
+                { value: "digest", label: t`One message for all new rows` },
+              ]}
+              value={notification.payload.send_mode}
+              onChange={(value: string | null) => {
+                if (
+                  !value ||
+                  notification.payload_type !== "notification/card-row-diff"
+                ) {
+                  return;
+                }
+                setNotification({
+                  ...notification,
+                  payload: {
+                    ...notification.payload,
+                    send_mode: value as NotificationCardRowDiffSendMode,
+                  },
+                });
+              }}
+            />
+          ) : (
+            <Switch
+              label={t`Delete this Alert after it's triggered`}
+              styles={{
+                label: {
+                  lineHeight: "1.5rem",
                 },
-              })
-            }
-          />
+              }}
+              labelPosition="right"
+              size="sm"
+              checked={notification.payload.send_once}
+              onChange={(e) =>
+                setNotification({
+                  ...notification,
+                  payload: {
+                    ...notification.payload,
+                    send_once: e.target.checked,
+                  },
+                })
+              }
+            />
+          )}
         </AlertModalSettingsBlock>
+
+        {notification.payload_type === "notification/card-row-diff" && (
+          <AlertModalSettingsBlock title={t`Message template (optional)`}>
+            <Stack gap="xs">
+              <Textarea
+                ref={templateTextareaRef}
+                placeholder={t`e.g. "Yesterday we sold {{count}} of {{product}}"`}
+                autosize
+                minRows={2}
+                value={notification.payload.message_template ?? ""}
+                onChange={(e) =>
+                  setNotification({
+                    ...notification,
+                    payload: {
+                      ...notification.payload,
+                      message_template: e.target.value || null,
+                    },
+                  })
+                }
+              />
+              {resultColumns.length > 0 && (
+                <Group gap="xs">
+                  <Text size="xs" c="text-secondary">{t`Insert column:`}</Text>
+                  {resultColumns.map((col) => (
+                    <Badge
+                      key={col.name}
+                      variant="outline"
+                      style={{ cursor: "pointer" }}
+                      onClick={() => {
+                        const el = templateTextareaRef.current;
+                        const placeholder = `{{${col.name}}}`;
+                        if (!el) {
+                          setNotification({
+                            ...notification,
+                            payload: {
+                              ...notification.payload,
+                              message_template:
+                                (notification.payload.message_template ?? "") +
+                                placeholder,
+                            },
+                          });
+                          return;
+                        }
+                        const start = el.selectionStart ?? el.value.length;
+                        const end = el.selectionEnd ?? el.value.length;
+                        const current = el.value;
+                        const next =
+                          current.slice(0, start) +
+                          placeholder +
+                          current.slice(end);
+                        setNotification({
+                          ...notification,
+                          payload: {
+                            ...notification.payload,
+                            message_template: next || null,
+                          },
+                        });
+                        requestAnimationFrame(() => {
+                          el.focus();
+                          el.setSelectionRange(
+                            start + placeholder.length,
+                            start + placeholder.length,
+                          );
+                        });
+                      }}
+                    >
+                      {col.display_name}
+                    </Badge>
+                  ))}
+                </Group>
+              )}
+            </Stack>
+          </AlertModalSettingsBlock>
+        )}
       </Stack>
       <Flex
         justify="space-between"

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/types.ts
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/types.ts
@@ -1,7 +1,11 @@
 import type { NotificationCardSendCondition } from "metabase-types/api";
 
+export type NotificationTriggerValue =
+  | NotificationCardSendCondition
+  | "watch_new_rows";
+
 // TODO: combine this with api types
 export type NotificationTriggerOption = {
-  value: NotificationCardSendCondition;
+  value: NotificationTriggerValue;
   label: string;
 };

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
@@ -14,7 +14,6 @@ import { Box, FixedSizeIcon, Group, Stack, Text } from "metabase/ui";
 import { isNotFalsy } from "metabase/utils/types";
 import type {
   Notification,
-  NotificationCardSendCondition,
   NotificationChannel,
   NotificationHandlerEmail,
   NotificationHandlerHttp,
@@ -78,7 +77,7 @@ export const AlertListItem = ({
       onClick={handleEdit}
     >
       <Text className={S.itemTitle} size="md" lineClamp={1} fw="bold">
-        {formatTitle(alert.payload.send_condition)}
+        {formatTitle(alert)}
       </Text>
       <Group gap="xs" align="center" c="text-secondary">
         {subscription && (
@@ -143,8 +142,11 @@ export const AlertListItem = ({
   );
 };
 
-const formatTitle = (sendCondition: NotificationCardSendCondition): string => {
-  switch (sendCondition) {
+const formatTitle = (alert: Notification): string => {
+  if (alert.payload_type === "notification/card-row-diff") {
+    return t`Alert when new rows appear`;
+  }
+  switch (alert.payload.send_condition) {
     case "has_result":
       return t`Alert when this has results`;
     case "goal_above":

--- a/frontend/src/metabase/notifications/utils.ts
+++ b/frontend/src/metabase/notifications/utils.ts
@@ -118,7 +118,8 @@ export const getDefaultQuestionAlertRequest = ({
   availableTriggerOptions: NotificationTriggerOption[];
   userCanAccessSettings: boolean;
 }): CreateAlertNotificationRequest => {
-  const sendCondition = availableTriggerOptions[0].value;
+  const sendCondition = availableTriggerOptions[0]
+    .value as NotificationCardSendCondition;
 
   return {
     payload_type: "notification/card",

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11776,6 +11776,111 @@ databaseChangeLog:
               - column:
                   name: match_status
 
+  - changeSet:
+      id: v55.2026-05-20T10:00:00
+      author: conorreid
+      comment: create the notification_card_row_diff table for card row diff notifications
+      changes:
+        - createTable:
+            tableName: notification_card_row_diff
+            remarks: Configuration for card-row-diff notifications
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: card_id
+                  type: int
+                  remarks: the card to watch for new rows
+                  constraints:
+                    nullable: false
+                    referencedTableName: report_card
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_card_row_diff_card_id
+                    deleteCascade: true
+              - column:
+                  name: send_mode
+                  type: varchar(32)
+                  remarks: per-row or digest
+                  defaultValue: per-row
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v55.2026-05-20T10:00:01
+      author: conorreid
+      comment: create the notification_row_diff_snapshot table for storing row snapshots
+      changes:
+        - createTable:
+            tableName: notification_row_diff_snapshot
+            remarks: Stores last-seen row snapshots for card-row-diff notifications
+            columns:
+              - column:
+                  name: notification_id
+                  type: bigint
+                  remarks: FK to notification; also the primary key (1:1 relation)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                    referencedTableName: notification
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_row_diff_snapshot_notification_id
+                    deleteCascade: true
+              - column:
+                  name: card_id
+                  type: int
+                  remarks: the card whose rows were snapshotted
+                  constraints:
+                    nullable: false
+                    referencedTableName: report_card
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_row_diff_snapshot_card_id
+                    deleteCascade: true
+              - column:
+                  name: snapshot
+                  type: text
+                  remarks: JSON array of rows from the last run
+                  constraints:
+                    nullable: false
+              - column:
+                  name: captured_at
+                  type: ${timestamp_type}
+                  remarks: when the snapshot was taken
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v55.2026-05-20T10:00:02
+      author: conorreid
+      comment: add message_template column to notification_card_row_diff
+      changes:
+        - addColumn:
+            tableName: notification_card_row_diff
+            columns:
+              - column:
+                  name: message_template
+                  type: text
+                  remarks: optional mustache-style template e.g. "Sold {{count}} of {{product}}"
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/channel/impl/slack_row_diff.clj
+++ b/src/metabase/channel/impl/slack_row_diff.clj
@@ -1,0 +1,100 @@
+(ns metabase.channel.impl.slack-row-diff
+  (:require
+   [clojure.string :as str]
+   [metabase.channel.core :as channel]
+   [metabase.channel.urls :as urls]))
+
+(def ^:private header-text-limit       150)
+(def ^:private block-text-length-limit 3000)
+(def ^:private slack-field-limit       10)
+
+(defn- truncate [s limit]
+  (if (> (count s) limit) (str (subs s 0 (dec limit)) "…") s))
+
+(defn- escape-mkdwn [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")))
+
+(defn- recipient->slack-channel [recipient]
+  (when (= (:type recipient) :notification-recipient/raw-value)
+    (or (get-in recipient [:details :channel_id])
+        (get-in recipient [:details :value]))))
+
+(defn- col-name [col] (or (:display_name col) (:name col) "?"))
+(defn- cell-value [v] (if (nil? v) "_nil_" (escape-mkdwn (str v))))
+
+(defn- interpolate-template
+  "Replace {{column_name}} placeholders in template with actual row values."
+  [template columns row]
+  (reduce (fn [s [col val]]
+            (str/replace s (str "{{" (:name col) "}}") (str val)))
+          template
+          (map vector columns row)))
+
+(defn- row->fields [columns row]
+  (mapv (fn [col val]
+          {:type "mrkdwn"
+           :text (truncate (format "*%s*\n%s" (col-name col) (cell-value val))
+                           block-text-length-limit)})
+        columns row))
+
+(defn- header-block [card-name n-new]
+  {:type "header"
+   :text {:type "plain_text"
+          :text (truncate (format "🆕 %s — %d new row%s"
+                                  card-name n-new (if (= 1 n-new) "" "s"))
+                          header-text-limit)
+          :emoji true}})
+
+(defn- context-block [card]
+  {:type "context"
+   :elements [{:type "mrkdwn"
+               :text (format "<%s|View question in Metabase>" (urls/card-url (:id card)))}]})
+
+(defn- divider [] {:type "divider"})
+
+(defn- per-row-messages [card columns new-rows channel-ids message-template]
+  (for [row new-rows ch-id channel-ids]
+    (let [body-blocks (if message-template
+                        [{:type "section"
+                          :text {:type "mrkdwn"
+                                 :text (truncate (interpolate-template message-template columns row)
+                                                 block-text-length-limit)}}]
+                        (let [field-chunks (partition-all slack-field-limit (row->fields columns row))]
+                          (mapv (fn [fields] {:type "section" :fields (vec fields)}) field-chunks)))]
+      {:channel ch-id
+       :blocks  (into [(header-block (:name card) 1)]
+                      (conj body-blocks (context-block card)))})))
+
+(defn- digest-row-block [columns row index message-template]
+  (if message-template
+    {:type "section"
+     :text {:type "mrkdwn"
+            :text (truncate (interpolate-template message-template columns row)
+                            block-text-length-limit)}}
+    {:type "section"
+     :text {:type "mrkdwn"
+            :text (truncate
+                   (str (format "*Row %d*\n" (inc index))
+                        (str/join "  |  "
+                                  (map (fn [col val] (format "*%s:* %s" (col-name col) (cell-value val)))
+                                       columns row)))
+                   block-text-length-limit)}}))
+
+(defn- digest-message [card columns new-rows channel-id message-template]
+  (let [n-new      (count new-rows)
+        row-blocks (map-indexed (fn [i row] (digest-row-block columns row i message-template)) new-rows)
+        all-blocks (vec (flatten [(header-block (:name card) n-new)
+                                  (interpose (divider) row-blocks)
+                                  (context-block card)]))]
+    {:channel channel-id :blocks all-blocks}))
+
+(defmethod channel/render-notification [:channel/slack :notification/card-row-diff]
+  [_channel-type {:keys [payload]} {:keys [recipients]}]
+  (let [{:keys [card columns new_rows send_mode message_template]} payload
+        channel-ids (keep recipient->slack-channel recipients)]
+    (case (keyword send_mode)
+      :digest (mapv #(digest-message card columns new_rows % message_template) channel-ids)
+      (doall (per-row-messages card columns new_rows channel-ids message_template)))))

--- a/src/metabase/channel/init.clj
+++ b/src/metabase/channel/init.clj
@@ -9,5 +9,6 @@
    [metabase.channel.impl.email]
    [metabase.channel.impl.http]
    [metabase.channel.impl.slack]
+   [metabase.channel.impl.slack-row-diff]
    [metabase.channel.settings]
    [metabase.channel.task.refresh-slack-channel-user-cache]))

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -87,7 +87,14 @@
                                    [:and
                                     [:= :notification_card.id :notification.payload_id]
                                     [:= :notification.payload_type "notification/card"]])
-                                  (sql.helpers/where [:= :notification_card.card_id card_id]))
+                                  (sql.helpers/left-join
+                                   :notification_card_row_diff
+                                   [:and
+                                    [:= :notification_card_row_diff.id :notification.payload_id]
+                                    [:= :notification.payload_type "notification/card-row-diff"]])
+                                  (sql.helpers/where [:or
+                                                      [:= :notification_card.card_id card_id]
+                                                      [:= :notification_card_row_diff.card_id card_id]]))
 
                               (and (nil? legacy-active) (not (true? include_inactive)))
                               (sql.helpers/where [:= :notification.active true])

--- a/src/metabase/notification/init.clj
+++ b/src/metabase/notification/init.clj
@@ -4,6 +4,7 @@
    [metabase.notification.events.notification]
    [metabase.notification.events.report-timezone-updated]
    [metabase.notification.payload.impl.card]
+   [metabase.notification.payload.impl.card-row-diff]
    [metabase.notification.payload.impl.dashboard]
    [metabase.notification.payload.impl.system-event]
    [metabase.notification.settings]

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -24,18 +24,24 @@
 (methodical/defmethod t2/table-name :model/NotificationSubscription [_model] :notification_subscription)
 (methodical/defmethod t2/table-name :model/NotificationHandler      [_model] :notification_handler)
 (methodical/defmethod t2/table-name :model/NotificationRecipient    [_model] :notification_recipient)
-(methodical/defmethod t2/table-name :model/NotificationCard         [_model] :notification_card)
+(methodical/defmethod t2/table-name :model/NotificationCard             [_model] :notification_card)
+(methodical/defmethod t2/table-name :model/NotificationCardRowDiff     [_model] :notification_card_row_diff)
+(methodical/defmethod t2/table-name :model/NotificationRowDiffSnapshot  [_model] :notification_row_diff_snapshot)
+(methodical/defmethod t2/primary-keys :model/NotificationRowDiffSnapshot [_] [:notification_id])
 
 (doseq [model [:model/Notification
                :model/NotificationSubscription
                :model/NotificationHandler
                :model/NotificationRecipient
-               :model/NotificationCard]]
+               :model/NotificationCard
+               :model/NotificationCardRowDiff]]
   (doto model
     (derive :metabase/model)
     (derive (if (= model :model/NotificationSubscription)
               :hook/created-at-timestamped?
               :hook/timestamped?))))
+
+(derive :model/NotificationRowDiffSnapshot :metabase/model)
 
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                       :model/Notification                                       ;;
@@ -46,6 +52,7 @@
   #{:notification/system-event
     :notification/dashboard
     :notification/card
+    :notification/card-row-diff
     ;; for testing only
     :notification/testing})
 
@@ -82,6 +89,13 @@
                                                                      :card)]
                                              (into {} (for [nc notification-cards]
                                                         [[:notification/card (:id nc)] nc])))
+
+                                           :notification/card-row-diff
+                                           (let [row-diffs (t2/select :model/NotificationCardRowDiff
+                                                                      :id [:in payload-ids])]
+                                             (into {} (for [rd row-diffs]
+                                                        [[:notification/card-row-diff (:id rd)] rd])))
+
                                            {[payload-type nil] nil})))]
 
     (for [notification notifications]
@@ -110,6 +124,10 @@
     [:notification/card
      [:map
       ;; optional during creation
+      [:payload_id {:optional true} int?]
+      [:creator_id {:optional true} int?]]]
+    [:notification/card-row-diff
+     [:map
       [:payload_id {:optional true} int?]
       [:creator_id {:optional true} int?]]]
     [:notification/testing :any]]])
@@ -157,7 +175,9 @@
   (when-let [payload-id (:payload_id instance)]
     (t2/delete! (case (:payload_type instance)
                   :notification/card
-                  :model/NotificationCard)
+                  :model/NotificationCard
+                  :notification/card-row-diff
+                  :model/NotificationCardRowDiff)
                 payload-id))
   instance)
 
@@ -416,6 +436,28 @@
          instance))
 
 ;; ------------------------------------------------------------------------------------------------;;
+;;                                  :model/NotificationCardRowDiff                                 ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(def ^:private row-diff-send-modes #{:per-row :digest})
+
+(t2/deftransforms :model/NotificationCardRowDiff
+  {:send_mode (mi/transform-validator mi/transform-keyword (partial mi/assert-enum row-diff-send-modes))})
+
+(mr/def ::NotificationCardRowDiff
+  "Schema for :model/NotificationCardRowDiff."
+  [:map
+   [:card_id                          ms/PositiveInt]
+   [:send_mode       {:optional true} (ms/enum-decode-keyword row-diff-send-modes)]
+   [:message_template {:optional true} [:maybe :string]]])
+
+(t2/define-before-insert :model/NotificationCardRowDiff
+  [instance]
+  (-> {:send_mode :per-row}
+      (merge instance)
+      (update :send_mode #(cond-> % (string? %) keyword))))
+
+;; ------------------------------------------------------------------------------------------------;;
 ;;                                            Helpers                                              ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
@@ -439,6 +481,9 @@
   [notification]
   (case (:payload_type notification)
     :notification/card
+    (mi/can-read? :model/Card (-> notification :payload :card_id))
+
+    :notification/card-row-diff
     (mi/can-read? :model/Card (-> notification :payload :card_id))
 
     :notification/system-event
@@ -555,7 +600,11 @@
                             (:notification/system-event :notification/testing)
                             nil
                             :notification/card
-                            (t2/insert-returning-pk! :model/NotificationCard (:payload notification)))
+                            (t2/insert-returning-pk! :model/NotificationCard (:payload notification))
+                            :notification/card-row-diff
+                            (t2/insert-returning-pk! :model/NotificationCardRowDiff
+                                                     (select-keys (:payload notification)
+                                                                  [:card_id :send_mode :message_template])))
           notification    (-> notification
                               (assoc :payload_id payload-id)
                               (dissoc :payload))

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -63,6 +63,10 @@
                        [:include_xls   {:optional true} [:maybe ms/BooleanValue]]
                        [:format_rows   {:optional true} [:maybe ms/BooleanValue]]
                        [:pivot_results {:optional true} [:maybe ms/BooleanValue]]]]]]]]]
+    [:notification/card-row-diff
+     [:map
+      [:payload_id {:optional true} [:maybe ms/PositiveInt]]
+      [:creator_id {:optional true} ms/PositiveInt]]]
     ;; for testing only
     [:notification/testing :map]]])
 
@@ -99,6 +103,16 @@
                  [:style             :map]
                  [:notification_card ::models.notification/NotificationCard]
                  [:subscriptions     [:sequential ::models.notification/NotificationSubscription]]]]]]
+    [:notification/card-row-diff
+     [:map
+      [:payload [:map
+                 [:card                                    :map]
+                 [:card_part                               [:maybe :map]]
+                 [:columns                                 [:sequential :map]]
+                 [:new_rows                                [:sequential :any]]
+                 [:send_mode                               [:enum :per-row :digest]]
+                 [:message_template {:optional true}       [:maybe :string]]
+                 [:is_first_run                            :boolean]]]]]
     [:notification/testing   :map]]])
 
 (defn- logo-url

--- a/src/metabase/notification/payload/impl/card_row_diff.clj
+++ b/src/metabase/notification/payload/impl/card_row_diff.clj
@@ -25,14 +25,13 @@
                    :snapshot        snapshot-json
                    :captured_at     now}))))
 
-(defn- row-set [rows]
-  (into #{} (map pr-str) rows))
-
 (defn- diff-rows [current-rows previous-rows]
   (if (nil? previous-rows)
     []
-    (let [prev-set (row-set previous-rows)]
-      (remove (fn [row] (prev-set (pr-str row))) current-rows))))
+    ;; Identify rows by their first column value (assumed to be a unique ID).
+    ;; This avoids flagging updated rows as new when mutable fields change.
+    (let [prev-ids (into #{} (map first) previous-rows)]
+      (remove (fn [row] (prev-ids (first row))) current-rows))))
 
 (mu/defmethod notification.payload/payload :notification/card-row-diff
   [{:keys [id creator_id payload_id payload] :as _notification-info}
@@ -53,8 +52,9 @@
                           {:card_id card-id :status (:status card-result)})))
         (let [columns      (get-in card-result [:data :cols])
               raw-rows     (get-in card-result [:data :rows])
-              ;; Large result sets are stored in a temp file — deref to get the plain vector.
-              current-rows (if (temp-storage/streaming-temp-file? raw-rows) @raw-rows raw-rows)
+              ;; Materialize into a vector so the seq can be iterated multiple times
+              ;; (once for diff, once for save-snapshot!) without exhausting a lazy cursor.
+              current-rows (vec (if (temp-storage/streaming-temp-file? raw-rows) @raw-rows raw-rows))
               prev-rows    (when-not unsaved? (load-snapshot id))
               ;; Unsaved preview: cap to 3 rows so per-row sends don't flood Slack.
               new-rows     (if unsaved? (take 3 current-rows) (diff-rows current-rows prev-rows))]

--- a/src/metabase/notification/payload/impl/card_row_diff.clj
+++ b/src/metabase/notification/payload/impl/card_row_diff.clj
@@ -1,0 +1,78 @@
+(ns metabase.notification.payload.impl.card-row-diff
+  (:require
+   [cheshire.core :as json]
+   [metabase.notification.payload.core :as notification.payload]
+   [metabase.notification.payload.execute :as notification.execute]
+   [metabase.notification.payload.temp-storage :as temp-storage]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
+
+(defn- load-snapshot [notification-id]
+  (when-let [row (t2/select-one :model/NotificationRowDiffSnapshot :notification_id notification-id)]
+    (json/parse-string (:snapshot row) true)))
+
+(defn- save-snapshot! [notification-id card-id rows]
+  (let [snapshot-json (json/generate-string rows)
+        now           (java.time.OffsetDateTime/now)]
+    (if (t2/exists? :model/NotificationRowDiffSnapshot :notification_id notification-id)
+      (t2/update! :model/NotificationRowDiffSnapshot
+                  {:notification_id notification-id}
+                  {:snapshot snapshot-json :captured_at now})
+      (t2/insert! :model/NotificationRowDiffSnapshot
+                  {:notification_id notification-id
+                   :card_id         card-id
+                   :snapshot        snapshot-json
+                   :captured_at     now}))))
+
+(defn- row-set [rows]
+  (into #{} (map pr-str) rows))
+
+(defn- diff-rows [current-rows previous-rows]
+  (if (nil? previous-rows)
+    []
+    (let [prev-set (row-set previous-rows)]
+      (remove (fn [row] (prev-set (pr-str row))) current-rows))))
+
+(mu/defmethod notification.payload/payload :notification/card-row-diff
+  [{:keys [id creator_id payload_id payload] :as _notification-info}
+   :- ::notification.payload/Notification]
+  ;; For unsaved "Send now" there is no DB record: read config from the inline :payload map.
+  (let [unsaved?         (nil? id)
+        config           (if payload_id
+                           (t2/select-one :model/NotificationCardRowDiff payload_id)
+                           payload)
+        card-id          (:card_id config)
+        send-mode        (keyword (get config :send_mode :per-row))
+        message-template (:message_template config)]
+    (log/with-context {:notification_id id :card_id card-id}
+      (let [card-part   (notification.execute/execute-card creator_id card-id)
+            card-result (:result card-part)]
+        (when (not= :completed (:status card-result))
+          (throw (ex-info (format "Card execution failed: %s" (:error card-result))
+                          {:card_id card-id :status (:status card-result)})))
+        (let [columns      (get-in card-result [:data :cols])
+              raw-rows     (get-in card-result [:data :rows])
+              ;; Large result sets are stored in a temp file — deref to get the plain vector.
+              current-rows (if (temp-storage/streaming-temp-file? raw-rows) @raw-rows raw-rows)
+              prev-rows    (when-not unsaved? (load-snapshot id))
+              ;; Unsaved preview: cap to 3 rows so per-row sends don't flood Slack.
+              new-rows     (if unsaved? (take 3 current-rows) (diff-rows current-rows prev-rows))]
+          (when-not unsaved?
+            (save-snapshot! id card-id current-rows))
+          {:card             (t2/select-one :model/Card card-id)
+           :card_part        card-part
+           :columns          columns
+           :new_rows         new-rows
+           :send_mode        send-mode
+           :message_template message-template
+           ;; Never block an unsaved preview send for being a first run.
+           :is_first_run     (and (not unsaved?) (nil? prev-rows))})))))
+
+(mu/defmethod notification.payload/skip-reason :notification/card-row-diff
+  [{:keys [payload]}]
+  (cond
+    (-> payload :card :archived true?) :archived
+    (:is_first_run payload)            :first-run-snapshot-only
+    (empty? (:new_rows payload))       :no-new-rows
+    :else                              nil))

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -99,7 +99,7 @@
 (defn- hydrate-notification
   [notification-info]
   (case (:payload_type notification-info)
-    (:notification/system-event :notification/testing :notification/card)
+    (:notification/system-event :notification/testing :notification/card :notification/card-row-diff)
     (cond-> notification-info
       (t2/instance? notification-info)
       models.notification/hydrate-notification)

--- a/test/metabase/notification/payload/impl/card_row_diff_test.clj
+++ b/test/metabase/notification/payload/impl/card_row_diff_test.clj
@@ -1,0 +1,145 @@
+(ns metabase.notification.payload.impl.card-row-diff-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.channel.core :as channel]
+   [metabase.channel.impl.slack-row-diff]
+   [metabase.notification.models :as models.notification]
+   [metabase.notification.payload.core :as notification.payload]
+   [metabase.notification.payload.impl.card-row-diff]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+;; ---------------------------------------------------------------------------
+;; pure unit tests — no DB needed
+;; ---------------------------------------------------------------------------
+
+(deftest diff-rows-test
+  (testing "diff-rows returns only genuinely new rows"
+    (let [diff    #'metabase.notification.payload.impl.card-row-diff/diff-rows
+          row-a   [1 "a"]
+          row-b   [2 "b"]
+          row-c   [3 "c"]]
+      (testing "nil previous = empty diff (first run, never send)"
+        (is (= [] (diff [row-a row-b] nil))))
+      (testing "same rows = empty diff"
+        (is (= [] (diff [row-a row-b] [row-a row-b]))))
+      (testing "new rows identified correctly"
+        (is (= [row-c] (seq (diff [row-a row-b row-c] [row-a row-b])))))
+      (testing "row removed from set does not appear as new"
+        (is (= [] (diff [row-a] [row-a row-b])))))))
+
+(deftest notification-types-includes-card-row-diff-test
+  (testing ":notification/card-row-diff is registered in notification-types"
+    (is (contains? models.notification/notification-types :notification/card-row-diff))))
+
+;; ---------------------------------------------------------------------------
+;; Slack rendering — no DB, no Slack API
+;; ---------------------------------------------------------------------------
+
+(def ^:private test-card     {:id 42 :name "Sales by Region" :archived false})
+(def ^:private test-columns  [{:name "region" :display_name "Region"}
+                              {:name "total"  :display_name "Total"}])
+(def ^:private test-new-rows [["East" 1000] ["West" 2000]])
+(def ^:private test-recipient {:type    :notification-recipient/raw-value
+                               :details {:channel_id "C0TEST" :value "#test"}})
+
+(defn- make-npl [send-mode]
+  {:payload_type :notification/card-row-diff
+   :payload      {:card         test-card
+                  :card_part    nil
+                  :columns      test-columns
+                  :new_rows     test-new-rows
+                  :send_mode    send-mode
+                  :is_first_run false}
+   :context      {}})
+
+(deftest slack-render-per-row-test
+  (testing "render-notification :per-row produces one message per new row"
+    (let [messages (channel/render-notification :channel/slack
+                                                (make-npl :per-row)
+                                                {:recipients [test-recipient]})]
+      (is (= 2 (count messages)) "one message per row")
+      (is (every? #(= "C0TEST" (:channel %)) messages) "correct channel")
+      (is (every? #(seq (:blocks %)) messages) "each message has blocks")
+      (testing "header block says 1 new row"
+        (doseq [msg messages]
+          (let [hdr (first (:blocks msg))]
+            (is (= "header" (:type hdr)))
+            (is (str/includes? (get-in hdr [:text :text]) "1 new row"))))))))
+
+(deftest slack-render-digest-test
+  (testing "render-notification :digest produces one message for all new rows"
+    (let [messages (channel/render-notification :channel/slack
+                                                (make-npl :digest)
+                                                {:recipients [test-recipient]})]
+      (is (= 1 (count messages)) "one digest message")
+      (is (= "C0TEST" (:channel (first messages))))
+      (testing "header block says 2 new rows"
+        (let [hdr (first (:blocks (first messages)))]
+          (is (= "header" (:type hdr)))
+          (is (str/includes? (get-in hdr [:text :text]) "2 new rows")))))))
+
+(deftest slack-render-no-recipients-test
+  (testing "no recipients → no messages"
+    (is (empty? (channel/render-notification :channel/slack
+                                             (make-npl :per-row)
+                                             {:recipients []})))))
+
+(deftest skip-reason-first-run-test
+  (testing "skip-reason returns :first-run-snapshot-only when is_first_run"
+    (let [npl (assoc-in (make-npl :per-row) [:payload :is_first_run] true)]
+      (is (= :first-run-snapshot-only (notification.payload/skip-reason npl))))))
+
+(deftest skip-reason-no-new-rows-test
+  (testing "skip-reason returns :no-new-rows when new_rows is empty"
+    (let [npl (assoc-in (make-npl :per-row) [:payload :new_rows] [])]
+      (is (= :no-new-rows (notification.payload/skip-reason npl))))))
+
+(deftest skip-reason-archived-test
+  (testing "skip-reason returns :archived when card is archived"
+    (let [npl (assoc-in (make-npl :per-row) [:payload :card :archived] true)]
+      (is (= :archived (notification.payload/skip-reason npl))))))
+
+(deftest skip-reason-nil-when-should-send-test
+  (testing "skip-reason returns nil when there are new rows and card is not archived"
+    (is (nil? (notification.payload/skip-reason (make-npl :per-row))))))
+
+;; ---------------------------------------------------------------------------
+;; DB-level tests — require migrations to have run
+;; ---------------------------------------------------------------------------
+
+(deftest new-tables-exist-test
+  (testing "Liquibase migrations created both new tables"
+    (is (number? (t2/count :model/NotificationCardRowDiff))
+        "notification_card_row_diff table must exist")
+    (is (number? (t2/count :model/NotificationRowDiffSnapshot))
+        "notification_row_diff_snapshot table must exist")))
+
+(deftest notification-card-row-diff-send-mode-default-test
+  (testing "send_mode defaults to :per-row on insert"
+    (mt/with-temp [:model/Card {card-id :id} {}]
+      (let [id (t2/insert-returning-pk! :model/NotificationCardRowDiff {:card_id card-id})]
+        (try
+          (is (= :per-row (:send_mode (t2/select-one :model/NotificationCardRowDiff id))))
+          (finally (t2/delete! :model/NotificationCardRowDiff id)))))))
+
+(deftest snapshot-upsert-test
+  (testing "save-snapshot! inserts on first call and updates on second"
+    (let [save!     #'metabase.notification.payload.impl.card-row-diff/save-snapshot!
+          load-snap #'metabase.notification.payload.impl.card-row-diff/load-snapshot]
+      (mt/with-temp [:model/Card      {card-id :id} {}
+                     :model/Notification {notif-id :id} {:payload_type :notification/card-row-diff
+                                                         :creator_id   (mt/user->id :rasta)
+                                                         :active       true}]
+        ;; insert
+        (save! notif-id card-id [[1 "a"] [2 "b"]])
+        (is (= [[1 "a"] [2 "b"]] (load-snap notif-id)) "snapshot persisted after insert")
+        ;; update
+        (save! notif-id card-id [[3 "c"]])
+        (is (= [[3 "c"]] (load-snap notif-id)) "snapshot updated on second save")))))


### PR DESCRIPTION
## Summary

- Adds a new `notification/card-row-diff` alert type that triggers when new rows appear in a question's result set
- Snapshot-based diffing compares each run against the previous result set, sending only genuinely new rows
- Supports per-row (one message per new row) and digest (one message for all new rows) Slack delivery modes
- Optional mustache-style message template editor (`{{column_name}}`) with clickable column chips for cursor-aware placeholder insertion
- First run takes a baseline snapshot and skips sending (prevents flooding on setup)

## Changes

**Backend**
- `notification/payload/impl/card_row_diff.clj` — payload multimethod: executes card, diffs against snapshot, saves new snapshot
- `channel/impl/slack_row_diff.clj` — Slack renderer with template interpolation for both delivery modes
- `notification/models.clj` — `NotificationCardRowDiff` model, transforms, before-insert validation, payload batch hydration
- `notification/api/notification.clj` — fix `list-notifications` to JOIN both `notification_card` and `notification_card_row_diff` when filtering by `card_id`
- `resources/migrations/` — `notification_card_row_diff`, `notification_row_diff_snapshot` tables, `message_template` column

**Frontend**
- Alert modal: "When new rows appear" trigger option, delivery format selector, message template textarea with column chip insertion
- Alert list item: displays "Alert when new rows appear" title for the new type
- Types: `NotificationCardRowDiffPayload`, `NotificationCardRowDiffSendMode`

## Test plan

- [ ] Create a "When new rows appear" alert on any question — verify it saves successfully
- [ ] Alert appears in the question's alerts menu with the correct title
- [ ] Click to edit — modal opens with correct `send_mode`, template, and schedule pre-filled
- [ ] "Send now" delivers a preview (capped to 3 rows) to the configured Slack channel
- [ ] Message template with `{{column_name}}` placeholders interpolates correctly
- [ ] After first save, subsequent runs only send rows not present in the previous snapshot
- [ ] Backend unit tests: `metabase.notification.payload.impl.card-row-diff-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

also to be clear this was a YOLO and something useful to me