### PR TITLE
fk deser completeness test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2070,8 +2070,9 @@
           (is (not (contains? ser :id)))
           (is (not (contains? ser :use_verified_content)))
 
-          (testing "metabot depends on its model entities"
-            (is (= #{[{:model "Card" :id model-eid}]}
+          (testing "metabot depends on its model entities and collection"
+            (is (= #{[{:model "Card" :id model-eid}]
+                     [{:model "Collection" :id coll-eid}]}
                    (set (serdes/dependencies ser)))))
 
           (testing "metabot storage-path uses top-level metabots directory"
@@ -2121,8 +2122,9 @@
           (is (not (contains? ser :id)))
           (is (not (contains? ser :use_verified_content)))
 
-          (testing "metabot depends on its prompts' cards"
-            (is (= #{[{:model "Card" :id card-eid}]}
+          (testing "metabot depends on its prompts' cards and its collection"
+            (is (= #{[{:model "Card" :id card-eid}]
+                     [{:model "Collection" :id coll-eid}]}
                    (set (serdes/dependencies ser))))))))))
 
 (deftest document-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -150,6 +150,19 @@
   whole import (see GDGT-2444 for an example)."
   #{:model/User :model/Table :model/Field})
 
+(def ^:private fk-completeness-known-exceptions
+  "`[model field]` pairs that look like FK-completeness violations but are intentionally
+  exempt. The map value is a human reason kept for grep-ability."
+  {["Database" :router_database_id]
+   "router_database_id rows are filtered out of `extract-query` (router DBs aren't serialized), so this FK never reaches the load path."})
+
+(defn- inlined-via-nested?
+  "True if `model-name` is loaded only as a nested child of some parent, never as a root.
+  Such models override `serdes/generate-path` to return nil so the extract pipeline skips
+  them as top-level entities, and their FKs are handled by the parent's `dependencies`."
+  [model-name]
+  (nil? (serdes/generate-path model-name {:entity_id "probe" :name "probe"})))
+
 (defn- direct-fks
   "Return a seq of `[field target-model]` for every entry in `transform-spec` that is a
   plain `(serdes/fk ...)` declaration whose target needs a `dependencies` entry. Nested
@@ -174,9 +187,15 @@
     (let [inlined? (set serdes.models/inlined-models)]
       (doseq [m (-> (methods serdes/make-spec) (dissoc :default) keys)
               ;; Inlined children are loaded inside their parent, so the FK-resolution
-              ;; check applies to the parent's `dependencies`, not theirs. Out of scope.
-              :when (not (inlined? m))
-              :let [fks (direct-fks (:transform (serdes/make-spec m nil)))]
+              ;; check applies to the parent's `dependencies`, not theirs. Skipped either
+              ;; via the explicit list in `serdes.models/inlined-models` or by detecting a
+              ;; nil `generate-path` (the convention for nested-only models like
+              ;; QueryAction / HTTPAction / ImplicitAction).
+              :when (not (or (inlined? m) (inlined-via-nested? m)))
+              :let [fks (->> (:transform (serdes/make-spec m nil))
+                             direct-fks
+                             (remove (fn [[field _]]
+                                       (contains? fk-completeness-known-exceptions [m field]))))]
               :when (seq fks)]
         (testing (format "%s\n" m)
           (let [entity     (into {:serdes/meta [{:model m :id "self"}]}

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -142,3 +142,53 @@
               (doseq [field-kw (keys declared-defaults)]
                 (testing (format "`%s.%s` in :defaults is a serialized field" m (name field-kw))
                   (is (contains? serialized-fields field-kw)))))))))))
+
+(def ^:private auto-synthesized-fk-targets
+  "FK target models whose importers auto-create a stub entity if the target is missing, so
+  they don't have to be declared in `serdes/dependencies`. Everything else MUST be declared
+  — otherwise `*import-fk*` throws \"Could not find foreign key target\" and aborts the
+  whole import (see GDGT-2444 for an example)."
+  #{:model/User :model/Table :model/Field})
+
+(defn- direct-fks
+  "Return a seq of `[field target-model]` for every entry in `transform-spec` that is a
+  plain `(serdes/fk ...)` declaration whose target needs a `dependencies` entry. Nested
+  child specs are NOT walked — their FKs flow through the parent's bespoke `dependencies`
+  method which knows how to dig into the nested data, and verifying that takes a
+  parent-by-parent treatment that's out of scope here."
+  [transform-spec]
+  (for [[field transform] transform-spec
+        :when             (and (map? transform)
+                               (::serdes/fk transform)
+                               (not (::serdes/nested transform)))
+        :let              [target (::serdes/fk-model transform)]
+        :when             (and target
+                               (not (auto-synthesized-fk-targets target)))]
+    [field target]))
+
+(deftest ^:parallel serialization-direct-fk-dependencies-completeness-test
+  (testing (str "Every direct FK declared via `(serdes/fk ...)` in a loadable (non-inlined) "
+                "model's `make-spec` is surfaced in that model's `serdes/dependencies` — "
+                "otherwise `*import-fk*` will throw \"Could not find foreign key target\" at "
+                "import time (see GDGT-2444).")
+    (let [inlined? (set serdes.models/inlined-models)]
+      (doseq [m (-> (methods serdes/make-spec) (dissoc :default) keys)
+              ;; Inlined children are loaded inside their parent, so the FK-resolution
+              ;; check applies to the parent's `dependencies`, not theirs. Out of scope.
+              :when (not (inlined? m))
+              :let [fks (direct-fks (:transform (serdes/make-spec m nil)))]
+              :when (seq fks)]
+        (testing (format "%s\n" m)
+          (let [entity     (into {:serdes/meta [{:model m :id "self"}]}
+                                 (for [[field _] fks]
+                                   [field (str "fake-eid-" (name field))]))
+                deps       (set (serdes/dependencies entity))
+                dep-models (set (keep (comp :model peek) deps))]
+            (doseq [[field target] fks]
+              (testing (format "FK `%s` -> `%s` must appear in `(serdes/dependencies)`"
+                               field target)
+                (is (contains? dep-models (name target))
+                    (format (str "`(serdes/dependencies %s)` did not include a `%s` entry "
+                                 "when `%s` was populated. Add the FK to the model's "
+                                 "`dependencies` method (see Table/Transform for an example).")
+                            m (name target) field))))))))))

--- a/src/metabase/metabot/models/metabot.clj
+++ b/src/metabase/metabot/models/metabot.clj
@@ -35,8 +35,9 @@
   [:name])
 
 (defmethod serdes/dependencies "Metabot"
-  [{:keys [prompts]}]
-  (set (mapcat serdes/dependencies prompts)))
+  [{:keys [collection_id prompts]}]
+  (cond-> (set (mapcat serdes/dependencies prompts))
+    collection_id (conj [{:model "Collection" :id collection_id}])))
 
 (defmethod serdes/generate-path "Metabot" [_ metabot]
   [(serdes/infer-self-path "Metabot" metabot)])

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1840,16 +1840,19 @@
 ;;; Common transformers
 
 (defn fk "Export Foreign Key" [model & [field-name]]
-  (cond
-    ;; this `::fk` is used in tests to determine that foreign keys are handled
-    (= model :model/User)     {::fk true :export *export-user* :import *import-user*}
-    (= model :model/Database) {::fk true :export *export-database-fk* :import *import-database-fk*}
-    (= model :model/Table)    {::fk true :export *export-table-fk* :import *import-table-fk*}
-    (= model :model/Field)    {::fk true :export *export-field-fk* :import *import-field-fk*}
-    field-name             {::fk    true
-                            :export #(*export-fk-keyed* % model field-name)
-                            :import #(*import-fk-keyed* % model field-name)}
-    :else                  {::fk true :export #(*export-fk* % model) :import #(*import-fk* % model)}))
+  (let [base {::fk true ::fk-model model}]
+    (cond
+      ;; this `::fk` is used in tests to determine that foreign keys are handled
+      (= model :model/User)     (assoc base :export *export-user* :import *import-user*)
+      (= model :model/Database) (assoc base :export *export-database-fk* :import *import-database-fk*)
+      (= model :model/Table)    (assoc base :export *export-table-fk* :import *import-table-fk*)
+      (= model :model/Field)    (assoc base :export *export-field-fk* :import *import-field-fk*)
+      field-name                (assoc base
+                                       :export #(*export-fk-keyed* % model field-name)
+                                       :import #(*import-fk-keyed* % model field-name))
+      :else                     (assoc base
+                                       :export #(*export-fk* % model)
+                                       :import #(*import-fk* % model)))))
 
 (defn nested "Nested entities" [model backward-fk opts]
   (let [model-name (name model)


### PR DESCRIPTION
Completion test to catch missing `serdes/dependencies` impls

Future proofing against other bugs like https://github.com/metabase/metabase/pull/74473

Already caught a missing ones. Example:
```
  Metabot FK `:collection_id` -> `:model/Collection` must appear in `(serdes/dependencies)`
`(serdes/dependencies Metabot)` did not include a `Collection` entry when `:collection_id` was populated. Add the FK to the model's `dependencies` method (see Table/Transform for an example).
expected: (contains? dep-models (name target))
  actual: (not (contains? #{} "Collection"))

```