### PR TITLE
Fix CodeMirror Suggestion hover background

### DIFF
--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
@@ -128,7 +128,7 @@
 
         &:hover,
         &[aria-selected="true"] {
-          background-color: var(--mb-color-background-secondary);
+          background-color: var(--mb-color-background-hover);
           color: var(--mb-color-text-primary);
         }
       }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74313
### Description
1 line CSS change to improve the background on hovered / selected autocoomplete suggestions

### How to verify
1. New -> SQL Query
2. Start typing a query and get autocomplete suggestions
3. Hover over a suggestion. The hover color should be lighter, not darker

### Demo

Before: 
<img width="357" height="101" alt="image" src="https://github.com/user-attachments/assets/04b976b0-f1d7-4de0-b68d-ac9d9f6e6c0b" />


After: 
<img width="432" height="250" alt="image" src="https://github.com/user-attachments/assets/f5fe8fa5-1372-4460-8bfa-e5a707de05d0" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
