### PR TITLE
Add description to auto sync toggle in remote sync setup

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -509,7 +509,7 @@ describe("Remote Sync", () => {
       cy.visit("/admin/settings/remote-sync");
       cy.button("Set up remote sync").should("be.disabled");
 
-      cy.findByRole("switch", { name: "Auto-sync with git" }).click({
+      cy.findByRole("switch", { name: /Auto-sync with git/ }).click({
         force: true,
       });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -491,7 +491,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     </Box>
                     <FormSwitch
                       label={t`Auto-sync with git`}
-                      description={t`Periodically check the connected branch for changes and import them automatically. When off, you'll need to pull changes manually.`}
+                      description={t`Periodically import changes from the sync branch. When auto-sync is off, you'll need to pull changes from the sync branch manually.`}
                       mb="0.6125rem"
                       name={AUTO_IMPORT_KEY}
                       size="sm"

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -491,6 +491,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     </Box>
                     <FormSwitch
                       label={t`Auto-sync with git`}
+                      description={t`Periodically check the connected branch for changes and import them automatically. When off, you'll need to pull changes manually.`}
                       mb="0.6125rem"
                       name={AUTO_IMPORT_KEY}
                       size="sm"

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -39,7 +39,9 @@ describe("RemoteSyncSettingsForm", () => {
       setup({ remoteSyncType: "read-only" });
 
       expect(screen.getByText("Branch to sync with")).toBeInTheDocument();
-      expect(screen.getByLabelText(/Sync branch/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("textbox", { name: "Sync branch" }),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText(/Auto-sync with git/i)).toBeInTheDocument();
     });
 
@@ -718,7 +720,9 @@ describe("RemoteSyncSettingsForm", () => {
         ).toBeInTheDocument();
       });
 
-      expect(screen.getByLabelText(/Sync branch/i)).toHaveAttribute("readonly");
+      expect(
+        screen.getByRole("textbox", { name: "Sync branch" }),
+      ).toHaveAttribute("readonly");
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -94,7 +94,7 @@ describe("RemoteSyncSettingsForm", () => {
         screen.getByRole("heading", { name: "Branch to sync with" }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("switch", { name: "Auto-sync with git" }),
+        screen.getByRole("switch", { name: /Auto-sync with git/ }),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
### Description
Small PR to add a description to the auto sync toggle. Updated a couple test selectors to accomodate the description

### How to verify
1. Admin -> Remote Sync
2. Set to read only, and you should see the Auto-Sync toggle has a description now


### Demo
<img width="829" height="377" alt="image" src="https://github.com/user-attachments/assets/de2374b0-4c4f-4472-a512-8ba92d711864" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~