### PR TITLE
fix: changing db clears drafted inline sql prompt

### DIFF
--- a/e2e/test/scenarios/metabot/native-sql-generation.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/native-sql-generation.cy.spec.ts
@@ -173,15 +173,14 @@ describe("Native SQL generation", () => {
       });
       acceptButton().should("be.visible");
 
-      // change the selected database, should close the input
+      // change the selected database, should keep the input open
       rejectButton().click();
       toggleInlineSQLPrompt();
       inlinePrompt().should("be.visible");
       H.NativeEditor.selectDataSource("QA Postgres12");
-      inlinePrompt().should("not.exist");
+      inlinePrompt().should("be.visible");
 
-      // open again, send a prompt, req.body.history should be empty
-      toggleInlineSQLPrompt();
+      // send a prompt, req.body.history should be empty
       inlinePromptInput().click();
       cy.realType("select something", { pressDelay: 10 });
       H.mockMetabotResponse({

--- a/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/useInlineSQLPrompt.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/useInlineSQLPrompt.tsx
@@ -88,14 +88,6 @@ export function useInlineSQLPrompt(
     return portalTarget?.view?.state.doc.toString() ?? "";
   }, [portalTarget?.view]);
 
-  const prevDatabaseIdRef = useRef(databaseId);
-  useEffect(() => {
-    if (prevDatabaseIdRef.current !== databaseId) {
-      setPromptValue("");
-      prevDatabaseIdRef.current = databaseId;
-    }
-  }, [databaseId]);
-
   const generatedSqlRef = useRef(generatedSource);
   generatedSqlRef.current = generatedSource;
 
@@ -123,14 +115,22 @@ export function useInlineSQLPrompt(
     [generatedSource, hideInput],
   );
 
+  const prevDatabaseIdRef = useRef(databaseId);
+  useEffect(() => {
+    if (prevDatabaseIdRef.current !== databaseId) {
+      resetSuggestionState();
+      prevDatabaseIdRef.current = databaseId;
+    }
+  }, [databaseId, resetSuggestionState]);
+
   useEffect(
-    function resetOnDbChangeAndUnmount() {
+    function resetOnUnmount() {
       return () => {
         hideInputRef.current();
         resetSuggestionState();
       };
     },
-    [resetSuggestionState, databaseId],
+    [resetSuggestionState],
   );
 
   const resetInput = useCallback(() => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72372

<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72372

Closes [BOT-1291: Changing DB clears drafted inline SQL prompt](https://linear.app/metabase/issue/BOT-1291/changing-db-clears-drafted-inline-sql-prompt)

### Description

Changing the DB in the line SQL prompt was clearing and closing the prompt pop-up. Now it doesn't

### How to verify

- Open SQL query page.

- Press Command+Shift+I.
- Type something in the prompt window.
- Change the database to something else.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)