### PR TITLE
Remove unused fingerprints (GHY-3636)

### DIFF
--- a/src/metabase/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/analyze/fingerprint/fingerprinters.clj
@@ -16,7 +16,7 @@
   (:import
    (java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime ZoneOffset)
    (java.time.chrono ChronoLocalDateTime ChronoZonedDateTime)
-   (java.time.temporal ChronoField Temporal)
+   (java.time.temporal Temporal)
    (org.apache.commons.codec.digest MurmurHash2)
    (org.apache.commons.math3.stat.descriptive SummaryStatistics)
    (org.apache.datasketches.hll HllSketch)
@@ -283,69 +283,13 @@
         (instance? OffsetTime t)     (recur (t/offset-date-time (t/local-date "1970-01-01") t (t/zone-offset t)))
         :else                        nil))
 
-(defn- temporal->zoned
-  "Promote a `Temporal` to a form whose ChronoField support covers DAY_OF_WEEK and
-   HOUR_OF_DAY. `Instant` is coerced to UTC; all other types pass through unchanged
-   (e.g. `LocalDate` still supports DAY_OF_WEEK; `LocalTime` still supports HOUR_OF_DAY;
-   downstream extractors check `isSupported` per-field)."
-  ^Temporal [^Temporal t]
-  (if (instance? Instant t)
-    (.atZone ^Instant t ZoneOffset/UTC)
-    t))
-
-(defn- temporal->weekday
-  "Return 1-7 for Monday-Sunday, or nil if `t` is nil or the Temporal has no day-of-week."
-  [t]
-  (when-let [^Temporal z (some-> t temporal->zoned)]
-    (when (.isSupported z ChronoField/DAY_OF_WEEK)
-      (.get z ChronoField/DAY_OF_WEEK))))
-
-(defn- temporal->hour
-  "Return 0-23 for hour-of-day, or nil if `t` is nil or the Temporal has no hour."
-  [t]
-  (when-let [^Temporal z (some-> t temporal->zoned)]
-    (when (.isSupported z ChronoField/HOUR_OF_DAY)
-      (.get z ChronoField/HOUR_OF_DAY))))
-
-(defn- bucket-distribution
-  "Reducer factory: returns a reducer that bucketizes values via `bucket-fn` into `n-buckets`
-   slots and, on completion, returns a vector of per-bucket fractions (summing to 1.0).
-   Values where `bucket-fn` returns nil or out-of-range are skipped. Returns nil if no
-   valid values were seen."
-  [n-buckets bucket-fn]
-  (fn
-    ([] [(vec (repeat n-buckets 0)) 0])
-    ([[buckets total]]
-     (when (pos? total)
-       (mapv #(/ (double %) (double total)) buckets)))
-    ([[buckets total] x]
-     (if-let [idx (bucket-fn x)]
-       (if (and (<= 0 idx) (< idx n-buckets))
-         [(update buckets idx inc) (inc total)]
-         [buckets total])
-       [buckets total]))))
-
-(defn- weekday-distribution
-  "Reducer producing a 7-element vector of per-weekday fractions (Monday=index 0 .. Sunday=6)."
-  []
-  (bucket-distribution 7 (fn [t]
-                           (when-let [dow (temporal->weekday t)]
-                             (dec dow)))))
-
-(defn- hour-distribution
-  "Reducer producing a 24-element vector of per-hour fractions (0..23)."
-  []
-  (bucket-distribution 24 temporal->hour))
-
 (deffingerprinter :type/DateTime
   ((map ->temporal)
    (redux/post-complete
-    (robust-fuse {:earliest             earliest
-                  :latest               latest
-                  :skewness             ((keep ->millis-from-epoch) stats/skewness)
-                  :mode-stats           ((keep ->millis-from-epoch) mode-stats)
-                  :weekday-distribution (weekday-distribution)
-                  :hour-distribution    (hour-distribution)})
+    (robust-fuse {:earliest   earliest
+                  :latest     latest
+                  :skewness   ((keep ->millis-from-epoch) stats/skewness)
+                  :mode-stats ((keep ->millis-from-epoch) mode-stats)})
     (fn [{:keys [mode-stats] :as fused}]
       (-> fused
           (dissoc :mode-stats)
@@ -427,8 +371,6 @@
                   :percent-state  (stats/share u/state?)
                   :percent-blank  (stats/share str/blank?)
                   :average-length ((map count) stats/mean)
-                  :min-length     ((map count) stats/min)
-                  :max-length     ((map count) stats/max)
                   :mode-stats     mode-stats})
     (fn [{:keys [mode-stats] :as fused}]
       (-> fused

--- a/src/metabase/lib/schema/metadata/fingerprint.cljc
+++ b/src/metabase/lib/schema/metadata/fingerprint.cljc
@@ -44,8 +44,6 @@
    [:percent-state  {:optional true} [:maybe [:ref ::percent]]]
    [:percent-blank  {:optional true} [:maybe [:ref ::percent]]]
    [:average-length {:optional true} [:maybe number?]]
-   [:min-length     {:optional true} [:maybe number?]]
-   [:max-length     {:optional true} [:maybe number?]]
    [:mode-fraction  {:optional true} [:maybe [:ref ::percent]]]
    [:top-3-fraction {:optional true} [:maybe [:ref ::percent]]]])
 
@@ -57,9 +55,7 @@
    [:latest               {:optional true} [:maybe :string]]
    [:skewness             {:optional true} [:maybe number?]]
    [:mode-fraction        {:optional true} [:maybe [:ref ::percent]]]
-   [:top-3-fraction       {:optional true} [:maybe [:ref ::percent]]]
-   [:weekday-distribution {:optional true} [:maybe [:sequential [:ref ::percent]]]]
-   [:hour-distribution    {:optional true} [:maybe [:sequential [:ref ::percent]]]]])
+   [:top-3-fraction       {:optional true} [:maybe [:ref ::percent]]]])
 
 (mr/def ::fingerprint.type-specific
   "Schema for type-specific fingerprint information."

--- a/test/metabase/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/analyze/fingerprint/fingerprinters_test.clj
@@ -15,7 +15,7 @@
 (defn- temporal-core-fields
   "Return the subset of a temporal fingerprint result containing the historically-asserted fields.
    We compare only :earliest / :latest (plus :global) to keep tests stable against new distribution
-   stats (skewness, mode-fraction, weekday-distribution, hour-distribution)."
+   stats (skewness, mode-fraction)."
   [result]
   {:global (:global result)
    :type   {:type/DateTime (select-keys (get-in result [:type :type/DateTime])
@@ -174,8 +174,6 @@
                                :percent-email  0.0
                                :percent-state  0.0
                                :average-length 6.4
-                               :min-length     4.0
-                               :max-length     9.0
                                :mode-fraction  0.2
                                :top-3-fraction 0.6
                                :percent-blank  0.0}}}
@@ -190,8 +188,6 @@
                                  :percent-email  0.0
                                  :percent-state  0.0
                                  :average-length 10.6
-                                 :min-length     4.0
-                                 :max-length     30.0
                                  :mode-fraction  0.2
                                  :top-3-fraction 0.6
                                  :percent-blank  0.0}}}

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1368,10 +1368,7 @@
                                                 :table_id (t2/select-one-pk :model/Table :db_id (u/the-id database)))
                 ;; Strip extended interestingness stats — this test covers the core TIME fingerprint
                 ;; shape (#5911), not the interestingness metrics.
-                extended-keys [:hour-distribution :weekday-distribution :skewness
-                               :mode-fraction :top-3-fraction
-                               :mode-fraction-by-weekday :mode-fraction-by-hour
-                               :min-length :max-length :percent-blank]
+                extended-keys [:skewness :mode-fraction :top-3-fraction :percent-blank]
                 trim-type     (fn [fp]
                                 (update fp :type
                                         (fn [types]

--- a/test/metabase/metabot/tools/field_stats_test.clj
+++ b/test/metabase/metabot/tools/field_stats_test.clj
@@ -48,14 +48,12 @@
                     (get-in result [:structured-output :value_metadata :statistics :skewness])
                     (update-in [:structured-output :value_metadata :statistics] dissoc :skewness))))
           people-id   birth-date-id {:statistics
-                                     {:distinct-count      2308
-                                      :percent-null        0.0
-                                      :earliest            "1958-04-26"
-                                      :latest              "2000-04-03"
-                                      :hour-distribution   nil
-                                      :mode-fraction       0.0012
-                                      :top-3-fraction      0.0032
-                                      :weekday-distribution [0.15 0.1304 0.1416 0.1372 0.156 0.1516 0.1332]}}
+                                     {:distinct-count 2308
+                                      :percent-null   0.0
+                                      :earliest       "1958-04-26"
+                                      :latest         "2000-04-03"
+                                      :mode-fraction  0.0012
+                                      :top-3-fraction 0.0032}}
           people-id   state-id      {:statistics   {:distinct-count 49
                                                     :percent-null   0.0
                                                     :percent-json   0.0
@@ -63,8 +61,6 @@
                                                     :percent-email  0.0
                                                     :percent-state  1.0
                                                     :average-length 2.0
-                                                    :max-length     2.0
-                                                    :min-length     2.0
                                                     :mode-fraction  0.0776
                                                     :top-3-fraction 0.1624
                                                     :percent-blank  0.0}
@@ -76,8 +72,6 @@
                                                     :percent-email  0.0
                                                     :percent-state  0.0
                                                     :average-length 6.375
-                                                    :max-length     9.0
-                                                    :min-length     5.0
                                                     :mode-fraction  0.27
                                                     :top-3-fraction 0.79
                                                     :percent-blank  0.0}

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -98,8 +98,6 @@
                                                       :percent-email  0.0
                                                       :percent-state  0.0
                                                       :average-length 13.532
-                                                      :max-length     23.0
-                                                      :min-length     7.0
                                                       :mode-fraction  4.0E-4
                                                       :top-3-fraction 0.0012
                                                       :percent-blank  0.0}}}


### PR DESCRIPTION
## Summary

Drop four fingerprint properties that have no production consumer:

- `:weekday-distribution`, `:hour-distribution` (temporal)
- `:min-length`, `:max-length` (text)

Also remove the helpers that only existed to feed the temporal distributions (`temporal->zoned`, `temporal->weekday`, `temporal->hour`, `bucket-distribution`) and the now-unused `ChronoField` import.

Schema entries are removed; `*latest-fingerprint-version*` is left alone, so existing rows keep stale keys until re-fingerprinted — nothing reads them, so no functional impact.

This is the first slice of [GHY-3636](https://linear.app/metabase/issue/GHY-3636/optimize-fingerprinting); the [fingerprint inventory comment](https://linear.app/metabase/issue/GHY-3636/optimize-fingerprinting) catalogs every fingerprint and its consumers. The remaining "single-consumer" candidates (`skewness`, `excess-kurtosis`, `mode-fraction`, `top-3-fraction`, `zero-fraction`, `percent-blank`) all feed `interestingness/impl/distribution-shape` → persisted `dimension_interestingness`. That column is currently write-only (no reader anywhere in backend or frontend), so they're effectively unused too — but touching them changes a persisted score, which deserves its own ticket / discussion.

## Performance

Micro-benchmark over 100k synthetic rows, fingerprinter transducer only, median ms per call across 3×5×20 iterations:

| Field type | Master | Branch | Δ |
|---|---|---|---|
| Number   | 35.2 ms | 37.0 ms | within process noise (code unchanged) |
| Text     | 41.9 ms | 44.6 ms | within process noise |
| Temporal | 33.9 ms | 29.8 ms | **~17% faster** after subtracting noise baseline |

The temporal win comes from dropping the 7- and 24-bucket distribution reducers; text `min-length`/`max-length` were O(1) per row and too cheap to measure. Could this be significant with larger datasets?

The real win is removing unused code. 

## Test plan

- [x] `metabase.analyze.fingerprint.fingerprinters-test` (9 tests / 37 assertions)
- [x] `metabase.metabot.tools.field-stats-test` (3 tests / 25 assertions)
- [x] `metabase.sample-data.impl-test` (5 tests / 25 assertions)
- [x] `metabase.driver.postgres-test/fingerprint-time-fields-test`
- [x] `metabase.analyze.fingerprint.insights-test` (10 tests / 57 assertions — collateral check)
- [x] Live REPL: text and temporal fingerprints confirmed to no longer emit the four removed keys