### PR TITLE
Fix error for pivot tables with no dimensions

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -125,7 +125,8 @@ export const settings = {
 
         if (dimensions.length < 2) {
           columns = [];
-          rows = [first];
+          // use `dimensions` so `rows` is `[]` when there are zero dimensions, not `[undefined]` (metabase#56235)
+          rows = dimensions;
         } else if (dimensions.length <= 3) {
           columns = [first];
           rows = [second, ...rest];

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.unit.spec.ts
@@ -1,0 +1,36 @@
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { settings } from "./settings";
+
+const COLUMN_SPLIT_SETTING = "pivot_table.column_split";
+
+describe("PivotTable settings", () => {
+  describe(`${COLUMN_SPLIT_SETTING} getValue`, () => {
+    it("should not throw when the query has no dimension columns (metabase#56235)", () => {
+      // a Count-only query has zero dimensions, which previously left an
+      // `undefined` slot in `rows` and threw when we mapped to `col.name`
+      const data = createMockDatasetData({
+        rows: [[0]],
+        cols: [
+          createMockColumn({
+            name: "count",
+            display_name: "Count",
+            source: "aggregation",
+            base_type: "type/Integer",
+            effective_type: "type/Integer",
+          }),
+        ],
+      });
+
+      const card = createMockCard({ display: "pivot" });
+
+      expect(() => {
+        settings[COLUMN_SPLIT_SETTING].getValue([{ data, card }], {});
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56235
### Description
Fixes a small issue with the pivot table visualization. It's possible to ask the QB for a pivot table when your query has no dimensions. Under certain situations (like building your query) you can have a metric but no dimensions selected. When this happens, computing a value for `pivot_table.column_split` can end up trying to access `name` of `undefined` due to some destructuring. This corrects that by changing from `[undefined]` to `[]`.


### How to verify
Best to follow the steps in the issue for the repro:
1. Open "Feedback" table from Sample Database
2. Choose pivot table as the visualization without aggregating the query
3. You should see this error
<img width="427" height="167" alt="image" src="https://github.com/user-attachments/assets/974f97ff-0e85-479f-91e6-30e92e7739f0" />

4. Click on "Summarize" - the "Count" will be preselected
5. Click "Done" in the summarize sidebar
6. New play icon should appear - click on it to run the updated query

Now you will see a pivot table with no dimensions, only a single metric

### Demo

<img width="257" height="176" alt="image" src="https://github.com/user-attachments/assets/9a97f4b7-9c8c-424c-9c66-24ea22380065" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
