### PR TITLE
Fix not-found state after permanently deleting a metric

### DIFF
--- a/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.tsx
@@ -1,8 +1,12 @@
 import type { ReactNode } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
 
 import { useDeleteCardMutation, useUpdateCardMutation } from "metabase/api";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
 import type { CollectionPickerValueItem } from "metabase/common/components/Pickers/CollectionPicker";
+import { useDispatch } from "metabase/redux";
+import { addUndo } from "metabase/redux/undo";
 import type { Card } from "metabase-types/api";
 
 import type { MetricUrls } from "../../types";
@@ -28,6 +32,7 @@ export function MetricPageShell({
 }: MetricPageShellProps) {
   const [updateCard] = useUpdateCardMutation();
   const [deleteCard] = useDeleteCardMutation();
+  const dispatch = useDispatch();
 
   return (
     <>
@@ -46,7 +51,23 @@ export function MetricPageShell({
               archived: false,
             })
           }
-          onDeletePermanently={() => deleteCard(card.id)}
+          onDeletePermanently={async () => {
+            try {
+              await deleteCard(card.id).unwrap();
+              dispatch(push("/trash"));
+              dispatch(
+                addUndo({
+                  message: t`This item has been permanently deleted.`,
+                }),
+              );
+            } catch {
+              dispatch(
+                addUndo({
+                  message: t`There was an error permanently deleting this item.`,
+                }),
+              );
+            }
+          }}
         />
       )}
       <MetricHeader

--- a/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPageShell/MetricPageShell.unit.spec.tsx
@@ -1,0 +1,58 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import { setupBookmarksEndpoints } from "__support__/server-mocks/bookmark";
+import { setupCollectionsEndpoints } from "__support__/server-mocks/collection";
+import { setupMetricEndpoint } from "__support__/server-mocks/metric";
+import { setupListNotificationEndpoints } from "__support__/server-mocks/notification";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockCard, createMockCollection } from "metabase-types/api/mocks";
+import { createMockMetric } from "metabase-types/api/mocks/metric";
+
+import { metricUrls } from "../../urls";
+
+import { MetricPageShell } from "./MetricPageShell";
+
+function setup() {
+  const card = createMockCard({
+    type: "metric",
+    archived: true,
+    can_delete: true,
+  });
+
+  setupCollectionsEndpoints({ collections: [createMockCollection()] });
+  setupMetricEndpoint(createMockMetric({ id: card.id }));
+  setupBookmarksEndpoints([]);
+  setupListNotificationEndpoints({ card_id: card.id }, []);
+  fetchMock.delete(`path:/api/card/${card.id}`, 200);
+
+  const { history } = renderWithProviders(
+    <Route
+      path="/"
+      component={() => <MetricPageShell card={card} urls={metricUrls} />}
+    />,
+    { withRouter: true, withUndos: true },
+  );
+
+  return { history };
+}
+
+describe("MetricPageShell", () => {
+  it("navigates to /trash with a success toast after permanently deleting the metric", async () => {
+    const { history } = setup();
+
+    await userEvent.click(await screen.findByText("Delete permanently"));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Delete permanently" }),
+    );
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation().pathname).toBe("/trash");
+    });
+
+    expect(
+      screen.getByText("This item has been permanently deleted."),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74462
### Description

Fixes [UXW-4175](https://linear.app/metabase/issue/UXW-4175/deleting-a-metric-permanently-from-the-homepage-puts-the-app-into-an).

**Cause:** the metric homepage's permanent-delete handler fired the delete mutation without awaiting or navigating away, so the page stayed mounted, refetched the now-deleted card, and rendered the 404 view.

**Fix:** await the deletion, redirect to `/trash`, and show the standard "permanently deleted" toast. This matches the pattern already used by questions, dashboards, documents, and collections.

### How to verify

- [ ] Create a metric, move it to trash, open it via its `/metric/:id` URL, click "Delete permanently" on the red banner and confirm. The app should land on `/trash` with a success toast instead of "Not found."

### Demo

https://github.com/user-attachments/assets/d2f84124-43b7-4424-8102-f8ee4767f755

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)