### PR TITLE
[Metabot] Fix AI settings inputs flickering + losing focus

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -164,7 +164,7 @@ export function MetabaseAIProviderSetup({
     removeCloudAddOn,
   ]);
 
-  const { isLoading, handleDisconnect, resetProvider, isModal } =
+  const { isMutating, handleDisconnect, resetProvider, isModal } =
     useMetabotSetupContext(connectAction, onDisconnect);
 
   const metabaseManagedAiPurchaseError = metabaseManagedAiPurchase.error
@@ -253,7 +253,7 @@ export function MetabaseAIProviderSetup({
             .otherwise(() => (
               <Checkbox
                 checked={hasAcceptedTerms}
-                disabled={isLoading}
+                disabled={isMutating}
                 onChange={(event) =>
                   setHasAcceptedTerms(event.currentTarget.checked)
                 }

--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -70,6 +70,7 @@ const MetabotSetupContext = createContext<{
   connectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
   disconnectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
   isLoading: boolean;
+  isMutating: boolean;
   isConnectButtonEnabled: boolean;
   setIsConnectButtonEnabled: (enabled: boolean) => void;
   resetProvider: VoidFunction;
@@ -77,6 +78,7 @@ const MetabotSetupContext = createContext<{
   isModal: boolean;
 }>({
   isLoading: false,
+  isMutating: false,
   connectHandlerRef: null,
   disconnectHandlerRef: null,
   isConnectButtonEnabled: false,
@@ -94,6 +96,7 @@ export function useMetabotSetupContext(
     connectHandlerRef,
     disconnectHandlerRef,
     isLoading,
+    isMutating,
     setIsConnectButtonEnabled,
     resetProvider,
     handleDisconnect,
@@ -126,7 +129,7 @@ export function useMetabotSetupContext(
     };
   }, [disconnectHandlerRef, onDisconnect]);
 
-  return { isLoading, resetProvider, handleDisconnect, isModal };
+  return { isLoading, isMutating, resetProvider, handleDisconnect, isModal };
 }
 
 export function MetabotSetup({ id }: { id?: string }) {
@@ -346,11 +349,10 @@ export function MetabotSetupInner({
     }
   };
 
-  const isLoading =
-    isConnecting ||
-    isDisconnecting ||
-    updateSettingsResult.isLoading ||
-    isMetabotProviderLoading;
+  const isMutating =
+    isConnecting || isDisconnecting || updateSettingsResult.isLoading;
+
+  const isLoading = isMutating || isMetabotProviderLoading;
 
   const [isConnectButtonEnabled, setIsConnectButtonEnabled] = useState(false);
 
@@ -360,6 +362,7 @@ export function MetabotSetupInner({
         connectHandlerRef,
         disconnectHandlerRef,
         isLoading,
+        isMutating,
         setIsConnectButtonEnabled,
         isConnectButtonEnabled,
         resetProvider,
@@ -506,7 +509,7 @@ const AIProviderSetup = ({
   const connectHandler =
     !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
 
-  const { isLoading } = useMetabotSetupContext(connectHandler);
+  const { isLoading, isMutating } = useMetabotSetupContext(connectHandler);
 
   const { details: providerApiKeyDetails } = useAdminSettings([
     "llm-anthropic-api-key",
@@ -605,7 +608,7 @@ const AIProviderSetup = ({
         <Select
           label={t`Model`}
           placeholder={
-            metabotSettingsQuery.isFetching
+            metabotSettingsQuery.isLoading
               ? t`Loading models...`
               : t`Select a model`
           }
@@ -614,7 +617,7 @@ const AIProviderSetup = ({
           data={modelOptions}
           value={model}
           onChange={handleModelChange}
-          disabled={isEnvSetting || needsApiKey || isLoading}
+          disabled={isEnvSetting || needsApiKey || isMutating}
           searchable
           nothingFoundMessage={t`No models found`}
         />

--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -69,7 +69,6 @@ function getModelDescription(provider: MetabotProvider | undefined) {
 const MetabotSetupContext = createContext<{
   connectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
   disconnectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
-  isLoading: boolean;
   isMutating: boolean;
   isConnectButtonEnabled: boolean;
   setIsConnectButtonEnabled: (enabled: boolean) => void;
@@ -77,7 +76,6 @@ const MetabotSetupContext = createContext<{
   handleDisconnect: VoidFunction;
   isModal: boolean;
 }>({
-  isLoading: false,
   isMutating: false,
   connectHandlerRef: null,
   disconnectHandlerRef: null,
@@ -95,7 +93,6 @@ export function useMetabotSetupContext(
   const {
     connectHandlerRef,
     disconnectHandlerRef,
-    isLoading,
     isMutating,
     setIsConnectButtonEnabled,
     resetProvider,
@@ -129,7 +126,7 @@ export function useMetabotSetupContext(
     };
   }, [disconnectHandlerRef, onDisconnect]);
 
-  return { isLoading, isMutating, resetProvider, handleDisconnect, isModal };
+  return { isMutating, resetProvider, handleDisconnect, isModal };
 }
 
 export function MetabotSetup({ id }: { id?: string }) {
@@ -206,11 +203,9 @@ export function MetabotSetupInner({
   const offerMetabaseAiManaged = PLUGIN_METABOT.isEnabled;
   const [sendToast] = useToast();
 
-  const {
-    value: savedProviderValue,
-    settingDetails,
-    isFetching: isMetabotProviderLoading,
-  } = useAdminSetting("llm-metabot-provider");
+  const { value: savedProviderValue, settingDetails } = useAdminSetting(
+    "llm-metabot-provider",
+  );
   const isEnvSetting =
     !!settingDetails &&
     !!settingDetails.is_env_setting &&
@@ -352,8 +347,6 @@ export function MetabotSetupInner({
   const isMutating =
     isConnecting || isDisconnecting || updateSettingsResult.isLoading;
 
-  const isLoading = isMutating || isMetabotProviderLoading;
-
   const [isConnectButtonEnabled, setIsConnectButtonEnabled] = useState(false);
 
   return (
@@ -361,7 +354,6 @@ export function MetabotSetupInner({
       value={{
         connectHandlerRef,
         disconnectHandlerRef,
-        isLoading,
         isMutating,
         setIsConnectButtonEnabled,
         isConnectButtonEnabled,

--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -425,8 +425,8 @@ export function MetabotSetupInner({
             .with({ isModal: true, isCurrentConfigured: true }, () => (
               <Button
                 variant="filled"
-                loading={isLoading}
-                disabled={isLoading}
+                loading={isMutating}
+                disabled={isMutating}
                 onClick={onClose}
               >
                 {t`Done`}
@@ -437,8 +437,8 @@ export function MetabotSetupInner({
               () => (
                 <Button
                   c="danger"
-                  loading={isLoading}
-                  disabled={isLoading}
+                  loading={isMutating}
+                  disabled={isMutating}
                   onClick={handleDisconnect}
                 >
                   {t`Disconnect`}
@@ -451,8 +451,8 @@ export function MetabotSetupInner({
               () => (
                 <Button
                   variant="filled"
-                  loading={isLoading}
-                  disabled={isLoading || !isConnectButtonEnabled}
+                  loading={isMutating}
+                  disabled={isMutating || !isConnectButtonEnabled}
                   onClick={handleConnect}
                 >
                   {t`Connect`}

--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -509,7 +509,7 @@ const AIProviderSetup = ({
   const connectHandler =
     !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
 
-  const { isLoading, isMutating } = useMetabotSetupContext(connectHandler);
+  const { isMutating } = useMetabotSetupContext(connectHandler);
 
   const { details: providerApiKeyDetails } = useAdminSettings([
     "llm-anthropic-api-key",
@@ -596,7 +596,7 @@ const AIProviderSetup = ({
         value={displayApiKeyValue}
         error={apiKeyError}
         onChange={handleApiKeyChange}
-        disabled={isLoading || isEnvSetting || !!apiKeyEnvSettingName}
+        disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
         w="100%"
       />
 

--- a/frontend/src/metabase/admin/ai/MetabotSetup.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.tsx
@@ -378,7 +378,7 @@ export function MetabotSetupInner({
             data={providerOptions}
             value={provider}
             onChange={setProvider}
-            disabled={isEnvSetting || isLoading}
+            disabled={isEnvSetting || isMutating}
             renderOption={({ option }) => (
               <Group
                 gap="xs"

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -519,6 +519,33 @@ describe("MetabotSetup", () => {
     sessionPropertiesDeferred.resolve({});
   });
 
+  it("BOT-1429: keeps the API key input enabled while session-properties refetches in the background", async () => {
+    const { store } = await setup();
+    await screen.findByLabelText("API key");
+    expect(screen.getByLabelText("API key")).toBeEnabled();
+
+    const sessionPropertiesDeferred = defer<unknown>();
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => sessionPropertiesDeferred.promise,
+    );
+
+    act(() => {
+      store.dispatch(Api.util.invalidateTags(["session-properties"]));
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/session/properties").length,
+      ).toBeGreaterThan(1);
+    });
+
+    expect(screen.getByLabelText("API key")).toBeEnabled();
+
+    sessionPropertiesDeferred.resolve({});
+  });
+
   it("shows the connected badge with the saved provider and model", async () => {
     await setup();
     await screen.findByLabelText("API key");

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -489,70 +489,18 @@ describe("MetabotSetup", () => {
     expect(screen.getAllByText("Coming soon")).toHaveLength(2);
   });
 
-  it("BOT-1429: keeps the Provider select enabled while session-properties refetches in the background", async () => {
-    const { store } = await setup({
-      savedProviderValue: null,
-      isConfigured: false,
-    });
-    await screen.findByLabelText("Provider");
-    expect(screen.getByLabelText("Provider")).toBeEnabled();
-
-    const sessionPropertiesDeferred = defer<unknown>();
-    fetchMock.removeRoute("get-session-properties");
-    fetchMock.get(
-      "path:/api/session/properties",
-      () => sessionPropertiesDeferred.promise,
-    );
-
-    act(() => {
-      store.dispatch(Api.util.invalidateTags(["session-properties"]));
-    });
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/session/properties").length,
-      ).toBeGreaterThan(1);
-    });
-
-    expect(screen.getByLabelText("Provider")).toBeEnabled();
-
-    sessionPropertiesDeferred.resolve({});
-  });
-
-  it("BOT-1429: keeps the API key input enabled while session-properties refetches in the background", async () => {
+  it("BOT-1429: keeps the form interactive while session-properties refetches in the background", async () => {
     const { store } = await setup();
-    await screen.findByLabelText("API key");
-    expect(screen.getByLabelText("API key")).toBeEnabled();
-
-    const sessionPropertiesDeferred = defer<unknown>();
-    fetchMock.removeRoute("get-session-properties");
-    fetchMock.get(
-      "path:/api/session/properties",
-      () => sessionPropertiesDeferred.promise,
-    );
-
-    act(() => {
-      store.dispatch(Api.util.invalidateTags(["session-properties"]));
-    });
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/session/properties").length,
-      ).toBeGreaterThan(1);
-    });
-
-    expect(screen.getByLabelText("API key")).toBeEnabled();
-
-    sessionPropertiesDeferred.resolve({});
-  });
-
-  it("BOT-1429: keeps the Disconnect button stable while session-properties refetches in the background", async () => {
-    const { store } = await setup();
-    const disconnectButton = await screen.findByRole("button", {
+    const apiKey = await screen.findByLabelText("API key");
+    const model = await screen.findByLabelText("Model");
+    const disconnect = await screen.findByRole("button", {
       name: "Disconnect",
     });
-    expect(disconnectButton).toBeEnabled();
-    expect(disconnectButton).not.toHaveAttribute("data-loading", "true");
+
+    expect(apiKey).toBeEnabled();
+    expect(model).toBeEnabled();
+    expect(disconnect).toBeEnabled();
+    expect(disconnect).not.toHaveAttribute("data-loading", "true");
 
     const sessionPropertiesDeferred = defer<unknown>();
     fetchMock.removeRoute("get-session-properties");
@@ -571,8 +519,10 @@ describe("MetabotSetup", () => {
       ).toBeGreaterThan(1);
     });
 
-    expect(disconnectButton).toBeEnabled();
-    expect(disconnectButton).not.toHaveAttribute("data-loading", "true");
+    expect(apiKey).toBeEnabled();
+    expect(model).toBeEnabled();
+    expect(disconnect).toBeEnabled();
+    expect(disconnect).not.toHaveAttribute("data-loading", "true");
 
     sessionPropertiesDeferred.resolve({});
   });
@@ -808,33 +758,6 @@ describe("MetabotSetup", () => {
     expect(await screen.findByText("Sonnet")).toBeInTheDocument();
   });
 
-  it("BOT-1429: keeps the Model select enabled while session-properties refetches in the background", async () => {
-    const { store } = await setup();
-    await screen.findByLabelText("Model");
-    expect(screen.getByLabelText("Model")).toBeEnabled();
-
-    const sessionPropertiesDeferred = defer<unknown>();
-    fetchMock.removeRoute("get-session-properties");
-    fetchMock.get(
-      "path:/api/session/properties",
-      () => sessionPropertiesDeferred.promise,
-    );
-
-    act(() => {
-      store.dispatch(Api.util.invalidateTags(["session-properties"]));
-    });
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/session/properties").length,
-      ).toBeGreaterThan(1);
-    });
-
-    expect(screen.getByLabelText("Model")).toBeEnabled();
-
-    sessionPropertiesDeferred.resolve({});
-  });
-
   it("does not show the API key input when no provider is selected", async () => {
     await setup({ savedProviderValue: null, isConfigured: false });
 
@@ -994,44 +917,6 @@ describe("MetabotSetup", () => {
     expect(settingsRequest?.options?.body).toBe(
       JSON.stringify({ provider: "metabase", model: "" }),
     );
-  });
-
-  it("BOT-1429: keeps the terms checkbox enabled while session-properties refetches in the background", async () => {
-    const { store } = await setup({
-      isHosted: true,
-      savedProviderValue: null,
-      isConfigured: false,
-      isStoreUser: true,
-      tokenStatusFeatures: [],
-    });
-
-    await selectProvider("Metabase");
-
-    const termsCheckbox = await screen.findByRole("checkbox", {
-      name: /I agree with the Metabase AI Service/i,
-    });
-    expect(termsCheckbox).toBeEnabled();
-
-    const sessionPropertiesDeferred = defer<unknown>();
-    fetchMock.removeRoute("get-session-properties");
-    fetchMock.get(
-      "path:/api/session/properties",
-      () => sessionPropertiesDeferred.promise,
-    );
-
-    act(() => {
-      store.dispatch(Api.util.invalidateTags(["session-properties"]));
-    });
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/session/properties").length,
-      ).toBeGreaterThan(1);
-    });
-
-    expect(termsCheckbox).toBeEnabled();
-
-    sessionPropertiesDeferred.resolve({});
   });
 
   it("calls onClose after directly connecting to the Metabase provider in modal mode", async () => {

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Api } from "metabase/api";
 import { reinitialize } from "metabase/plugins";
 import { defer } from "metabase/utils/promise";
 import type {
@@ -717,6 +718,33 @@ describe("MetabotSetup", () => {
     await openModelSelector();
 
     expect(await screen.findByText("Sonnet")).toBeInTheDocument();
+  });
+
+  it("BOT-1429: keeps the Model select enabled while session-properties refetches in the background", async () => {
+    const { store } = await setup();
+    await screen.findByLabelText("Model");
+    expect(screen.getByLabelText("Model")).toBeEnabled();
+
+    const sessionPropertiesDeferred = defer<unknown>();
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => sessionPropertiesDeferred.promise,
+    );
+
+    act(() => {
+      store.dispatch(Api.util.invalidateTags(["session-properties"]));
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/session/properties").length,
+      ).toBeGreaterThan(1);
+    });
+
+    expect(screen.getByLabelText("Model")).toBeEnabled();
+
+    sessionPropertiesDeferred.resolve({});
   });
 
   it("does not show the API key input when no provider is selected", async () => {

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -996,6 +996,44 @@ describe("MetabotSetup", () => {
     );
   });
 
+  it("BOT-1429: keeps the terms checkbox enabled while session-properties refetches in the background", async () => {
+    const { store } = await setup({
+      isHosted: true,
+      savedProviderValue: null,
+      isConfigured: false,
+      isStoreUser: true,
+      tokenStatusFeatures: [],
+    });
+
+    await selectProvider("Metabase");
+
+    const termsCheckbox = await screen.findByRole("checkbox", {
+      name: /I agree with the Metabase AI Service/i,
+    });
+    expect(termsCheckbox).toBeEnabled();
+
+    const sessionPropertiesDeferred = defer<unknown>();
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => sessionPropertiesDeferred.promise,
+    );
+
+    act(() => {
+      store.dispatch(Api.util.invalidateTags(["session-properties"]));
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/session/properties").length,
+      ).toBeGreaterThan(1);
+    });
+
+    expect(termsCheckbox).toBeEnabled();
+
+    sessionPropertiesDeferred.resolve({});
+  });
+
   it("calls onClose after directly connecting to the Metabase provider in modal mode", async () => {
     const onClose = jest.fn();
 

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -546,6 +546,37 @@ describe("MetabotSetup", () => {
     sessionPropertiesDeferred.resolve({});
   });
 
+  it("BOT-1429: keeps the Disconnect button stable while session-properties refetches in the background", async () => {
+    const { store } = await setup();
+    const disconnectButton = await screen.findByRole("button", {
+      name: "Disconnect",
+    });
+    expect(disconnectButton).toBeEnabled();
+    expect(disconnectButton).not.toHaveAttribute("data-loading", "true");
+
+    const sessionPropertiesDeferred = defer<unknown>();
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => sessionPropertiesDeferred.promise,
+    );
+
+    act(() => {
+      store.dispatch(Api.util.invalidateTags(["session-properties"]));
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/session/properties").length,
+      ).toBeGreaterThan(1);
+    });
+
+    expect(disconnectButton).toBeEnabled();
+    expect(disconnectButton).not.toHaveAttribute("data-loading", "true");
+
+    sessionPropertiesDeferred.resolve({});
+  });
+
   it("shows the connected badge with the saved provider and model", async () => {
     await setup();
     await screen.findByLabelText("API key");

--- a/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotSetup.unit.spec.tsx
@@ -489,6 +489,36 @@ describe("MetabotSetup", () => {
     expect(screen.getAllByText("Coming soon")).toHaveLength(2);
   });
 
+  it("BOT-1429: keeps the Provider select enabled while session-properties refetches in the background", async () => {
+    const { store } = await setup({
+      savedProviderValue: null,
+      isConfigured: false,
+    });
+    await screen.findByLabelText("Provider");
+    expect(screen.getByLabelText("Provider")).toBeEnabled();
+
+    const sessionPropertiesDeferred = defer<unknown>();
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => sessionPropertiesDeferred.promise,
+    );
+
+    act(() => {
+      store.dispatch(Api.util.invalidateTags(["session-properties"]));
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/session/properties").length,
+      ).toBeGreaterThan(1);
+    });
+
+    expect(screen.getByLabelText("Provider")).toBeEnabled();
+
+    sessionPropertiesDeferred.resolve({});
+  });
+
   it("shows the connected badge with the saved provider and model", async () => {
     await setup();
     await screen.findByLabelText("API key");


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73489
Closes [BOT-1429: AI settings flicker as they auto-reload, losing focus](https://linear.app/metabase/issue/BOT-1429/ai-settings-flicker-as-they-auto-reload-losing-focus)

### Description

Disabled state + other logic was around an `isLoading` calculation that included a check for `isFetching` for settings. I believe this is an overly conservative check, and given how `useAdminSetting` is designed `isFetching` is true whenever the sessions property endpoint is revalidated (which air-gapped instance will poll for this endpoint in certain states), so we can't rely on it for being `true` only for the setting name we're subscribed to. What I think we want is just a `isMutating` guard, which would drop the `isFetching` check.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
