### PR TITLE
fix: have metabot fix it button sometimes disappears

### DIFF
--- a/frontend/src/metabase/querying/components/QueryVisualization/QueryVisualization.jsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/QueryVisualization.jsx
@@ -87,7 +87,6 @@ export function QueryVisualization(props) {
             via={result.via}
             question={question}
             duration={result.duration}
-            isResultDirty={isResultDirty}
           />
         ) : result?.data ? (
           <VisualizationResult

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationError/VisualizationError.tsx
@@ -32,7 +32,6 @@ interface VisualizationErrorProps {
   duration: number;
   error: DatasetError;
   errorType?: DatasetErrorType;
-  isResultDirty?: boolean;
 }
 
 export function VisualizationError({
@@ -42,7 +41,6 @@ export function VisualizationError({
   duration,
   error,
   errorType,
-  isResultDirty,
 }: VisualizationErrorProps) {
   const query = question.query();
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
@@ -150,7 +148,7 @@ export function VisualizationError({
                 {t`Learn how to debug SQL errors`}
               </ExternalLink>
             )}
-            {!isResultDirty && <FixSqlQueryButton />}
+            <FixSqlQueryButton />
           </Flex>
         </Flex>
       </Box>

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationError/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationError/tests/premium.unit.spec.ts
@@ -51,6 +51,23 @@ describe("VisualizationError (EE with token)", () => {
         screen.queryByText("Learn how to debug SQL errors"),
       ).not.toBeInTheDocument();
     });
+
+    it("should show the Metabot fix button", async () => {
+      const card = createMockCard({
+        dataset_query: {
+          database: database.id,
+          type: "native",
+          native: {
+            query: "SELECT * FROM ORDERS",
+          },
+        },
+      });
+      setup({ database, card });
+
+      expect(
+        await screen.findByRole("button", { name: /Have Metabot fix it/ }),
+      ).toBeInTheDocument();
+    });
   });
 
   describe("NoSQL databases", () => {


### PR DESCRIPTION
Closes [BOT-1132: Have Metabot fix it button sometimes disappears on SQL errors](https://linear.app/metabase/issue/BOT-1132/have-metabot-fix-it-button-sometimes-disappears-on-sql-errors)

### Description

The button was only shown when the state was dirty. We need to always show it.

### How to verify

- Create a SQL query with an error
- run the query

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)