### PR TITLE
fix: native query editor cuts off last lines when viewing transform sql

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -135,6 +135,45 @@ describe("issue GDGT-1774", () => {
   });
 });
 
+describe("issue UXW-3160", () => {
+  beforeEach(() => {
+    H.restore("postgres-writable");
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+    H.updateSetting("transforms-enabled", true);
+  });
+
+  it("should let the read-only definition view scroll to the last line of a long SQL transform (UXW-3160)", () => {
+    const lastLineMarker = "-- UXW_3160_LAST_LINE";
+    const longSql =
+      "SELECT\n  " +
+      Array.from({ length: 80 }, (_, i) => `'col_${i}' AS col_${i}`).join(
+        ",\n  ",
+      ) +
+      `\n${lastLineMarker}`;
+
+    H.createSqlTransform({
+      name: "Long SQL transform",
+      sourceQuery: longSql,
+      targetTable: "uxw_3160_target",
+      targetSchema: "public",
+      visitTransform: true,
+    });
+
+    cy.get(".cm-scroller").then(($el) => {
+      const scroller = $el[0];
+      scroller.scrollTop = scroller.scrollHeight;
+    });
+
+    cy.get(".cm-scroller").should(($el) => {
+      const rect = $el[0].getBoundingClientRect();
+      expect(rect.bottom).to.be.at.most(Cypress.config("viewportHeight"));
+    });
+
+    cy.get(".cm-scroller").findByText(lastLineMarker).should("be.visible");
+  });
+});
+
 function visitTransformListPage() {
   return cy.visit("/data-studio/transforms");
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
@@ -9,7 +9,9 @@
 .editorWrapper {
   overflow: auto;
   width: 100%;
-  flex: 1 0 auto;
+  /* flex-shrink must be 1 so the wrapper fits when the topbar leaves less
+     space than the wrapper's content would claim. */
+  flex: 1 1 auto;
   max-height: 100%;
 }
 


### PR DESCRIPTION
### Description

Small adjustment to the native query editor so that when viewing transform sql definitions, you can scroll all the way to the bottom

### How to verify
1. Data Studio -> Transforms
2. Either go to an existing longer sql transform, or create a new one (65+ lines)
3. Save and view the definition. You should see all the lines

I manually verified the following other places that the native query editor is present:
- SQL Query Question editor
- native model editor
- Actions creating and viewing definition
- new native sql questions in documents

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
