### PR TITLE
Fix sandbox removed field references

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -292,6 +292,39 @@
                            :qp/native-sandbox-column.propagate-coercion?     true)))))
         original-table-cols))
 
+(defn- sandbox-exposed-field-ids
+  "Set of original-table field-ids the sandbox actually returns. MBQL GTAPs' returned columns carry `:id` from the
+  original table, so we take those ids directly. Native GTAPs' columns have only `:name` (no id), so bridge through
+  the original table's `:name → :id` mapping. The `:name` fallback is degenerate for tables with same-name columns —
+  those are unreachable through normal sync but we accept any matching id."
+  [sandbox-query original-table-id]
+  (let [sandbox-cols      (lib/returned-columns sandbox-query)
+        direct-ids        (into #{} (keep :id) sandbox-cols)
+        unresolved-names  (into #{}
+                                (comp (remove :id) (keep :name))
+                                sandbox-cols)
+        name-resolved-ids (when (seq unresolved-names)
+                            (into #{}
+                                  (keep (fn [{col-name :name id :id}]
+                                          (when (and id (contains? unresolved-names col-name))
+                                            id)))
+                                  (lib.metadata/fields sandbox-query original-table-id)))]
+    (into direct-ids name-resolved-ids)))
+
+(defn- filter-stage-fields-to-sandbox
+  "When wrapping a sandbox subquery with a stage that carries a `:fields` clause from before the swap, drop any
+  field-id refs the sandbox no longer exposes (e.g., a native GTAP that omits a column). Field refs by string name
+  refer to the previous stage's output and are preserved. See #73339."
+  [stage sandbox-field-ids]
+  (m/update-existing stage :fields
+                     (fn [fields]
+                       (filterv (fn [field-ref]
+                                  (let [[tag _opts id-or-name] field-ref]
+                                    (or (not= tag :field)
+                                        (not (integer? id-or-name))
+                                        (contains? sandbox-field-ids id-or-name))))
+                                fields))))
+
 (mu/defn- apply-sandbox-to-stage :- [:and
                                      [:sequential {:min 1} ::lib.schema/stage]
                                      ::lib.schema.util/unique-uuids]
@@ -328,8 +361,16 @@
                                 (empty? (->> (keys stage)
                                              (remove #{:source-table :fields})
                                              (remove qualified-keyword?))))
+        ;; #73339: an implicit-join sub-stage gets `:fields` populated by the post-implicit-joins
+        ;; `add-implicit-clauses` pass *from the original table's column set*, then we land here and swap
+        ;; `:source-table` for the sandbox subquery. Any field-id refs the sandbox doesn't expose (e.g., a column
+        ;; the native GTAP drops) would compile to `SELECT __mb_source.<dropped>` and fail at the DB. Filter them out.
+        wrapper-stage      (when-not skip-final-stage?
+                             (filter-stage-fields-to-sandbox
+                              (dissoc stage :source-table)
+                              (sandbox-exposed-field-ids sandbox-query source-table)))
         replacement-stages (cond-> new-source-stages
-                             (not skip-final-stage?) (conj (dissoc stage :source-table)))]
+                             wrapper-stage (conj wrapper-stage))]
     (log/tracef "Applied Sandbox: replaced stage\n\n%s\n\nwith stages\n\n%s"
                 (u/cprint-to-str stage)
                 (u/cprint-to-str replacement-stages))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -1721,6 +1721,46 @@
             (mt/with-premium-features #{}
               (is (thrown-with-msg? clojure.lang.ExceptionInfo sandboxing-disabled-error (qp.preprocess/preprocess query))))))))))
 
+(deftest sandboxed-implicit-join-omits-hidden-columns-test
+  (testing "Implicit joins to a native-GTAP-sandboxed table must not project columns the GTAP omits (#73339)"
+    ;; Native GTAP that drops ADDRESS from People. With an FK remapping Orders.user_id → People.name,
+    ;; the add-remaps middleware causes an implicit join into the sandboxed People table even though
+    ;; the user's Orders query references no People columns. The projection for that join must not
+    ;; reference ADDRESS, or the DB errors with: Column "__mb_source.ADDRESS" not found.
+    (met/with-gtaps! {:gtaps {:people {:query (lib/native-query (mt/metadata-provider)
+                                                                "SELECT ID, EMAIL, NAME, CITY, STATE FROM PEOPLE")}
+                              ;; Empty GTAP just to grant the sandbox group create-queries on Orders.
+                              :orders {}}
+                      :attributes {}}
+      (let [mp           (lib.tu/remap-metadata-provider (mt/metadata-provider)
+                                                         (mt/id :orders :user_id)
+                                                         (mt/id :people :name))
+            base         (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+            fieldable    (lib/fieldable-columns base)
+            orders-id    (lib.tu.notebook/find-col-with-spec base fieldable
+                                                             {:display-name "Orders"} {:display-name "ID"})
+            orders-total (lib.tu.notebook/find-col-with-spec base fieldable
+                                                             {:display-name "Orders"} {:display-name "Total"})
+            ;; Plain Orders query — no People columns referenced. The implicit join into People
+            ;; comes from the FK remapping above, mirroring what the FE sends when "visiting" a table.
+            query        (-> base
+                             (lib/with-fields [orders-id orders-total])
+                             (lib/order-by orders-id :asc)
+                             (lib/limit 3))]
+        (testing "Preprocessed query does not project the dropped ADDRESS column"
+          (let [preprocessed (qp.preprocess/preprocess query)
+                address-id   (mt/id :people :address)
+                field-refs   (filter #(and (vector? %)
+                                           (= :field (first %))
+                                           (= address-id (nth % 2 nil)))
+                                     (tree-seq coll? seq preprocessed))]
+            (is (empty? field-refs)
+                "preprocessed query should not contain any field ref to people.address")))
+        (testing "Query executes successfully"
+          (let [result (qp/process-query query)]
+            (is (= :completed (:status result)))
+            (is (= 3 (count (mt/rows result))))))))))
+
 (deftest sandboxing-throws-on-ee-without-token
   (mt/test-drivers (e2e-test-drivers)
     (testing "Basic test around querying a table by a user with segmented only permissions and a GTAP question that is a native query"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73339
Closes QUE2-589

### Description

the `add-implicit-clauses` call after `add-implicit-joins` populates the implicit join's inner stage `:fields` from the original table metadata, so it can reference fields that the sandbox query doesn't return. This PR removes those references.

### How to verify

The repro steps in #73339 should not lead to an error. The new regression test should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
