### PR TITLE
Use context-timeouts metric instead of timeouts metric

### DIFF
--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -61,7 +61,7 @@
          ;; This is necessary because future-cancel doesn't stop GraalVM execution
          (python.pool/interrupt! ~ctx 1000)
          (python.pool/poison! ~ctx)
-         (analytics/inc! :metabase-sql-parsing/timeouts)
+         (analytics/inc! :metabase-sql-parsing/context-timeouts)
          (log/warn "Python execution timed out after" ~timeout-ms "ms - GraalVM interrupted")
          (throw (TimeoutException. (str "Python execution timed out after " ~timeout-ms "ms"))))
        result#)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73180

### Description

Fixes what I believe is a typo in sql parsing timeout metric.

### How to verify


### Demo


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
