### PR TITLE
Drivers stability

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1666,7 +1666,8 @@ jobs:
               }));
 
             // are all jobs skipped or successful?
-            if (jobs.every(job => (job.result === 'skipped' || job.result === 'success' || job.name == 'be-tests-starburst-ee'))) {
+            if (jobs.every(job => (job.result === 'skipped' || job.result === 'success' ||
+                job.name == 'be-tests-starburst-ee' || job.name == 'be-tests-bigquery-cloud-sdk-ee'))) {
                 console.log("");
                 console.log("        _------.        ");
                 console.log("       /  ,     \_      ");

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -98,9 +98,9 @@
 
 (defn- old-dataset-names
   "Return a collection of all dataset names that are old
-   -- tracked that haven't been touched in 2 days or are not tracked and two days old"
+   -- tracked that haven't been touched in a while or are not tracked and too old"
   []
-  (let [days-ago -2
+  (let [days-ago -5
         ;; tracked UNION ALL untracked
         query "(select name from metabase_test_tracking.PUBLIC.datasets
                 where accessed_at < dateadd(day, ?, current_timestamp()))


### PR DESCRIPTION
### Description

Allow overall run pass even when bigquery driver tests fail.

We want to re-enable bigquery tests, but they are still unreliable. In order
to address their unreliability, we need to gather data about the failures. We
need the tests to run without impacting our ability to deliver, so we need to
not block the overall PR when they fail.

The bigquery driver tests were disabled over a month ago, so their logs are no
longer available in github or trunk.

Snowflake's driver tests will delete datasets that are considered "old" and have
them get re-created. The current threshold is for datasets where they haven't
been accessed in 2 days, which is too low; it ends up needlessly re-creating them
and causing contention with parallel test runs. This patch increases it to 5 days.