### PR TITLE
[Metabot] Show message feedback UI in OSS

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -215,7 +215,6 @@ function FeedbackCard({
             readonly
             hideActions
             getCopyText={noopGetCopyText}
-            showFeedbackButtons={false}
             submittedFeedback={undefined}
             bg="background-secondary"
             p="md"

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -193,7 +193,6 @@ export const MetabotChat = ({
               }
               isDoingScience={metabot.isDoingScience}
               debug={metabot.debugMode}
-              showFeedbackButtons
             />
             {/* loading */}
             {metabot.isDoingScience && (

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -9,8 +9,6 @@ import { useSetting } from "metabase/common/hooks";
 import { AIProviderConfigurationModal } from "metabase/metabot/components/AIProviderConfigurationModal";
 import { AIProviderConfigurationNotice } from "metabase/metabot/components/AIProviderConfigurationNotice";
 import { MetabotResetLongChatButton } from "metabase/metabot/components/MetabotChat/MetabotResetLongChatButton";
-import { useSelector } from "metabase/redux";
-import { getIsHosted } from "metabase/setup/selectors";
 import {
   ActionIcon,
   Box,
@@ -53,7 +51,6 @@ export const MetabotChat = ({
 }: {
   config?: MetabotConfig;
 }) => {
-  const isHosted = useSelector(getIsHosted);
   const [
     isAiProviderConfigurationModalOpen,
     {
@@ -196,7 +193,7 @@ export const MetabotChat = ({
               }
               isDoingScience={metabot.isDoingScience}
               debug={metabot.debugMode}
-              showFeedbackButtons={isHosted}
+              showFeedbackButtons
             />
             {/* loading */}
             {metabot.isDoingScience && (

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -171,7 +171,6 @@ interface AgentMessageProps extends Omit<BaseMessageProps, "message"> {
   readonly: boolean;
   onRetry?: (messageId: string) => void;
   getCopyText: () => string;
-  showFeedbackButtons: boolean;
   setFeedbackMessage?: (data: { messageId: string; positive: boolean }) => void;
   submittedFeedback: "positive" | "negative" | undefined;
   onInternalLinkClick?: (link: string) => void;
@@ -184,7 +183,6 @@ export const AgentMessage = ({
   readonly,
   getCopyText,
   onRetry,
-  showFeedbackButtons,
   setFeedbackMessage,
   submittedFeedback,
   onInternalLinkClick,
@@ -192,11 +190,7 @@ export const AgentMessage = ({
   ...props
 }: AgentMessageProps) => {
   const messageId = "externalId" in message ? (message.externalId ?? "") : "";
-  const canGiveFeedback = !!(
-    showFeedbackButtons &&
-    setFeedbackMessage &&
-    messageId
-  );
+  const canGiveFeedback = !!(setFeedbackMessage && messageId);
   const clipboard = useClipboard({ timeout: 2000 });
 
   return (
@@ -415,7 +409,6 @@ export const Messages = ({
   isDoingScience,
   debug,
   readonly = false,
-  showFeedbackButtons = false,
   onInternalLinkClick,
 }: {
   messages: MetabotChatMessage[];
@@ -423,7 +416,6 @@ export const Messages = ({
   isDoingScience: boolean;
   debug: boolean;
   readonly?: boolean;
-  showFeedbackButtons?: boolean;
   onInternalLinkClick?: (navigateToPath: string) => void;
 }) => {
   const visibleMessages = useMemo(
@@ -473,17 +465,6 @@ export const Messages = ({
     [messages],
   );
 
-  const setFeedbackModal = useCallback(
-    (data: { messageId: string; positive: boolean } | undefined) => {
-      if (!showFeedbackButtons) {
-        return;
-      }
-
-      setFeedbackState((prev) => ({ ...prev, modal: data }));
-    },
-    [showFeedbackButtons],
-  );
-
   return (
     <>
       {visibleMessages.map((message, index) => {
@@ -497,8 +478,9 @@ export const Messages = ({
             readonly={readonly}
             onRetry={onRetryMessage}
             getCopyText={() => getAgentReplyCopyText(message.id)}
-            showFeedbackButtons={showFeedbackButtons}
-            setFeedbackMessage={setFeedbackModal}
+            setFeedbackMessage={(data) =>
+              setFeedbackState((prev) => ({ ...prev, modal: data }))
+            }
             submittedFeedback={
               "externalId" in message && message.externalId
                 ? feedbackState.submitted[message.externalId]
@@ -520,7 +502,9 @@ export const Messages = ({
       {feedbackState.modal && (
         <MetabotFeedbackModal
           {...feedbackState.modal}
-          onClose={() => setFeedbackModal(undefined)}
+          onClose={() =>
+            setFeedbackState((prev) => ({ ...prev, modal: undefined }))
+          }
           onSubmit={submitFeedback}
         />
       )}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
@@ -9,7 +9,6 @@ const setup = (message: MetabotAgentChatMessage) =>
       debug={false}
       readonly={false}
       hideActions
-      showFeedbackButtons={false}
       setFeedbackMessage={() => {}}
       submittedFeedback={undefined}
       getCopyText={() => ""}
@@ -96,7 +95,6 @@ describe("AgentMessage", () => {
           debug
           readonly={false}
           hideActions
-          showFeedbackButtons={false}
           setFeedbackMessage={() => {}}
           submittedFeedback={undefined}
           getCopyText={() => ""}

--- a/frontend/src/metabase/metabot/tests/feedback.unit.spec.ts
+++ b/frontend/src/metabase/metabot/tests/feedback.unit.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "./utils";
 
 const setupWithNegativeFeedback = async () => {
-  setup({ isHosted: true });
+  setup();
   const feedbackEndpoint = mockFeedbackEndpoint();
   mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 
@@ -51,23 +51,8 @@ const submitFeedback = async (modal: HTMLElement) => {
 };
 
 describe("metabot > feedback", () => {
-  it("should not show feedback buttons for non-hosted instances", async () => {
-    setup({ isHosted: false });
-    mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
-
-    await enterChatMessage("Who is your favorite?");
-    const lastMessage = (await lastChatMessage())!;
-
-    expect(
-      within(lastMessage).queryByTestId("metabot-chat-message-thumbs-up"),
-    ).not.toBeInTheDocument();
-    expect(
-      within(lastMessage).queryByTestId("metabot-chat-message-thumbs-down"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("should present the user an option to provide feedback for hosted instances", async () => {
-    setup({ isHosted: true });
+  it("should present the user an option to provide feedback", async () => {
+    setup();
     const feedbackEndpoint = mockFeedbackEndpoint();
     mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 
@@ -136,7 +121,7 @@ describe("metabot > feedback", () => {
   });
 
   it("should submit positive feedback", async () => {
-    setup({ isHosted: true });
+    setup();
     const feedbackEndpoint = mockFeedbackEndpoint();
     mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -182,7 +182,6 @@ export function setup(
     metabotInitialState?: MetabotState;
     currentUser?: User | null | undefined;
     promptSuggestions?: { prompt: string }[];
-    isHosted?: boolean;
     storeInitialState?: RenderWithProvidersOptions["storeInitialState"];
     customReducers?: RenderWithProvidersOptions["customReducers"];
     isConfigured?: boolean;
@@ -190,7 +189,6 @@ export function setup(
 ) {
   const settings = mockSettings({
     "llm-metabot-configured?": options?.isConfigured ?? true,
-    "is-hosted?": options?.isHosted ?? false,
   });
 
   setupEnterprisePlugins();


### PR DESCRIPTION
Closes [BOT-1564: Show message feedback UI in OSS](https://linear.app/metabase/issue/BOT-1564/show-message-feedback-ui-in-oss)

### Description

Drops the `isHosted` gate on the Metabot chat feedback buttons so they show up on self-hosted instances too. Cleans up components / test code to remove logic supporting this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)