### PR TITLE
Metrics viewer: add column labels visibility toggle

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricControls/MetricControls.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricControls/MetricControls.tsx
@@ -2,7 +2,16 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
-import { Button, Divider, Flex, Icon } from "metabase/ui";
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Icon,
+  Menu,
+  Switch,
+} from "metabase/ui";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import type { TemporalUnit, VisualizationSettings } from "metabase-types/api";
 
@@ -52,6 +61,9 @@ type MetricControlsProps = {
   onTemporalUnitChange: (unit: TemporalUnit | undefined) => void;
   onBinningChange: (binningStrategy: string | undefined) => void;
   onAddTab: (tabInfo: TabInfo) => void;
+  canToggleColumnLabels?: boolean;
+  showColumnLabels?: boolean;
+  onShowColumnLabelsChange?: (show: boolean) => void;
   showStackSeries?: boolean;
   visualizationSettings?: Partial<VisualizationSettings>;
   onVisualizationSettingsChange?: (
@@ -76,6 +88,9 @@ export function MetricControls({
   onTemporalUnitChange,
   onBinningChange,
   onAddTab,
+  canToggleColumnLabels,
+  showColumnLabels = true,
+  onShowColumnLabelsChange,
   showStackSeries,
   visualizationSettings,
   onVisualizationSettingsChange,
@@ -111,99 +126,128 @@ export function MetricControls({
   const columnPickerLabel = tabLabel ?? t`Select column`;
 
   return (
-    <Flex
-      maw="100%"
-      h="3rem"
-      display="inline-flex"
-      bg="background-primary"
-      bd="1px solid var(--mb-color-border)"
-      bdrs="lg"
-      px="sm"
-      align="center"
-      gap="xs"
-      data-testid="metrics-viewer-controls"
-    >
-      <ChartTypePicker
-        chartTypes={chartTypes}
-        value={effectiveDisplayType}
-        onChange={onDisplayTypeChange}
-      />
-      {showStackSeries && onVisualizationSettingsChange && (
-        <>
-          <Divider orientation="vertical" className={S.divider} mx="xs" />
-          <ChartLayoutPicker
-            isStacked={!!visualizationSettings?.["graph.split_panels"]}
-            onToggle={(stacked) =>
-              onVisualizationSettingsChange({
-                "graph.split_panels": stacked,
-              })
-            }
-          />
-        </>
+    <Box pos="relative" display="inline-flex">
+      <Flex
+        maw="100%"
+        h="3rem"
+        display="inline-flex"
+        bg="background-primary"
+        bd="1px solid var(--mb-color-border)"
+        bdrs="lg"
+        px="sm"
+        align="center"
+        gap="xs"
+        data-testid="metrics-viewer-controls"
+      >
+        <ChartTypePicker
+          chartTypes={chartTypes}
+          value={effectiveDisplayType}
+          onChange={onDisplayTypeChange}
+        />
+        {showStackSeries && onVisualizationSettingsChange && (
+          <>
+            <Divider orientation="vertical" className={S.divider} mx="xs" />
+            <ChartLayoutPicker
+              isStacked={!!visualizationSettings?.["graph.split_panels"]}
+              onToggle={(stacked) =>
+                onVisualizationSettingsChange({
+                  "graph.split_panels": stacked,
+                })
+              }
+            />
+          </>
+        )}
+        {hasFilterControls && projectionInfo.filterDimension && (
+          <>
+            <Divider orientation="vertical" className={S.divider} mx="xs" />
+            {hasAvailableDimensions && (
+              <>
+                <AddDimensionPopover
+                  availableDimensions={availableDimensions}
+                  sourceOrder={sourceOrder}
+                  sourceDataById={sourceDataById}
+                  hasMultipleSources={hasMultipleSources}
+                  onAddTab={onAddTab}
+                  canAddScalarTab={canAddScalarTab}
+                  renderTrigger={({ toggle }) => (
+                    <Button
+                      w={184}
+                      justify="space-between"
+                      fw="bold"
+                      py="xs"
+                      px="sm"
+                      aria-label={t`Change column`}
+                      variant="subtle"
+                      color="text-primary"
+                      rightSection={<Icon name="chevrondown" size={12} />}
+                      onClick={toggle}
+                    >
+                      {columnPickerLabel}
+                    </Button>
+                  )}
+                />
+                <Divider orientation="vertical" className={S.divider} mx="xs" />
+              </>
+            )}
+            <DimensionFilterButton
+              definition={definition}
+              filterDimension={projectionInfo.filterDimension}
+              dimensionFilter={dimensionFilter}
+              allFilterDimensions={allFilterDimensions}
+              onChange={onDimensionFilterChange}
+            />
+          </>
+        )}
+        {hasBucketControls && projectionInfo.projectionDimension && (
+          <>
+            <Divider orientation="vertical" className={S.divider} mx="xs" />
+            <BucketButton
+              definition={definition}
+              dimension={projectionInfo.projectionDimension}
+              projection={projectionInfo.projection!}
+              onChange={onTemporalUnitChange}
+            />
+          </>
+        )}
+        {hasBinningControls && projectionInfo.projectionDimension && (
+          <>
+            <Divider orientation="vertical" className={S.divider} mx="xs" />
+            <BinningButton
+              definition={definition}
+              dimension={projectionInfo.projectionDimension}
+              projection={projectionInfo.projection!}
+              onBinningChange={onBinningChange}
+            />
+          </>
+        )}
+      </Flex>
+      {canToggleColumnLabels && onShowColumnLabelsChange && (
+        <Menu position="bottom-start" withinPortal>
+          <Menu.Target>
+            <ActionIcon
+              aria-label={t`Column label options`}
+              pos="absolute"
+              right="-2.5rem"
+              top="50%"
+              variant="subtle"
+              style={{ transform: "translateY(-50%)" }}
+            >
+              <Icon name="ellipsis" c="text-primary" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown p="md">
+            <Switch
+              label={t`Show column labels`}
+              size="sm"
+              labelPosition="right"
+              checked={showColumnLabels}
+              onChange={(event) =>
+                onShowColumnLabelsChange(event.currentTarget.checked)
+              }
+            />
+          </Menu.Dropdown>
+        </Menu>
       )}
-      {hasFilterControls && projectionInfo.filterDimension && (
-        <>
-          <Divider orientation="vertical" className={S.divider} mx="xs" />
-          {hasAvailableDimensions && (
-            <>
-              <AddDimensionPopover
-                availableDimensions={availableDimensions}
-                sourceOrder={sourceOrder}
-                sourceDataById={sourceDataById}
-                hasMultipleSources={hasMultipleSources}
-                onAddTab={onAddTab}
-                canAddScalarTab={canAddScalarTab}
-                renderTrigger={({ toggle }) => (
-                  <Button
-                    w={184}
-                    justify="space-between"
-                    fw="bold"
-                    py="xs"
-                    px="sm"
-                    aria-label={t`Change column`}
-                    variant="subtle"
-                    color="text-primary"
-                    rightSection={<Icon name="chevrondown" size={12} />}
-                    onClick={toggle}
-                  >
-                    {columnPickerLabel}
-                  </Button>
-                )}
-              />
-              <Divider orientation="vertical" className={S.divider} mx="xs" />
-            </>
-          )}
-          <DimensionFilterButton
-            definition={definition}
-            filterDimension={projectionInfo.filterDimension}
-            dimensionFilter={dimensionFilter}
-            allFilterDimensions={allFilterDimensions}
-            onChange={onDimensionFilterChange}
-          />
-        </>
-      )}
-      {hasBucketControls && projectionInfo.projectionDimension && (
-        <>
-          <Divider orientation="vertical" className={S.divider} mx="xs" />
-          <BucketButton
-            definition={definition}
-            dimension={projectionInfo.projectionDimension}
-            projection={projectionInfo.projection!}
-            onChange={onTemporalUnitChange}
-          />
-        </>
-      )}
-      {hasBinningControls && projectionInfo.projectionDimension && (
-        <>
-          <Divider orientation="vertical" className={S.divider} mx="xs" />
-          <BinningButton
-            definition={definition}
-            dimension={projectionInfo.projectionDimension}
-            projection={projectionInfo.projection!}
-            onBinningChange={onBinningChange}
-          />
-        </>
-      )}
-    </Flex>
+    </Box>
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricControls/MetricControls.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricControls/MetricControls.tsx
@@ -1,7 +1,19 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
+import type {
+  MetricSourceId,
+  MetricsViewerDisplayType,
+  MetricsViewerTabType,
+} from "metabase/metrics-viewer/types";
+import {
+  type AvailableDimensionsResult,
+  type DimensionFilterValue,
+  type SourceDisplayInfo,
+  type TabInfo,
+  getProjectionInfo,
+  getTabConfig,
+} from "metabase/metrics-viewer/utils";
 import {
   ActionIcon,
   Box,
@@ -15,18 +27,6 @@ import {
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import type { TemporalUnit, VisualizationSettings } from "metabase-types/api";
 
-import type {
-  MetricSourceId,
-  MetricsViewerDisplayType,
-  MetricsViewerTabType,
-} from "../../types/viewer-state";
-import { getProjectionInfo } from "../../utils/definition-builder";
-import type { DimensionFilterValue } from "../../utils/dimension-filters";
-import type {
-  AvailableDimensionsResult,
-  SourceDisplayInfo,
-} from "../../utils/dimension-picker";
-import { getTabConfig } from "../../utils/tab-config";
 import { AddDimensionPopover } from "../MetricsViewerTabs/AddDimensionPopover";
 
 import { BinningButton } from "./BinningButton";

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
@@ -4,18 +4,17 @@ import { t } from "ttag";
 
 import { AccordionList } from "metabase/common/components/AccordionList";
 import { trackMetricsViewerDimensionTabAdded } from "metabase/metrics-viewer/analytics";
-import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
+import type { MetricSourceId } from "metabase/metrics-viewer/types";
+import {
+  type AvailableDimensionsResult,
+  type DimensionPickerItem,
+  type DimensionPickerSection,
+  type SourceDisplayInfo,
+  type TabInfo,
+  buildDimensionPickerSections,
+  getScalarTabLabel,
+} from "metabase/metrics-viewer/utils";
 import { ActionIcon, Icon, Popover } from "metabase/ui";
-
-import type { MetricSourceId } from "../../../types/viewer-state";
-import type {
-  AvailableDimensionsResult,
-  DimensionPickerItem,
-  DimensionPickerSection,
-  SourceDisplayInfo,
-} from "../../../utils/dimension-picker";
-import { buildDimensionPickerSections } from "../../../utils/dimension-picker";
-import { getScalarTabLabel } from "../../../utils/tabs";
 
 import S from "./AddDimensionPopover.module.css";
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useMemo } from "react";
 
+import { DimensionPillBar } from "metabase/metrics-viewer/components/DimensionPillBar";
+import { MetricControls } from "metabase/metrics-viewer/components/MetricControls";
+import { MetricsViewerVisualization } from "metabase/metrics-viewer/components/MetricsViewerVisualization";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -9,19 +12,17 @@ import type {
   MetricsViewerTabState,
   SourceColorMap,
 } from "metabase/metrics-viewer/types/viewer-state";
-import { getProjectionInfo } from "metabase/metrics-viewer/utils/definition-builder";
-import type { DimensionFilterValue } from "metabase/metrics-viewer/utils/dimension-filters";
-import type {
-  AvailableDimensionsResult,
-  SourceDisplayInfo,
-} from "metabase/metrics-viewer/utils/dimension-picker";
-import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
 import {
+  type AvailableDimensionsResult,
+  type DimensionFilterValue,
+  type SourceDisplayInfo,
+  type TabInfo,
   buildDimensionItemsFromDefinitions,
+  getProjectionInfo,
+  getTabConfig,
   shouldShowStackSeries,
-} from "metabase/metrics-viewer/utils/series";
-import { getTabConfig } from "metabase/metrics-viewer/utils/tab-config";
-import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
+} from "metabase/metrics-viewer/utils";
+import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
 import { Box, Flex, Stack } from "metabase/ui";
 import { getObjectKeys, getObjectValues } from "metabase/utils/objects";
 import { isNotNull } from "metabase/utils/types";
@@ -33,10 +34,6 @@ import type {
   TemporalUnit,
   VisualizationSettings,
 } from "metabase-types/api";
-
-import { DimensionPillBar } from "../../DimensionPillBar";
-import { MetricControls } from "../../MetricControls";
-import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
 
 type MetricsViewerTabContentProps = {
   definitions: Record<MetricSourceId, MetricsViewerDefinitionEntry>;

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -187,6 +187,13 @@ export function MetricsViewerTabContent({
     [onTabUpdate, tab.visualizationSettings],
   );
 
+  const handleShowColumnLabelsChange = useCallback(
+    (showColumnLabels: boolean) => {
+      onTabUpdate({ showColumnLabels });
+    },
+    [onTabUpdate],
+  );
+
   const handleBrush = useCallback(
     ({ start, end }: { start: number; end: number }) => {
       updateProjectionConfig({
@@ -217,6 +224,7 @@ export function MetricsViewerTabContent({
       : item.availableOptions.length > 0,
   );
   const hideDimensionPill = tabConfig.minDimensions === 0 && !hasAnyOptions;
+  const showColumnLabels = tab.showColumnLabels !== false;
 
   const mappedDimensionCount = getObjectValues(tab.dimensionMapping).filter(
     isNotNull,
@@ -238,7 +246,7 @@ export function MetricsViewerTabContent({
         queriesAreLoading={queriesAreLoading}
         queriesError={queriesError}
       />
-      {!hideDimensionPill && (
+      {!hideDimensionPill && showColumnLabels && (
         <Box mt="sm">
           <DimensionPillBar
             items={dimensionItems}
@@ -267,6 +275,9 @@ export function MetricsViewerTabContent({
             onBinningChange={handleBinningChange}
             onAddTab={onAddTab}
             showStackSeries={showStackSeries}
+            canToggleColumnLabels={!hideDimensionPill}
+            showColumnLabels={showColumnLabels}
+            onShowColumnLabelsChange={handleShowColumnLabelsChange}
             visualizationSettings={tab.visualizationSettings}
             onVisualizationSettingsChange={handleVisualizationSettingsChange}
           />

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -2,21 +2,20 @@ import type { Location } from "history";
 import { useCallback } from "react";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Box, Center, Flex, Stack } from "metabase/ui";
-
 import {
   trackMetricsViewerMetricAdded,
   trackMetricsViewerMetricRemoved,
-} from "../../analytics";
-import { BreakoutLegend } from "../../components/BreakoutLegend/BreakoutLegend";
+} from "metabase/metrics-viewer/analytics";
+import { BreakoutLegend } from "metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend";
 import {
   MetricsViewerEmptyState,
   MetricsViewerNoTabsEmptyState,
-} from "../../components/EmptyState";
-import { MetricSearchPanel } from "../../components/MetricSearchPanel";
-import { MetricsViewerTabContent } from "../../components/MetricsViewerTabs";
-import { useMetricsViewer } from "../../hooks/use-metrics-viewer";
-import type { SelectedMetric } from "../../types/viewer-state";
+} from "metabase/metrics-viewer/components/EmptyState";
+import { MetricSearchPanel } from "metabase/metrics-viewer/components/MetricSearchPanel";
+import { MetricsViewerTabContent } from "metabase/metrics-viewer/components/MetricsViewerTabs";
+import { useMetricsViewer } from "metabase/metrics-viewer/hooks";
+import type { SelectedMetric } from "metabase/metrics-viewer/types";
+import { Box, Center, Flex, Stack } from "metabase/ui";
 
 import S from "./MetricsViewerPage.module.css";
 

--- a/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
@@ -109,6 +109,7 @@ export interface MetricsViewerTabState {
   type: MetricsViewerTabType;
   label: string | null;
   display: MetricsViewerDisplayType;
+  showColumnLabels?: boolean;
   visualizationSettings?: Partial<VisualizationSettings>;
   dimensionMapping: Record<number, DimensionId | null>;
   projectionConfig: MetricsViewerTabProjectionConfig;

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
@@ -199,6 +199,7 @@ interface SerializedTab {
   type: MetricsViewerTabType;
   label: string | null;
   display: MetricsViewerDisplayType;
+  showColumnLabels?: boolean;
   visualizationSettings?: Partial<VisualizationSettings>;
   definitions: SerializedTabDef[];
   projectionConfig?: SerializedProjectionConfig;
@@ -343,6 +344,7 @@ function tabToSerializedTab(tab: MetricsViewerTabState): SerializedTab {
     type: tab.type,
     label: tab.label,
     display: tab.display,
+    ...(tab.showColumnLabels === false ? { showColumnLabels: false } : {}),
     ...(tab.visualizationSettings &&
     Object.keys(tab.visualizationSettings).length > 0
       ? { visualizationSettings: tab.visualizationSettings }
@@ -376,6 +378,9 @@ export function deserializeTab(
     type: serializedTab.type,
     label: serializedTab.label,
     display: serializedTab.display,
+    ...(serializedTab.showColumnLabels === false
+      ? { showColumnLabels: false }
+      : {}),
     ...(serializedTab.visualizationSettings
       ? { visualizationSettings: serializedTab.visualizationSettings }
       : {}),
@@ -547,6 +552,7 @@ const tabSchema = defineCompactSchema<SerializedTab>({
   type: "t",
   label: { key: "l", default: null },
   display: { key: "d", default: "line" },
+  showColumnLabels: { key: "c", optional: true },
   visualizationSettings: { key: "V", optional: true },
   definitions: { key: "D", schema: tabDefSchema, default: [] },
   projectionConfig: {

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
@@ -42,6 +42,27 @@ describe("url-serialization", () => {
       expect(decoded).toEqual(state);
     });
 
+    it("round-trips disabled column labels", () => {
+      const state: SerializedMetricsViewerPageState = {
+        formulaEntities: [{ type: "metric", id: 1 }],
+        tabs: [
+          {
+            id: "tab-1",
+            type: "time",
+            label: "By Month",
+            display: "line",
+            showColumnLabels: false,
+            definitions: [{ slotIndex: 0, dimensionId: "created_at" }],
+          },
+        ],
+        selectedTabId: "tab-1",
+      };
+
+      const hash = encodeStateOrThrow(state);
+      const decoded = decodeState(hash);
+      expect(decoded).toEqual(state);
+    });
+
     it("round-trips a metric with breakoutTemporalUnit", () => {
       const state: SerializedMetricsViewerPageState = {
         formulaEntities: [


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4193/add-ellipsis-menu-for-the-show-column-labels-option

### Description

Adds a metrics viewer ellipsis menu outside the right edge of the bottom controls for toggling the column labels above the controls. The setting is tab-scoped and serialized in the viewer URL when disabled.

### How to verify

1. Open Explore with a metric that has a column label above the controls.
2. Click the ellipsis button to the right of the controls.
3. Toggle `Show column labels` off and verify the label pill above the controls disappears.
4. Toggle it back on and verify the label pill returns.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
