### PR TITLE
docs: link correct doc for existing user session failed

### DIFF
--- a/frontend/src/embedding-sdk-bundle/errors/error-docs-links.ts
+++ b/frontend/src/embedding-sdk-bundle/errors/error-docs-links.ts
@@ -10,5 +10,5 @@ type ErrorDocLinks = Partial<Record<MetabaseErrorCode, string>>;
 export const ERROR_DOC_LINKS: ErrorDocLinks = {
   EXISTING_USER_SESSION_FAILED:
     // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- error documentation link
-    "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js#use-existing-user-session-to-test-embeds",
+    "https://www.metabase.com/docs/latest/embedding/authentication#embedding-metabase-in-a-different-domain",
 };


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/74341

### Description

Updates the broken documentation link for the `EXISTING_USER_SESSION_FAILED` error. The old link (`embedded-analytics-js#use-existing-user-session-to-test-embeds`) pointed to a page that has been moved during docs reorganization.

### How to verify

1. Confirm the new URL loads correctly and lands on the right section:
   https://www.metabase.com/docs/latest/embedding/authentication#embedding-metabase-in-a-different-domain

### Demo

N/A - documentation link change only

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
  - No tests needed for a URL string change