### PR TITLE
Remove infinite type instantiations in reducers files

### DIFF
--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -360,7 +360,7 @@ export const tabsReducer = createReducer<DashboardState>(
           };
 
           // We don't have card (question) data for virtual dashcards (text, heading, link, action)
-          if (isVirtualDashCard(sourceDashCard as StoreDashcard)) {
+          if (isVirtualDashCard(sourceDashCard as unknown as StoreDashcard)) {
             return;
           }
 

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -25,6 +25,7 @@ import {
 } from "metabase/redux/query-builder";
 import type {
   DashboardSidebarName,
+  DashboardState,
   StoreDashboard,
 } from "metabase/redux/store/dashboard";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -305,10 +306,15 @@ export const dashboards = createReducer(
       }))
       .addCase(
         setDashboardAttributes,
-        (state, { payload: { id, attributes, isDirty = true } }) => ({
-          ...state,
-          [id]: newDashboard(state[id], attributes, isDirty),
-        }),
+        (state, { payload: { id, attributes, isDirty = true } }) => {
+          // Cast away the Immer draft type to avoid a `possibly infinite` type
+          // instantiation error when comparing the deep StoreDashboard type.
+          const dashboards = state as unknown as DashboardState["dashboards"];
+          return {
+            ...dashboards,
+            [id]: newDashboard(dashboards[id], attributes, isDirty),
+          };
+        },
       )
       .addCase(addCardToDash, (state, { payload: dashcard }) => {
         state[dashcard.dashboard_id].dashcards.push(dashcard.id);


### PR DESCRIPTION
Fixes the infinite type instantation erros typescript throws by shortcutting `immer`'s `Draft` with `unknown`, which prevents TypeScript from comparing infinite types.