### PR TITLE
Fix NullPointerException in render-minibar with missing range stats

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -270,13 +270,23 @@
          result-attachments
          html-contents]     (reduce
                              (fn [[merged-attachments result-attachments html-contents] part]
-                               (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
-                                                                                               :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
-                                     result-attachment             (email.result-attachment/result-attachment part creator_id)]
-                                 [(merge merged-attachments attachments)
-                                  (into result-attachments result-attachment)
-                                  (when-not attachment_only
-                                    (conj html-contents (html content)))]))
+                               ;; Isolate each part: realizing one part's Hiccup (here, via `html`) must not
+                               ;; abort the whole subscription. On failure, substitute the error placeholder so
+                               ;; the remaining cards still deliver (#74007).
+                               (try
+                                 (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
+                                                                                                 :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
+                                       result-attachment             (email.result-attachment/result-attachment part creator_id)]
+                                   [(merge merged-attachments attachments)
+                                    (into result-attachments result-attachment)
+                                    (when-not attachment_only
+                                      (conj html-contents (html content)))])
+                                 (catch Throwable e
+                                   (log/error e "Error rendering dashboard subscription part; substituting error placeholder")
+                                   [merged-attachments
+                                    result-attachments
+                                    (when-not attachment_only
+                                      (conj html-contents (html (:content (channel.render/error-rendered-part)))))])))
                              [{} [] []]
                              (assoc-attachment-booleans (:dashboard_subscription_dashcards dashboard_subscription) dashboard_parts))
         icon-attachment     (make-message-attachment (first (icon-bundle :dashboard)))

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -11,6 +11,8 @@
    [metabase.parameters.shared :as shared.params]
    [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.markdown :as markdown]))
 
@@ -237,7 +239,16 @@
         top-level-params (impl.util/remove-inline-parameters all-params (:dashboard_parts payload))
         dashboard        (:dashboard payload)
         blocks           (->> [(slack-dashboard-header dashboard (:common_name creator) all-params top-level-params)
-                               (mapcat (partial part->sections! all-params) (:dashboard_parts payload))]
+                               ;; Isolate each part: rendering one part (e.g. realizing its Hiccup into a PNG)
+                               ;; must not abort the whole subscription. On failure, substitute an error
+                               ;; placeholder block so the remaining cards still deliver (#74007).
+                               (mapcat (fn [part]
+                                         (try
+                                           (part->sections! all-params part)
+                                           (catch Throwable e
+                                             (log/error e "Error rendering dashboard subscription part for Slack; substituting error placeholder")
+                                             [(text->markdown-section (str (tru "An error occurred while displaying this card.")))])))
+                                       (:dashboard_parts payload))]
                               flatten
                               (remove nil?))]
     (for [channel-id (map notification-recipient->channel recipients)]

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -181,6 +181,13 @@
                   (log/error e "Pulse card render error")
                   (body/render :render-error nil nil nil nil nil)))))))
 
+(mu/defn error-rendered-part :- ::body/RenderedPartCard
+  "The placeholder rendered-part shown when an individual card/part of a notification fails to
+  render. Channels substitute this for a failed part so one failure degrades to an error box
+  instead of breaking the whole alert/dashboard subscription."
+  []
+  (body/render :render-error nil nil nil nil nil))
+
 (mu/defn render-pulse-card :- ::body/RenderedPartCard
   "Render a single `card` for a `Pulse` to Hiccup HTML. `result` is the QP results. Returns a map with keys
 

--- a/src/metabase/channel/render/core.clj
+++ b/src/metabase/channel/render/core.clj
@@ -26,6 +26,7 @@
  [render.card
   detect-pulse-chart-type
   defaulted-timezone
+  error-rendered-part
   render-pulse-card
   render-pulse-card-for-display
   render-pulse-section

--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -124,7 +124,7 @@
   - Hiccup data structure for rendering HTML, or
   - Formatted value alone if not a valid numeric value"
   [val {:keys [min max]} col-styles]
-  (if-let [num (and (some? min) (some? max) (:num-value val))] ;; Assumes NumericWrapper
+  (if-let [num (and min max (:num-value val))] ;; Assumes NumericWrapper
     (let [is-neg?        (< num 0)
           has-neg?       (< min 0)
           normalized-max (clojure.core/max (abs min) (abs max))

--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -124,7 +124,7 @@
   - Hiccup data structure for rendering HTML, or
   - Formatted value alone if not a valid numeric value"
   [val {:keys [min max]} col-styles]
-  (if-let [num (:num-value val)] ;; Assumes NumericWrapper
+  (if-let [num (and (some? min) (some? max) (:num-value val))] ;; Assumes NumericWrapper
     (let [is-neg?        (< num 0)
           has-neg?       (< min 0)
           normalized-max (clojure.core/max (abs min) (abs max))

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -94,6 +94,31 @@
               (is (string? rendered-content))
               (is (str/includes? rendered-content "http://example.com/dashboard/42?state=CA&amp;state=NY&amp;state=NJ#scrollTo=456")))))))))
 
+(deftest dashboard-subscription-part-error-isolation-test
+  (testing "One card failing to render does not break the whole dashboard subscription; the failed
+            card degrades to an error placeholder and the remaining cards still render (#74007)"
+    (let [notification {:payload_type :notification/dashboard
+                        :payload {:dashboard       {:id 1 :name "Test Dashboard"}
+                                  :parameters      []
+                                  :dashboard_parts [{:type :card :card {:id 1 :name "Good Card"} :dashcard {:id 10 :dashboard_id 1}}
+                                                    {:type :card :card {:id 2 :name "Bad Card"}  :dashcard {:id 20 :dashboard_id 1}}]
+                                  :dashboard_subscription {:id 9 :dashboard_subscription_dashcards []}}}
+          recipients   [{:type :notification-recipient/user :user {:email "test@example.com"}}]]
+      (mt/with-temporary-setting-values [site-url "http://example.com"]
+        ;; The bad card returns lazy Hiccup that throws only when realized by `html` - the exact failure
+        ;; mode where a render error escapes the per-card try/catch and would otherwise abort delivery.
+        (mt/with-dynamic-fn-redefs [email.impl/render-part (fn [_timezone part _options]
+                                                             (if (= 2 (-> part :card :id))
+                                                               {:content [:div (lazy-seq (throw (ex-info "boom while realizing" {})))]}
+                                                               {:content [:div "GOOD-CARD-BODY"]}))]
+          (let [result  (channel/render-notification :channel/email notification {:recipients recipients})
+                content (-> result first :message first :content)]
+            (is (string? content))
+            (testing "the healthy card still renders"
+              (is (str/includes? content "GOOD-CARD-BODY")))
+            (testing "the failed card degrades to the error placeholder"
+              (is (str/includes? content "An error occurred while displaying this card.")))))))))
+
 (deftest render-body-prometheus-metric-test
   (testing "rendering a user-provided template increments the template-render counter"
     (mt/with-prometheus-system! [_ system]

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.channel.impl.slack-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
    [metabase.channel.impl.slack :as channel.slack]
@@ -161,3 +162,28 @@
           (is (= "section" (:type card-section)))
           (is (= "<http://example.com/dashboard/42?state=CA&state=NY&state=NJ#scrollTo=456|Test Card>"
                  (-> card-section :text :text))))))))
+
+(deftest dashboard-subscription-part-error-isolation-test
+  (testing "One card failing to render does not break the whole Slack dashboard subscription; the
+            failed card degrades to an error placeholder block and the rest still render (#74007)"
+    (let [orig         @#'channel.slack/part->sections!
+          notification {:payload_type :notification/dashboard
+                        :payload {:dashboard       {:id 1 :name "Test Dashboard"}
+                                  :parameters      []
+                                  :dashboard_parts [{:type :card :card {:id 1 :name "Good Card"} :dashcard {:id 10 :dashboard_id 1}}
+                                                    {:type :card :card {:id 2 :name "Bad Card"}  :dashcard {:id 20 :dashboard_id 1}}]}
+                        :creator {:common_name "Test User"}}
+          recipient    {:type :notification-recipient/raw-value :details {:value "#test-channel"}}]
+      (mt/with-dynamic-fn-redefs [slack/upload-file!             (fn [_ _] {:id "uploaded-file-id"})
+                                  channel.slack/part->sections! (fn [params part]
+                                                                  (if (= 2 (-> part :card :id))
+                                                                    (throw (ex-info "boom rendering part" {}))
+                                                                    (orig params part)))]
+        (mt/with-temporary-setting-values [site-url "http://example.com"]
+          (let [blocks   (-> (channel/render-notification :channel/slack notification {:recipients [recipient]})
+                             first :blocks)
+                all-text (str/join " " (keep #(-> % :text :text) blocks))]
+            (testing "the failed card degrades to the error placeholder block"
+              (is (str/includes? all-text "An error occurred while displaying this card.")))
+            (testing "the healthy card still produced its block (delivery not aborted)"
+              (is (str/includes? all-text "Good Card")))))))))

--- a/test/metabase/channel/render/table_test.clj
+++ b/test/metabase/channel/render/table_test.clj
@@ -2,11 +2,14 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [hiccup.core :refer [html]]
+   [hickory.core :as hik]
    [hickory.select :as hik.s]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.render.js.color :as js.color]
    [metabase.channel.render.table :as table]
    [metabase.formatter.core :as formatter]
+   [metabase.models.visualization-settings :as mb.viz]
    [metabase.pulse.render.test-util :as render.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -262,6 +265,34 @@
                                                  :visualization_settings formatting-viz}]
         (testing "Minibar handles 0 gracefully"
           (is (some? (render.tu/render-card-as-hickory! card-id2))))))))
+
+(deftest table-minibar-missing-fingerprint-test
+  (testing "A minibar column whose fingerprint lacks numeric range stats renders the plain value
+            instead of crashing notification delivery (#74007)"
+    ;; A column can be numeric yet have no `:type/Number` fingerprint stats (an unsynced or
+    ;; computed column), leaving `min`/`max` nil. The bug surfaced only during notification
+    ;; delivery because `render-pulse-card` returns lazy hiccup: the NPE escaped its try/catch
+    ;; and fired later when the hiccup was realized into HTML. So we realize it here too.
+    (let [data    {:cols             [{:name "A" :display_name "A" :base_type :type/Integer :semantic_type nil}]
+                   :rows             [[5] [10]]
+                   :format-rows?     true
+                   :results_metadata {:columns [{:name "A" :base_type :type/Integer
+                                                 :fingerprint {:global {:distinct-count 2}}}]}
+                   :viz-settings     {::mb.viz/column-settings
+                                      {{::mb.viz/column-name "A"} {::mb.viz/show-mini-bar true}}}}
+          ;; render-pulse-card returns lazy hiccup, so realize it into HTML (as delivery does)
+          ;; before parsing; this is the step that throws on the unfixed code.
+          doc        (-> (channel.render/render-pulse-card :inline "UTC" render.tu/test-card nil {:data data})
+                         :content
+                         html
+                         hik/parse
+                         hik/as-hickory)
+          body-cells (hik.s/select (hik.s/descendant (hik.s/tag :tbody) (hik.s/tag :td)) doc)]
+      (testing "no minibar is rendered in any data cell - it falls back to the plain value"
+        (is (not-any? (fn [cell] (seq (hik.s/select (hik.s/tag :table) cell))) body-cells)))
+      (testing "the cell values are still rendered"
+        (is (seq (hik.s/select (hik.s/find-in-text #"^5$") doc)))
+        (is (seq (hik.s/select (hik.s/find-in-text #"^10$") doc)))))))
 
 (defn- render-table [dashcard results]
   (channel.render/render-pulse-card :attachment "America/Los_Angeles" render.tu/test-card dashcard results))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74007

Fixes the `render-minibar` NPE that crashed Slack/email delivery when a minibar column has no fingerprint range stats. Also adds per-card isolation so one failing card degrades to an error placeholder instead of taking down the whole dashboard subscription.

Fixes [GDGT-2418](https://linear.app/metabase/issue/GDGT-2418/nullpointerexception-in-render-minibar-crashes-slackemail).
