### PR TITLE
Fix adding rows to editable tables with a date column

### DIFF
--- a/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
+++ b/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
@@ -628,6 +628,67 @@ describe("scenarios > table-editing", () => {
         .findByRole("option", { name: `Add option: ${NON_EXISTING_ID}` })
         .should("be.visible");
     });
+
+    it("should allow creating a record in a table with a required date column (metabase#70647)", () => {
+      const TABLE_NAME = "date_create_test";
+
+      H.queryWritableDB(`DROP TABLE IF EXISTS ${TABLE_NAME}`, "postgres");
+      H.queryWritableDB(
+        `CREATE TABLE ${TABLE_NAME} (
+          id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+          sale_date DATE NOT NULL
+        )`,
+        "postgres",
+      );
+      H.resyncDatabase({ dbId: WRITABLE_DB_ID });
+
+      cy.intercept("GET", "/api/table/*/query_metadata").as("getTableMetadata");
+      cy.intercept("POST", "api/ee/action-v2/execute-bulk").as("executeBulk");
+
+      H.getTableId({ databaseId: WRITABLE_DB_ID, name: TABLE_NAME }).then(
+        (tableId) => {
+          cy.visit(
+            `/browse/databases/${WRITABLE_DB_ID}/tables/${tableId}/edit`,
+          );
+        },
+      );
+      cy.wait("@getTableMetadata");
+
+      cy.findByTestId("new-record-button").click();
+      H.modal().findByText("Create a new record").should("be.visible");
+
+      // The DATE column is NOT NULL, so the form stays invalid until a date is
+      // picked. Before the fix, picking a date never reached the form state, so
+      // the submit button stayed disabled and the row could not be created.
+      cy.findByTestId("Sale Date-field-input").should("be.visible");
+      cy.findByTestId("create-row-form-submit-button").should("be.disabled");
+
+      const targetDay = dayjs().date(15);
+      cy.findByTestId("Sale Date-field-input").click();
+      H.popover()
+        .findByRole("button", { name: targetDay.format("D MMMM YYYY") })
+        .click();
+
+      cy.findByTestId("create-row-form-submit-button")
+        .should("be.enabled")
+        .click();
+
+      cy.wait("@executeBulk").then(({ request, response }) => {
+        expect(request.body.action).to.equal("data-grid.row/create");
+        expect(response?.body.outputs[0].op).to.equal("created");
+
+        const responseDate = dayjs(
+          response?.body.outputs[0].row.sale_date,
+        ).format("YYYY-MM-DD");
+        expect(responseDate).to.equal(targetDay.format("YYYY-MM-DD"));
+      });
+
+      H.undoToast()
+        .findByText("Record successfully created")
+        .should("be.visible");
+
+      H.queryWritableDB(`DROP TABLE IF EXISTS ${TABLE_NAME}`, "postgres");
+    });
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputDate.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputDate.tsx
@@ -9,10 +9,7 @@ import {
   useDateValueWithoutTimezone,
 } from "./use-date-value-without-timezone";
 
-export type TableActionInputDateProps = Omit<
-  TableActionInputSharedProps,
-  "onChange"
-> & {
+export type TableActionInputDateProps = TableActionInputSharedProps & {
   dateStyle?: string;
   classNames?: {
     wrapper?: string;
@@ -26,6 +23,7 @@ export const TableActionInputDate = ({
   inputProps,
   initialValue,
   classNames,
+  onChange,
   onBlur,
   onEscape,
   onEnter,
@@ -42,9 +40,12 @@ export const TableActionInputDate = ({
   const handleChange = useCallback(
     (value: string | null) => {
       setValue(value);
-      onEnter?.(restoreTimezone(value));
+      setFocused(false);
+      const restored = restoreTimezone(value);
+      onChange?.(restored);
+      onBlur?.(restored);
     },
-    [restoreTimezone, onEnter],
+    [restoreTimezone, onChange, onBlur],
   );
 
   const handleFocus = useCallback(() => {
@@ -76,11 +77,11 @@ export const TableActionInputDate = ({
         wrapper: classNames?.wrapper,
         input: classNames?.dateTextInputElement,
       }}
-      // Keeps popover mounted when focused to improve time editing UX
       popoverProps={{ opened: isFocused }}
       onChange={handleChange}
       onBlur={handleBlur}
       onFocus={handleFocus}
+      onClick={handleFocus}
       onKeyUp={handleKeyUp}
       {...inputProps}
     />


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70647
Closes [GDGT-1946](https://linear.app/metabase/issue/GDGT-1946), #70647

### Description

Adding a row to an editable table failed when the table had a required `DATE` column — the **Create** button stayed disabled no matter what date you picked.

This happened because `TableActionInputDate` didn't emit an `onChange` event on pick, so the value never reached the modal's Formik state and the form stayed invalid. The fix aligns it with the other atomic selects (boolean, dropdown): it now emits `onChange` (and commits on `onBlur` instead of `onEnter`).

**Note:** the issue was reported on MySQL, but it affected Postgres too — it's a frontend bug independent of the driver, which is why the regression test runs against Postgres.

### How to verify

Follow the reproduction steps in the original issue (#70647) — adding a row to a table with a required `DATE` column should now work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR