### PR TITLE
Select schema if it is missing

### DIFF
--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -304,7 +304,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
 describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   const MONGO_DB_NAME = "QA Mongo";
   const MONGO_DB_ID = 2;
-  before(() => {
+  beforeEach(() => {
     cy.intercept("POST", "/api/card").as("createQuestion");
     cy.intercept("POST", "/api/dataset").as("dataset");
 

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
@@ -401,6 +401,7 @@ export class UnconnectedDataSelector extends Component {
       selectedSchema,
       selectedTable,
       selectedField,
+      schemas,
     } = this.state;
 
     const invalidSchema =
@@ -428,6 +429,19 @@ export class UnconnectedDataSelector extends Component {
       selectedField &&
       selectedField.table.id !== selectedTable.id;
 
+    // A database with a single schema auto-selects it (see `skipSteps`). When the
+    // schema list arrives asynchronously *after* we already switched to the schema
+    // step (e.g. a freshly selected Mongo database in the native editor), that
+    // auto-selection ran against stale state and didn't advance, leaving us
+    // stranded on the schema step. Retry it now that the schema is available.
+    const onStepMissingOnlySchemaSelection =
+      activeStep === SCHEMA_STEP &&
+      !selectedSchema &&
+      this.props.useOnlyAvailableSchema &&
+      !this.props.readOnly &&
+      this.props.selectedSchemaId == null &&
+      schemas.length === 1;
+
     if (invalidSchema || onStepMissingSchemaAndTable) {
       await this.switchToStep(SCHEMA_STEP, {
         selectedSchemaId: null,
@@ -441,6 +455,8 @@ export class UnconnectedDataSelector extends Component {
       });
     } else if (invalidField) {
       await this.switchToStep(FIELD_STEP, { selectedFieldId: null });
+    } else if (onStepMissingOnlySchemaSelection) {
+      await this.onChangeSchema(schemas[0]);
     }
   }
 

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
@@ -433,13 +433,16 @@ export class UnconnectedDataSelector extends Component {
     // schema list arrives asynchronously *after* we already switched to the schema
     // step (e.g. a freshly selected Mongo database in the native editor), that
     // auto-selection ran against stale state and didn't advance, leaving us
-    // stranded on the schema step. Retry it now that the schema is available.
+    // stranded on the schema step. Retry it now that the schema is available,
+    // but only if schema selection is truly missing in both controlled and
+    // uncontrolled usage.
     const onStepMissingOnlySchemaSelection =
       activeStep === SCHEMA_STEP &&
       !selectedSchema &&
       this.props.useOnlyAvailableSchema &&
       !this.props.readOnly &&
       this.props.selectedSchemaId == null &&
+      this.state.selectedSchemaId == null &&
       schemas.length === 1;
 
     if (invalidSchema || onStepMissingSchemaAndTable) {

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.unit.spec.js
@@ -220,6 +220,55 @@ describe("DataSelector", () => {
     expect(await screen.findByText("Orders")).toBeInTheDocument();
   });
 
+  it("should auto-advance past a single schema that loads asynchronously", async () => {
+    // Reproduces a flake in the native editor's table picker for single-schema
+    // databases (e.g. Mongo): when the schema list arrives *after* the picker
+    // has already switched to the schema step, the lone schema must still be
+    // auto-selected so the user lands on the table list rather than getting
+    // stranded on the schema step.
+    const fetchDatabases = jest.fn();
+    const fetchSchemas = jest.fn();
+    const fetchSchemaTables = jest.fn();
+
+    const metadataWithoutTables = createMockMetadata({
+      databases: [createMockDatabase({ id: SAMPLE_DB_ID, tables: [] })],
+    });
+
+    const props = {
+      steps: ["SCHEMA", "TABLE"],
+      selectedDatabaseId: SAMPLE_DB_ID,
+      triggerElement: <div />,
+      isOpen: true,
+      fetchDatabases,
+      fetchSchemas,
+      fetchSchemaTables,
+    };
+
+    const { rerender } = render(
+      <DataSelector
+        {...props}
+        databases={[metadataWithoutTables.database(SAMPLE_DB_ID)]}
+        metadata={metadataWithoutTables}
+      />,
+    );
+
+    // entering the schema step triggers a schema fetch
+    await delay(1);
+    expect(fetchSchemas).toHaveBeenCalled();
+    expect(screen.queryByText("Orders")).not.toBeInTheDocument();
+
+    // the schema (and its tables) arrive asynchronously
+    rerender(
+      <DataSelector
+        {...props}
+        databases={[metadata.database(SAMPLE_DB_ID)]}
+        metadata={metadata}
+      />,
+    );
+
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
+  });
+
   it("shouldn't fetch databases until it's opened", async () => {
     const fetchDatabases = jest.fn();
     render(


### PR DESCRIPTION
Closes DEV-2010

A database with a single schema auto-selects it (see `skipSteps`). 
If the schema list arrives asynchronously after we already switched to the schema
step (e.g. a freshly selected Mongo database in the native editor), that
auto-selection ran against stale state and didn't advance, leaving us
stranded on the schema step.

Retry it now that the schema is available.

This flake was likely caused due to timing differences after removing the Schema entity and switching to RTK hooks.


[stress test](https://github.com/metabase/metabase/actions/runs/26551916354)