### PR TITLE
Handle query cache update race

### DIFF
--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require
    [java-time.api :as t]
+   [metabase.app-db.core :as app-db]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.util.date-2 :as u.date]
@@ -87,13 +88,9 @@
   (let [final-results (encryption/maybe-encrypt-for-stream results)
         timestamp     (t/offset-date-time)]
     (try
-      (or (pos? (t2/update! :model/QueryCache {:query_hash query-hash}
-                            {:updated_at timestamp
-                             :results    final-results}))
-          (first (t2/insert-returning-instances! :model/QueryCache
-                                                 :updated_at timestamp
-                                                 :query_hash query-hash
-                                                 :results final-results)))
+      (app-db/update-or-insert! :model/QueryCache {:query_hash query-hash}
+                                (constantly {:updated_at timestamp
+                                             :results    final-results}))
       (catch Throwable e
         (log/error e "Error saving query results to cache.")))
     nil))

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -8,7 +8,9 @@
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.test :as mt]
    [metabase.util.encryption-test :as encryption-test])
-  (:import (java.sql Connection)))
+  (:import
+   (java.sql Connection)
+   (java.util.concurrent CountDownLatch TimeUnit)))
 
 (set! *warn-on-reflection* true)
 
@@ -38,3 +40,43 @@
           (let [cached (codecs/bytes->str (cache-results conn))]
             (is (str/starts-with? cached "AES/CBC/PKCS5Padding"))
             (is (not (str/includes? cached "cache-value")))))))))
+
+(deftest save-results-concurrent-race-test
+  (testing "Concurrent save-results! calls with the same query hash should not violate the PK constraint (#73770)"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      ;; Real query hashes are 32-byte SHA-256 digests; the query_cache PK is BINARY(32). With a
+      ;; shorter hash, H2 pads stored values with zeros, so a subsequent select-by-hash would not
+      ;; match — masking the retry logic in update-or-insert!.
+      (let [query-hash    (byte-array 32 (map byte (concat (.getBytes "race-test-hash") (repeat 0))))
+            results-bytes (codecs/to-bytes "result-bytes")
+            ;; Force both threads into the INSERT call simultaneously, so they both attempt to
+            ;; insert the same primary key. The latch wraps both t2 insert variants so the race
+            ;; is deterministically exercised regardless of which one the implementation uses.
+            latch                (CountDownLatch. 2)
+            ins-pks-var          (requiring-resolve 'toucan2.core/insert-returning-pk!)
+            ins-instances-var    (requiring-resolve 'toucan2.core/insert-returning-instances!)
+            orig-ins-pks         @ins-pks-var
+            orig-ins-instances   @ins-instances-var
+            await-race!          (fn [model]
+                                   (when (= model :model/QueryCache)
+                                     (.countDown latch)
+                                     (.await latch 5 TimeUnit/SECONDS)))
+            coordinated-ins-pks  (fn [& args]
+                                   (await-race! (first args))
+                                   (apply orig-ins-pks args))
+            coordinated-ins-inst (fn [& args]
+                                   (await-race! (first args))
+                                   (apply orig-ins-instances args))
+            cache-backend        (i/cache-backend :db)]
+        #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+        (with-redefs-fn {ins-pks-var       coordinated-ins-pks
+                         ins-instances-var coordinated-ins-inst}
+          (fn []
+            (mt/with-log-messages-for-level [messages :error]
+              (mt/repeat-concurrently 2 #(i/save-results! cache-backend query-hash results-bytes))
+              (testing "both threads reached the coordination point (otherwise the race wasn't exercised)"
+                (is (zero? (.getCount latch))))
+              (testing "no \"Error saving query results to cache.\" should be logged"
+                (is (empty? (filter #(some-> % :message (str/includes? "Error saving query results to cache"))
+                                    (messages))))))))))))


### PR DESCRIPTION
Closes #73770

### Description

The s
### How to verify

When several threads were executing the same query concurrently, both could see `t2/update!` not updating any records and try to insert.

The solution is to use `update-or-insert!` created for such situations.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
