### PR TITLE
add dev server for local development

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -201,6 +201,7 @@
         "@redocly/cli": "^2.14.3",
         "@rspack/cli": "^2.0.3",
         "@rspack/core": "^2.0.3",
+        "@rspack/dev-server": "^2.0.1",
         "@rspack/plugin-react-refresh": "^2.0.0",
         "@sinonjs/fake-timers": "^9.1.2",
         "@storybook/addon-a11y": "^8.5.0",
@@ -1434,6 +1435,10 @@
     "@rspack/cli": ["@rspack/cli@2.0.3", "", { "peerDependencies": { "@rspack/core": "^2.0.0-0", "@rspack/dev-server": "^2.0.0-0" }, "optionalPeers": ["@rspack/dev-server"], "bin": { "rspack": "bin/rspack.js" } }, "sha512-h/Xbkupx82UaPr5Ye3hNORi5eXmpEGSPri7WkEOrKIcT+Y3h603kujCQziNIPX3G4UURWPiksIArp1GBTF+A9w=="],
 
     "@rspack/core": ["@rspack/core@2.0.3", "", { "dependencies": { "@rspack/binding": "2.0.3" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": ">=0.5.1" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-2ufO/8FHIA/lX6UOgSsKPhpDvHr0sh9lYq/n/LsIZsTwu3973BGbu2fg1Akvuu3rEnskPqXjsqH2EPBzEA42uA=="],
+
+    "@rspack/dev-middleware": ["@rspack/dev-middleware@2.0.1", "", { "peerDependencies": { "@rspack/core": "^2.0.0-0" }, "optionalPeers": ["@rspack/core"] }, "sha512-cXSubf5/C+dvkWV2/+rGTtiZ93wSLd3OlTQhwMvsmsmGDdPlkYqIvQ+BTkOk9UCXxKIaF0DDYYmCpBeRRYJfJw=="],
+
+    "@rspack/dev-server": ["@rspack/dev-server@2.0.1", "", { "dependencies": { "@rspack/dev-middleware": "^2.0.1" }, "peerDependencies": { "@rspack/core": "^2.0.0-0", "selfsigned": "^5.0.0" }, "optionalPeers": ["selfsigned"] }, "sha512-N5sIdU9v6WhwPH6Ek8QCj4IMvGd8jA3ZW1NMAyHP1ezzKIr2/idcNV2zX5vbC6FJvOLRLww0rFjfKA+z4tshDA=="],
 
     "@rspack/plugin-react-refresh": ["@rspack/plugin-react-refresh@2.0.0", "", { "peerDependencies": { "@rspack/core": "^2.0.0-0", "react-refresh": ">=0.10.0 <1.0.0" }, "optionalPeers": ["@rspack/core"] }, "sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g=="],
 

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "@redocly/cli": "^2.14.3",
     "@rspack/cli": "^2.0.3",
     "@rspack/core": "^2.0.3",
+    "@rspack/dev-server": "^2.0.1",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@sinonjs/fake-timers": "^9.1.2",
     "@storybook/addon-a11y": "^8.5.0",


### PR DESCRIPTION
Adds `@rspack/dev-server` as a development dependency, as it's now a separate requirement after upgrading to `rspack 2.0.3`