### PR TITLE
Disable rspack lazy compilation in dev mode

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -337,6 +337,9 @@ if (shouldEnableHotRefresh) {
   config.output.publicPath =
     `http://localhost:${PORT}/` + config.output.publicPath;
 
+  // Disable lazy compilation explicitly to match behavior of rspack 1.x
+  config.lazyCompilation = false;
+
   config.devServer = {
     port: PORT, // make the port explicit so it errors if it's already in use
     hot: true,


### PR DESCRIPTION
Closes [GDGT-2488](https://linear.app/metabase/issue/GDGT-2488)

### Description

When running the dev environment after the rspack/swc upgrade (#74564), creating a visualization — and any other lazily-imported feature — breaks with a 500. `@rspack/cli` 2.0 auto-enables `lazyCompilation` (`{ imports: true, entries: false }`) for web-only targets whenever the config doesn't set it; this is new behavior that 1.x didn't have. We hit it because `rspack.main.config.js` is `target: "web"` and never set `lazyCompilation`.

The lazy-compilation client posts to a *relative* URL (`/_rspack/lazy/trigger__N`) to trigger on-demand compilation. Since `index.html` is served by the backend on `:3000` while the dev server runs on `:8080`, those POSTs land on the Clojure backend, which has no `/_rspack/*` route and returns a 500.

This sets `config.lazyCompilation = false` in the hot-refresh block to restore the rspack 1.x behavior (eager compilation). We can later explore setting it up properly (as this has potential to make dev builds faster), but main goal of this PR is to fix and unblock master.

### How to verify

1. On `master` (with the rspack upgrade), run the dev environment (`bun run dev`, or the backend + `bun run build-hot:js`).
2. Open the app at http://localhost:3000, create a question, and run it / build a visualization.
3. Without this fix: it fails, and devtools shows `POST http://localhost:3000/_rspack/lazy/trigger__0` returning 500 (Clojure `StreamableResponseBody` error in the backend log).
4. With this fix: no `/_rspack/lazy/*` requests are made; visualizations work normally.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR