### PR TITLE
Guard v60 dependency_status drop changesets against missing source columns

### DIFF
--- a/resources/migrations/060/20260402_dependency_status.yaml
+++ b/resources/migrations/060/20260402_dependency_status.yaml
@@ -259,6 +259,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:11
       author: ericnormand
       comment: Drop dependency_analysis_version index from report_card
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: report_card
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: report_card
@@ -275,6 +281,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:12
       author: ericnormand
       comment: Drop dependency_analysis_version index from transform
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: transform
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: transform
@@ -291,6 +303,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:13
       author: ericnormand
       comment: Drop dependency_analysis_version index from native_query_snippet
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: native_query_snippet
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: native_query_snippet
@@ -307,6 +325,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:14
       author: ericnormand
       comment: Drop dependency_analysis_version index from report_dashboard
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: report_dashboard
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: report_dashboard
@@ -323,6 +347,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:15
       author: ericnormand
       comment: Drop dependency_analysis_version index from document
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: document
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: document
@@ -339,6 +369,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:16
       author: ericnormand
       comment: Drop dependency_analysis_version index from sandboxes
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: sandboxes
+            columnName: dependency_analysis_version
       changes:
         - dropIndex:
             tableName: sandboxes
@@ -357,6 +393,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:17
       author: ericnormand
       comment: Drop dependency_analysis_version column from report_card
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: report_card
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: report_card
@@ -376,6 +418,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:18
       author: ericnormand
       comment: Drop dependency_analysis_version column from transform
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: transform
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: transform
@@ -395,6 +443,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:19
       author: ericnormand
       comment: Drop dependency_analysis_version column from native_query_snippet
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: native_query_snippet
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: native_query_snippet
@@ -414,6 +468,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:20
       author: ericnormand
       comment: Drop dependency_analysis_version column from report_dashboard
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: report_dashboard
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: report_dashboard
@@ -433,6 +493,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:21
       author: ericnormand
       comment: Drop dependency_analysis_version column from document
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: document
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: document
@@ -452,6 +518,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:22
       author: ericnormand
       comment: Drop dependency_analysis_version column from sandboxes
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: sandboxes
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: sandboxes
@@ -471,6 +543,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:23
       author: ericnormand
       comment: Drop dependency_analysis_version column from segment
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: segment
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: segment
@@ -490,6 +568,12 @@ databaseChangeLog:
       id: v60.2026-04-02T00:00:24
       author: ericnormand
       comment: Drop dependency_analysis_version column from measure
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: measure
+            columnName: dependency_analysis_version
       changes:
         - dropColumn:
             tableName: measure

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2933,15 +2933,20 @@
                                                   :updated_at     :%now}))))))))
 
 (deftest dependency-status-segment-handles-missing-column-migration-test
-  (testing "Migration v60.2026-04-02T00:00:09 MARK_RANs when segment.dependency_analysis_version is missing (issue #74443)"
-    (impl/test-migrations ["v60.2026-04-02T00:00:09" "v60.2026-04-02T00:00:09"] [migrate!]
-      ;; Simulate the broken partial-migration state: source column gone before the data-migration runs.
+  (testing "The whole 20260402_dependency_status changeset run survives a missing
+            segment.dependency_analysis_version column (issue #74443). Every changeset that
+            touches the column — the INSERT (T00:00:09) and the DROP COLUMN (T00:00:23) —
+            must MARK_RAN rather than fail."
+    (impl/test-migrations ["v60.2026-04-02T00:00:09" "v60.2026-04-02T00:00:24"] [migrate!]
+      ;; Simulate an instance whose segment table never got dependency_analysis_version.
       (t2/query "ALTER TABLE segment DROP COLUMN dependency_analysis_version")
+      ;; Must not throw: the migration run completes despite the missing column.
       (migrate!)
-      (testing "T00:00:09 is recorded as MARK_RAN"
-        (is (= "MARK_RAN"
-               (:exectype (liquibase/changelog-by-id mdb.connection/*application-db*
-                                                     "v60.2026-04-02T00:00:09"))))))))
+      (doseq [id ["v60.2026-04-02T00:00:09"   ; INSERT … SELECT FROM segment
+                  "v60.2026-04-02T00:00:23"]] ; ALTER TABLE segment DROP COLUMN
+        (testing (str id " is recorded as MARK_RAN")
+          (is (= "MARK_RAN"
+                 (:exectype (liquibase/changelog-by-id mdb.connection/*application-db* id)))))))))
 
 ;;;
 ;;; 62 tests


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74443
## Summary

Follow-up to #74463, for [GHY-3638](https://linear.app/metabase/issue/GHY-3638) / #74443.

#74463 added `columnExists` + `onFail: MARK_RAN` guards to the eight **INSERT** changesets (`T00:00:03–10`) in `migrations/060/20260402_dependency_status.yaml`. But the migration touches each entity table's `dependency_analysis_version` column in **three** phases:

| Phase | Changesets | Guarded by #74463? |
|---|---|---|
| `INSERT … SELECT` | T00:00:03–10 | ✅ |
| `DROP INDEX` | T00:00:11–16 | ❌ |
| `DROP COLUMN` | T00:00:17–24 | ❌ |

On an instance whose entity table never received `dependency_analysis_version`, the INSERT now skips cleanly — so the migration *proceeds* and then fails on the unguarded DROP instead:

```
Migration failed for changeset migrations/060/20260402_dependency_status.yaml::v60.2026-04-02T00:00:23::ericnormand:
Reason: ERROR: column "dependency_analysis_version" of relation "segment" does not exist
[Failed SQL: ALTER TABLE public.segment DROP COLUMN dependency_analysis_version]
```

Observed in production on `v1.61.2.2` — the original fix moved the failure from `T00:00:09` to `T00:00:23` rather than resolving it.

## Fix

Add the same `columnExists` precondition with `onFail: MARK_RAN` (plus `validCheckSum: ANY`) to all fourteen drop changesets (`T00:00:11–24`). Now every changeset that touches an entity table's `dependency_analysis_version` is guarded consistently — if the column isn't there, the changeset is recorded as `MARK_RAN` and the migration continues.

A uniform `columnExists` guard (rather than `indexExists` for the index drops) encodes the migration's actual invariant — "this entity table has the column" — and is the most reliable precondition across H2 / MySQL / MariaDB / Postgres.

## Test plan

- [x] Regression test widened from the single changeset `T00:00:09` to the **full file range** `T00:00:09–T00:00:24` against a missing-column instance; asserts both the INSERT (`T00:00:09`) and the DROP COLUMN (`T00:00:23`) are recorded as `MARK_RAN`.
- [x] **Negative check**: with the `T00:00:23` guard removed, the test errors with the exact production failure — confirming the test has teeth (the previous test only covered `T00:00:09`, which is why this gap shipped).
- [x] Test passes on H2 and Postgres.
- [x] Clojure-kondo: 0 errors, 0 warnings.