### PR TITLE
Add documents to search page

### DIFF
--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -44,6 +44,10 @@ const typeFilters = [
     label: "Indexed record",
     type: "indexed-entity",
   },
+  {
+    label: "Document",
+    type: "document",
+  },
 ];
 
 const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -156,6 +160,20 @@ describe("scenarios > search", () => {
             pkName: "ID",
             valueName: "TITLE",
           });
+        });
+
+        H.createDocument({
+          name: "Releases overview",
+          document: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                attrs: { _id: "1" },
+                content: [{ type: "text", text: "Document body" }],
+              },
+            ],
+          },
         });
       });
 

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -22,6 +22,7 @@ export const enabledSearchTypes: EnabledSearchModel[] = [
   "table",
   "action",
   "indexed-entity",
+  "document",
 ];
 
 export const SearchContextTypes = {


### PR DESCRIPTION
### Description

Adds `Document` as a filter option on the search page. The API already supported it, so it was an FE only change

### How to verify
1. Open the command palette and type a search query
2. Click "View and filter all results"
3. On the search page, you should be able to search specifically for Documents


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
