### PR TITLE
Adds link support to Dashboard PDFs

### DIFF
--- a/frontend/src/metabase/dashboard/visualizations/Text/Text.styled.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/Text/Text.styled.tsx
@@ -243,7 +243,7 @@ export const ReactMarkdownStyleWrapper = styled.div`
   }
 
   .text-card-markdown a {
-    display: inline-block;
+    display: inline;
     font-weight: bold;
     cursor: pointer;
     text-decoration: none;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -135,6 +135,67 @@ export const getPageBreaks = (
   return result;
 };
 
+interface LinkBox {
+  url: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const SUPPORTED_LINK_PROTOCOL = /^(https?:|mailto:|tel:)/i;
+
+// Coordinates are relative to gridNode; the rendered canvas shifts them down by verticalOffset.
+export const collectClickableLinks = (gridNode: HTMLElement): LinkBox[] => {
+  const gridRect = gridNode.getBoundingClientRect();
+  return Array.from(gridNode.querySelectorAll<HTMLAnchorElement>("a[href]"))
+    .map((anchor) => {
+      const url = anchor.href;
+      if (!url || !SUPPORTED_LINK_PROTOCOL.test(url)) {
+        return null;
+      }
+      const rect = anchor.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) {
+        return null;
+      }
+      return {
+        url,
+        x: rect.left - gridRect.left,
+        y: rect.top - gridRect.top,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+    .filter((link): link is LinkBox => link !== null);
+};
+
+export const getLinkAnnotationsForPage = (
+  links: LinkBox[],
+  pageStartCanvasY: number,
+  pageHeightCanvasY: number,
+  verticalOffset: number,
+  pagePadding: number,
+): LinkBox[] => {
+  const pageEnd = pageStartCanvasY + pageHeightCanvasY;
+  return links.flatMap((link) => {
+    const canvasTop = link.y + verticalOffset;
+    const canvasBottom = canvasTop + link.height;
+    // Skip links that straddle a page break — we don't split annotations.
+    if (canvasTop < pageStartCanvasY || canvasBottom > pageEnd) {
+      return [];
+    }
+    return [
+      {
+        url: link.url,
+        x: pagePadding + link.x,
+        y: pagePadding + (canvasTop - pageStartCanvasY),
+        width: link.width,
+        height: link.height,
+      },
+    ];
+  });
+};
+
 const createHeaderElement = (dashboardName: string, marginBottom: number) => {
   const header = document.createElement("div");
   header.style.cssText = `
@@ -189,6 +250,7 @@ export const saveDashboardPdf = async ({
     return;
   }
   const cardsBounds = getSortedDashCardBounds(gridNode);
+  const clickableLinks = collectClickableLinks(gridNode);
 
   const pdfHeader = createHeaderElement(dashboardName, HEADER_MARGIN_BOTTOM);
   const parametersNode = dashboardRoot
@@ -368,6 +430,19 @@ export const saveDashboardPdf = async ({
         pdf.link(PAGE_PADDING, PAGE_PADDING, contentWidth, brandingHeight, {
           url,
         });
+      }
+
+      // Re-add clickable links that were flattened into the page image so
+      // anchors in markdown text / link cards stay clickable in the PDF.
+      const pageLinks = getLinkAnnotationsForPage(
+        clickableLinks,
+        sourceY,
+        sourceHeight,
+        verticalOffset,
+        PAGE_PADDING,
+      );
+      for (const link of pageLinks) {
+        pdf.link(link.x, link.y, link.width, link.height, { url: link.url });
       }
     }
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -148,24 +148,27 @@ const SUPPORTED_LINK_PROTOCOL = /^(https?:|mailto:|tel:)/i;
 // Coordinates are relative to gridNode; the rendered canvas shifts them down by verticalOffset.
 export const collectClickableLinks = (gridNode: HTMLElement): LinkBox[] => {
   const gridRect = gridNode.getBoundingClientRect();
-  return Array.from(gridNode.querySelectorAll<HTMLAnchorElement>("a[href]"))
+  return Array.from(
+    gridNode.querySelectorAll<HTMLAnchorElement>(
+      '[data-viz-ui-name="Text"] a[href]',
+    ),
+  )
     .map((anchor) => {
       const url = anchor.href;
       if (!url || !SUPPORTED_LINK_PROTOCOL.test(url)) {
         return null;
       }
-      const rect = anchor.getBoundingClientRect();
-      if (rect.width <= 0 || rect.height <= 0) {
-        return null;
-      }
-      return {
-        url,
-        x: rect.left - gridRect.left,
-        y: rect.top - gridRect.top,
-        width: rect.width,
-        height: rect.height,
-      };
+      return Array.from(anchor.getClientRects())
+        .filter((rect) => rect.width > 0 && rect.height > 0)
+        .map((rect) => ({
+          url,
+          x: rect.left - gridRect.left,
+          y: rect.top - gridRect.top,
+          width: rect.width,
+          height: rect.height,
+        }));
     })
+    .flat()
     .filter((link): link is LinkBox => link !== null);
 };
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
@@ -1,4 +1,8 @@
-import { findPageBreakCandidates, getPageBreaks } from "./save-dashboard-pdf";
+import {
+  findPageBreakCandidates,
+  getLinkAnnotationsForPage,
+  getPageBreaks,
+} from "./save-dashboard-pdf";
 
 describe("save-dashboard-pdf", () => {
   describe("findPageBreakCandidates", () => {
@@ -167,6 +171,158 @@ describe("save-dashboard-pdf", () => {
       // of only 150px height, which is less than minimum, so no breaks should occur
       const breaks = getPageBreaks(cards, 250, 400, 200);
       expect(breaks).toEqual([]);
+    });
+  });
+
+  describe("getLinkAnnotationsForPage (metabase#35742)", () => {
+    const verticalOffset = 50;
+    const pagePadding = 16;
+
+    it("places a link on the first page when it falls within the page slice", () => {
+      const links = [
+        { url: "https://example.com", x: 10, y: 100, width: 80, height: 20 },
+      ];
+
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        0,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      // Canvas-space top = link.y + verticalOffset = 150
+      // PDF y = pagePadding + (canvasTop - pageStart) = 16 + 150 = 166
+      expect(annotations).toEqual([
+        {
+          url: "https://example.com",
+          x: 16 + 10,
+          y: 16 + 150,
+          width: 80,
+          height: 20,
+        },
+      ]);
+    });
+
+    it("translates link coordinates relative to the page slice on later pages", () => {
+      const links = [
+        { url: "https://example.com", x: 5, y: 350, width: 60, height: 18 },
+      ];
+
+      // Page starts at canvas y=400 (after vertical offset, link sits at 400)
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        400,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      // canvasTop = 350 + 50 = 400, pageStart = 400 → relative y = 0
+      expect(annotations).toEqual([
+        {
+          url: "https://example.com",
+          x: 16 + 5,
+          y: 16 + 0,
+          width: 60,
+          height: 18,
+        },
+      ]);
+    });
+
+    it("excludes links above the current page slice", () => {
+      const links = [
+        { url: "https://example.com", x: 0, y: 10, width: 50, height: 15 },
+      ];
+
+      // canvasTop = 60 — sits in page 1, not page 2
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        200,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      expect(annotations).toEqual([]);
+    });
+
+    it("excludes links below the current page slice", () => {
+      const links = [
+        { url: "https://example.com", x: 0, y: 500, width: 50, height: 15 },
+      ];
+
+      // canvasTop = 550 — sits in a later page, not page 1
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        0,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      expect(annotations).toEqual([]);
+    });
+
+    it("excludes links that straddle a page break", () => {
+      const links = [
+        { url: "https://example.com", x: 0, y: 240, width: 100, height: 40 },
+      ];
+
+      // canvasTop = 290, canvasBottom = 330, pageEnd = 300 → straddles, skip
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        0,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      expect(annotations).toEqual([]);
+    });
+
+    it("returns an empty list when there are no links", () => {
+      const annotations = getLinkAnnotationsForPage(
+        [],
+        0,
+        300,
+        verticalOffset,
+        pagePadding,
+      );
+
+      expect(annotations).toEqual([]);
+    });
+
+    it("includes multiple links on the same page", () => {
+      const links = [
+        { url: "https://a.example", x: 0, y: 10, width: 50, height: 15 },
+        { url: "https://b.example", x: 60, y: 30, width: 70, height: 18 },
+      ];
+
+      const annotations = getLinkAnnotationsForPage(
+        links,
+        0,
+        500,
+        verticalOffset,
+        pagePadding,
+      );
+
+      expect(annotations).toEqual([
+        {
+          url: "https://a.example",
+          x: 16,
+          y: 16 + 60,
+          width: 50,
+          height: 15,
+        },
+        {
+          url: "https://b.example",
+          x: 16 + 60,
+          y: 16 + 80,
+          width: 70,
+          height: 18,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #35742
### Description

Compute link positions and add them in when creating dashboard PDFs. Still doesn't work for images though, since we can't render those as in dashboard PDFs. 

### How to verify
1. Go to a dashboard
2. Ensure that there is a text card with some markdown in it that contains a link. eg: `[link](http://google.ca)`.
3. Export that dashboard as a PDF. The pdf should have a clickable link 

### Demo

https://github.com/user-attachments/assets/f966e030-8581-494e-9a15-7c96bfe6ab31


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
