### PR TITLE
Fix /api/frontend-errors 404 in embedded contexts

### DIFF
--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -20,6 +20,9 @@ const getBaseUrlByEmbedType = (embedType: EmbedType): string =>
 const getIgnoreOverridePatterns = () => [
   sessionPropertiesPath,
   PLUGIN_CONTENT_TRANSLATION.getDictionaryBasePath,
+  // `/api/frontend-errors` only exists at the canonical path (see
+  // metabase.frontend-errors.api) — rewriting it would 404.
+  "/api/frontend-errors",
 ];
 
 /**
@@ -182,7 +185,7 @@ function replaceWithEmbedBase({
   return url;
 }
 
-const overrideRequests = async ({
+export const overrideRequests = async ({
   embedType,
   method,
   url,

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
@@ -1,4 +1,7 @@
-import { matchUrlPattern } from "./override-requests-for-embeds";
+import {
+  matchUrlPattern,
+  overrideRequests,
+} from "./override-requests-for-embeds";
 
 describe("matchUrlPattern", () => {
   it("should match URL with single parameter", () => {
@@ -89,5 +92,50 @@ describe("matchUrlPattern", () => {
         "/api/dashboard/789/params/456/remapping",
       ),
     ).toBe(true);
+  });
+});
+
+describe("overrideRequests", () => {
+  const defaultOptions = { hasBody: false };
+
+  it.each(["guest", "static", "public"] as const)(
+    "leaves /api/frontend-errors untouched in %s embed mode",
+    async (embedType) => {
+      const result = await overrideRequests({
+        embedType,
+        method: "POST",
+        url: "/api/frontend-errors",
+        options: { ...defaultOptions, hasBody: true },
+        data: { type: "component-crash" },
+      });
+
+      expect(result.url).toBe("/api/frontend-errors");
+      expect(result.method).toBe("POST");
+    },
+  );
+
+  it("still applies the default /api → /api/embed rewrite to passthrough endpoints", async () => {
+    const result = await overrideRequests({
+      embedType: "guest",
+      method: "GET",
+      url: "/api/card/THE_JWT_TOKEN",
+      options: defaultOptions,
+      data: {},
+    });
+
+    expect(result.url).toBe("/api/embed/card/THE_JWT_TOKEN");
+  });
+
+  it("still applies explicit transformations (card query → embed card query)", async () => {
+    const result = await overrideRequests({
+      embedType: "guest",
+      method: "POST",
+      url: "/api/card/123/query",
+      options: { ...defaultOptions, hasBody: true },
+      data: {},
+    });
+
+    expect(result.url).toBe("/api/embed/card/:token/query");
+    expect(result.method).toBe("GET");
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74599
Closes [EMB-1770: Frontend errors are always posted to an invalid endpoint](https://linear.app/metabase/issue/EMB-1770/frontend-errors-are-always-posted-to-an-invalid-endpoint)

### Description

`/api/frontend-errors` only exists at its canonical path (see `metabase.frontend-errors.api`), but in embedded contexts the request override pipeline runs every URL through `replaceWithEmbedBase`, which blindly substitutes `/api` → `/api/embed` (or `/api/public`) when no explicit transformation applies. That turned `POST /api/frontend-errors` into a 404 against `/api/embed/frontend-errors`, so the frontend error reporting feature has been broken in guest embeds since the override mechanism was introduced and in public/static embeds since #67358 generalized it.

`getIgnoreOverridePatterns` already opts a couple of endpoints out of the rewrite (`/api/session/properties`, the content-translation dictionary path). This PR adds `/api/frontend-errors` to that list.

### How to verify

1. Run Metabase from source.
2. In `frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx`, make `CartesianChartInner` throw immediately (e.g. `throw new Error("boom")`).
3. Generate a Guest embed for any dashboard, copy the HTML, serve it from a separate web server (e.g. `python -m http.server`).
4. Open it and watch the network panel.
   - Before: `POST /api/embed/frontend-errors` → 404.
   - After: `POST /api/frontend-errors` → 204.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR