### PR TITLE
adjust min height of container so that there is no scroll for simple series

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -51,7 +51,7 @@ export const ChartSettingsWidgetPopover = ({
           <Box
             pt={hasMultipleSections ? 0 : undefined}
             ref={contentRef}
-            mah="37.5rem"
+            mah="40rem"
             miw="336px"
             className={CS.overflowYAuto}
           >


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74530
### Description

Adds 4px to the size of the popover for series formatting so that for non currency series, we don't have a 4px scroll

### How to verify
1. New -> Question
2. Orders -> Count -> group by created at
3. in the viz settings, open the count series formatting
4. open the formatting tab, and attempt to scroll

### Demo

<img width="762" height="731" alt="image" src="https://github.com/user-attachments/assets/16664a04-9ecb-4680-b18f-e88ac28c586d" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
