### PR TITLE
Add overflow-wrap to tooltip content globally

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -6,7 +6,7 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS_ID, ORDERS_ID } = SAMPLE_DATABASE;
 
 const verifiedFilterToggleButton = () =>
   cy
@@ -407,5 +407,34 @@ describe("issue 37907", () => {
 
     H.tableInteractive().findByTextEnsureVisible("Discount ($)").realHover();
     H.popover().should("include.text", "Discount amount.");
+  });
+});
+
+describe("issue 74433", () => {
+  const LONG_TABLE_NAME =
+    "thisisaverylongtablenamewithoutspacesthatshouldoverflowthetooltipboxbecausetherearenospacesforbreakingxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", `/api/table/${ORDERS_ID}`, {
+      display_name: LONG_TABLE_NAME,
+    });
+  });
+
+  it("table-name tooltip in Browse Databases should not overflow when the name has no spaces (metabase#74433)", () => {
+    cy.visit(`/browse/databases/${SAMPLE_DB_ID}`);
+
+    cy.findByRole("heading", { name: LONG_TABLE_NAME }).realHover();
+
+    H.tooltip()
+      .should("be.visible")
+      .and(($tooltip) => {
+        const tooltip = $tooltip[0];
+        expect(
+          tooltip.scrollWidth,
+          "tooltip content fits within its box",
+        ).to.be.lte(tooltip.clientWidth);
+      });
   });
 });

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -425,7 +425,9 @@ describe("issue 74433", () => {
   it("table-name tooltip in Browse Databases should not overflow when the name has no spaces (metabase#74433)", () => {
     cy.visit(`/browse/databases/${SAMPLE_DB_ID}`);
 
-    cy.findByRole("heading", { name: LONG_TABLE_NAME }).realHover();
+    // Browse cards actually have a <Title> as the child of the <Ellipsified> component,
+    // so we need to target the parent for the hover
+    cy.findByRole("heading", { name: LONG_TABLE_NAME }).parent().realHover();
 
     H.tooltip()
       .should("be.visible")

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
@@ -5,6 +5,8 @@
   padding: 0.6rem 0.75rem;
   white-space: unset;
   max-width: 320px;
+  /* Break long unbreakable strings so the tooltip can't overflow its max-width (metabase#74433). */
+  overflow-wrap: anywhere;
 }
 
 .arrow {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74433
### Description

Small update, but could impact a few places. When configuring the Mantine tooltip to be used in Metabase, we set a max width (something not set by default by mantine). However, the tooltip does not have an `overflow-wrap` rule by default, which meant that when content was too long to fix in `320px`, it would overflow out of the contianer.

This change will enable wrapping on all tooltips, including generated tooltips for the `<Ellipsisified>` component

### How to verify
1. Give a table a really long display name
2. Go to the Database reference, and navigate to that table
3. Hover over the ellipsisified name, the tooltop should not overflow

### Demo

<img width="406" height="289" alt="image" src="https://github.com/user-attachments/assets/6e46dadf-4b43-4001-99b6-da3e20462e29" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR