### PR TITLE
Pass column settings when formatting pivot column headers

### DIFF
--- a/frontend/src/metabase/visualizations/lib/data_grid.js
+++ b/frontend/src/metabase/visualizations/lib/data_grid.js
@@ -120,7 +120,7 @@ export function multiLevelPivot(data, settings) {
 }
 
 // This is the pivot function used in the normal table visualization.
-export function pivot(data, normalCol, pivotCol, cellCol) {
+export function pivot(data, normalCol, pivotCol, cellCol, settings) {
   const { pivotValues, normalValues } = distinctValuesSorted(
     data.rows,
     pivotCol,
@@ -154,6 +154,13 @@ export function pivot(data, normalCol, pivotCol, cellCol) {
     sourceRows[normalColIdx][pivotColIdx] = j;
   }
 
+  // Use the pivot column's full visualization settings (date_style, time_style, etc.)
+  // when formatting headers so units like hour-of-day render as just the hour.
+  const pivotColumn = data.cols[pivotCol];
+  const pivotColumnSettings = settings?.column?.(pivotColumn) ?? {
+    column: pivotColumn,
+  };
+
   // provide some column metadata to maintain consistency
   const cols = pivotValues.map(function (value, idx) {
     if (idx === 0) {
@@ -164,11 +171,11 @@ export function pivot(data, normalCol, pivotCol, cellCol) {
         ...data.cols[cellCol],
         // `name` must be the same for conditional formatting, but put the
         // formatted pivotted value in the `display_name`
-        display_name: formatValue(value, { column: data.cols[pivotCol] }) || "",
+        display_name: formatValue(value, pivotColumnSettings) || "",
         // for onVisualizationClick:
         _dimension: {
           value: value,
-          column: data.cols[pivotCol],
+          column: pivotColumn,
         },
       };
     }

--- a/frontend/src/metabase/visualizations/lib/data_grid.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/data_grid.unit.spec.js
@@ -133,6 +133,42 @@ describe("data_grid", () => {
       expect(pivotedData.cols[1].display_name).toEqual(expect.any(String));
     });
 
+    it("should format hour-of-day pivot column headers without the date (metabase#74525)", () => {
+      const Dhour = {
+        name: "Dhour",
+        display_name: "Created At: Hour of day",
+        base_type: TYPE.DateTime,
+        unit: "hour-of-day",
+        source: "breakout",
+      };
+      const data = {
+        rows: [
+          ["a", "2020-01-01T00:00:00", 1],
+          ["a", "2020-01-01T06:00:00", 2],
+          ["b", "2020-01-01T00:00:00", 3],
+          ["b", "2020-01-01T06:00:00", 4],
+        ],
+        cols: [D1, Dhour, M],
+      };
+      const settings = {
+        column: (col) =>
+          col === Dhour
+            ? {
+                column: col,
+                date_style: "",
+                time_style: "h:mm A",
+                time_enabled: "minutes",
+              }
+            : { column: col },
+      };
+      const pivotedData = pivot(data, 0, 1, 2, settings);
+      expect(pivotedData.cols.map((col) => col.display_name)).toEqual([
+        "Dimension 1",
+        "12:00 AM",
+        "6:00 AM",
+      ]);
+    });
+
     it("should infer sort order of sparse data correctly", () => {
       const data = makeData([
         ["a", "x", 1],

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -492,7 +492,13 @@ export class Table extends Component<TableProps, TableState> {
         (col, index) => index !== pivotIndex && index !== cellIndex,
       );
       this.setState({
-        data: DataGrid.pivot(data, normalIndex, pivotIndex, cellIndex),
+        data: DataGrid.pivot(
+          data,
+          normalIndex,
+          pivotIndex,
+          cellIndex,
+          settings,
+        ),
         question,
       });
     } else {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74525
### Description

Small adjustment to how column headers are formatted for pivot tables. The format function is now passed column settings to be used, so things like dates are formatted as we expect they should be. Note that this does not impact static viz.

### How to verify
1. New -> Question
2. Orders -> Count, Grouped by Product Category, Order created at
3. Visualize as a pivot table and ensure that created at is a column for the table

### Demo

<img width="1728" height="992" alt="image" src="https://github.com/user-attachments/assets/d25a28e8-1a07-4226-a1b6-c6b20cef31f6" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR