### PR TITLE
Update persist and refreshModelCache mutation onQueryStarted

### DIFF
--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -150,6 +150,16 @@ describe("scenarios > admin > databases > writable connection", () => {
 
       createWritableConnection(DEFAULT_USER);
       refreshModelPersistenceAndAwaitSuccess(model.id);
+
+      // Regression for metabase#74449: the Persist model data toggle must
+      // reflect the mutation result without a page reload (persistModel
+      // returns HTTP 204, and the UI relies on RTK cache invalidation to
+      // refetch the persisted state).
+      cy.visit(`/model/${model.id}`);
+      H.openQuestionActions("Edit settings");
+      cy.findByLabelText("Persist model data").should("be.checked").click();
+      cy.findByLabelText("Persist model data").should("not.be.checked").click();
+      cy.findByLabelText("Persist model data").should("be.checked");
     });
   });
 

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -35,7 +35,6 @@ import {
   provideParameterValuesTags,
 } from "./tags";
 import { hydrateLegacyEntities } from "./utils/hydrate-legacy-entities";
-import { handleQueryFulfilled } from "./utils/lifecycle";
 
 const PERSISTED_MODEL_REFRESH_DELAY = 200;
 
@@ -241,8 +240,9 @@ export const cardApi = Api.injectEndpoints({
           method: "POST",
           url: `/api/persist/card/${id}/persist`,
         }),
-        onQueryStarted: (id, { dispatch, queryFulfilled }) =>
-          handleQueryFulfilled(queryFulfilled, () => {
+        onQueryStarted: async (id, { dispatch, queryFulfilled }) => {
+          try {
+            await queryFulfilled;
             // we wait to invalidate this tag so the cache refresh has time to start before we refetch
             setTimeout(() => {
               dispatch(
@@ -253,7 +253,10 @@ export const cardApi = Api.injectEndpoints({
                 ]),
               );
             }, PERSISTED_MODEL_REFRESH_DELAY);
-          }),
+          } catch {
+            // mutation failed — nothing to invalidate
+          }
+        },
       }),
       unpersistModel: builder.mutation<void, CardId>({
         query: (id) => ({
@@ -272,8 +275,9 @@ export const cardApi = Api.injectEndpoints({
           method: "POST",
           url: `/api/persist/card/${id}/refresh`,
         }),
-        onQueryStarted: (id, { dispatch, queryFulfilled }) =>
-          handleQueryFulfilled(queryFulfilled, () => {
+        onQueryStarted: async (id, { dispatch, queryFulfilled }) => {
+          try {
+            await queryFulfilled;
             // we wait to invalidate this tag so the cache refresh has time to start before we refetch
             setTimeout(() => {
               dispatch(
@@ -284,7 +288,10 @@ export const cardApi = Api.injectEndpoints({
                 ]),
               );
             }, PERSISTED_MODEL_REFRESH_DELAY);
-          }),
+          } catch {
+            // mutation failed — nothing to invalidate
+          }
+        },
       }),
       listEmbeddableCards: builder.query<GetEmbeddableCard[], void>({
         query: (params) => ({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74449
### Description

Updates the onQueryStarted function to simple await the `queryFullfilled` promise, rather than pass it to `handleQueryFulfilled`. This is because these endpoints return `204` statuses with a response body of `""`, which `handleQueryFulfilled` doesn't handle properly (data will not be of type `object`). This change should be fine, since there is no data to handle anyways.

We could update handleQueryFulfilled, but that would have a much larger scope

### How to verify
1. Go to a model who's database has model persistance enabled
2. Toggle model persistance on and off, the switch should update accordingly

### Demo

https://github.com/user-attachments/assets/a605516e-9fd0-45dc-8d32-8c8b6f1f4f9f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
