### PR TITLE
Embedding wizard: fix docs link and show error when Site URL is misconfigured

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -160,7 +160,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
         .should("have.attr", "href")
         .and(
           "include",
-          "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js#use-existing-user-session-to-test-embeds",
+          "https://www.metabase.com/docs/latest/embedding/authentication#configure-session-cookies-when-testing-locally",
         );
 
       cy.findByTestId("sdk-error-container").should("be.visible");

--- a/frontend/src/embedding-sdk-bundle/errors/error-docs-links.ts
+++ b/frontend/src/embedding-sdk-bundle/errors/error-docs-links.ts
@@ -10,5 +10,5 @@ type ErrorDocLinks = Partial<Record<MetabaseErrorCode, string>>;
 export const ERROR_DOC_LINKS: ErrorDocLinks = {
   EXISTING_USER_SESSION_FAILED:
     // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- error documentation link
-    "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js#use-existing-user-session-to-test-embeds",
+    "https://www.metabase.com/docs/latest/embedding/authentication#configure-session-cookies-when-testing-locally",
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -7,9 +7,11 @@ import "react-resizable/css/styles.css";
 
 import noResultsSource from "assets/img/no_results.svg";
 import { useUpdateSettingsMutation } from "metabase/api";
+import { useSetting } from "metabase/common/hooks";
 import { SdkIframeGuestEmbedStatusBar } from "metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeGuestEmbedStatusBar";
 import { EMBED_STEPS } from "metabase/embedding/embedding-iframe-sdk-setup/constants";
 import { isQuestionOrDashboardSettings } from "metabase/embedding/embedding-iframe-sdk-setup/utils/is-question-or-dashboard-settings";
+import { isSiteUrlMatchingCurrentOrigin } from "metabase/embedding/embedding-iframe-sdk-setup/utils/is-site-url-matching-current-origin";
 import type { SdkIframeEmbedSetupModalProps } from "metabase/plugins";
 import { useDispatch } from "metabase/redux";
 import { closeModal } from "metabase/redux/ui";
@@ -32,6 +34,7 @@ import { useSdkIframeEmbedSetupContext } from "../context";
 import { SdkIframeEmbedPreview } from "./SdkIframeEmbedPreview";
 import S from "./SdkIframeEmbedSetup.module.css";
 import { SdkIframeEmbedSetupProvider } from "./SdkIframeEmbedSetupProvider";
+import { SdkIframeEmbedSiteUrlMismatchError } from "./SdkIframeEmbedSiteUrlMismatchError";
 
 export const SdkIframeEmbedSetupContent = () => {
   const dispatch = useDispatch();
@@ -76,6 +79,9 @@ export const SdkIframeEmbedSetupContent = () => {
 
   const isMissingResource =
     isQuestionOrDashboard && !isLoading && (!resource || resource.archived);
+
+  const siteUrl = useSetting("site-url");
+  const isSiteUrlMismatched = !isSiteUrlMatchingCurrentOrigin(siteUrl);
 
   const nextStepButton = match(currentStep)
     .with("get-code", () => (
@@ -143,7 +149,11 @@ export const SdkIframeEmbedSetupContent = () => {
           <SdkIframeGuestEmbedStatusBar />
 
           {allowPreviewAndNavigation && !isMissingResource ? (
-            <SdkIframeEmbedPreview />
+            isSiteUrlMismatched ? (
+              <SdkIframeEmbedSiteUrlMismatchError siteUrl={siteUrl} />
+            ) : (
+              <SdkIframeEmbedPreview />
+            )
           ) : (
             <Card h="100%">
               <Flex h="100%" align="center" justify="center">

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSiteUrlMismatchError.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSiteUrlMismatchError.tsx
@@ -1,8 +1,9 @@
 import { jt, t } from "ttag";
 
+import { Link } from "metabase/common/components/Link";
 import { useSelector } from "metabase/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Anchor, Card, Code, Flex, Icon, Stack, Text } from "metabase/ui";
+import { Card, Code, Flex, Icon, Stack, Text } from "metabase/ui";
 
 interface SdkIframeEmbedSiteUrlMismatchErrorProps {
   siteUrl: string;
@@ -14,9 +15,9 @@ export const SdkIframeEmbedSiteUrlMismatchError = ({
   const applicationName = useSelector(getApplicationName);
 
   const siteUrlSettingLink = (
-    <Anchor key="link" href="/admin/settings/general" target="_blank">
+    <Link key="link" to="/admin/settings/general" target="_blank">
       {t`Site URL`}
-    </Anchor>
+    </Link>
   );
 
   return (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSiteUrlMismatchError.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSiteUrlMismatchError.tsx
@@ -1,0 +1,55 @@
+import { jt, t } from "ttag";
+
+import { useSelector } from "metabase/redux";
+import { getApplicationName } from "metabase/selectors/whitelabel";
+import { Anchor, Card, Code, Flex, Icon, Stack, Text } from "metabase/ui";
+
+interface SdkIframeEmbedSiteUrlMismatchErrorProps {
+  siteUrl: string;
+}
+
+export const SdkIframeEmbedSiteUrlMismatchError = ({
+  siteUrl,
+}: SdkIframeEmbedSiteUrlMismatchErrorProps) => {
+  const applicationName = useSelector(getApplicationName);
+
+  const siteUrlSettingLink = (
+    <Anchor key="link" href="/admin/settings/general" target="_blank">
+      {t`Site URL`}
+    </Anchor>
+  );
+
+  return (
+    <Card h="100%" data-testid="sdk-iframe-embed-site-url-mismatch-error">
+      <Flex
+        h="100%"
+        align="center"
+        justify="center"
+        direction="column"
+        gap="md"
+        maw={520}
+        mx="auto"
+        p="xl"
+      >
+        <Icon name="warning" size={48} c="warning" />
+
+        <Text fw="bold" size="lg" ta="center">
+          {t`The preview can't load because the Site URL doesn't match the host you're using.`}
+        </Text>
+
+        <Stack gap="xs" align="center">
+          <Text ta="center" c="text-secondary">
+            {jt`Configured: ${<Code key="configured">{siteUrl}</Code>}`}
+          </Text>
+          <Text ta="center" c="text-secondary">
+            {jt`Current: ${<Code key="current">{window.location.origin}</Code>}`}
+          </Text>
+        </Stack>
+
+        <Text ta="center">
+          {jt`Update the ${siteUrlSettingLink} setting to match the host you're using to access ${applicationName}, or open ${applicationName} via the configured Site URL.`}
+        </Text>
+      </Flex>
+    </Card>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -31,6 +31,64 @@ describe("Embed flow > initial setup", () => {
   });
 });
 
+describe("Embed flow > misconfigured Site URL (EMB-1747)", () => {
+  beforeEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = () => false;
+  });
+
+  it("renders a Site URL mismatch error in the preview area when the configured Site URL origin doesn't match the current host", async () => {
+    setup({
+      simpleEmbeddingEnabled: true,
+      siteUrl: "http://different-host.example:9999",
+      initialState: {
+        resourceType: "dashboard",
+        resourceId: 1,
+        isGuest: false,
+        useExistingUserSession: true,
+      },
+    });
+
+    expect(
+      await screen.findByTestId("sdk-iframe-embed-site-url-mismatch-error"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Site URL doesn't match the host/i),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("http://different-host.example:9999"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the Site URL mismatch error when origins match", async () => {
+    setup({
+      simpleEmbeddingEnabled: true,
+      siteUrl: window.location.origin,
+      initialState: {
+        resourceType: "dashboard",
+        resourceId: 1,
+        isGuest: false,
+        useExistingUserSession: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("sdk-iframe-embed-setup-modal-content"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("sdk-iframe-embed-site-url-mismatch-error"),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("Embed flow > forward and backward navigation", () => {
   beforeEach(() => {
     PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isEnabled = jest.fn(() => true);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -36,6 +36,7 @@ export const setup = (options?: {
   initialState?: SdkIframeEmbedSetupModalInitialState;
   hasEmailSetup?: boolean;
   metabotEnabled?: boolean;
+  siteUrl?: string;
 }) => {
   const { enterprisePlugins } = options ?? {};
 
@@ -62,6 +63,9 @@ export const setup = (options?: {
     "jwt-enabled-and-configured": options?.jwtReady ?? false,
     "embedded-metabot-enabled?": options?.metabotEnabled ?? false,
     "llm-metabot-configured?": options?.metabotEnabled ?? false,
+    // Default to the jsdom test origin so the embed wizard preview renders
+    // (mismatched origins surface a Site URL configuration error).
+    "site-url": options?.siteUrl ?? window.location.origin,
   });
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/is-site-url-matching-current-origin.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/is-site-url-matching-current-origin.ts
@@ -1,0 +1,22 @@
+/**
+ * The embed wizard preview renders the Metabase instance in an iframe loaded
+ * from the configured Site URL. The page's CSP includes `frame-src 'self'`,
+ * which only allows iframes from the same origin as the wizard page. When the
+ * Site URL setting points to a different origin than the host the user is on
+ * (e.g. site-url=`localhost:3000` but accessed at `metabase.localhost:3000`),
+ * the iframe is silently blocked and the preview never loads.
+ */
+export const isSiteUrlMatchingCurrentOrigin = (
+  siteUrl: string | null | undefined,
+  currentOrigin: string = window.location.origin,
+): boolean => {
+  if (!siteUrl) {
+    return true;
+  }
+
+  try {
+    return new URL(siteUrl).origin === currentOrigin;
+  } catch {
+    return true;
+  }
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/is-site-url-matching-current-origin.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/is-site-url-matching-current-origin.unit.spec.ts
@@ -1,0 +1,66 @@
+import { isSiteUrlMatchingCurrentOrigin } from "./is-site-url-matching-current-origin";
+
+describe("isSiteUrlMatchingCurrentOrigin", () => {
+  it("returns true when site URL origin matches the current origin", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin(
+        "http://localhost:3000",
+        "http://localhost:3000",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores trailing slashes on the site URL", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin(
+        "http://localhost:3000/",
+        "http://localhost:3000",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when site URL host differs from the current host", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin(
+        "http://localhost:3000",
+        "http://metabase.localhost:3000",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when site URL port differs from the current port", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin(
+        "http://localhost:4000",
+        "http://localhost:3000",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when site URL scheme differs from the current scheme", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin(
+        "http://example.com",
+        "https://example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when the site URL is empty or null (treated as not configured)", () => {
+    expect(isSiteUrlMatchingCurrentOrigin("", "http://localhost:3000")).toBe(
+      true,
+    );
+    expect(isSiteUrlMatchingCurrentOrigin(null, "http://localhost:3000")).toBe(
+      true,
+    );
+    expect(
+      isSiteUrlMatchingCurrentOrigin(undefined, "http://localhost:3000"),
+    ).toBe(true);
+  });
+
+  it("returns true when the site URL is malformed (let other validation surface it)", () => {
+    expect(
+      isSiteUrlMatchingCurrentOrigin("not a url", "http://localhost:3000"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74340 closes #74341
Closes [EMB-1749: `useExistingSession` auth error links to wrong docs page](https://linear.app/metabase/issue/EMB-1749/useexistingsession-auth-error-links-to-wrong-docs-page)
Closes [EMB-1747: Embed wizard preview never loads with misconfigured site URL](https://linear.app/metabase/issue/EMB-1747/embed-wizard-preview-never-loads-with-misconfigured-site-url)

### Description

Two small embedding wizard bug fixes bundled in one PR.

**EMB-1749 — `useExistingSession` error links to a dead docs anchor.**
The "Read more" link on the `EXISTING_USER_SESSION_FAILED` error pointed at `embedding/embedded-analytics-js#use-existing-user-session-to-test-embeds`, which no longer exists — the page was renamed to `modular-embedding` (redirect-only) and the relevant cross-domain session-cookie section now lives in `embedding/authentication.md`. Updated the link to `embedding/authentication#configure-session-cookies-when-testing-locally`, which is the section that explains how to configure `SameSite=None` for the exact scenario the error fires in.

**EMB-1747 — Embed wizard preview silently fails on Site URL mismatch.**
The embed wizard preview iframe loads from the configured `site-url`. The page's CSP `frame-src 'self'` blocks the iframe whenever the configured Site URL has a different origin than the host the user is on (e.g. `site-url=localhost:3000` accessed at `metabase.localhost:3000`), and the preview never loads — no user-visible error. Added a proactive origin comparison; on mismatch the preview area renders an actionable error card showing the configured and current origins and linking to the admin Site URL setting.

### How to verify

#### EMB-1749 — corrected docs link

1. Run the instance locally on `http://localhost:3000`.
2. Make `metabase.localhost` resolve to your loopback (most OSes resolve `*.localhost` to `127.0.0.1` automatically; if not, add `127.0.0.1 metabase.localhost` to `/etc/hosts`).
3. Open `http://localhost:3000`, log in as admin (session cookie is set on the `localhost` host).
4. Create a small static HTML test page that loads `embed.js` and embeds e.g. a dashboard with `useExistingUserSession: true` and `instanceUrl: "http://localhost:3000"`. Serve it from `http://metabase.localhost:3000` (any process serving HTML on that host works).
5. Load the page in Chrome — the embed renders the error: _"Failed to authenticate using an existing Metabase user session. Read more."_
6. Click **Read more**. Before this PR: lands on a dead URL. After this PR: lands on `https://www.metabase.com/docs/latest/embedding/authentication#configure-session-cookies-when-testing-locally`.

(Shortcut for reviewers who don't want to repro: the change is a single constant in `frontend/src/embedding-sdk-bundle/errors/error-docs-links.ts` and its matching e2e assertion.)

#### EMB-1747 — wizard error on misconfigured Site URL

1. Log in to your local instance as admin at `http://localhost:3000`.
2. Set Site URL to a value whose origin differs from the host you'll use to access Metabase. On hosted-flavored dev instances the Site URL widget is hidden, so set it via the API in the browser devtools console:
   ```js
   fetch('/api/setting/site-url', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value: 'http://localhost:3000' })
   })
   ```
3. Access Metabase at a different host pointing at the same backend, e.g. `http://metabase.localhost:3000`.
4. Open the embed wizard (Cmd+K → "new embed").
5. Before this PR: the preview area is blank (only a CSP error appears in devtools). After this PR: an error card shows _"The preview can't load because the Site URL doesn't match the host you're using"_, displays both origins as code, and links to the Site URL setting.
6. Restore: from the configured Site URL host, set Site URL back to `http://metabase.localhost:3000` (or whatever you access Metabase at). The wizard preview should load normally again.

### Demo

#### EMB-1749 — corrected docs link
<img width="1604" height="1086" alt="image" src="https://github.com/user-attachments/assets/9b88ec3f-5e95-4ca1-b3b4-f0753eb30027" />

#### EMB-1747 — wizard error on misconfigured Site URL
<img width="1605" height="1038" alt="SCR-20260522-lnvg" src="https://github.com/user-attachments/assets/46aabde2-39a8-4be7-8a08-a4d265d215d8" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR