### PR TITLE
Disallow brushing charts with an aggregated x axis

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -70,6 +70,7 @@ import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type {
   CardDisplayType,
   CardId,
+  DatasetColumn,
   RawSeries,
   TimelineEvent,
   TimelineEventId,
@@ -302,6 +303,7 @@ const computeDiffWithPreviousPeriod = (
 export const canBrush = (
   series: RawSeries,
   settings: ComputedVisualizationSettings,
+  dimensionColumn: DatasetColumn | undefined,
   onChangeCardAndRun?: OnChangeCardAndRun | null,
   onBrush?: ((range: { start: number; end: number }) => void) | null,
 ) => {
@@ -315,6 +317,11 @@ export const canBrush = (
 
   if (onBrush) {
     return true;
+  }
+
+  // Can't filter an aggregation in the stage that produces it (metabase#71073).
+  if (dimensionColumn?.source === "aggregation") {
+    return false;
   }
 
   const hasCombinedCards = series.length > 1;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.unit.spec.ts
@@ -10,13 +10,19 @@ import type {
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import {
   createMockColumn,
   createMockDatetimeColumn,
+  createMockSingleSeries,
   createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 
-import { getEventDimensions, getTimelineEventsForEvent } from "./events";
+import {
+  canBrush,
+  getEventDimensions,
+  getTimelineEventsForEvent,
+} from "./events";
 
 const CARD_ID = 107;
 
@@ -258,6 +264,90 @@ describe("getEventDimensions", () => {
     expect(dimensions).toEqual([
       { column: categoryColumn, value: "Doohickey" },
     ]);
+  });
+});
+
+describe("canBrush", () => {
+  const productIdColumn = createMockColumn({
+    name: "PRODUCT_ID",
+    display_name: "Product ID",
+    source: "breakout",
+    base_type: "type/Integer",
+    effective_type: "type/Integer",
+  });
+
+  const sumSubtotalColumn = createMockColumn({
+    name: "sum",
+    display_name: "Sum of Subtotal",
+    source: "aggregation",
+    base_type: "type/Float",
+    effective_type: "type/Float",
+  });
+
+  const sumTotalColumn = createMockColumn({
+    name: "sum_2",
+    display_name: "Sum of Total",
+    source: "aggregation",
+    base_type: "type/Float",
+    effective_type: "type/Float",
+  });
+
+  const baseSettings: ComputedVisualizationSettings = {
+    "graph.x_axis.scale": "linear",
+  };
+
+  const onChangeCardAndRun = jest.fn();
+
+  // Reproduces UXW-3333 (metabase#71073): a scatter chart with aggregations on
+  // both axes ends up with `dimensionModel.column.source === "aggregation"`.
+  // The brush-to-filter handler can't safely filter an aggregation in the same
+  // stage that produces it (the resulting MBQL is rejected by the QP), so brush
+  // must be disabled in this configuration.
+  it("returns false when the x-axis dimension is an aggregation column (metabase#71073)", () => {
+    const series = [
+      createMockSingleSeries(
+        {},
+        {
+          data: { cols: [sumSubtotalColumn, sumTotalColumn, productIdColumn] },
+        },
+      ),
+    ];
+
+    expect(
+      canBrush(series, baseSettings, sumSubtotalColumn, onChangeCardAndRun),
+    ).toBe(false);
+  });
+
+  it("returns true when the x-axis dimension is a breakout column", () => {
+    const series = [
+      createMockSingleSeries(
+        {},
+        { data: { cols: [productIdColumn, sumSubtotalColumn] } },
+      ),
+    ];
+
+    expect(
+      canBrush(series, baseSettings, productIdColumn, onChangeCardAndRun),
+    ).toBe(true);
+  });
+
+  // External `onBrush` consumers (e.g. MetricsViewer) handle the range
+  // themselves and never produce an aggregation-on-aggregation filter, so brush
+  // should remain enabled even when the x-axis dimension is an aggregation.
+  it("returns true for external onBrush even when the x-axis is an aggregation", () => {
+    const series = [
+      createMockSingleSeries(
+        {},
+        {
+          data: { cols: [sumSubtotalColumn, sumTotalColumn, productIdColumn] },
+        },
+      ),
+    ];
+    const onBrush = jest.fn();
+
+    expect(
+      canBrush(series, baseSettings, sumSubtotalColumn, undefined, onBrush),
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -361,6 +361,7 @@ export const useChartEvents = (
   const canBrushChart = canBrush(
     rawSeries,
     settings,
+    chartModel.dimensionModel.column,
     onChangeCardAndRun,
     onBrush,
   );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71073
### Description

Updates `canBrush` to detect if the x axis is a aggregate column (like what you would typically see in a scatter chart), and disables brushing on the chart

### How to verify
1. New Question -> Orders
2. Avg: Total, Avg Subtotal, group by product id
3. Select scatter chart viz type

Instead of brushing the chart and getting an MBQL error, you should not be able to brush the chart

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
