### PR TITLE
Sanitize workspace creation sql exception messages

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -421,7 +421,10 @@
                       (conj (format "GRANT SHOW DATABASES ON `%s`.* TO `%s`"
                                     canonical-db (:user read-user))))]
           (.addBatch ^Statement stmt ^String sql))
-        (.executeBatch ^Statement stmt)))
+        (try
+          (.executeBatch ^Statement stmt)
+          (catch Throwable t
+            (throw (driver.u/scrub-exceptions t [(:password read-user)]))))))
     {:schema           db-name
      :database_details read-user}))
 

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -779,7 +779,10 @@
                        (format "ALTER DEFAULT PRIVILEGES IN SCHEMA \"%s\" GRANT ALL ON TABLES TO \"%s\""
                                schema-name (:user read-user))]]
             (.addBatch ^Statement stmt ^String sql))
-          (.executeBatch ^Statement stmt))))
+          (try
+            (.executeBatch ^Statement stmt)
+            (catch Throwable t
+              (throw (driver.u/scrub-exceptions t [(:password read-user)])))))))
     {:schema           schema-name
      :database_details read-user}))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1082,17 +1082,20 @@
       (throw (ex-info (tru "Snowflake database configuration is missing required ''warehouse'' setting")
                       {:database-id (:id database) :step :init})))
     ;; Snowflake RBAC: create schema -> create role -> grant privileges to role -> create user -> grant role to user
-    (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"" db-name schema-name)
-                 (format "CREATE ROLE IF NOT EXISTS \"%s\"" role-name)
-                 (format "GRANT USAGE ON DATABASE \"%s\" TO ROLE \"%s\"" db-name role-name)
-                 (format "GRANT USAGE ON WAREHOUSE \"%s\" TO ROLE \"%s\"" warehouse role-name)
-                 (format "GRANT USAGE ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "GRANT ALL PRIVILEGES ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "GRANT ALL ON FUTURE TABLES IN SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "CREATE USER IF NOT EXISTS \"%s\" PASSWORD = '%s' MUST_CHANGE_PASSWORD = FALSE DEFAULT_ROLE = \"%s\""
-                         (:user read-user) (:password read-user) role-name)
-                 (format "GRANT ROLE \"%s\" TO USER \"%s\"" role-name (:user read-user))]]
-      (jdbc/execute! conn-spec [sql]))
+    (try
+      (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"" db-name schema-name)
+                   (format "CREATE ROLE IF NOT EXISTS \"%s\"" role-name)
+                   (format "GRANT USAGE ON DATABASE \"%s\" TO ROLE \"%s\"" db-name role-name)
+                   (format "GRANT USAGE ON WAREHOUSE \"%s\" TO ROLE \"%s\"" warehouse role-name)
+                   (format "GRANT USAGE ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
+                   (format "GRANT ALL PRIVILEGES ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
+                   (format "GRANT ALL ON FUTURE TABLES IN SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
+                   (format "CREATE USER IF NOT EXISTS \"%s\" PASSWORD = '%s' MUST_CHANGE_PASSWORD = FALSE DEFAULT_ROLE = \"%s\""
+                           (:user read-user) (:password read-user) role-name)
+                   (format "GRANT ROLE \"%s\" TO USER \"%s\"" role-name (:user read-user))]]
+        (jdbc/execute! conn-spec [sql]))
+      (catch Throwable t
+        (throw (driver.u/scrub-exceptions t [(:password read-user)]))))
     {:schema           schema-name
      :database_details (assoc read-user :role role-name :use-password true)}))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1152,18 +1152,21 @@
         escaped-password (sql.u/escape-sql password :ansi)
         conn-spec        (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     ;; SQL Server: create login (server level), then user (database level), then schema
-    (doseq [sql [(format (str "IF NOT EXISTS (SELECT name FROM master.sys.server_principals WHERE name = '%s') "
-                              "CREATE LOGIN [%s] WITH PASSWORD = N'%s'")
-                         username username escaped-password)
-                 (format "IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = '%s') CREATE USER [%s] FOR LOGIN [%s]"
-                         username username username)
-                 (format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA [%s]')"
-                         schema-name schema-name)
-                 ;; CONTROL ON SCHEMA gives ALTER (needed for creating objects in schema)
-                 (format "GRANT CONTROL ON SCHEMA::[%s] TO [%s]" schema-name username)
-                 ;; CREATE TABLE at database level is also required in SQL Server
-                 (format "GRANT CREATE TABLE TO [%s]" username)]]
-      (jdbc/execute! conn-spec [sql]))
+    (try
+      (doseq [sql [(format (str "IF NOT EXISTS (SELECT name FROM master.sys.server_principals WHERE name = '%s') "
+                                "CREATE LOGIN [%s] WITH PASSWORD = N'%s'")
+                           username username escaped-password)
+                   (format "IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = '%s') CREATE USER [%s] FOR LOGIN [%s]"
+                           username username username)
+                   (format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA [%s]')"
+                           schema-name schema-name)
+                   ;; CONTROL ON SCHEMA gives ALTER (needed for creating objects in schema)
+                   (format "GRANT CONTROL ON SCHEMA::[%s] TO [%s]" schema-name username)
+                   ;; CREATE TABLE at database level is also required in SQL Server
+                   (format "GRANT CREATE TABLE TO [%s]" username)]]
+        (jdbc/execute! conn-spec [sql]))
+      (catch Throwable t
+        (throw (driver.u/scrub-exceptions t [password escaped-password]))))
     {:schema           schema-name
      :database_details {:user     username
                         :password password}}))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1843,6 +1843,10 @@
   {:added "0.59.0" :arglists '([driver database workspace])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
+(defn init-workspace-isolation
+  [driver database workspace]
+  (try (init-workspace-isolation! driver database workspace)
+       (catch Exception e (scrub-exception e (secrets-of workspace)))))
 
 (defmulti destroy-workspace-isolation!
   "Destroy all database resources created for workspace isolation.

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1843,10 +1843,6 @@
   {:added "0.59.0" :arglists '([driver database workspace])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
-(defn init-workspace-isolation
-  [driver database workspace]
-  (try (init-workspace-isolation! driver database workspace)
-       (catch Exception e (scrub-exception e (secrets-of workspace)))))
 
 (defmulti destroy-workspace-isolation!
   "Destroy all database resources created for workspace isolation.

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -743,7 +743,10 @@
                      (format "CREATE SCHEMA IF NOT EXISTS \"%s\" AUTHORIZATION \"%s\"" schema-name username)
                      (format "GRANT ALL ON SCHEMA \"%s\" TO \"%s\"" schema-name username)]]
           (.addBatch ^Statement stmt ^String sql))
-        (.executeBatch ^Statement stmt)))
+        (try
+          (.executeBatch ^Statement stmt)
+          (catch Throwable t
+            (throw (driver.u/scrub-exceptions t [password]))))))
     {:schema           schema-name
      :database_details {:db new-db}}))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1329,7 +1329,7 @@
           (try
             (.executeBatch ^Statement stmt)
             (catch Throwable t
-              (throw (driver.u/scrub-exceptions t [password escaped-password]))))))))
+              (throw (driver.u/scrub-exceptions t [password escaped-password])))))))
     {:schema           db-name
      ;; Intentionally omit `:db` from `:database_details`: when the workspace
      ;; loader merges these over the canonical Database's `:details`, we must

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1326,7 +1326,10 @@
                        ;; Grant all privileges on the isolated database
                        (format "GRANT ALL PRIVILEGES ON `%s`.* TO `%s`@'%%'" db-name user)]]
             (.addBatch ^Statement stmt ^String sql))
-          (.executeBatch ^Statement stmt))))
+          (try
+            (.executeBatch ^Statement stmt)
+            (catch Throwable t
+              (throw (driver.u/scrub-exceptions t [password escaped-password]))))))))
     {:schema           db-name
      ;; Intentionally omit `:db` from `:database_details`: when the workspace
      ;; loader merges these over the canonical Database's `:details`, we must

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1518,7 +1518,10 @@
                        ;; grant role membership to admin so DROP OWNED BY works during cleanup
                        (format "GRANT \"%s\" TO CURRENT_USER" (:user read-user))]]
             (.addBatch ^Statement stmt ^String sql))
-          (.executeBatch ^Statement stmt))))
+          (try
+            (.executeBatch ^Statement stmt)
+            (catch Throwable t
+              (throw (driver.u/scrub-exceptions t [(:password read-user)])))))))
     {:schema           schema-name
      :database_details read-user}))
 

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -840,6 +840,33 @@
        shuffle
        (apply str)))
 
+(defn- redact-msg
+  "Replace all `secrets` in `msg` with `****`."
+  [msg secrets]
+  (reduce (fn [s secret] (str/replace s secret "****")) (or msg "") secrets))
+
+(defn scrub-exceptions
+  "Scrub `secrets` from the exception message and cause chain of `t`. Returns a new
+   exception with every occurrence of each secret replaced by `****`. Use this to prevent
+   credentials embedded in DDL SQL from leaking into logs via exception messages."
+  [^Throwable t secrets]
+  (let [msg   (redact-msg (ex-message t) secrets)
+        cause (some-> (.getCause t) (scrub-exceptions secrets))]
+    (cond
+      (instance? clojure.lang.ExceptionInfo t)
+      (ex-info msg (ex-data t) cause)
+
+      (instance? java.sql.SQLException t)
+      (let [^java.sql.SQLException sql-ex t
+            next-ex (some-> (.getNextException sql-ex) (scrub-exceptions secrets))]
+        (doto (java.sql.SQLException. msg (.getSQLState sql-ex) (.getErrorCode sql-ex) cause)
+          (.setStackTrace (.getStackTrace t))
+          (cond-> next-ex (.setNextException next-ex))))
+
+      :else
+      (doto (Exception. msg cause)
+        (.setStackTrace (.getStackTrace t))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Macaw parsing helpers                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -14,6 +14,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u])
   (:import
+   (java.sql BatchUpdateException SQLException)
    (javax.net.ssl SSLSocketFactory)))
 
 (comment h2/keep-me)
@@ -613,3 +614,50 @@
           (is (some? group-info))
           (is (= "Group info message" (:placeholder group-info)))
           (is (nil? (:getter group-info)) "Getter should be removed"))))))
+
+;;; ---------------------------------------- scrub-exceptions -------------------------------------------------
+
+(deftest ^:parallel scrub-exceptions-test
+  (testing "plain Exception: secret is redacted from message"
+    (let [e (driver.u/scrub-exceptions (Exception. "PASSWORD='s3cret'") ["s3cret"])]
+      (is (= "PASSWORD='****'" (ex-message e)))))
+  (testing "secret not present: message unchanged"
+    (let [e (driver.u/scrub-exceptions (Exception. "no secret here") ["s3cret"])]
+      (is (= "no secret here" (ex-message e)))))
+  (testing "cause chain is scrubbed"
+    (let [e (driver.u/scrub-exceptions
+             (Exception. "outer pw=s3cret" (Exception. "inner pw=s3cret"))
+             ["s3cret"])]
+      (is (= "outer pw=****" (ex-message e)))
+      (is (= "inner pw=****" (ex-message (.getCause ^Exception e))))))
+  (testing "ExceptionInfo: ex-data is preserved, message is scrubbed"
+    (let [e (driver.u/scrub-exceptions (ex-info "pw=s3cret" {:code 42}) ["s3cret"])]
+      (is (= "pw=****" (ex-message e)))
+      (is (= {:code 42} (ex-data e)))))
+  (testing "SQLException: SQLState and errorCode are preserved"
+    (let [e (driver.u/scrub-exceptions (SQLException. "pw=s3cret" "42501" 7) ["s3cret"])]
+      (is (= "pw=****" (ex-message e)))
+      (is (= "42501" (.getSQLState ^SQLException e)))
+      (is (= 7 (.getErrorCode ^SQLException e)))))
+  (testing "SQLException next-exception chain is scrubbed"
+    (let [next-ex (SQLException. "next pw=s3cret" "42501" 7)
+          main    (doto (SQLException. "main pw=s3cret" "42000" 1)
+                    (.setNextException next-ex))
+          e       (driver.u/scrub-exceptions main ["s3cret"])]
+      (is (= "main pw=****" (ex-message e)))
+      (is (= "next pw=****" (ex-message (.getNextException ^SQLException e))))
+      (is (= "42501" (.getSQLState (.getNextException ^SQLException e))))))
+  (testing "multiple secrets are all redacted"
+    (let [e (driver.u/scrub-exceptions
+             (Exception. "user=admin password=s3cret escaped=s3cr\\et")
+             ["s3cret" "s3cr\\et"])]
+      (is (= "user=admin password=**** escaped=****" (ex-message e)))))
+  (testing "password with backslash sequences is treated literally, not as regex"
+    (let [pw "p\\nass\\r\\twor$d"
+          e  (driver.u/scrub-exceptions (Exception. (str "CREATE USER x PASSWORD='" pw "'")) [pw])]
+      (is (= "CREATE USER x PASSWORD='****'" (ex-message e)))))
+  (testing "stack trace is preserved"
+    (let [original (Exception. "pw=s3cret")
+          trace    (.getStackTrace original)
+          e        (driver.u/scrub-exceptions original ["s3cret"])]
+      (is (= (seq trace) (seq (.getStackTrace ^Exception e)))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -14,7 +14,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u])
   (:import
-   (java.sql BatchUpdateException SQLException)
+   (java.sql SQLException)
    (javax.net.ssl SSLSocketFactory)))
 
 (comment h2/keep-me)


### PR DESCRIPTION
just str/replace the secrets in the sql statements. Execute batch returns sql in statements.

I'd really like to do something like this:

```clojure
(defmulti init-workspace-isolation!
  "Initialize database isolation for a workspace. Creates an isolated schema/database,
   user credentials, and grants appropriate permissions for the workspace to operate
   within its own namespace.

   Returns a map with:
   - :schema           - The name of the isolated schema/database created
   - :database_details - Connection details (user, password, etc.) for the isolated user

   Implementations should:
   - Create an isolated schema or database for the workspace
   - Create a user with credentials that can only access that schema
   - Grant appropriate permissions (CREATE, INSERT, SELECT, etc.) on the isolated schema

   This is an enterprise feature. Drivers must also return true for
   (database-supports? driver :workspace database) to indicate support."
  {:added "0.59.0" :arglists '([driver database workspace])}
  dispatch-on-initialized-driver
  :hierarchy #'hierarchy)

;; introduce a new actual public api and have the multimethod be the impl
;; and we can in one place solve this.
(defn init-workspace-isolation
  [driver database workspace]
  (try (init-workspace-isolation! driver database workspace)
       (catch Exception e (scrub-exception e (secrets-of workspace)))))
```

But the current impl is fine as well and allows each driver to catch particular driver exceptions.