### PR TITLE
Fix inactive-tables filter on file metadata reimport

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/metadata_file_import/processors.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/metadata_file_import/processors.clj
@@ -310,14 +310,12 @@
   "Set `metabase_table_import.target_id` to the int id of the matching
   `metabase_table` row for every staging row whose match key resolves. The
   match key is `(db_name, schema, name)` against `(d.name, t.schema, t.name)`,
-  restricted to active, non-defective live rows.
+  restricted to non-defective live rows.
 
-  Rows that do not match keep `target_id` NULL. Inactive matches are
-  deliberately not resolved so a re-import after a deactivation creates a
-  fresh active row.
+  Inactive matches will be reactivated on import.
 
-  Idempotent — running again with the same staging contents produces the
-  same assignments."
+  Rows that do not match keep `target_id` NULL. Idempotent — running again with
+  the same staging contents produces the same assignments."
   []
   (t2/query
    {:update :metabase_table_import
@@ -334,8 +332,7 @@
                        [:= [:coalesce :t.schema [:inline ""]]
                         [:coalesce :metabase_table_import.schema [:inline ""]]]
                        [:= :t.name :metabase_table_import.name]
-                       [:= :t.is_defective_duplicate [:inline false]]
-                       [:= :t.active [:inline true]]]}}}))
+                       [:= :t.is_defective_duplicate [:inline false]]]}}}))
 
 ;; UPDATE before INSERT: on a clean-schema import the UPDATE matches nothing
 ;; (fast no-op) and the INSERT then writes each row exactly once.
@@ -378,16 +375,23 @@
                                :where    [:= :it.target_id :metabase_table.id]
                                :order-by [[:it.source_id :asc]]
                                :limit    1}
+                 ;; reactivate in place:
+                 :active     [:inline true]
                  :updated_at :%now}
         :where  [:and
                  [:= :metabase_table.is_defective_duplicate [:inline false]]
-                 [:= :metabase_table.active [:inline true]]
                  [:exists {:select [[[:inline 1]]]
                            :from   [[:metabase_table_import :it]]
                            :where  [:and
                                     [:= :it.target_id :metabase_table.id]
-                                    [:!= [:coalesce :metabase_table.description [:inline ""]]
-                                     [:coalesce :it.description             [:inline ""]]]]}]]})
+                                    ;; Fire when the description differs OR the row needs
+                                    ;; reactivating — otherwise re-importing a deactivated
+                                    ;; but otherwise-unchanged table would skip the UPDATE
+                                    ;; and leave it inactive.
+                                    [:or
+                                     [:!= [:coalesce :metabase_table.description [:inline ""]]
+                                      [:coalesce :it.description [:inline ""]]]
+                                     [:= :metabase_table.active [:inline false]]]]}]]})
       ;; INSERT bypasses :model/Table's :after-insert hook — that hook
       ;; schedules per-DB Quartz triggers we don't want and fires
       ;; `set-new-table-permissions!` once per row. The JOIN on db_name

--- a/enterprise/backend/test/metabase_enterprise/serialization/metadata_file_import/tables_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/metadata_file_import/tables_test.clj
@@ -69,16 +69,17 @@
             "NULL-safe match: staging schema=NULL ⇔ target schema=NULL"))
       (finally (p/clear-staging-tables!)))))
 
-(deftest resolve-skips-inactive-target-test
+(deftest resolve-matches-inactive-target-test
   (mt/with-temp [:model/Database {db-id :id db-name :name} {:engine :h2}
-                 :model/Table {} {:db_id db-id :schema "PUBLIC" :name "users" :active false}]
+                 :model/Table {tid :id} {:db_id db-id :schema "PUBLIC" :name "users" :active false}]
     (try
       (p/clear-staging-tables!)
       (t2/insert! :metabase_table_import [(staging-row 100 db-name "users")])
       (p/resolve-target-table-ids-in-staging!)
       (let [row (get (staging-rows-by-source-id) 100)]
-        (is (nil? (:target_id row))
-            "inactive target rows are intentionally not resolved — re-import creates a fresh active row"))
+        (is (= tid (:target_id row))
+            "inactive (non-defective) target rows resolve to the existing row — the merge reactivates
+             it in place rather than inserting a duplicate that collides on the unique index"))
       (finally (p/clear-staging-tables!)))))
 
 (deftest resolve-skips-defective-duplicate-target-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/metadata_file_import_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/metadata_file_import_test.clj
@@ -176,6 +176,29 @@
           (is (= 1 (t2/count :model/Field :table_id tbl-id :name "x")))
           (is (= "v1" (:description (t2/select-one :model/Field :table_id tbl-id :name "x")))))))))
 
+(deftest re-import-reactivates-deactivated-table-test
+  (testing "re-importing a table that was deactivated after the first import reactivates it in place
+            rather than inserting a duplicate (which violates idx_uniq_table_db_id_schema_name). The
+            field path already matches + reactivates regardless of `active`; tables must too."
+    (mt/with-temp [:model/Database {tgt-db :id} {:name "reactivate-db" :engine :postgres}]
+      (let [meta-file (json-file
+                       {:databases [{:id 7 :name "reactivate-db" :engine "postgres"}]
+                        :tables    [{:id 100 :db_id 7 :schema "public" :name "orders"}]
+                        :fields    [{:id 1000 :table_id 100 :name "id"
+                                     :base_type "type/Integer" :database_type "integer"}]})]
+        (loader/import-metadata-file! meta-file)
+        (let [tbl-id (:id (t2/select-one :model/Table :db_id tgt-db :name "orders"))]
+          ;; simulate sync (or a prior run) deactivating the table after the first import
+          (t2/update! :model/Table tbl-id {:active false})
+          ;; re-import the same file: must reactivate in place, not insert a duplicate
+          (loader/import-metadata-file! meta-file)
+          (testing "no duplicate row was inserted (would otherwise collide on the unique index)"
+            (is (= 1 (t2/count :model/Table :db_id tgt-db :schema "public" :name "orders"))))
+          (testing "the existing row was reactivated in place (same id, active=true)"
+            (let [tbl (t2/select-one :model/Table :db_id tgt-db :schema "public" :name "orders")]
+              (is (= tbl-id (:id tbl)))
+              (is (true? (:active tbl))))))))))
+
 ;;; ============================== Pre-flight orphan bail ==============================
 
 (deftest pre-flight-orphan-bail-test


### PR DESCRIPTION
### Description

Reimporting warehouse metadata could fail with a uniqueness constraint violation on `metabase_table`.

### How to verify

To reproduce, import the metadata, deactivate a table, and then reimport that metadata. A regression test is included.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
