### PR TITLE
Test connection button for Remote Sync

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.remote-sync.api
   (:require
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.remote-sync.core :as remote-sync.core]
    [metabase-enterprise.remote-sync.impl :as impl]
@@ -8,11 +9,13 @@
    [metabase-enterprise.remote-sync.schema :as remote-sync.schema]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
+   [metabase-enterprise.remote-sync.source.git :as source.git]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.events.core :as events]
+   [metabase.settings.core :as setting]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -137,6 +140,55 @@
     (api/check-400 (and (some? task) (remote-sync.task/running? task)) "No active task to cancel")
     (remote-sync.task/cancel-sync-task! (:id task))
     (t2/hydrate (remote-sync.task/most-recent-task) :status)))
+
+(api.macros/defendpoint :post "/test-connection" :- remote-sync.schema/TestConnectionResponse
+  "Test whether the configured Remote Sync credentials can reach the git repository.
+
+  When called with an empty body, validates the currently saved settings. When the body provides
+  any of `remote-sync-url`, `remote-sync-token`, `remote-sync-branch`, or `remote-sync-type`, those
+  override the saved values for the test — useful for verifying a new Personal Access Token before
+  saving. An obfuscated token (matching the existing token's masked representation) is treated as
+  \"unchanged\" and the stored token value is used for the test.
+
+  Returns `{:status :success}` on success. On failure, returns a 400 with a user-friendly error
+  message describing the connection problem (network, authentication, repository, or branch error).
+
+  Requires superuser permissions."
+  [_route-params
+   _query-params
+   {:keys [remote-sync-url remote-sync-token remote-sync-branch remote-sync-type] :as body}
+   :- [:map
+       [:remote-sync-url {:optional true} [:maybe :string]]
+       [:remote-sync-token {:optional true} [:maybe :string]]
+       [:remote-sync-branch {:optional true} [:maybe :string]]
+       [:remote-sync-type {:optional true} [:maybe [:enum :read-only :read-write]]]]]
+  (api/check-superuser)
+  (let [current-token  (settings/remote-sync-token)
+        obfuscated?    (and remote-sync-token
+                            (= remote-sync-token (setting/obfuscate-value current-token)))
+        effective-token (if (or obfuscated? (not (contains? body :remote-sync-token)))
+                          current-token
+                          remote-sync-token)
+        effective-settings {:remote-sync-url    (or remote-sync-url (settings/remote-sync-url))
+                            :remote-sync-token  effective-token
+                            :remote-sync-branch (or remote-sync-branch (settings/remote-sync-branch))
+                            :remote-sync-type   (or remote-sync-type (settings/remote-sync-type))}]
+    (api/check-400 (not (str/blank? (:remote-sync-url effective-settings)))
+                   "Remote sync is not configured.")
+    (try
+      (settings/check-git-settings! effective-settings)
+      ;; check-git-settings! only authenticates against the remote in :read-only mode with a
+      ;; non-blank branch. Force a fresh lsRemote here so a rotated token is detected on every
+      ;; Test Connection click, even when the cached JGit instance would otherwise short-circuit.
+      (-> (source.git/git-source (:remote-sync-url effective-settings)
+                                 "HEAD"
+                                 (:remote-sync-token effective-settings)
+                                 nil)
+          source.git/branches)
+      {:status :success}
+      (catch Exception e
+        (throw (ex-info (impl/source-error-message e)
+                        {:status-code 400} e))))))
 
 (api.macros/defendpoint :put "/settings" :- remote-sync.schema/SettingsUpdateResponse
   "Update Remote Sync related settings. You must be a superuser to do this."

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -142,48 +142,41 @@
     (t2/hydrate (remote-sync.task/most-recent-task) :status)))
 
 (api.macros/defendpoint :post "/test-connection" :- remote-sync.schema/TestConnectionResponse
-  "Test whether the configured Remote Sync credentials can reach the git repository.
+  "Test whether the Remote Sync credentials can reach the git repository.
 
-  When called with an empty body, validates the currently saved settings. When the body provides
-  any of `remote-sync-url`, `remote-sync-token`, `remote-sync-branch`, or `remote-sync-type`, those
-  override the saved values for the test — useful for verifying a new Personal Access Token before
-  saving. An obfuscated token (matching the existing token's masked representation) is treated as
-  \"unchanged\" and the stored token value is used for the test.
+  When called with an empty body, validates the currently saved URL and token. When the body provides
+  `remote-sync-url` or `remote-sync-token`, those override the saved values — useful for verifying a
+  new Personal Access Token before saving. An obfuscated token (matching the existing token's masked
+  representation) is treated as \"unchanged\" and the stored token value is used for the test.
+
+  Only validates connection and authentication; branch existence is not checked here.
 
   Returns `{:status :success}` on success. On failure, returns a 400 with a user-friendly error
-  message describing the connection problem (network, authentication, repository, or branch error).
+  message describing the connection problem.
 
   Requires superuser permissions."
   [_route-params
    _query-params
-   {:keys [remote-sync-url remote-sync-token remote-sync-branch remote-sync-type] :as body}
+   {:keys [remote-sync-url remote-sync-token] :as body}
    :- [:map
        [:remote-sync-url {:optional true} [:maybe :string]]
-       [:remote-sync-token {:optional true} [:maybe :string]]
-       [:remote-sync-branch {:optional true} [:maybe :string]]
-       [:remote-sync-type {:optional true} [:maybe [:enum :read-only :read-write]]]]]
+       [:remote-sync-token {:optional true} [:maybe :string]]]]
   (api/check-superuser)
-  (let [current-token  (settings/remote-sync-token)
-        obfuscated?    (and remote-sync-token
-                            (= remote-sync-token (setting/obfuscate-value current-token)))
+  (let [current-token   (settings/remote-sync-token)
+        obfuscated?     (and remote-sync-token
+                             (= remote-sync-token (setting/obfuscate-value current-token)))
         effective-token (if (or obfuscated? (not (contains? body :remote-sync-token)))
                           current-token
                           remote-sync-token)
-        effective-settings {:remote-sync-url    (or remote-sync-url (settings/remote-sync-url))
-                            :remote-sync-token  effective-token
-                            :remote-sync-branch (or remote-sync-branch (settings/remote-sync-branch))
-                            :remote-sync-type   (or remote-sync-type (settings/remote-sync-type))}]
-    (api/check-400 (not (str/blank? (:remote-sync-url effective-settings)))
-                   "Remote sync is not configured.")
+        effective-url   (or remote-sync-url (settings/remote-sync-url))]
+    (api/check-400 (not (str/blank? effective-url)) "Remote sync is not configured.")
     (try
-      (settings/check-git-settings! effective-settings)
-      ;; check-git-settings! only authenticates against the remote in :read-only mode with a
-      ;; non-blank branch. Force a fresh lsRemote here so a rotated token is detected on every
-      ;; Test Connection click, even when the cached JGit instance would otherwise short-circuit.
-      (-> (source.git/git-source (:remote-sync-url effective-settings)
-                                 "HEAD"
-                                 (:remote-sync-token effective-settings)
-                                 nil)
+      ;; Runs the URL protocol check; branch/type omitted so the branch-existence path is skipped.
+      (settings/check-git-settings! {:remote-sync-url   effective-url
+                                     :remote-sync-token effective-token})
+      ;; Force a fresh lsRemote so a rotated token is detected on every click, even when the
+      ;; cached JGit instance would otherwise short-circuit.
+      (-> (source.git/git-source effective-url "HEAD" effective-token nil)
           source.git/branches)
       {:status :success}
       (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
@@ -133,3 +133,8 @@
    [:remote_version [:maybe :string]]
    [:local_version [:maybe :string]]
    [:cached :boolean]])
+
+(def TestConnectionResponse
+  "Schema for POST /test-connection response."
+  [:map
+   [:status [:= :success]]])

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -103,25 +103,21 @@
                (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {})))))))
 
 (deftest test-connection-uses-body-overrides-test
-  (testing "POST /api/ee/remote-sync/test-connection passes body overrides to check-git-settings!"
+  (testing "POST /api/ee/remote-sync/test-connection passes URL and token from the body through to the lsRemote call"
     (let [captured (atom nil)]
       (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
                                          remote-sync-token  "saved-token"
                                          remote-sync-branch "main"
                                          remote-sync-type   :read-only]
-        (with-redefs [settings/check-git-settings! (fn [s] (reset! captured s) nil)
-                      source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+        (with-redefs [settings/check-git-settings! (constantly nil)
+                      source.git/git-source        (fn [url _ token _]
+                                                     (reset! captured {:url url :token token})
+                                                     {:fake-source true})
                       source.git/branches          (fn [_] [])]
           (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
-                                {:remote-sync-url    "https://github.com/other/repo.git"
-                                 :remote-sync-token  "new-token"
-                                 :remote-sync-branch "develop"
-                                 :remote-sync-type   "read-write"})
-          (is (= {:remote-sync-url    "https://github.com/other/repo.git"
-                  :remote-sync-token  "new-token"
-                  :remote-sync-branch "develop"
-                  :remote-sync-type   :read-write}
-                 @captured)))))))
+                                {:remote-sync-url   "https://github.com/other/repo.git"
+                                 :remote-sync-token "new-token"})
+          (is (= {:url "https://github.com/other/repo.git" :token "new-token"} @captured)))))))
 
 (deftest test-connection-treats-obfuscated-token-as-unchanged-test
   (testing "POST /api/ee/remote-sync/test-connection uses stored token when body sends the obfuscated value"
@@ -131,12 +127,14 @@
                                          remote-sync-token  full-token
                                          remote-sync-branch "main"
                                          remote-sync-type   :read-only]
-        (with-redefs [settings/check-git-settings! (fn [s] (reset! captured s) nil)
-                      source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+        (with-redefs [settings/check-git-settings! (constantly nil)
+                      source.git/git-source        (fn [_ _ token _]
+                                                     (reset! captured token)
+                                                     {:fake-source true})
                       source.git/branches          (fn [_] [])]
           (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
                                 {:remote-sync-token (setting/obfuscate-value full-token)})
-          (is (= full-token (:remote-sync-token @captured))
+          (is (= full-token @captured)
               "Obfuscated tokens must be replaced with the stored token before testing"))))))
 
 (deftest test-connection-requires-superuser-test
@@ -152,7 +150,7 @@
              (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {}))))))
 
 (deftest test-connection-returns-friendly-message-on-failure-test
-  (testing "POST /api/ee/remote-sync/test-connection wraps check-git-settings! exceptions in a user-friendly message"
+  (testing "POST /api/ee/remote-sync/test-connection wraps exceptions in a user-friendly message"
     (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
                                        remote-sync-token  "bad-token"
                                        remote-sync-branch "main"
@@ -164,10 +162,6 @@
       (testing "Repository-not-found maps to URL error"
         (with-redefs [settings/check-git-settings! (fn [_] (throw (ex-info "Repository not found" {})))]
           (is (= "Repository not found: Please check the repository URL"
-                 (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {})))))
-      (testing "Branch failure maps to branch error"
-        (with-redefs [settings/check-git-settings! (fn [_] (throw (ex-info "Invalid branch name" {})))]
-          (is (= "Branch error: Please check the specified branch exists"
                  (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {}))))))))
 
 ;;; ------------------------------------------------- Branches Endpoint -------------------------------------------------

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -10,8 +10,10 @@
    [metabase-enterprise.remote-sync.models.remote-sync-task :as remote-sync.task]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
+   [metabase-enterprise.remote-sync.source.git :as source.git]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -56,6 +58,117 @@
         (when (nil? (:ended_at <>))
           (throw (ex-info "Not finished" {:task-id task-id
                                           :result <>})))))))
+
+;;; ------------------------------------------------- Test Connection Endpoint -------------------------------------------------
+
+(deftest test-connection-succeeds-with-current-settings-test
+  (testing "POST /api/ee/remote-sync/test-connection returns success when current settings can reach the repo"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                       remote-sync-token  "valid-token"
+                                       remote-sync-branch "main"
+                                       remote-sync-type   :read-only]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+                    source.git/branches          (fn [_] ["main"])]
+        (is (= {:status "success"}
+               (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection" {})))))))
+
+(deftest test-connection-forces-fresh-remote-call-test
+  (testing "POST /api/ee/remote-sync/test-connection always calls git/branches so rotated tokens are detected"
+    ;; check-git-settings! only authenticates when :read-only + branch is set, so the JGit cache
+    ;; would otherwise short-circuit subsequent tests with the same token. We need a fresh
+    ;; lsRemote on every click — this guards that.
+    (let [branches-calls (atom 0)]
+      (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                         remote-sync-token  "valid-token"
+                                         remote-sync-branch ""
+                                         remote-sync-type   :read-write]
+        (with-redefs [settings/check-git-settings! (constantly nil)
+                      source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+                      source.git/branches          (fn [_] (swap! branches-calls inc) [])]
+          (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection" {})
+          (is (= 1 @branches-calls)
+              "Test Connection must call git/branches even when check-git-settings! skips the remote check"))))))
+
+(deftest test-connection-surfaces-fresh-remote-auth-failure-test
+  (testing "POST /api/ee/remote-sync/test-connection returns 400 when the forced lsRemote rejects the token"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                       remote-sync-token  "rotated-token"
+                                       remote-sync-branch ""
+                                       remote-sync-type   :read-write]
+      (with-redefs [settings/check-git-settings! (constantly nil)
+                    source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+                    source.git/branches          (fn [_] (throw (ex-info "Authentication failed" {})))]
+        (is (= "Authentication failed: Please check your git credentials"
+               (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {})))))))
+
+(deftest test-connection-uses-body-overrides-test
+  (testing "POST /api/ee/remote-sync/test-connection passes body overrides to check-git-settings!"
+    (let [captured (atom nil)]
+      (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                         remote-sync-token  "saved-token"
+                                         remote-sync-branch "main"
+                                         remote-sync-type   :read-only]
+        (with-redefs [settings/check-git-settings! (fn [s] (reset! captured s) nil)
+                      source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+                      source.git/branches          (fn [_] [])]
+          (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
+                                {:remote-sync-url    "https://github.com/other/repo.git"
+                                 :remote-sync-token  "new-token"
+                                 :remote-sync-branch "develop"
+                                 :remote-sync-type   "read-write"})
+          (is (= {:remote-sync-url    "https://github.com/other/repo.git"
+                  :remote-sync-token  "new-token"
+                  :remote-sync-branch "develop"
+                  :remote-sync-type   :read-write}
+                 @captured)))))))
+
+(deftest test-connection-treats-obfuscated-token-as-unchanged-test
+  (testing "POST /api/ee/remote-sync/test-connection uses stored token when body sends the obfuscated value"
+    (let [captured (atom nil)
+          full-token "ghp_full_secret_token_value"]
+      (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                         remote-sync-token  full-token
+                                         remote-sync-branch "main"
+                                         remote-sync-type   :read-only]
+        (with-redefs [settings/check-git-settings! (fn [s] (reset! captured s) nil)
+                      source.git/git-source        (fn [_ _ _ _] {:fake-source true})
+                      source.git/branches          (fn [_] [])]
+          (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
+                                {:remote-sync-token (setting/obfuscate-value full-token)})
+          (is (= full-token (:remote-sync-token @captured))
+              "Obfuscated tokens must be replaced with the stored token before testing"))))))
+
+(deftest test-connection-requires-superuser-test
+  (testing "POST /api/ee/remote-sync/test-connection requires superuser permissions"
+    (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"]
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "ee/remote-sync/test-connection" {}))))))
+
+(deftest test-connection-errors-when-not-configured-test
+  (testing "POST /api/ee/remote-sync/test-connection returns 400 when no url is configured or provided"
+    (mt/with-temporary-setting-values [remote-sync-url nil]
+      (is (= "Remote sync is not configured."
+             (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {}))))))
+
+(deftest test-connection-returns-friendly-message-on-failure-test
+  (testing "POST /api/ee/remote-sync/test-connection wraps check-git-settings! exceptions in a user-friendly message"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                       remote-sync-token  "bad-token"
+                                       remote-sync-branch "main"
+                                       remote-sync-type   :read-only]
+      (testing "Authentication failure maps to credentials error"
+        (with-redefs [settings/check-git-settings! (fn [_] (throw (ex-info "Authentication failed" {})))]
+          (is (= "Authentication failed: Please check your git credentials"
+                 (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {})))))
+      (testing "Repository-not-found maps to URL error"
+        (with-redefs [settings/check-git-settings! (fn [_] (throw (ex-info "Repository not found" {})))]
+          (is (= "Repository not found: Please check the repository URL"
+                 (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {})))))
+      (testing "Branch failure maps to branch error"
+        (with-redefs [settings/check-git-settings! (fn [_] (throw (ex-info "Invalid branch name" {})))]
+          (is (= "Branch error: Please check the specified branch exists"
+                 (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection" {}))))))))
 
 ;;; ------------------------------------------------- Branches Endpoint -------------------------------------------------
 

--- a/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
@@ -10,6 +10,8 @@ import type {
   RemoteSyncConfigurationSettings,
   RemoteSyncHasChangesResponse,
   RemoteSyncTask,
+  TestRemoteSyncConnectionRequest,
+  TestRemoteSyncConnectionResponse,
   UpdateRemoteSyncConfigurationResponse,
 } from "metabase-types/api";
 
@@ -140,6 +142,16 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
       }),
       invalidatesTags: () => [tag("remote-sync-current-task")],
     }),
+    testRemoteSyncConnection: builder.mutation<
+      TestRemoteSyncConnectionResponse,
+      TestRemoteSyncConnectionRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: `/api/ee/remote-sync/test-connection`,
+        body,
+      }),
+    }),
   }),
 });
 
@@ -154,4 +166,5 @@ export const {
   useImportChangesMutation,
   useGetRemoteSyncCurrentTaskQuery,
   useCancelRemoteSyncCurrentTaskMutation,
+  useTestRemoteSyncConnectionMutation,
 } = remoteSyncApi;

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
@@ -50,6 +50,7 @@ const setupEndpoints = ({
   dirty = [] as any[],
   rootCollectionItems = [] as CollectionItem[],
   settingsError,
+  testConnectionError,
   envSettings = [],
   isDevInstance,
   upsellDismissed,
@@ -65,6 +66,7 @@ const setupEndpoints = ({
   dirty?: any[];
   rootCollectionItems?: CollectionItem[];
   settingsError?: { status: number; message: string };
+  testConnectionError?: { status: number; message: string };
   envSettings?: EnterpriseSettingKey[];
   isDevInstance?: boolean;
   upsellDismissed?: boolean;
@@ -97,6 +99,7 @@ const setupEndpoints = ({
     ...(settingsError && {
       settingsResponse: { error: settingsError },
     }),
+    ...(testConnectionError && { testConnectionError }),
   });
   setupUserKeyValueEndpoints({
     namespace: "user_acknowledgement",
@@ -143,6 +146,7 @@ interface SetupOpts {
   rootCollectionItems?: CollectionItem[];
   variant?: RemoteSyncSettingsFormProps["variant"];
   settingsError?: { status: number; message: string };
+  testConnectionError?: { status: number; message: string };
   envSettings?: EnterpriseSettingKey[];
   isDevInstance?: boolean;
   upsellDismissed?: boolean;
@@ -161,6 +165,7 @@ export const setup = ({
   rootCollectionItems = [],
   variant,
   settingsError,
+  testConnectionError,
   envSettings = [],
   isDevInstance = false,
   upsellDismissed = false,
@@ -176,6 +181,7 @@ export const setup = ({
     dirty,
     rootCollectionItems,
     settingsError,
+    testConnectionError,
     envSettings,
     isDevInstance,
     upsellDismissed,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -72,6 +72,7 @@ import { TopLevelCollectionsList } from "../TopLevelCollectionsList";
 
 import { DevInstanceUpsell } from "./DevInstanceUpsell";
 import { PullChangesButton } from "./PullChangesButton";
+import { TestConnectionButton } from "./TestConnectionButton";
 
 export type RemoteSyncSettingsFormProps = {
   onCancel?: VoidFunction;
@@ -406,6 +407,9 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     inputWrapperOrder: ["label", "description", "erorr"],
                   })}
                 />
+                <Box>
+                  <TestConnectionButton values={values} />
+                </Box>
               </RemoteSyncSettingsSection>
 
               {/* Section 2: Sync mode for this instance */}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -556,7 +556,7 @@ describe("RemoteSyncSettingsForm", () => {
       });
     });
 
-    it("should POST the current form values to the test-connection endpoint", async () => {
+    it("should POST only the URL and token to the test-connection endpoint", async () => {
       setup({
         remoteSyncType: "read-only",
         remoteSyncUrl: "https://github.com/test/repo.git",
@@ -580,8 +580,6 @@ describe("RemoteSyncSettingsForm", () => {
         expect(testRequest?.body).toEqual({
           "remote-sync-url": "https://github.com/test/repo.git",
           "remote-sync-token": "ghp_abc123",
-          "remote-sync-branch": "main",
-          "remote-sync-type": "read-only",
         });
       });
     });

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -529,6 +529,100 @@ describe("RemoteSyncSettingsForm", () => {
     });
   });
 
+  describe("test connection button", () => {
+    it("should be disabled when no URL is provided", async () => {
+      setup({
+        remoteSyncType: "read-only",
+        remoteSyncUrl: "",
+        remoteSyncEnabled: false,
+      });
+
+      expect(
+        screen.getByRole("button", { name: /Test connection/i }),
+      ).toBeDisabled();
+    });
+
+    it("should be enabled when a URL is provided", async () => {
+      setup({
+        remoteSyncType: "read-only",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        remoteSyncEnabled: true,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Test connection/i }),
+        ).toBeEnabled();
+      });
+    });
+
+    it("should POST the current form values to the test-connection endpoint", async () => {
+      setup({
+        remoteSyncType: "read-only",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        remoteSyncToken: "ghp_abc123",
+        remoteSyncBranch: "main",
+        remoteSyncEnabled: true,
+      });
+
+      const testButton = await screen.findByRole("button", {
+        name: /Test connection/i,
+      });
+      await waitFor(() => expect(testButton).toBeEnabled());
+      await userEvent.click(testButton);
+
+      await waitFor(async () => {
+        const posts = await findRequests("POST");
+        const testRequest = posts.find((r) =>
+          r.url.includes("/api/ee/remote-sync/test-connection"),
+        );
+        expect(testRequest).toBeDefined();
+        expect(testRequest?.body).toEqual({
+          "remote-sync-url": "https://github.com/test/repo.git",
+          "remote-sync-token": "ghp_abc123",
+          "remote-sync-branch": "main",
+          "remote-sync-type": "read-only",
+        });
+      });
+    });
+
+    it("should still call the endpoint when the connection fails so the user gets feedback", async () => {
+      setup({
+        remoteSyncType: "read-only",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        remoteSyncToken: "ghp_bad",
+        remoteSyncEnabled: true,
+        testConnectionError: {
+          status: 400,
+          message: "Authentication failed: Please check your git credentials",
+        },
+      });
+
+      const testButton = await screen.findByRole("button", {
+        name: /Test connection/i,
+      });
+      await waitFor(() => expect(testButton).toBeEnabled());
+      await userEvent.click(testButton);
+
+      await waitFor(async () => {
+        const posts = await findRequests("POST");
+        const testRequest = posts.find((r) =>
+          r.url.includes("/api/ee/remote-sync/test-connection"),
+        );
+        expect(testRequest).toBeDefined();
+      });
+
+      // Failures must not crash the form — the button stays enabled afterward
+      // and the URL field keeps its value.
+      expect(
+        screen.getByRole("button", { name: /Test connection/i }),
+      ).toBeEnabled();
+      expect(screen.getByLabelText(/Repository URL/i)).toHaveValue(
+        "https://github.com/test/repo.git",
+      );
+    });
+  });
+
   describe("save error handling", () => {
     it("should show backend error message in toast when save fails", async () => {
       setup({

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/TestConnectionButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/TestConnectionButton.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
+import { Button } from "metabase/ui";
+import { useTestRemoteSyncConnectionMutation } from "metabase-enterprise/api/remote-sync";
+import type {
+  RemoteSyncConfigurationSettings,
+  TestRemoteSyncConnectionRequest,
+} from "metabase-types/api";
+
+import { BRANCH_KEY, TOKEN_KEY, TYPE_KEY, URL_KEY } from "../../constants";
+
+interface TestConnectionButtonProps {
+  values: RemoteSyncConfigurationSettings;
+}
+
+export const TestConnectionButton = ({ values }: TestConnectionButtonProps) => {
+  const [testConnection, { isLoading }] = useTestRemoteSyncConnectionMutation();
+  const [sendToast] = useToast();
+
+  const handleTestConnection = useCallback(async () => {
+    const body: TestRemoteSyncConnectionRequest = {
+      [URL_KEY]: values[URL_KEY],
+      [TOKEN_KEY]: values[TOKEN_KEY],
+      [BRANCH_KEY]: values[BRANCH_KEY],
+      [TYPE_KEY]: values[TYPE_KEY],
+    };
+
+    try {
+      await testConnection(body).unwrap();
+      sendToast({
+        message: t`Connected to remote sync repository`,
+        icon: "check",
+      });
+    } catch (error) {
+      sendToast({
+        message: getErrorMessage(error, t`Could not connect to repository`),
+        icon: "warning",
+      });
+    }
+  }, [testConnection, values, sendToast]);
+
+  return (
+    <Button
+      data-testid="remote-sync-test-connection-button"
+      disabled={isLoading || !values[URL_KEY]}
+      loading={isLoading}
+      onClick={handleTestConnection}
+      variant="outline"
+    >
+      {t`Test connection`}
+    </Button>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/TestConnectionButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/TestConnectionButton.tsx
@@ -10,7 +10,7 @@ import type {
   TestRemoteSyncConnectionRequest,
 } from "metabase-types/api";
 
-import { BRANCH_KEY, TOKEN_KEY, TYPE_KEY, URL_KEY } from "../../constants";
+import { TOKEN_KEY, URL_KEY } from "../../constants";
 
 interface TestConnectionButtonProps {
   values: RemoteSyncConfigurationSettings;
@@ -24,8 +24,6 @@ export const TestConnectionButton = ({ values }: TestConnectionButtonProps) => {
     const body: TestRemoteSyncConnectionRequest = {
       [URL_KEY]: values[URL_KEY],
       [TOKEN_KEY]: values[TOKEN_KEY],
-      [BRANCH_KEY]: values[BRANCH_KEY],
-      [TYPE_KEY]: values[TYPE_KEY],
     };
 
     try {

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -141,8 +141,6 @@ export type CreateBranchResponse = {
 export type TestRemoteSyncConnectionRequest = {
   "remote-sync-url"?: string | null;
   "remote-sync-token"?: string | null;
-  "remote-sync-branch"?: string | null;
-  "remote-sync-type"?: "read-only" | "read-write" | null;
 };
 
 export type TestRemoteSyncConnectionResponse = {

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -137,3 +137,14 @@ export type CreateBranchResponse = {
   status: string;
   message: string;
 };
+
+export type TestRemoteSyncConnectionRequest = {
+  "remote-sync-url"?: string | null;
+  "remote-sync-token"?: string | null;
+  "remote-sync-branch"?: string | null;
+  "remote-sync-type"?: "read-only" | "read-write" | null;
+};
+
+export type TestRemoteSyncConnectionResponse = {
+  status: "success";
+};

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -120,6 +120,30 @@ export const setupRemoteSyncCancelTaskEndpoint = ({
 };
 
 /**
+ * Setup the remote-sync test-connection POST endpoint
+ */
+export const setupRemoteSyncTestConnectionEndpoint = ({
+  error,
+}: {
+  error?: { status: number; message: string };
+} = {}) => {
+  fetchMock.removeRoute("remote-sync-test-connection");
+  if (error) {
+    fetchMock.post(
+      "path:/api/ee/remote-sync/test-connection",
+      { status: error.status, body: { message: error.message } },
+      { name: "remote-sync-test-connection" },
+    );
+  } else {
+    fetchMock.post(
+      "path:/api/ee/remote-sync/test-connection",
+      { status: "success" },
+      { name: "remote-sync-test-connection" },
+    );
+  }
+};
+
+/**
  * Setup all remote-sync endpoints at once
  */
 export const setupRemoteSyncEndpoints = ({
@@ -130,6 +154,7 @@ export const setupRemoteSyncEndpoints = ({
   hasRemoteChangesDelay = 0,
   hasRemoteChangesError = false,
   settingsResponse = { success: true },
+  testConnectionError,
 }: {
   branches?: string[];
   dirty?: RemoteSyncEntity[];
@@ -140,12 +165,14 @@ export const setupRemoteSyncEndpoints = ({
   settingsResponse?: Partial<RemoteSyncSettingsResponse> & {
     error?: { status: number; message: string };
   };
+  testConnectionError?: { status: number; message: string };
 } = {}) => {
   setupRemoteSyncBranchesEndpoint(branches);
   setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });
   setupRemoteSyncCurrentTaskEndpoint("idle");
   setupRemoteSyncImportEndpoint();
   setupRemoteSyncSettingsEndpoint(settingsResponse);
+  setupRemoteSyncTestConnectionEndpoint({ error: testConnectionError });
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
   fetchMock.get(
     "path:/api/ee/remote-sync/has-remote-changes",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71149
### Description

Adds a new endpoint and to test remote sync connections, and a button in the Remote Sync Form to call it

### How to verify
1. Admin -> Remot-sync
2. If remote sync is already set up, hit the test connection button
3. If it succeeds, modify either the Repo URL or token fields and hit test connection again, it should fail

### Demo


https://github.com/user-attachments/assets/9dcbed55-d72b-44f5-a054-e18a2648f1ee


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
