### PR TITLE
docs - adds dedicated AI privacy page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,6 +158,7 @@ Metabase's reference documentation.
 - [Agent API](./ai/agent-api.md)
 - [MCP server](./ai/mcp.md)
 - [Metabot in Slack](./ai/metabot-slack.md)
+- [AI privacy](./ai/privacy.md)
 
 ### Exploration and organization
 

--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -70,7 +70,7 @@ A first-time connection will go something like this:
 3. You're redirected to Metabase to log in (if you aren't already) and approve the connection.
 4. The client receives an access token scoped to the permissions you have in Metabase.
 
-Results returned by the MCP server are sent to your MCP client, which may forward them to an AI provider depending on how the client is configured. See [Privacy](./settings.md#privacy).
+Results returned by the MCP server are sent to your MCP client, which may forward them to an AI provider depending on how the client is configured. See [AI privacy](./privacy.md).
 
 ### Site URL must match the URL your client uses
 

--- a/docs/ai/privacy.md
+++ b/docs/ai/privacy.md
@@ -18,7 +18,7 @@ What we send:
 - Your prompts.
 - Metadata (like table and field names), so Metabot knows what to query.
 - A sampling of field values from your database. For example, if you ask Metabot to "Filter everyone from Wisconsin," it might check the values in the state field to see how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
-- The data plotted in a chart when you ask Metabot to analyze a visualization — the points drawn on the chart, not the underlying row-level query results. What's sent depends on the chart type.
+- For chart analysis, AI might see the timeseries data used to draw certain visualizations, depending on the chart type.
 
 We, Metabase the company, also collect some of this metadata to gauge usage and improve the AI integration.
 

--- a/docs/ai/privacy.md
+++ b/docs/ai/privacy.md
@@ -18,7 +18,7 @@ What we send:
 - Your prompts.
 - Metadata (like table and field names), so Metabot knows what to query.
 - A sampling of field values from your database. For example, if you ask Metabot to "Filter everyone from Wisconsin," it might check the values in the state field to see how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
-- For chart analysis, AI might see the timeseries data used to draw certain visualizations, depending on the chart type.
+- For chart analysis, AI won't see the raw timeseries data, but it does see some metrics derived from that data (like slopes, series correlations, etc). AI may also see some categorical values. For example, if a question breaks out orders over time by a product category, the AI could see the category values ("Gadgets", "Widgets", etc).
 
 We, Metabase the company, also collect some of this metadata to gauge usage and improve the AI integration.
 

--- a/docs/ai/privacy.md
+++ b/docs/ai/privacy.md
@@ -1,0 +1,40 @@
+---
+title: AI privacy
+summary: What data Metabase sends to AI providers and MCP clients when you use AI features, and what Metabase the company collects.
+---
+
+# AI privacy
+
+Using [AI features](./settings.md) in Metabase means sending some data outside your instance. This page covers what gets sent, and to whom.
+
+## Data sent to the Metabase AI service
+
+When using the Metabase AI service, we don't send the _results_ of your queries to a third-party AI provider, and we don't look at them ourselves.
+
+What we send:
+
+- Your prompts.
+- Metadata (like table and field names), so Metabot knows what to query.
+- A sampling of field values from your database. For example, if you ask Metabot to "Filter everyone from Wisconsin," it might check the values in the state field to see how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
+- The data plotted in a chart when you ask Metabot to analyze a visualization — the points drawn on the chart, not the underlying row-level query results. What's sent depends on the chart type.
+
+We, Metabase the company, also collect some of this metadata to gauge usage and improve the AI integration.
+
+## Data sent to your own AI provider
+
+If you're using your own API key, everything listed above is sent to your selected AI provider. Review your provider's data handling and privacy policies.
+
+## Data sent to the MCP client
+
+When using the [MCP server](./mcp.md), query _results_ are sent to the connected MCP client.
+
+## Data sent when submitting feedback
+
+If you [submit feedback](./metabot.md#giving-feedback-on-metabot-responses) on a Metabot response, the context for that conversation, including metadata and your prompts, might be sent to Metabase the company, and may contain sensitive data.
+
+## Further reading
+
+- [AI settings](./settings.md)
+- [Using Metabot](./metabot.md)
+- [MCP server](./mcp.md)
+- [Privacy and GDPR](../installation-and-operation/privacy.md)

--- a/docs/ai/privacy.md
+++ b/docs/ai/privacy.md
@@ -7,7 +7,7 @@ summary: What data Metabase sends to AI providers and MCP clients when you use A
 
 AI in Metabase is optional.
 
-If you do use AI (which you can set up in [AI settings](./settings.md), we need to send some data outside of your Metabase. This page covers what gets sent, and to whom.
+If you do use AI (which you can set up in [AI settings](./settings.md)), we need to send some data outside of your Metabase. This page covers what gets sent, and to whom.
 
 ## Data sent to the Metabase AI service
 

--- a/docs/ai/privacy.md
+++ b/docs/ai/privacy.md
@@ -5,7 +5,9 @@ summary: What data Metabase sends to AI providers and MCP clients when you use A
 
 # AI privacy
 
-Using [AI features](./settings.md) in Metabase means sending some data outside your instance. This page covers what gets sent, and to whom.
+AI in Metabase is optional.
+
+If you do use AI (which you can set up in [AI settings](./settings.md), we need to send some data outside of your Metabase. This page covers what gets sent, and to whom.
 
 ## Data sent to the Metabase AI service
 

--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -193,37 +193,11 @@ If you're using your own API key, you can track usage and costs through your AI 
 
 On Metabase Pro/Enterprise, you also get access to detailed [AI usage auditing](usage-auditing.md) with detailed breakdown of AI usage by user, tool, feature etc.
 
-## Privacy
-
-### Data sent to the Metabase AI service
-
-When using the Metabase AI service, we don't send the _results_ of your queries to a third-party AI provider, and we don't look at them ourselves.
-
-What we send:
-
-- Your prompts.
-- Metadata (like table and field names), so Metabot knows what to query.
-- A sampling of field values from your database. For example, if you ask Metabot to "Filter everyone from Wisconsin," it might check the values in the state field to see how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
-- The data plotted in a chart when you ask Metabot to analyze a visualization — the points drawn on the chart, not the underlying row-level query results. What's sent depends on the chart type.
-
-We, Metabase the company, also collect some of this metadata to gauge usage and improve the AI integration.
-
-### Data sent to your own AI provider
-
-If you're using your own API key, everything listed above is sent to your selected AI provider. Review your provider's data handling and privacy policies.
-
-### Data sent to the MCP client
-
-When using the [MCP server](./mcp.md), query _results_ are sent to the connected MCP client.
-
-### Data sent when submitting feedback
-
-If you [submit feedback](./metabot.md#giving-feedback-on-metabot-responses) on a Metabot response, the context for that conversation, including metadata and your prompts, might be sent to Metabase the company, and may contain sensitive data.
-
 ## Further reading
 
 - [Using Metabot](metabot.md)
 - [MCP server](mcp.md)
+- [AI privacy](privacy.md)
 - [AI access and usage controls](usage-controls.md)
 - [AI usage auditing](usage-auditing.md)
 - [Metabot customization](customization.md)

--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -195,21 +195,30 @@ On Metabase Pro/Enterprise, you also get access to detailed [AI usage auditing](
 
 ## Privacy
 
-When using the Metabase AI service, your questions and conversations remain private to your Metabase -- we don't send your data to external services. We do collect some metadata to gauge and improve usage.
+### Data sent to the Metabase AI service
 
-If you're using your own API key, your prompts and data are sent to your selected AI provider. Review your provider's data handling and privacy policies. When using the [MCP server](./mcp.md), query results are sent to the connected MCP client.
+When using the Metabase AI service, we don't send the _results_ of your queries to a third-party AI provider, and we don't look at them ourselves.
 
-In both cases, Metabot can't create assets or write data. If you [submit feedback](./metabot.md#giving-feedback-on-metabot-responses), the form you send may contain sensitive data from your conversation.
+What we send:
 
-### What Metabot can see
+- Your prompts.
+- Metadata (like table and field names), so Metabot knows what to query.
+- A sampling of field values from your database. For example, if you ask Metabot to "Filter everyone from Wisconsin," it might check the values in the state field to see how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
+- The data plotted in a chart when you ask Metabot to analyze a visualization — the points drawn on the chart, not the underlying row-level query results. What's sent depends on the chart type.
 
-Metabot has access to your Metabase metadata and some data values to help answer your questions:
+We, Metabase the company, also collect some of this metadata to gauge usage and improve the AI integration.
 
-- **Table, Question, Model, Dashboard, and Metric metadata**: Metabot can see the structure and configuration of your content.
-- **Sample field values**: When you ask questions like "Filter everyone from Wisconsin," Metabot might check the values in the state field to understand how the data is stored (like "WI" vs "Wisconsin"). See [syncs](../databases/sync-scan.md).
-- **Timeseries data**: For chart analysis, Metabot might see the timeseries data used to draw certain visualizations, depending on the chart type.
+### Data sent to your own AI provider
 
-When you [submit feedback](./metabot.md#giving-feedback-on-metabot-responses), the context for the conversation - including this metadata and conversation prompts - might be sent to Metabase.
+If you're using your own API key, everything listed above is sent to your selected AI provider. Review your provider's data handling and privacy policies.
+
+### Data sent to the MCP client
+
+When using the [MCP server](./mcp.md), query _results_ are sent to the connected MCP client.
+
+### Data sent when submitting feedback
+
+If you [submit feedback](./metabot.md#giving-feedback-on-metabot-responses) on a Metabot response, the context for that conversation, including metadata and your prompts, might be sent to Metabase the company, and may contain sensitive data.
 
 ## Further reading
 

--- a/docs/ai/start.md
+++ b/docs/ai/start.md
@@ -12,6 +12,10 @@ Metabot is an AI assistant that helps you explore and analyze your data.
 
 Connect an AI provider and configure AI features like Metabot.
 
+## [AI privacy](./privacy.md)
+
+What data Metabase sends to AI providers and MCP clients, and what Metabase collects.
+
 ## [AI usage controls](./usage-controls.md)
 
 Control who can use Metabot, and set token and message limits.

--- a/docs/installation-and-operation/privacy.md
+++ b/docs/installation-and-operation/privacy.md
@@ -16,4 +16,8 @@ If you self-host your Metabase instance, we have no access to any of your data, 
 
 If you're a [Metabase Cloud](https://www.metabase.com/pricing/) customer, your [Terms of Service](https://www.metabase.com/license/hosting) include a Data Processing Agreement (DPA).
 
+## Further reading
+
+- [AI privacy](../ai/privacy.md) — what data Metabase's AI features send, and to whom
+
 [information-collection]: information-collection.md


### PR DESCRIPTION
Also clarifies some of the language.

See https://metaboat.slack.com/archives/C01LQQ2UW03/p1779463839283299.