### PR TITLE
Inactive table field import

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -290,7 +290,7 @@
                 (testing "import succeeds by synthesizing the missing Table/Field"
                   (let [import-task (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import"
                                                                                     :initiated_by   (mt/user->id :rasta)})
-                        result      (impl/import! (source.p/snapshot mock) import-task)]
+                        result      (impl/import! (source.p/snapshot mock) import-task :force? true)]
                     (is (= :success (:status result)))
                     (let [table (t2/select-one :model/Table :db_id db-id :name "customers")
                           field (some->> table :id (t2/select-one :model/Field :name "age" :table_id))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -13,7 +13,6 @@
    [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
    [metabase.app-db.core :as app-db]
    [metabase.collections.models.collection :as collection]
-   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.search.core :as search]
@@ -254,51 +253,6 @@
               (is (= "Test Card" (:name card)))
               (is (= "test-card-1xxxxxxxxxx" (:entity_id card)))
               (is (= coll-id (:collection_id card))))))))))
-
-(deftest import-card-referencing-unpublished-table-test
-  (testing "a Card referencing an unpublished (hence un-exported) Table/Field re-imports by synthesizing inactive rows"
-    (mt/with-model-cleanup [:model/Table :model/Field]
-      (mt/with-temporary-setting-values [remote-sync-type :read-write]
-        (mt/with-temp [:model/Database   {db-id :id}     {:name "my-db"}
-                       :model/Table      {table-id :id}  {:name "customers" :db_id db-id :is_published false}
-                       :model/Field      {field-id :id}  {:name "age" :table_id table-id :base_type :type/Integer}
-                       :model/Collection {coll-id :id}   {:name "Synced" :is_remote_synced true :location "/"}]
-          (let [mp    (lib-be/application-database-metadata-provider db-id)
-                query (-> (lib/query mp (lib.metadata/table mp table-id))
-                          (lib/filter (lib/>= (lib.metadata/field mp field-id) 18)))]
-            (mt/with-temp [:model/Card {card-id  :id
-                                        card-eid :entity_id} {:name          "Customers Card"
-                                                              :collection_id coll-id
-                                                              :database_id   db-id
-                                                              :table_id      table-id
-                                                              :dataset_query query}]
-              (let [mock        (test-helpers/create-mock-source :branch "main")
-                    export-task (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export"
-                                                                                :initiated_by   (mt/user->id :rasta)})]
-                (testing "export succeeds; the unpublished Table/Field are not part of the bundle"
-                  (is (= :success (:status (impl/export! (source.p/snapshot mock) export-task "export"))))
-                  (remote-sync.task/complete-sync-task! export-task)
-                  (let [files (keys (get @(:files-atom mock) "main"))]
-                    (is (some #(str/includes? % "card") files) "the card was exported")
-                    (is (not-any? #(str/includes? % "/tables/") files) "no table/field files were exported")))
-
-                ;; Simulate importing onto an instance where the unpublished Table/Field do not exist.
-                (t2/update! :model/Card card-id {:table_id nil})
-                (t2/delete! :model/Field :id field-id)
-                (t2/delete! :model/Table :id table-id)
-
-                (testing "import succeeds by synthesizing the missing Table/Field"
-                  (let [import-task (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import"
-                                                                                    :initiated_by   (mt/user->id :rasta)})
-                        result      (impl/import! (source.p/snapshot mock) import-task :force? true)]
-                    (is (= :success (:status result)))
-                    (let [table (t2/select-one :model/Table :db_id db-id :name "customers")
-                          field (some->> table :id (t2/select-one :model/Field :name "age" :table_id))
-                          query (:dataset_query (t2/select-one :model/Card :entity_id card-eid))]
-                      (is (=? {:active false} table) "inactive Table was synthesized")
-                      (is (=? {:active false} field) "inactive Field was synthesized")
-                      (is (= (:id table) (lib/primary-source-table-id query))
-                          "the Card's query resolves to the synthesized Table"))))))))))))
 
 (deftest collection-cleanup-during-import-test
   (testing "collection cleanup during import (tests clean-synced! private function)"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -13,8 +13,6 @@
    [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
    [metabase.app-db.core :as app-db]
    [metabase.collections.models.collection :as collection]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -13,6 +13,9 @@
    [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
    [metabase.app-db.core :as app-db]
    [metabase.collections.models.collection :as collection]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
@@ -251,6 +254,51 @@
               (is (= "Test Card" (:name card)))
               (is (= "test-card-1xxxxxxxxxx" (:entity_id card)))
               (is (= coll-id (:collection_id card))))))))))
+
+(deftest import-card-referencing-unpublished-table-test
+  (testing "a Card referencing an unpublished (hence un-exported) Table/Field re-imports by synthesizing inactive rows"
+    (mt/with-model-cleanup [:model/Table :model/Field]
+      (mt/with-temporary-setting-values [remote-sync-type :read-write]
+        (mt/with-temp [:model/Database   {db-id :id}     {:name "my-db"}
+                       :model/Table      {table-id :id}  {:name "customers" :db_id db-id :is_published false}
+                       :model/Field      {field-id :id}  {:name "age" :table_id table-id :base_type :type/Integer}
+                       :model/Collection {coll-id :id}   {:name "Synced" :is_remote_synced true :location "/"}]
+          (let [mp    (lib-be/application-database-metadata-provider db-id)
+                query (-> (lib/query mp (lib.metadata/table mp table-id))
+                          (lib/filter (lib/>= (lib.metadata/field mp field-id) 18)))]
+            (mt/with-temp [:model/Card {card-id  :id
+                                        card-eid :entity_id} {:name          "Customers Card"
+                                                              :collection_id coll-id
+                                                              :database_id   db-id
+                                                              :table_id      table-id
+                                                              :dataset_query query}]
+              (let [mock        (test-helpers/create-mock-source :branch "main")
+                    export-task (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "export"
+                                                                                :initiated_by   (mt/user->id :rasta)})]
+                (testing "export succeeds; the unpublished Table/Field are not part of the bundle"
+                  (is (= :success (:status (impl/export! (source.p/snapshot mock) export-task "export"))))
+                  (remote-sync.task/complete-sync-task! export-task)
+                  (let [files (keys (get @(:files-atom mock) "main"))]
+                    (is (some #(str/includes? % "card") files) "the card was exported")
+                    (is (not-any? #(str/includes? % "/tables/") files) "no table/field files were exported")))
+
+                ;; Simulate importing onto an instance where the unpublished Table/Field do not exist.
+                (t2/update! :model/Card card-id {:table_id nil})
+                (t2/delete! :model/Field :id field-id)
+                (t2/delete! :model/Table :id table-id)
+
+                (testing "import succeeds by synthesizing the missing Table/Field"
+                  (let [import-task (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import"
+                                                                                    :initiated_by   (mt/user->id :rasta)})
+                        result      (impl/import! (source.p/snapshot mock) import-task)]
+                    (is (= :success (:status result)))
+                    (let [table (t2/select-one :model/Table :db_id db-id :name "customers")
+                          field (some->> table :id (t2/select-one :model/Field :name "age" :table_id))
+                          query (:dataset_query (t2/select-one :model/Card :entity_id card-eid))]
+                      (is (=? {:active false} table) "inactive Table was synthesized")
+                      (is (=? {:active false} field) "inactive Field was synthesized")
+                      (is (= (:id table) (lib/primary-source-table-id query))
+                          "the Card's query resolves to the synthesized Table"))))))))))))
 
 (deftest collection-cleanup-during-import-test
   (testing "collection cleanup during import (tests clean-synced! private function)"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -560,10 +560,7 @@
                          [{:id coll-eid          :model "Collection"}]
                          [{:id model-eid         :model "Card"}]
                          [{:id card-eid          :model "Card"}]
-                         [{:id "Linked database" :model "Database"}]
-                         [{:model "Database" :id "Linked database"}
-                          {:model "Schema"   :id "Public"}
-                          {:model "Table"    :id "Linked table"}]}
+                         [{:id "Linked database" :model "Database"}]}
                        (set (serdes/dependencies extracted-dashboard))))
 
                 (storage/store! (seq extraction) (storage.files/file-writer dump-dir))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -185,10 +185,9 @@
               :dashboard-card          (many-random-fks 300 {} {:card_id      [:c 100]
                                                                 :dashboard_id [:d 100]})
               :dimension               (vec (concat
-                                             ;; 20 with both IDs set
-                                             (many-random-fks 20 {}
-                                                              {:field_id                [:field 1000]
-                                                               :human_readable_field_id [:field 1000]})
+                                             (vec (repeatedly 20 #(let [f (random-keyword :field 1000)]
+                                                                    [1 {:refs {:field_id                f
+                                                                               :human_readable_field_id f}}])))
                                              ;; 20 with just :field_id
                                              (many-random-fks 20 {:refs {:human_readable_field_id ::rs/omit}}
                                                               {:field_id [:field 1000]})))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -353,13 +353,8 @@
                   ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Collection, and anything referenced in the query (including :database)"
+          (testing "cards depend on their Collection and the query's Database (not the Tables/Fields it references)"
             (is (= #{[{:model "Database" :id "My Database"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}
-                      {:model "Field" :id "Some Field"}]
                      [{:model "Collection" :id coll-eid}]}
                    (set (serdes/dependencies ser))))))
 
@@ -378,17 +373,10 @@
           (is (not (contains? ser :table_id)) "table_id always skipped for cards — re-derived on import")
           (is (contains? ser :database_id) "database_id kept when query is empty")
 
-          (testing "cards depend on their Database (kept because query is empty), Collection, and parameter_mappings refs"
+          (testing "cards depend on their Database (kept because query is empty), Collection, and parameter_mappings card refs (not the Fields)"
             (is (= #{[{:model "Database" :id "My Database"}]
                      [{:model "Collection" :id coll-eid}]
-                     [{:model "Card" :id c1-eid}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}
-                      {:model "Field" :id "Some Field"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Schema" :id "PUBLIC"}
-                      {:model "Table" :id "Schema'd Table"}
-                      {:model "Field" :id "Other Field"}]}
+                     [{:model "Card" :id c1-eid}]}
                    (set (serdes/dependencies ser))))))
 
         (let [ser (serdes/extract-one "Card" {} (t2/select-one :model/Card :id c3-id))]
@@ -421,16 +409,9 @@
                   ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Database (kept, query empty), Collection, and visualization_settings refs"
+          (testing "cards depend on their Database (kept, query empty) and Collection (not the Fields in visualization_settings)"
             (is (= #{[{:model "Database" :id "My Database"}]
-                     [{:model "Collection" :id coll-eid}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}
-                      {:model "Field" :id "Some Field"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Schema" :id "PUBLIC"}
-                      {:model "Table" :id "Schema'd Table"}
-                      {:model "Field" :id "Other Field"}]}
+                     [{:model "Collection" :id coll-eid}]}
                    (set (serdes/dependencies ser)))))))
 
       (testing "Cards can be based on other cards"
@@ -481,16 +462,10 @@
                   ser))
           (is (not (contains? ser :id)))
 
-          (testing "and depend on all referenced cards and actions, including those in visualization_settings"
+          (testing "and depend on all referenced cards and actions, plus the Database of fields referenced in visualization_settings"
             (is (= #{[{:model "Card" :id c2-eid}]
                      [{:model "Action" :id action-eid}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}
-                      {:model "Field" :id "Some Field"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Schema" :id "PUBLIC"}
-                      {:model "Table" :id "Schema'd Table"}
-                      {:model "Field" :id "Other Field"}]
+                     [{:model "Database" :id "My Database"}]
                      [{:model "Collection" :id dave-coll-eid}]}
                    (set (serdes/dependencies ser)))))))
 
@@ -508,9 +483,8 @@
                   ser))
           (is (= #{[{:model "Collection" :id dave-coll-eid}]
                    [{:model "Card" :id c1-eid}]
-                   [{:model "Database", :id "My Database"}
-                    {:model "Table", :id "Schemaless Table"}
-                    {:model "Field", :id "Some Field"}]}
+                   ;; the parameter's value_field references a Field, but only its Database is a dependency
+                   [{:model "Database", :id "My Database"}]}
                  (set (serdes/dependencies ser))))))
 
       (testing "Cards with parameters where the source is a card"
@@ -527,9 +501,8 @@
                   ser))
           (is (= #{[{:model "Collection" :id dave-coll-eid}]
                    [{:model "Card" :id c1-eid}]
-                   [{:model "Database", :id "My Database"}
-                    {:model "Table", :id "Schemaless Table"}
-                    {:model "Field", :id "Some Field"}]}
+                   ;; the parameter's value_field references a Field, but only its Database is a dependency
+                   [{:model "Database", :id "My Database"}]}
                  (set (serdes/dependencies ser))))))
 
       (testing "collection filtering based on :user option"
@@ -641,9 +614,8 @@
             (is (= [dim1-eid]
                    (->> ser :dimensions (map :entity_id)))))
 
-          (testing "which depend on just the table"
-            (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}]}
+          (testing "depend only on the Database; the Table is synthesized on import if missing"
+            (is (= #{[{:model "Database"   :id "My Database"}]}
                    (set (serdes/dependencies ser)))))))
 
       (testing "foreign key dimensions are inlined into their Fields"
@@ -667,18 +639,8 @@
                       :created_at              string?}]
                     (:dimensions ser))))
 
-          (testing "which depend on the Table and both real and human-readable foreign Fields"
-            (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Schema"     :id "PUBLIC"}
-                      {:model "Table"      :id "Orders"}]
-                     [{:model "Database"   :id "My Database"}
-                      {:model "Schema"     :id "PUBLIC"}
-                      {:model "Table"      :id "Customers"}
-                      {:model "Field"      :id "id"}]
-                     [{:model "Database"   :id "My Database"}
-                      {:model "Schema"     :id "PUBLIC"}
-                      {:model "Table"      :id "Customers"}
-                      {:model "Field"      :id "name"}]}
+          (testing "depend only on the Database; the Table, FK target and human-readable Fields are synthesized on import if missing"
+            (is (= #{[{:model "Database"   :id "My Database"}]}
                    (set (serdes/dependencies ser))))))))))
 
 (deftest native-query-snippets-test
@@ -908,13 +870,8 @@
                    :created_at  string?}
                   ser))
           (is (not (contains? ser :id)))
-          (testing "depend on the Database, the Table and any fields from the definition"
-            (is (= #{[{:model "Database" :id "My Database"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}]
-                     [{:model "Database" :id "My Database"}
-                      {:model "Table" :id "Schemaless Table"}
-                      {:model "Field" :id "Some Field"}]}
+          (testing "depend only on the Database; the Table/Fields from the definition are not dependencies"
+            (is (= #{[{:model "Database" :id "My Database"}]}
                    (set (serdes/dependencies ser))))))))))
 
 (defn- mbql5-measure-definition
@@ -954,13 +911,8 @@
                        :created_at  string?}
                       ser))
               (is (not (contains? ser :id)))
-              (testing "depend on the Database, the Table and any fields from the definition"
-                (is (= #{[{:model "Database" :id "My Database"}]
-                         [{:model "Database" :id "My Database"}
-                          {:model "Table" :id "Schemaless Table"}]
-                         [{:model "Database" :id "My Database"}
-                          {:model "Table" :id "Schemaless Table"}
-                          {:model "Field" :id "Some Field"}]}
+              (testing "depend only on the Database; the Table/Fields from the definition are not dependencies"
+                (is (= #{[{:model "Database" :id "My Database"}]}
                        (set (serdes/dependencies ser))))))))))))
 
 (deftest measure-referencing-measure-test
@@ -1205,10 +1157,8 @@
           (is (not (contains? ser :field_id))
               ":field_id is dropped; its implied by the path")
 
-          (testing "depend on the parent Field"
-            (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}
-                      {:model "Field"      :id "Some Field"}]}
+          (testing "depend only on the Database; the parent Field is synthesized on import if missing"
+            (is (= #{[{:model "Database"   :id "My Database"}]}
                    (set (serdes/dependencies ser)))))))
       (testing "extract-metabase behavior"
         (testing "without :include-field-values"
@@ -1241,10 +1191,8 @@
           (is (not (contains? ser :field_id))
               ":field_id is dropped; its implied by the path")
 
-          (testing "depend on the parent Field"
-            (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}
-                      {:model "Field"      :id "Some Field"}]}
+          (testing "depend only on the Database; the parent Field is synthesized on import if missing"
+            (is (= #{[{:model "Database"   :id "My Database"}]}
                    (set (serdes/dependencies ser)))))))
       (testing "extract-metabase behavior"
         (let [models (->> {} (extract/extract) (map (comp :model last :serdes/meta)))]
@@ -1301,12 +1249,11 @@
                    :values_source_config {:card_id card-eid-1,
                                           :value_field [:field ["My Database" nil "Schemaless Table" "A Field"] nil]}}]
                  (:parameters ser)))
+          ;; The parameter's value_field references a Field, but Tables/Fields are not dependencies — only their
+          ;; Database is.
           (is (= #{[{:model "Database"   :id "My Database"}]
                    [{:model "Collection" :id coll-eid-2}]
-                   [{:model "Card"       :id card-eid-1}]
-                   [{:model "Database"   :id "My Database"}
-                    {:model "Table"      :id "Schemaless Table"}
-                    {:model "Field"      :id "A Field"}]}
+                   [{:model "Card"       :id card-eid-1}]}
                  (set (serdes/dependencies ser))))))
       (testing "Nullable transformations are omitted"
         (let [ser (serdes/extract-one "Card" {} (t2/select-one :model/Card :id card-id-2))]
@@ -2405,11 +2352,12 @@
                 (is (= [hourly-tag-eid custom-tag-eid daily-tag-eid] tag-ids))
                 (is (= [0 1 2] positions))))
 
-            (testing "dependencies include collection, source table, and tags"
+            (testing "dependencies include collection, source database, and tags (the source Table itself is not a dependency)"
               (let [deps (set (serdes/dependencies ser))]
                 (is (contains? deps [{:model "Collection" :id coll-eid}]))
-                (is (contains? deps [{:model "Database" :id "My Database"}
-                                     {:model "Table" :id "Schemaless Table"}]))
+                (is (contains? deps [{:model "Database" :id "My Database"}]))
+                (is (not (contains? deps [{:model "Database" :id "My Database"}
+                                          {:model "Table" :id "Schemaless Table"}])))
                 (is (contains? deps [{:model "TransformTag" :id hourly-tag-eid}]))
                 (is (contains? deps [{:model "TransformTag" :id custom-tag-eid}]))
                 (is (contains? deps [{:model "TransformTag" :id daily-tag-eid}])))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2901,9 +2901,10 @@
           ;; Database dep comes from mbql-deps on the query's :database key
           (is (contains? (set deps) [{:model "Database" :id "Test DB"}])
               "Database dependency should come from the query")
-          ;; Table dep comes from mbql-deps on the query's :source-table
-          (is (some #(some (fn [step] (= "Table" (:model step))) %) deps)
-              "Table dependency should come from the query"))))))
+          ;; Tables/Fields are intentionally not dependencies — they're synthesized as inactive rows on import
+          ;; if missing, and upserted otherwise.
+          (is (not-any? #(some (fn [step] (#{"Table" "Field"} (:model step))) %) deps)
+              "Table/Field should not be dependencies"))))))
 
 (deftest segment-export-strips-table-id-test
   (testing "Segment export omits table_id — derivable from definition"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -286,6 +286,51 @@
                        :database (:id @db1d)}
                       (:dataset_query @card1d))))))))))
 
+(deftest card-with-unexported-table-and-field-test
+  (testing "a Card referencing a Table/Field absent from the bundle still loads by synthesizing inactive rows"
+    (let [serialized (atom nil)]
+      (ts/with-dbs [source-db dest-db]
+        (testing "serializing a database, table, field and a card that references them"
+          (ts/with-db source-db
+            (let [coll  (ts/create! :model/Collection :name "pop! minis")
+                  db    (ts/create! :model/Database :name "my-db")
+                  table (ts/create! :model/Table :name "customers" :db_id (:id db))
+                  field (ts/create! :model/Field :name "age" :table_id (:id table) :base_type :type/Integer)
+                  _user (ts/create! :model/User :first_name "Tom" :last_name "Scholz" :email "tom@bost.on")
+                  mp    (lib-be/application-database-metadata-provider (:id db))
+                  query (-> (lib/query mp (lib.metadata/table mp (:id table)))
+                            (lib/filter (lib/>= (lib.metadata/field mp (:id field)) 18))
+                            (lib/aggregate (lib/count)))]
+              (ts/create! :model/Card
+                          :database_id   (:id db)
+                          :table_id      (:id table)
+                          :collection_id (:id coll)
+                          :query_type    :query
+                          :name          "Example Card"
+                          :dataset_query query
+                          :display       :line)
+              (reset! serialized (into [] (remove #(#{"Table" "Field"} (-> % :serdes/meta last :model))
+                                                  (serdes.extract/extract {})))))))
+
+        (testing "the bundle has the Card but no Table/Field"
+          (is (seq (by-model @serialized "Card")))
+          (is (empty? (by-model @serialized "Table")))
+          (is (empty? (by-model @serialized "Field"))))
+
+        (testing "deserializing synthesizes inactive Table and Field for the dangling references"
+          (ts/with-db dest-db
+            (ts/create! :model/Database :name "my-db")
+            (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+            (let [db    (t2/select-one :model/Database :name "my-db")
+                  table (t2/select-one :model/Table :name "customers" :db_id (:id db))
+                  field (and table (t2/select-one :model/Field :name "age" :table_id (:id table)))
+                  card  (t2/select-one :model/Card :name "Example Card")
+                  query (:dataset_query card)]
+              (is (=? {:active false} table))
+              (is (=? {:active false} field))
+              (is (= (:id db) (lib/database-id query)))
+              (is (= (:id table) (lib/primary-source-table-id query))))))))))
+
 (deftest segment-test
   ;; Segment.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
   ;; converted to a portable form and read back in.
@@ -487,7 +532,6 @@
             (is (=? {:definition {:stages [{:aggregation [[:* {} [:measure {} (:entity_id @msr1s)] 2]]}]}}
                     derived-measure))
             (is (= #{[{:id "my-db", :model "Database"}]
-                     [{:id "my-db", :model "Database"} {:id "sales", :model "Table"}]
                      [{:id (:entity_id @msr1s), :model "Measure"}]}
                    (serdes/mbql-deps (:definition derived-measure))))))
         (testing "deserializing adjusts the measure IDs properly"

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -190,9 +190,8 @@
   [_measure]
   [:name (serdes/hydrated-hash :table) :created_at])
 
-(defmethod serdes/dependencies "Measure" [{:keys [definition table_id]}]
-  (cond-> (serdes/mbql-deps definition)
-    table_id (conj (serdes/table->path table_id))))
+(defmethod serdes/dependencies "Measure" [{:keys [definition]}]
+  (serdes/mbql-deps definition))
 
 (defmethod serdes/storage-path "Measure" [measure _ctx]
   (let [table-path (-> measure :definition serdes/serialized-query-source-table)]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -834,7 +834,7 @@
 (defn- xform-one [model-name ingested]
   (let [spec (*make-spec* model-name nil)]
     (assert spec (str "No serialization spec defined for model " model-name))
-    (-> (select-keys ingested (:copy spec))
+    (-> (merge (:defaults spec) (select-keys ingested (:copy spec)))
         (into (for [[k transform] (:transform spec)
                     :when (and (not (::nested transform))
                                ;; handling circuit-breaking
@@ -1389,10 +1389,22 @@
 
 (declare ^:private mbql-deps-map)
 
+(defn- ref->db-dep
+  "Given a portable table or field reference (a vector like `[db-name schema table-name ...]`), return a set with
+  its Database dependency, or nil. Table and Field references are intentionally *not* dependencies — missing ones
+  are synthesized as inactive rows on import — but their Database is, since it can't be synthesized. We can't rely
+  on the query's top-level `:database` for this because some references (e.g. dashboard parameter mappings) are
+  bare field refs with no surrounding query."
+  [ref]
+  (when-let [db-name (first ref)]
+    #{[{:model "Database" :id db-name}]}))
+
 (defn- mbql-deps-vector [entity]
   (match/match-one entity
-    [#{:field "field"} (opts :guard map?) (id :guard vector?)]
-    (into #{(field->path id)} (mbql-deps-map opts))
+    ;; A `:field`/`:field-id` clause's only dependency is the Database of its referenced field; the Field itself
+    ;; is not a dependency, and a field clause never contains nested metric/segment/card refs, so we don't descend.
+    [#{:field "field"} (_opts :guard map?) (ref :guard vector?)]
+    (ref->db-dep ref)
 
     [(tag :guard #{:metric "metric" :segment "segment" :measure "measure"})
      (opts :guard map?)
@@ -1405,8 +1417,8 @@
           (mbql-deps-map opts))
 
     ;; legacy (MBQL 4) refs
-    [#{:field "field" :field-id "field-id"} (id :guard vector?) opts]
-    (into #{(field->path id)} (mbql-deps-map opts))
+    [#{:field "field" :field-id "field-id"} (ref :guard vector?) _opts]
+    (ref->db-dep ref)
 
     [(tag :guard #{:metric "metric" :segment "segment" :measure "measure"}) (field :guard portable-id?)]
     #{[{:model (case tag
@@ -1429,12 +1441,13 @@
                     (and (= k :database)
                          (string? v)
                          (not= v "database/__virtual"))        #{[{:model "Database" :id v}]}
-                    (and (= k :source-table) (vector? v))      #{(table->path v)}
+                    ;; Table/Field references contribute only their Database as a dependency (see `ref->db-dep`).
+                    (and (= k :source-table) (vector? v))      (ref->db-dep v)
                     (and (= k :source-table) (portable-id? v)) #{[{:model "Card" :id v}]}
                     (and (= k :source-card)  (portable-id? v)) #{[{:model "Card" :id v}]}
-                    (and (= k :source-field) (vector? v))      #{(field->path v)}
+                    (and (= k :source-field) (vector? v))      (ref->db-dep v)
                     (and (= k :snippet-id)   (portable-id? v)) #{[{:model "NativeQuerySnippet" :id v}]}
-                    (and (= k :table-id)     (vector? v))      #{(table->path v)}
+                    (and (= k :table-id)     (vector? v))      (ref->db-dep v)
                     (and (#{:card_id :card-id} k) (string? v)) #{[{:model "Card" :id v}]}
                     (map? v)                                   (mbql-deps-map v)
                     (vector? v)                                (mbql-deps-vector v))))
@@ -1777,7 +1790,8 @@
   [settings]
   (when-let [{:keys [model id]} (get-in settings [:link :entity])]
     #{(case model
-        "table" (table->path id)
+        ;; A linked Table is not a dependency (synthesized on import if missing), but its Database is.
+        "table" [{:model "Database" :id (first id)}]
         [{:model (name (link-card-model->toucan-model model))
           :id    id}])}))
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1289,15 +1289,7 @@
 (defn- result-metadata-deps [metadata]
   (when (seq metadata)
     (-> (reduce into #{} (for [m metadata]
-                           (conj (serdes/mbql-deps (:field_ref m))
-                                 (when (:table_id m)
-                                   (serdes/table->path (:table_id m)))
-                                 (when (:id m)
-                                   (serdes/field->path (:id m)))
-                                 (when (and (:fk_target_field_id m)
-                                            ;; FIXME: remove that check after v52
-                                            (not (number? (:fk_target_field_id m))))
-                                   (serdes/field->path (:fk_target_field_id m))))))
+                           (serdes/mbql-deps (:field_ref m))))
         (disj nil))))
 
 (defmethod serdes/storage-path "Card" [card ctx]
@@ -1375,7 +1367,8 @@
     (mapcat serdes/mbql-deps parameter_mappings)
     (serdes/parameters-deps parameters)
     (when database_id [[{:model "Database" :id database_id}]])
-    (when table_id #{(serdes/table->path table_id)})
+    ;; Note: `table_id` is intentionally not a dependency — the Database (above) is, and a missing Table is
+    ;; synthesized as an inactive row on import.
     (when source_card_id #{[{:model "Card" :id source_card_id}]})
     (when collection_id #{[{:model "Collection" :id collection_id}]})
     (when dashboard_id #{[{:model "Dashboard" :id dashboard_id}]})

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1360,7 +1360,7 @@
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings
-           result_metadata table_id source_card_id visualization_settings
+           result_metadata source_card_id visualization_settings
            dashboard_id document_id]}]
   (set
    (concat

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -217,9 +217,8 @@
   [_segment]
   [:name (serdes/hydrated-hash :table) :created_at])
 
-(defmethod serdes/dependencies "Segment" [{:keys [definition table_id]}]
-  (cond-> (serdes/mbql-deps definition)
-    table_id (conj (serdes/table->path table_id))))
+(defmethod serdes/dependencies "Segment" [{:keys [definition]}]
+  (serdes/mbql-deps definition))
 
 (defmethod serdes/storage-path "Segment" [segment _ctx]
   (let [table-path (-> segment :definition serdes/serialized-query-source-table)]

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -383,10 +383,7 @@
       [[{:model "Database" :id source_database_id}]])
     (for [{tag-id :tag_id} tags]
       [{:model "TransformTag" :id tag-id}])
-    (serdes/mbql-deps source)
-    (for [{:keys [table_id]} (:source-tables source)
-          :when (vector? table_id)]
-      (serdes/table->path table_id)))))
+    (serdes/mbql-deps source))))
 
 (defmethod serdes/storage-path "Transform" [transform ctx]
   (serdes/storage-default-collection-path transform ctx "transforms"))

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -468,7 +468,7 @@
 
 (defmethod serdes/dependencies "Field" [field]
   (let [db-path (first (serdes/path field))]
-    [[db-path]]))
+    #{[db-path]}))
 
 (defmethod serdes/make-spec "Field" [_model-name opts]
   {:copy      [:active :base_type :caveats :coercion_strategy :custom_position :database_default :database_indexed

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -1,6 +1,5 @@
 (ns metabase.warehouse-schema.models.field
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [honey.sql :as sql]
    [medley.core :as m]
@@ -468,21 +467,8 @@
     (t2/select-one :model/Field field-q)))
 
 (defmethod serdes/dependencies "Field" [field]
-  ;; Fields depend on their parent Table, plus any foreign Fields referenced by their Dimensions.
-  ;; Take the path, but drop the Field section to get the parent Table's path instead.
-  (let [this  (serdes/path field)
-        table (remove #(= "Field" (:model %)) this)
-        fks   (some->> field :fk_target_field_id serdes/field->path)
-        human (->> (:dimensions field)
-                   (keep :human_readable_field_id)
-                   (map serdes/field->path)
-                   set)]
-    (-> (set/union
-         #{table}
-         human
-         (when fks #{fks})
-         (when (:parent_id field) #{(butlast this)}))
-        (disj this))))
+  (let [db-path (first (serdes/path field))]
+    [[db-path]]))
 
 (defmethod serdes/make-spec "Field" [_model-name opts]
   {:copy      [:active :base_type :caveats :coercion_strategy :custom_position :database_default :database_indexed

--- a/src/metabase/warehouse_schema/models/field_user_settings.clj
+++ b/src/metabase/warehouse_schema/models/field_user_settings.clj
@@ -45,8 +45,8 @@
         {:model "FieldUserSettings" :id "1"}))
 
 (defmethod serdes/dependencies "FieldUserSettings" [fv]
-  ;; Take the path, but drop the FieldUserSettings section at the end, to get the parent Field's path instead.
-  [(pop (serdes/path fv))])
+  (let [db-path (first (serdes/path fv))]
+    [[db-path]]))
 
 (defmethod serdes/load-find-local "FieldUserSettings" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldUserSettings.

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -575,8 +575,8 @@
         {:model "FieldValues" :id "0"}))
 
 (defmethod serdes/dependencies "FieldValues" [fv]
-  ;; Take the path, but drop the FieldValues section at the end, to get the parent Field's path instead.
-  [(pop (serdes/path fv))])
+  (let [db-path (first (serdes/path fv))]
+    [[db-path]]))
 
 (defmethod serdes/load-find-local "FieldValues" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldValues.

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -197,11 +197,10 @@
                (get-in (#'serdes/import-mbql* exported) ["table" :table-id])))))))
 
 (deftest ^:parallel template-tag-table-id-deps-test
-  (testing "template tag :table-id contributes a Table dependency"
-    (is (contains? (#'serdes/mbql-deps-map {:table-id ["DB" "SCHEMA" "TABLE"]})
-                   [{:model "Database" :id "DB"}
-                    {:model "Schema" :id "SCHEMA"}
-                    {:model "Table" :id "TABLE"}]))))
+  (testing "template tag :table-id contributes only its Database dependency — the referenced Table itself is not a
+            dependency (it's synthesized on import if missing)"
+    (is (= #{[{:model "Database" :id "DB"}]}
+           (#'serdes/mbql-deps-map {:table-id ["DB" "SCHEMA" "TABLE"]})))))
 
 (deftest ^:parallel export-parameters-test
   (binding [serdes/*export-fk*       (fn [id model]


### PR DESCRIPTION
Fixes an issue that prevented serdes/git sync work with not-yet existent tables and fields:
- Leave only `Database` in dependencies when we used to require table or fields. `Database` is always required.
- Fix default values usage on import. Before, we didn't apply them, so there was a mismatch between fields on upsert.