### PR TITLE
Upgrade `actions/setup-node@v4` to v6.4.0

### DIFF
--- a/.github/actions/prepare-node-bun/action.yml
+++ b/.github/actions/prepare-node-bun/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Prepare Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ".nvmrc"

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -223,7 +223,7 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ needs.get-build-requirements.outputs.java_version }}
     - name: Setup Node.js ${{ needs.get-build-requirements.outputs.node_version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: ${{ needs.get-build-requirements.outputs.node_version }}.x
     - name: Check out the code

--- a/.github/workflows/disabled-drivers-slack-notification.yml
+++ b/.github/workflows/disabled-drivers-slack-notification.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/Jod
 

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -33,7 +33,7 @@ jobs:
           sparse-checkout: |
             .github
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/Jod # 22.x.x
       - name: Build e2e matrix

--- a/.github/workflows/release-custom-viz.yml
+++ b/.github/workflows/release-custom-viz.yml
@@ -128,7 +128,7 @@ jobs:
       # Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
       # Node 22.x ships npm 10.x, so pin Node 24.x which ships npm 11.x.
       - name: Setup Node.js for npm publish with trusted publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -387,7 +387,7 @@ jobs:
       # Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
       # Node 22.x line bundles npm 10.x, so pin Node 24.x which ships npm 11.x.
       - name: Setup Node.js for npm publish with trusted publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -23,7 +23,7 @@ jobs:
           echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY
           echo "${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/Jod # 22.x.x
       - run: npm install @slack/web-api

--- a/.github/workflows/translation-context.yml
+++ b/.github/workflows/translation-context.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
       - name: Harvest and write AI context to Crowdin

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
 

--- a/docs/ai/file-based-development.md
+++ b/docs/ai/file-based-development.md
@@ -298,7 +298,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
Related to DEV-1942

## Summary

Bumps actions/setup-node from v4 to v6.4.0 across all 9 workflow/action files (plus one docs example).

On the v6 auto-caching breaking change: v5 began auto-caching whenever a packageManager field exists in package.json, and v6.0.0 narrowed that to npm only. Since we declare "packageManager": "bun@1.3.7" and no step sets cache:, v6 skips auto-caching entirely (bun ≠ npm, no error) — so behavior is unchanged from v4. Jumping straight to v6.4.0 also sidesteps the v5 bun-autocaching trap.

Other changes are runtime-only (Node 24, minimum runner 2.327.1) and don't affect us — no self-hosted runners, and inputs in use (node-version, node-version-file, registry-url) are unchanged.
