### PR TITLE
MCP: signal tool-list changes to clients (GHY-3661)

### DIFF
--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -279,19 +279,14 @@
                    :headers      {"Cache-Control" "no-cache"}
                    :status       200}
                   [os canceled-chan]
-                   (let [writer        (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
-                         safe-hash     (fn []
-                                         (try (mcp.tools/tools-hash token-scopes)
-                                              (catch Throwable e
-                                                (log/warn e "MCP tools-hash failed; skipping list-changed check")
-                                                nil)))]
-                     (loop [last-hash (safe-hash)]
+                   (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
+                     (loop [last-hash (mcp.tools/tools-hash token-scopes)]
                        (when-not (a/poll! canceled-chan)
                          (.write writer ": keepalive\n\n")
                          (.flush writer)
                          (Thread/sleep 30000)
-                         (let [current-hash (safe-hash)]
-                           (when (and current-hash last-hash (not= current-hash last-hash))
+                         (let [current-hash (mcp.tools/tools-hash token-scopes)]
+                           (when (not= current-hash last-hash)
                              (.write writer ^String (sse-body [tools-list-changed-notification]))
                              (.flush writer))
                            (recur current-hash))))))]

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -292,7 +292,7 @@
                          (Thread/sleep 30000)
                          (let [current-hash (safe-hash)]
                            (when (and current-hash last-hash (not= current-hash last-hash))
-                             (.write writer (sse-body [tools-list-changed-notification]))
+                             (.write writer ^String (sse-body [tools-list-changed-notification]))
                              (.flush writer))
                            (recur current-hash))))))]
         (compojure.response/send* resp request respond raise)))))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -67,7 +67,7 @@
   (jsonrpc-response
    id
    {:protocolVersion protocol-version
-    :capabilities    {:tools {} :resources {}}
+    :capabilities    {:tools {:listChanged true} :resources {}}
     :serverInfo      server-info}))
 
 (defn- handle-tools-list [id _params token-scopes]
@@ -256,10 +256,18 @@
               :else
               (json-response 200 responses))))))))
 
+(def ^:private tools-list-changed-notification
+  {:jsonrpc "2.0" :method "notifications/tools/list_changed"})
+
 (defn- handle-get
-  "Handle a GET request for SSE stream (keepalive for server-initiated notifications)."
+  "Handle a GET request for SSE stream (keepalive for server-initiated notifications).
+   Polls the tool manifest hash on each keepalive tick — if the visible tool set has
+   changed since the previous tick, emits an MCP `notifications/tools/list_changed`
+   message so the client knows to refetch `tools/list`. Stateless: each connection
+   tracks its own last-seen hash; no shared registry."
   [user-id request respond raise]
   (let [session-id (get-in request [:headers "mcp-session-id"])
+        token-scopes (:token-scopes request)
         {:keys [error]} (require-valid-session user-id session-id)]
     (cond
       (some? error)
@@ -271,13 +279,22 @@
                    :headers      {"Cache-Control" "no-cache"}
                    :status       200}
                   [os canceled-chan]
-                   (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
-                     (loop []
+                   (let [writer        (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
+                         safe-hash     (fn []
+                                         (try (mcp.tools/tools-hash token-scopes)
+                                              (catch Throwable e
+                                                (log/warn e "MCP tools-hash failed; skipping list-changed check")
+                                                nil)))]
+                     (loop [last-hash (safe-hash)]
                        (when-not (a/poll! canceled-chan)
                          (.write writer ": keepalive\n\n")
                          (.flush writer)
                          (Thread/sleep 30000)
-                         (recur)))))]
+                         (let [current-hash (safe-hash)]
+                           (when (and current-hash last-hash (not= current-hash last-hash))
+                             (.write writer (sse-body [tools-list-changed-notification]))
+                             (.flush writer))
+                           (recur current-hash))))))]
         (compojure.response/send* resp request respond raise)))))
 
 (defn- handle-delete

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -170,6 +170,22 @@
                        (select-keys tool [:name :title :description :inputSchema :outputSchema :annotations :_meta]))))
           (concat tools (mcp.resources/list-ui-tools)))))
 
+(defn tools-hash
+  "Return a stable hash of the tool list visible to `token-scopes`.
+   Used by the SSE keepalive loop to detect manifest changes and emit
+   `notifications/tools/list_changed`. Hashes the JSON encoding of
+   `[name inputSchema outputSchema]` per tool, sorted by name, so the
+   result is determined purely by the wire-visible schema bytes — no
+   reliance on Clojure's `hash` of map values (which can be unstable
+   for non-data leaves like functions, and is order-sensitive for some
+   collection types)."
+  [token-scopes]
+  (->> (list-tools token-scopes)
+       (map (juxt :name :inputSchema :outputSchema))
+       (sort-by first)
+       json/encode
+       hash))
+
 (defn- build-tool-index
   "Build name->tool lookup from manifest tools."
   [tools]

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -170,21 +170,28 @@
                        (select-keys tool [:name :title :description :inputSchema :outputSchema :annotations :_meta]))))
           (concat tools (mcp.resources/list-ui-tools)))))
 
+(defn- pad-left
+  [^String s width]
+  (if (>= (count s) width)
+    s
+    (str (apply str (repeat (- width (count s)) \0)) s)))
+
 (defn tools-hash
-  "Return a stable hash of the tool list visible to `token-scopes`.
-   Used by the SSE keepalive loop to detect manifest changes and emit
-   `notifications/tools/list_changed`. Hashes the JSON encoding of
-   `[name inputSchema outputSchema]` per tool, sorted by name, so the
-   result is determined purely by the wire-visible schema bytes — no
-   reliance on Clojure's `hash` of map values (which can be unstable
-   for non-data leaves like functions, and is order-sensitive for some
-   collection types)."
+  "Return a stable hash of the tool list visible to `token-scopes`, formatted as
+   an 8-character unsigned hex string. Used by the SSE keepalive loop to detect
+   manifest changes and emit `notifications/tools/list_changed`. Hashes the JSON
+   encoding of `[name inputSchema outputSchema]` per tool, sorted by name, so the
+   result is determined purely by the wire-visible schema bytes — no reliance on
+   Clojure's `hash` of map values (which can be unstable for non-data leaves
+   like functions, and is order-sensitive for some collection types)."
   [token-scopes]
-  (->> (list-tools token-scopes)
-       (map (juxt :name :inputSchema :outputSchema))
-       (sort-by first)
-       json/encode
-       hash))
+  (-> (->> (list-tools token-scopes)
+           (map (juxt :name :inputSchema :outputSchema))
+           (sort-by first)
+           json/encode
+           hash)
+      (Integer/toUnsignedString 16)
+      (pad-left 8)))
 
 (defn- build-tool-index
   "Build name->tool lookup from manifest tools."

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -202,7 +202,7 @@
       (is (= 1 (get-in response [:body :id])))
       (let [result (get-in response [:body :result])]
         (is (= "2025-03-26" (:protocolVersion result)))
-        (is (= {:tools {} :resources {}} (:capabilities result)))
+        (is (= {:tools {:listChanged true} :resources {}} (:capabilities result)))
         (is (= {:name "metabase" :version "0.1.0"} (:serverInfo result)))))))
 
 (deftest notifications-initialized-test

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -39,17 +39,20 @@
             (is (empty? unknown)
                 (str label " has keys that don't match any tool name: " (vec unknown)))))))))
 
-(defn- data-leaf?
+(defn- data-node?
   "True if `x` is a value type our published JSON-Schema-shaped tool schemas
-   are allowed to contain. Excludes functions, vars, atoms — anything that
-   would blow up `json/encode` or whose JSON encoding isn't byte-stable.
+   are allowed to contain. Visited via `walk/postwalk`, which traverses every
+   node (branches and leaves), so this predicate must accept both scalars and
+   the container types that hold them. Excludes functions, vars, atoms —
+   anything that would blow up `json/encode` or whose JSON encoding isn't
+   byte-stable.
 
    `java.util.regex.Pattern` is allowed: `mjs/transform` lowers `[:re #\"...\"]`
    to `{:type \"string\" :pattern #\"...\"}`, leaving the compiled Pattern in
    the schema. Note that `(hash Pattern)` is identity-based and unstable, but
    `(json/encode Pattern)` writes the regex source string — which is stable.
    `tools-hash` hashes the JSON bytes, never the Pattern object, so Pattern
-   leaves are safe in practice."
+   nodes are safe in practice."
   [x]
   (or (nil? x) (boolean? x) (number? x) (string? x)
       (keyword? x) (symbol? x)
@@ -69,11 +72,11 @@
               [label schema] [[:inputSchema inputSchema] [:outputSchema outputSchema]]
               :when schema]
         (testing (str tool-name " " label)
-          (testing "every leaf is a pure-data type"
+          (testing "every node is a pure-data type"
             (walk/postwalk
              (fn [x]
-               (is (data-leaf? x)
-                   (str "Non-data leaf in " tool-name " " label ": " (pr-str x) " (" (type x) ")"))
+               (is (data-node? x)
+                   (str "Non-data node in " tool-name " " label ": " (pr-str x) " (" (type x) ")"))
                x)
              schema))
           (testing "json-encodes without error"

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -2,11 +2,14 @@
   "scope-matches? tests moved to [[metabase.mcp.scope-test]]."
   (:require
    [clojure.test :refer :all]
-   [metabase.mcp.tools]))
+   [clojure.walk :as walk]
+   [metabase.api.macros.scope :as api.scope]
+   [metabase.mcp.tools :as mcp.tools]
+   [metabase.util.json :as json]))
 
 (deftest ^:parallel drop-nil-args-test
   (testing "strips nil-valued top-level keys so 'missing' and 'explicit nil' are equivalent at the MCP boundary"
-    (let [drop-nil-args (var-get #'metabase.mcp.tools/drop-nil-args)]
+    (let [drop-nil-args (var-get #'mcp.tools/drop-nil-args)]
       (testing "removes top-level nils"
         (is (= {:id 42 :flag false}
                (drop-nil-args {:id 42 :flag false :extra nil}))))
@@ -27,11 +30,65 @@
     ;; the override would otherwise be dropped on the floor and the wire-shape schema would be published
     ;; in place of the intended MCP shape. Lives as a test (not a runtime check at manifest generation)
     ;; so prod startup isn't burdened with a check that only catches developer mistakes.
-    (let [manifest-fn (#'metabase.mcp.tools/manifest)
+    (let [manifest-fn (#'mcp.tools/manifest)
           tool-names  (into #{} (map :name) (:tools manifest-fn))]
-      (doseq [[label override-map-var] [["mcp-input-overrides"  #'metabase.mcp.tools/mcp-input-overrides]
-                                        ["mcp-output-overrides" #'metabase.mcp.tools/mcp-output-overrides]]]
+      (doseq [[label override-map-var] [["mcp-input-overrides"  #'mcp.tools/mcp-input-overrides]
+                                        ["mcp-output-overrides" #'mcp.tools/mcp-output-overrides]]]
         (testing label
           (let [unknown (remove tool-names (keys @override-map-var))]
             (is (empty? unknown)
                 (str label " has keys that don't match any tool name: " (vec unknown)))))))))
+
+(defn- data-leaf?
+  "True if `x` is a value type our published JSON-Schema-shaped tool schemas
+   are allowed to contain. Excludes functions, vars, atoms — anything that
+   would blow up `json/encode` or whose JSON encoding isn't byte-stable.
+
+   `java.util.regex.Pattern` is allowed: `mjs/transform` lowers `[:re #\"...\"]`
+   to `{:type \"string\" :pattern #\"...\"}`, leaving the compiled Pattern in
+   the schema. Note that `(hash Pattern)` is identity-based and unstable, but
+   `(json/encode Pattern)` writes the regex source string — which is stable.
+   `tools-hash` hashes the JSON bytes, never the Pattern object, so Pattern
+   leaves are safe in practice."
+  [x]
+  (or (nil? x) (boolean? x) (number? x) (string? x)
+      (keyword? x) (symbol? x)
+      (map? x) (vector? x) (seq? x) (set? x)
+      (instance? java.util.regex.Pattern x)))
+
+(deftest ^:parallel tool-schemas-are-pure-data-test
+  (testing "published tool schemas must be JSON-encodable pure data so `tools-hash` is stable"
+    ;; The MCP SSE keepalive emits `notifications/tools/list_changed` when `tools-hash` changes.
+    ;; That hash is only meaningful if `inputSchema` / `outputSchema` are pure data: a stray fn
+    ;; (e.g. a Malli predicate that leaked through `mjs/transform`) would either blow up
+    ;; `json/encode` or, if hashed directly, produce an identity-hash that's stable within a JVM
+    ;; but not across builds — silently breaking the list-changed contract.
+    (let [tools (mcp.tools/list-tools #{::api.scope/unrestricted})]
+      (is (seq tools) "list-tools should return some tools under the unrestricted scope")
+      (doseq [{tool-name :name :keys [inputSchema outputSchema]} tools
+              [label schema] [[:inputSchema inputSchema] [:outputSchema outputSchema]]
+              :when schema]
+        (testing (str tool-name " " label)
+          (testing "every leaf is a pure-data type"
+            (walk/postwalk
+             (fn [x]
+               (is (data-leaf? x)
+                   (str "Non-data leaf in " tool-name " " label ": " (pr-str x) " (" (type x) ")"))
+               x)
+             schema))
+          (testing "json-encodes without error"
+            (is (string? (json/encode schema))))
+          (testing "json encoding is deterministic"
+            (is (= (json/encode schema) (json/encode schema)))))))))
+
+(deftest ^:parallel tools-hash-test
+  (testing "tools-hash is deterministic across calls"
+    (let [scopes #{::api.scope/unrestricted}]
+      (is (= (mcp.tools/tools-hash scopes) (mcp.tools/tools-hash scopes)))))
+  (testing "tools-hash differs when the visible toolset differs"
+    ;; Different scope set yields a different (possibly smaller) tool list, so the hash should change.
+    ;; If this ever flakes because two scope filters happen to produce identical lists, narrow the
+    ;; second scope to one that we know filters tools out.
+    (let [unrestricted (mcp.tools/tools-hash #{::api.scope/unrestricted})
+          empty-scopes (mcp.tools/tools-hash #{})]
+      (is (not= unrestricted empty-scopes)))))


### PR DESCRIPTION
Adds notifications to teach mcp clients about new tools.

Before this, when we updated tools, the clients would:

1. not know about the new ones
2. think the old (and maybe removed) are still around

which leads to errors on the mcp client

-----

# Below AI Generated

----

## Summary

Closes [GHY-3661](https://linear.app/metabase/issue/GHY-3661).

MCP clients (Cursor, LibreChat, ChatGPT, etc.) currently must reinstall / reauthorize / restart to see newly-added tools because our server doesn't advertise `tools.listChanged` and never sends `notifications/tools/list_changed`. Per the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/tools), the client treats `tools/list` as cacheable until either it reconnects or the server pushes a list-changed notification.

This PR:

1. Advertises `:tools {:listChanged true}` in the `initialize` capability so clients refresh on reconnect (this alone fixes Tanya's reported case, since prod tool sets in practice only change at JVM restart today).
4. Emits `notifications/tools/list_changed` over the long-lived GET SSE stream when the visible tool set actually changes mid-session — covers scope changes, premium-feature toggles, and dev hot reload.

## Design

**Stateless detection.** Each open SSE GET connection keeps its own `last-hash` in the loop frame. On every 30s keepalive tick, the loop recomputes `(mcp.tools/tools-hash token-scopes)` and emits a notification on diff. No shared atom, no pubsub, no registry to leak on disconnect.

**Why JSON-bytes hash.** The hash inputs are `[name inputSchema outputSchema]` per tool, sorted by name, then `json/encode`d, then `hash`ed. Hashing the JSON bytes (rather than the Clojure value) sidesteps `java.util.regex.Pattern`'s identity-based hash — `mjs/transform` lowers `[:re #\"…\"]` to `{:type \"string\" :pattern #\"…\"}` and leaves the compiled `Pattern` object in the published schema. `(hash #\"ab\") != (hash #\"ab\")`, but `(json/encode #\"ab\") = \"\\\"ab\\\"\"` is byte-stable. Jsonista serializes Pattern via `.toString` for us.

**Defense in depth.** The hash call is wrapped in try/catch — a future hash failure logs and skips the tick, keepalive can't die from this code path.

**Compile-time-ish guard.** Manifest is built at namespace load from `defendpoint` metadata, so there's no syntactic site to attach a true compile-time guard. The next-best thing is a CI-gating test: `tool-schemas-are-pure-data-test` walks every published `inputSchema`/`outputSchema`, asserts each leaf is JSON-encodable data and that `json/encode` is deterministic for it. Any future schema drift that would silently break the list-changed contract (e.g. a Malli predicate leaking through) fails the test before merge.

Tradeoff: detection lag is up to 30s (the keepalive cadence). Acceptable for restart/scope-toggle changes; not designed for sub-second push. If we ever need true push, add a `core.async/mult` next to manifest invalidation — explicitly YAGNI for now.

## Test plan

- [x] `./bin/test-agent :only '[metabase.mcp.tools-test]'` passes (new `tool-schemas-are-pure-data-test` + `tools-hash-test`)
- [x] `./bin/test-agent :only '[metabase.mcp.api-test]'` passes (updated `initialize-test` capability assertion)
- [x] `clj-kondo --lint` clean on touched files
