### PR TITLE
Open metric caching settings in a modal (UXW-4236)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/MetricCachingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/MetricCachingModal.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useMemo } from "react";
+import { t } from "ttag";
+
+import { StrategyForm } from "metabase/admin/performance/components/StrategyForm";
+import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfigs";
+import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
+import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import { FormSubmitButton } from "metabase/forms";
+import type { MetricCachingModalProps } from "metabase/plugins";
+import { Button, Group, Modal, Title } from "metabase/ui";
+import type { CacheStrategy, CacheableModel } from "metabase-types/api";
+
+import { InvalidateNowButton } from "./InvalidateNowButton";
+
+/** Metric cache configs are stored under the `question` model on the API
+ * (metrics are `card`s in the backend); the writer hook handles the
+ * `metric → question` translation internally, but the reader takes the
+ * API-side model name directly. */
+const CACHING_MODEL: CacheableModel[] = ["question"];
+
+export function MetricCachingModal({ card, onClose }: MetricCachingModalProps) {
+  const { configs, isLoading, error } = useCacheConfigs({
+    model: CACHING_MODEL,
+    id: card.id,
+  });
+
+  const { savedStrategy } = useMemo(() => {
+    const targetConfig = (configs ?? []).find(
+      (config) => config.model_id === card.id,
+    );
+    return { savedStrategy: targetConfig?.strategy };
+  }, [configs, card.id]);
+
+  const saveStrategy = useSaveStrategy(card.id, "metric");
+
+  const {
+    confirmationModal,
+    setIsStrategyFormDirty,
+    isStrategyFormDirty,
+    askBeforeDiscardingChanges,
+  } = useConfirmIfFormIsDirty();
+
+  const handleClose = useCallback(() => {
+    if (isStrategyFormDirty) {
+      askBeforeDiscardingChanges(onClose);
+    } else {
+      onClose();
+    }
+  }, [isStrategyFormDirty, askBeforeDiscardingChanges, onClose]);
+
+  const handleSaveAndClose = useCallback(
+    async (values: CacheStrategy) => {
+      await saveStrategy(values);
+      onClose();
+    },
+    [saveStrategy, onClose],
+  );
+
+  return (
+    <Modal
+      opened
+      onClose={handleClose}
+      title={<Title order={3}>{t`Caching`}</Title>}
+      size="lg"
+      padding="xl"
+    >
+      <DelayedLoadingAndErrorWrapper loading={isLoading} error={error}>
+        <StrategyForm
+          targetId={card.id}
+          targetModel="metric"
+          targetName={card.name}
+          setIsDirty={setIsStrategyFormDirty}
+          saveStrategy={handleSaveAndClose}
+          savedStrategy={savedStrategy}
+          shouldAllowInvalidation
+          shouldShowName={false}
+          onReset={onClose}
+          formBoxProps={{ pb: 0, px: 0 }}
+          renderFooter={() => (
+            <MetricCachingModalFooter cardId={card.id} cardName={card.name} />
+          )}
+        />
+      </DelayedLoadingAndErrorWrapper>
+      {confirmationModal}
+    </Modal>
+  );
+}
+
+function MetricCachingModalFooter({
+  cardId,
+  cardName,
+}: {
+  cardId: number;
+  cardName: string;
+}) {
+  return (
+    <Group justify="space-between" wrap="nowrap" mt="xl" gap="md">
+      <InvalidateNowButton
+        targetId={cardId}
+        targetModel="metric"
+        targetName={cardName}
+      />
+      <Group gap="md" wrap="nowrap">
+        <Button type="reset">{t`Cancel`}</Button>
+        <FormSubmitButton
+          h="40px"
+          label={t`Save`}
+          variant="filled"
+          data-testid="strategy-form-submit-button"
+          className="strategy-form-submit-button"
+        />
+      </Group>
+    </Group>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
@@ -4,6 +4,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { DashboardAndQuestionCachingTab } from "./components/DashboardAndQuestionCachingTab";
 import { GranularControlsExplanation } from "./components/GranularControlsExplanation";
 import { InvalidateNowButton } from "./components/InvalidateNowButton";
+import { MetricCachingModal } from "./components/MetricCachingModal";
 import { PreemptiveCachingSwitch } from "./components/PreemptiveCachingSwitch";
 import { SidebarCacheForm } from "./components/SidebarCacheForm";
 import { SidebarCacheSection } from "./components/SidebarCacheSection";
@@ -42,6 +43,7 @@ export function initializePlugin() {
       StrategyEditorForQuestionsAndDashboards;
     PLUGIN_CACHING.getTabMetadata = getEnterprisePerformanceTabMetadata;
     PLUGIN_CACHING.MetricCachingPage = MetricCachingPage;
+    PLUGIN_CACHING.MetricCachingModal = MetricCachingModal;
   }
 
   if (hasPremiumFeature("cache_preemptive")) {

--- a/enterprise/frontend/src/metabase-enterprise/caching/pages/MetricCachingPage/MetricCachingPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/pages/MetricCachingPage/MetricCachingPage.tsx
@@ -7,7 +7,6 @@ import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfig
 import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
 import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import CS from "metabase/css/core/index.css";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { useLoadCardWithMetadata } from "metabase/data-studio/common/hooks/use-load-card-with-metadata";
 import { MetricPageShell } from "metabase/metrics/components/MetricPageShell";
@@ -88,7 +87,7 @@ export function MetricCachingPage({
             shouldAllowInvalidation
             shouldShowName={false}
             buttonLabels={{ save: t`Save`, discard: t`Cancel` }}
-            classNames={{ formBox: CS.pt4 }}
+            formBoxProps={{ pt: "xl" }}
           />
           {confirmationModal}
         </Card>

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -22,6 +22,7 @@ import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/selectors/settings";
 import {
   Box,
+  type BoxProps,
   Button,
   FixedSizeIcon,
   Flex,
@@ -86,7 +87,10 @@ interface StrategyFormProps {
    * provides the Formik context so the consumer's buttons can dispatch
    * submit / reset via `useFormikContext`. */
   renderFooter?: (ctx: StrategyFormFooterContext) => ReactNode;
-  classNames?: { formBox?: string };
+  /** Mantine props applied to the inner `FormBox` wrapper, useful for
+   * neutralizing its default padding when the surrounding surface already
+   * provides its own inset (e.g. a Mantine `Modal`). */
+  formBoxProps?: BoxProps;
 }
 
 export const StrategyForm = ({
@@ -101,7 +105,7 @@ export const StrategyForm = ({
   onReset,
   isInSidebar = false,
   renderFooter,
-  classNames,
+  formBoxProps,
   buttonLabels = isInSidebar
     ? {
         save: t`Save`,
@@ -137,7 +141,7 @@ export const StrategyForm = ({
         isInSidebar={isInSidebar}
         renderFooter={renderFooter}
         strategyType={initialValues.type}
-        classNames={classNames}
+        formBoxProps={formBoxProps}
       />
     </FormProvider>
   );
@@ -179,7 +183,7 @@ const StrategyFormBody = ({
   buttonLabels,
   isInSidebar,
   renderFooter,
-  classNames,
+  formBoxProps,
 }: {
   targetId: number | null;
   targetModel: CacheableModel;
@@ -191,7 +195,7 @@ const StrategyFormBody = ({
   buttonLabels: ButtonLabels;
   isInSidebar?: boolean;
   renderFooter?: (ctx: StrategyFormFooterContext) => ReactNode;
-  classNames?: { formBox?: string };
+  formBoxProps?: BoxProps;
 }) => {
   const { values, initialValues, setFieldValue } =
     useFormikContext<CacheStrategy>();
@@ -248,9 +252,10 @@ const StrategyFormBody = ({
         data-testid={`strategy-form-for-${targetModel}-${targetId}`}
       >
         <Box
-          className={cx(Styles.FormBox, classNames?.formBox, {
+          className={cx(Styles.FormBox, {
             [Styles.FormBoxSidebar]: isInSidebar,
           })}
+          {...formBoxProps}
         >
           {shouldShowName && (
             <Box lh="1rem" pt="md" c="text-secondary">

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -39,7 +39,8 @@ type MetricModalType =
   | "copy"
   | "archive"
   | "add-to-dashboard"
-  | "alert";
+  | "alert"
+  | "caching";
 
 interface MetricToolbarProps {
   card: Card;
@@ -58,7 +59,6 @@ export function MetricToolbar({
     <>
       <MetricToolbarButtons
         card={card}
-        urls={urls}
         showDataStudioLink={showDataStudioLink}
         onOpenModal={setModalType}
       />
@@ -76,14 +76,12 @@ export function MetricToolbar({
 
 interface MetricToolbarButtonsProps {
   card: Card;
-  urls: MetricUrls;
   showDataStudioLink: boolean;
   onOpenModal: (modalType: MetricModalType) => void;
 }
 
 function MetricToolbarButtons({
   card,
-  urls,
   showDataStudioLink: showDataStudioLinkProp,
   onOpenModal,
 }: MetricToolbarButtonsProps) {
@@ -197,9 +195,8 @@ function MetricToolbarButtons({
             <>
               <Menu.Divider role="separator" />
               <Menu.Item
-                leftSection={<Icon name="gear" />}
-                component={ForwardRefLink}
-                to={urls.caching(card.id)}
+                leftSection={<Icon name="sync" />}
+                onClick={() => onOpenModal("caching")}
               >
                 {t`Caching`}
               </Menu.Item>
@@ -278,6 +275,10 @@ function MetricModal({ card, urls, modalType, onClose }: MetricModalProps) {
           question={new Question(card)}
           onClose={onClose}
         />
+      );
+    case "caching":
+      return (
+        <PLUGIN_CACHING.MetricCachingModal card={card} onClose={onClose} />
       );
     default:
       return null;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   PLUGIN_CACHING,
   type InvalidateNowButtonProps,
+  type MetricCachingModalProps,
   type SidebarCacheSectionProps,
   type SidebarCacheFormProps,
   type PreemptiveCachingSwitchProps,

--- a/frontend/src/metabase/plugins/oss/caching.ts
+++ b/frontend/src/metabase/plugins/oss/caching.ts
@@ -50,6 +50,11 @@ export interface MetricSettingsPageProps {
   showDataStudioLink?: boolean;
 }
 
+export interface MetricCachingModalProps {
+  card: Card;
+  onClose: () => void;
+}
+
 const getDefaultPluginCaching = () => ({
   isGranularCachingEnabled: () => false,
   StrategyFormLauncherPanel: PluginPlaceholder as any,
@@ -69,6 +74,8 @@ const getDefaultPluginCaching = () => ({
     PluginPlaceholder as ComponentType<PreemptiveCachingSwitchProps>,
   MetricCachingPage:
     PluginPlaceholder as ComponentType<MetricSettingsPageProps>,
+  MetricCachingModal:
+    PluginPlaceholder as ComponentType<MetricCachingModalProps>,
 });
 
 export const PLUGIN_CACHING = getDefaultPluginCaching();


### PR DESCRIPTION
### Description

Closes [UXW-4236](https://linear.app/metabase/issue/UXW-4236).

Second of a 3-PR stack on top of [UXW-3839](https://linear.app/metabase/issue/UXW-3839). Adds the metric "Caching" overflow-menu entry as a Mantine modal instead of a route.

- Clicking **Caching** in the metric `…` menu now opens a focused modal with the strategy picker, Clear cache button, and Cancel / Save actions.
- Wires up via a new `PLUGIN_CACHING.MetricCachingModal` slot so OSS keeps the placeholder and EE provides the real implementation.
- The legacy `/metric/:id/caching` route is still reachable; PR 3 removes it.

### How to verify

- [ ] On a Pro/EE instance with `cache_granular_controls`, open a writable numeric metric → `…` → **Caching** → modal opens, lets you switch policy, Clear cache, Save, Cancel.
- [ ] Pick **Duration**, set hours, click **Save** → modal closes and the new policy persists on re-open.
- [ ] Make a change and click the **X** → "Discard changes?" confirmation appears.
