### PR TITLE
handle duplicate copies of gson on classpath

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -167,13 +167,25 @@
    #"META-INF/license.*"
    #"META-INF/LICENSE.*"])
 
+(def ^:private gson-conflict-handler
+  "vertica-jdbc (and potentially other fat JARs) bundle their own copy of gson classes.
+   When these overwrite the correct version from com.google.code.gson/gson, BigQuery's
+   error-handling path crashes with NoSuchMethodError on JsonWriter.value(float),
+   introduced in gson 2.9.0. This handler ensures the pinned gson version always wins
+   regardless of JAR processing order. See #73736."
+  {"com/google/gson/.*"
+   (fn [{:keys [lib path in]}]
+     (if (= lib 'com.google.code.gson/gson)
+       {:write {path {:stream in}}}
+       nil))})
+
 (defn- create-uberjar! [basis]
   (u/step "Create uberjar"
     (with-duration-ms [duration-ms]
       (b/uber {:class-dir         class-dir
                :uber-file         uberjar-filename
-               ;; merge Log4j2Plugins.dat files. (#50721)
-               :conflict-handlers log4j2-conflict-handler
+               :conflict-handlers (merge log4j2-conflict-handler
+                                         gson-conflict-handler)
                :basis             basis
                :exclude           dependency-ignore-patterns})
       (u/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -1,12 +1,14 @@
 (ns build.uberjar
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [clojure.tools.build.util.zip :as build.zip]
    [clojure.tools.namespace.dependency :as ns.deps]
    [clojure.tools.namespace.find :as ns.find]
    [clojure.tools.namespace.parse :as ns.parse]
    [metabuild-common.core :as u]
+   [metabuild-common.misc :as misc]
    [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]])
   (:import
    (java.io File OutputStream)
@@ -167,6 +169,19 @@
    #"META-INF/license.*"
    #"META-INF/LICENSE.*"])
 
+(def ^:private activation-conflict-handler
+  "hive-jdbc bundles its own copy of javax.activation classes with package-private visibility on
+   LogSupport. When these overwrite the correct public versions from jakarta.activation, javax.mail
+   (postal) fails at runtime with IllegalAccessError. This handler ensures jakarta.activation's
+   versions always win regardless of JAR processing order."
+  (let [prefer-jakarta-activation
+        (fn [{:keys [lib path in]}]
+          (if (= lib 'com.sun.activation/jakarta.activation)
+            {:write {path {:stream in}}}
+            nil))]
+    {"com/sun/activation/.*" prefer-jakarta-activation
+     "javax/activation/.*"  prefer-jakarta-activation}))
+
 (def ^:private gson-conflict-handler
   "vertica-jdbc (and potentially other fat JARs) bundle their own copy of gson classes.
    When these overwrite the correct version from com.google.code.gson/gson, BigQuery's
@@ -179,13 +194,30 @@
        {:write {path {:stream in}}}
        nil))})
 
+(def ^:private slf4j-conflict-handler
+  "avatica (Hive transitive dep) bundles the entire SLF4J API unshaded. When those
+   classes overwrite the real SLF4J, logging can break or produce 'multiple providers'
+   warnings. This handler ensures org.slf4j/slf4j-api always wins."
+  {"org/slf4j/.*"
+   (fn [{:keys [lib path in]}]
+     (if (= lib 'org.slf4j/slf4j-api)
+       {:write {path {:stream in}}}
+       nil))})
+
+(def conflict-handlers
+  "Merged conflict handlers for the uberjar build. Handles Log4j2 plugin merging,
+   jakarta.activation class visibility, gson version pinning, and SLF4J API."
+  (merge log4j2-conflict-handler
+         activation-conflict-handler
+         gson-conflict-handler
+         slf4j-conflict-handler))
+
 (defn- create-uberjar! [basis]
   (u/step "Create uberjar"
     (with-duration-ms [duration-ms]
       (b/uber {:class-dir         class-dir
                :uber-file         uberjar-filename
-               :conflict-handlers (merge log4j2-conflict-handler
-                                         gson-conflict-handler)
+               :conflict-handlers conflict-handlers
                :basis             basis
                :exclude           dependency-ignore-patterns})
       (u/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))
@@ -221,8 +253,8 @@
                   :when (.isFile f)]
             (let [rel-path (.toString (.relativize (.toPath src-dir) (.toPath f)))
                   target   (u/get-path-in-filesystem fs rel-path)]
-              (Files/createDirectories (.getParent target) (into-array java.nio.file.attribute.FileAttribute []))
-              (Files/copy (.toPath f) target (into-array java.nio.file.CopyOption [])))))))))
+              (Files/createDirectories (.getParent target) (misc/varargs java.nio.file.attribute.FileAttribute))
+              (Files/copy (.toPath f) target (misc/varargs java.nio.file.CopyOption)))))))))
 
 (defn update-manifest!
   "Start a build step that updates the manifest.
@@ -253,3 +285,42 @@
         (add-non-aot-driver-sources!)
         (update-manifest!))
       (u/announce "Built %s in %.1f seconds." uberjar-filename (/ duration-ms 1000.0)))))
+
+(defn detect-class-conflicts
+  "Run `b/uber` against `basis` (no AOT, no resources) and return a seq of
+   `{:path ... :lib ...}` for every `.class` file conflict not already handled
+   by our conflict handlers."
+  [basis]
+  (let [conflicts (atom [])]
+    (clean!)
+    (b/uber {:class-dir         class-dir
+             :uber-file         uberjar-filename
+             :conflict-handlers (merge conflict-handlers
+                                       {:default (fn [{:keys [lib path]}]
+                                                   (when (str/ends-with? path ".class")
+                                                     (swap! conflicts conj {:path path :lib lib}))
+                                                   nil)})
+             :basis             basis
+             :exclude           dependency-ignore-patterns})
+    @conflicts))
+
+(defn audit-conflicts
+  "Build a bare uberjar (no AOT, no resources) and report all class file conflicts.
+   Useful for detecting vendored/unshaded dependencies in fat JARs.
+
+     clojure -X:build:build/uberjar build.uberjar/audit-conflicts
+     clojure -X:build:build/uberjar build.uberjar/audit-conflicts :edition :ee"
+  [{:keys [edition], :or {edition :ee}}]
+  (u/step (format "Audit %s uberjar class file conflicts" edition)
+    (let [basis     (create-basis edition)
+          conflicts (detect-class-conflicts basis)]
+      (u/announce "=== %d class file conflicts detected ===" (count conflicts))
+      (when (seq conflicts)
+        (let [report-file "target/conflict-report.txt"]
+          (spit report-file
+                (str/join "\n"
+                          (for [[path libs] (->> conflicts
+                                                 (group-by :path)
+                                                 (sort-by key))]
+                            (format "%s — %s" path (str/join ", " (map :lib libs))))))
+          (u/announce "Conflict report written to %s" report-file))))))

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -169,40 +169,30 @@
    #"META-INF/license.*"
    #"META-INF/LICENSE.*"])
 
+(defn- prefer-lib
+  "Returns a conflict handler fn that ensures `preferred` lib's classes always win.
+   The returned fn writes when the incoming class is from `preferred`, skips otherwise."
+  [preferred]
+  (fn prefer-lib' [{:keys [lib path in]}]
+    (when (= lib preferred)
+      {:write {path {:stream in}}})))
+
+;; hive-jdbc bundles javax.activation classes with package-private visibility on LogSupport.
+;; When these overwrite jakarta.activation's public versions, javax.mail (postal) fails with
+;; IllegalAccessError.
 (def ^:private activation-conflict-handler
-  "hive-jdbc bundles its own copy of javax.activation classes with package-private visibility on
-   LogSupport. When these overwrite the correct public versions from jakarta.activation, javax.mail
-   (postal) fails at runtime with IllegalAccessError. This handler ensures jakarta.activation's
-   versions always win regardless of JAR processing order."
-  (let [prefer-jakarta-activation
-        (fn [{:keys [lib path in]}]
-          (if (= lib 'com.sun.activation/jakarta.activation)
-            {:write {path {:stream in}}}
-            nil))]
-    {"com/sun/activation/.*" prefer-jakarta-activation
-     "javax/activation/.*"  prefer-jakarta-activation}))
+  (let [from-com-sun-activation (prefer-lib 'com.sun.activation/jakarta.activation)]
+    {"com/sun/activation/.*" from-com-sun-activation
+     "javax/activation/.*"   from-com-sun-activation}))
 
+;; vertica-jdbc bundles unshaded gson 2.8.9. When these overwrite the pinned 2.12.1,
+;; BigQuery crashes with NoSuchMethodError on JsonWriter.value(float). See #73736.
 (def ^:private gson-conflict-handler
-  "vertica-jdbc (and potentially other fat JARs) bundle their own copy of gson classes.
-   When these overwrite the correct version from com.google.code.gson/gson, BigQuery's
-   error-handling path crashes with NoSuchMethodError on JsonWriter.value(float),
-   introduced in gson 2.9.0. This handler ensures the pinned gson version always wins
-   regardless of JAR processing order. See #73736."
-  {"com/google/gson/.*"
-   (fn [{:keys [lib path in]}]
-     (if (= lib 'com.google.code.gson/gson)
-       {:write {path {:stream in}}}
-       nil))})
+  {"com/google/gson/.*" (prefer-lib 'com.google.code.gson/gson)})
 
+;; avatica (Hive transitive dep) bundles the entire SLF4J API unshaded.
 (def ^:private slf4j-conflict-handler
-  "avatica (Hive transitive dep) bundles the entire SLF4J API unshaded. When those
-   classes overwrite the real SLF4J, logging can break or produce 'multiple providers'
-   warnings. This handler ensures org.slf4j/slf4j-api always wins."
-  {"org/slf4j/.*"
-   (fn [{:keys [lib path in]}]
-     (if (= lib 'org.slf4j/slf4j-api)
-       {:write {path {:stream in}}}
-       nil))})
+  {"org/slf4j/.*" (prefer-lib 'org.slf4j/slf4j-api)})
 
 (def conflict-handlers
   "Merged conflict handlers for the uberjar build. Handles Log4j2 plugin merging,
@@ -314,8 +304,8 @@
   (u/step (format "Audit %s uberjar class file conflicts" edition)
     (let [basis     (create-basis edition)
           conflicts (detect-class-conflicts basis)]
-      (u/announce "=== %d class file conflicts detected ===" (count conflicts))
       (when (seq conflicts)
+        (u/announce "=== %d class file conflicts detected ===" (count conflicts))
         (let [report-file "target/conflict-report.txt"]
           (spit report-file
                 (str/join "\n"

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -1,0 +1,59 @@
+(ns build.uberjar-test
+  (:require
+   [build.uberjar :as uberjar]
+   [clojure.test :refer [deftest is testing]]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private basis
+  "EE basis — includes all drivers, which is where the worst conflicts live."
+  (delay (#'uberjar/create-basis :ee)))
+
+(defn- conflicting-prefixes
+  "Return a sorted set of Java package paths that have class file conflicts.
+   e.g. `com/google/gson/Gson.class` → `com/google/gson`"
+  [conflicts]
+  (into (sorted-set)
+        (keep (fn [{:keys [path]}]
+                (let [last-slash (.lastIndexOf ^String path "/")]
+                  (when (pos? last-slash)
+                    (subs path 0 last-slash)))))
+        conflicts))
+
+;; Known conflicting packages, annotated with what's conflicting and why it's tolerated.
+;; The test asserts on *package prefix* (stable) rather than *lib* (order-dependent).
+;; As we fix these, remove entries — the goal is to shrink this to #{}.
+(def ^:private known-conflicting-prefixes
+  {"com/microsoft/schemas"     "poi-ooxml vs poi-ooxml-lite — same version, XML schema overlap"
+   "org/openxmlformats/schemas" "poi-ooxml vs poi-ooxml-lite — same version"
+   "org/apache/poi/schemas"    "poi-ooxml vs poi-ooxml-lite — same version"
+   "org/w3/x2000"              "poi-ooxml vs poi-ooxml-lite — XML digital signature schemas"
+   "org/etsi/uri"              "poi-ooxml vs poi-ooxml-lite — digital signature schemas"
+   "jakarta/servlet"           "jetty-servlet vs jakarta.servlet-api — same API version"
+   "javax/annotation"          "jsr250-api vs jsr305 — annotation-only JARs"
+   "net/jcip/annotations"      "jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords"
+   "io/netty/buffer"           "databricks-jdbc-thin bundles custom Arrow netty buffers"
+   "org/apache/calcite/avatica" "avatica vs avatica-core — Hive transitive dep"
+   ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
+   "org/apache/hadoop"         "hadoop-common single-class overlap"
+   "org/apache/hive"           "hive-common single-class overlap"})
+
+(defn- prefix-matches?
+  "True if `prefix` equals or is under any of the known prefixes."
+  [prefix]
+  (some (fn [known]
+          (or (= prefix known)
+              (.startsWith ^String prefix (str known "/"))))
+        (keys known-conflicting-prefixes)))
+
+(deftest class-file-conflicts-test
+  (testing "No unexpected class file conflicts in the EE uberjar"
+    ;; Takes ~2 minutes — runs b/uber without AOT or resources
+    (let [conflicts    (uberjar/detect-class-conflicts @basis)
+          prefixes     (conflicting-prefixes conflicts)
+          unexpected   (into (sorted-set) (remove prefix-matches?) prefixes)]
+      (is (empty? unexpected)
+          (str "Unexpected class file conflicts in packages:\n"
+               (pr-str unexpected)
+               "\nIf benign, add to known-conflicting-prefixes with a comment. "
+               "If dangerous, add a conflict handler in build.uberjar.")))))

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -10,33 +10,33 @@
   (delay (#'uberjar/create-basis :ee)))
 
 (defn- conflicting-prefixes
-  "Return a sorted set of Java package paths that have class file conflicts.
+  "Return Java package paths that have class file conflicts.
    e.g. `com/google/gson/Gson.class` → `com/google/gson`"
   [conflicts]
-  (into (sorted-set)
+  (into #{}
         (keep (fn [{:keys [path]}]
                 (let [last-slash (.lastIndexOf ^String path "/")]
                   (when (pos? last-slash)
                     (subs path 0 last-slash)))))
         conflicts))
 
-;; Known conflicting packages, annotated with what's conflicting and why it's tolerated.
-;; The test asserts on *package prefix* (stable) rather than *lib* (order-dependent).
+;; Known conflicting packages. The test asserts on *package prefix* (stable) rather than
+;; *lib* (order-dependent — the conflict handler only sees the second writer).
 ;; As we fix these, remove entries — the goal is to shrink this to #{}.
 (def ^:private known-conflicting-prefixes
-  {"com/microsoft/schemas"     "poi-ooxml vs poi-ooxml-lite — same version, XML schema overlap"
-   "org/openxmlformats/schemas" "poi-ooxml vs poi-ooxml-lite — same version"
-   "org/apache/poi/schemas"    "poi-ooxml vs poi-ooxml-lite — same version"
-   "org/w3/x2000"              "poi-ooxml vs poi-ooxml-lite — XML digital signature schemas"
-   "org/etsi/uri"              "poi-ooxml vs poi-ooxml-lite — digital signature schemas"
-   "jakarta/servlet"           "jetty-servlet vs jakarta.servlet-api — same API version"
-   "javax/annotation"          "jsr250-api vs jsr305 — annotation-only JARs"
-   "net/jcip/annotations"      "jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords"
-   "io/netty/buffer"           "databricks-jdbc-thin bundles custom Arrow netty buffers"
-   "org/apache/calcite/avatica" "avatica vs avatica-core — Hive transitive dep"
-   ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
-   "org/apache/hadoop"         "hadoop-common single-class overlap"
-   "org/apache/hive"           "hive-common single-class overlap"})
+  '#{"com/microsoft/schemas"        ;; poi-ooxml vs poi-ooxml-lite — same version, XML schema overlap
+     "org/openxmlformats/schemas"   ;; poi-ooxml vs poi-ooxml-lite — same version
+     "org/apache/poi/schemas"       ;; poi-ooxml vs poi-ooxml-lite — same version
+     "org/w3/x2000"                 ;; poi-ooxml vs poi-ooxml-lite — XML digital signature schemas
+     "org/etsi/uri"                 ;; poi-ooxml vs poi-ooxml-lite — digital signature schemas
+     "jakarta/servlet"              ;; jetty-servlet vs jakarta.servlet-api — same API version
+     "javax/annotation"             ;; jsr250-api vs jsr305 — annotation-only JARs
+     "net/jcip/annotations"         ;; jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords
+     "io/netty/buffer"              ;; databricks-jdbc-thin bundles custom Arrow netty buffers
+     "org/apache/calcite/avatica"   ;; avatica vs avatica-core — Hive transitive dep
+     ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
+     "org/apache/hadoop"            ;; hadoop-common single-class overlap
+     "org/apache/hive"})            ;; hive-common single-class overlap
 
 (defn- prefix-matches?
   "True if `prefix` equals or is under any of the known prefixes."
@@ -44,14 +44,14 @@
   (some (fn [known]
           (or (= prefix known)
               (.startsWith ^String prefix (str known "/"))))
-        (keys known-conflicting-prefixes)))
+        known-conflicting-prefixes))
 
 (deftest class-file-conflicts-test
   (testing "No unexpected class file conflicts in the EE uberjar"
     ;; Takes ~2 minutes — runs b/uber without AOT or resources
     (let [conflicts    (uberjar/detect-class-conflicts @basis)
           prefixes     (conflicting-prefixes conflicts)
-          unexpected   (into (sorted-set) (remove prefix-matches?) prefixes)]
+          unexpected   (sort (remove prefix-matches? prefixes))]
       (is (empty? unexpected)
           (str "Unexpected class file conflicts in packages:\n"
                (pr-str unexpected)

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -4,9 +4,8 @@
  :deps
  {at.yawk.lz4/lz4-java                {:mvn/version "1.10.4"} ; pin newer version because version included in JDBC driver has security warnings
   com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"
-                                       ;; lang3 is a dep in top-level deps.edn, so not actually used anyway; exclusion
-                                       ;; here fixes security warnings about version used in JDBC driver
-                                       :exclusions  [org.apache.commons/commons-lang3]}
+                                       :exclusions  [org.apache.commons/commons-lang3  ;; dep in top-level deps.edn; exclusion fixes security warnings
+                                                     org.slf4j/slf4j-jdk14]}           ;; conflicts with our log4j2 SLF4J provider
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/73736

The relevant error message for us:

```
java.lang.NoSuchMethodError:
  'com.google.gson.stream.JsonWriter com.google.gson.stream.JsonWriter.value(float)'
  com.google.api.client.json.gson.GsonGenerator.writeNumber(GsonGenerator.java:105)
  com.google.cloud.bigquery.BigQueryRetryAlgorithm.getErrorDescFromResponse(BigQueryRetryAlgorithm.java:227)
  com.google.cloud.bigquery.BigQueryRetryAlgorithm.shouldRetryBasedOnBigQueryRetryConfig(BigQueryRetryAlgorithm.java:115)
  com.google.cloud.bigquery.BigQueryRetryHelper.run(...:108)
  driver.bigquery_cloud_sdk$execute_bigquery(bigquery_cloud_sdk.clj:751)
```

```clojure
user=> (enumeration-seq (.. (Thread/currentThread) getContextClassLoader (getResources "com/google/gson/stream/JsonWriter.class")))
(#object[java.net.URL
         "0x3bc8ea4f"
         "jar:file:/Users/dan/.m2/repository/com/google/code/gson/gson/2.12.1/gson-2.12.1.jar!/com/google/gson/stream/JsonWriter.class"]
 #object[java.net.URL
         "0x50073d1c"
         "jar:file:/Users/dan/.m2/repository/com/vertica/jdbc/vertica-jdbc/23.4.0-0/vertica-jdbc-23.4.0-0.jar!/com/google/gson/stream/JsonWriter.class"])
```

- Vertica bundles: gson 2.8.9 (vendored, unshaded)
- BigQuery demands: gson 2.12.1 (via com.google.code.gson/gson in deps tree — needs JsonWriter.value(float) which was added in 2.9.0)

contents of vertica jar:
 71 com/vertica/io
 70 com/google/gson/internal/bind
 61 com/vertica/utilities/conversion

188 gson class files bundled inside vertica-jdbc, vs ~600 Vertica classes. They just vendored the entire gson library unshaded into their fat JAR. Only gson — nothing else third-party.

So mystery solved. We had two copies of gson and vertica could slip through. Our fix is to ensure that we only accept (or overwrite) when it comes from a gson lib

```clojure
(def ^:private gson-conflict-handler
  "vertica-jdbc (and potentially other fat JARs) bundle their own copy of gson classes.
   When these overwrite the correct version from com.google.code.gson/gson, BigQuery's
   error-handling path crashes with NoSuchMethodError on JsonWriter.value(float),
   introduced in gson 2.9.0. This handler ensures the pinned gson version always wins
   regardless of JAR processing order. See #73736."
  {"com/google/gson/.*"
   (fn [{:keys [lib path in]}]
     (if (= lib 'com.google.code.gson/gson)
       {:write {path {:stream in}}}
       nil))})
```


 ## Summary

  - **Fix**: BigQuery `NoSuchMethodError` on `JsonWriter.value(float)` caused by
    `vertica-jdbc` bundling unshaded gson 2.8.9 classes that can overwrite the
    pinned 2.12.1 during uberjar assembly (#73736)
  - **Restore**: `activation-conflict-handler` from v59 — dropped during the
    hive-jdbc standalone→modules restructuring. Prevents `IllegalAccessError`
    in email sending (javax.mail/postal)
  - **New**: `slf4j-conflict-handler` — avatica bundles unshaded SLF4J API classes
    that can overwrite the real `slf4j-api`
  - **Fix**: Exclude `slf4j-jdk14` from `databricks-jdbc-thin` — eliminates
    "Class path contains multiple SLF4J providers" dev warning
  - **Tooling**: `audit-conflicts` build entrypoint and `detect-class-conflicts`
    function for diagnosing uberjar class file conflicts
  - **Test**: `class-file-conflicts-test` asserts no unexpected class file
    conflicts, with a documented allowlist of known benign overlaps

  ## How it works

  `tools.build/uber` flattens all dependency JARs into one. When multiple JARs
  contain the same `.class` file, the default behavior is first-write-wins — the
  processing order is non-deterministic. Fat JARs like `vertica-jdbc` and
  `avatica` vendor third-party classes unshaded, so their old copies can silently
  overwrite the correct pinned versions.

  Conflict handlers intercept these collisions and ensure the canonical artifact
  always wins:

  ```clojure
  {"com/google/gson/.*"
   (fn [{:keys [lib path in]}]
     (if (= lib 'com.google.code.gson/gson)
       {:write {path {:stream in}}}  ;; write the correct version
       nil))}                         ;; skip the vendored copy
```

  Audit entrypoint

```
  clojure -X:build:build/uberjar build.uberjar/audit-conflicts :edition :ee
```

  Builds a bare uberjar (no AOT, no resources) and writes a conflict report to
  target/conflict-report.txt. Current state: 2,765 class file conflicts from
  10 libraries, all either handled by conflict handlers or documented in the
  test allowlist.

Test plan

  - Build EE uberjar — no errors
  - build.uberjar-test/class-file-conflicts-test passes
  - BigQuery queries that trigger rate-limiting/retries no longer crash
  - Email sending (postal/javax.mail) still works
  - Dev REPL no longer shows "multiple SLF4J providers" warning