### PR TITLE
Fix remapping with custom values

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
@@ -101,7 +101,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       mapFilterToQuestion();
       H.sidebar().findByText("Search box").click();
       H.setFilterListSource({
-        values: [[10, "Ten"], [20, "Twenty"], 30],
+        values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
       H.saveDashboard();
 
@@ -265,7 +265,7 @@ const getListDashboard = (values_query_type) => {
     values_source_type: "static-list",
     values_query_type,
     values_source_config: {
-      values: [[10, "Ten"], [20, "Twenty"], 30],
+      values: [["10", "Ten"], ["20", "Twenty"], "30"],
     },
   });
 };

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -739,7 +739,7 @@ describe("ValuesSourceModal", () => {
           parameter: createMockUiParameter({
             fields: [field1, field2],
             values_source_config: {
-              values: [[1], [2]],
+              values: [["1"], ["2"]],
             },
           }),
           parameterValues: createMockParameterValues({
@@ -762,7 +762,7 @@ describe("ValuesSourceModal", () => {
           parameter: createMockUiParameter({
             fields: [field1, field2],
             values_source_config: {
-              values: [[1], [2]],
+              values: [["1"], ["2"]],
             },
           }),
           parameterValues: createMockParameterValues({
@@ -836,7 +836,7 @@ describe("ValuesSourceModal", () => {
             fields: [field1],
             values_source_type: "static-list",
             values_source_config: {
-              values: [[1], [2]],
+              values: [["1"], ["2"]],
             },
           }),
         });
@@ -858,7 +858,7 @@ describe("ValuesSourceModal", () => {
             fields: [field1],
             values_source_type: "static-list",
             values_source_config: {
-              values: [[1, "Label"], [2]],
+              values: [["1", "Label"], ["2"]],
             },
           }),
         });
@@ -882,7 +882,7 @@ describe("ValuesSourceModal", () => {
             fields: [field1],
             values_source_type: "static-list",
             values_source_config: {
-              values: [[1, "Label"], [2]],
+              values: [["1", "Label"], ["2"]],
             },
           }),
         });

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -23,6 +23,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.performance :as perf]
    [toucan2.core :as t2]))
 
 ;;; ------------------------------------------------- source=static-list --------------------------------------------------
@@ -110,10 +111,20 @@
                 (cond-> query-filter (lib/filter query-filter))
                 (lib/breakout value-column)
                 ;; add the label as a second breakout so each row is a [value label] pair
-                (cond-> label-column (lib/breakout label-column))
-                ;; TODO(Braden, 07/04/2025): This should probably become a lib helper? I suspect this isn't the only
-                ;; "internal" query in the BE.
-                (assoc-in [:middleware :disable-remaps?] true))))))))
+                (cond-> label-column (lib/breakout label-column)))))))))
+
+(defn- result->rows
+  "Extract rows from a QP result, dropping values for any display columns the QP injected for
+  remapped breakouts. Those columns are referenced by a `:remapped_to` entry on their source
+  column; when none are present the raw rows are returned as-is."
+  [result]
+  (let [cols       (get-in result [:data :cols])
+        rows       (get-in result [:data :rows])
+        drop-names (into #{} (keep :remapped_to) cols)]
+    (if (empty? drop-names)
+      rows
+      (let [keep-idxs (into [] (keep-indexed (fn [i c] (when-not (drop-names (:name c)) i))) cols)]
+        (perf/mapv (fn [row] (perf/mapv #(nth row %) keep-idxs)) rows)))))
 
 (mu/defn values-from-card
   "Get distinct values of a field from a card.
@@ -135,10 +146,10 @@
   ([card      :- :metabase.queries.schema/card
     field-ref :- [:or :mbql.clause/field :mbql.clause/expression]
     opts      :- [:maybe ::values-from-card-query.options]]
-   (let [mbql-query   (values-from-card-query card field-ref opts)
-         result       (some-> mbql-query qp/process-query)
-         values       (get-in result [:data :rows])]
-     {:values         (or values [])
+   (let [mbql-query (values-from-card-query card field-ref opts)
+         result     (some-> mbql-query qp/process-query)
+         values     (some-> result result->rows)]
+     {:values          (or values [])
       ;; If the row_count returned = the limit we specified, then it's probably has more than that.
       ;; If the query has its own limit smaller than *max-rows*, then there's no more values.
       :has_more_values (= (:row_count result) *max-rows*)})))

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -1730,6 +1730,29 @@
                   url   (format "embed/dashboard/%s/params/%s/remapping?value=%s" token "user-id-param" value)]
               (is (= expected (client/client :get 200 url))))))))))
 
+(deftest dashboard-param-value-remapping-static-list-test
+  (testing "remapping endpoint returns [value label] for a numeric param backed by a static list"
+    (with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Dashboard {dashboard-id :id}
+                     {:enable_embedding true
+                      :parameters       [{:name                 "Seats"
+                                          :slug                 "seats"
+                                          :id                   "seats-param"
+                                          :type                 :number/=
+                                          :values_source_type   "static-list"
+                                          :values_source_config {:values [["10" "Ten"]
+                                                                          ["20" "Twenty"]
+                                                                          "30"]}}]
+                      :embedding_params {:seats "enabled"}}]
+        (let [token (dash-token dashboard-id)
+              url   #(format "embed/dashboard/%s/params/%s/remapping?value=%s" token "seats-param" %)]
+          (testing "labeled value is returned"
+            (is (= ["20" "Twenty"] (client/client :get 200 (url "20")))))
+          (testing "unlabeled value is returned as a singleton"
+            (is (= ["30"] (client/client :get 200 (url "30")))))
+          (testing "value not in the list falls back to [value]"
+            (is (= ["999"] (client/client :get 200 (url "999"))))))))))
+
 (deftest card-param-value-remapping-test
   (let [param-static-list          "_STATIC_CATEGORY_"
         param-static-list-label    "_STATIC_CATEGORY_LABEL_"

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -2,6 +2,7 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.parameters.custom-values-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -415,6 +416,71 @@
                                            :value_field (mt/$ids $venues.id)}}
                    1
                    (fn [] (throw (ex-info "Shouldn't call this function" {}))))))))))
+
+(deftest ^:parallel values-from-card-external-remapping-test
+  (testing "remapped breakouts are stripped from the result, leaving only the requested columns in the requested order"
+    (mt/dataset test-data
+      (mt/with-column-remappings [orders.user_id    people.name
+                                  orders.product_id products.title]
+        (binding [custom-values/*max-rows* 3]
+          (mt/with-temp
+            [:model/Card card (mt/card-with-source-metadata-for-query (mt/mbql-query orders))]
+            (let [user-id-ref       (lib/ensure-uuid [:field {} (mt/id :orders :user_id)])
+                  people-name-ref   (lib/ensure-uuid [:field {} (mt/id :people :name)])
+                  product-title-ref (lib/ensure-uuid [:field {} (mt/id :products :title)])]
+              (testing "value-field is a remapped FK with no label"
+                (is (= {:has_more_values true
+                        :values          [[2210] [624] [276]]}
+                       (custom-values/values-from-card card user-id-ref))))
+              (testing "value-field is a remapped FK, label-field is its remap target"
+                (is (= {:has_more_values true
+                        :values          [[2210 "Abbey Satterfield"]
+                                          [624 "Abbie Parisian"]
+                                          [276 "Abbie Ryan"]]}
+                       (custom-values/values-from-card card user-id-ref {:label-field people-name-ref}))))
+              (testing "value-field and label-field are remap targets reached via different FKs"
+                (is (= {:has_more_values true
+                        :values          [["Abbey Satterfield" "Aerodynamic Leather Toucan"]
+                                          ["Abbey Satterfield" "Awesome Plastic Watch"]
+                                          ["Abbey Satterfield" "Enormous Cotton Pants"]]}
+                       (custom-values/values-from-card card people-name-ref {:label-field product-title-ref})))))))))))
+
+(deftest ^:parallel parameter-remapped-value-external-remapping-test
+  (testing "parameter-remapped-value returns the [value label] pair for a single value when breakouts are remapped"
+    (mt/dataset test-data
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-column-remappings [orders.user_id    people.name
+                                    orders.product_id products.title]
+          (binding [custom-values/*max-rows* 3]
+            (mt/with-temp
+              [:model/Card card (mt/card-with-source-metadata-for-query (mt/mbql-query orders))]
+              (let [raise (fn [] (throw (ex-info "Shouldn't call this function" {})))]
+                (testing "value-field is a remapped FK, label-field is its remap target"
+                  (is (= [2210 "Abbey Satterfield"]
+                         (custom-values/parameter-remapped-value
+                          {:name                 "Card as source"
+                           :slug                 "card"
+                           :id                   "_CARD_"
+                           :type                 :category
+                           :values_source_type   :card
+                           :values_source_config {:card_id     (:id card)
+                                                  :value_field (mt/$ids $orders.user_id)
+                                                  :label_field (mt/$ids $people.name)}}
+                          2210
+                          raise))))
+                (testing "value-field and label-field are remap targets reached via different FKs"
+                  (is (= ["Abbey Satterfield" "Aerodynamic Leather Toucan"]
+                         (custom-values/parameter-remapped-value
+                          {:name                 "Card as source"
+                           :slug                 "card"
+                           :id                   "_CARD_"
+                           :type                 :category
+                           :values_source_type   :card
+                           :values_source_config {:card_id     (:id card)
+                                                  :value_field (mt/$ids $orders.user_id->people.name)
+                                                  :label_field (mt/$ids $orders.product_id->products.title)}}
+                          "Abbey Satterfield"
+                          raise))))))))))))
 
 (deftest ^:parallel order-by-aggregation-fields-test
   (testing "Values could be retrieved for queries containing ordering by aggregation (#46369)"


### PR DESCRIPTION
Fixes remapping in the query and filters out unused columns.

How to verify:
- Make sure to remap Orders.Product ID to Products.Title and Orders.User ID to People.Name in Admin or Data Studio
- New -> Question -> Orders -> Run (important) -> Save as Q1
- New -> Dashboard -> Add Q1 -> Add ID param -> Map to Orders.User ID, Dropdown source -> Q1 -> Select Orders.User ID column and User -> Name column (remapped) for the Label.
- Save and make sure it works (previously throwed)

<img width="1728" height="812" alt="Screenshot 2026-05-25 at 12 11 57 PM" src="https://github.com/user-attachments/assets/79c8c271-270a-4f5b-92e0-d6b31ee14649" />
