### PR TITLE
[perf] Optimize metabase.search.spec for wide tables

### DIFF
--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -244,49 +244,60 @@
     (keyword (str (name table) "." (name kw)))
     kw))
 
-(defn- find-fields-kw [kw]
+(defn- find-fields-kw [acc kw]
   ;; Filter out SQL functions
-  (when-not (or (str/starts-with? (name kw) "%")
-                (#{:else :integer :float} kw))
-    (let [table (get-table kw)]
-      [[(or table :this) (remove-table table kw)]])))
+  (if (or (str/starts-with? (name kw) "%")
+          (#{:else :integer :float} kw))
+    acc
+    (conj! acc
+           (if-let [table (get-table kw)]
+             [table (remove-table table kw)]
+             [:this kw]))))
 
-(defn- find-fields-expr [expr]
-  (cond
-    (keyword? expr)
-    (find-fields-kw expr)
+(defn- find-fields-expr
+  ([expr] (persistent! (find-fields-expr (transient []) expr)))
+  ([acc expr]
+   (cond
+     (keyword? expr)
+     (find-fields-kw acc expr)
 
-    (and (vector? expr) (> (count expr) 1))
-    (into [] (mapcat find-fields-expr) (subvec expr 1))
+     (and (vector? expr) (> (count expr) 1))
+     (reduce find-fields-expr acc (subvec expr 1))
 
-    (and (map? expr) (:fields expr))
-    (into [] (mapcat find-fields-expr) (:fields expr))))
+     (and (map? expr) (:fields expr))
+     (reduce-kv #(find-fields-expr %1 %3) acc (:fields expr))
 
-(defn- find-fields-attr [[k v]]
-  (when v
+     :else acc)))
+
+(defn- find-fields-attr [acc k v]
+  (if v
     (if (true? v)
-      [[:this (keyword (u/->snake_case_en (name k)))]]
-      (find-fields-expr v))))
+      (conj! acc [:this (keyword (u/->snake_case_en (name k)))])
+      (find-fields-expr acc v))
+    acc))
 
-(defn- find-fields-search [item]
+(defn- find-fields-search [acc item]
   (let [x (if (map-entry? item) (key item) item)]
     (cond
       (keyword? x)
-      (find-fields-kw x)
+      (find-fields-kw acc x)
 
       (vector? x)
-      (find-fields-expr (first x)))))
+      (find-fields-expr acc (first x))
+
+      :else acc)))
 
 (defn- find-fields
   "Search within a definition for all the fields referenced on the given table alias."
   [spec]
   (u/group-by #(nth % 0) #(nth % 1) conj #{}
-              (-> []
-                  ;; select fields that will influence content
-                  (into (mapcat find-fields-attr (:attrs spec)))
-                  (into (mapcat find-fields-search (:search-terms spec)))
-                  (into (mapcat find-fields-attr (:render-terms spec)))
-                  (into (find-fields-expr (:where spec))))))
+              (as-> (transient []) acc
+                ;; select fields that will influence content
+                (reduce-kv find-fields-attr acc (:attrs spec))
+                (reduce find-fields-search acc (:search-terms spec))
+                (reduce-kv find-fields-attr acc (:render-terms spec))
+                (find-fields-expr acc (:where spec))
+                (persistent! acc))))
 
 (defn- replace-qualification [expr from to]
   (cond


### PR DESCRIPTION
When adding a new database or syncing database schema in the existing one, if the DB uses many wide tables (a lot of columns), the process is aritificially slowed down by quite naive `metabase.search.spec` implementation. This is the initial attempt to reduce redundant work and allocations in it.

DIffgraph: https://flamebin.dev/LgYwnh
