### PR TITLE
Fix Snowflake python transform e2e test: explicit target schema

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
@@ -24,7 +24,7 @@
 (defn- execute-e2e-transform!
   "Execute an e2e Python transform test using execute-python-transform!"
   [table-name transform-code source-tables]
-  (let [schema (when (#{:postgres :bigquery-cloud-sdk} driver/*driver*)
+  (let [schema (when (#{:postgres :bigquery-cloud-sdk :snowflake} driver/*driver*)
                  (sql.tx/session-schema driver/*driver*))
         target {:type "table"
                 :schema schema

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -2,6 +2,8 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.snowflake-test]}
                                                             metabase.test.data/run-mbql-query {:namespaces [metabase.driver.snowflake-test]}}}}}}
   (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
    [clojure.data :as data]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -1486,11 +1488,16 @@
                  (is (true? (sql-jdbc.sync.interface/have-select-privilege?
                              driver/*driver* conn schema table-name))))))))))))
 
-(defn- get-db-priv-key [db]
+(defn- get-db-priv-key
+  "Returns a SHA-256 digest of the resolved private key file for `db`."
+  [db]
   (-> (:details db)
       (#'driver.snowflake/resolve-private-key)
       :private_key_file
-      slurp))
+      slurp
+      (.getBytes "UTF-8")
+      buddy-hash/sha256
+      codecs/bytes->hex))
 
 (defn- get-priv-key-details [details pk-user priv-key-var]
   (let [priv-key (tx/db-test-env-var-or-throw :snowflake priv-key-var)]


### PR DESCRIPTION
The Snowflake `comprehensive-e2e-python-transform-test` was blowing up with `CREATE TABLE ... This session does not have a current schema` (error 90106).

Turns out the test leaves the target schema as `nil` for Snowflake, so it ends up running an unqualified `CREATE TABLE`, which Snowflake rejects when the session has no current schema.

Failing CI: https://github.com/metabase/metabase/actions/runs/26390880175/job/77685635058

So I just set an explicit `PUBLIC` schema for Snowflake (using `sql.tx/session-schema`), same as we already do for Postgres and BigQuery. Test-only change, and it's green on CI now (ran with `ci:run-snowflake`).