### PR TITLE
Fix ChatGPT drill-through render by giving render_drill_through its own UI resource URI

### DIFF
--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -268,22 +268,43 @@
   :mimeType    "text/markdown"
   :render-fn   (classpath-text-resource "metabot/prompts/tools/construct_notebook_query.md")})
 
+(defn- visualize-query-render-fn
+  "Shared render-fn for visualize_query and render_drill_through. Both expose the
+   same iframe template; they only differ in URI so hosts that dedupe by URI
+   (notably ChatGPT, which otherwise skips rendering a new iframe for a tool
+   whose `_meta.ui.resourceUri` already has one mounted) treat them as distinct.
+   `tag` is a per-URI marker embedded in the rendered HTML so the bytes hash
+   differently — ChatGPT's asset CDN appears to dedupe by body hash, and without
+   distinct bodies the second URI's asset is silently dropped and the widget 404s."
+  [tag]
+  (fn [opts]
+    (let [site-url    (system/site-url)
+          session-key (:session-key opts)
+          session-id  (:session-id opts)]
+      (str "<!-- metabase-mcp-asset: " tag " -->\n"
+           (render-embed-mcp-template
+            {:instanceUrl    (json/encode site-url)
+             :instanceUrlRaw site-url
+             :sessionToken   (when session-key (json/encode session-key))
+             :mcpSessionId   (when session-id (json/encode session-id))})))))
+
 (register-ui-resource!
  :visualize-query
  "ui://metabase/visualize-query.html"
  "agent:visualize"
- {:name        "Visualize Query"
-  :description "Interactive Metabase SDK visualization for a query"
+ {:name          "Visualize Query"
+  :description   "Interactive Metabase SDK visualization for a query"
   :prefersBorder true
-  :render-fn   (fn [opts]
-                 (let [site-url    (system/site-url)
-                       session-key (:session-key opts)
-                       session-id  (:session-id opts)]
-                   (render-embed-mcp-template
-                    {:instanceUrl    (json/encode site-url)
-                     :instanceUrlRaw site-url
-                     :sessionToken   (when session-key (json/encode session-key))
-                     :mcpSessionId   (when session-id (json/encode session-id))})))})
+  :render-fn     (visualize-query-render-fn "visualize-query")})
+
+(register-ui-resource!
+ :render-drill-through
+ "ui://metabase/render-drill-through.html"
+ "agent:visualize"
+ {:name          "Render Drill Through"
+  :description   "Interactive Metabase SDK visualization for a drill-through follow-up"
+  :prefersBorder true
+  :render-fn     (visualize-query-render-fn "render-drill-through")})
 
 (register-ui-tool!
  :visualize-query
@@ -343,7 +364,7 @@
                       :isError true})))})
 
 (register-ui-tool!
- :visualize-query
+ :render-drill-through
  {:name        "render_drill_through"
   :description (str "Render the drill-through visualization the user just navigated into. "
                     "Use this tool, not execute_query, when the user asks to show the result and "

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -715,6 +715,18 @@
 
 ;;; ----------------------------------------------- Drill Handles ---------------------------------------------------
 
+(deftest render-drill-through-publishes-its-own-resource-uri-test
+  (testing "render_drill_through publishes a distinct `_meta.ui.resourceUri` from visualize_query — ChatGPT dedupes iframes by URI, and reusing the visualize_query URI would prevent a fresh drill widget from mounting"
+    (let [[session-id _] (initialize!)
+          response       (mcp-request (jsonrpc-request "tools/list") {"mcp-session-id" session-id})
+          tools-by-name  (into {} (map (juxt :name identity)) (get-in response [:body :result :tools]))
+          drill-uri      (get-in tools-by-name ["render_drill_through" :_meta :ui :resourceUri])
+          viz-uri        (get-in tools-by-name ["visualize_query"      :_meta :ui :resourceUri])]
+      (is (string? drill-uri))
+      (is (string? viz-uri))
+      (is (not= drill-uri viz-uri)
+          "render_drill_through and visualize_query must publish different resourceUris"))))
+
 (deftest tools-call-render-drill-through-test
   (testing "render_drill_through resolves a stored handle to its encoded query"
     (let [user-id        (mt/user->id :crowberto)

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -90,6 +90,24 @@
                                            #{"agent:visualize"}
                                            {}))))))
 
+(deftest drill-through-ui-resource-is-distinct-from-visualize-query-test
+  (testing "render_drill_through has its own UI resource URI (ChatGPT dedupes the iframe by `_meta.ui.resourceUri`; sharing the URI prevents a fresh widget from mounting on drill)"
+    (let [uris (set (map :uri (:resources (mcp.resources/list-resources #{"agent:visualize"}))))]
+      (is (contains? uris "ui://metabase/visualize-query.html"))
+      (is (contains? uris "ui://metabase/render-drill-through.html"))))
+  (testing "the two UI resources return byte-distinct HTML (ChatGPT's asset CDN appears to dedupe by body hash, so identical bodies cause the second asset to silently 404)"
+    (mcp.resources/with-fallback-template
+      (let [viz-html   (-> (mcp.resources/read-resource "ui://metabase/visualize-query.html"
+                                                        #{"agent:visualize"} {})
+                           :contents first :text)
+            drill-html (-> (mcp.resources/read-resource "ui://metabase/render-drill-through.html"
+                                                        #{"agent:visualize"} {})
+                           :contents first :text)]
+        (is (string? viz-html))
+        (is (string? drill-html))
+        (is (not= viz-html drill-html)
+            "visualize-query and render-drill-through HTML must differ byte-wise")))))
+
 (deftest builtin-visualize-query-ui-resource-metadata-test
   (testing "the visualize_query UI resource publishes bare origins; :domain is gated on the ChatGPT client"
     ;; site-url is set with a subpath to confirm `_meta.ui.domain` and the CSP domain lists strip the


### PR DESCRIPTION
Closes EMB-1771

Fix ChatGPT drill-through rendering. `render_drill_through` was sharing
  `_meta.ui.resourceUri` with `visualize_query`, so ChatGPT skipped mounting
  a new iframe (URI dedupe) and tried to update the existing one - which
  silently failed because each ChatGPT tool call runs in a fresh MCP session.
  Split the URIs and added a per-URI HTML marker so ChatGPT's install-time
  asset CDN doesn't body-hash-dedupe the second template.

@heypoom please test it 🙏 


https://github.com/user-attachments/assets/b863b2df-6ce6-483c-a82f-fe42db769a38





