### PR TITLE
feat: add copy button to metabot code snippets

### DIFF
--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -42,6 +42,10 @@
   background: var(--mb-color-background-secondary);
 }
 
+.codeBlock {
+  position: relative;
+}
+
 .aiMarkdown pre {
   overflow: auto hidden;
   max-width: 100%;
@@ -53,6 +57,17 @@
   border: 1px solid var(--mb-color-border);
   scrollbar-width: thin;
   scrollbar-color: var(--mb-color-border) transparent;
+}
+
+.aiMarkdown .codeBlock pre {
+  margin: 0;
+  padding-right: 2.5rem;
+}
+
+.copyCodeButton {
+  position: absolute;
+  top: 0.375rem;
+  right: 0.375rem;
 }
 
 .aiMarkdown pre::-webkit-scrollbar {

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -1,13 +1,22 @@
 // TODO: consolidate this component w/ AIAnalysisContent
 
 import cx from "classnames";
-import { type ComponentPropsWithoutRef, memo, useMemo } from "react";
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  isValidElement,
+  memo,
+  useMemo,
+} from "react";
+import { t } from "ttag";
 
 import {
   Markdown,
   type MarkdownProps,
 } from "metabase/common/components/Markdown";
 import { parseMetabaseProtocolLink } from "metabase/metabot/utils/links";
+import { ActionIcon, CopyButton, Icon, Tooltip } from "metabase/ui";
 
 import S from "./AIMarkdown.module.css";
 import { InternalLink } from "./components/InternalLink";
@@ -20,6 +29,52 @@ type AIMarkdownProps = MarkdownProps & {
 
 const splitMessageLinesAsParagraphs = (message: string) =>
   message.replaceAll(/\r?\n|\r/g, "\n\n");
+
+const getNodeText = (node: ReactNode): string =>
+  Children.toArray(node)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+
+      if (isValidElement<{ children?: ReactNode }>(child)) {
+        return getNodeText(child.props.children);
+      }
+
+      return "";
+    })
+    .join("");
+
+const MarkdownCodeBlock = ({
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"pre">) => {
+  const code = getNodeText(children);
+
+  return (
+    <div className={S.codeBlock}>
+      <pre {...props}>{children}</pre>
+      <CopyButton value={code}>
+        {({ copied, copy }: { copied: boolean; copy: () => void }) => (
+          <Tooltip
+            label={copied ? t`Copied!` : t`Copy code`}
+            opened={copied || undefined}
+          >
+            <ActionIcon
+              aria-label={t`Copy code`}
+              className={S.copyCodeButton}
+              data-testid="metabot-code-block-copy"
+              size="sm"
+              onClick={copy}
+            >
+              <Icon name="copy" size="1rem" />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </CopyButton>
+    </div>
+  );
+};
 
 const getComponents = ({
   onInternalLinkClick,
@@ -68,6 +123,7 @@ const getComponents = ({
       </div>
     </div>
   ),
+  pre: MarkdownCodeBlock,
 });
 
 export const AIMarkdown = memo(

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
@@ -24,6 +25,10 @@ const setup = (props: { children: string }) => {
 };
 
 describe("AIMarkdown", () => {
+  beforeEach(() => {
+    jest.mocked(navigator.clipboard.writeText).mockClear();
+  });
+
   it("should render internal links for Metabase protocol links", async () => {
     setup({ children: "[My Question](metabase://question/123)" });
 
@@ -54,5 +59,25 @@ describe("AIMarkdown", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "Revenue" })).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "$42" })).toBeInTheDocument();
+  });
+
+  it("should copy fenced code blocks", async () => {
+    setup({
+      children: `
+\`\`\`sql
+SELECT *
+FROM orders
+\`\`\`
+      `.trim(),
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Copy code" }),
+    );
+
+    const writeText = jest.mocked(navigator.clipboard.writeText);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain("SELECT *\nFROM orders");
+    expect(writeText.mock.calls[0][0]).not.toContain("```");
   });
 });


### PR DESCRIPTION
Closes [BOT-1571: Add copy button to Metabot code snippets](https://linear.app/metabase/issue/BOT-1571/add-copy-button-to-metabot-code-snippets)

### Description

Adds a button to copy and embed code snippets.

### How to verify

1. Open Metabot sidebar.
2. Type `Create plain markdown code block without using tools. Write SELECT from accounts repeated 100 times`
3. Send message.

### Demo

![image.png](https://app.graphite.com/user-attachments/assets/eebb4810-fd75-4d55-8607-3339009904e7.png)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)