### PR TITLE
feat: make slackbot use the default internal metabot id

### DIFF
--- a/frontend/src/metabase/metabot/constants.ts
+++ b/frontend/src/metabase/metabot/constants.ts
@@ -6,7 +6,6 @@ export const LONG_CONVO_MSG_LENGTH_THRESHOLD = 120000;
 export const FIXED_METABOT_IDS = {
   DEFAULT: 1 as const,
   EMBEDDED: 2 as const,
-  SLACKBOT: 3 as const,
 };
 
 export const METABOT_REQUEST_IDS = {
@@ -16,7 +15,6 @@ export const METABOT_REQUEST_IDS = {
 export const FIXED_METABOT_ENTITY_IDS = {
   DEFAULT: "metabotmetabotmetabot" as const,
   EMBEDDED: "embeddedmetabotmetabo" as const,
-  SLACKBOT: "slackbotmetabotmetabo" as const,
 };
 
 export const METABOT_PROFILES = {

--- a/resources/migrations/063/20260525_remove_slack_metabot.yaml
+++ b/resources/migrations/063/20260525_remove_slack_metabot.yaml
@@ -1,0 +1,35 @@
+## Remove legacy Slack Metabot instance
+
+databaseChangeLog:
+  - changeSet:
+      id: v63.ksjdfh
+      author: undrfined
+      comment: Remove the separate Slack Metabot instance
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 1
+            sql: >-
+              SELECT COUNT(*) FROM metabot WHERE entity_id = 'slackbotmetabotmetabo';
+      changes:
+        - sql:
+            sql: >-
+              DELETE FROM metabot WHERE entity_id = 'slackbotmetabotmetabo';
+      rollback:
+        - sql:
+            sql: >-
+              INSERT INTO metabot (
+                  id
+                  , name
+                  , description
+                  , entity_id
+                  , created_at
+                  , updated_at
+              ) VALUES (
+                  3
+                  , 'Slack Metabot'
+                  , 'Metabot instance for Slack users.'
+                  , 'slackbotmetabotmetabo'
+                  , now()
+                  , now()
+              );

--- a/src/metabase/metabot/config.clj
+++ b/src/metabase/metabot/config.clj
@@ -14,10 +14,6 @@
   "The ID of the embedded Metabot instance."
   "c61bf5f5-1025-47b6-9298-bf1827105bb6")
 
-(def slackbot-metabot-id
-  "The ID of the Slack Metabot instance."
-  "9a89fe64-54b9-4ab2-8022-eccd772e5073")
-
 (defn any-metabot-enabled?
   "Returns true if at least one of the metabot instances (internal or embedded) is enabled."
   []
@@ -47,9 +43,7 @@
   {internal-metabot-id {:profile-id "internal"
                         :entity-id "metabotmetabotmetabot"}
    embedded-metabot-id {:profile-id "embedding_next"
-                        :entity-id "embeddedmetabotmetabo"}
-   slackbot-metabot-id {:profile-id "slackbot"
-                        :entity-id "slackbotmetabotmetabo"}})
+                        :entity-id "embeddedmetabotmetabo"}})
 
 (defn metabot-id->profile-id
   "Return the profile-id for the Metabot instance with ID `metabot-id` or \"default\" if no profile-id is configured."

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -199,7 +199,7 @@
                          {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
                           :capabilities               capabilities
                           :slack_channel_id           channel-id}
-                         {:metabot-id metabot.config/slackbot-metabot-id})
+                         {:metabot-id metabot.config/internal-metabot-id})
         messages        (conj (vec history) request-message)
         parts-atom      (atom [])
         ;; Sibling capture for throwables that escape the agent loop's own

--- a/test_resources/serialization_baseline/metabots/slack_metabot.yaml
+++ b/test_resources/serialization_baseline/metabots/slack_metabot.yaml
@@ -1,9 +1,0 @@
-name: Slack Metabot
-description: Metabot instance for Slack users.
-created_at: '2026-04-02T02:59:01.71366Z'
-entity_id: slackbotmetabotmetabo
-updated_at: '2026-04-02T02:59:01.71366Z'
-serdes/meta:
-- id: slackbotmetabotmetabo
-  model: Metabot
-prompts: []


### PR DESCRIPTION
Closes [BOT-1581: Slackbot `metabot` record can not be configured in the admin UI](https://linear.app/metabase/issue/BOT-1581/slackbot-metabot-record-can-not-be-configured-in-the-admin-ui)

### Description

Smartbot was using its own separate Metabot i, which made it unconfigurable via admin settings. Now it uses the same internal id as the Metabot inside the app.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)