### PR TITLE
Fix a couple bugs on the metrics viewer dimension sidebar state

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
@@ -309,6 +309,62 @@ describe("DimensionPickerSidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("merges shared and metric sections with the same table name", async () => {
+    setup({
+      dimensions: {
+        shared: [
+          {
+            icon: "calendar",
+            group: { id: "products", type: "main", displayName: "Product" },
+            tabInfo: {
+              type: "time",
+              label: "Created At",
+              dimensionMapping: {
+                0: "dim-product-created-at",
+                1: "dim-product-created-at",
+              },
+            },
+          },
+        ],
+        bySource: {
+          [SOURCE_ID]: [
+            {
+              icon: "label",
+              group: {
+                id: "products",
+                type: "main",
+                displayName: "Product",
+              },
+              tabInfo: {
+                type: "category",
+                label: "Title",
+                dimensionMapping: { 0: "dim-product-title" },
+              },
+            },
+          ],
+          [SECOND_SOURCE_ID]: [],
+        },
+      },
+      slots: [
+        { slotIndex: 0, entityIndex: 0, sourceId: SOURCE_ID },
+        { slotIndex: 1, entityIndex: 1, sourceId: SECOND_SOURCE_ID },
+      ],
+      sourceOrder: [SOURCE_ID, SECOND_SOURCE_ID],
+      sources: {
+        [SOURCE_ID]: { type: "metric", name: "Revenue" },
+        [SECOND_SOURCE_ID]: { type: "metric", name: "Number of Orders" },
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "See all" }));
+
+    expect(screen.getAllByText("Product")).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "Created At" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Title" })).toBeInTheDocument();
+  });
+
   it("shows per-metric column selects from the settings button", async () => {
     setup();
 
@@ -322,6 +378,46 @@ describe("DimensionPickerSidebar", () => {
     expect(
       screen.queryByRole("button", { name: "Created At" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("uses the active time mapping for column select values", async () => {
+    setup({
+      tab: {
+        ...timeTab,
+        dimensionMapping: { 0: "dim-created-at" },
+      },
+      dimensions: {
+        shared: [],
+        bySource: {
+          [SOURCE_ID]: [
+            {
+              icon: "calendar",
+              tabInfo: {
+                type: "time",
+                label: "Birth Date",
+                dimensionMapping: { 0: "dim-birth-date" },
+              },
+            },
+            {
+              icon: "calendar",
+              tabInfo: {
+                type: "time",
+                label: "Created At",
+                dimensionMapping: { 0: "dim-created-at" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Configure Time" }),
+    );
+
+    expect(screen.getByLabelText("Select dimension for Revenue")).toHaveValue(
+      "Created At",
+    );
   });
 
   it("does not show column selects when the category row is clicked", async () => {

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
@@ -10,6 +10,55 @@ import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
 
 import type { AllFieldsMetricGroup } from "./types";
 
+function getSectionKey(section: DimensionPickerSection) {
+  return section.name;
+}
+
+function getDimensionItemKey(item: DimensionPickerSection["items"][number]) {
+  const dimensionIds = Object.values(item.tabInfo.dimensionMapping).join("|");
+
+  return `${item.tabInfo.type}:${dimensionIds}`;
+}
+
+function mergeSectionsByName(sections: DimensionPickerSection[]) {
+  const mergedSections: DimensionPickerSection[] = [];
+  const sectionIndexesByKey = new Map<string, number>();
+
+  for (const section of sections) {
+    const sectionKey = getSectionKey(section);
+
+    if (sectionKey == null) {
+      mergedSections.push({ ...section, items: [...section.items] });
+      continue;
+    }
+
+    const sectionIndex = sectionIndexesByKey.get(sectionKey);
+
+    if (sectionIndex == null) {
+      sectionIndexesByKey.set(sectionKey, mergedSections.length);
+      mergedSections.push({ ...section, items: [...section.items] });
+      continue;
+    }
+
+    const mergedSection = mergedSections[sectionIndex];
+    const existingItemKeys = new Set(
+      mergedSection.items.map(getDimensionItemKey),
+    );
+    const newItems = section.items.filter(
+      (item) => !existingItemKeys.has(getDimensionItemKey(item)),
+    );
+
+    if (newItems.length > 0) {
+      mergedSections[sectionIndex] = {
+        ...mergedSection,
+        items: [...mergedSection.items, ...newItems],
+      };
+    }
+  }
+
+  return mergedSections;
+}
+
 export function buildAllFieldsMetricGroups({
   sections,
   sourceOrder,
@@ -27,14 +76,16 @@ export function buildAllFieldsMetricGroups({
     .map((sourceId) => {
       const metricSlot = metricSlots.find((slot) => slot.sourceId === sourceId);
 
+      const matchingSections = sections.filter(
+        (section) => section.isShared || section.sourceId === sourceId,
+      );
+
       return {
         key: sourceId,
         name: sourceDataById[sourceId]?.name ?? sourceId,
         colors:
           metricSlot != null ? sourceColors[metricSlot.entityIndex] : undefined,
-        sections: sections.filter(
-          (section) => section.isShared || section.sourceId === sourceId,
-        ),
+        sections: mergeSectionsByName(matchingSections),
       };
     })
     .filter((group) => group.sections.length > 0);

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
@@ -15,9 +15,11 @@ function getSectionKey(section: DimensionPickerSection) {
 }
 
 function getDimensionItemKey(item: DimensionPickerSection["items"][number]) {
-  const dimensionIds = Object.values(item.tabInfo.dimensionMapping).join("|");
-
-  return `${item.tabInfo.type}:${dimensionIds}`;
+  const entries = Object.entries(item.tabInfo.dimensionMapping)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("|");
+  return `${item.tabInfo.type}:${entries}`;
 }
 
 function mergeSectionsByName(sections: DimensionPickerSection[]) {

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/utils.ts
@@ -72,6 +72,10 @@ export function isCategorySelected(
   category: DimensionPickerSidebarCategory,
   activeTab: MetricsViewerTabState,
 ) {
+  if (category.tabInfo.type === "time" && activeTab.type === "time") {
+    return true;
+  }
+
   return (
     hasSameDimensions(category, activeTab) ||
     category.targetItems.some((item) => hasSameDimensions(item, activeTab))


### PR DESCRIPTION
### Description

Fixes two metrics viewer dimension sidebar issues:

- Merges shared and metric-specific all-fields sections with the same table name, so tables like Product are not duplicated per metric.
- Keeps the Time category selected when the active tab is a configured time tab, so per-metric column selects display the active mapped field instead of falling back to the default.

### How to verify

- On /explore, select the metrics Revenue and Number of Orders. Click run.
- Click the 'Time' dimension button on the viewer controls to open the sidebar
- In the Time category row, click the setting icon and change the selected time columns to a few different value and see that the changes are reflected in the chart and in the select element state.
- Click the 'see all' button, expand the 'Number of Orders' metric accordion. Check the the 'Product' table column group is not duplicated.

### Demo

https://github.com/user-attachments/assets/1c813345-5ef1-4ef2-b5b1-8665f306623b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

### Tests
