### PR TITLE
Upgrade docker-related GitHub actions to their latest versions

### DIFF
--- a/.github/actions/e2e-prepare-containers/action.yml
+++ b/.github/actions/e2e-prepare-containers/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "composite"
   steps:
     - name: Authenticate to prevent API rate limit
-      uses: docker/login-action@v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}

--- a/.github/actions/prepare-shoppy-e2e/action.yml
+++ b/.github/actions/prepare-shoppy-e2e/action.yml
@@ -54,7 +54,7 @@ runs:
 
     # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
     - name: Set up Docker Compose
-      uses: docker/setup-compose-action@v1
+      uses: docker/setup-compose-action@8cccb8c14b6500aaffebff1aa49c502c34d2e5e6 # v2.1.0
       with:
         version: latest
 

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -92,7 +92,7 @@ jobs:
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Set up QEMU
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
     - name: Set up Docker Buildx
       if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Move the Uberjar to the context dir
       run: mv ./metabase.jar bin/docker/.
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -98,7 +98,7 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
     - name: Build multi-arch container
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: bin/docker/.
         platforms: ${{ steps.platforms.outputs.result }}

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -95,7 +95,7 @@ jobs:
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
     - name: Set up Docker Buildx
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Build multi-arch container
       if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -116,7 +116,7 @@ jobs:
 
       # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@2fe291b7677a45ee1269ec56a42604c143505e7e # v1
+        uses: docker/setup-compose-action@8cccb8c14b6500aaffebff1aa49c502c34d2e5e6 # v2.1.0
         with:
           version: latest
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -38,7 +38,7 @@ jobs:
           jar xf target/uberjar/metabase.jar
           mv target/uberjar/metabase.jar bin/docker/metabase.jar
       - name: Build container
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: bin/docker/
           platforms: linux/amd64

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -49,7 +49,7 @@ jobs:
           jar xf target/uberjar/metabase.jar
           mv target/uberjar/metabase.jar bin/docker/metabase.jar
       - name: Build container
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: bin/docker/
           platforms: linux/amd64

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -247,7 +247,7 @@ jobs:
         fi
 
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summmary

*Upgrade Docker GitHub Actions to latest major versions*

Pins five Docker actions to their latest major releases (by commit SHA, matching our existing convention):


| Action | From | To | Pinned SHA |
|---|---|---|---|
| `docker/login-action` | v3 | **v4.2.0** | `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` |
| `docker/setup-compose-action` | v1 | **v2.1.0** | `8cccb8c14b6500aaffebff1aa49c502c34d2e5e6` |
| `docker/build-push-action` | v6 | **v7.2.0** | `f9f3042f7e2789586610d6e8b85c8f03e5195baf` |
| `docker/setup-qemu-action` | v3 | **v4.0.0** | `ce360397dd3f832beb865e1373c09c0e9f86d70a` |
| `docker/setup-buildx-action` | v3 | **v4.1.0** | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` |


Each action is upgraded in its own self-contained commit.

### Notes

- The major bumps all switch the default runtime to Node 24 (requires Actions Runner ≥ v2.327.1). All affected workflows run on GitHub-hosted runners, which are auto-patched, so no action needed.
- `build-push-action@v7` dropped the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs
  and `setup-buildx@v4` removed some deprecated inputs — neither is used in this repo.
- Also SHA-pins two references that were previously on floating tags (@v1, @v3). This increases the security.
