### PR TITLE
Upgrade peter evans actions

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Auto approve backport PR
       if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
-      uses: juliangruber/approve-pull-request-action@v1
+      uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
       with:
         github-token: ${{ inputs.github-token-2 }}
         number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -91,7 +91,8 @@ runs:
 
     - name: Enable Pull Request Automerge
       if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
-      run: gh pr merge $PR_NUMBER --squash --auto "1"
+      run: gh pr merge --squash --auto "$PR_NUMBER"
+      shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         PR_NUMBER: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -91,11 +91,10 @@ runs:
 
     - name: Enable Pull Request Automerge
       if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
-      uses: peter-evans/enable-pull-request-automerge@v2
-      with:
-        token: ${{ inputs.github-token }}
-        pull-request-number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
-        merge-method: squash
+      run: gh pr merge $PR_NUMBER --squash --auto "1"
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
 
     - uses: ./.github/actions/notify-pull-request
       if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'true' }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.codespell_check.outcome == 'failure'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: claude-fix/codespell-${{ steps.date.outputs.date }}

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -151,7 +151,7 @@ jobs:
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge
-        run: gh pr merge $PR_NUMBER --squash --auto "1"
+        run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -145,7 +145,7 @@ jobs:
           )"
 
       - name: Auto approve PR
-        uses: juliangruber/approve-pull-request-action@f83b836abaed1b3ab639ae61f9117c52ae405f65 # v1
+        uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
         with:
           github-token: ${{ github.token }}
           number: ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -151,8 +151,7 @@ jobs:
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge
-        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2
-        with:
-          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-          pull-request-number: ${{ steps.create_pr.outputs.pr_number }}
-          merge-method: squash
+        run: gh pr merge $PR_NUMBER --squash --auto "1"
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Branch name will be: $BRANCH_NAME"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Related to DEV-1942

## Summary

Upgrades two GitHub Actions to their latest majors (SHA-pinned) and removes `peter-evans/enable-pull-request-automerge` in favor of the `gh` CLI, as recommended by [the action's own README](https://github.com/peter-evans/enable-pull-request-automerge/blob/v3.0.0/README.md).

<img width="1312" height="570" alt="image" src="https://github.com/user-attachments/assets/6f9f2cd9-e395-4eb0-9139-84a9cd1df9a8" />

| Action | From | To | Pinned SHA |
|---|---|---|---|
| `peter-evans/create-pull-request` | v6 | **v8.1.1** | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |
| `juliangruber/approve-pull-request-action` | v1 | **v2.1.0** | `68fcc9a5a73b5641cadf757cf99d73720dcb05d0` |
| `peter-evans/enable-pull-request-automerge` | v2 | **removed** → `gh pr merge --squash --auto` | n/a |

Each change is in its own self-contained commit.

### Notes
- The `gh pr merge` replacement preserves the original behavior: `--squash` matches the old `merge-method: squash`, and the same non-default tokens are passed via `GH_TOKEN` (a PAT/app token is required so the merge triggers downstream workflows).
- `create-pull-request` v6 → v8 breaking changes don't affect us: the renamed `git-token` input and removed `PULL_REQUEST_NUMBER` output are unused. v8's only other change is the Node 24 / Runner v2.327.1 requirement, which is moot on GitHub-hosted runners.
