### PR TITLE
Fix ChatGPT and Cursor dark theme override for MCP Apps

### DIFF
--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -60,8 +60,13 @@ export function McpUiAppRoute() {
   );
 
   const theme = useMemo(
-    () => buildMcpAppsTheme(hostCssVariables, scheme),
-    [hostCssVariables, scheme],
+    () =>
+      buildMcpAppsTheme({
+        hostCssVariables,
+        preset: scheme,
+        agentName: hostContext?.userAgent,
+      }),
+    [hostCssVariables, scheme, hostContext?.userAgent],
   );
 
   return (

--- a/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
@@ -43,6 +43,20 @@ const AGENT_CSS_VARIABLE_OVERRIDES: Record<
       "--color-background-secondary": "#181818",
     },
   },
+
+  // Cursor's agents window does not send theming variables,
+  // so we can provide a default based on agents window's theme.
+  // Agents window only supports 2 themes, no custom theme.
+  cursor: {
+    light: {
+      "--color-background-primary": "#FFFFFF",
+      "--color-background-secondary": "#F8F8F8",
+    },
+    dark: {
+      "--color-background-primary": "#181818",
+      "--color-background-secondary": "#141414",
+    },
+  },
 };
 
 interface BuildMcpAppsThemeOptions {

--- a/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
@@ -52,7 +52,9 @@ export function buildMcpAppsTheme({
   const agentOverrides =
     (agentName && AGENT_CSS_VARIABLE_OVERRIDES[agentName]?.[preset]) || {};
 
-  const mergedCssVariables = { ...hostCssVariables, ...agentOverrides };
+  // Agent overrides serve as per-key defaults — any value the host actually
+  // sends takes precedence.
+  const mergedCssVariables = { ...agentOverrides, ...hostCssVariables };
 
   const colors: MetabaseTheme["colors"] = {};
 

--- a/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
@@ -22,16 +22,44 @@ const MCP_HOST_VAR_TO_SDK_COLOR: Record<
   "--color-text-tertiary": "text-tertiary",
 };
 
-export function buildMcpAppsTheme(
-  hostCssVariables: Record<string, string>,
-  preset: ResolvedColorScheme,
-): MetabaseTheme {
+/**
+ * Per-agent CSS variable overrides, applied on top of what the host sends.
+ * Keyed by `hostContext.userAgent`. Each agent may define `light` and/or `dark`
+ * overrides; both are optional.
+ */
+const AGENT_CSS_VARIABLE_OVERRIDES: Record<
+  string,
+  Partial<Record<ResolvedColorScheme, Record<string, string>>>
+> = {
+  chatgpt: {
+    dark: {
+      "--color-background-primary": "#212121",
+    },
+  },
+};
+
+interface BuildMcpAppsThemeOptions {
+  hostCssVariables: Record<string, string>;
+  preset: ResolvedColorScheme;
+  agentName?: string;
+}
+
+export function buildMcpAppsTheme({
+  hostCssVariables,
+  preset,
+  agentName,
+}: BuildMcpAppsThemeOptions): MetabaseTheme {
+  const agentOverrides =
+    (agentName && AGENT_CSS_VARIABLE_OVERRIDES[agentName]?.[preset]) || {};
+
+  const mergedCssVariables = { ...hostCssVariables, ...agentOverrides };
+
   const colors: MetabaseTheme["colors"] = {};
 
   for (const [cssVarKey, sdkKey] of Object.entries(MCP_HOST_VAR_TO_SDK_COLOR)) {
-    if (hostCssVariables[cssVarKey]) {
+    if (mergedCssVariables[cssVarKey]) {
       colors[sdkKey] = resolveConcreteColor(
-        hostCssVariables[cssVarKey],
+        mergedCssVariables[cssVarKey],
         preset,
       );
     }

--- a/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.ts
@@ -31,9 +31,16 @@ const AGENT_CSS_VARIABLE_OVERRIDES: Record<
   string,
   Partial<Record<ResolvedColorScheme, Record<string, string>>>
 > = {
+  // ChatGPT does not send theming variables, so we have to
+  // provide them to match ChatGPT's looks.
   chatgpt: {
+    light: {
+      "--color-background-primary": "#FFFFFF",
+      "--color-background-secondary": "#F9F9F9",
+    },
     dark: {
       "--color-background-primary": "#212121",
+      "--color-background-secondary": "#181818",
     },
   },
 };

--- a/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/buildMcpAppsTheme.unit.spec.ts
@@ -1,0 +1,36 @@
+import { buildMcpAppsTheme } from "./buildMcpAppsTheme";
+
+describe("buildMcpAppsTheme", () => {
+  it("applies ChatGPT dark theme overrides", () => {
+    expect(
+      buildMcpAppsTheme({
+        hostCssVariables: {},
+        preset: "dark",
+        agentName: "chatgpt",
+      }),
+    ).toEqual({
+      preset: "dark",
+      colors: {
+        background: "#212121",
+        "background-secondary": "#181818",
+      },
+    });
+  });
+
+  it("lets host variables override ChatGPT theme defaults", () => {
+    expect(
+      buildMcpAppsTheme({
+        hostCssVariables: {
+          "--color-background-primary": "#000000",
+        },
+        preset: "dark",
+        agentName: "chatgpt",
+      }).colors,
+    ).toEqual(
+      expect.objectContaining({
+        background: "#000000",
+        "background-secondary": "#181818",
+      }),
+    );
+  });
+});

--- a/resources/frontend_client/mcp_apps_template.html
+++ b/resources/frontend_client/mcp_apps_template.html
@@ -30,6 +30,9 @@
         color: var(--vscode-foreground);
         background: var(--vscode-editor-background);
         font-family: var(--vscode-font-family);
+
+        /* Remove card padding from cursor */
+        padding: 0;
       }
 
       .mcp-loading {


### PR DESCRIPTION
Closes EMB-1756

## Description

Adds background overrides for ChatGPT and Cursor's MCP Apps frames, and lets host-provided CSS variables take precedence over agent defaults when the host sends a value.

## Screenshots

Before fix (Cursor)

<img width="1452" height="1364" alt="CleanShot 2569-05-26 at 11 03 04@2x" src="https://github.com/user-attachments/assets/68be0aea-7ba5-44fd-99f2-6db5b94a4b80" />

After fix (Cursor)

<img width="1350" height="1120" alt="CleanShot 2569-05-26 at 11 36 59@2x" src="https://github.com/user-attachments/assets/e6c845d1-fff7-4dd7-ad5b-940a0542f1d0" />

After fix (ChatGPT)

<img width="1408" height="1208" alt="CleanShot 2569-05-26 at 10 52 36@2x" src="https://github.com/user-attachments/assets/25420330-2122-4976-b0ed-b6daf0e61ed6" />

## How to verify

- Open an MCP Apps response in ChatGPT dark mode and verify the card background matches ChatGPT's dark surface. Same for the footer - its `background-secondary` should match ChatGPT's.
- Verify other hosts continue to use their provided CSS variables.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR