### PR TITLE
Add CSP configuration to make images load in MCP Apps

### DIFF
--- a/resources/frontend_client/mcp_apps_template.html
+++ b/resources/frontend_client/mcp_apps_template.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex" />
+    <base href="{{{instanceUrlRaw}}}/" />
 
     <title>Metabase</title>
 

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -29,8 +29,6 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private embed-mcp-template-path "frontend_client/embed-mcp.html")
-(def ^:private frontend-dev-port (or (env/env :mb-frontend-dev-port) "8080"))
-(def ^:private frontend-dev-origin (str "http://localhost:" frontend-dev-port))
 
 ;; The built template is emitted by HtmlWebpackPlugin into resources/frontend_client/
 ;; during the frontend build. Backend-only test runs (e.g. CI app-db tests) don't produce
@@ -118,7 +116,7 @@
 (defn- resource-domains
   [url]
   (cond-> [url]
-    config/is-dev? (conj frontend-dev-origin)))
+    config/is-dev? (conj (str "http://localhost:" (or (env/env :mb-frontend-dev-port) "8080")))))
 
 (defn- ui-meta
   "MCP `_meta.ui` block returned alongside UI resources.
@@ -141,7 +139,7 @@
    it out narrows the CSP for security review."
   [resource]
   (let [url (site-origin)]
-    {:ui (cond-> {:csp {:baseUriDomains [url]
+    {:ui (cond-> {:csp {:baseUriDomains  [url]
                         :connectDomains  [url]
                         :resourceDomains (resource-domains url)}}
            (contains? resource :prefersBorder)

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -11,8 +11,10 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [environ.core :as env]
    [metabase.api.common :as api]
    [metabase.api.macros.defendpoint.tools-manifest :as tools-manifest]
+   [metabase.config.core :as config]
    [metabase.mcp.scope :as mcp.scope]
    [metabase.mcp.session :as mcp.session]
    [metabase.request.core :as request]
@@ -27,6 +29,8 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private embed-mcp-template-path "frontend_client/embed-mcp.html")
+(def ^:private frontend-dev-port (or (env/env :mb-frontend-dev-port) "8080"))
+(def ^:private frontend-dev-origin (str "http://localhost:" frontend-dev-port))
 
 ;; The built template is emitted by HtmlWebpackPlugin into resources/frontend_client/
 ;; during the frontend build. Backend-only test runs (e.g. CI app-db tests) don't produce
@@ -111,6 +115,11 @@
       (cond-> (str scheme "://" host)
         (not (neg? port)) (str ":" port)))))
 
+(defn- resource-domains
+  [url]
+  (cond-> [url]
+    config/is-dev? (conj frontend-dev-origin)))
+
 (defn- ui-meta
   "MCP `_meta.ui` block returned alongside UI resources.
    Hosts that render the resource in a sandboxed iframe (notably ChatGPT's MCP app surface) use this
@@ -131,7 +140,7 @@
   [resource]
   (let [url (site-origin)]
     {:ui (cond-> {:csp {:connectDomains  [url]
-                        :resourceDomains [url]}}
+                        :resourceDomains (resource-domains url)}}
            (contains? resource :prefersBorder)
            (assoc :prefersBorder (:prefersBorder resource))
 

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -36,7 +36,7 @@
 ;; during the frontend build. Backend-only test runs (e.g. CI app-db tests) don't produce
 ;; it, so tests install a minimal inline template via `with-fallback-template`.
 (def ^:private test-fallback-template
-  (str "<!doctype html><html><body><script>"
+  (str "<!doctype html><html><head><base href=\"{{{instanceUrlRaw}}}/\"></head><body><script>"
        "window.metabaseConfig = {"
        "instanceUrl: {{{instanceUrl}}},"
        "sessionToken: {{{sessionToken}}}"
@@ -130,6 +130,8 @@
                           Claude validates this against its own namespace
                           (`*.claudemcpcontent.com`) and rejects anything else,
                           so we emit it only for ChatGPT (gated by [[chatgpt-client?]]).
+   - `csp.baseUriDomains`  — hosts the iframe may use in its document `<base>` tag
+                              (relative bundle assets resolve against the Metabase instance)
    - `csp.connectDomains`  — hosts the iframe may XHR/fetch/WebSocket to
                               (the embedded SDK calls back to this Metabase instance)
    - `csp.resourceDomains` — hosts the iframe may load scripts/styles/images from
@@ -139,7 +141,8 @@
    it out narrows the CSP for security review."
   [resource]
   (let [url (site-origin)]
-    {:ui (cond-> {:csp {:connectDomains  [url]
+    {:ui (cond-> {:csp {:baseUriDomains [url]
+                        :connectDomains  [url]
                         :resourceDomains (resource-domains url)}}
            (contains? resource :prefersBorder)
            (assoc :prefersBorder (:prefersBorder resource))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.mcp.resources-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
    [metabase.config.core :as config]
@@ -109,13 +110,15 @@
           (with-redefs [config/is-dev? false]
             (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
               (is (=? {:prefersBorder true
-                       :csp           {:connectDomains  [origin]
+                       :csp           {:baseUriDomains [origin]
+                                       :connectDomains  [origin]
                                        :resourceDomains [origin]}}
                       ui-meta))
               (is (not (contains? ui-meta :domain))))))
         (testing "development metadata allows resources from the frontend dev server"
           (with-redefs [config/is-dev? true]
-            (is (=? {:csp {:resourceDomains [origin "http://localhost:8080"]}}
+            (is (=? {:csp {:baseUriDomains [origin]
+                           :resourceDomains [origin "http://localhost:8080"]}}
                     (-> (read-ui) :contents first :_meta :ui)))))
         (testing "non-ChatGPT User-Agent → :domain suppressed"
           (with-redefs [config/is-dev? false]
@@ -130,6 +133,17 @@
                                    :mimeType "text/html;profile=mcp-app"
                                    :_meta    {:ui {:prefersBorder true
                                                    :domain        origin
-                                                   :csp           {:connectDomains  [origin]
+                                                   :csp           {:baseUriDomains [origin]
+                                                                   :connectDomains  [origin]
                                                                    :resourceDomains [origin]}}}}]}
                       (read-ui))))))))))
+
+(deftest embed-mcp-template-base-url-test
+  (testing "the MCP iframe document resolves relative bundle assets from the Metabase instance"
+    (let [site-url "https://metabase.example.com/sub/path"
+          html     (mcp.resources/render-embed-mcp-template
+                    {:instanceUrl    "\"https://metabase.example.com/sub/path\""
+                     :instanceUrlRaw site-url
+                     :sessionToken   nil
+                     :mcpSessionId   nil})]
+      (is (str/includes? html "<base href=\"https://metabase.example.com/sub/path/\"")))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
+   [metabase.config.core :as config]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.request.core :as request]
    [metabase.system.core :as system]))
@@ -105,23 +106,30 @@
                        (mcp.resources/read-resource uri #{"agent:visualize"} {})))]
       (with-redefs [system/site-url (constantly site-url)]
         (testing "no request bound → CSP origins still emitted, :domain suppressed"
-          (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
-            (is (=? {:prefersBorder true
-                     :csp           {:connectDomains  [origin]
-                                     :resourceDomains [origin]}}
-                    ui-meta))
-            (is (not (contains? ui-meta :domain)))))
-        (testing "non-ChatGPT User-Agent → :domain suppressed"
-          (request/with-current-request {:headers {"user-agent" "claude-ai/0.1.0"}}
+          (with-redefs [config/is-dev? false]
             (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
+              (is (=? {:prefersBorder true
+                       :csp           {:connectDomains  [origin]
+                                       :resourceDomains [origin]}}
+                      ui-meta))
               (is (not (contains? ui-meta :domain))))))
+        (testing "development metadata allows resources from the frontend dev server"
+          (with-redefs [config/is-dev? true]
+            (is (=? {:csp {:resourceDomains [origin "http://localhost:8080"]}}
+                    (-> (read-ui) :contents first :_meta :ui)))))
+        (testing "non-ChatGPT User-Agent → :domain suppressed"
+          (with-redefs [config/is-dev? false]
+            (request/with-current-request {:headers {"user-agent" "claude-ai/0.1.0"}}
+              (let [ui-meta (-> (read-ui) :contents first :_meta :ui)]
+                (is (not (contains? ui-meta :domain)))))))
         (testing "ChatGPT User-Agent (`openai-mcp/...`) → :domain = origin"
-          (request/with-current-request {:headers {"user-agent" "openai-mcp/1.0.0 (ChatGPT)"}}
-            (is (=? {:status   :ok
-                     :contents [{:uri      uri
-                                 :mimeType "text/html;profile=mcp-app"
-                                 :_meta    {:ui {:prefersBorder true
-                                                 :domain        origin
-                                                 :csp           {:connectDomains  [origin]
-                                                                 :resourceDomains [origin]}}}}]}
-                    (read-ui)))))))))
+          (with-redefs [config/is-dev? false]
+            (request/with-current-request {:headers {"user-agent" "openai-mcp/1.0.0 (ChatGPT)"}}
+              (is (=? {:status   :ok
+                       :contents [{:uri      uri
+                                   :mimeType "text/html;profile=mcp-app"
+                                   :_meta    {:ui {:prefersBorder true
+                                                   :domain        origin
+                                                   :csp           {:connectDomains  [origin]
+                                                                   :resourceDomains [origin]}}}}]}
+                      (read-ui))))))))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -6,7 +6,8 @@
    [metabase.config.core :as config]
    [metabase.mcp.resources :as mcp.resources]
    [metabase.request.core :as request]
-   [metabase.system.core :as system]))
+   [metabase.system.core :as system]
+   [stencil.core :as stencil]))
 
 (set! *warn-on-reflection* true)
 
@@ -141,7 +142,8 @@
 (deftest embed-mcp-template-base-url-test
   (testing "the MCP iframe document resolves relative bundle assets from the Metabase instance"
     (let [site-url "https://metabase.example.com/sub/path"
-          html     (mcp.resources/render-embed-mcp-template
+          html     (stencil/render-file
+                    "frontend_client/mcp_apps_template.html"
                     {:instanceUrl    "\"https://metabase.example.com/sub/path\""
                      :instanceUrlRaw site-url
                      :sessionToken   nil


### PR DESCRIPTION
Closes #74493
Closes EMB-1763

### Description

Images such as the "No results" sailboat image do not load in MCP Apps, both in development and in production. The cause for production and localhost are actually different, so we need two different fixes:

- In local development: caused by missing rspack server (port 8080) in CSP resourceDomains
- In production on Cursor: caused by images trying to be loaded in the `vscode-webview://0eg07ovag6jmkacldppik7fk94o9theivhv1ti97d56lrgnabeub/app/dist` prefix, when SVGs are supposed to be loaded from the instance origin, not `vscode-webview://` domain

### Screenshot

On ChatGPT on localhost

<img width="1400" height="1336" alt="CleanShot 2569-05-26 at 12 02 29@2x" src="https://github.com/user-attachments/assets/a16c2720-d797-4232-ae0a-1987c9d7d422" />

On Cursor on localhost

<img width="1390" height="1156" alt="CleanShot 2569-05-26 at 12 51 58@2x" src="https://github.com/user-attachments/assets/bc39acab-5002-4740-a841-1062226ca1ae" />

### How to verify

If you don't know how to setup MCP Apps with Cursor, please read https://github.com/metabase/metabase/pull/71001. PR environment MCP URL for this PR is `https://pr74741.coredev.metabase.com/api/mcp`

1. On local development: try to ask for queries that returns no results e.g. `visualize the orders table in metabase, filter with subtotal > 1000`. You should see the boat "no results" image.

1. On Cursor + PR environment: try to ask for queries that returns no results e.g. `visualize the orders table in metabase, filter with subtotal > 1000`. You should see the boat "no results" image on Cursor.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
