### PR TITLE
Add url to create dashboard and create question tool

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -160,6 +160,7 @@
               metabase.agent-api.init}
    :uses    #{api
               auth-identity
+              channel
               collections
               dashboards
               events

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -10,6 +10,7 @@
    [metabase.api.macros.scope :as scope]
    [metabase.api.routes.common :as api.routes.common]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.channel.urls :as channel.urls]
    [metabase.collections.core :as collections]
    [metabase.collections.models.collection :as collection]
    [metabase.dashboards.autoplace :as autoplace]
@@ -787,6 +788,7 @@
   [:map
    [:id            ms/PositiveInt]
    [:name          ms/NonBlankString]
+   [:url           :string]
    [:collection_id [:maybe ms/PositiveInt]]
    [:description   [:maybe :string]]
    [:dashcard_ids  [:sequential ms/PositiveInt]]])
@@ -800,7 +802,8 @@
    :tool  {:name "create_dashboard"
            :description (str "Create a dashboard in Metabase. "
                              "Optionally pass question_ids to add saved questions as cards. "
-                             "Cards are auto-positioned on the dashboard grid.")}}
+                             "Cards are auto-positioned on the dashboard grid. "
+                             "Returns the dashboard URL.")}}
   [_route-params
    _query-params
    {:keys [description collection_id question_ids]
@@ -832,6 +835,7 @@
     (events/publish-event! :event/dashboard-create {:object dash :user-id api/*current-user-id*})
     {:id           (:id dash)
      :name         (:name dash)
+     :url          (channel.urls/dashboard-url (:id dash))
      :collection_id (:collection_id dash)
      :description  (:description dash)
      :dashcard_ids (mapv :id (t2/select :model/DashboardCard :dashboard_id (:id dash)))}))

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -614,6 +614,7 @@
   [:map
    [:id            ms/PositiveInt]
    [:name          ms/NonBlankString]
+   [:url           :string]
    [:display       :string]
    [:collection_id [:maybe ms/PositiveInt]]
    [:description   [:maybe :string]]])
@@ -659,6 +660,7 @@
                 {:id api/*current-user-id*})]
       {:id            (:id card)
        :name          (:name card)
+       :url           (channel.urls/card-url (:id card))
        :display       (name (:display card))
        :collection_id (:collection_id card)
        :description   (:description card)})))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -702,6 +702,8 @@
                                                                                (mt/user->id :crowberto)
                                                                                (:query_handle construct-data))})
                     _              (reset! question-id (:id question-data))
+                    _              (is (= (format "https://stats.metabase.test/question/%d" @question-id)
+                                          (:url question-data)))
                     _              (call-tool session-id "update_question"
                                               {:id          (:id question-data)
                                                :description "Smoke updated description"})

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -5,6 +5,7 @@
    [clojure.walk :as walk]
    [metabase.agent-api.settings :as agent-api.settings]
    [metabase.api.macros.scope :as scope]
+   [metabase.channel.urls :as channel.urls]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mcp.api :as mcp.api]
@@ -704,6 +705,8 @@
                   dash-data      (call-tool session-id "create_dashboard"
                                             {:name "Smoke Dashboard"})
                   _              (reset! dash-id (:id dash-data))
+                  _              (is (= (channel.urls/dashboard-url @dash-id)
+                                         (:url dash-data)))
                   _              (call-tool session-id "update_dashboard"
                                             {:id          (:id dash-data)
                                              :description "Smoke updated dashboard"})

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -655,12 +655,14 @@
     "create_question" "create_dashboard"
     "update_question" "update_dashboard" "create_collection"})
 
-(deftest tools-call-smoke-test
+(deftest tools-call-smoke-test-covers-all-agent-api-backed-tools-test
   (testing "every Agent API-backed tool is exercised by the smoke test"
     (is (= (apply disj (set (map :name (mcp.tools/list-tools nil)))
                   ["visualize_query" "render_drill_through"])
            smoke-tested-tools)
-        "Add the missing tool to `smoke-tested-tools` and the call sequence below."))
+        "Add the missing tool to `smoke-tested-tools` and the call sequence below.")))
+
+(deftest tools-call-smoke-test
   (testing "every tool returns a successful response with valid parameters"
     (mt/with-temporary-setting-values [system.settings/site-url "https://stats.metabase.test"]
       (search.tu/with-legacy-search
@@ -707,7 +709,7 @@
                                               {:name "Smoke Dashboard"})
                     _              (reset! dash-id (:id dash-data))
                     _              (is (= (format "https://stats.metabase.test/dashboard/%d" @dash-id)
-                                           (:url dash-data)))
+                                          (:url dash-data)))
                     _              (call-tool session-id "update_dashboard"
                                               {:id          (:id dash-data)
                                                :description "Smoke updated dashboard"})

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -5,7 +5,6 @@
    [clojure.walk :as walk]
    [metabase.agent-api.settings :as agent-api.settings]
    [metabase.api.macros.scope :as scope]
-   [metabase.channel.urls :as channel.urls]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mcp.api :as mcp.api]
@@ -15,6 +14,7 @@
    [metabase.mcp.tools :as mcp.tools]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.search.test-util :as search.tu]
+   [metabase.system.settings :as system.settings]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
@@ -662,61 +662,62 @@
            smoke-tested-tools)
         "Add the missing tool to `smoke-tested-tools` and the call sequence below."))
   (testing "every tool returns a successful response with valid parameters"
-    (search.tu/with-legacy-search
-      (mt/with-temp [:model/Card _metric {:name          "Smoke Metric"
-                                          :type          :metric
-                                          :database_id   (mt/id)
-                                          :dataset_query (orders-count-query)}]
-        (let [[session-id _] (initialize!)
-              db-name        (t2/select-one-fn :name :model/Database (mt/id))
-              orders-query   {:lib/type "mbql/query"
-                              :stages   [{:lib/type     "mbql.stage/mbql"
-                                          :source-table [db-name "PUBLIC" "ORDERS"]
-                                          :limit        5}]}
-              ;; Track write-tool outputs in atoms so the `finally` cleanup runs even if an
-              ;; assertion in `call-tool` fails partway through the sequence.
-              question-id    (atom nil)
-              dash-id        (atom nil)
-              coll-id        (atom nil)]
-          (try
-            (let [;; Discovery tools — call-tool helper asserts (not :isError) internally.
-                  _              (call-tool session-id "search" {:term_queries ["orders"]})
-                  ;; Query construction + execution
-                  construct-data (call-tool session-id "construct_query" {:query orders-query})
-                  _              (call-tool session-id "query" {:query orders-query})
-                  _              (call-tool session-id "execute_query"
-                                            {:query_handle (:query_handle construct-data)})
-                  _              (call-tool session-id "execute_sql"
-                                            {:database_id (mt/id)
-                                             :sql         "SELECT 1"})
-                  _              (call-tool session-id "read_resource"
-                                            {:uris ["metabase://databases"]})
-                  ;; Write tools — record IDs as soon as they're known so the `finally` block
-                  ;; can clean up even if a later step throws.
-                  question-data  (call-tool session-id "create_question"
-                                            {:name  "Smoke Question"
-                                             :query (mcp.session/read-handle session-id
-                                                                             (mt/user->id :crowberto)
-                                                                             (:query_handle construct-data))})
-                  _              (reset! question-id (:id question-data))
-                  _              (call-tool session-id "update_question"
-                                            {:id          (:id question-data)
-                                             :description "Smoke updated description"})
-                  dash-data      (call-tool session-id "create_dashboard"
-                                            {:name "Smoke Dashboard"})
-                  _              (reset! dash-id (:id dash-data))
-                  _              (is (= (channel.urls/dashboard-url @dash-id)
-                                         (:url dash-data)))
-                  _              (call-tool session-id "update_dashboard"
-                                            {:id          (:id dash-data)
-                                             :description "Smoke updated dashboard"})
-                  coll-data      (call-tool session-id "create_collection"
-                                            {:name "Smoke Collection"})]
-              (reset! coll-id (:id coll-data)))
-            (finally
-              (when-let [qid @question-id] (t2/delete! :model/Card :id qid))
-              (when-let [did @dash-id]     (t2/delete! :model/Dashboard :id did))
-              (when-let [cid @coll-id]     (t2/delete! :model/Collection :id cid)))))))))
+    (mt/with-temporary-setting-values [system.settings/site-url "https://stats.metabase.test"]
+      (search.tu/with-legacy-search
+        (mt/with-temp [:model/Card _metric {:name          "Smoke Metric"
+                                            :type          :metric
+                                            :database_id   (mt/id)
+                                            :dataset_query (orders-count-query)}]
+          (let [[session-id _] (initialize!)
+                db-name        (t2/select-one-fn :name :model/Database (mt/id))
+                orders-query   {:lib/type "mbql/query"
+                                :stages   [{:lib/type     "mbql.stage/mbql"
+                                            :source-table [db-name "PUBLIC" "ORDERS"]
+                                            :limit        5}]}
+                ;; Track write-tool outputs in atoms so the `finally` cleanup runs even if an
+                ;; assertion in `call-tool` fails partway through the sequence.
+                question-id    (atom nil)
+                dash-id        (atom nil)
+                coll-id        (atom nil)]
+            (try
+              (let [;; Discovery tools — call-tool helper asserts (not :isError) internally.
+                    _              (call-tool session-id "search" {:term_queries ["orders"]})
+                    ;; Query construction + execution
+                    construct-data (call-tool session-id "construct_query" {:query orders-query})
+                    _              (call-tool session-id "query" {:query orders-query})
+                    _              (call-tool session-id "execute_query"
+                                              {:query_handle (:query_handle construct-data)})
+                    _              (call-tool session-id "execute_sql"
+                                              {:database_id (mt/id)
+                                               :sql         "SELECT 1"})
+                    _              (call-tool session-id "read_resource"
+                                              {:uris ["metabase://databases"]})
+                    ;; Write tools — record IDs as soon as they're known so the `finally` block
+                    ;; can clean up even if a later step throws.
+                    question-data  (call-tool session-id "create_question"
+                                              {:name  "Smoke Question"
+                                               :query (mcp.session/read-handle session-id
+                                                                               (mt/user->id :crowberto)
+                                                                               (:query_handle construct-data))})
+                    _              (reset! question-id (:id question-data))
+                    _              (call-tool session-id "update_question"
+                                              {:id          (:id question-data)
+                                               :description "Smoke updated description"})
+                    dash-data      (call-tool session-id "create_dashboard"
+                                              {:name "Smoke Dashboard"})
+                    _              (reset! dash-id (:id dash-data))
+                    _              (is (= (format "https://stats.metabase.test/dashboard/%d" @dash-id)
+                                           (:url dash-data)))
+                    _              (call-tool session-id "update_dashboard"
+                                              {:id          (:id dash-data)
+                                               :description "Smoke updated dashboard"})
+                    coll-data      (call-tool session-id "create_collection"
+                                              {:name "Smoke Collection"})]
+                (reset! coll-id (:id coll-data)))
+              (finally
+                (when-let [qid @question-id] (t2/delete! :model/Card :id qid))
+                (when-let [did @dash-id]     (t2/delete! :model/Dashboard :id did))
+                (when-let [cid @coll-id]     (t2/delete! :model/Collection :id cid))))))))))
 
 (deftest tools-call-visualize-query-direct-test
   (testing "visualize_query returns UI structured content"


### PR DESCRIPTION
Closes [BOT-1577](https://linear.app/metabase/issue/BOT-1577/mcp-dashboard-links-point-to-the-wrong-destination)
Closes #74385

### Description

MCP clients currently return hallucinated dashboard links after calling `create_dashboard`. This returns the dashboard url in the tool call response, so MCP clients can tell the user the correct url by default.

### How to verify

- Connect your MCP client.
- Tell it to create a dashboard. Example: `Create a dashboard with an order table in it. Use the Metabase MCP tool.`. You can give it an existing question id if you want it to be more reliable/deterministic.
- It should show you the correct dashboard url.

### Demo

It now returns the correct dashboard url

<img width="1282" height="734" alt="CleanShot 2569-05-26 at 15 48 36@2x" src="https://github.com/user-attachments/assets/80dd56ab-aea1-49b6-a4a6-916f71bb2ae2" />

Opening the url confirms dashboard url is indeed correct

<img width="2208" height="1190" alt="CleanShot 2569-05-26 at 15 49 11@2x" src="https://github.com/user-attachments/assets/5474e235-d8dc-4b2a-ace3-fed4e06b4403" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR