### PR TITLE
Fix misalignment in horizontal Schedule when "Custom" is selected

### DIFF
--- a/frontend/src/metabase/common/components/CronExpressioInput/CronExpressionInput.tsx
+++ b/frontend/src/metabase/common/components/CronExpressioInput/CronExpressionInput.tsx
@@ -57,8 +57,7 @@ export function CronExpressionInput({
   };
 
   return (
-    <Flex direction="column" {...flexProps}>
-      <CustomScheduleInputHint />
+    <Flex direction="column" gap="xs" {...flexProps}>
       <TextInput
         placeholder="For example 5   0   *   Aug   ?"
         size="md"
@@ -79,6 +78,8 @@ export function CronExpressionInput({
           getExplainMessage={getExplainMessage}
         />
       )}
+
+      <CustomScheduleInputHint />
     </Flex>
   );
 }
@@ -101,7 +102,7 @@ function CustomScheduleInputHint() {
     >{t`quartz cron syntax`}</ExternalLink>
   );
   return (
-    <Text>{jt`Our ${cronSyntaxDocsLink} is a string of 5 fields, starting from minutes, separated by spaces`}</Text>
+    <Text>{jt`Our ${cronSyntaxDocsLink} is a string of 5 fields, starting from minutes, separated by spaces.`}</Text>
   );
 }
 

--- a/frontend/src/metabase/common/components/Schedule/Schedule.module.css
+++ b/frontend/src/metabase/common/components/Schedule/Schedule.module.css
@@ -38,7 +38,7 @@
 .Horizontal {
   display: flex;
   flex-flow: row wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.25rem 0.5rem;
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73343
Closes [GDGT-2369](https://linear.app/metabase/issue/GDGT-2369), [UXW-2923: Cron helper text alignment in schedule UI](https://linear.app/metabase/issue/UXW-2923/cron-helper-text-alignment-in-schedule-ui), #73343

### Description

This PR fixes alignment of the horizontal Schedule when a custom schedule is selected. The row now anchors to the top with `align-items: flex-start` instead of being vertically centered, and the cron input's "quartz cron syntax" hint moved from above to below the input — together these make the cron input line up with sibling controls in the flex container instead of drifting down.

Having the cron hint below the input I think better reflects its purpose — i.e. helping users who are confused by the input. I think most users have heard of cron and recognize it on sight from the example expression we put in the input field, so the explanation only "gets in the way". It's also easier to build visual hierarchy in the horizontal Schedule if the hint is placed below — otherwise we'd need grid/subgrids to align everything, and still introduce layout shifts when the user switches from e.g. hourly to custom cron.

### How to verify

1. Go to a Job in Data Studio (`/data-studio/transforms/jobs/<id>`) and set the schedule to **Custom**. The Select and the cron input should be vertically aligned at the top — see the screenshot in the linked issue for the before state.
2. Anywhere else `CronExpressionInput` appears (Admin → Settings → Caching → Model persistence → Custom; admin performance caching strategy; question alert custom schedule), the "quartz cron syntax" hint should now sit below the input rather than above.

### Demo

### Before

<img width="990" height="410" alt="CleanShot 2026-05-26 at 11 11 10" src="https://github.com/user-attachments/assets/b79d5b3b-0ba1-4d39-9936-03b9f0a2e9ff" />
<img width="708" height="501" alt="CleanShot 2026-05-26 at 11 11 24" src="https://github.com/user-attachments/assets/25bf8109-9550-4d38-833e-531b51eb902a" />


### After

<img width="991" height="403" alt="CleanShot 2026-05-26 at 11 07 49" src="https://github.com/user-attachments/assets/a6cb3a89-8ae6-4858-bad9-88a030f8a631" />
<img width="726" height="528" alt="CleanShot 2026-05-26 at 11 08 07" src="https://github.com/user-attachments/assets/a193e3c8-7615-47f3-a667-c12c49a288fb" />




### Checklist

- [ ] Tests have been added/updated to cover changes in this PR