### PR TITLE
Default the embed wizard auth mode to SSO when configured, guest otherwise

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
@@ -136,71 +136,63 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
           });
       };
 
+      const openFromAdminGuestEmbeds = () => {
+        cy.visit("/admin/embedding/guest");
+        cy.findAllByTestId("guest-embeds-setting-card")
+          .first()
+          .within(() => {
+            cy.findByText("New embed").click();
+          });
+      };
+
       const openFromSharingMenu = () => {
         H.visitQuestion(ORDERS_QUESTION_ID);
         H.openSharingMenu("Embed");
       };
 
-      describe("when JWT SSO is configured", () => {
-        beforeEach(() => {
-          enableJwtAuth();
+      const assertCheckedAuth = (mode: "sso" | "guest") => {
+        const ssoLabel = "Metabase account (SSO)";
+        const guestLabel = "Guest";
+        getEmbedSidebar().within(() => {
+          cy.findByLabelText(mode === "sso" ? ssoLabel : guestLabel).should(
+            "be.checked",
+          );
+          cy.findByLabelText(mode === "sso" ? guestLabel : ssoLabel).should(
+            "not.be.checked",
+          );
         });
+      };
 
-        it("defaults to SSO from the command palette (EMB-1783)", () => {
-          openFromCommandPalette();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
-            cy.findByLabelText("Guest").should("not.be.checked");
-          });
-        });
+      it("defaults to SSO from non-guest entry points when JWT SSO is configured (EMB-1783)", () => {
+        enableJwtAuth();
 
-        it("defaults to SSO from admin → Embedding → New embed", () => {
-          openFromAdminEmbedding();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
-            cy.findByLabelText("Guest").should("not.be.checked");
-          });
-        });
+        openFromCommandPalette();
+        assertCheckedAuth("sso");
 
-        it("defaults to SSO from a resource's sharing menu", () => {
-          openFromSharingMenu();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
-            cy.findByLabelText("Guest").should("not.be.checked");
-          });
-        });
+        openFromAdminEmbedding();
+        assertCheckedAuth("sso");
+
+        openFromSharingMenu();
+        assertCheckedAuth("sso");
+
+        // The Guest embeds admin section is intentionally guest-only and
+        // forces guest mode regardless of SSO configuration.
+        openFromAdminGuestEmbeds();
+        assertCheckedAuth("guest");
       });
 
-      describe("when SSO is not configured", () => {
-        it("defaults to Guest from the command palette", () => {
-          openFromCommandPalette();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Guest").should("be.checked");
-            cy.findByLabelText("Metabase account (SSO)").should(
-              "not.be.checked",
-            );
-          });
-        });
+      it("defaults to Guest from all entry points when SSO is not configured", () => {
+        openFromCommandPalette();
+        assertCheckedAuth("guest");
 
-        it("defaults to Guest from admin → Embedding → New embed", () => {
-          openFromAdminEmbedding();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Guest").should("be.checked");
-            cy.findByLabelText("Metabase account (SSO)").should(
-              "not.be.checked",
-            );
-          });
-        });
+        openFromAdminEmbedding();
+        assertCheckedAuth("guest");
 
-        it("defaults to Guest from a resource's sharing menu", () => {
-          openFromSharingMenu();
-          getEmbedSidebar().within(() => {
-            cy.findByLabelText("Guest").should("be.checked");
-            cy.findByLabelText("Metabase account (SSO)").should(
-              "not.be.checked",
-            );
-          });
-        });
+        openFromSharingMenu();
+        assertCheckedAuth("guest");
+
+        openFromAdminGuestEmbeds();
+        assertCheckedAuth("guest");
       });
     });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
@@ -2,6 +2,7 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
 import {
   getEmbedSidebar,
@@ -113,6 +114,23 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
       visitNewEmbedPage({ waitForResource: false });
 
       cy.findByLabelText("Metabase account (SSO)").should("be.enabled");
+    });
+
+    it("defaults to SSO when opening the wizard from the command palette with JWT configured (EMB-1783)", () => {
+      enableJwtAuth();
+
+      cy.visit("/");
+      H.commandPaletteButton().click();
+      H.commandPaletteInput().should("be.visible").type("new embed");
+      H.commandPalette()
+        .findByRole("option", { name: "New embed" })
+        .should("be.visible")
+        .click();
+
+      getEmbedSidebar().within(() => {
+        cy.findByLabelText("Metabase account (SSO)").should("be.checked");
+        cy.findByLabelText("Guest").should("not.be.checked");
+      });
     });
 
     it("should not reset experience when changing auth type for Embed JS wizard opened from an entity page", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/common-ee.cy.spec.ts
@@ -116,20 +116,91 @@ describe("scenarios > embedding > sdk iframe embed setup > common", () => {
       cy.findByLabelText("Metabase account (SSO)").should("be.enabled");
     });
 
-    it("defaults to SSO when opening the wizard from the command palette with JWT configured (EMB-1783)", () => {
-      enableJwtAuth();
+    describe("default auth mode follows SSO configuration", () => {
+      const openFromCommandPalette = () => {
+        cy.visit("/");
+        H.commandPaletteButton().click();
+        H.commandPaletteInput().should("be.visible").type("new embed");
+        H.commandPalette()
+          .findByRole("option", { name: "New embed" })
+          .should("be.visible")
+          .click();
+      };
 
-      cy.visit("/");
-      H.commandPaletteButton().click();
-      H.commandPaletteInput().should("be.visible").type("new embed");
-      H.commandPalette()
-        .findByRole("option", { name: "New embed" })
-        .should("be.visible")
-        .click();
+      const openFromAdminEmbedding = () => {
+        cy.visit("/admin/embedding");
+        cy.findAllByTestId("sdk-setting-card")
+          .first()
+          .within(() => {
+            cy.findByText("New embed").click();
+          });
+      };
 
-      getEmbedSidebar().within(() => {
-        cy.findByLabelText("Metabase account (SSO)").should("be.checked");
-        cy.findByLabelText("Guest").should("not.be.checked");
+      const openFromSharingMenu = () => {
+        H.visitQuestion(ORDERS_QUESTION_ID);
+        H.openSharingMenu("Embed");
+      };
+
+      describe("when JWT SSO is configured", () => {
+        beforeEach(() => {
+          enableJwtAuth();
+        });
+
+        it("defaults to SSO from the command palette (EMB-1783)", () => {
+          openFromCommandPalette();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
+            cy.findByLabelText("Guest").should("not.be.checked");
+          });
+        });
+
+        it("defaults to SSO from admin → Embedding → New embed", () => {
+          openFromAdminEmbedding();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
+            cy.findByLabelText("Guest").should("not.be.checked");
+          });
+        });
+
+        it("defaults to SSO from a resource's sharing menu", () => {
+          openFromSharingMenu();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Metabase account (SSO)").should("be.checked");
+            cy.findByLabelText("Guest").should("not.be.checked");
+          });
+        });
+      });
+
+      describe("when SSO is not configured", () => {
+        it("defaults to Guest from the command palette", () => {
+          openFromCommandPalette();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Guest").should("be.checked");
+            cy.findByLabelText("Metabase account (SSO)").should(
+              "not.be.checked",
+            );
+          });
+        });
+
+        it("defaults to Guest from admin → Embedding → New embed", () => {
+          openFromAdminEmbedding();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Guest").should("be.checked");
+            cy.findByLabelText("Metabase account (SSO)").should(
+              "not.be.checked",
+            );
+          });
+        });
+
+        it("defaults to Guest from a resource's sharing menu", () => {
+          openFromSharingMenu();
+          getEmbedSidebar().within(() => {
+            cy.findByLabelText("Guest").should("be.checked");
+            cy.findByLabelText("Metabase account (SSO)").should(
+              "not.be.checked",
+            );
+          });
+        });
       });
     });
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -88,12 +88,13 @@ export const useSdkIframeEmbedSettings = ({
   const exampleDashboardId = useSetting("example-dashboard-id");
 
   const defaultSettings = useMemo(() => {
-    // Default to guest when SSO is not available (OSS) or not configured;
-    // otherwise default to SSO. Callers that need a specific mode pass
-    // `initialState.isGuest` explicitly.
-    const defaultIsGuest = !(
+    // Default to SSO when it's available and configured; otherwise default
+    // to guest. Callers that need a specific mode pass `initialState.isGuest`
+    // explicitly.
+    const defaultMode: "sso" | "guest" =
       isSimpleEmbedFeatureAvailable && isSsoEnabledAndConfigured
-    );
+        ? "sso"
+        : "guest";
 
     return match(initialState)
       .with(
@@ -105,7 +106,7 @@ export const useSdkIframeEmbedSettings = ({
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
-            isGuest: initialState.isGuest ?? defaultIsGuest,
+            isGuest: initialState.isGuest ?? defaultMode === "guest",
             useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
@@ -118,7 +119,7 @@ export const useSdkIframeEmbedSettings = ({
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
-            isGuest: initialState.isGuest ?? defaultIsGuest,
+            isGuest: initialState.isGuest ?? defaultMode === "guest",
             useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
@@ -133,7 +134,7 @@ export const useSdkIframeEmbedSettings = ({
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
-          isGuest: initialState?.isGuest ?? defaultIsGuest,
+          isGuest: initialState?.isGuest ?? defaultMode === "guest",
           useExistingUserSession: !!initialState?.useExistingUserSession,
         }),
       );

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-sdk-iframe-embed-settings.ts
@@ -88,6 +88,13 @@ export const useSdkIframeEmbedSettings = ({
   const exampleDashboardId = useSetting("example-dashboard-id");
 
   const defaultSettings = useMemo(() => {
+    // Default to guest when SSO is not available (OSS) or not configured;
+    // otherwise default to SSO. Callers that need a specific mode pass
+    // `initialState.isGuest` explicitly.
+    const defaultIsGuest = !(
+      isSimpleEmbedFeatureAvailable && isSsoEnabledAndConfigured
+    );
+
     return match(initialState)
       .with(
         { resourceType: "dashboard", resourceId: P.nonNullable },
@@ -98,7 +105,7 @@ export const useSdkIframeEmbedSettings = ({
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
-            isGuest: !!initialState.isGuest,
+            isGuest: initialState.isGuest ?? defaultIsGuest,
             useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
@@ -111,7 +118,7 @@ export const useSdkIframeEmbedSettings = ({
             isSimpleEmbedFeatureAvailable,
             isGuestEmbedsEnabled,
             isSsoEnabledAndConfigured,
-            isGuest: !!initialState.isGuest,
+            isGuest: initialState.isGuest ?? defaultIsGuest,
             useExistingUserSession: !!initialState.useExistingUserSession,
           }),
       )
@@ -126,7 +133,7 @@ export const useSdkIframeEmbedSettings = ({
           isSimpleEmbedFeatureAvailable,
           isGuestEmbedsEnabled,
           isSsoEnabledAndConfigured,
-          isGuest: !!initialState?.isGuest,
+          isGuest: initialState?.isGuest ?? defaultIsGuest,
           useExistingUserSession: !!initialState?.useExistingUserSession,
         }),
       );

--- a/frontend/src/metabase/embedding/hooks/use-sharing-modal.ts
+++ b/frontend/src/metabase/embedding/hooks/use-sharing-modal.ts
@@ -30,8 +30,6 @@ export const useSharingModal = <
     initialState: {
       resourceId: resource.id,
       resourceType,
-      isGuest: true,
-      useExistingUserSession: true,
     },
   });
 

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -225,12 +225,7 @@ export const useCommandPaletteBasicActions = ({
         perform: () =>
           openNewModalWithProps({
             id: "embed",
-            props: {
-              initialState: {
-                isGuest: true,
-                useExistingUserSession: true,
-              },
-            },
+            props: null,
           }),
       });
     }


### PR DESCRIPTION
Closes [EMB-1783: Command palette "New embed" defaults to guest instead of SSO](https://linear.app/metabase/issue/EMB-1783/command-palette-new-embed-defaults-to-guest-instead-of-sso)

### Description

The "New embed" entry from the command palette hardcoded `isGuest: true` in the modal's initial state, so it always opened in guest mode even when JWT/SAML SSO was enabled and configured. Other entry points were inconsistent too — `Admin → Embedding → New embed` always defaulted to SSO (even with SSO not configured, surfacing the "SSO not configured" warning), and the resource sharing menu always defaulted to guest regardless of SSO state.

This PR centralizes the default auth mode in the wizard itself (`useSdkIframeEmbedSettings`): when a caller does not pass `initialState.isGuest` explicitly, the wizard now picks **SSO if the simple-embedding feature is available and SSO is configured, guest otherwise**. The three user-facing entry points (command palette, `Admin → Embedding → New embed`, resource sharing menu) all rely on this default and now behave identically. Callers that need to force a specific mode (the combined OSS/Starter admin page via `forceIsGuest`, and the embedding hub's "Embed in production with SSO" step) still pass `isGuest` explicitly and are unaffected.

### How to verify

For each entry point below, the wizard's Authentication step should preselect the expected radio:

**With JWT SSO configured** (`Admin → Authentication → JWT`, enabled + identity provider URI + shared secret):
1. `cmd+k` → "New embed" → wizard opens with **Metabase account (SSO)** selected.
2. `Admin → Embedding → New embed` (top card) → **Metabase account (SSO)** selected.
3. On any dashboard/question: sharing menu → Embed → **Metabase account (SSO)** selected.

**With JWT SSO not configured** (fresh instance or JWT disabled):
1. `cmd+k` → "New embed" → wizard opens with **Guest** selected.
2. `Admin → Embedding → New embed` → **Guest** selected.
3. Sharing menu → Embed → **Guest** selected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR