### PR TITLE
gitignore new rspack compilation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ cypress.env.json
 /reset-password-artifacts
 /resources/frontend_client/app/**/*.br
 /resources/frontend_client/app/**/*.gz
+/resources/frontend_client/app/**/*.hot-update.js
+/resources/frontend_client/app/**/*.hot-update.json
 /resources/frontend_client/app/dist/
 /resources/frontend_client/app/locales
 /resources/frontend_client/app/embed.js


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2499/gitignore-new-rspack-compilation-artifacts

### Description

Most probably after recent rspack update (https://github.com/metabase/metabase/pull/74564) I've started getting those unignored dev server compilation artifacts. We should add them to `.gitignore`.

```
resources/frontend_client/app/main.0724c47a7b205af2.hot-update.js
resources/frontend_client/app/main.0724c47a7b205af2.hot-update.json
resources/frontend_client/app/main.24ec2771c5620a63.hot-update.js
resources/frontend_client/app/main.24ec2771c5620a63.hot-update.json
resources/frontend_client/app/main.c9ddbe04536c3aca.hot-update.js
resources/frontend_client/app/main.c9ddbe04536c3aca.hot-update.json
```

### How to verify

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
