### PR TITLE
Make default embedding service base url match AI service

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -270,7 +270,8 @@
 (defn- trim-trailing-slashes
   [s]
   (cond-> s
-    (string? s) (str/replace #"/+$" "")))
+    (string? s) (-> (str/trim)
+                    (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
   "Returns [endpoint api-key]. When api key is not set or when service url is not set but

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.core :as analytics.core]
+   [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
@@ -267,15 +268,19 @@
 ;;;; Embedding-service provider
 
 (defn- embedding-service-resolve-config!
-  "Returns [endpoint api-key]. Throws if base url is not configured. When api key is not set
-  the ai service proxying is assumed. In that case premium-embedding-token is used for authentication."
+  "Returns [endpoint api-key]. When api key is not set or when service url is not set but
+  `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
+  is used for authentication. Throws if base url of both vars is not set is not configured."
   []
-  (let [base-url (semantic-settings/ee-embedding-service-base-url)
-        api-key  (semantic-settings/ee-embedding-service-api-key)]
-    (when-not base-url
-      (throw (ex-info "Embedding service base URL not configured"
-                      {:setting "ee-embedding-service-base-url"})))
-    [(str base-url "/v1/embeddings") api-key]))
+  (if (empty? (semantic-settings/ee-embedding-service-base-url))
+    (if (empty? (llm.settings/ai-service-base-url))
+      (throw (ex-info "Embedding service and ai service base URLs and not configured"
+                      {:setting ["ee-embedding-service-base-url"
+                                 "ai-service-base-url"]}))
+      [(llm.settings/ai-service-base-url) nil])
+    (let [base-url (semantic-settings/ee-embedding-service-base-url)
+          api-key  (semantic-settings/ee-embedding-service-api-key)]
+      [(str base-url "/v1/embeddings") api-key])))
 
 (defmethod get-embedding "ai-service"
   [{:keys [model-name]} text & {:keys [record-tokens? type]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -282,11 +282,11 @@
          (semantic-settings/ee-embedding-service-api-key)]
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
-        [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
+        [(str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
          nil]
 
         :else
-        (throw (ex-info "Embedding service and ai service base URLs and not configured"
+        (throw (ex-info "Embedding service and ai service base URLs are not configured"
                         {:settings ["ee-embedding-service-base-url"
                                     "ai-service-base-url"]}))))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -267,20 +267,28 @@
 
 ;;;; Embedding-service provider
 
+(defn- trim-trailing-slashes
+  [s]
+  (cond-> s
+    (string? s) (str/replace #"/+$" "")))
+
 (defn- embedding-service-resolve-config!
   "Returns [endpoint api-key]. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication. Throws if base url of both vars is not set is not configured."
+  is used for authentication. Throws if neither base URL is configured."
   []
-  (if (empty? (semantic-settings/ee-embedding-service-base-url))
-    (if (empty? (llm.settings/ai-service-base-url))
-      (throw (ex-info "Embedding service and ai service base URLs and not configured"
-                      {:setting ["ee-embedding-service-base-url"
-                                 "ai-service-base-url"]}))
-      [(str (llm.settings/ai-service-base-url) "/v1/embeddings") nil])
-    (let [base-url (semantic-settings/ee-embedding-service-base-url)
-          api-key  (semantic-settings/ee-embedding-service-api-key)]
-      [(str base-url "/v1/embeddings") api-key])))
+  (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
+        [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
+         (semantic-settings/ee-embedding-service-api-key)]
+
+        (string? (not-empty (llm.settings/ai-service-base-url)))
+        [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
+         nil]
+
+        :else
+        (throw (ex-info "Embedding service and ai service base URLs and not configured"
+                        {:settings ["ee-embedding-service-base-url"
+                                    "ai-service-base-url"]}))))
 
 (defmethod get-embedding "ai-service"
   [{:keys [model-name]} text & {:keys [record-tokens? type]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -277,7 +277,7 @@
       (throw (ex-info "Embedding service and ai service base URLs and not configured"
                       {:setting ["ee-embedding-service-base-url"
                                  "ai-service-base-url"]}))
-      [(llm.settings/ai-service-base-url) nil])
+      [(str (llm.settings/ai-service-base-url) "/v1/embeddings") nil])
     (let [base-url (semantic-settings/ee-embedding-service-base-url)
           api-key  (semantic-settings/ee-embedding-service-api-key)]
       [(str base-url "/v1/embeddings") api-key])))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -232,7 +232,6 @@
                                        :model-name "test-model"
                                        :vector-dimensions 4}
                                       "test text")))))
-
     (testing "ai-service falls back to ai-service-base-url when ee-embedding-service-base-url is not set"
       (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                   llm.settings/ai-service-base-url                    (constantly "http://mock-ai-service")
@@ -253,9 +252,7 @@
               (is (= "http://mock-ai-service/v1/embeddings" (:url @captured)))
               (is (= "mock-token" (get-in @captured [:headers "x-metabase-instance-token"])))
               (is (nil? (get-in @captured [:headers "Authorization"]))))
-
             (reset! captured nil)
-
             (testing "get-embeddings-batch uses ai-service URL with instance-token auth"
               (is (= [mock-embedding]
                      (mapv vec (embedding/get-embeddings-batch {:provider          "ai-service"
@@ -266,7 +263,6 @@
               (is (= "http://mock-ai-service/v1/embeddings" (:url @captured)))
               (is (= "mock-token" (get-in @captured [:headers "x-metabase-instance-token"])))
               (is (nil? (get-in @captured [:headers "Authorization"]))))))))
-
     (testing "ee-embedding-service-base-url wins when both are configured"
       (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
                                          ee-embedding-service-api-key  "embedding-api-key"]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -214,42 +214,78 @@
                 (is (= 2 (t2/count :model/SemanticSearchTokenTracking)))))))))))
 
 (deftest test-embedding-service-validation
-  (testing "ai-service throws when both base URLs are not configured"
-    (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly nil)
-                                semantic.settings/ee-embedding-service-base-url (constantly nil)
-                                semantic.settings/ee-embedding-service-api-key (constantly "key")]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Embedding service and ai service base URLs are not configured"
-           (embedding/get-embedding {:provider "ai-service"
-                                     :model-name "test-model"
-                                     :vector-dimensions 4}
-                                    "test text")))))
+  (let [mock-embedding [1.0 2.0 3.0 4.0]
+        mock-response  {:data  [{:object    "embedding"
+                                 :embedding (encode-floats-to-base64 mock-embedding)
+                                 :index     0}]
+                        :model "test-model"
+                        :usage {:prompt_tokens 1
+                                :total_tokens  1}}]
+    (testing "ai-service throws when both base URLs are not configured"
+      (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url                    (constantly nil)
+                                  semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                  semantic.settings/ee-embedding-service-api-key  (constantly "key")]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Embedding service and ai service base URLs are not configured"
+             (embedding/get-embedding {:provider "ai-service"
+                                       :model-name "test-model"
+                                       :vector-dimensions 4}
+                                      "test text")))))
 
-  (testing "ai-service falls back to ai-service-base-url when ee-embedding-service-base-url is not set"
-    (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
-                                llm.settings/ai-service-base-url (constantly "http://mock-ai-service")
-                                premium-features/premium-embedding-token (constantly "token")]
-      (let [mock-embedding [1.0 2.0 3.0 4.0]
-            mock-response  {:data  [{:object    "embedding"
-                                     :embedding (encode-floats-to-base64 mock-embedding)
-                                     :index     0}]
-                            :model "test-model"
-                            :usage {:prompt_tokens 1
-                                    :total_tokens  1}}
-            captured-url   (atom nil)]
-        (mt/with-dynamic-fn-redefs [http/post (fn [url & _opts]
-                                                (reset! captured-url url)
-                                                {:status  200
-                                                 :headers {"Content-Type" "application/json"}
-                                                 :body    (json/encode mock-response)})]
-          (is (= mock-embedding
-                 (vec (embedding/get-embedding {:provider          "ai-service"
-                                                :model-name        "test-model"
-                                                :vector-dimensions 4}
-                                               "test text"
-                                               {:record-tokens? false}))))
-          (is (= "http://mock-ai-service/v1/embeddings" @captured-url)))))))
+    (testing "ai-service falls back to ai-service-base-url when ee-embedding-service-base-url is not set"
+      (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                  llm.settings/ai-service-base-url                    (constantly "http://mock-ai-service")
+                                  premium-features/premium-embedding-token         (constantly "mock-token")]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [http/post (fn [url opts]
+                                                  (reset! captured {:url url :headers (:headers opts)})
+                                                  {:status  200
+                                                   :headers {"Content-Type" "application/json"}
+                                                   :body    (json/encode mock-response)})]
+            (testing "get-embedding uses ai-service URL with instance-token auth"
+              (is (= mock-embedding
+                     (vec (embedding/get-embedding {:provider          "ai-service"
+                                                    :model-name        "test-model"
+                                                    :vector-dimensions 4}
+                                                   "test text"
+                                                   {:record-tokens? false}))))
+              (is (= "http://mock-ai-service/v1/embeddings" (:url @captured)))
+              (is (= "mock-token" (get-in @captured [:headers "x-metabase-instance-token"])))
+              (is (nil? (get-in @captured [:headers "Authorization"]))))
+
+            (reset! captured nil)
+
+            (testing "get-embeddings-batch uses ai-service URL with instance-token auth"
+              (is (= [mock-embedding]
+                     (mapv vec (embedding/get-embeddings-batch {:provider          "ai-service"
+                                                                :model-name        "test-model"
+                                                                :vector-dimensions 4}
+                                                               ["test text"]
+                                                               {:record-tokens? false}))))
+              (is (= "http://mock-ai-service/v1/embeddings" (:url @captured)))
+              (is (= "mock-token" (get-in @captured [:headers "x-metabase-instance-token"])))
+              (is (nil? (get-in @captured [:headers "Authorization"]))))))))
+
+    (testing "ee-embedding-service-base-url wins when both are configured"
+      (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
+                                         ee-embedding-service-api-key  "embedding-api-key"]
+        (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly "http://mock-ai-service")]
+          (let [captured (atom nil)]
+            (mt/with-dynamic-fn-redefs [http/post (fn [url opts]
+                                                    (reset! captured {:url url :headers (:headers opts)})
+                                                    {:status  200
+                                                     :headers {"Content-Type" "application/json"}
+                                                     :body    (json/encode mock-response)})]
+              (is (= mock-embedding
+                     (vec (embedding/get-embedding {:provider          "ai-service"
+                                                    :model-name        "test-model"
+                                                    :vector-dimensions 4}
+                                                   "test text"
+                                                   {:record-tokens? false}))))
+              (is (= "http://mock-embedding-service/v1/embeddings" (:url @captured)))
+              (is (= "Bearer embedding-api-key" (get-in @captured [:headers "Authorization"])))
+              (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -14,6 +14,8 @@
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.snowplow-test :as snowplow-test]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
@@ -212,16 +214,42 @@
                 (is (= 2 (t2/count :model/SemanticSearchTokenTracking)))))))))))
 
 (deftest test-embedding-service-validation
-  (testing "ai-service throws when base URL not configured"
-    (mt/with-temporary-setting-values [ee-embedding-service-base-url nil
-                                       ee-embedding-service-api-key  "some-key"]
+  (testing "ai-service throws when both base URLs are not configured"
+    (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly nil)
+                                semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                semantic.settings/ee-embedding-service-api-key (constantly "key")]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"Embedding service base URL not configured"
+           #"Embedding service and ai service base URLs and not configured"
            (embedding/get-embedding {:provider "ai-service"
                                      :model-name "test-model"
                                      :vector-dimensions 4}
-                                    "test text"))))))
+                                    "test text")))))
+
+  (testing "ai-service falls back to ai-service-base-url when ee-embedding-service-base-url is not set"
+    (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                llm.settings/ai-service-base-url (constantly "http://mock-ai-service")
+                                premium-features/premium-embedding-token (constantly "token")]
+      (let [mock-embedding [1.0 2.0 3.0 4.0]
+            mock-response  {:data  [{:object    "embedding"
+                                     :embedding (encode-floats-to-base64 mock-embedding)
+                                     :index     0}]
+                            :model "test-model"
+                            :usage {:prompt_tokens 1
+                                    :total_tokens  1}}
+            captured-url   (atom nil)]
+        (mt/with-dynamic-fn-redefs [http/post (fn [url & _opts]
+                                                (reset! captured-url url)
+                                                {:status  200
+                                                 :headers {"Content-Type" "application/json"}
+                                                 :body    (json/encode mock-response)})]
+          (is (= mock-embedding
+                 (vec (embedding/get-embedding {:provider          "ai-service"
+                                                :model-name        "test-model"
+                                                :vector-dimensions 4}
+                                               "test text"
+                                               {:record-tokens? false}))))
+          (is (= "http://mock-ai-service/v1/embeddings" @captured-url)))))))
 
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -220,7 +220,7 @@
                                 semantic.settings/ee-embedding-service-api-key (constantly "key")]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"Embedding service and ai service base URLs and not configured"
+           #"Embedding service and ai service base URLs are not configured"
            (embedding/get-embedding {:provider "ai-service"
                                      :model-name "test-model"
                                      :vector-dimensions 4}


### PR DESCRIPTION
Closes [BOT-1440: Configure embedding service base URL to stop error logs](https://linear.app/metabase/issue/BOT-1440/configure-embedding-service-base-url-to-stop-error-logs)

Follow-up to https://github.com/metabase/metabase/pull/74526. This PR makes the default of the embedding service base url same as ai service url. That behavior matches state prior migration to clojure.

The variable precedence is now handled as follows:
1. ee-embedding-service-base-url,
2. ai-service-base-url.

Then, if the ee-embedding-service-api-key is set it is used as bearer for auth token. If not, premium-embedding-token is used as value of x-metabase-instance-token for that purpose.