### PR TITLE
Fix search values remap

### DIFF
--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -93,18 +93,22 @@
                                                id
                                                (pr-str field-ref)
                                                (pr-str (map (some-fn :lib/source-column-alias :name) visible-columns))))]
-          (let [label-column (when label-field
-                               (or (lib/find-matching-column query -1 label-field visible-columns)
-                                   (log/warnf "Cannot get labels from Card %d: failed to find column for ref %s"
-                                              id
-                                              (pr-str label-field))))
-                textual?     (lib.types.isa/string? value-column)
-                nonempty     ((if textual? lib/not-empty lib/not-null) value-column)
-                query-filter (cond
-                               (some? exact-value) (lib/= value-column exact-value)
-                               query-string        (if textual?
-                                                     (lib/contains (lib/lower value-column) (u/lower-case-en query-string))
-                                                     (lib/= value-column query-string)))]
+          (let [label-column   (when label-field
+                                 (or (lib/find-matching-column query -1 label-field visible-columns)
+                                     (log/warnf "Cannot get labels from Card %d: failed to find column for ref %s"
+                                                id
+                                                (pr-str label-field))))
+                ;; Search against the label when one is configured so users find rows by the label
+                ;; they see in the dropdown — matches the static-list source behavior.
+                search-column   (or label-column value-column)
+                value-textual?  (lib.types.isa/string? value-column)
+                search-textual? (lib.types.isa/string? search-column)
+                nonempty        ((if value-textual? lib/not-empty lib/not-null) value-column)
+                query-filter    (cond
+                                  (some? exact-value) (lib/= value-column exact-value)
+                                  query-string        (if search-textual?
+                                                        (lib/ignore-case (lib/contains search-column query-string))
+                                                        (lib/= search-column query-string)))]
             (-> query
                 (lib/limit *max-rows*)
                 (lib/filter nonempty)

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -98,8 +98,6 @@
                                      (log/warnf "Cannot get labels from Card %d: failed to find column for ref %s"
                                                 id
                                                 (pr-str label-field))))
-                ;; Search against the label when one is configured so users find rows by the label
-                ;; they see in the dropdown — matches the static-list source behavior.
                 search-column   (or label-column value-column)
                 value-textual?  (lib.types.isa/string? value-column)
                 search-textual? (lib.types.isa/string? search-column)

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -54,6 +54,22 @@
                 [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} (mt/id :venues :id)]
                 {:label-field [:field {:lib/uuid "00000000-0000-0000-0000-000000000001"} (mt/id :venues :name)]})))))))
 
+(deftest ^:parallel search-by-label-field-test
+  (testing "query-string with a label-field filters by the label, not the value"
+    (mt/with-temp
+      [:model/Card card (merge (mt/card-with-source-metadata-for-query (mt/mbql-query venues))
+                               {:database_id (mt/id)
+                                :type        :question
+                                :table_id    (mt/id :venues)})]
+      (let [{:keys [values]} (custom-values/values-from-card
+                              card
+                              [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} (mt/id :venues :id)]
+                              {:query-string "bakery"
+                               :label-field  [:field {:lib/uuid "00000000-0000-0000-0000-000000000001"}
+                                              (mt/id :venues :name)]})]
+        (is (seq values))
+        (is (every? (fn [[_id label]] (re-find #"(?i)bakery" label)) values))))))
+
 (deftest ^:parallel with-mbql-card-test-2
   (testing "source card is a model" ; Models are opaque, so this sees the post-aggregation columns.
     (binding [custom-values/*max-rows* 3]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74766
Fix https://linear.app/metabase/issue/GHY-3693/search-box-filter-500-error-with-uuid-column-type-and-value-label

Fix the card values source config path:
- proper case-insensitive `contains` call that should work for ClickHouse
- use `label` for search when it's set, matching static-list behavior