### PR TITLE
Display column labels below split map charts

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
@@ -53,9 +53,13 @@ export type DimensionPillBarItem =
 
 export interface DimensionPillBarProps {
   items: DimensionPillBarItem[];
+  textSize?: "xs" | "sm";
 }
 
-export function DimensionPillBar({ items }: DimensionPillBarProps) {
+export function DimensionPillBar({
+  items,
+  textSize = "sm",
+}: DimensionPillBarProps) {
   if (items.length === 0) {
     return null;
   }
@@ -76,6 +80,7 @@ export function DimensionPillBar({ items }: DimensionPillBarProps) {
           label={item.label}
           icon={item.icon}
           colors={item.colors}
+          textSize={textSize}
         />
       ))}
     </Flex>
@@ -86,10 +91,12 @@ function DimensionLabel({
   label,
   icon,
   colors,
+  textSize,
 }: {
   label?: string;
   icon?: IconName;
   colors?: string[];
+  textSize: "xs" | "sm";
 }) {
   if (!label) {
     return null;
@@ -102,7 +109,7 @@ function DimensionLabel({
         fallbackIcon={icon ?? "add"}
         size={12}
       />
-      <Text size="sm" lh="1rem" c="text-primary">
+      <Text size={textSize} lh="1rem" c="text-primary">
         {label}
       </Text>
     </Flex>

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
@@ -12,7 +12,7 @@ import S from "./DimensionPillBar.module.css";
 
 export interface MetricDimensionItem {
   type: "metric";
-  id: number;
+  slotIndex: number;
   label?: string;
   icon?: IconName;
   colors?: string[];
@@ -36,8 +36,7 @@ export interface ExpressionMetricSource {
 
 export interface ExpressionDimensionItem {
   type: "expression";
-  /** Expression entity index — used as the React key. */
-  id: number;
+  entityIndex: number;
   colors?: string[];
   icon?: IconName;
   /** Aggregate label derived from selected dimensions. */
@@ -76,7 +75,11 @@ export function DimensionPillBar({
     >
       {items.map((item) => (
         <DimensionLabel
-          key={item.type === "expression" ? `expr-${item.id}` : item.id}
+          key={
+            item.type === "expression"
+              ? `expr-${item.entityIndex}`
+              : item.slotIndex
+          }
           label={item.label}
           icon={item.icon}
           colors={item.colors}

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerDimensionBreakoutContent/MetricsViewerDimensionBreakoutContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerDimensionBreakoutContent/MetricsViewerDimensionBreakoutContent.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useMemo } from "react";
 
-import { DimensionPillBar } from "metabase/metrics-viewer/components/DimensionPillBar";
+import {
+  DimensionPillBar,
+  type DimensionPillBarItem,
+} from "metabase/metrics-viewer/components/DimensionPillBar";
 import { MetricControls } from "metabase/metrics-viewer/components/MetricControls";
 import { MetricsViewerVisualization } from "metabase/metrics-viewer/components/MetricsViewerVisualization";
 import { useMetricsViewerContext } from "metabase/metrics-viewer/context";
@@ -10,6 +13,7 @@ import {
   getProjectionInfo,
   shouldShowStackSeries,
 } from "metabase/metrics-viewer/utils";
+import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
 import { Box, Flex, Stack } from "metabase/ui";
 import { getObjectKeys } from "metabase/utils/objects";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
@@ -97,6 +101,11 @@ export function MetricsViewerDimensionBreakoutContent() {
     return filterDimensions;
   }, [dimensionBreakout, modifiedDefinitionsBySlotIndex]);
 
+  const dimensionItemsByEntityIndex = useMemo(
+    () => getDimensionItemsByEntityIndex(dimensionItems, metricSlots),
+    [dimensionItems, metricSlots],
+  );
+
   const handleBrush = useCallback(
     ({ start, end }: { start: number; end: number }) => {
       onDimensionBreakoutUpdate({
@@ -137,6 +146,12 @@ export function MetricsViewerDimensionBreakoutContent() {
   );
   const hideDimensionPill =
     dimensionBreakoutConfig.minDimensions === 0 && !hasAnyOptions;
+
+  const showPerMapColumnLabels =
+    showColumnLabels &&
+    dimensionBreakout.display === "map" &&
+    rawSeries.length > 1;
+
   return (
     <Stack flex="1 0 auto" gap={0}>
       <MetricsViewerVisualization
@@ -150,8 +165,11 @@ export function MetricsViewerDimensionBreakoutContent() {
         cardIdToEntityIndex={cardIdToEntityIndex}
         queriesAreLoading={queriesAreLoading}
         queriesError={queriesError}
+        chartColumnLabelsByEntityIndex={
+          showPerMapColumnLabels ? dimensionItemsByEntityIndex : undefined
+        }
       />
-      {!hideDimensionPill && showColumnLabels && (
+      {!hideDimensionPill && showColumnLabels && !showPerMapColumnLabels && (
         <Box mt="sm">
           <DimensionPillBar items={dimensionItems} />
         </Box>
@@ -168,4 +186,25 @@ export function MetricsViewerDimensionBreakoutContent() {
       )}
     </Stack>
   );
+}
+
+function getDimensionItemsByEntityIndex(
+  dimensionItems: DimensionPillBarItem[],
+  metricSlots: MetricSlot[],
+): Map<number, DimensionPillBarItem> {
+  const itemsByEntityIndex = new Map<number, DimensionPillBarItem>();
+
+  for (const item of dimensionItems) {
+    if (item.type === "expression") {
+      itemsByEntityIndex.set(item.id, item);
+      continue;
+    }
+
+    const slot = metricSlots.find((slot) => slot.slotIndex === item.id);
+    if (slot) {
+      itemsByEntityIndex.set(slot.entityIndex, item);
+    }
+  }
+
+  return itemsByEntityIndex;
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerDimensionBreakoutContent/MetricsViewerDimensionBreakoutContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerDimensionBreakoutContent/MetricsViewerDimensionBreakoutContent.tsx
@@ -196,11 +196,11 @@ function getDimensionItemsByEntityIndex(
 
   for (const item of dimensionItems) {
     if (item.type === "expression") {
-      itemsByEntityIndex.set(item.id, item);
+      itemsByEntityIndex.set(item.entityIndex, item);
       continue;
     }
 
-    const slot = metricSlots.find((slot) => slot.slotIndex === item.id);
+    const slot = metricSlots.find((slot) => slot.slotIndex === item.slotIndex);
     if (slot) {
       itemsByEntityIndex.set(slot.entityIndex, item);
     }

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.module.css
@@ -2,6 +2,24 @@
   flex: 1;
 }
 
+.gridChart {
+  position: relative;
+}
+
+.gridChartLabel {
+  position: absolute;
+  right: 0;
+  bottom: 2.75rem;
+  left: 0;
+  pointer-events: none;
+}
+
+.gridChart:has([data-legend-position="horizontal"]) .gridChartLabel {
+  /* Horizontal ChartWithLegend layouts render the legend to the left of the map,
+   * so shift labels to the map area instead of centering them across both. */
+  left: 27%;
+}
+
 .chart {
   background-color: var(--mb-color-background-primary);
   overflow: hidden;

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useMemo } from "react";
 import { t } from "ttag";
 import { noop } from "underscore";
@@ -5,6 +6,10 @@ import { noop } from "underscore";
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
 import { ErrorMessage } from "metabase/common/components/ErrorMessage";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import {
+  DimensionPillBar,
+  type DimensionPillBarItem,
+} from "metabase/metrics-viewer/components/DimensionPillBar";
 import { DISPLAY_TYPE_REGISTRY } from "metabase/metrics-viewer/utils";
 import { MetricsViewerClickActionsMode } from "metabase/metrics-viewer/utils/MetricsViewerClickActionsMode";
 import { getGridColumns } from "metabase/metrics-viewer/utils/grid-columns";
@@ -38,6 +43,7 @@ type MetricsViewerVisualizationProps = {
   interactive?: boolean;
   queriesAreLoading: boolean;
   queriesError: string | null;
+  chartColumnLabelsByEntityIndex?: Map<number, DimensionPillBarItem>;
 };
 
 export function MetricsViewerVisualization({
@@ -53,6 +59,7 @@ export function MetricsViewerVisualization({
   interactive = true,
   queriesAreLoading,
   queriesError,
+  chartColumnLabelsByEntityIndex,
 }: MetricsViewerVisualizationProps) {
   const { ref, width } = useElementSize();
   const cols = getGridColumns(width, rawSeries.length);
@@ -121,13 +128,13 @@ export function MetricsViewerVisualization({
       className={className}
     >
       {rawSeries.length > 1 &&
-      DISPLAY_TYPE_REGISTRY[dimensionBreakout.display]
-        .supportsMultipleSeries === false ? (
+      !DISPLAY_TYPE_REGISTRY[dimensionBreakout.display]
+        .supportsMultipleSeries ? (
         <SimpleGrid cols={cols} flex={1} spacing={0}>
           {rawSeries.map((series, i) => (
             <Stack
               gap="sm"
-              className={className}
+              className={cx(className, S.gridChart)}
               key={`series-${i}`}
               data-in-grid
             >
@@ -144,6 +151,11 @@ export function MetricsViewerVisualization({
                   isMetricsViewer
                 />
               </DebouncedFrame>
+              <ChartColumnLabel
+                cardId={series.card.id}
+                cardIdToEntityIndex={cardIdToEntityIndex}
+                chartColumnLabelsByEntityIndex={chartColumnLabelsByEntityIndex}
+              />
             </Stack>
           ))}
         </SimpleGrid>
@@ -161,5 +173,32 @@ export function MetricsViewerVisualization({
         </DebouncedFrame>
       )}
     </Flex>
+  );
+}
+
+function ChartColumnLabel({
+  cardId,
+  cardIdToEntityIndex,
+  chartColumnLabelsByEntityIndex,
+}: {
+  cardId: CardId;
+  cardIdToEntityIndex: Record<CardId, number>;
+  chartColumnLabelsByEntityIndex?: Map<number, DimensionPillBarItem>;
+}) {
+  const entityIndex = cardIdToEntityIndex[cardId];
+  if (entityIndex == null) {
+    return null;
+  }
+
+  const item = chartColumnLabelsByEntityIndex?.get(entityIndex);
+
+  if (!item?.label) {
+    return null;
+  }
+
+  return (
+    <div className={S.gridChartLabel}>
+      <DimensionPillBar items={[item]} textSize="xs" />
+    </div>
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.unit.spec.tsx
@@ -50,14 +50,14 @@ describe("MetricsViewerVisualization", () => {
   it("renders column labels below each split map chart", () => {
     const firstLabel: DimensionPillBarItem = {
       type: "metric",
-      id: 0,
+      slotIndex: 0,
       label: "Customer State",
       icon: "pinmap",
       availableOptions: [],
     };
     const secondLabel: DimensionPillBarItem = {
       type: "metric",
-      id: 1,
+      slotIndex: 1,
       label: "Delivery State",
       icon: "pinmap",
       availableOptions: [],

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.unit.spec.tsx
@@ -1,0 +1,93 @@
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "__support__/ui";
+import type { DimensionPillBarItem } from "metabase/metrics-viewer/components/DimensionPillBar";
+import type { MetricsViewerDimensionBreakoutState } from "metabase/metrics-viewer/types/viewer-state";
+import { createMockColumn } from "metabase-types/api/mocks";
+import { createMockSingleSeries } from "metabase-types/api/mocks/series";
+
+import { MetricsViewerVisualization } from "./MetricsViewerVisualization";
+
+jest.mock("metabase/visualizations/components/Visualization", () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="visualization" />),
+}));
+
+const dimensionBreakout: MetricsViewerDimensionBreakoutState = {
+  id: "location",
+  type: "geo",
+  label: "State",
+  display: "map",
+  dimensionMapping: {},
+  projectionConfig: {},
+};
+
+const stateColumn = createMockColumn({
+  name: "STATE",
+  display_name: "State",
+  base_type: "type/State",
+});
+
+const metricColumn = createMockColumn({
+  name: "COUNT",
+  display_name: "Count",
+  base_type: "type/Integer",
+});
+
+function createMapSeries(id: number, name: string) {
+  return createMockSingleSeries(
+    { id, name, display: "map" },
+    {
+      data: {
+        cols: [stateColumn, metricColumn],
+        rows: [["CA", 1]],
+      },
+    },
+  );
+}
+
+describe("MetricsViewerVisualization", () => {
+  it("renders column labels below each split map chart", () => {
+    const firstLabel: DimensionPillBarItem = {
+      type: "metric",
+      id: 0,
+      label: "Customer State",
+      icon: "pinmap",
+      availableOptions: [],
+    };
+    const secondLabel: DimensionPillBarItem = {
+      type: "metric",
+      id: 1,
+      label: "Delivery State",
+      icon: "pinmap",
+      availableOptions: [],
+    };
+
+    renderWithProviders(
+      <MetricsViewerVisualization
+        rawSeries={[
+          createMapSeries(100, "Orders"),
+          createMapSeries(200, "ARR"),
+        ]}
+        definitions={{}}
+        formulaEntities={[]}
+        metricSlots={[]}
+        dimensionBreakout={dimensionBreakout}
+        onDimensionBreakoutUpdate={jest.fn()}
+        cardIdToEntityIndex={{ 100: 0, 200: 1 }}
+        queriesAreLoading={false}
+        queriesError={null}
+        chartColumnLabelsByEntityIndex={
+          new Map([
+            [0, firstLabel],
+            [1, secondLabel],
+          ])
+        }
+      />,
+    );
+
+    expect(screen.getAllByTestId("visualization")).toHaveLength(2);
+    expect(screen.getByText("Customer State")).toBeInTheDocument();
+    expect(screen.getByText("Delivery State")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -614,7 +614,7 @@ export function buildDimensionItemsFromDefinitions(
 
       items.push({
         type: "expression",
-        id: slot.entityIndex,
+        entityIndex: slot.entityIndex,
         colors: expressionColors,
         label,
         icon,
@@ -686,8 +686,8 @@ function buildStandaloneDimensionItem(
     );
 
     return {
-      id: slot.slotIndex,
       type: "metric",
+      slotIndex: slot.slotIndex,
       label: dimensionInfo.longDisplayName,
       icon: getDimensionIcon(projectionDimension),
       colors: entryColors,
@@ -700,8 +700,8 @@ function buildStandaloneDimensionItem(
   }
 
   return {
-    id: slot.slotIndex,
     type: "metric",
+    slotIndex: slot.slotIndex,
     label: undefined,
     icon: undefined,
     colors: entryColors,

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.tsx
@@ -192,6 +192,7 @@ const ChartWithLegendInner = ({
         paddingRight: PADDING,
       }}
       data-testid="chart-with-legend"
+      data-legend-position={layout.type}
       ref={forwardedRef}
     >
       {legend && (


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4234/display-column-labels-below-each-map-chart-when-visualizing-location

### Description

Display column labels below each split map chart instead of showing one shared label bar below the whole visualization.

Map labels use the smaller 12px treatment from the Figma reference, while non-map charts keep the existing global label bar style.

### How to verify

1. Open Metrics Viewer with tree or more metrics grouped by a location dimension. You can use for example the 'Revenue' metric tree times and choose State as dimension. 
2. Adjust your window length so that you can see two columns of map charts (they are in a 2x2 grid)
3. Enable column labels (ellipsis menu on viewer controls)
4. Confirm each map chart has its own centered location label below it.
5. Confirm non-map visualizations still show one shared column label bar below the visualization.

### Demo
Before:
<img width="884" height="796" alt="image" src="https://github.com/user-attachments/assets/cfc58123-3086-432b-b5f0-991813c55ba1" />

After:
<img width="884" height="796" alt="image" src="https://github.com/user-attachments/assets/c67d8b9a-59f8-4b2a-a02c-599fb9ad3830" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
