### PR TITLE
Workspace provisioning honors admin-connection-details

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.workspaces.remapping-cleanup :as ws.remapping-cleanup]
    [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.driver :as driver]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.util :as driver.u]
    [metabase.util.log :as log]
    [potemkin.types :as p]
@@ -28,14 +29,23 @@
     "Tear down isolated schema + user. Should be idempotent."))
 
 (def dispatching-provisioner
-  "Default Provisioner that dispatches to the driver multimethods."
+  "Default Provisioner that dispatches to the driver multimethods.
+
+   Each call is wrapped in [[driver.conn/with-admin-connection]] so the underlying
+   driver impls acquire connections via the database's `:admin-details` overlay
+   (when configured). Workspace DDL — `CREATE USER`, `CREATE SCHEMA`, `GRANT` —
+   typically needs higher-privilege credentials than the regular query user, and
+   the admin overlay is how operators provide them."
   (reify Provisioner
     (init! [_ driver database workspace]
-      (driver/init-workspace-isolation! driver database workspace))
+      (driver.conn/with-admin-connection
+        (driver/init-workspace-isolation! driver database workspace)))
     (grant! [_ driver database workspace schemas]
-      (driver/grant-workspace-read-access! driver database workspace schemas))
+      (driver.conn/with-admin-connection
+        (driver/grant-workspace-read-access! driver database workspace schemas)))
     (destroy! [_ driver database workspace]
-      (driver/destroy-workspace-isolation! driver database workspace))))
+      (driver.conn/with-admin-connection
+        (driver/destroy-workspace-isolation! driver database workspace)))))
 
 ;;; ---------------------------------------------- Implementation ----------------------------------------------------
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1833,7 +1833,13 @@
    - Grant appropriate permissions (CREATE, INSERT, SELECT, etc.) on the isolated schema
 
    This is an enterprise feature. Drivers must also return true for
-   (database-supports? driver :workspace database) to indicate support."
+   (database-supports? driver :workspace database) to indicate support.
+
+   Callers are expected to bind [[metabase.driver.connection/with-admin-connection]]
+   around this call so connections resolve against the database's `:admin-details`
+   overlay when configured. The default `dispatching-provisioner` in
+   `metabase-enterprise.workspaces.provisioning` does this; do not rely on
+   default connection details from inside impls."
   {:added "0.59.0" :arglists '([driver database workspace])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
@@ -1844,7 +1850,10 @@
    resources created by init-workspace-isolation!.
 
    Should be called when deleting a workspace. Implementations should be
-   idempotent - calling on an already-destroyed workspace should not error."
+   idempotent - calling on an already-destroyed workspace should not error.
+
+   Same admin-connection-scope contract as [[init-workspace-isolation!]]: callers
+   bind [[metabase.driver.connection/with-admin-connection]] before invoking."
   {:added "0.59.0" :arglists '([driver database workspace])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
@@ -1862,7 +1871,10 @@
    - 3-slot (Snowflake, SQL Server, BigQuery): read `:db` + `:schema`. `:db`
      falls back to the connection's bound db when absent.
    - schema-less (MySQL): read `:db`; the `qualified-name-components` is `[]`
-     and the database name lives in the `:db` slot."
+     and the database name lives in the `:db` slot.
+
+   Same admin-connection-scope contract as [[init-workspace-isolation!]]: callers
+   bind [[metabase.driver.connection/with-admin-connection]] before invoking."
   {:added "0.59.0" :arglists '([driver database workspace input])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)


### PR DESCRIPTION
We were not using the admin connection (which has the correct permissons) to setup the workspace isolation mechanism on postgres. I noticed we actually don't do that for most workspace databases, so I added a call to `driver.conn/with-admin-connection` around each provisioning multimethod call.


### Below is AI generated

-----

## Why

A user reported [`permission denied to create role`](https://linear.app/metabase/issue/GHY-3691) when adding a database/schema to a workspace, despite having correctly configured admin connection details (a separate user with `CREATEROLE`) at `/admin/databases/<id>/admin`.

Root cause: the orchestrator that drives workspace provisioning (`metabase-enterprise.workspaces.provisioning/dispatching-provisioner`) invokes the driver multimethods (`init-workspace-isolation!`, `grant-workspace-read-access!`, `destroy-workspace-isolation!`) without binding `metabase.driver.connection/with-admin-connection`. The `:admin-details` overlay only applies inside that dynamic scope, so DDL ran as the regular `:details` user — which on the reporter's setup lacked `CREATEROLE`.

The "admin connection details" UI form saves successfully; the field is just never read by the provisioning path.

The same gap was present in every driver (postgres, mysql, h2, snowflake, redshift, sqlserver, clickhouse, bigquery). `check-isolation-permissions` paths in `mysql.clj` and `sql_jdbc.clj` did wrap correctly, but that's a different probe path; production provisioning did not.

## Approach

Wrap at the orchestration layer (`dispatching-provisioner`) rather than per-driver. Pros:

- One change, all 8 drivers covered.
- Future drivers inherit the contract.
- Symmetric with how `check-isolation-permissions` already wraps once at `sql_jdbc.clj`.

Trade-off: driver impls now implicitly depend on dynamic scope. Mitigated by adding the admin-connection-scope contract to the multimethod docstrings in `src/metabase/driver.clj`, so direct callers (REPL, tests reifying a custom `Provisioner`) know to bind themselves.

## Verification

- Ran existing workspace tests: `driver-isolation-test`, `core-test`, `remapping-cleanup-test`, `e2e-test`, `api.workspace-manager-test` — 27 tests / 74 assertions, all passing.
- Kondo + paren-repair clean.
- The reporter's stats environment unblocks via either retrying after this PR ships, or as a stopgap: `ALTER ROLE <regular-connection-role> CREATEROLE CREATEDB;` on the source DB (less ideal — elevates the regular query user).

## Test plan

- [x] Existing workspace test suite passes
- [ ] Manual: configure admin-connection-details on a postgres DB with a low-priv `:details` user + high-priv `:admin-details` user, add database to workspace, observe provisioning succeeds against the admin overlay
- [ ] CI green

## Related

- [GHY-3691](https://linear.app/metabase/issue/GHY-3691)
- Separately: commit `9fbd1cce377` ("Sanitize workspace creation sql exception messages") that scrubs passwords from JDBC exception messages was authored but never merged. Worth re-landing in a follow-up — orthogonal to this fix.