### PR TITLE
Prevent snowflake tests from deleting old data and failing build.

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1648,7 +1648,9 @@ jobs:
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
       - be-tests-athena-ee
-      - be-tests-bigquery-cloud-sdk-ee
+      # these are not reliable, but we want to run them anyway to gather data about failures
+      # - be-tests-snowflake-ee
+      # - be-tests-bigquery-cloud-sdk-ee
       - be-tests-druid-ee
       - be-tests-databricks-ee
       - be-tests-druid-jdbc-ee
@@ -1660,7 +1662,6 @@ jobs:
       - be-tests-postgres
       - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
-      - be-tests-snowflake-ee
       - be-tests-sparksql-ee
       - be-tests-sqlite-ee
       - be-tests-sqlserver
@@ -1688,7 +1689,7 @@ jobs:
               }));
 
             // are all jobs skipped or successful?
-            if (jobs.every(job => (job.result === 'skipped' || job.result === 'success' || job.name == 'be-tests-starburst-ee'))) {
+            if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {
                 console.log("");
                 console.log("        _------.        ");
                 console.log("       /  ,     \_      ");

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -89,7 +89,7 @@
 (defmethod sql.tx/create-db-sql :snowflake
   [driver dbdef]
   (let [db (sql.tx/qualify-and-quote driver (qualified-db-name dbdef))]
-    (format "DROP DATABASE IF EXISTS %s; CREATE DATABASE %s;" db db)))
+    (format "CREATE DATABASE IF NOT EXISTS %s;" db)))
 
 (defn- no-db-connection-spec
   "Connection spec for connecting to our Snowflake instance without specifying a DB."
@@ -182,6 +182,7 @@
 (defonce ^:private deleted-old-test-data?
   (atom false))
 
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- delete-old-test-data-if-needed!
   "Call [[delete-old-test-data!]], only if we haven't done so already."
   []
@@ -203,7 +204,15 @@
   ;; qualify the DB name with the unique prefix
   (let [db-def (assoc db-def :database-name (qualified-db-name db-def))]
     ;; clean up any old test data (datasets and isolation schemas)
-    (delete-old-test-data-if-needed!)
+    ;; disabling this temporarily as it has caused very difficult-to-debug failures
+    ;; in CI. even tho the datasets *have* been accessed recently, they are still
+    ;; being deleted and reinserted, with race conditions that cause some data to be
+    ;; inserted three times. this does mean that if datasets change, old versions
+    ;; will not be cleaned up automatically and will need to be manually GCed.
+    ;; local testing shows that identifying old datasets works correctly, but
+    ;; sometimes randomly in CI it seems to decide that datasets are old and
+    ;; deletes them even tho they are not old.
+    ;; (delete-old-test-data-if-needed!)
     ;; Snowflake by default uses America/Los_Angeles timezone. See https://docs.snowflake.com/en/sql-reference/parameters#timezone.
     ;; We expect UTC in tests. Hence fixing [[metabase.query-processor.timezone/database-timezone-id]] (PR #36413)
     ;; produced lot of failures. Following expression addresses that, setting timezone for the test user.


### PR DESCRIPTION
Prevent snowflake tests from deleting old data and failing build.
    
Manual backport of https://github.com/metabase/metabase/pull/74663
