### PR TITLE
fix: honor continue_on_error during serialization escape analysis

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -185,25 +185,28 @@
         ;; cards referenced by dashboards live outside the target collections.
         {:keys [reportable-escaped analytics-card-ids]} (when has-content?
                                                           (escape-analysis by-model nodes))]
-    (if (seq reportable-escaped)
+    (if (and (seq reportable-escaped)
+             (not (:continue-on-error opts))
       (log-escape-report! reportable-escaped)
-      (let [coll-set        (get by-model "Collection")
+      (let [_                   (when (seq reportable-escaped)
+                                  (log-escape-report! reportable-escaped))
+            coll-set            (get by-model "Collection")
             ;; When targets are specified, also include Tables found via descendants
             ;; (published tables in target collections). These are extracted by ID, not all.
             targeted-data-model (when (seq targets)
                                   (select-keys by-model serdes.models/data-model-in-collection))
-            by-model        (cond-> (select-keys by-model models)
-                              ;; Add Tables back if they were found in descendants
-                              (seq targeted-data-model) (merge targeted-data-model)
-                              ;; Remove analytics cards from extraction - they have stable entity_ids across instances
-                              ;; so cards that reference them can still be exported and imported correctly
-                              (and analytics-card-ids (contains? by-model "Card"))
-                              (update "Card" (fn [ids] (vec (remove analytics-card-ids ids)))))
-            extract-by-ids  (fn [[model ids]]
-                              (serdes/extract-all model (merge opts {:collection-set coll-set
-                                                                     :where          [:in :id ids]})))
-            extract-all     (fn [model]
-                              (serdes/extract-all model (assoc opts :collection-set coll-set)))]
+            by-model            (cond-> (select-keys by-model models)
+                                  ;; Add Tables back if they were found in descendants
+                                  (seq targeted-data-model) (merge targeted-data-model)
+                                  ;; Remove analytics cards from extraction - they have stable entity_ids across instances
+                                  ;; so cards that reference them can still be exported and imported correctly
+                                  (and analytics-card-ids (contains? by-model "Card"))
+                                  (update "Card" (fn [ids] (vec (remove analytics-card-ids ids)))))
+            extract-by-ids      (fn [[model ids]]
+                                  (serdes/extract-all model (merge opts {:collection-set coll-set
+                                                                         :where          [:in :id ids]})))
+            extract-all         (fn [model]
+                                  (serdes/extract-all model (assoc opts :collection-set coll-set)))]
         (eduction cat
                   [(if (seq targets)
                      (eduction (map extract-by-ids) cat by-model)


### PR DESCRIPTION
### Summary
Fixes #74622. 

During enterprise serialization, the escape analysis block inside `extract-subtrees` was hard-aborting and returning `nil` when handling `reportable-escaped` items, completely bypassing the user's `continue_on_error` configuration.

### Proposed Changes
- Modified the `extract-subtrees` conditional check in `metabase_enterprise/serialization/v2/extract.clj`.
- If `reportable-escaped` entities exist but `continue_on_error` is set to `true`, the engine now logs the escape report via `log-escape-report!` but continues to build the eduction map extraction stream instead of dropping execution.