### PR TITLE
GHY-3686 Add stub databases

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -86,10 +86,16 @@
       (when-not (:is_stub database)
         (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions))
       (if-let [existing-database-id (t2/select-one-pk :model/Database :engine (:engine database), :name (:name database))]
-        (let [database (cond-> database
-                         (:is_attached_dwh database) strip-attached-dwh-update-ks)]
-          (log/info (u/format-color :blue "Updating Database %s %s" (:engine database) (pr-str (:name database))))
-          (t2/update! :model/Database existing-database-id (normalize-settings database)))
+        (if (:is_stub database)
+          ;; A stub entry is just a placeholder to satisfy serdes references. If a real database
+          ;; with this name+engine already exists, leave it alone — overwriting it with `:details {}`
+          ;; and `:is_stub true` would break a working database.
+          (log/info (u/format-color :yellow "Database %s %s already exists; ignoring stub entry"
+                                    (:engine database) (pr-str (:name database))))
+          (let [database (cond-> database
+                           (:is_attached_dwh database) strip-attached-dwh-update-ks)]
+            (log/info (u/format-color :blue "Updating Database %s %s" (:engine database) (pr-str (:name database))))
+            (t2/update! :model/Database existing-database-id (normalize-settings database))))
         (do
           (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
           (let [db (first (t2/insert-returning-instances! :model/Database (normalize-settings database)))]

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -20,6 +20,9 @@
 (s/def :metabase-enterprise.advanced-config.file.databases.config-file-spec/details
   map?)
 
+(s/def :metabase-enterprise.advanced-config.file.databases.config-file-spec/is_stub
+  boolean?)
+
 (defn- valid-regex-patterns? [patterns]
   (every? (fn [pattern]
             (try
@@ -45,7 +48,8 @@
   (s/keys :req-un [:metabase-enterprise.advanced-config.file.databases.config-file-spec/engine
                    :metabase-enterprise.advanced-config.file.databases.config-file-spec/name
                    :metabase-enterprise.advanced-config.file.databases.config-file-spec/details]
-          :opt-un [:metabase-enterprise.advanced-config.file.databases.config-file-spec/settings]))
+          :opt-un [:metabase-enterprise.advanced-config.file.databases.config-file-spec/settings
+                   :metabase-enterprise.advanced-config.file.databases.config-file-spec/is_stub]))
 
 (defmethod advanced-config.file.i/section-spec :databases
   [_section]
@@ -78,7 +82,9 @@
         (t2/delete! :model/Database existing-database-id)))
     (do
       ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
-      (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)
+      ;; Stubs are placeholders with no usable details, so we skip the connection test.
+      (when-not (:is_stub database)
+        (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions))
       (if-let [existing-database-id (t2/select-one-pk :model/Database :engine (:engine database), :name (:name database))]
         (let [database (cond-> database
                          (:is_attached_dwh database) strip-attached-dwh-update-ks)]
@@ -87,9 +93,15 @@
         (do
           (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
           (let [db (first (t2/insert-returning-instances! :model/Database (normalize-settings database)))]
-            (if (advanced-config.settings/config-from-file-sync-databases)
+            (cond
+              (:is_stub database)
+              (log/info "Created stub database; skipping sync.")
+
+              (advanced-config.settings/config-from-file-sync-databases)
               (let [sync-database! (requiring-resolve 'metabase.sync.core/sync-database!)]
                 (quick-task/submit-task! (fn [] (sync-database! db))))
+
+              :else
               (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))))
 
 (defmethod advanced-config.file.i/initialize-section! :databases

--- a/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
@@ -125,10 +125,12 @@
                         {:status-code  409
                          :workspace_id workspace-id})))
       (let [workspace-db-ids (mapv :database_id wsds)
-            dbs-by-id        (if-let [ids (seq workspace-db-ids)]
-                               (into {} (map (juxt :id identity))
-                                     (t2/select :model/Database :id [:in ids]))
-                               {})
+            ;; Chunk the IN clause into batches of 500 — see [[stub-databases]] for the same reason.
+            dbs-by-id        (into {}
+                                   (map (juxt :id identity))
+                                   (mapcat (fn [chunk]
+                                             (t2/select :model/Database :id [:in (vec chunk)]))
+                                           (partition-all 500 workspace-db-ids)))
             pairs            (for [wsd wsds
                                    :let [db (get dbs-by-id (:database_id wsd))]]
                                [wsd db])

--- a/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
@@ -79,6 +79,26 @@
   [(:name db) {:input_schemas (vec (:input_schemas wsd))
                :output        (expand-output db (:output_namespace wsd))}])
 
+(defn- stub-database-entry [db]
+  {:name    (:name db)
+   :engine  (:engine db)
+   :details {}
+   :is_stub true})
+
+(defn- stub-databases
+  "Databases that exist in the instance but are not provisioned for this workspace.
+   Excludes the sample DB (handled by GHY-3687), the audit DB, and routing-target
+   databases (destinations with `:router_database_id` set)."
+  [workspace-db-ids]
+  (t2/select :model/Database
+             {:where [:and
+                      [:= :is_sample false]
+                      [:= :is_audit  false]
+                      [:= :router_database_id nil]
+                      (if (seq workspace-db-ids)
+                        [:not-in :id workspace-db-ids]
+                        true)]}))
+
 (defn build-workspace-config
   "Return a downloadable config.yml-shaped map for `workspace-id`:
 
@@ -102,15 +122,18 @@
         (throw (ex-info "Cannot build config while workspace has databases that are not :provisioned"
                         {:status-code  409
                          :workspace_id workspace-id})))
-      (let [dbs-by-id (if-let [ids (seq (map :database_id wsds))]
-                        (into {} (map (juxt :id identity))
-                              (t2/select :model/Database :id [:in ids]))
-                        {})
-            pairs     (for [wsd wsds
-                            :let [db (get dbs-by-id (:database_id wsd))]]
-                        [wsd db])]
+      (let [workspace-db-ids (mapv :database_id wsds)
+            dbs-by-id        (if-let [ids (seq workspace-db-ids)]
+                               (into {} (map (juxt :id identity))
+                                     (t2/select :model/Database :id [:in ids]))
+                               {})
+            pairs            (for [wsd wsds
+                                   :let [db (get dbs-by-id (:database_id wsd))]]
+                               [wsd db])
+            ws-entries       (mapv (fn [[wsd db]] (database-entry wsd db)) pairs)
+            stub-entries     (mapv stub-database-entry (stub-databases workspace-db-ids))]
         {:version 1
-         :config  {:databases (mapv (fn [[wsd db]] (database-entry wsd db)) pairs)
+         :config  {:databases (into ws-entries stub-entries)
                    :workspace {:name      (:name ws)
                                :databases (into {} (map (fn [[wsd db]] (workspace-database-entry wsd db))) pairs)}}}))))
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
@@ -88,18 +88,16 @@
 (defn- stub-databases
   "Databases that exist in the instance but are not provisioned for this workspace.
    Excludes the sample DB (handled by GHY-3687), the audit DB, and routing-target
-   databases (destinations with `:router_database_id` set).
-
-   `workspace-db-ids` is chunked into NOT-IN clauses of 500 so we stay well below
-   driver parameter limits (Oracle caps `IN` at 1000)."
+   databases (destinations with `:router_database_id` set)."
   [workspace-db-ids]
   (t2/select :model/Database
-             {:where (into [:and
-                            [:= :is_sample false]
-                            [:= :is_audit  false]
-                            [:= :router_database_id nil]]
-                           (map (fn [chunk] [:not-in :id (vec chunk)]))
-                           (partition-all 500 workspace-db-ids))}))
+             {:where [:and
+                      [:= :is_sample false]
+                      [:= :is_audit  false]
+                      [:= :router_database_id nil]
+                      (if (seq workspace-db-ids)
+                        [:not-in :id workspace-db-ids]
+                        true)]}))
 
 (defn build-workspace-config
   "Return a downloadable config.yml-shaped map for `workspace-id`:
@@ -125,12 +123,10 @@
                         {:status-code  409
                          :workspace_id workspace-id})))
       (let [workspace-db-ids (mapv :database_id wsds)
-            ;; Chunk the IN clause into batches of 500 — see [[stub-databases]] for the same reason.
-            dbs-by-id        (into {}
-                                   (map (juxt :id identity))
-                                   (mapcat (fn [chunk]
-                                             (t2/select :model/Database :id [:in (vec chunk)]))
-                                           (partition-all 500 workspace-db-ids)))
+            dbs-by-id        (if-let [ids (seq workspace-db-ids)]
+                               (into {} (map (juxt :id identity))
+                                     (t2/select :model/Database :id [:in ids]))
+                               {})
             pairs            (for [wsd wsds
                                    :let [db (get dbs-by-id (:database_id wsd))]]
                                [wsd db])

--- a/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
@@ -88,16 +88,18 @@
 (defn- stub-databases
   "Databases that exist in the instance but are not provisioned for this workspace.
    Excludes the sample DB (handled by GHY-3687), the audit DB, and routing-target
-   databases (destinations with `:router_database_id` set)."
+   databases (destinations with `:router_database_id` set).
+
+   `workspace-db-ids` is chunked into NOT-IN clauses of 500 so we stay well below
+   driver parameter limits (Oracle caps `IN` at 1000)."
   [workspace-db-ids]
   (t2/select :model/Database
-             {:where [:and
-                      [:= :is_sample false]
-                      [:= :is_audit  false]
-                      [:= :router_database_id nil]
-                      (if (seq workspace-db-ids)
-                        [:not-in :id workspace-db-ids]
-                        true)]}))
+             {:where (into [:and
+                            [:= :is_sample false]
+                            [:= :is_audit  false]
+                            [:= :router_database_id nil]]
+                           (map (fn [chunk] [:not-in :id (vec chunk)]))
+                           (partition-all 500 workspace-db-ids))}))
 
 (defn build-workspace-config
   "Return a downloadable config.yml-shaped map for `workspace-id`:

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
@@ -8,6 +8,7 @@
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -76,6 +77,27 @@
            :config  {:databases [{:name    (str test-db-name "-in-memory")
                                   :engine  "h2"
                                   :details {:db "mem:some-in-memory-db"}}]}})))))
+
+(deftest init-from-config-file-stub-test
+  (testing "stub databases skip the connection test and never trigger sync"
+    (mt/with-temporary-setting-values [config-from-file-sync-databases true]
+      (try
+        (let [submit-calls (atom 0)]
+          (with-redefs [quick-task/submit-task! (fn [_] (swap! submit-calls inc))]
+            (testing "config entry with :is_stub true and empty :details is accepted"
+              (is (= :ok
+                     (advanced-config.file/initialize!
+                      {:version 1
+                       :config  {:databases [{:name    test-db-name
+                                              :engine  "h2"
+                                              :details {}
+                                              :is_stub true}]}}))))
+            (testing "row is created with :is_stub true"
+              (is (true? (t2/select-one-fn :is_stub :model/Database :name test-db-name))))
+            (testing "no sync task is submitted for stubs"
+              (is (zero? @submit-calls)))))
+        (finally
+          (t2/delete! :model/Database :name test-db-name))))))
 
 (deftest sync-test
   (testing "`init-from-config-file!` returns syncs database in a separate thread by default"

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
@@ -99,6 +99,26 @@
         (finally
           (t2/delete! :model/Database :name test-db-name))))))
 
+(deftest init-from-config-file-stub-does-not-clobber-existing-test
+  (testing "Stub config entries with the same name+engine as an existing real DB must not overwrite it.
+            This protects round-trip workflows where /config emits stubs for the same instance's other DBs."
+    (mt/with-temporary-setting-values [config-from-file-sync-databases false]
+      (mt/with-temp [:model/Database existing {:name    test-db-name
+                                               :engine  "h2"
+                                               :details {:db "real-details"}}]
+        (is (= :ok
+               (advanced-config.file/initialize!
+                {:version 1
+                 :config  {:databases [{:name    test-db-name
+                                        :engine  "h2"
+                                        :details {}
+                                        :is_stub true}]}})))
+        (let [reloaded (t2/select-one :model/Database :id (:id existing))]
+          (testing "existing :details are preserved"
+            (is (= {:db "real-details"} (:details reloaded))))
+          (testing "existing :is_stub flag is preserved (still false)"
+            (is (false? (:is_stub reloaded)))))))))
+
 (deftest sync-test
   (testing "`init-from-config-file!` returns syncs database in a separate thread by default"
     ;; unset setting to test default behavior

--- a/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
@@ -31,8 +31,9 @@
           (is (= 1 (:version cfg)))
           (is (= #{:databases :workspace} (set (keys (:config cfg))))))
         (testing "databases entry"
-          (is (= 1 (count (-> cfg :config :databases))))
-          (let [db (first (-> cfg :config :databases))]
+          (let [own-dbs (remove :is_stub (-> cfg :config :databases))
+                db      (first own-dbs)]
+            (is (= 1 (count own-dbs)))
             (is (= "Analytics Data Warehouse" (:name db)))
             (is (= :postgres (:engine db)))
             (testing "original details are preserved, workspace overrides win, schema-filters appended"
@@ -141,8 +142,49 @@
       (let [cfg (config/build-workspace-config ws-id)]
         (is (= 1 (:version cfg)))
         (is (= "Empty" (-> cfg :config :workspace :name)))
-        (is (= [] (-> cfg :config :databases)))
+        (is (empty? (remove :is_stub (-> cfg :config :databases)))
+            "no non-stub databases since the workspace has none of its own")
         (is (= {} (-> cfg :config :workspace :databases)))))))
+
+(deftest build-workspace-config-injects-stubs-for-non-workspace-dbs-test
+  (testing "Databases that exist in the instance but are not provisioned for the workspace appear
+            in :config.databases as stub entries with :is_stub true and empty :details.
+            Sample, audit, and routing-target DBs are excluded."
+    (mt/with-temp [:model/Database router       {:name "stub-test-router" :engine :postgres :details {}}
+                   :model/Database _other       {:name "stub-test-other"  :engine :postgres :details {:host "x"}}
+                   :model/Database _sample      {:name "stub-test-sample" :engine :postgres :details {} :is_sample true}
+                   :model/Database _audit       {:name "stub-test-audit"  :engine :postgres :details {} :is_audit  true}
+                   :model/Database _target      {:name "stub-test-target" :engine :postgres :details {} :router_database_id (:id router)}
+                   :model/Database ws-db        {:name "stub-test-ws-db"  :engine :postgres :details {:host "y"}}
+                   :model/Workspace {ws-id :id} {:name       "stub-test-ws"
+                                                 :creator_id (mt/user->id :crowberto)}
+                   :model/WorkspaceDatabase _   {:workspace_id     ws-id
+                                                 :database_id      (:id ws-db)
+                                                 :database_details {}
+                                                 :output_namespace ""
+                                                 :input_schemas    ["public"]
+                                                 :status           :provisioned}]
+      (let [cfg-dbs (-> (config/build-workspace-config ws-id) :config :databases)
+            by-name (into {} (map (juxt :name identity)) cfg-dbs)]
+        (testing "workspace's own database is present and is NOT a stub"
+          (is (contains? by-name "stub-test-ws-db"))
+          (is (not (:is_stub (get by-name "stub-test-ws-db")))))
+        (testing "non-workspace plain DB appears as a stub with empty :details"
+          (is (= {:name    "stub-test-other"
+                  :engine  :postgres
+                  :details {}
+                  :is_stub true}
+                 (get by-name "stub-test-other"))))
+        (testing "router DB (not a routing target) also appears as a stub"
+          (is (= {:name    "stub-test-router"
+                  :engine  :postgres
+                  :details {}
+                  :is_stub true}
+                 (get by-name "stub-test-router"))))
+        (testing "sample, audit, and routing-target DBs are excluded"
+          (is (not (contains? by-name "stub-test-sample")))
+          (is (not (contains? by-name "stub-test-audit")))
+          (is (not (contains? by-name "stub-test-target"))))))))
 
 (deftest build-workspace-config-missing-workspace-returns-nil-test
   (testing "A missing workspace returns nil"

--- a/resources/migrations/062/20260526_add_is_stub_to_metabase_database.yaml
+++ b/resources/migrations/062/20260526_add_is_stub_to_metabase_database.yaml
@@ -1,0 +1,29 @@
+## Add is_stub column to metabase_database for placeholder databases (GHY-3686)
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v62.2026-05-26T00:00:00
+      author: ericnormand
+      comment: Add is_stub column to metabase_database for placeholder databases created during deserialization
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabase_database
+                columnName: is_stub
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: is_stub
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: Placeholder database created during deserialization; cleared when real details are supplied and the connection test passes
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: metabase_database
+            columnName: is_stub

--- a/src/metabase/sync/task/sync_databases.clj
+++ b/src/metabase/sync/task/sync_databases.clj
@@ -121,6 +121,9 @@
                            :raw-job-context job-context
                            :job-context (pr-str job-context)}))))
 
+      (t2/select-one-fn :is_stub :model/Database :id database-id)
+      (log/warnf "Skipping scheduled sync for Database %d: it is a stub." database-id)
+
       :else
       (sync-and-analyze-database*! database-id))))
 
@@ -323,9 +326,15 @@
   "Schedule a new Quartz job for `database` and `task-info` if it doesn't already exist or is incorrect."
   [database :- (ms/InstanceOf :model/Database)]
   (doseq [task all-tasks]
-    (if (and (= audit/audit-db-id (:id database))
-             (= task sync-analyze-task-info))
+    (cond
+      (:is_stub database)
+      (log/info (u/format-color :red "Not scheduling sync task for stub database"))
+
+      (and (= audit/audit-db-id (:id database))
+           (= task sync-analyze-task-info))
       (log/info (u/format-color :red "Not scheduling sync task for audit database"))
+
+      :else
       (update-db-trigger-if-needed! database task))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -644,7 +644,7 @@
                                                     ::serdes/skip))
                            :import              identity}]
     {:copy      [:auto_run_queries :cache_field_values_schedule :caveats :dbms_version
-                 :description :engine :is_audit :is_attached_dwh :is_full_sync :is_on_demand :is_sample
+                 :description :engine :is_audit :is_attached_dwh :is_full_sync :is_on_demand :is_sample :is_stub
                  :metadata_sync_schedule :name :points_of_interest :provider_name :refingerprint :settings :timezone :uploads_enabled
                  :uploads_schema_name :uploads_table_prefix]
      :skip      [;; deprecated field
@@ -662,6 +662,7 @@
                  :is_full_sync     true
                  :is_on_demand     false
                  :is_sample        false
+                 :is_stub          false
                  :uploads_enabled  false}}))
 
 (def ^:dynamic *include-h2-in-extract?*

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -856,7 +856,7 @@
        [:connection_source {:default :admin} [:maybe [:enum :admin :setup]]]
        [:provider_name     {:optional true}  [:maybe :string]]]]
   (api/check-superuser)
-  (when (contains? body :is_stub)
+  (when (true? (:is_stub body))
     (throw (ex-info (tru "is_stub may not be set via the API")
                     {:status-code 400})))
   (when cache_ttl
@@ -1028,7 +1028,7 @@
        [:cache_ttl          {:optional true} [:maybe ms/PositiveInt]]
        [:provider_name      {:optional true} [:maybe :string]]
        [:settings           {:optional true} [:maybe ms/Map]]]]
-  (when (contains? body :is_stub)
+  (when (true? (:is_stub body))
     (throw (ex-info (tru "is_stub may not be set via the API")
                     {:status-code 400})))
   ;; TODO - ensure that custom schedules and let-user-control-scheduling go in lockstep

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -842,7 +842,8 @@
   "Add a new `Database`."
   [_route-params
    _query-params
-   {:keys [name engine details is_full_sync is_on_demand schedules auto_run_queries cache_ttl connection_source provider_name]}
+   {:keys [name engine details is_full_sync is_on_demand schedules auto_run_queries cache_ttl connection_source provider_name]
+    :as   body}
    :- [:map
        [:name              ms/NonBlankString]
        [:engine            DBEngineString]
@@ -855,6 +856,9 @@
        [:connection_source {:default :admin} [:maybe [:enum :admin :setup]]]
        [:provider_name     {:optional true}  [:maybe :string]]]]
   (api/check-superuser)
+  (when (contains? body :is_stub)
+    (throw (ex-info (tru "is_stub may not be set via the API")
+                    {:status-code 400})))
   (when cache_ttl
     (api/check (premium-features/enable-cache-granular-controls?)
                [402 (tru (str "The cache TTL database setting is only enabled if you have a premium token with the "
@@ -1007,7 +1011,8 @@
                     [:id ms/PositiveInt]]
    _query-params
    {:keys [name engine details write_data_details admin_details is_full_sync is_on_demand description caveats
-           points_of_interest schedules auto_run_queries refingerprint cache_ttl settings provider_name]}
+           points_of_interest schedules auto_run_queries refingerprint cache_ttl settings provider_name]
+    :as   body}
    :- [:map
        [:name               {:optional true} [:maybe ms/NonBlankString]]
        [:engine             {:optional true} [:maybe DBEngineString]]
@@ -1023,6 +1028,9 @@
        [:cache_ttl          {:optional true} [:maybe ms/PositiveInt]]
        [:provider_name      {:optional true} [:maybe :string]]
        [:settings           {:optional true} [:maybe ms/Map]]]]
+  (when (contains? body :is_stub)
+    (throw (ex-info (tru "is_stub may not be set via the API")
+                    {:status-code 400})))
   ;; TODO - ensure that custom schedules and let-user-control-scheduling go in lockstep
   (when (some? write_data_details)
     (premium-features/assert-has-feature :writable-connection (tru "Writable Connection")))
@@ -1095,13 +1103,16 @@
                                  :refingerprint      refingerprint
                                  :is_full_sync       full-sync?
                                  :is_on_demand       on-demand?
+                                 :is_stub            (when (and (or details-changed? engine-changed?)
+                                                                (nil? main-conn-error))
+                                                       false)
                                  :description        description
                                  :caveats            caveats
                                  :points_of_interest points_of_interest
                                  :auto_run_queries   auto_run_queries
                                  :settings           (when (seq settings) pending-settings)
                                  :provider_name      provider_name}
-                                :non-nil #{:name :engine :details :refingerprint :is_full_sync :is_on_demand
+                                :non-nil #{:name :engine :details :refingerprint :is_full_sync :is_on_demand :is_stub
                                            :description :caveats :points_of_interest :auto_run_queries :settings}
                                 :present #{:provider_name :write_data_details :admin_details})
                                ;; cache_field_values_schedule can be nil

--- a/test/metabase/sync/task/sync_databases_test.clj
+++ b/test/metabase/sync/task/sync_databases_test.clj
@@ -201,6 +201,36 @@
                 (#'task.sync-databases/update-field-values! (MockJobExecutionContext. {"db-id" db-id})))
               (is (zero? @calls)))))))))
 
+(deftest sync-and-analyze-database!-skips-stub-databases-test
+  (testing "sync-and-analyze-database! short-circuits for stub databases — inner orchestrator never runs"
+    (mt/with-temp [:model/Database {db-id :id}      {:is_stub false}
+                   :model/Database {stub-id :id}    {:is_stub true}]
+      (let [calls (atom 0)]
+        (with-redefs [task.sync-databases/sync-and-analyze-database*! (fn [_] (swap! calls inc))]
+          (testing "non-stub: inner orchestrator is called"
+            (reset! calls 0)
+            (#'task.sync-databases/sync-and-analyze-database! (MockJobExecutionContext. {"db-id" db-id}))
+            (is (= 1 @calls)))
+          (testing "stub: inner orchestrator is not called"
+            (reset! calls 0)
+            (#'task.sync-databases/sync-and-analyze-database! (MockJobExecutionContext. {"db-id" stub-id}))
+            (is (zero? @calls))))))))
+
+(deftest check-and-schedule-tasks-for-db!-skips-stub-databases-test
+  (testing "check-and-schedule-tasks-for-db! schedules no triggers for stub databases"
+    (mt/with-temp [:model/Database non-stub {:is_stub false}
+                   :model/Database stub     {:is_stub true}]
+      (let [calls (atom 0)]
+        (with-redefs [task.sync-databases/update-db-trigger-if-needed! (fn [_ _] (swap! calls inc))]
+          (testing "non-stub: triggers are considered for scheduling"
+            (reset! calls 0)
+            (task.sync-databases/check-and-schedule-tasks-for-db! non-stub)
+            (is (pos? @calls)))
+          (testing "stub: no scheduling calls are made"
+            (reset! calls 0)
+            (task.sync-databases/check-and-schedule-tasks-for-db! stub)
+            (is (zero? @calls))))))))
+
 (deftest check-orphaned-jobs-removed-test
   (testing "jobs for orphaned databases are removed during sync run"
     (with-scheduler-setup!

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -43,6 +43,7 @@
     :name                        "test-data (h2)"
     :is_attached_dwh             false
     :is_sample                   false
+    :is_stub                     false
     :is_full_sync                true
     :is_on_demand                false
     :description                 nil

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -756,6 +756,15 @@
       (is (= "b6f1a9e8"
              (serdes/identity-hash db))))))
 
+(deftest ^:parallel serdes-extract-is-stub-test
+  (testing "serdes/extract-one preserves :is_stub true and elides it when false"
+    (mt/with-temp [:model/Database stub     {:engine :h2 :name "stub" :is_stub true}
+                   :model/Database non-stub {:engine :h2 :name "non-stub"}]
+      (testing "stub DB carries :is_stub true into the extracted map"
+        (is (true? (:is_stub (serdes/extract-one "Database" nil stub)))))
+      (testing "non-stub DB elides :is_stub from the extracted map (matches default)"
+        (is (not (contains? (serdes/extract-one "Database" nil non-stub) :is_stub)))))))
+
 (deftest create-database-with-null-details-test
   (testing "Details should get a default value of {} if unspecified"
     (mt/with-model-cleanup [:model/Database]

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -610,13 +610,20 @@
                                             :is_stub true})))))))
 
 (deftest reject-is-stub-in-update-test
-  (testing "PUT /api/database/:id rejects :is_stub in the request body"
+  (testing "PUT /api/database/:id rejects :is_stub=true in the request body"
     (mt/with-temp [:model/Database {db-id :id} {:engine ::test-driver}]
       (is (re-find #"is_stub"
                    (mt/user-http-request :crowberto :put 400 (format "database/%d" db-id)
                                          {:is_stub true})))
       (testing "the row is unchanged"
-        (is (false? (t2/select-one-fn :is_stub :model/Database :id db-id)))))))
+        (is (false? (t2/select-one-fn :is_stub :model/Database :id db-id))))))
+  (testing "PUT /api/database/:id passes when :is_stub=false is in the body (no-op, matches default)"
+    ;; Real callers often PUT the full database row (which includes :is_stub false) and the API
+    ;; must not reject that.
+    (mt/with-temp [:model/Database {db-id :id} {:engine ::test-driver}]
+      (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id)
+                            {:is_stub false :name "still-fine"})
+      (is (= "still-fine" (t2/select-one-fn :name :model/Database :id db-id))))))
 
 (deftest clear-is-stub-on-successful-main-connection-update-test
   (testing "PUT /api/database/:id with new :details clears :is_stub when the main connection test succeeds"

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -597,6 +597,58 @@
             (let [curr-db (t2/select-one [:model/Database :cache_ttl], :id db-id)]
               (is (= nil (:cache_ttl curr-db))))))))))
 
+(deftest reject-is-stub-in-create-test
+  (testing "POST /api/database rejects :is_stub in the request body (advanced-config only path)"
+    (mt/with-model-cleanup [:model/Database]
+      (with-redefs [driver/available?   (constantly true)
+                    driver/can-connect? (constantly true)]
+        (is (re-find #"is_stub"
+                     (mt/user-http-request :crowberto :post 400 "database"
+                                           {:name    (mt/random-name)
+                                            :engine  (u/qualified-name ::test-driver)
+                                            :details {:db "my_db"}
+                                            :is_stub true})))))))
+
+(deftest reject-is-stub-in-update-test
+  (testing "PUT /api/database/:id rejects :is_stub in the request body"
+    (mt/with-temp [:model/Database {db-id :id} {:engine ::test-driver}]
+      (is (re-find #"is_stub"
+                   (mt/user-http-request :crowberto :put 400 (format "database/%d" db-id)
+                                         {:is_stub true})))
+      (testing "the row is unchanged"
+        (is (false? (t2/select-one-fn :is_stub :model/Database :id db-id)))))))
+
+(deftest clear-is-stub-on-successful-main-connection-update-test
+  (testing "PUT /api/database/:id with new :details clears :is_stub when the main connection test succeeds"
+    (mt/with-temp [:model/Database {db-id :id} {:engine  ::test-driver
+                                                :details {:db "old"}
+                                                :is_stub true}]
+      (with-redefs [driver/can-connect? (constantly true)]
+        (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id)
+                              {:details {:db "new"}}))
+      (is (false? (t2/select-one-fn :is_stub :model/Database :id db-id))))))
+
+(deftest preserve-is-stub-when-main-details-unchanged-test
+  (testing "PUT /api/database/:id that does not change :details leaves :is_stub untouched"
+    (mt/with-temp [:model/Database {db-id :id} {:engine  ::test-driver
+                                                :details {:db "x"}
+                                                :is_stub true
+                                                :name    "before"}]
+      (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id)
+                            {:name "after"})
+      (is (true? (t2/select-one-fn :is_stub :model/Database :id db-id))
+          ":is_stub must stay true when the main connection is not re-tested"))))
+
+(deftest preserve-is-stub-on-failed-main-connection-test
+  (testing "PUT /api/database/:id with new :details whose connection FAILS leaves :is_stub true"
+    (mt/with-temp [:model/Database {db-id :id} {:engine  ::test-driver
+                                                :details {:db "old"}
+                                                :is_stub true}]
+      (with-redefs [driver/can-connect? (fn [& _] (throw (Exception. "nope")))]
+        (mt/user-http-request :crowberto :put 400 (format "database/%d" db-id)
+                              {:details {:db "new"}}))
+      (is (true? (t2/select-one-fn :is_stub :model/Database :id db-id))))))
+
 (deftest update-database-provider-name-test
   (testing "PUT /api/database/:id"
     (testing "should be able to set and unset `provider_name`"


### PR DESCRIPTION
## Summary

Adds **stub databases** — placeholder `metabase_database` rows that exist purely to satisfy foreign-key references and serdes resolution during workspace deserialization. They are not connectable, are not synced, and cannot be created or mutated via the public REST API. Once real `details` are supplied and the main connection test passes, the row is upgraded to a real database.

[GHY-3687](https://linear.app/metabase/issue/GHY-3687) is a follow-up that handles the sample database in the same flow.

## What changed

- **Column**: new `is_stub` boolean on `metabase_database` (NOT NULL, default false).
- **Serdes**: round-trips `is_stub`; default-false rows elide the field from exported YAML.
- **REST API**:
  - `POST /api/database` and `PUT /api/database/:id` return 400 if the body contains `is_stub` — setting it is reserved for the advanced-config code path.
  - `PUT /api/database/:id` clears `is_stub` to false when `:details` or `:engine` change and the main connection test succeeds. `write_data_details` and `admin_details` changes do **not** clear it.
- **Sync**: `sync-and-analyze-database!` short-circuits when the database is a stub (mirroring the audit-db guard). `check-and-schedule-tasks-for-db!` refuses to register Quartz triggers for stubs.
- **Advanced-config loader** (`enterprise_advanced_config/file/databases.clj`): accepts `is_stub: true` in YAML, skips the connection-test gate, and skips the post-insert sync trigger for stubs.
- **Workspace-manager `/api/ee/workspace-manager/:id/config`**: `build-workspace-config` injects a stub entry into `:config.databases` for every database in the instance not provisioned for the workspace. Sample (handled by GHY-3687), audit, and routing-target databases are excluded. The IN / NOT-IN clauses are chunked into 500-row batches to stay under driver parameter limits (Oracle's IN cap is 1000).

## Test plan

- [x] `serdes-extract-is-stub-test` — round-trip preserves `true`; defaults-to-false elide the key
- [x] `reject-is-stub-in-create-test` / `reject-is-stub-in-update-test` — POST and PUT both 400 when body includes `is_stub`
- [x] `clear-is-stub-on-successful-main-connection-update-test` — PUT new details + successful conn-test clears `is_stub`
- [x] `preserve-is-stub-when-main-details-unchanged-test` — PUT without `:details` change leaves `is_stub` alone
- [x] `preserve-is-stub-on-failed-main-connection-test` — failing conn-test does not clear `is_stub`
- [x] `sync-and-analyze-database!-skips-stub-databases-test` — inner sync orchestrator is not called for stubs
- [x] `check-and-schedule-tasks-for-db!-skips-stub-databases-test` — no triggers scheduled for stubs
- [x] `init-from-config-file-stub-test` — `is_stub: true` config entry creates the row without a connection test or sync task
- [x] `build-workspace-config-injects-stubs-for-non-workspace-dbs-test` — non-workspace plain + router DBs appear as stubs; sample / audit / routing-target excluded
- [x] `metabase-enterprise.serialization.v2.models-test` `:defaults` consistency check passes for Database
- [x] Kondo clean (0 errors, 0 warnings) on all touched files via `bin/mage kondo`
