### PR TITLE
Fix legacy Library entity ID migration collisions

### DIFF
--- a/resources/migrations/062/20260513_legacy_library_root_entity_ids.yaml
+++ b/resources/migrations/062/20260513_legacy_library_root_entity_ids.yaml
@@ -4,6 +4,44 @@ databaseChangeLog:
   - logicalFilePath: migrations/062_update_migrations.yaml
 
   - changeSet:
+      id: v62.2026-05-13T11:59:58
+      author: andsalves
+      comment: Backfill type column value for Library collections
+      changes:
+        - sql:
+            sql: >-
+              UPDATE collection
+              SET type = 'library'
+              WHERE entity_id = 'librarylibrarylibrary' AND (type IS NULL OR type <> 'library');
+
+              UPDATE collection
+              SET type = 'library-data'
+              WHERE entity_id = 'librarylibrarydatadat' AND (type IS NULL OR type <> 'library-data');
+
+              UPDATE collection
+              SET type = 'library-metrics'
+              WHERE entity_id = 'librarylibrarymetrics' AND (type IS NULL OR type <> 'library-metrics');
+      rollback:
+        - empty: {}
+  - changeSet:
+      id: v62.2026-05-13T11:59:59
+      author: andsalves
+      comment: Make sure the root collection with library type and canonical entity_id is unique
+      changes:
+        - sql:
+            sql: >-
+              UPDATE collection
+              SET type = NULL
+              WHERE type = 'library' AND location = '/' AND entity_id != 'librarylibrarylibrary'
+                AND EXISTS (
+                  SELECT 1 FROM (
+                    SELECT entity_id FROM collection WHERE entity_id = 'librarylibrarylibrary'
+                  ) existing
+                );
+      rollback:
+        - empty: {}
+
+  - changeSet:
       id: v62.2026-05-13T12:00:00
       author: andsalves
       comment: Backfill canonical entity_id for legacy Library root collection

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2893,8 +2893,8 @@
   (str/trim (t2/select-one-fn :entity_id :collection :id collection-id)))
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test
-  (testing "v62.2026-05-13T12:00:00 through v62.2026-05-13T12:00:02: backfill canonical Library root entity IDs"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
+  (testing "v62.2026-05-13T11:59:59 through v62.2026-05-13T12:00:02: backfill canonical Library root entity IDs"
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id (insert-legacy-library-collection! {:name      "Library"
                                                            :slug      "library"
                                                            :type      "library"
@@ -2919,7 +2919,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-2
   (testing "ambiguous Library Data direct children are not modified"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id        (insert-legacy-library-collection! {:name      "Library"
                                                                   :slug      "library"
                                                                   :type      "library"
@@ -2951,7 +2951,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-3
   (testing "Library Data collections outside Library root do not count as ambiguous"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id      (insert-legacy-library-collection! {:name      "Library"
                                                                 :slug      "library"
                                                                 :type      "library"
@@ -2976,6 +2976,73 @@
                (collection-entity-id data-id)))
         (is (= "legacy-orphan-data"
                (collection-entity-id orphan-data-id)))))))
+
+(deftest backfill-legacy-library-root-skips-when-canonical-entity-id-exists-test
+  (testing "v62.2026-05-13T11:59:59 + T12:00:00: pre-existing canonical Library root entity_id prevents collision"
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+      (let [canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Library"
+                                                             :slug      "canonical-library"
+                                                             :type      nil
+                                                             :entity_id "librarylibrarylibrary"})
+            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Library"
+                                                             :slug      "legacy-library"
+                                                             :type      "library"
+                                                             :entity_id "legacy-library-root"})]
+        (migrate!)
+        (is (= "library"
+               (t2/select-one-fn :type :collection :id canonical-id)))
+        (is (= "librarylibrarylibrary"
+               (collection-entity-id canonical-id)))
+        (is (= "legacy-library-root"
+               (collection-entity-id legacy-id)))))))
+
+(deftest backfill-legacy-library-data-skips-when-canonical-entity-id-exists-test
+  (testing "v62.2026-05-13T12:00:01: pre-existing canonical Library Data entity_id prevents collision"
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+      (let [library-id   (insert-legacy-library-collection! {:name      "Library"
+                                                             :slug      "library"
+                                                             :type      "library"
+                                                             :entity_id "legacy-library-root"})
+            canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Data"
+                                                             :slug      "canonical-data"
+                                                             :type      nil
+                                                             :entity_id "librarylibrarydatadat"})
+            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Data"
+                                                             :slug      "legacy-data"
+                                                             :type      "library-data"
+                                                             :location  (str "/" library-id "/")
+                                                             :entity_id "legacy-library-data"})]
+        (migrate!)
+        (is (= "library-data"
+               (t2/select-one-fn :type :collection :id canonical-id)))
+        (is (= "librarylibrarydatadat"
+               (collection-entity-id canonical-id)))
+        (is (= "legacy-library-data"
+               (collection-entity-id legacy-id)))))))
+
+(deftest backfill-legacy-library-metrics-skips-when-canonical-entity-id-exists-test
+  (testing "v62.2026-05-13T12:00:02: pre-existing canonical Library Metrics entity_id prevents collision"
+    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+      (let [library-id   (insert-legacy-library-collection! {:name      "Library"
+                                                             :slug      "library"
+                                                             :type      "library"
+                                                             :entity_id "legacy-library-root"})
+            canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Metrics"
+                                                             :slug      "canonical-metrics"
+                                                             :type      nil
+                                                             :entity_id "librarylibrarymetrics"})
+            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Metrics"
+                                                             :slug      "legacy-metrics"
+                                                             :type      "library-metrics"
+                                                             :location  (str "/" library-id "/")
+                                                             :entity_id "legacy-library-metric"})]
+        (migrate!)
+        (is (= "library-metrics"
+               (t2/select-one-fn :type :collection :id canonical-id)))
+        (is (= "librarylibrarymetrics"
+               (collection-entity-id canonical-id)))
+        (is (= "legacy-library-metric"
+               (collection-entity-id legacy-id)))))))
 
 (deftest heal-effective-type-drift-without-coercion-test
   (testing "GHY-3388: heal metabase_field rows where coercion_strategy is NULL and effective_type

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2893,8 +2893,8 @@
   (str/trim (t2/select-one-fn :entity_id :collection :id collection-id)))
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test
-  (testing "v62.2026-05-13T11:59:59 through v62.2026-05-13T12:00:02: backfill canonical Library root entity IDs"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+  (testing "v62.2026-05-13T12:00:00 through v62.2026-05-13T12:00:02: backfill canonical Library root entity IDs"
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id (insert-legacy-library-collection! {:name      "Library"
                                                            :slug      "library"
                                                            :type      "library"
@@ -2919,7 +2919,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-2
   (testing "ambiguous Library Data direct children are not modified"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id        (insert-legacy-library-collection! {:name      "Library"
                                                                   :slug      "library"
                                                                   :type      "library"
@@ -2951,7 +2951,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-3
   (testing "Library Data collections outside Library root do not count as ambiguous"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02"] [migrate!]
       (let [library-id      (insert-legacy-library-collection! {:name      "Library"
                                                                 :slug      "library"
                                                                 :type      "library"
@@ -2977,72 +2977,70 @@
         (is (= "legacy-orphan-data"
                (collection-entity-id orphan-data-id)))))))
 
-(deftest backfill-legacy-library-root-skips-when-canonical-entity-id-exists-test
-  (testing "v62.2026-05-13T11:59:59 + T12:00:00: pre-existing canonical Library root entity_id prevents collision"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
-      (let [canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Library"
-                                                             :slug      "canonical-library"
-                                                             :type      nil
-                                                             :entity_id "librarylibrarylibrary"})
-            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Library"
-                                                             :slug      "legacy-library"
-                                                             :type      "library"
-                                                             :entity_id "legacy-library-root"})]
+(deftest backfill-legacy-library-root-collection-entity-ids-test-4
+  (testing "pre-existing canonical Library rows with missing types prevent entity_id collisions"
+    (impl/test-migrations ["v62.2026-05-13T11:59:58" "v62.2026-05-13T12:00:02"] [migrate!]
+      (let [canonical-library-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Library"
+                                                                     :slug      "canonical-library"
+                                                                     :type      nil
+                                                                     :entity_id "librarylibrarylibrary"})
+            legacy-library-id    (insert-legacy-library-collection! {:name      "Legacy Library"
+                                                                     :slug      "legacy-library"
+                                                                     :type      "library"
+                                                                     :entity_id "legacy-library-root"})
+            canonical-data-id    (insert-legacy-library-collection! {:name      "Pre-existing canonical Data"
+                                                                     :slug      "canonical-data"
+                                                                     :type      nil
+                                                                     :location  (str "/" canonical-library-id "/")
+                                                                     :entity_id "librarylibrarydatadat"})
+            legacy-data-id       (insert-legacy-library-collection! {:name      "Legacy Data"
+                                                                     :slug      "legacy-data"
+                                                                     :type      "library-data"
+                                                                     :location  (str "/" canonical-library-id "/")
+                                                                     :entity_id "legacy-library-data"})
+            canonical-metrics-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Metrics"
+                                                                     :slug      "canonical-metrics"
+                                                                     :type      nil
+                                                                     :location  (str "/" canonical-library-id "/")
+                                                                     :entity_id "librarylibrarymetrics"})
+            legacy-metrics-id    (insert-legacy-library-collection! {:name      "Legacy Metrics"
+                                                                     :slug      "legacy-metrics"
+                                                                     :type      "library-metrics"
+                                                                     :location  (str "/" canonical-library-id "/")
+                                                                     :entity_id "legacy-library-metric"})]
         (migrate!)
         (is (= "library"
-               (t2/select-one-fn :type :collection :id canonical-id)))
-        (is (= "librarylibrarylibrary"
-               (collection-entity-id canonical-id)))
-        (is (= "legacy-library-root"
-               (collection-entity-id legacy-id)))))))
-
-(deftest backfill-legacy-library-data-skips-when-canonical-entity-id-exists-test
-  (testing "v62.2026-05-13T12:00:01: pre-existing canonical Library Data entity_id prevents collision"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
-      (let [library-id   (insert-legacy-library-collection! {:name      "Library"
-                                                             :slug      "library"
-                                                             :type      "library"
-                                                             :entity_id "legacy-library-root"})
-            canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Data"
-                                                             :slug      "canonical-data"
-                                                             :type      nil
-                                                             :entity_id "librarylibrarydatadat"})
-            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Data"
-                                                             :slug      "legacy-data"
-                                                             :type      "library-data"
-                                                             :location  (str "/" library-id "/")
-                                                             :entity_id "legacy-library-data"})]
-        (migrate!)
+               (t2/select-one-fn :type :collection :id canonical-library-id)))
+        (is (nil? (t2/select-one-fn :type :collection :id legacy-library-id)))
         (is (= "library-data"
-               (t2/select-one-fn :type :collection :id canonical-id)))
-        (is (= "librarylibrarydatadat"
-               (collection-entity-id canonical-id)))
-        (is (= "legacy-library-data"
-               (collection-entity-id legacy-id)))))))
-
-(deftest backfill-legacy-library-metrics-skips-when-canonical-entity-id-exists-test
-  (testing "v62.2026-05-13T12:00:02: pre-existing canonical Library Metrics entity_id prevents collision"
-    (impl/test-migrations ["v62.2026-05-13T11:59:59" "v62.2026-05-13T12:00:02"] [migrate!]
-      (let [library-id   (insert-legacy-library-collection! {:name      "Library"
-                                                             :slug      "library"
-                                                             :type      "library"
-                                                             :entity_id "legacy-library-root"})
-            canonical-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Metrics"
-                                                             :slug      "canonical-metrics"
-                                                             :type      nil
-                                                             :entity_id "librarylibrarymetrics"})
-            legacy-id    (insert-legacy-library-collection! {:name      "Legacy Metrics"
-                                                             :slug      "legacy-metrics"
-                                                             :type      "library-metrics"
-                                                             :location  (str "/" library-id "/")
-                                                             :entity_id "legacy-library-metric"})]
-        (migrate!)
+               (t2/select-one-fn :type :collection :id canonical-data-id)))
         (is (= "library-metrics"
-               (t2/select-one-fn :type :collection :id canonical-id)))
+               (t2/select-one-fn :type :collection :id canonical-metrics-id)))
+        (is (= "librarylibrarylibrary"
+               (collection-entity-id canonical-library-id)))
+        (is (= "legacy-library-root"
+               (collection-entity-id legacy-library-id)))
+        (is (= "librarylibrarydatadat"
+               (collection-entity-id canonical-data-id)))
+        (is (= "legacy-library-data"
+               (collection-entity-id legacy-data-id)))
         (is (= "librarylibrarymetrics"
-               (collection-entity-id canonical-id)))
+               (collection-entity-id canonical-metrics-id)))
         (is (= "legacy-library-metric"
-               (collection-entity-id legacy-id)))))))
+               (collection-entity-id legacy-metrics-id)))))))
+
+(deftest backfill-legacy-library-root-collection-entity-ids-test-5
+  (testing "legacy Library root is backfilled when the canonical entity_id does not already exist"
+    (impl/test-migrations ["v62.2026-05-13T11:59:58" "v62.2026-05-13T12:00:00"] [migrate!]
+      (let [library-id (insert-legacy-library-collection! {:name      "Library"
+                                                           :slug      "library"
+                                                           :type      "library"
+                                                           :entity_id "legacy-library-root"})]
+        (migrate!)
+        (is (= "library"
+               (t2/select-one-fn :type :collection :id library-id)))
+        (is (= "librarylibrarylibrary"
+               (collection-entity-id library-id)))))))
 
 (deftest heal-effective-type-drift-without-coercion-test
   (testing "GHY-3388: heal metabase_field rows where coercion_strategy is NULL and effective_type


### PR DESCRIPTION
Related to #74178

### Description

The v62 Library root migration from #74178 backfills canonical `entity_id` values for legacy Library, Data, and Metrics root collections. A dev app DB surfaced a duplicate-key failure when `librarylibrarylibrary` already existed on a collection row with a missing type. See [this Slack convo](https://metaboat.slack.com/archives/C096M2BBGHH/p1779812600853889) for additional context.

### How to verify
We need to set the database in a specific state to test these migration updates.
Make sure you have a root library collection in your database, with entity_id=librarylibrarylibrary. If you don't, spin up your app as enterprise and enable the Library in Data Studio.
- Set your db to the invalid state:
`UPDATE collection SET type = null WHERE entity_id = 'librarylibrarylibrary';`
- Rollback the target migration directly in the db:
```sql
DELETE FROM databasechangelog
WHERE id IN (
 'v62.2026-05-13T11:59:58',
 'v62.2026-05-13T11:59:59',
 'v62.2026-05-13T12:00:00',
 'v62.2026-05-13T12:00:01',
 'v62.2026-05-13T12:00:02'
);
```
- Run migrations against master, e.g.:
```
MB_DB_CONNECTION_URI='postgresql://user:password@localhost:5432/metabase_local' \
clojure -M:run migrate up
```
You should see the unique constraint error.
- Checkout this branch and run migrations again. Should execute with no issues. In your database, your root library collection should be properly set with type=library and entity_id=librarylibrarylibrary.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)