### PR TITLE
Chill out ci

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -197,17 +197,50 @@
 (def ^:private gson-conflict-handler
   {"com/google/gson/.*" (prefer-lib 'com.google.code.gson/gson)})
 
+;; jakarta.servlet-api 6.1 (Servlet 6.x, EE10) conflicts with jetty-jakarta-servlet-api 5.0
+;; (Servlet 5.0, EE9). We use Jetty 12 with the EE9 adapter, so we need the 5.0 API.
+(def ^:private servlet-conflict-handler
+  {"jakarta/servlet/.*" (prefer-lib 'org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api)})
+
+;; databricks-jdbc-thin bundles Arrow's netty buffer patch classes. When these overwrite
+;; the real arrow-memory-netty-buffer-patch, BigQuery's Arrow integration can break.
+(def ^:private netty-buffer-conflict-handler
+  {"io/netty/buffer/.*" (prefer-lib 'org.apache.arrow/arrow-memory-netty-buffer-patch)})
+
 ;; avatica (Hive transitive dep) bundles the entire SLF4J API unshaded.
 (def ^:private slf4j-conflict-handler
   {"org/slf4j/.*" (prefer-lib 'org.slf4j/slf4j-api)})
 
+;; hive-jdbc-standalone bundles JAXB, guava internals, j2objc, animal-sniffer, and netty
+;; all unshaded. Prefer the real artifacts so runtime behavior matches what Maven resolved.
+(def ^:private hive-standalone-conflict-handler
+  {"javax/xml/bind/.*"                     (prefer-lib 'javax.xml.bind/jaxb-api)
+   "META-INF/versions/9/javax/xml/bind/.*" (prefer-lib 'javax.xml.bind/jaxb-api)
+   "com/google/j2objc/annotations/.*"      (prefer-lib 'com.google.j2objc/j2objc-annotations)
+   "com/google/thirdparty/publicsuffix/.*" (prefer-lib 'com.google.guava/guava)
+   "org/codehaus/mojo/animal_sniffer/.*"   (prefer-lib 'org.codehaus.mojo/animal-sniffer-annotations)})
+
+;; lz4-java 1.8.0 (hive transitive) vs at.yawk.lz4/lz4-java 1.10.2 (pinned).
+;; Same package, different Maven coords. Prefer the pinned newer version.
+(def ^:private lz4-conflict-handler
+  {"net/jpountz/.*" (prefer-lib 'at.yawk.lz4/lz4-java)})
+
+;; netty 4.2 split netty-codec into netty-codec-base. Both contain the same classes.
+;; Prefer the newer codec-base.
+(def ^:private netty-codec-conflict-handler
+  {"io/netty/handler/codec/.*" (prefer-lib 'io.netty/netty-codec-base)})
+
 (def conflict-handlers
-  "Merged conflict handlers for the uberjar build. Handles Log4j2 plugin merging,
-   jakarta.activation class visibility, gson version pinning, and SLF4J API."
+  "Merged conflict handlers for the uberjar build."
   (merge log4j2-conflict-handler
          activation-conflict-handler
          gson-conflict-handler
-         slf4j-conflict-handler))
+         servlet-conflict-handler
+         slf4j-conflict-handler
+         netty-buffer-conflict-handler
+         hive-standalone-conflict-handler
+         lz4-conflict-handler
+         netty-codec-conflict-handler))
 
 (defn- create-uberjar! [basis]
   (u/step "Create uberjar"

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -1,12 +1,14 @@
 (ns build.uberjar
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [clojure.tools.build.util.zip :as build.zip]
    [clojure.tools.namespace.dependency :as ns.deps]
    [clojure.tools.namespace.find :as ns.find]
    [clojure.tools.namespace.parse :as ns.parse]
    [metabuild-common.core :as u]
+   [metabuild-common.misc :as misc]
    [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]])
   (:import
    (java.io File OutputStream)
@@ -174,24 +176,45 @@
    #"META-INF/license.*"
    #"META-INF/LICENSE.*"])
 
+(defn- prefer-lib
+  "Returns a conflict handler fn that ensures `preferred` lib's classes always win.
+   The returned fn writes when the incoming class is from `preferred`, skips otherwise."
+  [preferred]
+  (fn prefer-lib' [{:keys [lib path in]}]
+    (when (= lib preferred)
+      {:write {path {:stream in}}})))
+
+;; hive-jdbc bundles javax.activation classes with package-private visibility on LogSupport.
+;; When these overwrite jakarta.activation's public versions, javax.mail (postal) fails with
+;; IllegalAccessError.
 (def ^:private activation-conflict-handler
-  "hive-jdbc-standalone bundles its own copy of javax.activation classes with package-private visibility on
-  LogSupport. When these overwrite the correct public versions from jakarta.activation, javax.mail (postal) fails at
-  runtime with IllegalAccessError. This handler ensures jakarta.activation's versions always win regardless of JAR
-  processing order."
-  {"com/sun/activation/registries/.*"
-   (fn [{:keys [lib path in]}]
-     (if (= lib 'com.sun.activation/jakarta.activation)
-       {:write {path {:stream in}}}
-       nil))})
+  (let [from-com-sun-activation (prefer-lib 'com.sun.activation/jakarta.activation)]
+    {"com/sun/activation/.*" from-com-sun-activation
+     "javax/activation/.*"   from-com-sun-activation}))
+
+;; vertica-jdbc bundles unshaded gson 2.8.9. When these overwrite the pinned 2.12.1,
+;; BigQuery crashes with NoSuchMethodError on JsonWriter.value(float). See #73736.
+(def ^:private gson-conflict-handler
+  {"com/google/gson/.*" (prefer-lib 'com.google.code.gson/gson)})
+
+;; avatica (Hive transitive dep) bundles the entire SLF4J API unshaded.
+(def ^:private slf4j-conflict-handler
+  {"org/slf4j/.*" (prefer-lib 'org.slf4j/slf4j-api)})
+
+(def conflict-handlers
+  "Merged conflict handlers for the uberjar build. Handles Log4j2 plugin merging,
+   jakarta.activation class visibility, gson version pinning, and SLF4J API."
+  (merge log4j2-conflict-handler
+         activation-conflict-handler
+         gson-conflict-handler
+         slf4j-conflict-handler))
 
 (defn- create-uberjar! [basis]
   (u/step "Create uberjar"
     (with-duration-ms [duration-ms]
       (b/uber {:class-dir         class-dir
                :uber-file         uberjar-filename
-               :conflict-handlers (merge log4j2-conflict-handler
-                                         activation-conflict-handler)
+               :conflict-handlers conflict-handlers
                :basis             basis
                :exclude           dependency-ignore-patterns})
       (u/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))
@@ -227,8 +250,8 @@
                   :when (.isFile f)]
             (let [rel-path (.toString (.relativize (.toPath src-dir) (.toPath f)))
                   target   (u/get-path-in-filesystem fs rel-path)]
-              (Files/createDirectories (.getParent target) (into-array java.nio.file.attribute.FileAttribute []))
-              (Files/copy (.toPath f) target (into-array java.nio.file.CopyOption [])))))))))
+              (Files/createDirectories (.getParent target) (misc/varargs java.nio.file.attribute.FileAttribute))
+              (Files/copy (.toPath f) target (misc/varargs java.nio.file.CopyOption)))))))))
 
 (defn update-manifest!
   "Start a build step that updates the manifest.
@@ -259,3 +282,42 @@
         (add-non-aot-driver-sources!)
         (update-manifest!))
       (u/announce "Built %s in %.1f seconds." uberjar-filename (/ duration-ms 1000.0)))))
+
+(defn detect-class-conflicts
+  "Run `b/uber` against `basis` (no AOT, no resources) and return a seq of
+   `{:path ... :lib ...}` for every `.class` file conflict not already handled
+   by our conflict handlers."
+  [basis]
+  (let [conflicts (atom [])]
+    (clean!)
+    (b/uber {:class-dir         class-dir
+             :uber-file         uberjar-filename
+             :conflict-handlers (merge conflict-handlers
+                                       {:default (fn [{:keys [lib path]}]
+                                                   (when (str/ends-with? path ".class")
+                                                     (swap! conflicts conj {:path path :lib lib}))
+                                                   nil)})
+             :basis             basis
+             :exclude           dependency-ignore-patterns})
+    @conflicts))
+
+(defn audit-conflicts
+  "Build a bare uberjar (no AOT, no resources) and report all class file conflicts.
+   Useful for detecting vendored/unshaded dependencies in fat JARs.
+
+     clojure -X:build:build/uberjar build.uberjar/audit-conflicts
+     clojure -X:build:build/uberjar build.uberjar/audit-conflicts :edition :ee"
+  [{:keys [edition], :or {edition :ee}}]
+  (u/step (format "Audit %s uberjar class file conflicts" edition)
+    (let [basis     (create-basis edition)
+          conflicts (detect-class-conflicts basis)]
+      (when (seq conflicts)
+        (u/announce "=== %d class file conflicts detected ===" (count conflicts))
+        (let [report-file "target/conflict-report.txt"]
+          (spit report-file
+                (str/join "\n"
+                          (for [[path libs] (->> conflicts
+                                                 (group-by :path)
+                                                 (sort-by key))]
+                            (format "%s — %s" path (str/join ", " (map :lib libs))))))
+          (u/announce "Conflict report written to %s" report-file))))))

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -1,0 +1,59 @@
+(ns build.uberjar-test
+  (:require
+   [build.uberjar :as uberjar]
+   [clojure.test :refer [deftest is testing]]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private basis
+  "EE basis — includes all drivers, which is where the worst conflicts live."
+  (delay (#'uberjar/create-basis :ee)))
+
+(defn- conflicting-prefixes
+  "Return Java package paths that have class file conflicts.
+   e.g. `com/google/gson/Gson.class` → `com/google/gson`"
+  [conflicts]
+  (into #{}
+        (keep (fn [{:keys [path]}]
+                (let [last-slash (.lastIndexOf ^String path "/")]
+                  (when (pos? last-slash)
+                    (subs path 0 last-slash)))))
+        conflicts))
+
+;; Known conflicting packages. The test asserts on *package prefix* (stable) rather than
+;; *lib* (order-dependent — the conflict handler only sees the second writer).
+;; As we fix these, remove entries — the goal is to shrink this to #{}.
+(def ^:private known-conflicting-prefixes
+  '#{"com/microsoft/schemas"        ;; poi-ooxml vs poi-ooxml-lite — same version, XML schema overlap
+     "org/openxmlformats/schemas"   ;; poi-ooxml vs poi-ooxml-lite — same version
+     "org/apache/poi/schemas"       ;; poi-ooxml vs poi-ooxml-lite — same version
+     "org/w3/x2000"                 ;; poi-ooxml vs poi-ooxml-lite — XML digital signature schemas
+     "org/etsi/uri"                 ;; poi-ooxml vs poi-ooxml-lite — digital signature schemas
+     "jakarta/servlet"              ;; jetty-servlet vs jakarta.servlet-api — same API version
+     "javax/annotation"             ;; jsr250-api vs jsr305 — annotation-only JARs
+     "net/jcip/annotations"         ;; jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords
+     "io/netty/buffer"              ;; databricks-jdbc-thin bundles custom Arrow netty buffers
+     "org/apache/calcite/avatica"   ;; avatica vs avatica-core — Hive transitive dep
+     ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
+     "org/apache/hadoop"            ;; hadoop-common single-class overlap
+     "org/apache/hive"})            ;; hive-common single-class overlap
+
+(defn- prefix-matches?
+  "True if `prefix` equals or is under any of the known prefixes."
+  [prefix]
+  (some (fn [known]
+          (or (= prefix known)
+              (.startsWith ^String prefix (str known "/"))))
+        known-conflicting-prefixes))
+
+(deftest class-file-conflicts-test
+  (testing "No unexpected class file conflicts in the EE uberjar"
+    ;; Takes ~2 minutes — runs b/uber without AOT or resources
+    (let [conflicts    (uberjar/detect-class-conflicts @basis)
+          prefixes     (conflicting-prefixes conflicts)
+          unexpected   (sort (remove prefix-matches? prefixes))]
+      (is (empty? unexpected)
+          (str "Unexpected class file conflicts in packages:\n"
+               (pr-str unexpected)
+               "\nIf benign, add to known-conflicting-prefixes with a comment. "
+               "If dangerous, add a conflict handler in build.uberjar.")))))

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -33,10 +33,18 @@
      "javax/annotation"             ;; jsr250-api vs jsr305 — annotation-only JARs
      "net/jcip/annotations"         ;; jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords
      "io/netty/buffer"              ;; databricks-jdbc-thin bundles custom Arrow netty buffers
+     "io/netty/handler/codec"       ;; netty-codec-base 4.2 vs netty-codec 4.1 — codec was split in netty 4.2
      "org/apache/calcite/avatica"   ;; avatica vs avatica-core — Hive transitive dep
      ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
      "org/apache/hadoop"            ;; hadoop-common single-class overlap
-     "org/apache/hive"})            ;; hive-common single-class overlap
+     "org/apache/hive"              ;; hive-common single-class overlap
+     ;; hive-jdbc-standalone fat JAR bundles everything unshaded (v59 only — master uses individual modules)
+     "javax/xml/bind"               ;; hive-jdbc-standalone vs jaxb-api
+     "META-INF/versions/9/javax/xml/bind" ;; hive-jdbc-standalone vs jaxb-api (multi-release)
+     "com/google/j2objc/annotations" ;; hive-jdbc-standalone vs j2objc-annotations
+     "com/google/thirdparty/publicsuffix" ;; hive-jdbc-standalone vs guava
+     "net/jpountz"                  ;; lz4-java 1.8.0 (hive transitive) vs at.yawk.lz4/lz4-java 1.10.2
+     "org/codehaus/mojo/animal_sniffer"}) ;; hive-jdbc-standalone vs animal-sniffer-annotations
 
 (defn- prefix-matches?
   "True if `prefix` equals or is under any of the known prefixes."

--- a/bin/build/test/build/uberjar_test.clj
+++ b/bin/build/test/build/uberjar_test.clj
@@ -29,22 +29,18 @@
      "org/apache/poi/schemas"       ;; poi-ooxml vs poi-ooxml-lite — same version
      "org/w3/x2000"                 ;; poi-ooxml vs poi-ooxml-lite — XML digital signature schemas
      "org/etsi/uri"                 ;; poi-ooxml vs poi-ooxml-lite — digital signature schemas
-     "jakarta/servlet"              ;; jetty-servlet vs jakarta.servlet-api — same API version
      "javax/annotation"             ;; jsr250-api vs jsr305 — annotation-only JARs
      "net/jcip/annotations"         ;; jcip-annotations vs stephenc jcip-annotations — same lib, two Maven coords
-     "io/netty/buffer"              ;; databricks-jdbc-thin bundles custom Arrow netty buffers
-     "io/netty/handler/codec"       ;; netty-codec-base 4.2 vs netty-codec 4.1 — codec was split in netty 4.2
      "org/apache/calcite/avatica"   ;; avatica vs avatica-core — Hive transitive dep
-     ;; org/slf4j — handled by slf4j-conflict-handler (prefers org.slf4j/slf4j-api)
      "org/apache/hadoop"            ;; hadoop-common single-class overlap
      "org/apache/hive"              ;; hive-common single-class overlap
-     ;; hive-jdbc-standalone fat JAR bundles everything unshaded (v59 only — master uses individual modules)
-     "javax/xml/bind"               ;; hive-jdbc-standalone vs jaxb-api
-     "META-INF/versions/9/javax/xml/bind" ;; hive-jdbc-standalone vs jaxb-api (multi-release)
-     "com/google/j2objc/annotations" ;; hive-jdbc-standalone vs j2objc-annotations
-     "com/google/thirdparty/publicsuffix" ;; hive-jdbc-standalone vs guava
-     "net/jpountz"                  ;; lz4-java 1.8.0 (hive transitive) vs at.yawk.lz4/lz4-java 1.10.2
-     "org/codehaus/mojo/animal_sniffer"}) ;; hive-jdbc-standalone vs animal-sniffer-annotations
+     ;; Handled by conflict handlers (not listed here):
+     ;; jakarta/servlet — servlet-conflict-handler (prefers jetty EE9 5.0 over 6.1)
+     ;; io/netty/handler/codec — netty-codec-conflict-handler
+     ;; org/slf4j — slf4j-conflict-handler
+     ;; javax/xml/bind, j2objc, publicsuffix, animal_sniffer — hive-standalone-conflict-handler
+     ;; net/jpountz — lz4-conflict-handler
+     })
 
 (defn- prefix-matches?
   "True if `prefix` equals or is under any of the known prefixes."

--- a/deps.edn
+++ b/deps.edn
@@ -96,6 +96,7 @@
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
   metabase/saml20-clj                       {:mvn/version "4.2.1"
                                              :exclusions [; EE SAML integration TODO: bump version when we release the library
+                                                          jakarta.servlet/jakarta.servlet-api
                                                           org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on
                                                           org.bouncycastle/bcpkix-jdk18on

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,7 +2,10 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"}
+ {at.yawk.lz4/lz4-java                {:mvn/version "1.10.4"} ; pin newer version because version included in JDBC driver has security warnings
+  com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"
+                                       :exclusions  [org.apache.commons/commons-lang3  ;; dep in top-level deps.edn; exclusion fixes security warnings
+                                                     org.slf4j/slf4j-jdk14]}           ;; conflicts with our log4j2 SLF4J provider
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}}}


### PR DESCRIPTION
backporting the gson fixes and then a few more fixes

#### before

```clojure
uberjar-test=> (clojure.test/run-test class-file-conflicts-test)

Testing build.uberjar-test
Clean
  Delete /Users/dan/projects/work/metabase/target/classes
  Delete /Users/dan/projects/work/metabase/target/uberjar/metabase.jar
FAIL in (class-file-conflicts-test) (uberjar_test.clj:55)
No unexpected class file conflicts in the EE uberjar
Unexpected class file conflicts in packages:
("META-INF/versions/9/javax/xml/bind" "com/google/j2objc/annotations" "com/google/thirdparty/publicsuffix" "io/netty/handler/codec" "io/netty/handler/codec/base64" "io/netty/handler/codec/bytes" "io/netty/handler/codec/compression" "io/netty/handler/codec/json" "io/netty/handler/codec/serialization" "io/netty/handler/codec/string" "javax/xml/bind" "javax/xml/bind/annotation" "javax/xml/bind/annotation/adapters" "javax/xml/bind/attachment" "javax/xml/bind/helpers" "javax/xml/bind/util" "net/jpountz/lz4" "net/jpountz/util" "net/jpountz/xxhash" "org/codehaus/mojo/animal_sniffer")
If benign, add to known-conflicting-prefixes with a comment. If dangerous, add a conflict handler in build.uberjar.
expected: (empty? unexpected)
  actual: (not
           (empty?
            ("META-INF/versions/9/javax/xml/bind"
             "com/google/j2objc/annotations"
             "com/google/thirdparty/publicsuffix"
             "io/netty/handler/codec"
             "io/netty/handler/codec/base64"
             "io/netty/handler/codec/bytes"
             "io/netty/handler/codec/compression"
             "io/netty/handler/codec/json"
             "io/netty/handler/codec/serialization"
             "io/netty/handler/codec/string"
             "javax/xml/bind"
             "javax/xml/bind/annotation"
             "javax/xml/bind/annotation/adapters"
             "javax/xml/bind/attachment"
             "javax/xml/bind/helpers"
             "javax/xml/bind/util"
             "net/jpountz/lz4"
             "net/jpountz/util"
             "net/jpountz/xxhash"
             "org/codehaus/mojo/animal_sniffer")))

Ran 1 tests containing 1 assertions.
1 failures, 0 errors.
{:test 1, :pass 0, :fail 1, :error 0, :type :summary}
```