### PR TITLE
Move Explore button into the chart card (UXW-4237)

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -255,7 +255,7 @@ describe("scenarios > data studio > library > metrics", () => {
       .should("be.visible");
   });
 
-  it("should view metric in the metrics explorer view via more menu", () => {
+  it("should view metric in the metrics explorer view via the Explore button", () => {
     cy.log("Navigate to Data Studio Library");
     cy.visit("/data-studio/library");
 
@@ -269,8 +269,7 @@ describe("scenarios > data studio > library > metrics", () => {
       .findByDisplayValue("Trusted Orders Metric")
       .should("be.visible");
 
-    cy.log("Verify View link opens in new tab");
-    H.DataStudio.Metrics.moreMenu().click();
+    cy.log("Verify the Explore button points to the metrics explorer");
     H.DataStudio.Metrics.exploreLink()
       .should("have.attr", "href")
       .and("match", /\/explore\?metricId=\d+/);

--- a/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
@@ -68,9 +68,7 @@ describe("scenarios > metrics > metric page", () => {
     });
 
     cy.log("explore link");
-    H.MetricPage.header()
-      .findByText("Explore")
-      .closest("a")
+    H.MetricPage.exploreLink()
       .should("have.attr", "href")
       .and("include", "/explore");
 

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -24,7 +24,7 @@ import { useDispatch, useSelector } from "metabase/redux";
 import { openUrl } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/selectors/user";
-import { ActionIcon, Group, Icon, Menu } from "metabase/ui";
+import { ActionIcon, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
@@ -118,113 +118,111 @@ function MetricToolbarButtons({
     PLUGIN_CACHING.hasQuestionCacheSection(new Question(card));
 
   return (
-    <Group wrap="nowrap" gap="sm">
-      <Menu position="bottom-end">
-        <Menu.Target>
-          <ActionIcon
-            variant="default"
-            size="lg"
-            className={S.moreOptionsButton}
-            aria-label={t`More options`}
-          >
-            <Icon name="ellipsis" />
-          </ActionIcon>
-        </Menu.Target>
-        <Menu.Dropdown>
+    <Menu position="bottom-end">
+      <Menu.Target>
+        <ActionIcon
+          variant="default"
+          size="lg"
+          className={S.moreOptionsButton}
+          aria-label={t`More options`}
+        >
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Item
+          leftSection={
+            <Icon name={isBookmarked ? "bookmark_filled" : "bookmark"} />
+          }
+          onClick={() =>
+            isBookmarked
+              ? deleteBookmark({ id: card.id, type: "card" })
+              : createBookmark({ id: card.id, type: "card" })
+          }
+        >
+          {isBookmarked ? t`Remove from bookmarks` : t`Bookmark`}
+        </Menu.Item>
+        {moderationMenuItems}
+        {card.can_write && (
           <Menu.Item
-            leftSection={
-              <Icon name={isBookmarked ? "bookmark_filled" : "bookmark"} />
-            }
-            onClick={() =>
-              isBookmarked
-                ? deleteBookmark({ id: card.id, type: "card" })
-                : createBookmark({ id: card.id, type: "card" })
-            }
+            leftSection={<Icon name="move" />}
+            onClick={() => onOpenModal("move")}
           >
-            {isBookmarked ? t`Remove from bookmarks` : t`Bookmark`}
+            {c("A verb, not a noun").t`Move`}
           </Menu.Item>
-          {moderationMenuItems}
-          {card.can_write && (
-            <Menu.Item
-              leftSection={<Icon name="move" />}
-              onClick={() => onOpenModal("move")}
-            >
-              {c("A verb, not a noun").t`Move`}
-            </Menu.Item>
-          )}
-          {queryInfo.isEditable && (
-            <Menu.Item
-              leftSection={<Icon name="clone" />}
-              onClick={() => onOpenModal("copy")}
-            >
-              {c("A verb, not a noun").t`Duplicate`}
-            </Menu.Item>
-          )}
-
-          <Menu.Divider role="separator" />
-
+        )}
+        {queryInfo.isEditable && (
           <Menu.Item
-            leftSection={<Icon name="add_to_dash" />}
-            onClick={() => onOpenModal("add-to-dashboard")}
+            leftSection={<Icon name="clone" />}
+            onClick={() => onOpenModal("copy")}
           >
-            {t`Add to a dashboard`}
+            {c("A verb, not a noun").t`Duplicate`}
           </Menu.Item>
-          {canManageSubscriptions && (
-            <Menu.Item
-              leftSection={<Icon name="alert" />}
-              disabled={isNotificationsLoading}
-              onClick={() => onOpenModal("alert")}
-            >
-              {questionNotifications?.length
-                ? t`Edit alerts`
-                : t`Create an alert`}
-            </Menu.Item>
-          )}
+        )}
 
-          {isCacheableQuestion && (
-            <>
-              <Menu.Divider role="separator" />
-              <Menu.Item
-                leftSection={<Icon name="sync" />}
-                onClick={() => onOpenModal("caching")}
-              >
-                {t`Caching`}
-              </Menu.Item>
-            </>
-          )}
+        <Menu.Divider role="separator" />
 
-          {(PLUGIN_AUDIT.isEnabled || showDataStudioLink) && (
+        <Menu.Item
+          leftSection={<Icon name="add_to_dash" />}
+          onClick={() => onOpenModal("add-to-dashboard")}
+        >
+          {t`Add to a dashboard`}
+        </Menu.Item>
+        {canManageSubscriptions && (
+          <Menu.Item
+            leftSection={<Icon name="alert" />}
+            disabled={isNotificationsLoading}
+            onClick={() => onOpenModal("alert")}
+          >
+            {questionNotifications?.length
+              ? t`Edit alerts`
+              : t`Create an alert`}
+          </Menu.Item>
+        )}
+
+        {isCacheableQuestion && (
+          <>
             <Menu.Divider role="separator" />
-          )}
-
-          {showDataStudioLink && (
             <Menu.Item
-              leftSection={<Icon name="grid_bordered" />}
-              onClick={() => dispatch(openUrl(Urls.dataStudioMetric(card.id)))}
+              leftSection={<Icon name="sync" />}
+              onClick={() => onOpenModal("caching")}
             >
-              {t`Open in Data Studio`}
+              {t`Caching`}
             </Menu.Item>
-          )}
-          <PLUGIN_AUDIT.InsightsMenuItem
-            card={card}
-            label={t`Metric usage analytics`}
-            iconName="pie_slice"
-          />
+          </>
+        )}
 
-          {card.can_write && (
-            <>
-              <Menu.Divider role="separator" />
-              <Menu.Item
-                leftSection={<Icon name="trash" />}
-                onClick={() => onOpenModal("archive")}
-              >
-                {t`Move to trash`}
-              </Menu.Item>
-            </>
-          )}
-        </Menu.Dropdown>
-      </Menu>
-    </Group>
+        {(PLUGIN_AUDIT.isEnabled || showDataStudioLink) && (
+          <Menu.Divider role="separator" />
+        )}
+
+        {showDataStudioLink && (
+          <Menu.Item
+            leftSection={<Icon name="grid_bordered" />}
+            onClick={() => dispatch(openUrl(Urls.dataStudioMetric(card.id)))}
+          >
+            {t`Open in Data Studio`}
+          </Menu.Item>
+        )}
+        <PLUGIN_AUDIT.InsightsMenuItem
+          card={card}
+          label={t`Metric usage analytics`}
+          iconName="pie_slice"
+        />
+
+        {card.can_write && (
+          <>
+            <Menu.Divider role="separator" />
+            <Menu.Item
+              leftSection={<Icon name="trash" />}
+              onClick={() => onOpenModal("archive")}
+            >
+              {t`Move to trash`}
+            </Menu.Item>
+          </>
+        )}
+      </Menu.Dropdown>
+    </Menu>
   );
 }
 

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -8,10 +8,8 @@ import {
   useListBookmarksQuery,
   useListNotificationsQuery,
 } from "metabase/api";
-import { ForwardRefLink } from "metabase/common/components/Link";
 import { AddToDashSelectDashModal } from "metabase/common/components/Pickers/AddToDashSelectDashModal";
 import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/data-studio/selectors";
-import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { QuestionAlertListModal } from "metabase/notifications/modals/QuestionAlertListModal";
 import {
   PLUGIN_AUDIT,
@@ -26,7 +24,7 @@ import { useDispatch, useSelector } from "metabase/redux";
 import { openUrl } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/selectors/user";
-import { ActionIcon, Button, Group, Icon, Menu } from "metabase/ui";
+import { ActionIcon, Group, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
@@ -121,16 +119,6 @@ function MetricToolbarButtons({
 
   return (
     <Group wrap="nowrap" gap="sm">
-      {isNumericMetric(card) && (
-        <Button
-          component={ForwardRefLink}
-          to={Urls.exploreMetric(card.id)}
-          leftSection={<Icon name="external" />}
-          data-testid="explore-link"
-        >
-          {t`Explore`}
-        </Button>
-      )}
       <Menu position="bottom-end">
         <Menu.Target>
           <ActionIcon

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
@@ -255,4 +255,14 @@ describe("MetricToolbar", () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe("Explore button", () => {
+    it("should not render an Explore button in the toolbar for numeric metrics", () => {
+      const validation = jest.requireMock("metabase/metrics/utils/validation");
+      validation.isNumericMetric.mockReturnValueOnce(true);
+      setup({ canWrite: true });
+
+      expect(screen.queryByTestId("explore-link")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
@@ -257,9 +257,7 @@ describe("MetricToolbar", () => {
   });
 
   describe("Explore button", () => {
-    it("should not render an Explore button in the toolbar for numeric metrics", () => {
-      const validation = jest.requireMock("metabase/metrics/utils/validation");
-      validation.isNumericMetric.mockReturnValueOnce(true);
+    it("should not render an Explore button in the toolbar", () => {
       setup({ canWrite: true });
 
       expect(screen.queryByTestId("explore-link")).not.toBeInTheDocument();

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/ExploreMetricButton.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/ExploreMetricButton.tsx
@@ -1,0 +1,24 @@
+import { t } from "ttag";
+
+import { ForwardRefLink } from "metabase/common/components/Link";
+import { Button, Icon } from "metabase/ui";
+import * as Urls from "metabase/urls";
+import type { CardId } from "metabase-types/api";
+
+interface ExploreMetricButtonProps {
+  cardId: CardId;
+}
+
+export function ExploreMetricButton({ cardId }: ExploreMetricButtonProps) {
+  return (
+    <Button
+      component={ForwardRefLink}
+      to={Urls.exploreMetric(cardId)}
+      variant="default"
+      leftSection={<Icon name="click" />}
+      data-testid="explore-link"
+    >
+      {t`Explore`}
+    </Button>
+  );
+}

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/ExploreMetricButton.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/ExploreMetricButton.tsx
@@ -15,6 +15,7 @@ export function ExploreMetricButton({ cardId }: ExploreMetricButtonProps) {
       component={ForwardRefLink}
       to={Urls.exploreMetric(cardId)}
       variant="default"
+      size="xs"
       leftSection={<Icon name="click" />}
       data-testid="explore-link"
     >

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
@@ -5,13 +5,7 @@
 .chartContainer {
   display: flex;
   flex-direction: column;
-  cursor: pointer;
-  transition: box-shadow 200ms ease;
   border-radius: var(--default-border-radius) 0 0 var(--default-border-radius);
-
-  &:hover {
-    box-shadow: var(--mantine-shadow-md);
-  }
 }
 
 .descriptionSection {

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
@@ -8,6 +8,13 @@
   border-radius: var(--default-border-radius) 0 0 var(--default-border-radius);
 }
 
+.exploreButtonOverlay {
+  position: absolute;
+  top: var(--mantine-spacing-md);
+  right: var(--mantine-spacing-md);
+  z-index: 1;
+}
+
 .descriptionSection {
   background-color: var(--mb-color-background-primary);
   border: 1px solid var(--mb-color-border);

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
@@ -10,8 +10,8 @@
 
 .exploreButtonOverlay {
   position: absolute;
-  top: var(--mantine-spacing-md);
-  right: var(--mantine-spacing-md);
+  top: var(--mantine-spacing-xl);
+  right: var(--mantine-spacing-xl);
   z-index: 1;
 }
 

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.module.css
@@ -5,7 +5,7 @@
 .chartContainer {
   display: flex;
   flex-direction: column;
-  border-radius: var(--default-border-radius) 0 0 var(--default-border-radius);
+  position: relative;
 }
 
 .exploreButtonOverlay {
@@ -30,6 +30,7 @@
   border-top-left-radius: var(--default-border-radius);
   border-bottom-left-radius: var(--default-border-radius);
   overflow: hidden;
+  /* keeps the embedded visualization non-interactive (no tooltips/hover) */
   pointer-events: none;
 }
 

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useMemo } from "react";
-import { push } from "react-router-redux";
+import { useMemo } from "react";
 
 import { OverviewVisualization } from "metabase/data-studio/common/components/OverviewVisualization";
 import { useMetricDefinition } from "metabase/metrics/common/hooks";
-import { useDispatch } from "metabase/redux";
+import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { Box, Flex, Stack } from "metabase/ui";
-import * as Urls from "metabase/urls";
 import * as LibMetric from "metabase-lib/metric";
 import type { Card } from "metabase-types/api";
 
@@ -13,6 +11,7 @@ import type { MetricUrls } from "../../../types";
 
 import { AboutVisualization } from "./AboutVisualization";
 import { DescriptionSection } from "./DescriptionSection";
+import { ExploreMetricButton } from "./ExploreMetricButton";
 import S from "./MetricAbout.module.css";
 
 interface MetricAboutProps {
@@ -22,7 +21,6 @@ interface MetricAboutProps {
 
 export function MetricAbout({ card, urls }: MetricAboutProps) {
   const { definition } = useMetricDefinition(card.id ?? null);
-  const dispatch = useDispatch();
 
   const hasTimeDimension = useMemo(
     () =>
@@ -34,20 +32,14 @@ export function MetricAbout({ card, urls }: MetricAboutProps) {
     [definition],
   );
 
-  const handleChartClick = useCallback(() => {
-    if (card.id != null) {
-      dispatch(push(Urls.exploreMetric(card.id)));
-    }
-  }, [dispatch, card.id]);
-
   return (
     <Flex className={S.root} flex={1}>
-      <Box
-        className={S.chartContainer}
-        flex={1}
-        mah={700}
-        onClick={handleChartClick}
-      >
+      <Box className={S.chartContainer} flex={1} mah={700} pos="relative">
+        {isNumericMetric(card) && (
+          <Box pos="absolute" top="md" right="md" style={{ zIndex: 1 }}>
+            <ExploreMetricButton cardId={card.id} />
+          </Box>
+        )}
         {hasTimeDimension ? (
           <AboutVisualization card={card} />
         ) : (

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
@@ -34,7 +34,7 @@ export function MetricAbout({ card, urls }: MetricAboutProps) {
 
   return (
     <Flex className={S.root} flex={1}>
-      <Box className={S.chartContainer} flex={1} mah={700} pos="relative">
+      <Box className={S.chartContainer} flex={1} mah={700}>
         {isNumericMetric(card) && (
           <Box className={S.exploreButtonOverlay}>
             <ExploreMetricButton cardId={card.id} />

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.tsx
@@ -36,7 +36,7 @@ export function MetricAbout({ card, urls }: MetricAboutProps) {
     <Flex className={S.root} flex={1}>
       <Box className={S.chartContainer} flex={1} mah={700} pos="relative">
         {isNumericMetric(card) && (
-          <Box pos="absolute" top="md" right="md" style={{ zIndex: 1 }}>
+          <Box className={S.exploreButtonOverlay}>
             <ExploreMetricButton cardId={card.id} />
           </Box>
         )}

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
@@ -1,36 +1,33 @@
 import { Route } from "react-router";
 
+import {
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+  setupCardQueryMetadataEndpoint,
+  setupDatabaseEndpoints,
+  setupMetricEndpoint,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { createMockCard } from "metabase-types/api/mocks";
+import type { Card, Field } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockCardQueryMetadata,
+  createMockDataset,
+  createMockDatasetData,
+  createMockField,
+  createMockMetric,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
+import {
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
 import { MetricAbout } from "./MetricAbout";
 
-jest.mock("metabase/metrics/utils/validation", () => ({
-  isNumericMetric: jest.fn().mockReturnValue(false),
-}));
-
-jest.mock("metabase/metrics/common/hooks", () => ({
-  useMetricDefinition: jest.fn().mockReturnValue({
-    definition: null,
-    isLoading: false,
-  }),
-}));
-
-jest.mock("./AboutVisualization", () => ({
-  AboutVisualization: () => <div data-testid="about-visualization" />,
-}));
-
-jest.mock(
-  "metabase/data-studio/common/components/OverviewVisualization",
-  () => ({
-    OverviewVisualization: () => <div data-testid="overview-visualization" />,
-  }),
-);
-
-jest.mock("./DescriptionSection", () => ({
-  DescriptionSection: () => <div data-testid="description-section" />,
-}));
+const SAMPLE_DB = createSampleDatabase();
 
 const mockUrls = {
   about: (id: number) => `/metric/${id}`,
@@ -41,11 +38,41 @@ const mockUrls = {
   history: (id: number) => `/metric/${id}/history`,
 };
 
-function setup({ isNumeric = false }: { isNumeric?: boolean } = {}) {
-  const validation = jest.requireMock("metabase/metrics/utils/validation");
-  validation.isNumericMetric.mockReturnValue(isNumeric);
+function makeMetricCard(resultMetadata: Field[]): Card {
+  return createMockCard({
+    id: 42,
+    type: "metric",
+    database_id: SAMPLE_DB_ID,
+    table_id: ORDERS_ID,
+    result_metadata: resultMetadata,
+    dataset_query: {
+      type: "query",
+      database: SAMPLE_DB_ID,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+      },
+    },
+  });
+}
 
-  const card = createMockCard({ id: 42, type: "metric" });
+function setup(card: Card) {
+  setupDatabaseEndpoints(SAMPLE_DB);
+  setupCardEndpoints(card);
+  setupCardQueryMetadataEndpoint(
+    card,
+    createMockCardQueryMetadata({ databases: [SAMPLE_DB] }),
+  );
+  setupCardQueryEndpoints(
+    card,
+    createMockDataset({
+      data: createMockDatasetData({
+        cols: [createMockNumericColumn({ name: "count" })],
+        rows: [],
+      }),
+    }),
+  );
+  setupMetricEndpoint(createMockMetric({ id: card.id, name: card.name }));
 
   renderWithProviders(
     <Route
@@ -58,24 +85,32 @@ function setup({ isNumeric = false }: { isNumeric?: boolean } = {}) {
       initialRoute: "/",
     },
   );
-
-  return { card };
 }
 
 describe("MetricAbout", () => {
-  it("renders the Explore button on the chart card for numeric metrics", () => {
-    setup({ isNumeric: true });
+  it("renders the Explore button on the chart card for numeric metrics", async () => {
+    setup(
+      makeMetricCard([
+        createMockField({ name: "count", base_type: "type/Integer" }),
+      ]),
+    );
 
-    expect(screen.getByTestId("explore-link")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Explore/i })).toHaveAttribute(
+    expect(await screen.findByTestId("explore-link")).toHaveAttribute(
       "href",
       "/explore?metricId=42",
     );
   });
 
-  it("does not render the Explore button for non-numeric metrics", () => {
-    setup({ isNumeric: false });
+  it("does not render the Explore button when the metric has no summable column", async () => {
+    setup(
+      makeMetricCard([
+        createMockField({ name: "category", base_type: "type/Text" }),
+      ]),
+    );
 
+    // Wait for the description section to render so the negative assertion
+    // isn't trivially true (the page hasn't loaded yet).
+    expect(await screen.findByText("Source table")).toBeInTheDocument();
     expect(screen.queryByTestId("explore-link")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAbout/MetricAbout.unit.spec.tsx
@@ -1,0 +1,81 @@
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockCard } from "metabase-types/api/mocks";
+
+import { MetricAbout } from "./MetricAbout";
+
+jest.mock("metabase/metrics/utils/validation", () => ({
+  isNumericMetric: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock("metabase/metrics/common/hooks", () => ({
+  useMetricDefinition: jest.fn().mockReturnValue({
+    definition: null,
+    isLoading: false,
+  }),
+}));
+
+jest.mock("./AboutVisualization", () => ({
+  AboutVisualization: () => <div data-testid="about-visualization" />,
+}));
+
+jest.mock(
+  "metabase/data-studio/common/components/OverviewVisualization",
+  () => ({
+    OverviewVisualization: () => <div data-testid="overview-visualization" />,
+  }),
+);
+
+jest.mock("./DescriptionSection", () => ({
+  DescriptionSection: () => <div data-testid="description-section" />,
+}));
+
+const mockUrls = {
+  about: (id: number) => `/metric/${id}`,
+  overview: (id: number) => `/metric/${id}/overview`,
+  query: (id: number) => `/metric/${id}/query`,
+  dependencies: (id: number) => `/metric/${id}/dependencies`,
+  caching: (id: number) => `/metric/${id}/caching`,
+  history: (id: number) => `/metric/${id}/history`,
+};
+
+function setup({ isNumeric = false }: { isNumeric?: boolean } = {}) {
+  const validation = jest.requireMock("metabase/metrics/utils/validation");
+  validation.isNumericMetric.mockReturnValue(isNumeric);
+
+  const card = createMockCard({ id: 42, type: "metric" });
+
+  renderWithProviders(
+    <Route
+      path="/"
+      component={() => <MetricAbout card={card} urls={mockUrls} />}
+    />,
+    {
+      storeInitialState: createMockState(),
+      withRouter: true,
+      initialRoute: "/",
+    },
+  );
+
+  return { card };
+}
+
+describe("MetricAbout", () => {
+  it("renders the Explore button on the chart card for numeric metrics", () => {
+    setup({ isNumeric: true });
+
+    expect(screen.getByTestId("explore-link")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Explore/i })).toHaveAttribute(
+      "href",
+      "/explore?metricId=42",
+    );
+  });
+
+  it("does not render the Explore button for non-numeric metrics", () => {
+    setup({ isNumeric: false });
+
+    expect(screen.queryByTestId("explore-link")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Closes [UXW-4237](https://linear.app/metabase/issue/UXW-4237/move-explore-button-into-the-chart).

Moves the Explore button from the metric page header into the top-right of the chart card on the About tab. The chart-card click shortcut is gone — the button replaces it. Same numeric-metric gate; same behavior in Data Studio.

### How to verify

- [ ] Numeric metric: Explore button is on the chart card (not the header), navigates to the metrics explorer in-place.
- [ ] Non-numeric metric: button is hidden.
- [ ] Clicking elsewhere in the chart card does nothing.

### Demo

<img width="540" height="427" alt="image" src="https://github.com/user-attachments/assets/ebd6088c-5c27-4fe2-bc75-e337fe542b9f" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)