### PR TITLE
Log resolved email recipients when sending an email

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -1,5 +1,7 @@
 (ns metabase.channel.impl.email
   (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
    [medley.core :as m]
@@ -45,8 +47,25 @@
    [:message                         :any]
    [:recipient-type {:optional true} [:maybe (ms/enum-keywords-and-strings :cc :bcc)]]])
 
+(defn- email->digest
+  "A short, stable digest of an email address, for logging recipients without writing the raw address
+  to logs. Not meant to be irreversible — email space is enumerable — just to keep PII out of plain
+  sight. To check whether an address was a recipient, digest it the same way and grep the logs:
+  lower-cased + trimmed, SHA-256, first 12 hex chars."
+  [email]
+  (-> (u/lower-case-en (str/trim (str email)))
+      buddy-hash/sha256
+      codecs/bytes->hex
+      (subs 0 12)))
+
 (mu/defmethod channel/send! :channel/email
   [_channel {:keys [subject recipients message-type message recipient-type]} :- EmailMessage]
+  ;; Make deliverability debuggable from logs (Grafana/Loki). info: recipient count only (always on,
+  ;; no PII). debug: short per-recipient digests, so "was address X sent to?" can be answered by
+  ;; digesting the suspected address the same way and grepping (see [[email->digest]]) — opt-in.
+  ;; Carries the caller's log context (e.g. :notification_id) via MDC. (GDGT-2416)
+  (log/infof "Sending email to %d recipient(s)" (count recipients))
+  (log/debugf "Email recipient digests: %s" (pr-str (mapv email->digest recipients)))
   (email/send-message-or-throw! {:subject      subject
                                  :recipients   recipients
                                  :message-type message-type


### PR DESCRIPTION
A team member isn't receiving our transform-job-failed emails and we can't tell why — Metabase thinks it sent them, but there's no way to confirm from logs whether their address was actually a recipient. This adds that: recipient count at info, and short SHA-256 digests of each address at debug — so you can digest the suspected address the same way and grep for it, without writing raw emails to logs.

Part of https://linear.app/metabase/issue/GDGT-2416/investigate-missing-failed-job-notifications-for-admins
