### PR TITLE
Gdgt 2434 render basic treemap from query result rows echarts

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -355,6 +355,10 @@ export type VisualizationSettings = {
   "sankey.show_edge_labels"?: boolean;
   "sankey.label_value_formatting"?: "auto" | "full" | "compact";
 
+  // Treemap settings
+  "treemap.grouping"?: string;
+  "treemap.value"?: string;
+
   // BoxPlot settings
   "boxplot.whisker_type"?: BoxPlotWhiskerType;
   "boxplot.points_mode"?: BoxPlotPointsMode;

--- a/frontend/src/metabase-types/api/visualization.ts
+++ b/frontend/src/metabase-types/api/visualization.ts
@@ -35,6 +35,7 @@ export const cardDisplayTypes = [
   "boxplot",
   "waterfall",
   "sankey",
+  "treemap",
   "list",
 ] as const;
 

--- a/frontend/src/metabase/embedding/mcp/utils/getMcpChartTypes.ts
+++ b/frontend/src/metabase/embedding/mcp/utils/getMcpChartTypes.ts
@@ -22,6 +22,7 @@ const MCP_CHART_TYPE_ICONS: Record<CardDisplayType, IconName> = {
   scatter: "bubble",
   smartscalar: "smartscalar",
   table: "table2",
+  treemap: "grid_2x2",
   waterfall: "waterfall",
   list: "table2",
 };

--- a/frontend/src/metabase/metabot/utils/chart-analysis.ts
+++ b/frontend/src/metabase/metabot/utils/chart-analysis.ts
@@ -19,6 +19,7 @@ const CHART_ANALYSIS_ENABLED = {
   row: true,
   sankey: true,
   scatter: true,
+  treemap: true,
   waterfall: true,
   // disabled
   action: false,
@@ -62,6 +63,7 @@ export const CHART_ANALYSIS_RENDER_FORMATS = {
   row: "svg",
   sankey: "svg",
   scatter: "svg",
+  treemap: "svg",
   waterfall: "svg",
 } as const satisfies { [display in EnabledChartTypes]: "png" | "svg" | "none" };
 

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
@@ -224,6 +224,19 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
       return t`E.g. Count of orders grouped by Month`;
     },
   },
+  treemap: {
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/treemap.svg",
+      );
+    },
+    get primaryText() {
+      return t`Then pick a metric and one or two columns to group by.`;
+    },
+    get secondaryText() {
+      return t`E.g., Revenue grouped by Region and Country`;
+    },
+  },
   waterfall: {
     get imgSrc() {
       return getSubpathSafeUrl(

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
@@ -1,0 +1,67 @@
+import { sumMetric } from "metabase/visualizations/lib/dataset";
+import { getColumnDescriptors } from "metabase/visualizations/lib/graph/columns";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { DatasetColumn, RawSeries, RowValue } from "metabase-types/api";
+
+import type { TreemapChartColumns, TreemapNode, TreemapTree } from "./types";
+
+export function getTreemapChartColumns<TColumn extends DatasetColumn>(
+  columns: TColumn[],
+  settings: Pick<
+    ComputedVisualizationSettings,
+    "treemap.grouping" | "treemap.value"
+  >,
+): TreemapChartColumns | null {
+  if (
+    settings["treemap.grouping"] == null ||
+    settings["treemap.value"] == null
+  ) {
+    return null;
+  }
+
+  const grouping = getColumnDescriptors(
+    [settings["treemap.grouping"]],
+    columns,
+  )[0];
+  const value = getColumnDescriptors([settings["treemap.value"]], columns)[0];
+
+  if (!grouping?.column || !value?.column) {
+    return null;
+  }
+
+  return { grouping, value };
+}
+
+export function getTreemapData(
+  rawSeries: RawSeries,
+  treemapColumns: TreemapChartColumns,
+): TreemapTree {
+  const [
+    {
+      data: { rows },
+    },
+  ] = rawSeries;
+  const { grouping, value } = treemapColumns;
+
+  const nodeByKey = new Map<RowValue, TreemapNode>();
+
+  rows.forEach((row, rowIndex) => {
+    const groupingValue = row[grouping.index];
+    const metricValue = row[value.index];
+
+    const existing = nodeByKey.get(groupingValue);
+    if (existing) {
+      existing.value = sumMetric(existing.value, metricValue) ?? existing.value;
+      existing.rowIndices.push(rowIndex);
+    } else {
+      nodeByKey.set(groupingValue, {
+        rawName: groupingValue,
+        displayName: String(groupingValue ?? ""),
+        value: sumMetric(0, metricValue) ?? 0,
+        rowIndices: [rowIndex],
+      });
+    }
+  });
+
+  return Array.from(nodeByKey.values());
+}

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
@@ -1,0 +1,167 @@
+import type { DatasetColumn, RowValue } from "metabase-types/api";
+import { createMockCard } from "metabase-types/api/mocks/card";
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks/dataset";
+
+import { getTreemapChartColumns, getTreemapData } from "./data";
+import type { TreemapChartColumns } from "./types";
+
+const columns: DatasetColumn[] = [
+  createMockColumn({
+    name: "Category",
+    display_name: "Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "Amount",
+    display_name: "Amount",
+    base_type: "type/Number",
+    semantic_type: "type/Number",
+  }),
+];
+
+const treemapColumns: TreemapChartColumns = {
+  grouping: { index: 0, column: columns[0] },
+  value: { index: 1, column: columns[1] },
+};
+
+describe("getTreemapChartColumns", () => {
+  it("returns null when treemap.grouping is missing", () => {
+    expect(
+      getTreemapChartColumns(columns, { "treemap.value": "Amount" }),
+    ).toBeNull();
+  });
+
+  it("returns null when treemap.value is missing", () => {
+    expect(
+      getTreemapChartColumns(columns, { "treemap.grouping": "Category" }),
+    ).toBeNull();
+  });
+
+  it("returns null when a referenced column is not present", () => {
+    expect(
+      getTreemapChartColumns(columns, {
+        "treemap.grouping": "DoesNotExist",
+        "treemap.value": "Amount",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns descriptors for both columns when all settings present", () => {
+    const result = getTreemapChartColumns(columns, {
+      "treemap.grouping": "Category",
+      "treemap.value": "Amount",
+    });
+
+    expect(result).toEqual({
+      grouping: expect.objectContaining({ index: 0 }),
+      value: expect.objectContaining({ index: 1 }),
+    });
+  });
+});
+
+describe("getTreemapData (1-level)", () => {
+  function makeRawSeries(rows: RowValue[][]) {
+    return [
+      {
+        card: createMockCard({ name: "Treemap card" }),
+        data: createMockDatasetData({ rows, cols: columns }),
+      },
+    ];
+  }
+
+  it("returns an empty tree for an empty rowset", () => {
+    expect(getTreemapData(makeRawSeries([]), treemapColumns)).toEqual([]);
+  });
+
+  it("builds one root node for a single row", () => {
+    const result = getTreemapData(makeRawSeries([["A", 10]]), treemapColumns);
+
+    expect(result).toEqual([
+      {
+        rawName: "A",
+        displayName: "A",
+        value: 10,
+        rowIndices: [0],
+      },
+    ]);
+  });
+
+  it("creates one root node per unique grouping value", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", 10],
+        ["B", 20],
+        ["C", 30],
+      ]),
+      treemapColumns,
+    );
+
+    expect(result).toHaveLength(3);
+    expect(result.map((n) => n.rawName)).toEqual(["A", "B", "C"]);
+    expect(result.map((n) => n.value)).toEqual([10, 20, 30]);
+  });
+
+  it("sums duplicate grouping rows and tracks all row indices", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", 10],
+        ["B", 20],
+        ["A", 5],
+        ["A", 1],
+      ]),
+      treemapColumns,
+    );
+
+    expect(result).toEqual([
+      {
+        rawName: "A",
+        displayName: "A",
+        value: 16,
+        rowIndices: [0, 2, 3],
+      },
+      {
+        rawName: "B",
+        displayName: "B",
+        value: 20,
+        rowIndices: [1],
+      },
+    ]);
+  });
+
+  it("treats a null metric value as zero contribution", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", 10],
+        ["A", null],
+      ]),
+      treemapColumns,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      rawName: "A",
+      value: 10,
+      rowIndices: [0, 1],
+    });
+  });
+
+  it("preserves null grouping values on the node and stringifies the display name", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        [null, 7],
+        ["A", 3],
+      ]),
+      treemapColumns,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      rawName: null,
+      displayName: "",
+      value: 7,
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/types.ts
@@ -1,0 +1,23 @@
+import type { ColumnDescriptor } from "metabase/visualizations/lib/graph/columns";
+import type { RowValue } from "metabase-types/api";
+
+export interface TreemapChartColumns {
+  grouping: ColumnDescriptor;
+  subGrouping?: ColumnDescriptor;
+  value: ColumnDescriptor;
+}
+
+export interface TreemapNode {
+  rawName: RowValue;
+  displayName: string;
+  value: number;
+  rowIndices: number[];
+  children?: TreemapNode[];
+}
+
+export type TreemapTree = TreemapNode[];
+
+export interface TreemapBuildResult {
+  tree: TreemapTree;
+  error?: { message: string };
+}

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
@@ -1,9 +1,8 @@
 import type { TreemapSeriesOption } from "echarts/charts";
-import type { EChartsCoreOption } from "echarts/core";
 
 import type { TreemapNode, TreemapTree } from "../model/types";
 
-interface TreemapSeriesNode {
+export interface TreemapSeriesNode {
   name: string;
   value: number;
   rawName: TreemapNode["rawName"];
@@ -11,8 +10,15 @@ interface TreemapSeriesNode {
   children?: TreemapSeriesNode[];
 }
 
-export function getTreemapChartOption(tree: TreemapTree): EChartsCoreOption {
-  const series: TreemapSeriesOption = {
+type TreemapChartSeriesOption = TreemapSeriesOption & {
+  type: "treemap";
+  data: TreemapSeriesNode[];
+};
+
+export function getTreemapChartOption(tree: TreemapTree): {
+  series: TreemapChartSeriesOption;
+} {
+  const series: TreemapChartSeriesOption = {
     type: "treemap",
     data: toSeriesData(tree),
   };

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
@@ -1,0 +1,31 @@
+import type { TreemapSeriesOption } from "echarts/charts";
+import type { EChartsCoreOption } from "echarts/core";
+
+import type { TreemapNode, TreemapTree } from "../model/types";
+
+interface TreemapSeriesNode {
+  name: string;
+  value: number;
+  rawName: TreemapNode["rawName"];
+  rowIndices: number[];
+  children?: TreemapSeriesNode[];
+}
+
+export function getTreemapChartOption(tree: TreemapTree): EChartsCoreOption {
+  const series: TreemapSeriesOption = {
+    type: "treemap",
+    data: toSeriesData(tree),
+  };
+
+  return { series };
+}
+
+function toSeriesData(nodes: TreemapTree): TreemapSeriesNode[] {
+  return nodes.map((node) => ({
+    name: node.displayName,
+    value: node.value,
+    rawName: node.rawName,
+    rowIndices: node.rowIndices,
+    ...(node.children ? { children: toSeriesData(node.children) } : {}),
+  }));
+}

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
@@ -21,7 +21,6 @@ describe("getTreemapChartOption (1-level)", () => {
     ];
 
     const option = getTreemapChartOption(tree);
-    // @ts-expect-error -- echarts series union narrowing not worth fighting in tests
     const data = option.series.data;
 
     expect(data).toHaveLength(3);
@@ -37,7 +36,6 @@ describe("getTreemapChartOption (1-level)", () => {
     ];
 
     const option = getTreemapChartOption(tree);
-    // @ts-expect-error -- see above
     const data = option.series.data;
 
     expect(data[0]).toMatchObject({
@@ -52,7 +50,6 @@ describe("getTreemapChartOption (1-level)", () => {
 
   it("returns an empty data array for an empty tree", () => {
     const option = getTreemapChartOption([]);
-    // @ts-expect-error -- see above
     expect(option.series.data).toEqual([]);
   });
 });

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.unit.spec.ts
@@ -1,0 +1,58 @@
+import type { TreemapTree } from "../model/types";
+
+import { getTreemapChartOption } from "./option";
+
+describe("getTreemapChartOption (1-level)", () => {
+  it("produces a single treemap series", () => {
+    const tree: TreemapTree = [
+      { rawName: "A", displayName: "A", value: 10, rowIndices: [0] },
+    ];
+
+    const option = getTreemapChartOption(tree);
+
+    expect(option.series).toMatchObject({ type: "treemap" });
+  });
+
+  it("emits one series data entry per top-level node", () => {
+    const tree: TreemapTree = [
+      { rawName: "A", displayName: "A", value: 10, rowIndices: [0, 2] },
+      { rawName: "B", displayName: "B", value: 25, rowIndices: [1] },
+      { rawName: "C", displayName: "C", value: 7, rowIndices: [3] },
+    ];
+
+    const option = getTreemapChartOption(tree);
+    // @ts-expect-error -- echarts series union narrowing not worth fighting in tests
+    const data = option.series.data;
+
+    expect(data).toHaveLength(3);
+    expect(data[0]).toMatchObject({ name: "A", value: 10 });
+    expect(data[1]).toMatchObject({ name: "B", value: 25 });
+    expect(data[2]).toMatchObject({ name: "C", value: 7 });
+  });
+
+  it("preserves rowIndices and rawName on each data node for downstream drill-through", () => {
+    const tree: TreemapTree = [
+      { rawName: null, displayName: "", value: 4, rowIndices: [0, 1] },
+      { rawName: "A", displayName: "A", value: 8, rowIndices: [2] },
+    ];
+
+    const option = getTreemapChartOption(tree);
+    // @ts-expect-error -- see above
+    const data = option.series.data;
+
+    expect(data[0]).toMatchObject({
+      rawName: null,
+      rowIndices: [0, 1],
+    });
+    expect(data[1]).toMatchObject({
+      rawName: "A",
+      rowIndices: [2],
+    });
+  });
+
+  it("returns an empty data array for an empty tree", () => {
+    const option = getTreemapChartOption([]);
+    // @ts-expect-error -- see above
+    expect(option.series.data).toEqual([]);
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/index.ts
@@ -6,6 +6,7 @@ import {
   SankeyChart,
   ScatterChart,
   SunburstChart,
+  TreemapChart,
 } from "echarts/charts";
 import {
   BrushComponent,
@@ -40,6 +41,7 @@ export const registerEChartsModules = () => {
     BrushComponent,
     DatasetComponent,
     SankeyChart,
+    TreemapChart,
     LabelLayout,
     TooltipComponent,
   ]);

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -22,6 +22,7 @@ import { Scalar } from "./visualizations/Scalar";
 import { ScatterPlot } from "./visualizations/ScatterPlot";
 import { SmartScalar } from "./visualizations/SmartScalar";
 import { Table } from "./visualizations/Table/Table";
+import { TreemapChart } from "./visualizations/TreemapChart";
 import { WaterfallChart } from "./visualizations/WaterfallChart";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
@@ -45,6 +46,7 @@ export default function () {
   registerVisualization(ObjectDetail);
   registerVisualization(PivotTable);
   registerVisualization(SankeyChart);
+  registerVisualization(TreemapChart);
 
   registerVisualization(ListViz);
 

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
@@ -10,6 +10,8 @@ import {
 import { getTreemapChartOption } from "metabase/visualizations/echarts/graph/treemap/option/option";
 import type { VisualizationProps } from "metabase/visualizations/types";
 
+import { TREEMAP_CHART_DEFINITION } from "./chart-definition";
+
 export const TreemapChart = ({ rawSeries, settings }: VisualizationProps) => {
   const rawSeriesWithRemappings = useMemo(
     () => extractRemappings(rawSeries),
@@ -45,3 +47,5 @@ export const TreemapChart = ({ rawSeries, settings }: VisualizationProps) => {
     />
   );
 };
+
+Object.assign(TreemapChart, TREEMAP_CHART_DEFINITION);

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
@@ -1,0 +1,47 @@
+import type { EChartsType } from "echarts/core";
+import { useCallback, useMemo, useRef } from "react";
+
+import { extractRemappings } from "metabase/visualizations";
+import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
+import {
+  getTreemapChartColumns,
+  getTreemapData,
+} from "metabase/visualizations/echarts/graph/treemap/model/data";
+import { getTreemapChartOption } from "metabase/visualizations/echarts/graph/treemap/option/option";
+import type { VisualizationProps } from "metabase/visualizations/types";
+
+export const TreemapChart = ({ rawSeries, settings }: VisualizationProps) => {
+  const rawSeriesWithRemappings = useMemo(
+    () => extractRemappings(rawSeries),
+    [rawSeries],
+  );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<EChartsType>();
+
+  const option = useMemo(() => {
+    const cols = rawSeriesWithRemappings[0]?.data?.cols ?? [];
+    const treemapColumns = getTreemapChartColumns(cols, settings);
+    if (!treemapColumns) {
+      return null;
+    }
+    const tree = getTreemapData(rawSeriesWithRemappings, treemapColumns);
+    return getTreemapChartOption(tree);
+  }, [rawSeriesWithRemappings, settings]);
+
+  const handleInit = useCallback((chart: EChartsType) => {
+    chartRef.current = chart;
+  }, []);
+
+  if (!option) {
+    return null;
+  }
+
+  return (
+    <ResponsiveEChartsRenderer
+      ref={containerRef}
+      option={option}
+      onInit={handleInit}
+    />
+  );
+};

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
@@ -1,0 +1,75 @@
+import { t } from "ttag";
+
+import { getTreemapChartColumns } from "metabase/visualizations/echarts/graph/treemap/model/data";
+import { ChartSettingsError } from "metabase/visualizations/lib/errors";
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import {
+  dimensionSetting,
+  metricSetting,
+} from "metabase/visualizations/lib/settings/utils";
+import type {
+  ComputedVisualizationSettings,
+  VisualizationDefinition,
+  VisualizationSettingsDefinitions,
+} from "metabase/visualizations/types";
+import { isDimension, isMetric } from "metabase-lib/v1/types/utils/isa";
+import type { DatasetData, RawSeries } from "metabase-types/api";
+
+export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
+  ...columnSettings({ getHidden: () => true }),
+  ...dimensionSetting("treemap.grouping", {
+    getSection: () => t`Data`,
+    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+    title: t`Grouping`,
+    showColumnSetting: true,
+    persistDefault: true,
+    dashboard: false,
+    autoOpenWhenUnset: false,
+  }),
+  ...metricSetting("treemap.value", {
+    getSection: () => t`Data`,
+    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+    title: t`Value`,
+    showColumnSetting: true,
+    persistDefault: true,
+    dashboard: false,
+    autoOpenWhenUnset: false,
+  }),
+};
+
+export const TREEMAP_CHART_DEFINITION: VisualizationDefinition = {
+  getUiName: () => t`Treemap`,
+  identifier: "treemap",
+  // Placeholder until T19 ships the real icon
+  iconName: "grid_2x2",
+  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+  noun: t`treemap chart`,
+  minSize: { width: 4, height: 4 },
+  defaultSize: { width: 6, height: 6 },
+  disableVisualizer: true,
+  hasEmptyState: true,
+  isSensible: (data: DatasetData) => {
+    const { cols, rows } = data;
+    const numDimensions = cols.filter(isDimension).length;
+    const numMetrics = cols.filter(isMetric).length;
+    return rows.length >= 1 && numDimensions >= 1 && numMetrics >= 1;
+  },
+  checkRenderable: (
+    rawSeries: RawSeries,
+    settings: ComputedVisualizationSettings,
+  ) => {
+    const { rows, cols } = rawSeries[0].data;
+    if (rows.length === 0) {
+      return;
+    }
+    const treemapColumns = getTreemapChartColumns(cols, settings);
+    if (!treemapColumns) {
+      throw new ChartSettingsError(t`Which columns do you want to use?`, {
+        section: "Data",
+      });
+    }
+  },
+  settings: {
+    ...SETTINGS_DEFINITIONS,
+  },
+};

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
@@ -25,15 +25,6 @@ const columns = [
 ];
 
 describe("TREEMAP_CHART_DEFINITION", () => {
-  it("declares the expected identifier, sizes, and empty state", () => {
-    expect(TREEMAP_CHART_DEFINITION).toMatchObject({
-      identifier: "treemap",
-      hasEmptyState: true,
-      minSize: { width: 4, height: 4 },
-      defaultSize: { width: 6, height: 6 },
-    });
-  });
-
   describe("isSensible", () => {
     it("returns true with at least one dimension, one metric, and one row", () => {
       const data = createMockDatasetData({

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
@@ -1,0 +1,135 @@
+import { checkNotNull } from "metabase/utils/types";
+import { ChartSettingsError } from "metabase/visualizations/lib/errors";
+import { createMockCard } from "metabase-types/api/mocks/card";
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks/dataset";
+
+import { TREEMAP_CHART_DEFINITION } from "./chart-definition";
+
+const isSensible = checkNotNull(TREEMAP_CHART_DEFINITION.isSensible);
+
+const columns = [
+  createMockColumn({
+    name: "Category",
+    display_name: "Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "Amount",
+    display_name: "Amount",
+    base_type: "type/Number",
+    semantic_type: "type/Number",
+  }),
+];
+
+describe("TREEMAP_CHART_DEFINITION", () => {
+  it("declares the expected identifier, sizes, and empty state", () => {
+    expect(TREEMAP_CHART_DEFINITION).toMatchObject({
+      identifier: "treemap",
+      hasEmptyState: true,
+      minSize: { width: 4, height: 4 },
+      defaultSize: { width: 6, height: 6 },
+    });
+  });
+
+  describe("isSensible", () => {
+    it("returns true with at least one dimension, one metric, and one row", () => {
+      const data = createMockDatasetData({
+        rows: [
+          ["A", 10],
+          ["B", 20],
+        ],
+        cols: columns,
+      });
+      expect(isSensible(data)).toBe(true);
+    });
+
+    it("returns false when there are no rows", () => {
+      const data = createMockDatasetData({ rows: [], cols: columns });
+      expect(isSensible(data)).toBe(false);
+    });
+
+    it("returns false when there are no metric columns", () => {
+      const noMetricCols = [
+        createMockColumn({
+          name: "Category",
+          display_name: "Category",
+          base_type: "type/Text",
+        }),
+        createMockColumn({
+          name: "Other",
+          display_name: "Other",
+          base_type: "type/Text",
+        }),
+      ];
+      const data = createMockDatasetData({
+        rows: [["A", "X"]],
+        cols: noMetricCols,
+      });
+      expect(isSensible(data)).toBe(false);
+    });
+  });
+
+  describe("checkRenderable", () => {
+    const validRawSeries = [
+      {
+        card: createMockCard(),
+        data: createMockDatasetData({
+          rows: [
+            ["A", 10],
+            ["B", 20],
+          ],
+          cols: columns,
+        }),
+      },
+    ];
+
+    it("does not throw for valid data and complete settings", () => {
+      const settings = {
+        "treemap.grouping": "Category",
+        "treemap.value": "Amount",
+      };
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(validRawSeries, settings),
+      ).not.toThrow();
+    });
+
+    it("does not throw for empty data", () => {
+      const emptyRawSeries = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({ rows: [], cols: columns }),
+        },
+      ];
+      const settings = {
+        "treemap.grouping": "Category",
+        "treemap.value": "Amount",
+      };
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(emptyRawSeries, settings),
+      ).not.toThrow();
+    });
+
+    it("throws ChartSettingsError when required columns are unset", () => {
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(validRawSeries, {}),
+      ).toThrow(
+        new ChartSettingsError("Which columns do you want to use?", {
+          section: "Data",
+        }),
+      );
+    });
+
+    it("throws ChartSettingsError when grouping setting points to a missing column", () => {
+      const settings = {
+        "treemap.grouping": "DoesNotExist",
+        "treemap.value": "Amount",
+      };
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(validRawSeries, settings),
+      ).toThrow(ChartSettingsError);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/index.ts
@@ -1,0 +1,1 @@
+export * from "./TreemapChart";


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2434/render-basic-treemap-from-query-result-rows-echarts-integration

### Description

### Demo


<img width="4640" height="2646" alt="image" src="https://github.com/user-attachments/assets/bba89636-2b54-4092-92b3-d380c956fbe3" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
