### PR TITLE
Rename MCP UI viz scope for metabot consistency

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -615,7 +615,7 @@
   Accepts either a JSON body (same shape as /v2/construct-query) or a `continuation_token`
   from a previous response. Returns results with column metadata and an optional
   `continuation_token` for fetching the next page."
-  {:scope "agent:query"
+  {:scope metabot/agent-query
    :tool  {:name "query"
            :title "Query Tables and Metrics"
            :description (str "Execute a Metabase query and return results with column "

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -301,7 +301,7 @@
 (register-ui-resource!
  :visualize-query
  "ui://metabase/visualize-query.html"
- "agent:visualize"
+ "agent:viz:mcp-ui:query"
  {:name          "Visualize Query"
   :description   "Interactive Metabase SDK visualization for a query"
   :prefersBorder true
@@ -310,7 +310,7 @@
 (register-ui-resource!
  :render-drill-through
  "ui://metabase/render-drill-through.html"
- "agent:visualize"
+ "agent:viz:mcp-ui:drill-through"
  {:name          "Render Drill Through"
   :description   "Interactive Metabase SDK visualization for a drill-through follow-up"
   :prefersBorder true

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -15,6 +15,7 @@
   agent-dashboard-create
   agent-metric-read
   agent-question-create
+  agent-query
   agent-query-construct
   agent-query-execute
   agent-search

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -69,6 +69,10 @@
   (deferred-tru "Edit charts and visualizations"))
 (api-scope/defscope agent-viz-navigate "agent:viz:navigate"
   (deferred-tru "Navigate to visualizations"))
+(api-scope/defscope agent-viz-mcp-ui-query "agent:viz:mcp-ui:query"
+  (deferred-tru "Render query visualizations in the MCP UI"))
+(api-scope/defscope agent-viz-mcp-ui-drill-through "agent:viz:mcp-ui:drill-through"
+  (deferred-tru "Render drill-through visualizations in the MCP UI"))
 
 ;; Alert
 (api-scope/defscope agent-alert-create "agent:alert:create"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1144,7 +1144,7 @@
 
 (deftest check-resource-access-test
   (testing "returns :ok for a known URI with matching scope"
-    (is (= :ok (mcp.resources/check-resource-access "ui://metabase/visualize-query.html" #{"agent:visualize"}))))
+    (is (= :ok (mcp.resources/check-resource-access "ui://metabase/visualize-query.html" #{"agent:viz:mcp-ui:query"}))))
   (testing "returns :ok with wildcard scope"
     (is (= :ok (mcp.resources/check-resource-access "ui://metabase/visualize-query.html" #{"agent:*"}))))
   (testing "returns :scope-denied for a known URI with non-matching scope"

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -90,21 +90,21 @@
                            :mimeType "text/html;profile=mcp-app"
                            :_meta    {:ui {:prefersBorder true}}}]}
               (mcp.resources/read-resource "ui://metabase/visualize-query.html"
-                                           #{"agent:visualize"}
+                                           #{"agent:viz:mcp-ui:query"}
                                            {}))))))
 
 (deftest drill-through-ui-resource-is-distinct-from-visualize-query-test
   (testing "render_drill_through has its own UI resource URI (ChatGPT dedupes the iframe by `_meta.ui.resourceUri`; sharing the URI prevents a fresh widget from mounting on drill)"
-    (let [uris (set (map :uri (:resources (mcp.resources/list-resources #{"agent:visualize"}))))]
+    (let [uris (set (map :uri (:resources (mcp.resources/list-resources #{"agent:viz:*"}))))]
       (is (contains? uris "ui://metabase/visualize-query.html"))
       (is (contains? uris "ui://metabase/render-drill-through.html"))))
   (testing "the two UI resources return byte-distinct HTML (ChatGPT's asset CDN appears to dedupe by body hash, so identical bodies cause the second asset to silently 404)"
     (mcp.resources/with-fallback-template
       (let [viz-html   (-> (mcp.resources/read-resource "ui://metabase/visualize-query.html"
-                                                        #{"agent:visualize"} {})
+                                                        #{"agent:viz:mcp-ui:query"} {})
                            :contents first :text)
             drill-html (-> (mcp.resources/read-resource "ui://metabase/render-drill-through.html"
-                                                        #{"agent:visualize"} {})
+                                                        #{"agent:viz:mcp-ui:drill-through"} {})
                            :contents first :text)]
         (is (string? viz-html))
         (is (string? drill-html))
@@ -123,7 +123,7 @@
           uri      "ui://metabase/visualize-query.html"
           read-ui  (fn []
                      (mcp.resources/with-fallback-template
-                       (mcp.resources/read-resource uri #{"agent:visualize"} {})))]
+                       (mcp.resources/read-resource uri #{"agent:viz:mcp-ui:query"} {})))]
       (with-redefs [system/site-url (constantly site-url)]
         (testing "no request bound → CSP origins still emitted, :domain suppressed"
           (with-redefs [config/is-dev? false]


### PR DESCRIPTION
## Summary

The MCP UI tools/resources (`visualize_query`, `render_drill_through`) used a bare `agent:visualize` literal — the only `agent:*` scope not declared via `defscope`. 

This renames it to fit the metabot `agent:<resource>:<action>` convention, under the existing `agent:viz:*` family:

| Tool / resource | Before | After |
| --- | --- | --- |
| `visualize_query` | `agent:visualize` | `agent:viz:mcp-ui:query` |
| `render_drill_through` | `agent:visualize` | `agent:viz:mcp-ui:drill-through` |

Both scopes are now registered via `defscope` in `metabase.metabot.scope`, so they appear in consent screens / OAuth metadata like every other agent scope. The `agent:viz:*` wildcard grant (`metabot-other-tools` permission) still authorizes them via prefix matching.

Also cleaned up the one other scope literal: the `/v2/query` endpoint used a bare `"agent:query"` string because `agent-query` wasn't re-exported from `metabase.metabot.core`. Now it's re-exported and referenced as a var, matching every other endpoint/tool.

## Context

Slack thread: https://metaboat.slack.com/archives/C07SJT1P0ET/p1779874187765289?thread_ts=1779830910.136169&cid=C07SJT1P0ET

## Testing

- `metabase.metabot.scope-test`, `metabase.mcp.resources-test`, `metabase.mcp.api-test` — 88 tests, 493 assertions, 0 failures
- `metabase.agent-api.api-test` — 27 tests, 155 assertions, 0 failures