### PR TITLE
Gdgt 2505 support two levels of data

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -357,6 +357,7 @@ export type VisualizationSettings = {
 
   // Treemap settings
   "treemap.grouping"?: string;
+  "treemap.sub_grouping"?: string;
   "treemap.value"?: string;
 
   // BoxPlot settings

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
@@ -1,3 +1,4 @@
+import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { sumMetric } from "metabase/visualizations/lib/dataset";
 import { getColumnDescriptors } from "metabase/visualizations/lib/graph/columns";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
@@ -9,7 +10,7 @@ export function getTreemapChartColumns<TColumn extends DatasetColumn>(
   columns: TColumn[],
   settings: Pick<
     ComputedVisualizationSettings,
-    "treemap.grouping" | "treemap.value"
+    "treemap.grouping" | "treemap.sub_grouping" | "treemap.value"
   >,
 ): TreemapChartColumns | null {
   if (
@@ -29,6 +30,14 @@ export function getTreemapChartColumns<TColumn extends DatasetColumn>(
     return null;
   }
 
+  const subGroupingSetting = settings["treemap.sub_grouping"];
+  if (subGroupingSetting != null) {
+    const subGrouping = getColumnDescriptors([subGroupingSetting], columns)[0];
+    if (subGrouping?.column) {
+      return { grouping, subGrouping, value };
+    }
+  }
+
   return { grouping, value };
 }
 
@@ -41,27 +50,81 @@ export function getTreemapData(
       data: { rows },
     },
   ] = rawSeries;
-  const { grouping, value } = treemapColumns;
+  const { grouping, subGrouping, value } = treemapColumns;
 
-  const nodeByKey = new Map<RowValue, TreemapNode>();
+  if (subGrouping == null) {
+    const nodeByKey = new Map<RowValue, TreemapNode>();
+
+    rows.forEach((row, rowIndex) => {
+      const groupingValue = row[grouping.index];
+      const metricValue = row[value.index];
+
+      const existing = nodeByKey.get(groupingValue);
+      if (existing) {
+        existing.value =
+          sumMetric(existing.value, metricValue) ?? existing.value;
+        existing.rowIndices.push(rowIndex);
+      } else {
+        nodeByKey.set(groupingValue, {
+          rawName: groupingValue,
+          displayName: String(groupingValue ?? ""),
+          value: sumMetric(0, metricValue) ?? 0,
+          rowIndices: [rowIndex],
+        });
+      }
+    });
+
+    return Array.from(nodeByKey.values());
+  }
+
+  type RootEntry = {
+    node: TreemapNode;
+    leafByKey: Map<RowValue, TreemapNode>;
+  };
+  const rootByKey = new Map<RowValue, RootEntry>();
 
   rows.forEach((row, rowIndex) => {
     const groupingValue = row[grouping.index];
+    const subGroupingValue = row[subGrouping.index];
     const metricValue = row[value.index];
 
-    const existing = nodeByKey.get(groupingValue);
-    if (existing) {
-      existing.value = sumMetric(existing.value, metricValue) ?? existing.value;
-      existing.rowIndices.push(rowIndex);
-    } else {
-      nodeByKey.set(groupingValue, {
+    let rootEntry = rootByKey.get(groupingValue);
+    if (!rootEntry) {
+      const rootNode: TreemapNode = {
         rawName: groupingValue,
         displayName: String(groupingValue ?? ""),
+        value: 0,
+        rowIndices: [],
+        children: [],
+      };
+      rootEntry = { node: rootNode, leafByKey: new Map() };
+      rootByKey.set(groupingValue, rootEntry);
+    }
+
+    const { node: rootNode, leafByKey } = rootEntry;
+
+    const existingLeaf = leafByKey.get(subGroupingValue);
+    if (existingLeaf) {
+      existingLeaf.value =
+        sumMetric(existingLeaf.value, metricValue) ?? existingLeaf.value;
+      existingLeaf.rowIndices.push(rowIndex);
+    } else {
+      const newLeaf: TreemapNode = {
+        rawName: subGroupingValue,
+        displayName:
+          subGroupingValue == null
+            ? NULL_DISPLAY_VALUE
+            : String(subGroupingValue),
         value: sumMetric(0, metricValue) ?? 0,
         rowIndices: [rowIndex],
-      });
+      };
+      leafByKey.set(subGroupingValue, newLeaf);
+      rootNode.children?.push(newLeaf);
     }
+
+    rootNode.value = sumMetric(rootNode.value, metricValue) ?? rootNode.value;
+    rootNode.rowIndices.push(rowIndex);
   });
 
-  return Array.from(nodeByKey.values());
+  return Array.from(rootByKey.values()).map((entry) => entry.node);
 }

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
@@ -52,79 +52,74 @@ export function getTreemapData(
   ] = rawSeries;
   const { grouping, subGrouping, value } = treemapColumns;
 
-  if (subGrouping == null) {
-    const nodeByKey = new Map<RowValue, TreemapNode>();
-
-    rows.forEach((row, rowIndex) => {
-      const groupingValue = row[grouping.index];
-      const metricValue = row[value.index];
-
-      const existing = nodeByKey.get(groupingValue);
-      if (existing) {
-        existing.value =
-          sumMetric(existing.value, metricValue) ?? existing.value;
-        existing.rowIndices.push(rowIndex);
-      } else {
-        nodeByKey.set(groupingValue, {
-          rawName: groupingValue,
-          displayName: String(groupingValue ?? ""),
-          value: sumMetric(0, metricValue) ?? 0,
-          rowIndices: [rowIndex],
-        });
-      }
-    });
-
-    return Array.from(nodeByKey.values());
-  }
-
-  type RootEntry = {
-    node: TreemapNode;
-    leafByKey: Map<RowValue, TreemapNode>;
-  };
-  const rootByKey = new Map<RowValue, RootEntry>();
+  const rootByKey = new Map<RowValue, TreemapNode>();
+  const leafMapByRoot = new Map<TreemapNode, Map<RowValue, TreemapNode>>();
 
   rows.forEach((row, rowIndex) => {
     const groupingValue = row[grouping.index];
-    const subGroupingValue = row[subGrouping.index];
     const metricValue = row[value.index];
 
-    let rootEntry = rootByKey.get(groupingValue);
-    if (!rootEntry) {
-      const rootNode: TreemapNode = {
-        rawName: groupingValue,
-        displayName: String(groupingValue ?? ""),
-        value: 0,
-        rowIndices: [],
-        children: [],
-      };
-      rootEntry = { node: rootNode, leafByKey: new Map() };
-      rootByKey.set(groupingValue, rootEntry);
+    const { node: rootNode } = getOrCreateNode(
+      rootByKey,
+      groupingValue,
+      String(groupingValue ?? ""),
+      subGrouping != null,
+    );
+    addRowMetric(rootNode, metricValue, rowIndex);
+
+    if (subGrouping == null) {
+      return;
     }
 
-    const { node: rootNode, leafByKey } = rootEntry;
-
-    const existingLeaf = leafByKey.get(subGroupingValue);
-    if (existingLeaf) {
-      existingLeaf.value =
-        sumMetric(existingLeaf.value, metricValue) ?? existingLeaf.value;
-      existingLeaf.rowIndices.push(rowIndex);
-    } else {
-      const newLeaf: TreemapNode = {
-        rawName: subGroupingValue,
-        displayName:
-          subGroupingValue == null
-            ? NULL_DISPLAY_VALUE
-            : String(subGroupingValue),
-        value: sumMetric(0, metricValue) ?? 0,
-        rowIndices: [rowIndex],
-      };
-      leafByKey.set(subGroupingValue, newLeaf);
-      rootNode.children?.push(newLeaf);
+    const subGroupingValue = row[subGrouping.index];
+    let leafMap = leafMapByRoot.get(rootNode);
+    if (leafMap == null) {
+      leafMap = new Map();
+      leafMapByRoot.set(rootNode, leafMap);
     }
-
-    rootNode.value = sumMetric(rootNode.value, metricValue) ?? rootNode.value;
-    rootNode.rowIndices.push(rowIndex);
+    const { node: leaf, wasCreated } = getOrCreateNode(
+      leafMap,
+      subGroupingValue,
+      subGroupingValue == null
+        ? NULL_DISPLAY_VALUE
+        : String(subGroupingValue),
+      false,
+    );
+    addRowMetric(leaf, metricValue, rowIndex);
+    if (wasCreated) {
+      rootNode.children?.push(leaf);
+    }
   });
 
-  return Array.from(rootByKey.values()).map((entry) => entry.node);
+  return Array.from(rootByKey.values());
+}
+
+function getOrCreateNode(
+  map: Map<RowValue, TreemapNode>,
+  rawName: RowValue,
+  displayName: string,
+  withChildren: boolean,
+): { node: TreemapNode; wasCreated: boolean } {
+  const existing = map.get(rawName);
+  if (existing != null) {
+    return { node: existing, wasCreated: false };
+  }
+  const node: TreemapNode = {
+    rawName,
+    displayName,
+    value: 0,
+    rowIndices: [],
+    ...(withChildren ? { children: [] } : {}),
+  };
+  map.set(rawName, node);
+  return { node, wasCreated: true };
+}
+
+function addRowMetric(
+  node: TreemapNode,
+  metricValue: RowValue,
+  rowIndex: number,
+): void {
+  node.value = sumMetric(node.value, metricValue) ?? node.value;
+  node.rowIndices.push(rowIndex);
 }

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
@@ -1,3 +1,4 @@
+import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import type { DatasetColumn, RowValue } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks/card";
 import {
@@ -22,9 +23,34 @@ const columns: DatasetColumn[] = [
   }),
 ];
 
+const columnsWithSub: DatasetColumn[] = [
+  createMockColumn({
+    name: "Category",
+    display_name: "Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "SubCategory",
+    display_name: "Sub-Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "Amount",
+    display_name: "Amount",
+    base_type: "type/Number",
+    semantic_type: "type/Number",
+  }),
+];
+
 const treemapColumns: TreemapChartColumns = {
   grouping: { index: 0, column: columns[0] },
   value: { index: 1, column: columns[1] },
+};
+
+const treemapColumnsWithSub: TreemapChartColumns = {
+  grouping: { index: 0, column: columnsWithSub[0] },
+  subGrouping: { index: 1, column: columnsWithSub[1] },
+  value: { index: 2, column: columnsWithSub[2] },
 };
 
 describe("getTreemapChartColumns", () => {
@@ -59,6 +85,41 @@ describe("getTreemapChartColumns", () => {
       grouping: expect.objectContaining({ index: 0 }),
       value: expect.objectContaining({ index: 1 }),
     });
+  });
+
+  it("returns a subGrouping descriptor when treemap.sub_grouping is set", () => {
+    const result = getTreemapChartColumns(columnsWithSub, {
+      "treemap.grouping": "Category",
+      "treemap.sub_grouping": "SubCategory",
+      "treemap.value": "Amount",
+    });
+
+    expect(result).toEqual({
+      grouping: expect.objectContaining({ index: 0 }),
+      subGrouping: expect.objectContaining({ index: 1 }),
+      value: expect.objectContaining({ index: 2 }),
+    });
+  });
+
+  it("omits subGrouping when treemap.sub_grouping is unset", () => {
+    const result = getTreemapChartColumns(columnsWithSub, {
+      "treemap.grouping": "Category",
+      "treemap.value": "Amount",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("subGrouping");
+  });
+
+  it("silently falls back to 1-level when treemap.sub_grouping references a missing column", () => {
+    const result = getTreemapChartColumns(columnsWithSub, {
+      "treemap.grouping": "Category",
+      "treemap.sub_grouping": "DoesNotExist",
+      "treemap.value": "Amount",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("subGrouping");
   });
 });
 
@@ -163,5 +224,185 @@ describe("getTreemapData (1-level)", () => {
       displayName: "",
       value: 7,
     });
+  });
+});
+
+describe("getTreemapData (2-level)", () => {
+  function makeRawSeries(rows: RowValue[][]) {
+    return [
+      {
+        card: createMockCard({ name: "Treemap card" }),
+        data: createMockDatasetData({ rows, cols: columnsWithSub }),
+      },
+    ];
+  }
+
+  it("returns an empty tree for an empty rowset", () => {
+    expect(getTreemapData(makeRawSeries([]), treemapColumnsWithSub)).toEqual(
+      [],
+    );
+  });
+
+  it("builds one leaf per (grouping, sub-grouping) pair under each root", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", "x", 10],
+        ["A", "y", 5],
+        ["B", "x", 20],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result).toEqual([
+      {
+        rawName: "A",
+        displayName: "A",
+        value: 15,
+        rowIndices: [0, 1],
+        children: [
+          {
+            rawName: "x",
+            displayName: "x",
+            value: 10,
+            rowIndices: [0],
+          },
+          {
+            rawName: "y",
+            displayName: "y",
+            value: 5,
+            rowIndices: [1],
+          },
+        ],
+      },
+      {
+        rawName: "B",
+        displayName: "B",
+        value: 20,
+        rowIndices: [2],
+        children: [
+          {
+            rawName: "x",
+            displayName: "x",
+            value: 20,
+            rowIndices: [2],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("sets root value as the sum of its children's values", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", "x", 3],
+        ["A", "y", 4],
+        ["A", "z", 5],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(12);
+    expect(result[0].children?.map((c) => c.value)).toEqual([3, 4, 5]);
+  });
+
+  it("sums duplicate (grouping, sub-grouping) pairs into a single leaf", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", "x", 10],
+        ["A", "x", 3],
+        ["A", "y", 2],
+        ["A", "x", 1],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(16);
+    expect(result[0].children).toEqual([
+      {
+        rawName: "x",
+        displayName: "x",
+        value: 14,
+        rowIndices: [0, 1, 3],
+      },
+      {
+        rawName: "y",
+        displayName: "y",
+        value: 2,
+        rowIndices: [2],
+      },
+    ]);
+  });
+
+  it("renders null sub-grouping as a leaf using the standard null display value", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", "x", 10],
+        ["A", null, 4],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toEqual([
+      {
+        rawName: "x",
+        displayName: "x",
+        value: 10,
+        rowIndices: [0],
+      },
+      {
+        rawName: null,
+        displayName: NULL_DISPLAY_VALUE,
+        value: 4,
+        rowIndices: [1],
+      },
+    ]);
+  });
+
+  it("aggregates duplicate null sub-grouping rows into a single (null) leaf", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", null, 4],
+        ["A", "x", 10],
+        ["A", null, 6],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(20);
+    expect(result[0].children).toEqual([
+      {
+        rawName: null,
+        displayName: NULL_DISPLAY_VALUE,
+        value: 10,
+        rowIndices: [0, 2],
+      },
+      {
+        rawName: "x",
+        displayName: "x",
+        value: 10,
+        rowIndices: [1],
+      },
+    ]);
+  });
+
+  it("accumulates rowIndices on the root across all of its leaves", () => {
+    const result = getTreemapData(
+      makeRawSeries([
+        ["A", "x", 10],
+        ["B", "x", 1],
+        ["A", "y", 4],
+        ["A", "x", 2],
+      ]),
+      treemapColumnsWithSub,
+    );
+
+    expect(result.find((n) => n.rawName === "A")?.rowIndices).toEqual([
+      0, 2, 3,
+    ]);
+    expect(result.find((n) => n.rawName === "B")?.rowIndices).toEqual([1]);
   });
 });

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/option/option.ts
@@ -15,12 +15,24 @@ type TreemapChartSeriesOption = TreemapSeriesOption & {
   data: TreemapSeriesNode[];
 };
 
+const TWO_LEVEL_LEVELS: TreemapSeriesOption["levels"] = [
+  {
+    itemStyle: { borderWidth: 0, gapWidth: 2 },
+  },
+  {
+    itemStyle: { borderWidth: 1, gapWidth: 1 },
+  },
+];
+
 export function getTreemapChartOption(tree: TreemapTree): {
   series: TreemapChartSeriesOption;
 } {
+  const hasChildren = tree.some((node) => node.children != null);
+
   const series: TreemapChartSeriesOption = {
     type: "treemap",
     data: toSeriesData(tree),
+    ...(hasChildren ? { levels: TWO_LEVEL_LEVELS } : {}),
   };
 
   return { series };

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
@@ -25,6 +25,39 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     persistDefault: true,
     dashboard: false,
     autoOpenWhenUnset: false,
+    getDefault: ([{ data }]) => {
+      const firstDimension = data.cols.find(
+        (col) => isDimension(col) && !isMetric(col),
+      );
+      return firstDimension?.name;
+    },
+  }),
+  ...dimensionSetting("treemap.sub_grouping", {
+    getSection: () => t`Data`,
+    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+    title: t`Sub-grouping`,
+    showColumnSetting: true,
+    dashboard: false,
+    autoOpenWhenUnset: false,
+    getDefault: ([{ data }], vizSettings) => {
+      const grouping = vizSettings["treemap.grouping"];
+      const value = vizSettings["treemap.value"];
+      const secondDimension = data.cols.find(
+        (col) =>
+          isDimension(col) && col.name !== grouping && col.name !== value,
+      );
+      return secondDimension?.name;
+    },
+    getProps: ([{ data }], vizSettings, onChange) => ({
+      options: data.cols
+        .filter(isDimension)
+        .map((col) => ({ name: col.display_name, value: col.name })),
+      columns: data.cols,
+      onRemove: vizSettings["treemap.sub_grouping"]
+        ? () => onChange(null as never)
+        : null,
+    }),
+    readDependencies: ["treemap.grouping", "treemap.value"],
   }),
   ...metricSetting("treemap.value", {
     getSection: () => t`Data`,
@@ -34,6 +67,14 @@ export const SETTINGS_DEFINITIONS: VisualizationSettingsDefinitions = {
     persistDefault: true,
     dashboard: false,
     autoOpenWhenUnset: false,
+    getDefault: ([{ data }], vizSettings) => {
+      const grouping = vizSettings["treemap.grouping"];
+      const firstMetric = data.cols.find(
+        (col) => isMetric(col) && col.name !== grouping,
+      );
+      return firstMetric?.name;
+    },
+    readDependencies: ["treemap.grouping"],
   }),
 };
 

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.unit.spec.ts
@@ -24,6 +24,25 @@ const columns = [
   }),
 ];
 
+const columnsWithSub = [
+  createMockColumn({
+    name: "Category",
+    display_name: "Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "SubCategory",
+    display_name: "Sub-Category",
+    base_type: "type/Text",
+  }),
+  createMockColumn({
+    name: "Amount",
+    display_name: "Amount",
+    base_type: "type/Number",
+    semantic_type: "type/Number",
+  }),
+];
+
 describe("TREEMAP_CHART_DEFINITION", () => {
   describe("isSensible", () => {
     it("returns true with at least one dimension, one metric, and one row", () => {
@@ -40,6 +59,17 @@ describe("TREEMAP_CHART_DEFINITION", () => {
     it("returns false when there are no rows", () => {
       const data = createMockDatasetData({ rows: [], cols: columns });
       expect(isSensible(data)).toBe(false);
+    });
+
+    it("returns true with two dimensions, one metric, and one row", () => {
+      const data = createMockDatasetData({
+        rows: [
+          ["A", "x", 10],
+          ["B", "y", 20],
+        ],
+        cols: columnsWithSub,
+      });
+      expect(isSensible(data)).toBe(true);
     });
 
     it("returns false when there are no metric columns", () => {
@@ -121,6 +151,249 @@ describe("TREEMAP_CHART_DEFINITION", () => {
       expect(() =>
         TREEMAP_CHART_DEFINITION.checkRenderable(validRawSeries, settings),
       ).toThrow(ChartSettingsError);
+    });
+
+    it("does not throw for valid 2-dim data when sub_grouping setting is set", () => {
+      const twoDimRawSeries = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [
+              ["A", "x", 10],
+              ["B", "y", 20],
+            ],
+            cols: columnsWithSub,
+          }),
+        },
+      ];
+      const settings = {
+        "treemap.grouping": "Category",
+        "treemap.sub_grouping": "SubCategory",
+        "treemap.value": "Amount",
+      };
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(twoDimRawSeries, settings),
+      ).not.toThrow();
+    });
+
+    it("does not throw when sub_grouping setting points to a missing column (silent fallback to 1-level)", () => {
+      const settings = {
+        "treemap.grouping": "Category",
+        "treemap.sub_grouping": "DoesNotExist",
+        "treemap.value": "Amount",
+      };
+      expect(() =>
+        TREEMAP_CHART_DEFINITION.checkRenderable(validRawSeries, settings),
+      ).not.toThrow();
+    });
+  });
+
+  describe("treemap.grouping setting", () => {
+    const groupingSetting = checkNotNull(
+      TREEMAP_CHART_DEFINITION.settings?.["treemap.grouping"],
+    );
+
+    it("defaults to the first non-metric dimension in a 1-dim + 1-metric query", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", 10]],
+            cols: columns,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(groupingSetting.getDefault);
+      const result = getDefault(series, {});
+      expect(result).toBe("Category");
+    });
+
+    it("defaults to the first non-metric dimension in a 2-dim + 1-metric query", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", "x", 10]],
+            cols: columnsWithSub,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(groupingSetting.getDefault);
+      const result = getDefault(series, {});
+      expect(result).toBe("Category");
+    });
+
+    it("defaults to undefined when every column is a metric", () => {
+      const allMetricCols = [
+        createMockColumn({
+          name: "MetricA",
+          display_name: "Metric A",
+          base_type: "type/Number",
+          semantic_type: "type/Number",
+        }),
+        createMockColumn({
+          name: "MetricB",
+          display_name: "Metric B",
+          base_type: "type/Number",
+          semantic_type: "type/Number",
+        }),
+      ];
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [[1, 10]],
+            cols: allMetricCols,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(groupingSetting.getDefault);
+      const result = getDefault(series, {});
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("treemap.value setting", () => {
+    const valueSetting = checkNotNull(
+      TREEMAP_CHART_DEFINITION.settings?.["treemap.value"],
+    );
+
+    it("defaults to the first metric column in a 1-dim + 1-metric query", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", 10]],
+            cols: columns,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(valueSetting.getDefault);
+      const result = getDefault(series, {});
+      expect(result).toBe("Amount");
+    });
+
+    it("defaults to the metric column in a 2-dim + 1-metric query", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", "x", 10]],
+            cols: columnsWithSub,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(valueSetting.getDefault);
+      const result = getDefault(series, {
+        "treemap.grouping": "Category",
+      });
+      expect(result).toBe("Amount");
+    });
+
+    it("skips a metric column that is already selected as grouping", () => {
+      const numericGroupingCols = [
+        createMockColumn({
+          name: "Id",
+          display_name: "Id",
+          base_type: "type/Integer",
+          semantic_type: "type/Number",
+        }),
+        createMockColumn({
+          name: "Amount",
+          display_name: "Amount",
+          base_type: "type/Number",
+          semantic_type: "type/Number",
+        }),
+      ];
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [[1, 10]],
+            cols: numericGroupingCols,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(valueSetting.getDefault);
+      const result = getDefault(series, {
+        "treemap.grouping": "Id",
+      });
+      expect(result).toBe("Amount");
+    });
+
+    it("defaults to undefined when there are no metric columns", () => {
+      const noMetricCols = [
+        createMockColumn({
+          name: "Category",
+          display_name: "Category",
+          base_type: "type/Text",
+        }),
+        createMockColumn({
+          name: "Other",
+          display_name: "Other",
+          base_type: "type/Text",
+        }),
+      ];
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", "X"]],
+            cols: noMetricCols,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(valueSetting.getDefault);
+      const result = getDefault(series, {
+        "treemap.grouping": "Category",
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("treemap.sub_grouping setting", () => {
+    const subGroupingSetting = checkNotNull(
+      TREEMAP_CHART_DEFINITION.settings?.["treemap.sub_grouping"],
+    );
+
+    it("uses the field widget", () => {
+      expect(subGroupingSetting.widget).toBe("field");
+    });
+
+    it("defaults to the second dimension when the data has two dimensions", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", "x", 10]],
+            cols: columnsWithSub,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(subGroupingSetting.getDefault);
+      const result = getDefault(series, {
+        "treemap.grouping": "Category",
+        "treemap.value": "Amount",
+      });
+      expect(result).toBe("SubCategory");
+    });
+
+    it("defaults to undefined when the data has only one dimension (numeric value column is excluded)", () => {
+      const series = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows: [["A", 10]],
+            cols: columns,
+          }),
+        },
+      ];
+      const getDefault = checkNotNull(subGroupingSetting.getDefault);
+      const result = getDefault(series, {
+        "treemap.grouping": "Category",
+        "treemap.value": "Amount",
+      });
+      expect(result).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2505/support-two-levels-of-data

### Description

add support for subgrouping

### How to verify

### Demo

<img width="4586" height="2522" alt="image" src="https://github.com/user-attachments/assets/6a0fe622-b0bc-4e0a-a5e4-dbc647ec80e4" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
