### PR TITLE
Fix Field Filter when there are no search results

### DIFF
--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -89,6 +89,8 @@ export const DataSelectorFieldPicker = ({
           maxHeight={Infinity}
           width="100%"
           searchable={hasFiltering}
+          // keep the search box + "no results" state visible when a search matches no fields
+          globalSearch={hasFiltering}
           onChange={(item: { field: Field }) => onChangeField(item.field)}
           itemIsSelected={checkIfItemIsSelected}
           itemIsClickable={(item: FieldWithName) => Boolean(item.field)}

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
@@ -73,5 +73,29 @@ describe("DataSelectorFieldPicker", () => {
       expect(screen.getByText("Product ID")).toBeInTheDocument();
       expect(screen.getByLabelText("More info")).toBeInTheDocument();
     });
+
+    it("keeps the search box visible and shows an empty state when no field matches the search (metabase#74670)", () => {
+      render(
+        <DataSelectorFieldPicker
+          {...props}
+          selectedTable={{ display_name: "Orders" } as Table}
+          fields={[
+            checkNotNull(metadata.field(ORDERS.ID)),
+            checkNotNull(metadata.field(ORDERS.TOTAL)),
+          ]}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("Find..."), {
+        target: { value: "xyznonexistent" },
+      });
+
+      // the search box must stay visible so the user can correct the query
+      expect(screen.getByPlaceholderText("Find...")).toBeInTheDocument();
+      // and an empty state should explain why no fields are shown
+      expect(screen.getByText("Didn't find any results")).toBeInTheDocument();
+      expect(screen.queryByText("ID")).not.toBeInTheDocument();
+      expect(screen.queryByText("Total")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
### Description

Small adjustment to `DataSelectorFieldPicker` to set the `<AccordianList>` component to have `gloablSearch` enabled when apropriate. This mirrors the fix for `<ParameterTargetList>` in [this PR](https://github.com/metabase/metabase/pull/60990/changes#diff-a03a1bb2cca146936ba708aff67fb7a4afd140463b182584f28dc01909a51a20R62).

It's worth pointing out that the AccordianList component does have a real bug. Without `gloablSearch` enabled, the search field is pushed into the individual sections. But if the search yeilds no results, then we exclude the section from rendering, which causes this issue.

### How to verify

1. Start a new SQL question and set up a parameter. eg: `Select * from {{foo}}`
2. Set the parameter type to Field Filter
3. In the `Field to Map` section, select a table and search for a field that doens't exist. You should see a no-results rendered

### Demo

<img width="362" height="681" alt="image" src="https://github.com/user-attachments/assets/76154fc5-cf33-42c1-b6e3-bea782e8ebd6" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
