### PR TITLE
Fix hide when no values for pivot table dashcards

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -614,6 +614,74 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText("3,798"); // subtotal value
     });
+
+    it("should show no-results then hide an empty pivot dashcard (UXW-4145)", () => {
+      const FILTER_ID = "d7988e02";
+
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: QUESTION_NAME,
+          query: testQuery.query,
+          display: "pivot",
+        },
+        dashboardDetails: {
+          name: DASHBOARD_NAME,
+        },
+        cardDetails: {
+          size_x: 16,
+          size_y: 8,
+        },
+      }).then(({ body: { id, card_id, dashboard_id } }) => {
+        cy.log(
+          "Add an ID filter to the dashboard and map it to the pivot card",
+        );
+        cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+          parameters: [{ id: FILTER_ID, name: "ID", slug: "id", type: "id" }],
+          dashcards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              size_x: 16,
+              size_y: 8,
+              parameter_mappings: [
+                {
+                  parameter_id: FILTER_ID,
+                  card_id,
+                  target: ["dimension", ["field", ORDERS.ID]],
+                },
+              ],
+            },
+          ],
+        });
+        H.visitDashboard(dashboard_id);
+      });
+
+      cy.log("Filtering to a value with no rows shows the no-results state");
+      H.filterWidget().click();
+      H.dashboardParametersPopover().within(() => {
+        cy.findByPlaceholderText("Enter an ID").type("-1{enter}");
+        cy.button("Add filter").click();
+      });
+      // Pre-fix this rendered a blank pivot; the grand-total row hid the emptiness.
+      H.getDashboardCard(0).findByText("No results!").should("be.visible");
+
+      cy.log("Enabling 'hide if empty' removes the now-empty card");
+      H.editDashboard();
+      cy.findByTestId("dashboardcard-actions-panel").within(() => {
+        cy.icon("palette").click({ force: true });
+      });
+      cy.findByRole("dialog").within(() => {
+        cy.findByLabelText("Hide this card if there are no results").click({
+          force: true,
+        });
+        cy.button("Done").click();
+      });
+      H.saveDashboard();
+
+      cy.findByTestId("dashcard").should("not.exist");
+    });
   });
 
   describe("sharing (metabase#14447)", () => {

--- a/frontend/src/metabase-lib/v1/queries/utils/dataset.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/dataset.ts
@@ -2,7 +2,7 @@ import type { DatasetData, TableColumnOrderSetting } from "metabase-types/api";
 
 import type { DatasetColumnReference } from "./column-key";
 
-export const datasetContainsNoResults = (data: DatasetData) =>
+export const datasetContainsNoResults = (data: Pick<DatasetData, "rows">) =>
   data.rows == null || data.rows.length === 0;
 
 export function findColumnIndexesForColumnSettings(

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -15,6 +15,7 @@ import {
   getGenericErrorMessage,
   getPermissionErrorMessage,
 } from "metabase/visualizations/lib/errors";
+import { hasNoResults } from "metabase/visualizations/lib/no-results";
 import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import Question from "metabase-lib/v1/Question";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -324,8 +325,7 @@ const hasRows = (dashcardData: Record<CardId, Dataset | EmbedDataset>) => {
   return (
     queryResults.length > 0 &&
     queryResults.every(
-      (queryResult) =>
-        "data" in queryResult && queryResult.data.rows.length > 0,
+      (queryResult) => "data" in queryResult && !hasNoResults(queryResult.data),
     )
   );
 };

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -22,6 +22,7 @@ import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";
 import type { ParameterValueOrArray } from "metabase-types/api";
 import {
   createMockActionDashboardCard,
+  createMockColumn,
   createMockDashboard,
   createMockDashboardCard,
   createMockDatabase,
@@ -426,6 +427,32 @@ describe("Dashboard utils", () => {
           hidingWhenEmptyCardId,
           visualizerCardId,
         ]),
+      );
+    });
+
+    // A pivot query with no matching data still returns a single grand-total
+    // row, so "hide when empty" pivot cards must be hidden based on detail rows
+    // (pivot-grouping === 0), not raw row count. (metabase#74387)
+    it("hides a hide-when-empty pivot card whose only row is the grand total", () => {
+      const pivotTotalsOnlyData = createMockDatasetData({
+        cols: [
+          createMockColumn({ name: "CATEGORY", source: "breakout" }),
+          createMockColumn({ name: "VENDOR", source: "breakout" }),
+          createMockColumn({ name: "pivot-grouping", source: "breakout" }),
+          createMockColumn({ name: "max", source: "aggregation" }),
+        ],
+        rows: [[null, null, 3, null]],
+      });
+      const loadedWithPivotTotalsOnly = {
+        ...loadedWithData,
+        [hidingWhenEmptyCardId]: {
+          200: createMockDataset({ data: pivotTotalsOnlyData }),
+        },
+      };
+
+      const visibleIds = getVisibleCardIds(cards, loadedWithPivotTotalsOnly);
+      expect(visibleIds).toStrictEqual(
+        new Set([virtualCardId, normalCardId, visualizerCardId]),
       );
     });
   });

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -45,6 +45,7 @@ import {
   ChartSettingsError,
   MinRowsError,
 } from "metabase/visualizations/lib/errors";
+import { hasNoResults } from "metabase/visualizations/lib/no-results";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { getCardKey, isSameSeries } from "metabase/visualizations/lib/utils";
 import {
@@ -67,7 +68,6 @@ import {
 } from "metabase/visualizer/utils";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import { datasetContainsNoResults } from "metabase-lib/v1/queries/utils/dataset";
 import type {
   Card,
   CardId,
@@ -798,10 +798,7 @@ class Visualization extends PureComponent<
     }
 
     if (!error && !genericError && series) {
-      noResults = _.every(
-        series,
-        (s) => s && s.data && datasetContainsNoResults(s.data),
-      );
+      noResults = _.every(series, (s) => s && s.data && hasNoResults(s.data));
     }
 
     const extra = (

--- a/frontend/src/metabase/visualizations/lib/data_grid.js
+++ b/frontend/src/metabase/visualizations/lib/data_grid.js
@@ -6,7 +6,7 @@ import { makeCellBackgroundGetter } from "metabase/visualizations/lib/table_form
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
 
 export function isPivotGroupColumn(col) {
-  return col.name === "pivot-grouping";
+  return col?.name === "pivot-grouping";
 }
 
 export const COLUMN_FORMATTING_SETTING = "table.column_formatting";

--- a/frontend/src/metabase/visualizations/lib/no-results.ts
+++ b/frontend/src/metabase/visualizations/lib/no-results.ts
@@ -1,0 +1,24 @@
+import { isPivotGroupColumn } from "metabase/visualizations/lib/data_grid";
+import { datasetContainsNoResults } from "metabase-lib/v1/queries/utils/dataset";
+import type { DatasetData } from "metabase-types/api";
+
+/**
+ * Pivot-aware datasetContainsNoResults: a pivot always returns a grand-total row
+ * via GROUPING SETS, so it has no results only when no row is a detail row.
+ */
+export function hasNoResults(
+  data: Pick<DatasetData, "rows" | "cols">,
+): boolean {
+  if (datasetContainsNoResults(data)) {
+    return true;
+  }
+
+  const pivotGroupingIndex = data.cols.findIndex(isPivotGroupColumn);
+  if (pivotGroupingIndex === -1) {
+    return false;
+  }
+
+  // Detail rows (real data, not subtotals/totals) have a pivot-grouping of 0;
+  // Number() so a string-typed value from some drivers still compares.
+  return !data.rows.some((row) => Number(row[pivotGroupingIndex]) === 0);
+}

--- a/frontend/src/metabase/visualizations/lib/no-results.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/no-results.unit.spec.ts
@@ -1,0 +1,66 @@
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { hasNoResults } from "./no-results";
+
+const pivotCols = [
+  createMockColumn({ name: "CATEGORY", source: "breakout" }),
+  createMockColumn({ name: "VENDOR", source: "breakout" }),
+  createMockColumn({ name: "pivot-grouping", source: "breakout" }),
+  createMockColumn({ name: "max", source: "aggregation" }),
+];
+
+describe("hasNoResults", () => {
+  it("returns true when there are no rows", () => {
+    expect(hasNoResults(createMockDatasetData({ rows: [] }))).toBe(true);
+  });
+
+  it("returns false for a non-pivot dataset with rows", () => {
+    expect(
+      hasNoResults(
+        createMockDatasetData({
+          rows: [[1]],
+          cols: [createMockColumn({ name: "count" })],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for a pivot whose only row is a grand total", () => {
+    expect(
+      hasNoResults(
+        createMockDatasetData({
+          rows: [[null, null, 3, null]],
+          cols: pivotCols,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for a pivot that has a detail row (grouping 0)", () => {
+    expect(
+      hasNoResults(
+        createMockDatasetData({
+          rows: [
+            [null, null, 3, 42],
+            ["Widget", "ACME", 0, 42],
+          ],
+          cols: pivotCols,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a string-typed grouping value as a number", () => {
+    expect(
+      hasNoResults(
+        createMockDatasetData({
+          rows: [["Widget", "ACME", "0", 42]],
+          cols: pivotCols,
+        }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74387
### Description

Creates a new `hasNoResults` util function that is a combination of `datasetContainsNoResults` while also being "Pivot Aware". This then gets used in Visualization.tsx (to show an empty state in dashboards), and in `hasRows` in `dashboard/utils.ts` to effectively hide the pivot table when the setting is true.

### How to verify

1. Add a pivot table to a dashboard and hook up a filter to it
2. Set the filter so that the pivot table will have no rows returned
3. You should see a "No Results" displayed
4. Open "Visualization Options" and check "Hide this card if there are no results"
5. Now, when the filter is applied, the card should disappear 
 
### Demo


https://github.com/user-attachments/assets/39b7e597-4629-4043-b7cb-0e1b35f7c6ba



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
