### PR TITLE
backported "Uxw 3359 visualizer breaks internal dimension remapping for integer"

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
@@ -181,6 +181,11 @@ export const ColumnsList = (props: ColumnListProps) => {
                     return null;
                   }
 
+                  // Hide remapped display columns; extractRemappedColumns pairs them at render time.
+                  if (column.remapped_from != null) {
+                    return null;
+                  }
+
                   const columnReference = referencedColumns.find((ref) =>
                     isReferenceToColumn(column, source.id, ref),
                   );

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/HorizontalWell/CartesianHorizontallWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/HorizontalWell/CartesianHorizontallWell.tsx
@@ -16,7 +16,7 @@ import {
   getVisualizerRawSettings,
 } from "metabase/visualizer/selectors";
 import { removeColumn } from "metabase/visualizer/visualizer.slice";
-import { isDate, isString } from "metabase-lib/v1/types/utils/isa";
+import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type { DatasetColumn } from "metabase-types/api";
 
 import { WellItem } from "../WellItem";
@@ -49,15 +49,15 @@ export function CartesianHorizontalWell({ style, ...props }: FlexProps) {
 
     const dimensions: DatasetColumn[] = [];
     const timeDimensions = allDimensions.filter(isDate);
-    const categoryDimensions = allDimensions.filter(isString);
+    // Non-temporal = category-like (string, integer-Category, binned numeric, etc.).
+    const categoryDimensions = allDimensions.filter((col) => !isDate(col));
 
-    // Show only one dimension for multiseries charts,
-    // as they have to be added/removed together, not individually
+    // Only one temporal x-axis is allowed; category dims can span multiple per-series slots.
     if (timeDimensions.length > 0) {
       dimensions.push(timeDimensions[0]);
     }
     if (categoryDimensions.length > 0) {
-      dimensions.push(...categoryDimensions); //.push(categoryDimensions[0]);
+      dimensions.push(...categoryDimensions);
     }
 
     return dimensions;

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -85,6 +85,30 @@ export function copyColumn(
   return copy;
 }
 
+// Point remapped_from/to at the renamed COLUMN_N so extractRemappedColumns can pair them.
+export function rewriteRemappedReferences(
+  column: DatasetColumn,
+  oldToNew: Map<string, string>,
+): DatasetColumn {
+  const remapped_from =
+    column.remapped_from != null
+      ? oldToNew.get(column.remapped_from)
+      : column.remapped_from;
+  const remapped_to =
+    column.remapped_to != null
+      ? oldToNew.get(column.remapped_to)
+      : column.remapped_to;
+
+  if (
+    remapped_from === column.remapped_from &&
+    remapped_to === column.remapped_to
+  ) {
+    return column;
+  }
+
+  return { ...column, remapped_from, remapped_to };
+}
+
 export function addColumnMapping(
   mapping: VisualizerColumnValueSource[] | undefined,
   source: VisualizerColumnValueSource,

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -27,6 +27,7 @@ import {
   copyColumn,
   createVisualizerColumnReference,
   extractReferencedColumns,
+  rewriteRemappedReferences,
 } from "./column";
 import {
   DEFAULT_VISUALIZER_DISPLAY,
@@ -87,13 +88,16 @@ function pickColumns(
       getColumnNameFromKey,
     );
 
-    return originalColumns.filter((col) => {
-      return (
-        settings["graph.metrics"]?.includes(col.name) ||
-        settings["graph.dimensions"]?.includes(col.name) ||
-        tooltipColumns.includes(col.name)
-      );
-    });
+    const isSelected = (name?: string) =>
+      name != null &&
+      (settings["graph.metrics"]?.includes(name) ||
+        settings["graph.dimensions"]?.includes(name) ||
+        tooltipColumns.includes(name));
+
+    // Keep the display-value column paired with any selected dim.
+    return originalColumns.filter(
+      (col) => isSelected(col.name) || isSelected(col.remapped_from),
+    );
   }
 
   return originalColumns;
@@ -179,6 +183,11 @@ export function getInitialStateForCardDataSource(
     state.columnValuesMapping[columnRef.name] = [columnRef];
     columnsToRefs[column.name] = columnRef.name;
   });
+
+  const columnRenames = new Map(Object.entries(columnsToRefs));
+  state.columns = state.columns.map((col) =>
+    rewriteRemappedReferences(col, columnRenames),
+  );
 
   const entries = getColumnVizSettings(state.display!)
     .map((setting) => {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -297,6 +297,72 @@ describe("getInitialStateForCardDataSource", () => {
     });
   });
 
+  it("should keep remapped display columns and rewrite references (UXW-3359)", () => {
+    const dataset = createMockDataset({
+      data: createMockDatasetData({
+        cols: [
+          createMockColumn({
+            name: "buyingstatus",
+            base_type: "type/Integer",
+            effective_type: "type/Integer",
+            semantic_type: "type/Category",
+            remapped_to: "buyingstatus_display",
+          }),
+          createMockColumn({
+            name: "buyingstatus_display",
+            base_type: "type/Text",
+            effective_type: "type/Text",
+            remapped_from: "buyingstatus",
+          }),
+          createMockColumn({
+            name: "count",
+            base_type: "type/BigInteger",
+            effective_type: "type/BigInteger",
+            semantic_type: "type/Quantity",
+          }),
+        ],
+      }),
+    });
+
+    const card = createMockCard({
+      display: "bar",
+      name: "Remapped",
+      description: null,
+      visualization_settings: {
+        "graph.dimensions": ["buyingstatus"],
+        "graph.metrics": ["count"],
+      },
+    });
+
+    const state = getInitialStateForCardDataSource(card, dataset);
+
+    expect(state.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        { name: "COLUMN_1", originalName: "buyingstatus", sourceId: "card:1" },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "buyingstatus_display",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_3: [
+        { name: "COLUMN_3", originalName: "count", sourceId: "card:1" },
+      ],
+    });
+
+    const baseCol = state.columns.find((c) => c.name === "COLUMN_1");
+    const displayCol = state.columns.find((c) => c.name === "COLUMN_2");
+    expect(baseCol?.remapped_to).toBe("COLUMN_2");
+    expect(displayCol?.remapped_from).toBe("COLUMN_1");
+
+    expect(state.settings).toEqual({
+      "graph.dimensions": ["COLUMN_1"],
+      "graph.metrics": ["COLUMN_3"],
+    });
+  });
+
   it.each<CardDisplayType>(["scalar", "gauge"])(
     "should return scalar funnel initial state if the original card is a %s",
     (vizType) => {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -13,6 +13,7 @@ import {
   copyColumn,
   createVisualizerColumnReference,
   extractReferencedColumns,
+  rewriteRemappedReferences,
 } from "./column";
 import { createDataSource } from "./data-source";
 import { updateVizSettingsWithRefs } from "./update-viz-settings-with-refs";
@@ -66,6 +67,8 @@ function processColumnsForDataSource(
 ): ColumnInfo[] {
   const columnInfos: ColumnInfo[] = [];
 
+  const firstNewIndex = state.columns.length;
+
   columns.forEach((column) => {
     const columnRef = createVisualizerColumnReference(
       dataSource,
@@ -88,6 +91,19 @@ function processColumnsForDataSource(
       column: processedColumn,
     });
   });
+
+  const columnRenames = new Map(
+    columnInfos.map(({ columnRef }) => [
+      columnRef.originalName,
+      columnRef.name,
+    ]),
+  );
+  for (let i = firstNewIndex; i < state.columns.length; i++) {
+    state.columns[i] = rewriteRemappedReferences(
+      state.columns[i],
+      columnRenames,
+    );
+  }
 
   return columnInfos;
 }

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.ts
@@ -12,7 +12,7 @@ import {
   isScalarFunnel,
 } from "../visualizations/funnel";
 
-import { copyColumn } from "./column";
+import { copyColumn, rewriteRemappedReferences } from "./column";
 
 /**
  * Creates visualization columns for a visualizer entity.
@@ -45,6 +45,22 @@ export const getVisualizationColumns = (
     ];
   }
 
+  // Per-source rename maps so remapped_from/to rewrites don't leak across sources.
+  const columnRenamesBySource = new Map<
+    VisualizerDataSourceId,
+    Map<string, string>
+  >();
+  Object.values(columnValuesMapping).forEach((mappings) =>
+    mappings.forEach((mapping) => {
+      if (typeof mapping !== "string") {
+        const existing =
+          columnRenamesBySource.get(mapping.sourceId) ?? new Map();
+        existing.set(mapping.originalName, mapping.name);
+        columnRenamesBySource.set(mapping.sourceId, existing);
+      }
+    }),
+  );
+
   const visualizationColumns: DatasetColumn[] = [];
   // For all other chart types, create visualization columns from column mappings
   Object.entries(columnValuesMapping).forEach(
@@ -63,11 +79,16 @@ export const getVisualizationColumns = (
             return;
           }
 
-          const visualizationColumn = copyColumn(
-            columnMapping.name,
-            datasetColumn,
-            dataSource.name,
-            visualizationColumns,
+          const columnRenames =
+            columnRenamesBySource.get(columnMapping.sourceId) ?? new Map();
+          const visualizationColumn = rewriteRemappedReferences(
+            copyColumn(
+              columnMapping.name,
+              datasetColumn,
+              dataSource.name,
+              visualizationColumns,
+            ),
+            columnRenames,
           );
 
           visualizationColumns.push(visualizationColumn);

--- a/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-visualization-columns.unit.spec.ts
@@ -159,6 +159,139 @@ describe("getVisualizationColumns", () => {
       ]);
     });
 
+    it("should rewrite remapped_from/remapped_to to the renamed COLUMN_N (UXW-3359)", () => {
+      const visualizerEntity: VisualizerVizDefinition = {
+        display: "bar",
+        settings: {},
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              name: "COLUMN_1",
+              originalName: "buyingstatus",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_2: [
+            {
+              name: "COLUMN_2",
+              originalName: "buyingstatus_display",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_3: [
+            {
+              name: "COLUMN_3",
+              originalName: "count",
+              sourceId: "card:1",
+            },
+          ],
+        },
+      };
+
+      const dataSource: VisualizerDataSource = {
+        id: "card:1",
+        sourceId: 1,
+        name: "Source 1",
+        type: "card",
+      };
+
+      const buyingStatusColumn = createMockColumn({
+        name: "buyingstatus",
+        base_type: "type/Integer",
+        effective_type: "type/Integer",
+        semantic_type: "type/Category",
+        remapped_to: "buyingstatus_display",
+      });
+      const buyingStatusDisplayColumn = createMockColumn({
+        name: "buyingstatus_display",
+        base_type: "type/Text",
+        effective_type: "type/Text",
+        remapped_from: "buyingstatus",
+      });
+      const countColumn = createMockColumn({
+        name: "count",
+        base_type: "type/BigInteger",
+      });
+
+      const dataset: Dataset = createMockDataset({
+        data: createMockDatasetData({
+          cols: [buyingStatusColumn, buyingStatusDisplayColumn, countColumn],
+        }),
+      });
+
+      const columns = getVisualizationColumns(
+        visualizerEntity,
+        { "card:1": dataset },
+        [dataSource],
+      );
+
+      const base = columns.find((c) => c.name === "COLUMN_1");
+      const display = columns.find((c) => c.name === "COLUMN_2");
+
+      expect(base?.remapped_to).toBe("COLUMN_2");
+      expect(display?.remapped_from).toBe("COLUMN_1");
+    });
+
+    it("should scope rewrites to the same data source", () => {
+      const visualizerEntity: VisualizerVizDefinition = {
+        display: "bar",
+        settings: {},
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              name: "COLUMN_1",
+              originalName: "buyingstatus",
+              sourceId: "card:1",
+            },
+          ],
+          COLUMN_2: [
+            {
+              name: "COLUMN_2",
+              originalName: "buyingstatus",
+              sourceId: "card:2",
+            },
+          ],
+        },
+      };
+
+      const dataSource1: VisualizerDataSource = {
+        id: "card:1",
+        sourceId: 1,
+        name: "Source 1",
+        type: "card",
+      };
+      const dataSource2: VisualizerDataSource = {
+        id: "card:2",
+        sourceId: 2,
+        name: "Source 2",
+        type: "card",
+      };
+
+      const colWithRemap = createMockColumn({
+        name: "buyingstatus",
+        remapped_to: "buyingstatus_display",
+      });
+      const colWithoutRemap = createMockColumn({ name: "buyingstatus" });
+
+      const datasets = {
+        "card:1": createMockDataset({
+          data: createMockDatasetData({ cols: [colWithRemap] }),
+        }),
+        "card:2": createMockDataset({
+          data: createMockDatasetData({ cols: [colWithoutRemap] }),
+        }),
+      };
+
+      const columns = getVisualizationColumns(visualizerEntity, datasets, [
+        dataSource1,
+        dataSource2,
+      ]);
+
+      // remapped_to gets cleared, not silently mapped to card:2's COLUMN_2.
+      const fromCard1 = columns.find((c) => c.name === "COLUMN_1");
+      expect(fromCard1?.remapped_to).toBeUndefined();
+    });
+
     it("should ignore missing dataset column or data source", () => {
       const visualizerEntity: VisualizerVizDefinition = {
         display: "bar",

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -15,6 +15,7 @@ import {
   createVisualizerColumnReference,
   extractReferencedColumns,
   isDraggedColumnItem,
+  rewriteRemappedReferences,
   shouldSplitVisualizerSeries,
   updateVizSettingsWithRefs,
 } from "metabase/visualizer/utils";
@@ -83,6 +84,16 @@ export const cartesianDropHandler = (
         columnRef,
         dataSource,
       );
+      const dataset = datasetMap[dataSource.id];
+      if (dataset) {
+        attachRemappedDisplayColumn(
+          state,
+          columnRef,
+          column,
+          dataset,
+          dataSource,
+        );
+      }
       maybeImportDimensionsFromOtherDataSources(
         state,
         settings,
@@ -399,9 +410,10 @@ function removeDimensionFromMultiSeriesChart(
     state.settings["graph.dimensions"] = originalDimensions.filter(
       (name) => !isDate(dimensionColumnMap[name]),
     );
-  } else if (isString(column)) {
-    state.settings["graph.dimensions"] = originalDimensions.filter(
-      (name) => !isString(dimensionColumnMap[name]),
+  } else {
+    // Non-date dim: clear all non-date dims (string, integer-Category, binned numeric, etc.).
+    state.settings["graph.dimensions"] = originalDimensions.filter((name) =>
+      isDate(dimensionColumnMap[name]),
     );
   }
 
@@ -409,10 +421,58 @@ function removeDimensionFromMultiSeriesChart(
     (name) => !state.settings["graph.dimensions"]?.includes(name),
   );
 
-  removedColumns.forEach((name) => {
+  // Strip orphan display columns too, or stale remapped_from refs misalign render-time rows.
+  const removedNameSet = new Set(removedColumns);
+  const orphanedDisplayCols = state.columns
+    .filter(
+      (col) =>
+        col.remapped_from != null && removedNameSet.has(col.remapped_from),
+    )
+    .map((col) => col.name);
+
+  [...removedColumns, ...orphanedDisplayCols].forEach((name) => {
     state.columns = state.columns.filter((col) => col.name !== name);
     delete state.columnValuesMapping[name];
   });
+}
+
+// Silently attach a base dim's display-value column (in state.columns/columnValuesMapping
+// but not graph.dimensions) and point both cols' remapped refs at the new COLUMN_N names.
+export function attachRemappedDisplayColumn(
+  state:
+    | Draft<VisualizerVizDefinitionWithColumns>
+    | VisualizerVizDefinitionWithColumns,
+  baseColRef: VisualizerColumnReference,
+  originalBaseCol: DatasetColumn,
+  dataset: Dataset,
+  dataSource: VisualizerDataSource,
+) {
+  const displayCol = dataset.data.cols.find(
+    (col) => col.remapped_from === originalBaseCol.name,
+  );
+  if (!displayCol) {
+    return;
+  }
+
+  const displayRef = createVisualizerColumnReference(
+    dataSource,
+    displayCol,
+    extractReferencedColumns(state.columnValuesMapping),
+  );
+  state.columns.push(
+    copyColumn(displayRef.name, displayCol, dataSource.name, state.columns),
+  );
+  state.columnValuesMapping[displayRef.name] = [displayRef];
+
+  const columnRenames = new Map([
+    [originalBaseCol.name, baseColRef.name],
+    [displayCol.name, displayRef.name],
+  ]);
+  state.columns = state.columns.map((col) =>
+    col.name === baseColRef.name || col.name === displayRef.name
+      ? rewriteRemappedReferences(col, columnRenames)
+      : col,
+  );
 }
 
 export function maybeImportDimensionsFromOtherDataSources(
@@ -450,6 +510,13 @@ export function maybeImportDimensionsFromOtherDataSources(
         settings,
         matchingDimension,
         columnRef,
+        dataSource,
+      );
+      attachRemappedDisplayColumn(
+        state,
+        columnRef,
+        matchingDimension,
+        dataset,
         dataSource,
       );
     }
@@ -504,11 +571,13 @@ export function combineWithCartesianChart(
   const { data } = dataset;
 
   const metrics = data.cols.filter((col) => isMetric(col));
+  // Display-value columns are attached separately below, not as graph.dimensions slots.
   const dimensions = data.cols.filter(
-    (col) => isDimension(col) && !isMetric(col),
+    (col) => isDimension(col) && !isMetric(col) && col.remapped_from == null,
   );
 
   const columnsToRefs: Record<string, string> = {};
+  const firstNewIndex = state.columns.length;
 
   metrics.forEach((column) => {
     const isCompatible = !!findColumnSlotForCartesianChart({
@@ -560,6 +629,35 @@ export function combineWithCartesianChart(
       columnsToRefs[column.name] = columnRef.name;
     }
   });
+
+  // Silent display-column attach: in columnValuesMapping/state.columns, NOT graph.dimensions
+  // (extra dim slots break cross-source axis merging).
+  data.cols
+    .filter(
+      (col) =>
+        col.remapped_from != null && columnsToRefs[col.remapped_from] != null,
+    )
+    .forEach((column) => {
+      const columnRef = createVisualizerColumnReference(
+        dataSource,
+        column,
+        extractReferencedColumns(state.columnValuesMapping),
+      );
+      state.columns.push(
+        copyColumn(columnRef.name, column, dataSource.name, state.columns),
+      );
+      state.columnValuesMapping[columnRef.name] = [columnRef];
+      columnsToRefs[column.name] = columnRef.name;
+    });
+
+  // Point remapped_from/to at the new COLUMN_N names so extractRemappedColumns can pair them.
+  const columnRenames = new Map(Object.entries(columnsToRefs));
+  for (let i = firstNewIndex; i < state.columns.length; i++) {
+    state.columns[i] = rewriteRemappedReferences(
+      state.columns[i],
+      columnRenames,
+    );
+  }
 
   if (vizSettings && vizSettings.column_settings) {
     const remappedSettings = updateVizSettingsWithRefs(

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1012,6 +1012,106 @@ describe("cartesian", () => {
       });
     });
 
+    it("should attach remapped display columns silently without adding them to graph.dimensions (UXW-3359)", () => {
+      const settings = createMockVisualizationSettings({
+        "graph.metrics": ["COLUMN_2"],
+        "graph.dimensions": ["COLUMN_1"],
+      });
+      const state: VisualizerVizDefinitionWithColumns = {
+        display: "bar",
+        columns: [
+          createMockColumn({
+            name: "COLUMN_1",
+            display_name: "Rating",
+            base_type: "type/Integer",
+            effective_type: "type/Integer",
+            semantic_type: "type/Category",
+            remapped_to: "COLUMN_3",
+          }),
+          createMockNumericColumn({ name: "COLUMN_2", display_name: "Count" }),
+          createMockColumn({
+            name: "COLUMN_3",
+            display_name: "Rating",
+            base_type: "type/Text",
+            effective_type: "type/Text",
+            remapped_from: "COLUMN_1",
+          }),
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "rating" },
+          ],
+          COLUMN_2: [
+            { sourceId: "card:1", name: "COLUMN_2", originalName: "count" },
+          ],
+          COLUMN_3: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_3",
+              originalName: "rating_display",
+            },
+          ],
+        },
+        settings,
+      };
+
+      const newRatingInt = createMockColumn({
+        name: "rating",
+        display_name: "Rating",
+        base_type: "type/Integer",
+        effective_type: "type/Integer",
+        semantic_type: "type/Category",
+        // source: "breakout" makes isMetric() false so the int col is a dimension.
+        source: "breakout",
+        remapped_to: "rating_display",
+      });
+      const newRatingDisplay = createMockColumn({
+        name: "rating_display",
+        display_name: "Rating",
+        base_type: "type/Text",
+        effective_type: "type/Text",
+        source: "breakout",
+        remapped_from: "rating",
+      });
+      const newCount = createMockNumericColumn({
+        name: "count",
+        display_name: "Count",
+      });
+
+      const nextState = _.clone(state);
+      combineWithCartesianChart(
+        nextState,
+        settings,
+        createMockDataset({
+          data: { cols: [newRatingInt, newRatingDisplay, newCount] },
+        }),
+        createDataSource("card", 2, "Card 2"),
+      );
+
+      // Metrics processed before dims → new metric is COLUMN_4, new dim is COLUMN_5.
+      expect(nextState.settings["graph.metrics"]).toEqual([
+        "COLUMN_2",
+        "COLUMN_4",
+      ]);
+      expect(nextState.settings["graph.dimensions"]).toEqual([
+        "COLUMN_1",
+        "COLUMN_5",
+      ]);
+
+      // Text display column lives in columnValuesMapping but NOT graph.dimensions.
+      expect(nextState.settings["graph.dimensions"]).not.toContain("COLUMN_6");
+      expect(nextState.columnValuesMapping).toMatchObject({
+        COLUMN_6: [
+          {
+            sourceId: "card:2",
+            name: "COLUMN_6",
+            originalName: "rating_display",
+          },
+        ],
+      });
+      expect(nextState.columns.map((col) => col.name)).toContain("COLUMN_6");
+    });
+
     describe("dimension sorting based on x-axis scale", () => {
       it("should prioritize date dimensions when x-axis scale is timeseries", () => {
         const settings = createMockVisualizationSettings({

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -50,6 +50,7 @@ import {
 import { getUpdatedSettingsForDisplay } from "./utils/get-updated-settings-for-display";
 import {
   addColumnToCartesianChart,
+  attachRemappedDisplayColumn,
   cartesianDropHandler,
   combineWithCartesianChart,
   maybeImportDimensionsFromOtherDataSources,
@@ -411,6 +412,17 @@ const visualizerSlice = createSlice({
 
         const dimension = state.settings["graph.dimensions"] ?? [];
         const isDimension = dimension.includes(column.name);
+
+        if (isDimension) {
+          // Re-attach display column so remapping survives remove + re-add.
+          attachRemappedDisplayColumn(
+            state,
+            columnRef,
+            originalColumn,
+            dataset as Dataset,
+            dataSource,
+          );
+        }
 
         if (isDimension && column.id) {
           const datasetMap = _.omit(state.datasets, dataSource.id) as Record<


### PR DESCRIPTION
Uxw 3359 visualizer breaks internal dimension remapping for integer (#74446)

* Fix visualizer dropping internal dimension remapping, make cards combineable

* Fix removing and re-adding integer-category dimensions in the visualizer

* PR Feedback, adjust helper function and variable names

Manual Backport. No Conflicts