### PR TITLE
Gate workspace config section on :workspaces feature

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -278,6 +278,8 @@
          (when-not (premium-features/enable-config-text-file?)
            (throw (ex-info (tru "Metabase config files require a Premium token with the :config-text-file feature.")
                            {}))))
+       (when (= section-name :workspace)
+         (premium-features/assert-has-feature :workspaces (tru "Workspaces")))
        (log/info (u/format-color :magenta "Initializing %s from config file..." section-name) (u/emoji "🗄️"))
        (advanced-config.file.i/initialize-section! section-name section-config))
      (log/info (u/colorize :magenta "Done initializing from file.") (u/emoji "🗄️")))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -37,7 +37,8 @@
    [metabase-enterprise.workspaces.settings :as ws.settings]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.util :as driver.u]
-   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.workspaces.core :as ws]
    [toucan2.core :as t2]))
@@ -93,12 +94,14 @@
   "Store the workspace config in the `instance-workspace` setting. Replaces any
    prior value. The shape is validated against `::ws/workspace-instance-config`."
   [config :- ::ws/workspace-instance-config]
+  (premium-features/assert-has-feature :workspaces (tru "Workspaces"))
   (ws.settings/instance-workspace! config)
   nil)
 
 (defn clear-instance-workspace!
   "Clear the `instance-workspace` setting."
   []
+  (premium-features/assert-has-feature :workspaces (tru "Workspaces"))
   (ws.settings/instance-workspace! nil)
   nil)
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -37,8 +37,7 @@
    [metabase-enterprise.workspaces.settings :as ws.settings]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.util :as driver.u]
-   [metabase.premium-features.core :as premium-features :refer [defenterprise]]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.malli :as mu]
    [metabase.workspaces.core :as ws]
    [toucan2.core :as t2]))
@@ -94,14 +93,12 @@
   "Store the workspace config in the `instance-workspace` setting. Replaces any
    prior value. The shape is validated against `::ws/workspace-instance-config`."
   [config :- ::ws/workspace-instance-config]
-  (premium-features/assert-has-feature :workspaces (tru "Workspaces"))
   (ws.settings/instance-workspace! config)
   nil)
 
 (defn clear-instance-workspace!
   "Clear the `instance-workspace` setting."
   []
-  (premium-features/assert-has-feature :workspaces (tru "Workspaces"))
   (ws.settings/instance-workspace! nil)
   nil)
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api_test.clj
@@ -58,7 +58,7 @@
                                          :databases {(keyword db-name) {:input_schemas ["public"]
                                                                         :output        {:schema "ws_uploaded"}}}}}}]
       (try
-        (mt/with-premium-features #{:config-text-file}
+        (mt/with-premium-features #{:config-text-file :workspaces}
           (mt/with-temporary-setting-values [config-from-file-sync-databases false]
             (with-redefs [metabase.driver.util/can-connect-with-details? (constantly true)]
               (mt/user-http-request :crowberto :post 204 "ee/advanced-config/"
@@ -72,6 +72,22 @@
                 (is (= "Uploaded Workspace" (:name stored)))
                 (is (= {:schema "ws_uploaded"} (get-in stored [:databases (:id db) :output])))))))
         (finally
-          (ws/clear-instance-workspace!)
+          ;; `clear-instance-workspace!` is gated on `:workspaces` (see GHY-3685); this
+          ;; cleanup must be allowed to run regardless of what features the test enabled.
+          (mt/with-premium-features #{:workspaces}
+            (ws/clear-instance-workspace!))
           (when-let [db-id (t2/select-one-pk :model/Database :name db-name :engine "postgres")]
             (t2/delete! :model/Database db-id)))))))
+
+(deftest workspace-section-rejected-without-workspaces-feature-test
+  (testing "POST /api/ee/advanced-config returns 402 when :workspace section requires :workspaces"
+    (let [payload {:version 1
+                   :config  {:workspace {:name      "Rejected Workspace"
+                                         :databases {:some-db {:input_schemas ["public"]
+                                                               :output        {:schema "ws_rejected"}}}}}}]
+      (mt/with-premium-features #{:config-text-file}
+        (mt/assert-has-premium-feature-error
+         "Workspaces"
+         (mt/user-http-request :crowberto :post 402 "ee/advanced-config/"
+                               (first (multipart (yaml-bytes payload)))
+                               (second (multipart (yaml-bytes payload)))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/workspace_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/workspace_test.clj
@@ -16,11 +16,16 @@
 
 (use-fixtures :each
   (fn [thunk]
-    (binding [advanced-config.file/*supported-versions* {:min 1, :max 1}]
-      (try
-        (thunk)
-        (finally
-          (ws/clear-instance-workspace!))))))
+    ;; Default to `:workspaces` enabled for tests in this ns — most exercise
+    ;; `apply-workspace-section!` which calls `set-instance-workspace!` (gated on
+    ;; `:workspaces`, see GHY-3685). Tests that need the feature *absent* override
+    ;; with their own `mt/with-premium-features` block.
+    (mt/with-premium-features #{:workspaces}
+      (binding [advanced-config.file/*supported-versions* {:min 1, :max 1}]
+        (try
+          (thunk)
+          (finally
+            (ws/clear-instance-workspace!)))))))
 
 (defn- load-fixture-by-driver [driver]
   (-> (str "metabase_enterprise/workspaces/resources/workspace_config_" (name driver) ".yml")
@@ -152,6 +157,42 @@
               {:version 1
                :config {:users [{:first_name "X" :last_name "Y"
                                  :email "x@example.com" :password "pw"}]}})))))))
+
+(deftest workspace-section-requires-workspaces-feature-test
+  (testing ":workspace section needs the :workspaces feature in addition to :config-text-file"
+    (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/Database _ {:name "ws-test-db" :engine :postgres}]
+        (mt/with-premium-features #{:config-text-file}
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"Workspaces is a paid feature"
+               (advanced-config.file/initialize!
+                {:version 1
+                 :config {:workspace (workspace-section "ws-test-db")}}))))))))
+
+(deftest workspace-section-loads-with-workspaces-feature-test
+  (testing ":workspace section loads cleanly when both :config-text-file and :workspaces are present"
+    (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/Database {db-id :id} {:name "ws-test-db" :engine :postgres}]
+        (mt/with-premium-features #{:config-text-file :workspaces}
+          (advanced-config.file/initialize!
+           {:version 1
+            :config {:workspace (workspace-section "ws-test-db")}})
+          (is (= "New workspace" (:name (ws/instance-workspace)))
+              "the workspace section should have been applied")
+          (is (= {:schema "mb__isolation_44490_1933"}
+                 (ws/db-workspace-namespace db-id))))))))
+
+(deftest workspaces-gate-is-scoped-to-workspace-section-test
+  (testing "without :workspaces, other non-:workspace sections still load (gate is :workspace-scoped)"
+    (mt/with-empty-h2-app-db!
+      (mt/with-premium-features #{:config-text-file}
+        (advanced-config.file/initialize!
+         {:version 1
+          :config {:users [{:first_name "X" :last_name "Y"
+                            :email "x@example.com" :password "pw"}]}})
+        (is (nil? (ws/instance-workspace))
+            "no workspace section means no workspace state was set")))))
 
 ;;; ----------------------------------------- per-driver shapes -----------------------------------------
 ;;;

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -7,7 +7,9 @@
    [metabase-enterprise.workspaces.test-util :as workspaces.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -70,7 +72,7 @@
     (mt/with-model-cleanup [:model/Workspace]
       (let [ws (ws/create-workspace! {:name "No Schema Add" :creator_id (mt/user->id :crowberto)})]
         (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo #"input_schemas is required"
+             ExceptionInfo #"input_schemas is required"
              (ws/add-database! (:id ws) (mt/id) []))))))
 
   (testing "input not required when database does not support :schemas (e.g. MySQL)"
@@ -89,7 +91,7 @@
         (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
           (ws/add-database! (:id ws) (mt/id) ["PUBLIC"]))
         (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo #"Database already in workspace"
+             ExceptionInfo #"Database already in workspace"
              (ws/add-database! (:id ws) (mt/id) ["PUBLIC"]))))))
 
   (testing "provisioning failure rolls the row back so the caller can retry cleanly"
@@ -100,7 +102,7 @@
                                   (grant!   [_ _ _ _ _] nil)
                                   (destroy! [_ _ _ _]   nil))]
         (with-redefs [provisioning/dispatching-provisioner failing-provisioner]
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"boom"
+          (is (thrown-with-msg? ExceptionInfo #"boom"
                                 (ws/add-database! (:id ws) (mt/id) ["PUBLIC"]))))
         (is (empty? (:databases (ws/get-workspace (:id ws))))
             "the failed add must not leave a workspace_database row behind")))))
@@ -116,7 +118,7 @@
 
   (testing "remove from non-existent workspace throws 404"
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"Workspace not found"
+         ExceptionInfo #"Workspace not found"
          (ws/remove-database! 999999 (mt/id))))))
 
 ;;; ----------------------------------------- Update Database --------------------------------------------------
@@ -161,3 +163,24 @@
                                        :to_table_name   "orders"})
     (let [remappings (ws/list-remappings)]
       (is (some #(= "orders" (:from_table_name %)) remappings)))))
+
+;;; ---------------------------- Instance-workspace setter / clearer gating ----------------------------
+
+(deftest set-instance-workspace!-requires-workspaces-feature-test
+  (testing "set-instance-workspace! throws when :workspaces is absent"
+    (mt/with-temp [:model/Database {db-id :id} {:name "set-iw-test-db" :engine :postgres}]
+      (mt/with-premium-features #{}
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Workspaces is a paid feature"
+             (ws/set-instance-workspace! {:name "X"
+                                          :databases {db-id {:input_schemas ["public"]
+                                                             :output {:schema "x"}}}})))))))
+
+(deftest clear-instance-workspace!-requires-workspaces-feature-test
+  (testing "clear-instance-workspace! throws when :workspaces is absent"
+    (mt/with-premium-features #{}
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Workspaces is a paid feature"
+           (ws/clear-instance-workspace!))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -163,24 +163,3 @@
                                        :to_table_name   "orders"})
     (let [remappings (ws/list-remappings)]
       (is (some #(= "orders" (:from_table_name %)) remappings)))))
-
-;;; ---------------------------- Instance-workspace setter / clearer gating ----------------------------
-
-(deftest set-instance-workspace!-requires-workspaces-feature-test
-  (testing "set-instance-workspace! throws when :workspaces is absent"
-    (mt/with-temp [:model/Database {db-id :id} {:name "set-iw-test-db" :engine :postgres}]
-      (mt/with-premium-features #{}
-        (is (thrown-with-msg?
-             ExceptionInfo
-             #"Workspaces is a paid feature"
-             (ws/set-instance-workspace! {:name "X"
-                                          :databases {db-id {:input_schemas ["public"]
-                                                             :output {:schema "x"}}}})))))))
-
-(deftest clear-instance-workspace!-requires-workspaces-feature-test
-  (testing "clear-instance-workspace! throws when :workspaces is absent"
-    (mt/with-premium-features #{}
-      (is (thrown-with-msg?
-           ExceptionInfo
-           #"Workspaces is a paid feature"
-           (ws/clear-instance-workspace!))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/query_processor/corpus_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/query_processor/corpus_test.clj
@@ -310,41 +310,42 @@
                                 :table  source-table}]
           (mt/with-empty-h2-app-db!
             (mt/with-temp [:model/Database {db-id :id} {:name db-name :engine engine :details details}]
-              (try
-                ;; 1. Load through the production loader. Populates the atom.
-                (advanced-config.file.workspace/apply-workspace-section! section)
-                ;; 2. Read the namespace via the production reader.
-                (let [ws-ns      (ws/db-workspace-namespace db-id)
-                      to-spec    (merge from-spec ws-ns)
-                      {:keys [tables rewritten]} (rewrite-and-parse
-                                                  driver canonical-sql
-                                                  {(ws.table-remapping/prune-no-level from-spec)
-                                                   (ws.table-remapping/prune-no-level to-spec)})]
-                  (testing "atom output matches the loader's expansion of fixture's output_namespace"
-                    (is (= expected-output ws-ns)
-                        "db-workspace-namespace must return the loader's expanded :output map"))
-                  ;; MySQL is special-cased: it has no schema layer, so Phase 1 (table
-                  ;; metadata mutation) adds the iso `:db` qualifier — Phase 2's SQLGlot
-                  ;; rewriter never sees a qualifier to swap. Skip the rewriter SQL
-                  ;; assertions for MySQL; the atom-output assertion above is what matters.
-                  (when (not= driver :mysql)
-                    (testing "rewritten SQL parses to the workspace :schema slot"
-                      (let [expected-schema (or (:schema expected-output) (:db expected-output))]
-                        (is (contains? tables {:schema expected-schema :table source-table})
-                            (str "expected {:schema " expected-schema ", :table " source-table
-                                 "} in parsed tables; got: " tables
-                                 "\n  rewritten SQL: " rewritten))))
-                    (testing "rewritten SQL no longer references the canonical schema"
-                      (when (:schema input-positions)
-                        (is (not-any? #(= (:schema %) (:schema input-positions)) tables)
-                            (str "expected canonical schema " (pr-str (:schema input-positions))
-                                 " gone from parsed refs; got: " tables))))
-                    ;; 3-slot drivers (where workspace output has :db): parser is lossy on :db,
-                    ;; so verify via the rewritten string.
-                    (when-let [output-db (:db expected-output)]
-                      (let [from-text (str (re-find #"(?i)\bFROM\b.*$" rewritten))]
-                        (testing "rewritten FROM clause contains workspace :db slot"
-                          (is (re-find (re-pattern (java.util.regex.Pattern/quote output-db)) from-text)
-                              (str "expected " (pr-str output-db) " in FROM; got: " from-text)))))))
-                (finally
-                  (ws/clear-instance-workspace!))))))))))
+              (mt/with-premium-features #{:workspaces}
+                (try
+                  ;; 1. Load through the production loader. Populates the atom.
+                  (advanced-config.file.workspace/apply-workspace-section! section)
+                  ;; 2. Read the namespace via the production reader.
+                  (let [ws-ns      (ws/db-workspace-namespace db-id)
+                        to-spec    (merge from-spec ws-ns)
+                        {:keys [tables rewritten]} (rewrite-and-parse
+                                                    driver canonical-sql
+                                                    {(ws.table-remapping/prune-no-level from-spec)
+                                                     (ws.table-remapping/prune-no-level to-spec)})]
+                    (testing "atom output matches the loader's expansion of fixture's output_namespace"
+                      (is (= expected-output ws-ns)
+                          "db-workspace-namespace must return the loader's expanded :output map"))
+                    ;; MySQL is special-cased: it has no schema layer, so Phase 1 (table
+                    ;; metadata mutation) adds the iso `:db` qualifier — Phase 2's SQLGlot
+                    ;; rewriter never sees a qualifier to swap. Skip the rewriter SQL
+                    ;; assertions for MySQL; the atom-output assertion above is what matters.
+                    (when (not= driver :mysql)
+                      (testing "rewritten SQL parses to the workspace :schema slot"
+                        (let [expected-schema (or (:schema expected-output) (:db expected-output))]
+                          (is (contains? tables {:schema expected-schema :table source-table})
+                              (str "expected {:schema " expected-schema ", :table " source-table
+                                   "} in parsed tables; got: " tables
+                                   "\n  rewritten SQL: " rewritten))))
+                      (testing "rewritten SQL no longer references the canonical schema"
+                        (when (:schema input-positions)
+                          (is (not-any? #(= (:schema %) (:schema input-positions)) tables)
+                              (str "expected canonical schema " (pr-str (:schema input-positions))
+                                   " gone from parsed refs; got: " tables))))
+                      ;; 3-slot drivers (where workspace output has :db): parser is lossy on :db,
+                      ;; so verify via the rewritten string.
+                      (when-let [output-db (:db expected-output)]
+                        (let [from-text (str (re-find #"(?i)\bFROM\b.*$" rewritten))]
+                          (testing "rewritten FROM clause contains workspace :db slot"
+                            (is (re-find (re-pattern (java.util.regex.Pattern/quote output-db)) from-text)
+                                (str "expected " (pr-str output-db) " in FROM; got: " from-text)))))))
+                  (finally
+                    (ws/clear-instance-workspace!)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/settings_test.clj
@@ -2,15 +2,19 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase-enterprise.workspaces.core :as ws]
+   [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
+;; All tests in this ns exercise set/clear-instance-workspace!, which are gated on :workspaces
+;; (see GHY-3685). Enable the feature for every test in this ns.
 (use-fixtures :each (fn [thunk]
-                      (try
-                        (thunk)
-                        (finally
-                          (ws/clear-instance-workspace!)))))
+                      (mt/with-premium-features #{:workspaces}
+                        (try
+                          (thunk)
+                          (finally
+                            (ws/clear-instance-workspace!))))))
 
 (deftest workspace-mode?-false-when-setting-empty-test
   (testing "workspace-mode? is false when no :workspace section has been loaded"

--- a/enterprise/backend/test/metabase_enterprise/workspaces/table_remapping_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/table_remapping_test.clj
@@ -29,15 +29,17 @@
 
 (defn- with-provisioned-workspace-db!
   "Set the `instance-workspace` setting so `db-workspace-namespace` returns
-   `{:schema output-schema}` for `db-id`, run `f`, clear it on the way out."
+   `{:schema output-schema}` for `db-id`, run `f`, clear it on the way out.
+   Enables `:workspaces` for the duration."
   [db-id output-schema f]
-  (try
-    (ws/set-instance-workspace! {:name "table-remapping-test-ws"
-                                 :databases {db-id {:input_schemas ["_"]
-                                                    :output        {:schema output-schema}}}})
-    (f)
-    (finally
-      (ws/clear-instance-workspace!))))
+  (mt/with-premium-features #{:workspaces}
+    (try
+      (ws/set-instance-workspace! {:name "table-remapping-test-ws"
+                                   :databases {db-id {:input_schemas ["_"]
+                                                      :output        {:schema output-schema}}}})
+      (f)
+      (finally
+        (ws/clear-instance-workspace!)))))
 
 (deftest remap-table-returns-nil-when-no-mapping-test
   (clean-db-fixture!
@@ -136,15 +138,17 @@
   "Variant of `with-provisioned-workspace-db!` that takes a full
    `::table-namespace` map (`{:db ?, :schema ?}`) instead of just a schema
    string. Used to exercise cross-DB workspaces (SQL Server / BigQuery) where
-   the to-side `:db` slot must flow through to the `TableRemapping` row."
+   the to-side `:db` slot must flow through to the `TableRemapping` row.
+   Enables `:workspaces` for the duration."
   [db-id output-namespace f]
-  (try
-    (ws/set-instance-workspace! {:name "ws-3-slot"
-                                 :databases {db-id {:input_schemas ["_"]
-                                                    :output        output-namespace}}})
-    (f)
-    (finally
-      (ws/clear-instance-workspace!))))
+  (mt/with-premium-features #{:workspaces}
+    (try
+      (ws/set-instance-workspace! {:name "ws-3-slot"
+                                   :databases {db-id {:input_schemas ["_"]
+                                                      :output        output-namespace}}})
+      (f)
+      (finally
+        (ws/clear-instance-workspace!)))))
 
 (deftest add-transform-target-mapping!-flows-both-slots-from-namespace-test
   (testing "When the workspace output namespace populates :db, both slots flow into the TableRemapping row"


### PR DESCRIPTION
Closes GHY-3685.

### Description

Loading the `:workspace` config-file section (at boot or at runtime via `POST /api/ee/advanced-config/`) only required the `:config-text-file` feature. They should require `:workspaces`.

### How to verify

Run tests, or attempt to load `:workspace` configuration without the `:workspaces` feature.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
