### PR TITLE
Auto-add issues only to open milestones

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -238,7 +238,7 @@ export async function setMilestoneForCommits({
   // figure out milestone
   const branchVersion = getVersionFromReleaseBranch(branchName);
   const majorVersion = getMajorVersion(branchVersion);
-  const openMilestones = await getMilestones({ github, owner, repo });
+  const openMilestones = await getMilestones({ github, owner, repo, state: 'open' });
   const nextMilestone = getNextMilestone({ openMilestones, majorVersion });
 
   if (!nextMilestone) {


### PR DESCRIPTION
We've been adding issues to closed milestones ever since https://github.com/metabase/metabase/pull/71392 😬 

New issues should only be auto-added to open milestones.
