### PR TITLE
Send cypress test failures info to ci conductor

### DIFF
--- a/.github/actions/resolve-job-id/action.yml
+++ b/.github/actions/resolve-job-id/action.yml
@@ -1,0 +1,35 @@
+name: Resolve current job id
+description: >
+  Resolve this job's GitHub workflow_jobs.id via the Actions API and export it
+  as JOB_ID (and JOB_HTML_URL) to $GITHUB_ENV, so any later step can read the
+  numeric job id without making its own API call. Best-effort: warns and
+  proceeds on failure so it can never break the run.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve JOB_ID
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RUNNER_NAME: ${{ runner.name }}
+      run: |
+        # GitHub doesn't expose the current job's numeric id, so we look it up
+        # from the Actions API. A runner runs exactly one job at a time, so
+        # filtering by runner_name within (run_id, run_attempt) is unique.
+        # max_by(.started_at) handles the rare case of a runner sequentially
+        # running multiple jobs in the same attempt — we want the latest.
+        set +e
+        out=$(gh api \
+          "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" \
+          --jq "[.jobs[] | select(.runner_name == \"$RUNNER_NAME\")] | max_by(.started_at) | \"\(.id) \(.html_url)\"" \
+          2>/dev/null)
+        if [ -n "$out" ] && [ "$out" != "null null" ]; then
+          read -r job_id job_url <<<"$out"
+          echo "JOB_ID=$job_id" >> "$GITHUB_ENV"
+          echo "JOB_HTML_URL=$job_url" >> "$GITHUB_ENV"
+          echo "Resolved JOB_ID=$job_id"
+        else
+          echo "::warning::Could not resolve current job id (runner=$RUNNER_NAME)"
+        fi
+        exit 0

--- a/.github/actions/resolve-job-id/action.yml
+++ b/.github/actions/resolve-job-id/action.yml
@@ -20,16 +20,29 @@ runs:
         # max_by(.started_at) handles the rare case of a runner sequentially
         # running multiple jobs in the same attempt — we want the latest.
         set +e
-        out=$(gh api \
-          "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" \
-          --jq "[.jobs[] | select(.runner_name == \"$RUNNER_NAME\")] | max_by(.started_at) | \"\(.id) \(.html_url)\"" \
-          2>/dev/null)
-        if [ -n "$out" ] && [ "$out" != "null null" ]; then
+        api_url="/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100"
+        jq_filter="[.jobs[] | select(.runner_name == \"$RUNNER_NAME\")] | max_by(.started_at) | \"\(.id) \(.html_url)\""
+
+        # The Actions jobs API is eventually consistent: after a runner picks
+        # up a job, it can take a few seconds for runner_name to appear in the
+        # response. Retry briefly to absorb that.
+        out=""
+        for attempt in 1 2 3 4 5; do
+          out=$(gh api "$api_url" --jq "$jq_filter" 2>/dev/null)
+          if [ -n "$out" ] && [ "$out" != "null null" ]; then
+            break
+          fi
+          out=""
+          echo "Attempt $attempt: job not yet visible in Actions API; retrying..."
+          sleep 3
+        done
+
+        if [ -n "$out" ]; then
           read -r job_id job_url <<<"$out"
           echo "JOB_ID=$job_id" >> "$GITHUB_ENV"
           echo "JOB_HTML_URL=$job_url" >> "$GITHUB_ENV"
-          echo "Resolved JOB_ID=$job_id"
+          echo "Resolved JOB_ID=$job_id (runner=$RUNNER_NAME)"
         else
-          echo "::warning::Could not resolve current job id (runner=$RUNNER_NAME)"
+          echo "::warning::Could not resolve current job id after 5 attempts (runner=$RUNNER_NAME)"
         fi
         exit 0

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,8 +37,9 @@ env:
   HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
   PR_NUMBER: ${{ github.event.pull_request.number || '' }}
   JOB_NAME: ${{ inputs.name }}
-  # ci-conductor failed-tests reporting (DEV-1999). URL is a secret (callers pass
-  # `secrets: inherit`); reporting no-ops when it's unset.
+  # ci-conductor failed-tests reporting (DEV-1999). Secret holds the webhooks
+  # base URL (".../webhooks"); the reporter appends the endpoint. Callers pass
+  # `secrets: inherit`; reporting no-ops when it's unset.
   CI_CONDUCTOR_WEBHOOK_URL: ${{ secrets.CI_CONDUCTOR_WEBHOOK_URL }}
   REPO_ID: ${{ github.event.repository.id }}
   # TODO(DEV-1999): dry run — log the payload instead of POSTing while we

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,6 +68,10 @@ jobs:
           submodules: true
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
+      # Export this job's numeric GitHub job id as $JOB_ID for any later step
+      # (e.g. ci-conductor failed-tests reporting in after:spec). DEV-1999.
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Setup python-runner
         if: ${{ inputs.name == 'python' }}
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,9 +44,6 @@ env:
   # Shared secret sent as the `x-internal-secret` header to authenticate.
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   REPO_ID: ${{ github.event.repository.id }}
-  # TODO(DEV-1999): dry run — log the payload instead of POSTing while we
-  # validate env resolution + payload shape. Remove to start sending for real.
-  CI_CONDUCTOR_DRY_RUN: "true"
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,6 +37,10 @@ env:
   HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
   PR_NUMBER: ${{ github.event.pull_request.number || '' }}
   JOB_NAME: ${{ inputs.name }}
+  # ci-conductor failed-tests reporting (DEV-1999). URL is a secret (callers pass
+  # `secrets: inherit`); reporting no-ops when it's unset.
+  CI_CONDUCTOR_WEBHOOK_URL: ${{ secrets.CI_CONDUCTOR_WEBHOOK_URL }}
+  REPO_ID: ${{ github.event.repository.id }}
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,6 +41,9 @@ env:
   # `secrets: inherit`); reporting no-ops when it's unset.
   CI_CONDUCTOR_WEBHOOK_URL: ${{ secrets.CI_CONDUCTOR_WEBHOOK_URL }}
   REPO_ID: ${{ github.event.repository.id }}
+  # TODO(DEV-1999): dry run — log the payload instead of POSTing while we
+  # validate env resolution + payload shape. Remove to start sending for real.
+  CI_CONDUCTOR_DRY_RUN: "true"
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,10 +71,6 @@ jobs:
           submodules: true
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      # Export this job's numeric GitHub job id as $JOB_ID for any later step
-      # (e.g. ci-conductor failed-tests reporting in after:spec). DEV-1999.
-      - uses: ./.github/actions/resolve-job-id
-
       - name: Setup python-runner
         if: ${{ inputs.name == 'python' }}
         env:
@@ -128,6 +124,15 @@ jobs:
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
+
+      # Export this job's numeric GitHub job id as $JOB_ID for the Cypress runs
+      # below (ci-conductor failed-tests reporting reads it in after:spec).
+      # Snapshot generation is itself a Cypress run that fires after:spec, so
+      # this must precede it. Placed late, not after checkout: the Actions jobs
+      # API is eventually consistent, so the longer the job has been alive the
+      # more reliably the lookup resolves. JOB_ID exported here persists to the
+      # steps below. DEV-1999.
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Generate database snapshots
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,12 @@ env:
   # Shared secret sent as the `x-internal-secret` header to authenticate.
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   REPO_ID: ${{ github.event.repository.id }}
+  # Commit + PR target branch under test, so conductor can tie failures to the
+  # right code. On PRs the ambient GITHUB_SHA is the synthetic merge commit and
+  # GITHUB_BASE_REF the target, so we pass the PR head sha / base ref explicitly
+  # (falling back to push-event values). The reporter reads these. DEV-1999.
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,6 +41,8 @@ env:
   # base URL (".../webhooks"); the reporter appends the endpoint. Callers pass
   # `secrets: inherit`; reporting no-ops when it's unset.
   CI_CONDUCTOR_WEBHOOK_URL: ${{ secrets.CI_CONDUCTOR_WEBHOOK_URL }}
+  # Shared secret sent as the `x-internal-secret` header to authenticate.
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   REPO_ID: ${{ github.event.repository.id }}
   # TODO(DEV-1999): dry run — log the payload instead of POSTing while we
   # validate env resolution + payload shape. Remove to start sending for real.

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -20,6 +20,7 @@ const {
   CI_CONDUCTOR_DRY_RUN,
   REPO_ID,
   GITHUB_RUN_ID,
+  JOB_ID,
 } = process.env;
 
 // When set, the payload is logged instead of POSTed — used to validate env
@@ -36,15 +37,14 @@ type ConductorTest = {
 };
 
 /**
- * The conductor's `failed_tests.job_id` is a GitHub *numeric* workflow-job id.
- * That number isn't exposed to a running job and isn't static across runs, so
- * for now we send `null` (the column is nullable, and `run_id` already ties a
- * failure to its PR/branch). Kept as a single seam so we can later return a
- * resolved id — or a job name, if the schema changes to accept one — without
- * reshaping the payload. See DEV-1999.
+ * GitHub doesn't expose the current job's numeric `workflow_jobs.id` to a
+ * running job, so the `./.github/actions/resolve-job-id` composite action
+ * resolves it once at job start and exports it as `JOB_ID`. We just read that
+ * env here. Falls back to null when the env isn't set (the column is
+ * nullable). See DEV-1999.
  */
 function getJobId(): number | null {
-  return null;
+  return toNumber(JOB_ID);
 }
 
 /** Parse a numeric env var, treating missing/blank/non-numeric as null. */

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,0 +1,132 @@
+import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
+
+// `Cypress` and `CypressCommandLine` are global namespaces provided by the
+// "cypress" types (see e2e/tsconfig.json), so they're referenced without import.
+
+/**
+ * Reports Cypress test failures to the ci-conductor service, mid-run, from the
+ * `after:spec` Node hook (see e2e/support/config.js). Sending per-spec — rather
+ * than waiting for the whole job to finish — lets failures be tied back to the
+ * CI run (and through it the PR / release branch) before the job completes.
+ *
+ * The URL is only supplied via env in CI, so local runs no-op.
+ *
+ * See DEV-1999.
+ */
+
+const { CI_CONDUCTOR_WEBHOOK_URL, REPO_ID, GITHUB_RUN_ID } = process.env;
+
+/** Matches the `tests[]` shape consumed by ci-conductor's `ingestFailedTests`. */
+type ConductorTest = {
+  name: string;
+  class?: string;
+  file?: string;
+  message?: string;
+  stack?: string;
+};
+
+/**
+ * The conductor's `failed_tests.job_id` is a GitHub *numeric* workflow-job id.
+ * That number isn't exposed to a running job and isn't static across runs, so
+ * for now we send `null` (the column is nullable, and `run_id` already ties a
+ * failure to its PR/branch). Kept as a single seam so we can later return a
+ * resolved id — or a job name, if the schema changes to accept one — without
+ * reshaping the payload. See DEV-1999.
+ */
+function getJobId(): number | null {
+  return null;
+}
+
+/** Parse a numeric env var, treating missing/blank/non-numeric as null. */
+function toNumber(value: string | undefined): number | null {
+  if (value == null || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstLine(text: string | null | undefined): string | undefined {
+  return text?.split("\n").find((line) => line.trim().length > 0);
+}
+
+/**
+ * Pull the failed tests out of a single spec's run results. Only tests whose
+ * final state is "failed" are included, so a test that flaked but passed on
+ * retry is not reported.
+ *
+ * If the spec crashed before any tests ran (e.g. a compile/import error),
+ * Cypress reports no failed tests but sets `results.error`; we surface that as
+ * a single synthetic entry so the failure isn't lost.
+ */
+export function extractFailedTests(
+  spec: Cypress.Spec,
+  results: CypressCommandLine.RunResult,
+): ConductorTest[] {
+  const file = spec?.relative;
+
+  const failedTests = (results?.tests ?? [])
+    .filter((test) => test.state === "failed")
+    .map((test) => {
+      const titlePath = test.title ?? [];
+      const name = titlePath[titlePath.length - 1] ?? "(unknown test)";
+      const suite = titlePath.slice(0, -1).join(" > ");
+      const displayError = test.displayError ?? undefined;
+      return {
+        name,
+        class: suite || undefined,
+        file,
+        message: firstLine(displayError),
+        stack: displayError,
+      };
+    });
+
+  if (failedTests.length === 0 && results?.error) {
+    return [
+      {
+        name: spec?.name ?? "(spec failed to run)",
+        file,
+        message: firstLine(results.error),
+        stack: results.error,
+      },
+    ];
+  }
+
+  return failedTests;
+}
+
+/**
+ * POST the given failures to ci-conductor. No-ops when the webhook URL isn't
+ * configured (local runs, PRs without the var). Never throws — reporting must
+ * not break a test run — so all errors are logged and swallowed.
+ */
+export async function reportFailedTestsToConductor(
+  tests: ConductorTest[],
+): Promise<void> {
+  if (!CI_CONDUCTOR_WEBHOOK_URL || tests.length === 0) {
+    return;
+  }
+
+  const body = {
+    repo_id: toNumber(REPO_ID),
+    run_id: toNumber(GITHUB_RUN_ID),
+    job_id: getJobId(),
+    tests,
+  };
+
+  try {
+    const response = await fetch(CI_CONDUCTOR_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[ci-conductor] failed-tests POST returned ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error("[ci-conductor] failed to POST failed-tests", error);
+  }
+}

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -22,6 +22,14 @@ const {
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
   JOB_ID,
+  // The commit and PR target branch under test. On PRs the ambient GITHUB_SHA is
+  // a synthetic merge commit and GITHUB_BASE_REF the target, so e2e-test.yml sets
+  // COMMIT_SHA/TARGET_BRANCH to the PR's head sha / base ref; we fall back to the
+  // ambient vars (push runs, local) when they're unset. See DEV-1999.
+  COMMIT_SHA,
+  GITHUB_SHA,
+  TARGET_BRANCH,
+  GITHUB_BASE_REF,
 } = process.env;
 
 // When set, the payload is logged instead of POSTed — used to validate env
@@ -31,11 +39,18 @@ const isDryRun = CI_CONDUCTOR_DRY_RUN === "true";
 /** Matches the `tests[]` shape consumed by ci-conductor's `ingestFailedTests`. */
 type ConductorTest = {
   name: string;
-  class?: string;
+  /** The test's suite path (the joined `describe` titles), formerly `class`. */
+  path?: string;
   file?: string;
   duration?: number;
   /** Raw per-attempt shape from Cypress, e.g. [{state:"failed"},{state:"passed"}]. */
   attempts?: { state: string }[];
+  /**
+   * "failure" when every attempt failed (broken), "flake" when it failed then
+   * passed on retry, "passed" when every attempt passed. Passes are only
+   * reported on re-runs (run attempt > 1). Derived from `attempts`.
+   */
+  status?: "failure" | "flake" | "passed";
   /**
    * Cypress' final `displayError` blob for the test. Null for flaky tests
    * (Cypress drops it when the final attempt passes); only broken tests carry a
@@ -43,6 +58,22 @@ type ConductorTest = {
    */
   message?: string | null;
 };
+
+/**
+ * Classify a test from its attempts: "passed" if every attempt passed,
+ * "failure" if every attempt failed, "flake" if it failed at least once but
+ * ultimately passed on retry. Callers only pass tests that ran (a non-empty
+ * attempts array of passes and/or fails), never pending/skipped.
+ */
+function classifyStatus(
+  attempts: { state: string }[],
+): "failure" | "flake" | "passed" {
+  if (attempts.every((attempt) => attempt.state === "passed")) {
+    return "passed";
+  }
+  const allFailed = attempts.every((attempt) => attempt.state === "failed");
+  return allFailed ? "failure" : "flake";
+}
 
 /**
  * GitHub doesn't expose the current job's numeric `workflow_jobs.id` to a
@@ -65,11 +96,13 @@ function toNumber(value: string | undefined): number | null {
 }
 
 /**
- * Pull the reportable tests out of a single spec's run results. We include any
- * test that had at least one failed attempt — so both "broken" (every attempt
- * failed) and "flaky" (failed at least once, passed on retry) are reported.
- * Healthy tests (no failed attempts) are omitted. Conductor classifies the
- * row from the raw `attempts` array.
+ * Pull the reportable tests out of a single spec's run results. We always
+ * include any test that had at least one failed attempt — so both "broken"
+ * (every attempt failed) and "flaky" (failed at least once, passed on retry)
+ * are reported. On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include
+ * tests that passed, so conductor can see a previously-failing test recover.
+ * Pending/skipped tests are never reported. Each row carries a derived `status`
+ * ("failure" | "flake" | "success"); see `classifyStatus`.
  *
  * Cypress only populates `displayError` for the *final* state, so flaky tests
  * arrive with `message: null` — we know *that* they flaked from `attempts`,
@@ -85,20 +118,34 @@ export function extractFailedTests(
 ): ConductorTest[] {
   const file = spec?.relative;
 
+  // On a re-run we also report passing tests (not just failures) so conductor
+  // can see a previously-failing test recover. Read at call time rather than the
+  // module-level destructure so it's controllable per-call in tests.
+  const isRerun = (toNumber(process.env.GITHUB_RUN_ATTEMPT) ?? 0) > 1;
+
   const tests = (results?.tests ?? [])
-    .filter((test) =>
-      (test.attempts ?? []).some((attempt) => attempt.state === "failed"),
-    )
+    .filter((test) => {
+      const attempts = test.attempts ?? [];
+      const failed = attempts.some((attempt) => attempt.state === "failed");
+      // A test "passed" only if it ran and every attempt passed — this excludes
+      // pending/skipped tests, which we never report.
+      const passed =
+        attempts.length > 0 &&
+        attempts.every((attempt) => attempt.state === "passed");
+      return failed || (isRerun && passed);
+    })
     .map((test) => {
       const titlePath = test.title ?? [];
       const name = titlePath[titlePath.length - 1] ?? "(unknown test)";
       const suite = titlePath.slice(0, -1).join(" > ");
+      const attempts = test.attempts ?? [];
       return {
         name,
-        class: suite || undefined,
+        path: suite || undefined,
         file,
         duration: test.duration,
-        attempts: test.attempts ?? [],
+        attempts,
+        status: classifyStatus(attempts),
         message: test.displayError ?? null,
       };
     });
@@ -109,6 +156,7 @@ export function extractFailedTests(
         name: spec?.name ?? "(spec failed to run)",
         file,
         attempts: [{ state: "failed" }],
+        status: "failure",
         message: results.error,
       },
     ];
@@ -136,8 +184,13 @@ export async function reportFailedTestsToConductor(
     const body = {
       repo_id: toNumber(REPO_ID),
       run_id: toNumber(GITHUB_RUN_ID),
-      run_attempt: toNumber(GITHUB_RUN_ATTEMPT),
+      attempt: toNumber(GITHUB_RUN_ATTEMPT),
       job_id: getJobId(),
+      test_suite: "e2e",
+      // PR head sha / target branch when set by e2e-test.yml, else the ambient
+      // (push/local) values. Empty strings collapse to null.
+      sha: COMMIT_SHA || GITHUB_SHA || null,
+      target_branch: TARGET_BRANCH || GITHUB_BASE_REF || null,
       // The retry ceiling so conductor can interpret per-test `attempts`.
       // CYPRESS_RETRIES isn't set in CI by default; e2e/support/config.js
       // surfaces the resolved Cypress config value into this env at startup.

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -20,6 +20,7 @@ const {
   CI_CONDUCTOR_DRY_RUN,
   REPO_ID,
   GITHUB_RUN_ID,
+  GITHUB_RUN_ATTEMPT,
   JOB_ID,
 } = process.env;
 
@@ -32,8 +33,15 @@ type ConductorTest = {
   name: string;
   class?: string;
   file?: string;
-  message?: string;
-  stack?: string;
+  duration?: number;
+  /** Raw per-attempt shape from Cypress, e.g. [{state:"failed"},{state:"passed"}]. */
+  attempts?: { state: string }[];
+  /**
+   * Cypress' final `displayError` blob for the test. Null for flaky tests
+   * (Cypress drops it when the final attempt passes); only broken tests carry a
+   * value. Conductor schema isn't final — fields it doesn't store are ignored.
+   */
+  message?: string | null;
 };
 
 /**
@@ -56,18 +64,20 @@ function toNumber(value: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function firstLine(text: string | null | undefined): string | undefined {
-  return text?.split("\n").find((line) => line.trim().length > 0);
-}
-
 /**
- * Pull the failed tests out of a single spec's run results. Only tests whose
- * final state is "failed" are included, so a test that flaked but passed on
- * retry is not reported.
+ * Pull the reportable tests out of a single spec's run results. We include any
+ * test that had at least one failed attempt — so both "broken" (every attempt
+ * failed) and "flaky" (failed at least once, passed on retry) are reported.
+ * Healthy tests (no failed attempts) are omitted. Conductor classifies the
+ * row from the raw `attempts` array.
+ *
+ * Cypress only populates `displayError` for the *final* state, so flaky tests
+ * arrive with `message: null` — we know *that* they flaked from `attempts`,
+ * but not *why*. Broken tests carry the full error blob.
  *
  * If the spec crashed before any tests ran (e.g. a compile/import error),
- * Cypress reports no failed tests but sets `results.error`; we surface that as
- * a single synthetic entry so the failure isn't lost.
+ * Cypress reports no tests but sets `results.error`; we surface that as a
+ * single synthetic entry so the failure isn't lost.
  */
 export function extractFailedTests(
   spec: Cypress.Spec,
@@ -75,34 +85,36 @@ export function extractFailedTests(
 ): ConductorTest[] {
   const file = spec?.relative;
 
-  const failedTests = (results?.tests ?? [])
-    .filter((test) => test.state === "failed")
+  const tests = (results?.tests ?? [])
+    .filter((test) =>
+      (test.attempts ?? []).some((attempt) => attempt.state === "failed"),
+    )
     .map((test) => {
       const titlePath = test.title ?? [];
       const name = titlePath[titlePath.length - 1] ?? "(unknown test)";
       const suite = titlePath.slice(0, -1).join(" > ");
-      const displayError = test.displayError ?? undefined;
       return {
         name,
         class: suite || undefined,
         file,
-        message: firstLine(displayError),
-        stack: displayError,
+        duration: test.duration,
+        attempts: test.attempts ?? [],
+        message: test.displayError ?? null,
       };
     });
 
-  if (failedTests.length === 0 && results?.error) {
+  if (tests.length === 0 && results?.error) {
     return [
       {
         name: spec?.name ?? "(spec failed to run)",
         file,
-        message: firstLine(results.error),
-        stack: results.error,
+        attempts: [{ state: "failed" }],
+        message: results.error,
       },
     ];
   }
 
-  return failedTests;
+  return tests;
 }
 
 /**
@@ -124,7 +136,12 @@ export async function reportFailedTestsToConductor(
     const body = {
       repo_id: toNumber(REPO_ID),
       run_id: toNumber(GITHUB_RUN_ID),
+      run_attempt: toNumber(GITHUB_RUN_ATTEMPT),
       job_id: getJobId(),
+      // The retry ceiling so conductor can interpret per-test `attempts`.
+      // CYPRESS_RETRIES isn't set in CI by default; e2e/support/config.js
+      // surfaces the resolved Cypress config value into this env at startup.
+      retries: toNumber(process.env.CYPRESS_RETRIES),
       tests,
     };
 

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -102,7 +102,7 @@ function toNumber(value: string | undefined): number | null {
  * are reported. On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include
  * tests that passed, so conductor can see a previously-failing test recover.
  * Pending/skipped tests are never reported. Each row carries a derived `status`
- * ("failure" | "flake" | "success"); see `classifyStatus`.
+ * ("failure" | "flake" | "passed"); see `classifyStatus`.
  *
  * Cypress only populates `displayError` for the *final* state, so flaky tests
  * arrive with `message: null` — we know *that* they flaked from `attempts`,

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -9,7 +9,7 @@ import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
  * than waiting for the whole job to finish — lets failures be tied back to the
  * CI run (and through it the PR / release branch) before the job completes.
  *
- * The URL is only supplied via env in CI, so local runs no-op.
+ * The webhooks base URL is only supplied via env in CI, so local runs no-op.
  *
  * See DEV-1999.
  */
@@ -135,7 +135,16 @@ export async function reportFailedTestsToConductor(
       return;
     }
 
-    const response = await fetch(CI_CONDUCTOR_WEBHOOK_URL, {
+    if (!CI_CONDUCTOR_WEBHOOK_URL) {
+      // already excluded by the guard above; this also narrows the type
+      return;
+    }
+
+    // The secret holds the webhooks *base* (e.g. ".../webhooks"); we append the
+    // specific endpoint so the same secret can serve other webhooks later.
+    const endpoint = `${CI_CONDUCTOR_WEBHOOK_URL.replace(/\/+$/, "")}/failed-tests`;
+
+    const response = await fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -16,6 +16,7 @@ import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
 const {
   CI_CONDUCTOR_WEBHOOK_URL,
+  CI_CONDUCTOR_WEBHOOK_SECRET,
   CI_CONDUCTOR_DRY_RUN,
   REPO_ID,
   GITHUB_RUN_ID,
@@ -140,13 +141,21 @@ export async function reportFailedTestsToConductor(
       return;
     }
 
-    // The secret holds the webhooks *base* (e.g. ".../webhooks"); we append the
-    // specific endpoint so the same secret can serve other webhooks later.
+    // CI_CONDUCTOR_WEBHOOK_URL holds the webhooks *base* (e.g. ".../webhooks");
+    // we append the specific endpoint so the same secret can serve others later.
     const endpoint = `${CI_CONDUCTOR_WEBHOOK_URL.replace(/\/+$/, "")}/failed-tests`;
+
+    // ci-conductor authenticates this endpoint via the x-internal-secret header.
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (CI_CONDUCTOR_WEBHOOK_SECRET) {
+      headers["x-internal-secret"] = CI_CONDUCTOR_WEBHOOK_SECRET;
+    }
 
     const response = await fetch(endpoint, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
 

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -14,7 +14,16 @@ import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
  * See DEV-1999.
  */
 
-const { CI_CONDUCTOR_WEBHOOK_URL, REPO_ID, GITHUB_RUN_ID } = process.env;
+const {
+  CI_CONDUCTOR_WEBHOOK_URL,
+  CI_CONDUCTOR_DRY_RUN,
+  REPO_ID,
+  GITHUB_RUN_ID,
+} = process.env;
+
+// When set, the payload is logged instead of POSTed — used to validate env
+// resolution and payload shape in CI before sending real data. See DEV-1999.
+const isDryRun = CI_CONDUCTOR_DRY_RUN === "true";
 
 /** Matches the `tests[]` shape consumed by ci-conductor's `ingestFailedTests`. */
 type ConductorTest = {
@@ -96,14 +105,15 @@ export function extractFailedTests(
 }
 
 /**
- * POST the given failures to ci-conductor. No-ops when the webhook URL isn't
- * configured (local runs, PRs without the var). Never throws — reporting must
- * not break a test run — so all errors are logged and swallowed.
+ * Report the given failures to ci-conductor. In dry-run mode the payload is
+ * logged and nothing is sent. Otherwise it's POSTed, no-opping when the webhook
+ * URL isn't configured (local runs, PRs without the secret). Never throws —
+ * reporting must not break a test run — so all errors are logged and swallowed.
  */
 export async function reportFailedTestsToConductor(
   tests: ConductorTest[],
 ): Promise<void> {
-  if (!CI_CONDUCTOR_WEBHOOK_URL || tests.length === 0) {
+  if (tests.length === 0 || (!CI_CONDUCTOR_WEBHOOK_URL && !isDryRun)) {
     return;
   }
 
@@ -113,6 +123,14 @@ export async function reportFailedTestsToConductor(
     job_id: getJobId(),
     tests,
   };
+
+  if (isDryRun) {
+    console.log(
+      `[ci-conductor] (dry run) would POST ${tests.length} failure(s):`,
+      JSON.stringify(body),
+    );
+    return;
+  }
 
   try {
     const response = await fetch(CI_CONDUCTOR_WEBHOOK_URL, {

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -117,22 +117,24 @@ export async function reportFailedTestsToConductor(
     return;
   }
 
-  const body = {
-    repo_id: toNumber(REPO_ID),
-    run_id: toNumber(GITHUB_RUN_ID),
-    job_id: getJobId(),
-    tests,
-  };
-
-  if (isDryRun) {
-    console.log(
-      `[ci-conductor] (dry run) would POST ${tests.length} failure(s):`,
-      JSON.stringify(body),
-    );
-    return;
-  }
-
+  // Everything below is wrapped so the reporter can never throw into the test
+  // run, regardless of payload contents or network behavior.
   try {
+    const body = {
+      repo_id: toNumber(REPO_ID),
+      run_id: toNumber(GITHUB_RUN_ID),
+      job_id: getJobId(),
+      tests,
+    };
+
+    if (isDryRun) {
+      console.log(
+        `[ci-conductor] (dry run) would POST ${tests.length} failure(s):`,
+        JSON.stringify(body),
+      );
+      return;
+    }
+
     const response = await fetch(CI_CONDUCTOR_WEBHOOK_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -211,6 +211,32 @@ describe("reportFailedTestsToConductor", () => {
     });
   });
 
+  it("sends the x-internal-secret header when the secret is configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      CI_CONDUCTOR_WEBHOOK_SECRET: "s3cr3t",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch.mock.calls[0][1].headers).toMatchObject({
+      "x-internal-secret": "s3cr3t",
+    });
+  });
+
+  it("omits the secret header when no secret is configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      CI_CONDUCTOR_WEBHOOK_SECRET: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch.mock.calls[0][1].headers).not.toHaveProperty(
+      "x-internal-secret",
+    );
+  });
+
   it("appends the endpoint regardless of a trailing slash on the base URL", async () => {
     const { reportFailedTestsToConductor } = await loadConductor({
       CI_CONDUCTOR_WEBHOOK_URL: `${url}/`,

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -160,7 +160,8 @@ describe("extractFailedTests", () => {
 });
 
 describe("reportFailedTestsToConductor", () => {
-  const url = "https://conductor.example/webhooks/failed-tests";
+  const url = "https://conductor.example/webhooks";
+  const endpoint = "https://conductor.example/webhooks/failed-tests";
   const oneTest = [{ name: "a test", file: "foo.cy.spec.ts" }];
 
   beforeEach(() => {
@@ -197,7 +198,7 @@ describe("reportFailedTestsToConductor", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [calledUrl, options] = mockFetch.mock.calls[0];
-    expect(calledUrl).toBe(url);
+    expect(calledUrl).toBe(endpoint);
     expect(options.method).toBe("POST");
     expect(options.headers).toMatchObject({
       "Content-Type": "application/json",
@@ -208,6 +209,15 @@ describe("reportFailedTestsToConductor", () => {
       job_id: null,
       tests: oneTest,
     });
+  });
+
+  it("appends the endpoint regardless of a trailing slash on the base URL", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: `${url}/`,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(mockFetch.mock.calls[0][0]).toBe(endpoint);
   });
 
   it("sends null ids when the env vars are missing or non-numeric", async () => {

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -289,4 +289,21 @@ describe("reportFailedTestsToConductor", () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("500"));
     (console.error as jest.Mock).mockRestore();
   });
+
+  it("never throws even when fetch throws synchronously", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockImplementation(() => {
+      throw new Error("synchronous boom");
+    });
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+    });
+
+    await expect(
+      reportFailedTestsToConductor(oneTest),
+    ).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+    (console.error as jest.Mock).mockRestore();
+  });
 });

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -9,17 +9,33 @@ jest.mock("node-fetch", () => ({
   default: (...args: unknown[]) => mockFetch(...args),
 }));
 
-// ci_conductor reads its env vars once at import time, so each send-path test
-// re-imports the module with a fresh process.env.
+// ci_conductor reads some env at import time (top-level destructure) and some
+// at call time (e.g. CYPRESS_RETRIES), so loadConductor applies the env BEFORE
+// re-importing and leaves it applied until afterEach restores it.
+const envBackups: Array<{ key: string; previous: string | undefined }> = [];
+
+afterEach(() => {
+  while (envBackups.length) {
+    const { key, previous } = envBackups.pop()!;
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+});
+
 const loadConductor = async (env: Record<string, string | undefined>) => {
   jest.resetModules();
-  const original = process.env;
-  process.env = { ...original, ...env };
-  try {
-    return await import("./ci_conductor");
-  } finally {
-    process.env = original;
+  for (const [key, value] of Object.entries(env)) {
+    envBackups.push({ key, previous: process.env[key] });
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
+  return await import("./ci_conductor");
 };
 
 // Minimal builders for the bits of Cypress' after:spec payload we read.
@@ -38,24 +54,32 @@ const makeResults = (
     ...overrides,
   }) as unknown as CypressCommandLine.RunResult;
 
+// Builds a TestResult-shaped object. The final `state` is derived from
+// `attemptStates` so callers can describe healthy/flaky/broken naturally.
 const test = (
   title: string[],
-  state: string,
+  attemptStates: string[],
   displayError: string | null = null,
-) => ({ title, state, displayError });
+  duration: number = 100,
+) => ({
+  title,
+  state: attemptStates[attemptStates.length - 1],
+  displayError,
+  duration,
+  attempts: attemptStates.map((state) => ({ state })),
+});
 
 describe("extractFailedTests", () => {
-  it("reports only failed tests, mapping suite/leaf/message/stack/file", () => {
+  it("reports broken tests with the full displayError as message", () => {
     const displayError =
       "AssertionError: expected true to be false\n    at Context.eval (foo.cy.spec.ts:42)";
 
     const results = makeResults({
-      stats: { failures: 1 } as CypressCommandLine.RunResult["stats"],
       tests: [
-        test(["Dashboard", "filters", "applies a filter"], "passed"),
+        test(["Dashboard", "filters", "applies a filter"], ["passed"]),
         test(
           ["Dashboard", "filters", "shows an error"],
-          "failed",
+          ["failed", "failed"],
           displayError,
         ),
       ],
@@ -66,33 +90,49 @@ describe("extractFailedTests", () => {
         name: "shows an error",
         class: "Dashboard > filters",
         file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
-        message: "AssertionError: expected true to be false",
-        stack: displayError,
+        duration: 100,
+        attempts: [{ state: "failed" }, { state: "failed" }],
+        message: displayError,
       },
     ]);
   });
 
-  it("excludes passed, pending, and skipped tests (incl. flaky-but-passed)", () => {
+  it("includes flaky tests too (final passed but ≥1 failed attempt), with null message", () => {
     const results = makeResults({
       tests: [
-        test(["a", "passed test"], "passed"),
-        test(["a", "pending test"], "pending"),
-        test(["a", "skipped test"], "skipped"),
-        // a test that flaked then passed on retry has a final state of "passed"
-        test(["a", "flaky test"], "passed"),
+        test(["a", "healthy"], ["passed"]),
+        test(["a", "flaky"], ["failed", "passed"]),
+      ],
+    });
+
+    const failures = extractFailedTests(spec, results);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      name: "flaky",
+      attempts: [{ state: "failed" }, { state: "passed" }],
+      message: null,
+    });
+  });
+
+  it("excludes healthy, pending, and skipped tests", () => {
+    const results = makeResults({
+      tests: [
+        test(["a", "passed test"], ["passed"]),
+        test(["a", "pending test"], ["pending"]),
+        test(["a", "skipped test"], ["skipped"]),
       ],
     });
 
     expect(extractFailedTests(spec, results)).toEqual([]);
   });
 
-  it("returns an empty array when nothing failed", () => {
+  it("returns an empty array when nothing has a failed attempt", () => {
     expect(extractFailedTests(spec, makeResults({}))).toEqual([]);
   });
 
   it("omits `class` for a top-level test with no suite", () => {
     const results = makeResults({
-      tests: [test(["lonely test"], "failed", "boom")],
+      tests: [test(["lonely test"], ["failed"], "boom")],
     });
 
     const [failure] = extractFailedTests(spec, results);
@@ -100,34 +140,21 @@ describe("extractFailedTests", () => {
     expect(failure.class).toBeUndefined();
   });
 
-  it("leaves message/stack undefined when a failed test has no displayError", () => {
+  it("sends message: null when a failed test has no displayError", () => {
     const results = makeResults({
-      tests: [test(["a", "no error string"], "failed", null)],
+      tests: [test(["a", "no error string"], ["failed"], null)],
     });
 
-    expect(extractFailedTests(spec, results)).toEqual([
-      {
-        name: "no error string",
-        class: "a",
-        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
-        message: undefined,
-        stack: undefined,
-      },
-    ]);
-  });
-
-  it("skips blank leading lines when deriving the message", () => {
-    const results = makeResults({
-      tests: [test(["a", "t"], "failed", "\n   \nReal message\nstack line")],
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
+      name: "no error string",
+      class: "a",
+      message: null,
     });
-
-    expect(extractFailedTests(spec, results)[0].message).toBe("Real message");
   });
 
   it("falls back to a synthetic entry when the spec crashes before any test runs", () => {
     const results = makeResults({
       error: "SyntaxError: Unexpected token\n  at compile",
-      stats: { failures: 1 } as CypressCommandLine.RunResult["stats"],
       tests: [],
     });
 
@@ -135,8 +162,8 @@ describe("extractFailedTests", () => {
       {
         name: "foo.cy.spec.ts",
         file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
-        message: "SyntaxError: Unexpected token",
-        stack: "SyntaxError: Unexpected token\n  at compile",
+        attempts: [{ state: "failed" }],
+        message: "SyntaxError: Unexpected token\n  at compile",
       },
     ]);
   });
@@ -144,7 +171,7 @@ describe("extractFailedTests", () => {
   it("prefers real failed tests over the spec-level error fallback", () => {
     const results = makeResults({
       error: "some run-level error",
-      tests: [test(["a", "real failure"], "failed", "boom")],
+      tests: [test(["a", "real failure"], ["failed"], "boom")],
     });
 
     const failures = extractFailedTests(spec, results);
@@ -187,11 +214,13 @@ describe("reportFailedTestsToConductor", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("POSTs the failures with parsed numeric ids and a null job_id", async () => {
+  it("POSTs the failures with parsed numeric ids and forwarded tests", async () => {
     const { reportFailedTestsToConductor } = await loadConductor({
       CI_CONDUCTOR_WEBHOOK_URL: url,
       REPO_ID: "123",
       GITHUB_RUN_ID: "456",
+      GITHUB_RUN_ATTEMPT: "2",
+      CYPRESS_RETRIES: "1",
     });
 
     await reportFailedTestsToConductor(oneTest);
@@ -206,9 +235,25 @@ describe("reportFailedTestsToConductor", () => {
     expect(JSON.parse(options.body)).toEqual({
       repo_id: 123,
       run_id: 456,
+      run_attempt: 2,
       job_id: null,
+      retries: 1,
       tests: oneTest,
     });
+  });
+
+  it("sends null run_attempt and retries when their envs are missing", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      GITHUB_RUN_ATTEMPT: undefined,
+      CYPRESS_RETRIES: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.run_attempt).toBeNull();
+    expect(body.retries).toBeNull();
   });
 
   it("sends the x-internal-secret header when the secret is configured", async () => {

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -1,0 +1,258 @@
+import { extractFailedTests } from "./ci_conductor";
+
+// jest.mock is hoisted; the mocked default must be referenced via a `mock`-
+// prefixed variable. node-fetch is unused by extractFailedTests, so mocking it
+// here is harmless for those tests.
+const mockFetch = jest.fn();
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// ci_conductor reads its env vars once at import time, so each send-path test
+// re-imports the module with a fresh process.env.
+const loadConductor = async (env: Record<string, string | undefined>) => {
+  jest.resetModules();
+  const original = process.env;
+  process.env = { ...original, ...env };
+  try {
+    return await import("./ci_conductor");
+  } finally {
+    process.env = original;
+  }
+};
+
+// Minimal builders for the bits of Cypress' after:spec payload we read.
+const spec = {
+  name: "foo.cy.spec.ts",
+  relative: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+} as Cypress.Spec;
+
+const makeResults = (
+  overrides: Partial<CypressCommandLine.RunResult>,
+): CypressCommandLine.RunResult =>
+  ({
+    error: null,
+    tests: [],
+    stats: { failures: 0 },
+    ...overrides,
+  }) as unknown as CypressCommandLine.RunResult;
+
+const test = (
+  title: string[],
+  state: string,
+  displayError: string | null = null,
+) => ({ title, state, displayError });
+
+describe("extractFailedTests", () => {
+  it("reports only failed tests, mapping suite/leaf/message/stack/file", () => {
+    const displayError =
+      "AssertionError: expected true to be false\n    at Context.eval (foo.cy.spec.ts:42)";
+
+    const results = makeResults({
+      stats: { failures: 1 } as CypressCommandLine.RunResult["stats"],
+      tests: [
+        test(["Dashboard", "filters", "applies a filter"], "passed"),
+        test(
+          ["Dashboard", "filters", "shows an error"],
+          "failed",
+          displayError,
+        ),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([
+      {
+        name: "shows an error",
+        class: "Dashboard > filters",
+        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+        message: "AssertionError: expected true to be false",
+        stack: displayError,
+      },
+    ]);
+  });
+
+  it("excludes passed, pending, and skipped tests (incl. flaky-but-passed)", () => {
+    const results = makeResults({
+      tests: [
+        test(["a", "passed test"], "passed"),
+        test(["a", "pending test"], "pending"),
+        test(["a", "skipped test"], "skipped"),
+        // a test that flaked then passed on retry has a final state of "passed"
+        test(["a", "flaky test"], "passed"),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
+  });
+
+  it("returns an empty array when nothing failed", () => {
+    expect(extractFailedTests(spec, makeResults({}))).toEqual([]);
+  });
+
+  it("omits `class` for a top-level test with no suite", () => {
+    const results = makeResults({
+      tests: [test(["lonely test"], "failed", "boom")],
+    });
+
+    const [failure] = extractFailedTests(spec, results);
+    expect(failure).toMatchObject({ name: "lonely test" });
+    expect(failure.class).toBeUndefined();
+  });
+
+  it("leaves message/stack undefined when a failed test has no displayError", () => {
+    const results = makeResults({
+      tests: [test(["a", "no error string"], "failed", null)],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([
+      {
+        name: "no error string",
+        class: "a",
+        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+        message: undefined,
+        stack: undefined,
+      },
+    ]);
+  });
+
+  it("skips blank leading lines when deriving the message", () => {
+    const results = makeResults({
+      tests: [test(["a", "t"], "failed", "\n   \nReal message\nstack line")],
+    });
+
+    expect(extractFailedTests(spec, results)[0].message).toBe("Real message");
+  });
+
+  it("falls back to a synthetic entry when the spec crashes before any test runs", () => {
+    const results = makeResults({
+      error: "SyntaxError: Unexpected token\n  at compile",
+      stats: { failures: 1 } as CypressCommandLine.RunResult["stats"],
+      tests: [],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([
+      {
+        name: "foo.cy.spec.ts",
+        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+        message: "SyntaxError: Unexpected token",
+        stack: "SyntaxError: Unexpected token\n  at compile",
+      },
+    ]);
+  });
+
+  it("prefers real failed tests over the spec-level error fallback", () => {
+    const results = makeResults({
+      error: "some run-level error",
+      tests: [test(["a", "real failure"], "failed", "boom")],
+    });
+
+    const failures = extractFailedTests(spec, results);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].name).toBe("real failure");
+  });
+
+  it("tolerates a missing tests array", () => {
+    expect(extractFailedTests(spec, makeResults({ tests: undefined }))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("reportFailedTestsToConductor", () => {
+  const url = "https://conductor.example/webhooks/failed-tests";
+  const oneTest = [{ name: "a test", file: "foo.cy.spec.ts" }];
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+  });
+
+  it("no-ops when the webhook URL is not configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there are no failures to report", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+    });
+
+    await reportFailedTestsToConductor([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the failures with parsed numeric ids and a null job_id", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      REPO_ID: "123",
+      GITHUB_RUN_ID: "456",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(url);
+    expect(options.method).toBe("POST");
+    expect(options.headers).toMatchObject({
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(options.body)).toEqual({
+      repo_id: 123,
+      run_id: 456,
+      job_id: null,
+      tests: oneTest,
+    });
+  });
+
+  it("sends null ids when the env vars are missing or non-numeric", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      REPO_ID: undefined,
+      GITHUB_RUN_ID: "not-a-number",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.repo_id).toBeNull();
+    expect(body.run_id).toBeNull();
+  });
+
+  it("never throws when the request fails", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+    });
+
+    await expect(
+      reportFailedTestsToConductor(oneTest),
+    ).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it("logs but does not throw on a non-ok response", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("500"));
+    (console.error as jest.Mock).mockRestore();
+  });
+});

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -239,6 +239,40 @@ describe("reportFailedTestsToConductor", () => {
     (console.error as jest.Mock).mockRestore();
   });
 
+  it("logs the payload and does not POST in dry-run mode", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_DRY_RUN: "true",
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      REPO_ID: "123",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("dry run"),
+      expect.stringContaining('"repo_id":123'),
+    );
+    logSpy.mockRestore();
+  });
+
+  it("logs in dry-run mode even when no webhook URL is configured", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_DRY_RUN: "true",
+      CI_CONDUCTOR_WEBHOOK_URL: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it("logs but does not throw on a non-ok response", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
     mockFetch.mockResolvedValue({

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -70,6 +70,18 @@ const test = (
 });
 
 describe("extractFailedTests", () => {
+  // Pin the default to "first attempt" so these tests are deterministic even
+  // when the CI job running them is itself a re-run (GITHUB_RUN_ATTEMPT > 1).
+  // The global afterEach restores the original via envBackups. Re-run cases
+  // override process.env.GITHUB_RUN_ATTEMPT in the test body.
+  beforeEach(() => {
+    envBackups.push({
+      key: "GITHUB_RUN_ATTEMPT",
+      previous: process.env.GITHUB_RUN_ATTEMPT,
+    });
+    delete process.env.GITHUB_RUN_ATTEMPT;
+  });
+
   it("reports broken tests with the full displayError as message", () => {
     const displayError =
       "AssertionError: expected true to be false\n    at Context.eval (foo.cy.spec.ts:42)";
@@ -88,10 +100,11 @@ describe("extractFailedTests", () => {
     expect(extractFailedTests(spec, results)).toEqual([
       {
         name: "shows an error",
-        class: "Dashboard > filters",
+        path: "Dashboard > filters",
         file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
         duration: 100,
         attempts: [{ state: "failed" }, { state: "failed" }],
+        status: "failure",
         message: displayError,
       },
     ]);
@@ -110,6 +123,7 @@ describe("extractFailedTests", () => {
     expect(failures[0]).toMatchObject({
       name: "flaky",
       attempts: [{ state: "failed" }, { state: "passed" }],
+      status: "flake",
       message: null,
     });
   });
@@ -130,14 +144,14 @@ describe("extractFailedTests", () => {
     expect(extractFailedTests(spec, makeResults({}))).toEqual([]);
   });
 
-  it("omits `class` for a top-level test with no suite", () => {
+  it("omits `path` for a top-level test with no suite", () => {
     const results = makeResults({
       tests: [test(["lonely test"], ["failed"], "boom")],
     });
 
     const [failure] = extractFailedTests(spec, results);
-    expect(failure).toMatchObject({ name: "lonely test" });
-    expect(failure.class).toBeUndefined();
+    expect(failure).toMatchObject({ name: "lonely test", status: "failure" });
+    expect(failure.path).toBeUndefined();
   });
 
   it("sends message: null when a failed test has no displayError", () => {
@@ -147,7 +161,7 @@ describe("extractFailedTests", () => {
 
     expect(extractFailedTests(spec, results)[0]).toMatchObject({
       name: "no error string",
-      class: "a",
+      path: "a",
       message: null,
     });
   });
@@ -163,6 +177,7 @@ describe("extractFailedTests", () => {
         name: "foo.cy.spec.ts",
         file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
         attempts: [{ state: "failed" }],
+        status: "failure",
         message: "SyntaxError: Unexpected token\n  at compile",
       },
     ]);
@@ -183,6 +198,50 @@ describe("extractFailedTests", () => {
     expect(extractFailedTests(spec, makeResults({ tests: undefined }))).toEqual(
       [],
     );
+  });
+
+  it("does not report passing tests on the first attempt", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "1";
+    const results = makeResults({
+      tests: [test(["a", "passing"], ["passed"])],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
+  });
+
+  it("on a re-run (attempt > 1) also reports passing tests with status passed", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "2";
+    const results = makeResults({
+      tests: [
+        test(["a", "now passing"], ["passed"]),
+        test(["a", "still broken"], ["failed", "failed"], "boom"),
+      ],
+    });
+
+    const reported = extractFailedTests(spec, results);
+    expect(reported).toHaveLength(2);
+    expect(reported).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "now passing",
+          status: "passed",
+          message: null,
+        }),
+        expect.objectContaining({ name: "still broken", status: "failure" }),
+      ]),
+    );
+  });
+
+  it("still excludes pending and skipped tests on a re-run", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "3";
+    const results = makeResults({
+      tests: [
+        test(["a", "pending test"], ["pending"]),
+        test(["a", "skipped test"], ["skipped"]),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
   });
 });
 
@@ -221,6 +280,8 @@ describe("reportFailedTestsToConductor", () => {
       GITHUB_RUN_ID: "456",
       GITHUB_RUN_ATTEMPT: "2",
       CYPRESS_RETRIES: "1",
+      COMMIT_SHA: "abc123",
+      TARGET_BRANCH: "master",
     });
 
     await reportFailedTestsToConductor(oneTest);
@@ -235,25 +296,50 @@ describe("reportFailedTestsToConductor", () => {
     expect(JSON.parse(options.body)).toEqual({
       repo_id: 123,
       run_id: 456,
-      run_attempt: 2,
+      attempt: 2,
       job_id: null,
+      test_suite: "e2e",
+      sha: "abc123",
+      target_branch: "master",
       retries: 1,
       tests: oneTest,
     });
   });
 
-  it("sends null run_attempt and retries when their envs are missing", async () => {
+  it("prefers COMMIT_SHA/TARGET_BRANCH but falls back to the ambient GITHUB_* vars", async () => {
     const { reportFailedTestsToConductor } = await loadConductor({
       CI_CONDUCTOR_WEBHOOK_URL: url,
-      GITHUB_RUN_ATTEMPT: undefined,
-      CYPRESS_RETRIES: undefined,
+      COMMIT_SHA: undefined,
+      GITHUB_SHA: "ambient-sha",
+      TARGET_BRANCH: undefined,
+      GITHUB_BASE_REF: "ambient-branch",
     });
 
     await reportFailedTestsToConductor(oneTest);
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.run_attempt).toBeNull();
+    expect(body.sha).toBe("ambient-sha");
+    expect(body.target_branch).toBe("ambient-branch");
+  });
+
+  it("sends null attempt, sha, target_branch, and retries when their envs are missing", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      GITHUB_RUN_ATTEMPT: undefined,
+      CYPRESS_RETRIES: undefined,
+      COMMIT_SHA: undefined,
+      GITHUB_SHA: undefined,
+      TARGET_BRANCH: undefined,
+      GITHUB_BASE_REF: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.attempt).toBeNull();
     expect(body.retries).toBeNull();
+    expect(body.sha).toBeNull();
+    expect(body.target_branch).toBeNull();
   });
 
   it("sends the x-internal-secret header when the secret is configured", async () => {

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -246,6 +246,26 @@ describe("reportFailedTestsToConductor", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(endpoint);
   });
 
+  it("uses JOB_ID env when set (populated by the resolve-job-id action)", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      JOB_ID: "789",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).job_id).toBe(789);
+  });
+
+  it("sends a null job_id when JOB_ID is missing or non-numeric", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+      JOB_ID: "not-a-number",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).job_id).toBeNull();
+  });
+
   it("sends null ids when the env vars are missing or non-numeric", async () => {
     const { reportFailedTestsToConductor } = await loadConductor({
       CI_CONDUCTOR_WEBHOOK_URL: url,

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -185,7 +185,14 @@ const defaultConfig = {
     on("after:spec", async (spec, results) => {
       // Report failures to ci-conductor mid-run (no-ops unless configured).
       if (isCI) {
-        await reportFailedTestsToConductor(extractFailedTests(spec, results));
+        // Reporting to ci-conductor must NEVER break the test run, so this is
+        // a hard backstop around everything — extraction, payload build, and
+        // the request. The reporter also handles its own errors internally.
+        try {
+          await reportFailedTestsToConductor(extractFailedTests(spec, results));
+        } catch (error) {
+          console.error("[ci-conductor] reporting failed (ignored)", error);
+        }
       }
 
       // this is an official workaround to keep recordings of the failed specs only

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -182,6 +182,15 @@ const defaultConfig = {
       collectFailingTests(on, config);
     }
 
+    // Surface the resolved Cypress retry ceiling so the ci-conductor reporter
+    // can include it in the payload (CYPRESS_RETRIES isn't otherwise set in CI;
+    // the value lives in mainConfig.retries.runMode). DEV-1999.
+    const resolvedRetries =
+      typeof config.retries === "number"
+        ? config.retries
+        : (config.retries?.runMode ?? 0);
+    process.env.CYPRESS_RETRIES = String(resolvedRetries);
+
     on("after:spec", async (spec, results) => {
       // Report failures to ci-conductor mid-run (no-ops unless configured).
       if (isCI) {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -8,6 +8,10 @@ import installLogsPrinter from "cypress-terminal-report/src/installLogsPrinter";
 
 import { BACKEND_HOST, BACKEND_PORT } from "../runner/constants/backend-port";
 
+import {
+  extractFailedTests,
+  reportFailedTestsToConductor,
+} from "./ci_conductor";
 import * as ciTasks from "./ci_tasks";
 import { collectFailingTests } from "./collectFailedTests";
 import {
@@ -178,9 +182,14 @@ const defaultConfig = {
       collectFailingTests(on, config);
     }
 
-    // this is an official workaround to keep recordings of the failed specs only
-    // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
-    on("after:spec", (spec, results) => {
+    on("after:spec", async (spec, results) => {
+      // Report failures to ci-conductor mid-run (no-ops unless configured).
+      if (isCI) {
+        await reportFailedTestsToConductor(extractFailedTests(spec, results));
+      }
+
+      // this is an official workaround to keep recordings of the failed specs only
+      // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
       if (results && results.video) {
         // Do we have test failures?
         if (results && results.video && results.stats.failures === 0) {


### PR DESCRIPTION
Resolves DEV-1999

# Report e2e test failures to ci-conductor

## Summary

Reports Cypress e2e failures to the ci-conductor service mid-run — from the `after:spec` NodeJS hook, *one POST per spec* — so failures get tied to a CI run (and its PR/branch) before the job finishes, not just after.

It sends broken and flaky tests (any test with ≥1 failed attempt), plus recovered passes on re-runs, each with name/path/file, raw attempts, a derived status, duration, and message; run context (repo_id/run_id/job_id/attempt/sha/target_branch/test_suite/retries) is sent once per request.

Mechanically: a new `e2e/support/ci_conductor.ts` (pure extractor + IO reporter, unit-tested) wired into `config.js`; authenticated via x-internal-secret with URL/secret from CI secrets (so it no-ops locally and on forks); and a resolve-job-id composite action that looks the numeric job id up from the Actions API and exports $JOB_ID, placed just before the Cypress  runs so the eventually-consistent jobs API resolves reliably.

> [!IMPORTANT]
> Reporting can never break the run — the whole path is wrapped, errors swallowed, gated on CI, with a dry-run mode for validating payloads.