### PR TITLE
Add locks around Snowflake dataset creation

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1360,6 +1360,10 @@
     :snowflake
     (let [original-set-current-user-timezone! @#'test.data.snowflake/set-current-user-timezone!
           original-dbdef->connection-details (get-method tx/dbdef->connection-details :snowflake)]
+      ;; load dataset as the default user before we switch to the belize-based
+      ;; user who may not have permission to create the dataset
+      (mt/dataset good-datetimes-in-belize
+        (mt/id :GOOD_DATETIMES))
       (with-redefs [test.data.snowflake/set-current-user-timezone!
                     (fn [_timezone]
                       (original-set-current-user-timezone! "America/Belize"))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -675,30 +675,12 @@
   (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
                               dataset-name)))
 
-(defn- read-lock [dataset-name]
-  (sql-jdbc.execute/do-with-connection-with-options
-   :snowflake
-   (no-db-connection-spec)
-   {:write? false}
-   (fn [^java.sql.Connection conn]
-     (loop [tries 0]
-       #_{:clj-kondo/ignore [:discouraged-var]}
-       (println "[Snowflake] read-locking attempt" tries "on" dataset-name)
-       (when (< 2000 tries)
-         (throw (Exception. "could not acquire snowflake read lock")))
-       (when (with-open [stmt (.createStatement conn)]
-               (.next (.executeQuery stmt (format "SELECT at FROM
-                                                   metabase_test_tracking.PUBLIC.locks
-                                                   WHERE dataset = '%s'" dataset-name))))
-         (Thread/sleep 100)
-         (recur (inc tries)))))))
-
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
   [_driver dataset-name]
   (reify ReadWriteLock
     (readLock [_]
       (reify Lock
-        (lock [_] (read-lock dataset-name))
+        (lock [_])
         (unlock [_])))
     (writeLock [_]
       (reify Lock

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -7,6 +7,7 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.test :as mt]
    [metabase.test.data.impl :as data.impl]
+   [metabase.test.data.impl.get-or-create :as test.data.impl.get-or-create]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
@@ -18,7 +19,9 @@
   (:import
    (java.sql PreparedStatement ResultSet)
    (java.time Instant)
-   (java.time.temporal ChronoUnit)))
+   (java.time.temporal ChronoUnit)
+   (java.util.concurrent.locks ReadWriteLock Lock)
+   (net.snowflake.client.api.exception SnowflakeSQLException)))
 
 (set! *warn-on-reflection* true)
 
@@ -293,6 +296,7 @@
   ;; local testing shows that identifying old datasets works correctly, but
   ;; sometimes randomly in CI it seems to decide that datasets are old and
   ;; deletes them even tho they are not old.
+  ;; TODO: we want to drop them only if they have random names
   ;; (drop-old-datasets!)
   (drop-orphan-isolation-schemas!)
   (drop-orphan-isolation-users!)
@@ -625,3 +629,48 @@
     "TIME"         :type/Time
     ;; Default: unknown types get :type/*
     :type/*))
+
+;; Sadly Snowflake does not implement locks outside very limited scope of
+;; automatic locking around DDL; there are no advisory locks, so we are stuck
+;; building them ourselves out of table rows.
+(defn- setup-locks [conn]
+  ;; Reuse the existing tracking database, but make a new table.
+  (jdbc/execute! conn "CREATE DATABASE IF NOT EXISTS metabase_test_tracking;")
+  ;; normal tables literally cannot have primary keys enforced! must be hybrid.
+  (jdbc/execute! conn "CREATE HYBRID TABLE IF NOT EXISTS metabase_test_tracking.PUBLIC.locks
+                       (dataset TEXT PRIMARY KEY, at TIMESTAMPTZ DEFAULT current_timestamp())"))
+
+(defn- acquire-lock [conn dataset-name]
+  (try
+    (jdbc/execute! conn ["INSERT INTO metabase_test_tracking.PUBLIC.locks (dataset) VALUES (?)"
+                         dataset-name])
+    true
+    (catch SnowflakeSQLException e
+      (when-not (= "A primary key already exists." (.getMessage e))
+        (throw e))
+      (jdbc/execute! conn ["DELETE FROM metabase_test_tracking.PUBLIC.locks
+                             WHERE TIMEDIFF('seconds', current_timestamp()::TIMESTAMPTZ, at) > 60"
+                           dataset-name])
+      false)))
+
+(defmethod test.data.impl.get-or-create/dataset-lock :snowflake
+  [_driver dataset-name]
+  (let [lock (reify Lock
+               (lock [_]
+                 (let [conn (no-db-connection-spec)]
+                   (setup-locks conn)
+                   (loop [locked? (acquire-lock conn dataset-name)
+                          tries 0]
+                     (when (< 10000 tries)
+                       (throw (Exception. "could not acquire snowflake lock")))
+                     (when (not locked?)
+                       (Thread/sleep 100)
+                       (recur (acquire-lock conn dataset-name) (inc tries))))))
+               (unlock [_]
+                 (jdbc/execute! (no-db-connection-spec)
+                                ["DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = ?"
+                                 dataset-name])))]
+    (reify ReadWriteLock
+      ;; currently readLock is only used for one call, so use same lock as write
+      (readLock [_] lock)
+      (writeLock [_] lock))))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -671,14 +671,32 @@
   (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
                               dataset-name)))
 
+(defn- read-lock [dataset-name]
+  (sql-jdbc.execute/do-with-connection-with-options
+   :snowflake
+   (no-db-connection-spec)
+   {:write? false}
+   (fn [^java.sql.Connection conn]
+     (loop [tries 0]
+       (when (< 1000 tries)
+        (throw (Exception. "could not acquire snowflake read lock")))
+       (when (with-open [stmt (.createStatement conn)]
+               (.next (.executeQuery stmt (format "SELECT at FROM
+                                                   metabase_test_tracking.PUBLIC.locks
+                                                   WHERE dataset = '%s'" dataset-name))))
+         (Thread/sleep 100)
+         (recur (inc tries)))))))
+
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
   [_driver dataset-name]
-  (let [lock (reify Lock
-               (lock [_]
-                 (lock! dataset-name))
-               (unlock [_]
-                 (with-write-stmt! (partial unlock! dataset-name))))]
-    (reify ReadWriteLock
-      ;; currently readLock is only used for one call, so use same lock as write
-      (readLock [_] lock)
-      (writeLock [_] lock))))
+  (reify ReadWriteLock
+    (readLock [_]
+      (reify Lock
+        (lock [_] (read-lock dataset-name))
+        (unlock [_])))
+    (writeLock [_]
+      (reify Lock
+        (lock [_]
+          (lock! dataset-name))
+        (unlock [_]
+          (with-write-stmt! (partial unlock! dataset-name)))))))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -195,14 +195,14 @@
   "Open a write-capable Snowflake connection + Statement, call `f` with the stmt,
   close everything. Centralizes the boilerplate so the per-resource drop fns
   don't repeat it."
-  [f]
+  [f & args]
   (sql-jdbc.execute/do-with-connection-with-options
    :snowflake
    (no-db-connection-spec)
    {:write? true}
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.createStatement conn)]
-       (f stmt)))))
+       (apply f stmt args)))))
 
 (defn- drop-old-datasets!
   "Drop test datasets (databases) prefixed by `sha_` that are >2 days old."
@@ -633,43 +633,51 @@
 ;; Sadly Snowflake does not implement locks outside very limited scope of
 ;; automatic locking around DDL; there are no advisory locks, so we are stuck
 ;; building them ourselves out of table rows.
-(defn- setup-locks [conn]
+(defn- setup-locks! []
   ;; Reuse the existing tracking database, but make a new table.
-  (jdbc/execute! conn "CREATE DATABASE IF NOT EXISTS metabase_test_tracking;")
+  (with-write-stmt! (fn [^java.sql.Statement stmt]
+                      (.executeQuery stmt "CREATE DATABASE IF NOT EXISTS metabase_test_tracking;")))
   ;; normal tables literally cannot have primary keys enforced! must be hybrid.
-  (jdbc/execute! conn "CREATE HYBRID TABLE IF NOT EXISTS metabase_test_tracking.PUBLIC.locks
-                       (dataset TEXT PRIMARY KEY, at TIMESTAMPTZ DEFAULT current_timestamp())"))
+  (with-write-stmt! (fn [^java.sql.Statement stmt]
+                      (.executeQuery stmt "CREATE HYBRID TABLE IF NOT EXISTS metabase_test_tracking.PUBLIC.locks
+                                          (dataset TEXT PRIMARY KEY, at TIMESTAMPTZ DEFAULT current_timestamp())"))))
 
-(defn- acquire-lock [conn dataset-name]
+(alter-var-root #'setup-locks! memoize)
+
+(defn- try-lock! [^java.sql.Statement stmt dataset-name]
   (try
-    (jdbc/execute! conn ["INSERT INTO metabase_test_tracking.PUBLIC.locks (dataset) VALUES (?)"
-                         dataset-name])
+    (.executeQuery stmt (format "INSERT INTO metabase_test_tracking.PUBLIC.locks (dataset) VALUES ('%s')"
+                                dataset-name))
     true
     (catch SnowflakeSQLException e
       (when-not (= "A primary key already exists." (.getMessage e))
         (throw e))
-      (jdbc/execute! conn ["DELETE FROM metabase_test_tracking.PUBLIC.locks
-                             WHERE TIMEDIFF('seconds', current_timestamp()::TIMESTAMPTZ, at) > 60"
-                           dataset-name])
+      (with-write-stmt! (fn [^java.sql.Statement stmt]
+                          (.executeQuery stmt "DELETE FROM metabase_test_tracking.PUBLIC.locks
+                                           WHERE TIMEDIFF('seconds', current_timestamp()::TIMESTAMPTZ, at) > 60")))
       false)))
+
+(defn- lock! [dataset-name]
+  (setup-locks!)
+  (loop [tries 0]
+    (let [locked? (with-write-stmt! try-lock! dataset-name)]
+      (when (< 10000 tries)
+        (throw (Exception. "could not acquire snowflake lock")))
+      (when (not locked?)
+        (Thread/sleep 100)
+        (recur (inc tries))))))
+
+(defn- unlock! [dataset-name ^java.sql.Statement stmt]
+  (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
+                              dataset-name)))
 
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
   [_driver dataset-name]
   (let [lock (reify Lock
                (lock [_]
-                 (let [conn (no-db-connection-spec)]
-                   (setup-locks conn)
-                   (loop [locked? (acquire-lock conn dataset-name)
-                          tries 0]
-                     (when (< 10000 tries)
-                       (throw (Exception. "could not acquire snowflake lock")))
-                     (when (not locked?)
-                       (Thread/sleep 100)
-                       (recur (acquire-lock conn dataset-name) (inc tries))))))
+                 (lock! dataset-name))
                (unlock [_]
-                 (jdbc/execute! (no-db-connection-spec)
-                                ["DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = ?"
-                                 dataset-name])))]
+                 (with-write-stmt! (partial unlock! dataset-name))))]
     (reify ReadWriteLock
       ;; currently readLock is only used for one call, so use same lock as write
       (readLock [_] lock)

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -654,14 +654,14 @@
         (throw e))
       (with-write-stmt! (fn [^java.sql.Statement stmt]
                           (.executeQuery stmt "DELETE FROM metabase_test_tracking.PUBLIC.locks
-                                           WHERE TIMEDIFF('seconds', current_timestamp()::TIMESTAMPTZ, at) > 60")))
+                                           WHERE TIMEDIFF('seconds', at, current_timestamp()::TIMESTAMPTZ) > 60")))
       false)))
 
 (defn- lock! [dataset-name]
   (setup-locks!)
   (loop [tries 0]
     (let [locked? (with-write-stmt! try-lock! dataset-name)]
-      (when (< 10000 tries)
+      (when (< 1000 tries)
         (throw (Exception. "could not acquire snowflake lock")))
       (when (not locked?)
         (Thread/sleep 100)

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -644,13 +644,24 @@
 
 (alter-var-root #'setup-locks! memoize)
 
+;; sometimes snowflake randomly throws an exception claiming
+;; "SQL compilation error: Object 'METABASE_TEST_TRACKING.PUBLIC.LOCKS' does not exist or not authorized."
+;; despite the fact that the table definitely exists. the cause is unknown,
+;; but the error goes away upon a retry. tacky as hell, but what else can we do?
+(defn- missing-table-ex? [^SnowflakeSQLException ex]
+  ;; snowflake documentation does not bother to define these so it's possible
+  ;; these codes are broader than what we are looking for.
+  (and (= "42S02" (.getSQLState ex))
+       (re-find #"does not exist or not authorized." (.getMessage ex))))
+
 (defn- try-lock! [^java.sql.Statement stmt dataset-name]
   (try
     (.executeQuery stmt (format "INSERT INTO metabase_test_tracking.PUBLIC.locks (dataset) VALUES ('%s')"
                                 dataset-name))
     true
     (catch SnowflakeSQLException e
-      (when-not (= "A primary key already exists." (.getMessage e))
+      (when-not (or (= "A primary key already exists." (.getMessage e))
+                    (missing-table-ex? e))
         (throw e))
       (with-write-stmt! (fn [^java.sql.Statement stmt]
                           (.executeQuery stmt "DELETE FROM metabase_test_tracking.PUBLIC.locks
@@ -672,8 +683,16 @@
 (defn- unlock! [dataset-name ^java.sql.Statement stmt]
   #_{:clj-kondo/ignore [:discouraged-var]}
   (println "[Snowflake] unlocking" dataset-name)
-  (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
-                              dataset-name)))
+  (try
+    (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
+                                dataset-name))
+    (catch SnowflakeSQLException e
+      ;; sometimes snowflake throws a missing table exception for no reason.
+      ;; when this happens, retrying immediately does not work; it just
+      ;; happens again.  so instead we can delay so that the lock will be
+      ;; considered stale when it's checked next.
+      (when (missing-table-ex? e)
+        (Thread/sleep 30000)))))
 
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
   [_driver dataset-name]

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -660,6 +660,8 @@
 (defn- lock! [dataset-name]
   (setup-locks!)
   (loop [tries 0]
+    #_{:clj-kondo/ignore [:discouraged-var]}
+    (println "[Snowflake] locking attempt" tries "on" dataset-name)
     (let [locked? (with-write-stmt! try-lock! dataset-name)]
       (when (< 1000 tries)
         (throw (Exception. "could not acquire snowflake lock")))
@@ -668,6 +670,8 @@
         (recur (inc tries))))))
 
 (defn- unlock! [dataset-name ^java.sql.Statement stmt]
+  #_{:clj-kondo/ignore [:discouraged-var]}
+  (println "[Snowflake] unlocking" dataset-name)
   (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
                               dataset-name)))
 
@@ -678,8 +682,10 @@
    {:write? false}
    (fn [^java.sql.Connection conn]
      (loop [tries 0]
-       (when (< 1000 tries)
-        (throw (Exception. "could not acquire snowflake read lock")))
+       #_{:clj-kondo/ignore [:discouraged-var]}
+       (println "[Snowflake] read-locking attempt" tries "on" dataset-name)
+       (when (< 2000 tries)
+         (throw (Exception. "could not acquire snowflake read lock")))
        (when (with-open [stmt (.createStatement conn)]
                (.next (.executeQuery stmt (format "SELECT at FROM
                                                    metabase_test_tracking.PUBLIC.locks

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -296,8 +296,7 @@
   ;; local testing shows that identifying old datasets works correctly, but
   ;; sometimes randomly in CI it seems to decide that datasets are old and
   ;; deletes them even tho they are not old.
-  ;; TODO: we want to drop them only if they have random names
-  ;; (drop-old-datasets!)
+  (drop-old-datasets!)
   (drop-orphan-isolation-schemas!)
   (drop-orphan-isolation-users!)
   (drop-orphan-isolation-roles!))
@@ -640,19 +639,13 @@
   ;; normal tables literally cannot have primary keys enforced! must be hybrid.
   (with-write-stmt! (fn [^java.sql.Statement stmt]
                       (.executeQuery stmt "CREATE HYBRID TABLE IF NOT EXISTS metabase_test_tracking.PUBLIC.locks
-                                          (dataset TEXT PRIMARY KEY, at TIMESTAMPTZ DEFAULT current_timestamp())"))))
+                                          (dataset TEXT PRIMARY KEY, at TIMESTAMPTZ DEFAULT current_timestamp())")))
+  ;; unfortuantely with-redefs in the test suite can mean that we end up trying
+  ;; to create locks as other users which will need access to the locks table
+  (with-write-stmt! (fn [^java.sql.Statement stmt]
+                      (.executeQuery stmt "GRANT ALL ON metabase_test_tracking.PUBLIC.locks TO SYSADMIN"))))
 
 (alter-var-root #'setup-locks! memoize)
-
-;; sometimes snowflake randomly throws an exception claiming
-;; "SQL compilation error: Object 'METABASE_TEST_TRACKING.PUBLIC.LOCKS' does not exist or not authorized."
-;; despite the fact that the table definitely exists. the cause is unknown,
-;; but the error goes away upon a retry. tacky as hell, but what else can we do?
-(defn- missing-table-ex? [^SnowflakeSQLException ex]
-  ;; snowflake documentation does not bother to define these so it's possible
-  ;; these codes are broader than what we are looking for.
-  (and (= "42S02" (.getSQLState ex))
-       (re-find #"does not exist or not authorized." (.getMessage ex))))
 
 (defn- try-lock! [^java.sql.Statement stmt dataset-name]
   (try
@@ -660,8 +653,7 @@
                                 dataset-name))
     true
     (catch SnowflakeSQLException e
-      (when-not (or (= "A primary key already exists." (.getMessage e))
-                    (missing-table-ex? e))
+      (when-not (= "A primary key already exists." (.getMessage e))
         (throw e))
       (with-write-stmt! (fn [^java.sql.Statement stmt]
                           (.executeQuery stmt "DELETE FROM metabase_test_tracking.PUBLIC.locks
@@ -683,16 +675,8 @@
 (defn- unlock! [dataset-name ^java.sql.Statement stmt]
   #_{:clj-kondo/ignore [:discouraged-var]}
   (println "[Snowflake] unlocking" dataset-name)
-  (try
-    (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
-                                dataset-name))
-    (catch SnowflakeSQLException e
-      ;; sometimes snowflake throws a missing table exception for no reason.
-      ;; when this happens, retrying immediately does not work; it just
-      ;; happens again.  so instead we can delay so that the lock will be
-      ;; considered stale when it's checked next.
-      (when (missing-table-ex? e)
-        (Thread/sleep 30000)))))
+  (.executeQuery stmt (format "DELETE FROM metabase_test_tracking.PUBLIC.locks WHERE dataset = '%s'"
+                              dataset-name)))
 
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
   [_driver dataset-name]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -125,7 +125,7 @@
       ...)"
   {:style/indent :defn}
   [table-definitions & body]
-  `(do-with-dataset-definition (tx/dataset-definition (format "temp-test-data-%s" (random-uuid))
+  `(do-with-dataset-definition (tx/dataset-definition (str "temp-test-data" (u.random/random-name))
                                                       ~table-definitions)
                                (fn [] ~@body)))
 

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -125,7 +125,9 @@
       ...)"
   {:style/indent :defn}
   [table-definitions & body]
-  `(do-with-dataset-definition (tx/dataset-definition "temp-test-data" ~table-definitions) (fn [] ~@body)))
+  `(do-with-dataset-definition (tx/dataset-definition (format "temp-test-data-%s" (random-uuid))
+                                                      ~table-definitions)
+                               (fn [] ~@body)))
 
 (defmacro with-empty-db
   "Sets the current dataset to a freshly created db that gets destroyed at the conclusion of `body`.

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -8,9 +8,7 @@
    [metabase.sync.core :as sync]
    [metabase.sync.sync-metadata.indexes :as sync.indexes]
    [metabase.test :as mt]
-   [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest sync-single-indexed-columns-test
@@ -30,19 +28,12 @@
                [{:field-name "first" :indexed? false :base-type :type/Integer}
                 {:field-name "second" :indexed? false :base-type :type/Integer}]
                [[1 2]]]]]
-      (mt/with-temp-test-data
-        ds
-        (try
-          (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-                         (sql.tx/create-index-sql driver/*driver* "table" ["first" "second"]))
-          (sync/sync-database! (mt/db))
-          (is (true? (t2/select-one-fn :database_indexed :model/Field (mt/id :table :first))))
-          (is (not= true (t2/select-one-fn :database_indexed :model/Field (mt/id :table :second))))
-          (finally
-            ;; clean the db so this test is repeatable
-            (t2/delete! :model/Database (mt/id))
-            (u/ignore-exceptions
-              (tx/destroy-db! driver/*driver* ds))))))))
+      (mt/with-temp-test-data ds
+        (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                       (sql.tx/create-index-sql driver/*driver* "table" ["first" "second"]))
+        (sync/sync-database! (mt/db))
+        (is (true? (t2/select-one-fn :database_indexed :model/Field (mt/id :table :first))))
+        (is (not= true (t2/select-one-fn :database_indexed :model/Field (mt/id :table :second))))))))
 
 (driver/register! ::not-support-index-test :abstract? true)
 

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -36,7 +36,7 @@
   multiple times in parallel -- for example my Oracle test that runs 30 sync calls at the same time to make sure
   nothing explodes and cursors aren't leaked. To make sure this doesn't happen we'll keep a map of
 
-    [driver dataset-name] -> ReentrantReadWriteLock
+    [driver dataset-name] -> ReadWriteLock
 
   and make sure data can be loaded and synced for a given driver + dataset in a synchronized fashion. Code path looks
   like this:
@@ -57,7 +57,7 @@
 
   Because each driver and dataset has its own lock, various datasets can be loaded in parallel, but this will prevent
   the same dataset from being loaded multiple times."
-  {:arglists '(^java.util.concurrent.locks.ReentrantReadWriteLock [driver dataset-name])}
+  {:arglists '(^java.util.concurrent.locks.ReadWriteLock [driver dataset-name])}
   tx/dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 


### PR DESCRIPTION
> ME: Moooooooom, can we have advisory locks?  
> SNOWFLAKE: No, we have advisory locks at home.  
> ADVISORY LOCKS AT HOME: `INSERT INTO locks VALUES (...)`

## Description

For normal databases, we have a `dataset-lock` method which creates an in-process lock that prevents more than one thread from creating/deleting datasets. With cloud databases like Snowflake, this doesn't work, because there's only one database shared across all test jobs happening at the same time, so there are many opportunities for contention. Previously we have seen many failures around datasets getting double-inserted or triple-inserted.

The solution is to extend `dataset-lock` for Snowflake to create a lock that uses the shared database instead of an in-memory lock. Unfortunately while Snowflake has locking features, they are inseperably tied to its DDL; you cannot create advisory locks on your own. So we are stuck implementing these from scratch using table rows.

There is a distinction between write locks, which are used when creating tables and inserting datasets, vs read locks, which are only used when reading the `:model/Database` from the appdb. The write locks lock by inserting a row into the locks table with the dataset name as the primary key and unlock by deleting the row. The read lock would ideally also insert a row in a way which would prevent the write lock from running, but the read lock is acquired so frequently that doing this the thorough way would definitely push us over the one-hour time limit for the job to complete, so this is a no-op.

The obvious problem here is that locks could grow stale if a process dies without unlocking, so all locks older than 60 seconds automatically get deleted when there's contention.

In addition, we went thru to find all callers of `destroy-db!` and ensure that they were always working with databases that had randomized names. We found one place (`with-temp-test-data`) which was using hard-coded names, which might be fine in a normal DB but would cause contention in cloud DBs. So that was fixed to be randomized.

### Considerations

Standard Snowflake tables ignore almost all consistency constraints, including `PRIMARY KEY` uniqueness. Because of this, the new `locks` table has to be a "hybrid" table.

I've changed the existing `dataset-lock` defmulti to use `ReadWriteLock` instead of `ReentrantReadWriteLock` because the former is an interface, so we can reify it, instead of being a concrete class. The default implementation still uses `ReentrantReadWriteLock`.

It sleeps 100ms in between attempts (cheesy as hell) and gives up after 1000 rounds. These numbers are somewhat arbitrary; happy to take suggestions for how to tune them.

Because of the way that we use top-level global state for database connections, some of our tests unfortunately use `with-redefs` to change the user accessing the database; this was interfering with dataset creation until I figured out what was going wrong. I've addressed this by granting access to the locks tables to the `SYSADMIN` role which seems to be the role used by the alternate user.