### PR TITLE
Use existing commit for cljfmt

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -4,7 +4,7 @@
  :paths ["mage/src" "mage/test" "bin/lint-migrations-file/src"]
  ;; use Cam's fork temporarily until a new release with https://github.com/weavejester/cljfmt/pull/420 is cut
  ;; (release > 0.16.4)
- :deps {dev.weavejester/cljfmt {:git/sha "05886be17744846685e6a733973fdfbd24e1acd5"
+ :deps {dev.weavejester/cljfmt {:git/sha "d7e7bb9130a8315b4b320823380a172e51657eb3"
                                 :git/url "https://github.com/camsaul/cljfmt"} ;; run cljfmt from bb
         io.github.paintparty/bling {:mvn/version "0.8.8"} ;; printing bells and whistles
         medley/medley {:mvn/version "1.3.0"} ;; utilities


### PR DESCRIPTION
Fixes CI and local dev by referencing a commit in camsaul/cljfmt that exists.

