### PR TITLE
Fix AIProvider config violations

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SessionTimeoutSetting/SessionTimeoutSetting.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SessionTimeoutSetting/SessionTimeoutSetting.tsx
@@ -2,11 +2,9 @@ import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import {
-  BasicAdminSettingInput,
-  SetByEnvVar,
-} from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { BasicAdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { Flex, Select, Stack, Text, TextInput } from "metabase/ui";
 import type { TimeoutValue } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -8,7 +8,7 @@ import {
 } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
-import { useAIProviderConfigurationContext } from "metabase/metabot/components/AIProviderConfigurationForm";
+import { useAIProviderConfigurationContext } from "metabase/metabot";
 import { MetabotManagedProviderLimitActions } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import type { MetabaseAIProviderSetupProps } from "metabase/plugins";
 import { useSelector } from "metabase/redux";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
-import { useMetabotSetupContext } from "metabase/admin/ai/MetabotSetup";
 import {
   useRefreshTokenStatusMutation,
   useUpdateMetabotSettingsMutation,
 } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
+import { useAIProviderConfigurationContext } from "metabase/metabot/components/AIProviderConfigurationForm";
 import { MetabotManagedProviderLimitActions } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import type { MetabaseAIProviderSetupProps } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
@@ -165,7 +165,7 @@ export function MetabaseAIProviderSetup({
   ]);
 
   const { isMutating, handleDisconnect, resetProvider, isModal } =
-    useMetabotSetupContext(connectAction, onDisconnect);
+    useAIProviderConfigurationContext(connectAction, onDisconnect);
 
   const metabaseManagedAiPurchaseError = metabaseManagedAiPurchase.error
     ? getErrorMessage(

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
@@ -9,7 +9,6 @@ import {
 import {
   AdminSettingInput,
   BasicAdminSettingInput,
-  SetByEnvVar,
 } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import {
   useGetAdminSettingsDetailsQuery,
@@ -18,6 +17,7 @@ import {
 } from "metabase/api";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import {
   Alert,

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettingsWidget/ColorSettingsWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettingsWidget/ColorSettingsWidget.tsx
@@ -1,7 +1,7 @@
 import { useDebouncedCallback } from "@mantine/hooks";
 
-import { SetByEnvVar } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useMantineTheme } from "metabase/ui";
 import type { ColorSettings as ColorSettingsType } from "metabase-types/api";
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
@@ -1,11 +1,9 @@
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import {
-  BasicAdminSettingInput,
-  SetByEnvVar,
-} from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { BasicAdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { Box } from "metabase/ui";
 
 import { FontFilesWidget } from "./FontFilesWidget";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
@@ -3,12 +3,10 @@ import { usePrevious } from "react-use";
 import { jt, t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import {
-  BasicAdminSettingInput,
-  SetByEnvVar,
-} from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { BasicAdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { getErrorMessage, useAdminSetting } from "metabase/api/utils";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { Stack, TextInput } from "metabase/ui";
 import type { HelpLinkSetting } from "metabase-types/api";
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
@@ -4,12 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import {
-  BasicAdminSettingInput,
-  SetByEnvVar,
-} from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { BasicAdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
 import { LighthouseIllustrationThumbnail } from "metabase/common/components/LighthouseIllustration";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import CS from "metabase/css/core/index.css";
 import { Box, Button, Flex, Icon, Paper, Text } from "metabase/ui";
 import type {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/ImageUploadWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/ImageUploadWidget.tsx
@@ -4,8 +4,8 @@ import { useRef, useState } from "react";
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import { SetByEnvVar } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import CS from "metabase/css/core/index.css";
 import { Box, Button, Flex, Icon, Paper, Text } from "metabase/ui";
 import type { EnterpriseSettingKey } from "metabase-types/api";

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
@@ -6,11 +6,11 @@ import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { skipToken, useGetMetabotSettingsQuery } from "metabase/api";
 import { useAdminSetting } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
-import { AIProviderConfigurationForm } from "metabase/metabot/components/AIProviderConfigurationForm";
 import {
+  AIProviderConfigurationForm,
   getProviderOptions,
   parseProviderAndModel,
-} from "metabase/metabot/components/AIProviderConfigurationForm/utils";
+} from "metabase/metabot";
 import { PLUGIN_METABOT } from "metabase/plugins";
 import { Badge, Flex, Group } from "metabase/ui";
 

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import { P, match } from "ts-pattern";
+import { t } from "ttag";
+
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import { skipToken, useGetMetabotSettingsQuery } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
+import { useSetting } from "metabase/common/hooks";
+import { AIProviderConfigurationForm } from "metabase/metabot/components/AIProviderConfigurationForm";
+import {
+  getProviderOptions,
+  parseProviderAndModel,
+} from "metabase/metabot/components/AIProviderConfigurationForm/utils";
+import { PLUGIN_METABOT } from "metabase/plugins";
+import { Badge, Flex, Group } from "metabase/ui";
+
+export function AIProviderSettingsSection({ id }: { id?: string }) {
+  const offerMetabaseAiManaged = PLUGIN_METABOT.isEnabled;
+  const { value: savedProviderValue } = useAdminSetting("llm-metabot-provider");
+  const config = useMemo(
+    () => parseProviderAndModel(savedProviderValue),
+    [savedProviderValue],
+  );
+  const isConfigured = !!useSetting("llm-metabot-configured?");
+  const connectedProvider = isConfigured ? config?.provider : undefined;
+  const connectedProviderSettingsQuery = useGetMetabotSettingsQuery(
+    connectedProvider && connectedProvider !== "metabase"
+      ? { provider: connectedProvider }
+      : skipToken,
+  );
+  const hasApiKeyError =
+    !!connectedProviderSettingsQuery.currentData?.["api-key-error"];
+
+  return (
+    <SettingsSection
+      id={id}
+      title={
+        <Flex justify="space-between" align="center">
+          <Group gap="xs" wrap="nowrap">
+            {connectedProvider && (
+              <Badge
+                circle
+                size="12"
+                bg={hasApiKeyError ? "error" : "success"}
+                mr="sm"
+              />
+            )}
+            <div>
+              {match({ connectedProvider, hasApiKeyError })
+                .with(
+                  { connectedProvider: P.nonNullable, hasApiKeyError: true },
+                  ({ connectedProvider }) =>
+                    t`Error connecting to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`,
+                )
+                .with(
+                  { connectedProvider: P.nonNullable },
+                  ({ connectedProvider }) =>
+                    t`Connected to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`,
+                )
+                .with(
+                  { connectedProvider: P.nullish },
+                  () => t`Connect to an AI provider`,
+                )
+                .exhaustive()}
+            </div>
+          </Group>
+        </Flex>
+      }
+      description={
+        !connectedProvider
+          ? t`Select your AI provider to use AI explorations, SQL generation and Metabot.`
+          : undefined
+      }
+    >
+      <AIProviderConfigurationForm />
+    </SettingsSection>
+  );
+}

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -11,6 +11,8 @@ import {
 import { mockSettings } from "__support__/settings";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Api } from "metabase/api";
+import { AIProviderConfigurationForm } from "metabase/metabot/components/AIProviderConfigurationForm";
+import type { MetabotApiKeyProvider } from "metabase/metabot/components/AIProviderConfigurationForm/utils";
 import { reinitialize } from "metabase/plugins";
 import { defer } from "metabase/utils/promise";
 import type {
@@ -27,8 +29,7 @@ import {
   createMockUser,
 } from "metabase-types/api/mocks";
 
-import { MetabotSetup, MetabotSetupInner } from "./MetabotSetup";
-import type { MetabotApiKeyProvider } from "./utils";
+import { AIProviderSettingsSection } from "./AIProviderSettingsSection";
 
 const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
   metabase: {
@@ -381,11 +382,14 @@ async function setup({
 
   const storeInitialState = { settings, currentUser: user };
   const view = renderAsModal
-    ? renderWithProviders(<MetabotSetupInner isModal onClose={onClose} />, {
-        storeInitialState,
-      })
+    ? renderWithProviders(
+        <AIProviderConfigurationForm isModal onClose={onClose} />,
+        {
+          storeInitialState,
+        },
+      )
     : renderWithProviders(
-        <Route path="/admin/metabot*" component={MetabotSetup} />,
+        <Route path="/admin/metabot*" component={AIProviderSettingsSection} />,
         {
           withRouter: true,
           initialRoute: "/admin/metabot",
@@ -434,7 +438,7 @@ async function confirmDisconnectProvider() {
   );
 }
 
-describe("MetabotSetup", () => {
+describe("AIProviderSettingsSection", () => {
   afterEach(() => {
     reinitialize();
   });
@@ -1272,6 +1276,7 @@ describe("MetabotSetup", () => {
 
   it("disconnects when clicking use a different AI provider from the locked managed-provider state", async () => {
     await setup({
+      isAdmin: true,
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
       tokenStatusFeatures: ["metabase-ai-managed"],
@@ -1338,6 +1343,7 @@ describe("MetabotSetup", () => {
 
   it("resets the form in modal mode without updating settings", async () => {
     await setup({
+      isAdmin: true,
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
       tokenStatusFeatures: ["metabase-ai-managed"],

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -11,8 +11,10 @@ import {
 import { mockSettings } from "__support__/settings";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { Api } from "metabase/api";
-import { AIProviderConfigurationForm } from "metabase/metabot/components/AIProviderConfigurationForm";
-import type { MetabotApiKeyProvider } from "metabase/metabot/components/AIProviderConfigurationForm/utils";
+import {
+  AIProviderConfigurationForm,
+  type MetabotApiKeyProvider,
+} from "metabase/metabot";
 import { reinitialize } from "metabase/plugins";
 import { defer } from "metabase/utils/promise";
 import type {

--- a/frontend/src/metabase/admin/ai/AISettingsPage.tsx
+++ b/frontend/src/metabase/admin/ai/AISettingsPage.tsx
@@ -20,10 +20,10 @@ import {
 import { useRouter } from "metabase/router/useRouter";
 import { Divider, Flex, Stack, Switch, Tabs } from "metabase/ui";
 
+import { AIProviderSettingsSection } from "./AIProviderSettingsSection";
 import { EmbeddedMetabotUpsell } from "./EmbeddedMetabotUpsell";
 import { McpAppsSettings } from "./McpAppsSettings";
 import { MetabotSettingsPanel } from "./MetabotSettingsPanel";
-import { MetabotSetup } from "./MetabotSetup";
 
 type MetabotTabId =
   | typeof FIXED_METABOT_IDS.DEFAULT
@@ -71,7 +71,7 @@ export function AISettingsPage() {
     >
       {areAiFeaturesEnabled && (
         <>
-          <MetabotSetup id={SETUP_SECTION_ID} />
+          <AIProviderSettingsSection id={SETUP_SECTION_ID} />
           <DisabledSection disabled={!isConfigured}>
             <MetabotSettingsSection
               hasEmbedding={hasEmbedding}

--- a/frontend/src/metabase/admin/ai/CursorInstallLink.tsx
+++ b/frontend/src/metabase/admin/ai/CursorInstallLink.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { Anchor } from "metabase/ui";
 
-import { useMCPServerURL } from "./utils";
+import { useMCPServerURL } from "./useMCPServerURL";
 
 const CURSOR_DEEPLINK = {
   url: "cursor://anysphere.cursor-deeplink/mcp/install",

--- a/frontend/src/metabase/admin/ai/MCPServerUrlSection.tsx
+++ b/frontend/src/metabase/admin/ai/MCPServerUrlSection.tsx
@@ -5,7 +5,7 @@ import { CopyTextInput } from "metabase/common/components/CopyTextInput";
 import { Box } from "metabase/ui";
 
 import S from "./MCPServerUrlSection.module.css";
-import { useMCPServerURL } from "./utils";
+import { useMCPServerURL } from "./useMCPServerURL";
 
 export function McpServerUrlSection() {
   const mcpServerUrl = useMCPServerURL();

--- a/frontend/src/metabase/admin/ai/useMCPServerURL.ts
+++ b/frontend/src/metabase/admin/ai/useMCPServerURL.ts
@@ -1,0 +1,11 @@
+import { useAdminSetting } from "metabase/api/utils";
+
+export function useMCPServerURL() {
+  const { value: siteUrl } = useAdminSetting("site-url");
+
+  if (!siteUrl) {
+    return null;
+  }
+
+  return `${siteUrl}/api/metabase-mcp`;
+}

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
-import { jt, t } from "ttag";
+import { t } from "ttag";
 
 import { isSettingSetFromEnvVar } from "metabase/admin/settings/settings";
 import { useAdminSetting } from "metabase/api/utils";
-import { ExternalLink } from "metabase/common/components/ExternalLink";
-import { useDocsUrl } from "metabase/common/hooks";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import {
   Box,
   type BoxProps,
@@ -258,22 +257,6 @@ function hasBooleanOptions(options: { label: string; value: string }[]) {
 function stringToBoolean(value: string): boolean | string {
   return value === "true";
 }
-
-export const SetByEnvVar = ({ varName }: { varName: string }) => {
-  const { url } = useDocsUrl("configuring-metabase/environment-variables", {
-    anchor: varName?.toLowerCase(),
-  });
-
-  return (
-    <Box data-testid="setting-env-var-message" fw="bold" p="sm">
-      {jt`This has been set by the ${(
-        <ExternalLink key="link" href={url}>
-          {varName}
-        </ExternalLink>
-      )} environment variable.`}
-    </Box>
-  );
-};
 
 type SetByEnvVarWrapperProps<S extends EnterpriseSettingKey> = {
   settingKey: S;

--- a/frontend/src/metabase/admin/settings/components/widgets/EmailReplyToWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmailReplyToWidget.tsx
@@ -2,11 +2,12 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { Stack } from "metabase/ui";
 
 import { SettingHeader } from "../SettingHeader";
 
-import { BasicAdminSettingInput, SetByEnvVar } from "./AdminSettingInput";
+import { BasicAdminSettingInput } from "./AdminSettingInput";
 
 // The backend accepts a string array for multiple reply-to emails,
 // but currently the frontend only lets the user enter a single email.

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { Box, Radio, Select, Stack, Switch, Text } from "metabase/ui";
 import {
   type CurrencyStyle,
@@ -15,8 +16,6 @@ import {
   getTimeStyleOptions,
 } from "metabase/visualizations/lib/formatting";
 import type { FormattingSettings } from "metabase-types/api";
-
-import { SetByEnvVar } from "./AdminSettingInput";
 
 const DEFAULT_FORMATTING_SETTINGS: FormattingSettings = {
   "type/Temporal": {

--- a/frontend/src/metabase/admin/settings/components/widgets/UsageTracking/BaseUsageTrackingSettingToggle.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/UsageTracking/BaseUsageTrackingSettingToggle.tsx
@@ -1,10 +1,11 @@
 import { isSettingSetFromEnvVar } from "metabase/admin/settings/settings";
 import { useAdminSetting } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { Stack } from "metabase/ui";
 import type { Settings } from "metabase-types/api";
 
 import { SettingHeader } from "../../SettingHeader";
-import { BasicAdminSettingInput, SetByEnvVar } from "../AdminSettingInput";
+import { BasicAdminSettingInput } from "../AdminSettingInput";
 
 interface BaseUsageTrackingSettingToggleProps {
   settingName: keyof Settings;

--- a/frontend/src/metabase/common/components/SetByEnvVar/SetByEnvVar.tsx
+++ b/frontend/src/metabase/common/components/SetByEnvVar/SetByEnvVar.tsx
@@ -1,0 +1,22 @@
+import { jt } from "ttag";
+
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { useDocsUrl } from "metabase/common/hooks";
+import { Box } from "metabase/ui";
+
+export const SetByEnvVar = ({ varName }: { varName: string }) => {
+  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- This component is only shown to admins.
+  const { url } = useDocsUrl("configuring-metabase/environment-variables", {
+    anchor: varName?.toLowerCase(),
+  });
+
+  return (
+    <Box data-testid="setting-env-var-message" fw="bold" p="sm">
+      {jt`This has been set by the ${(
+        <ExternalLink key="link" href={url}>
+          {varName}
+        </ExternalLink>
+      )} environment variable.`}
+    </Box>
+  );
+};

--- a/frontend/src/metabase/common/components/SetByEnvVar/index.ts
+++ b/frontend/src/metabase/common/components/SetByEnvVar/index.ts
@@ -1,0 +1,1 @@
+export { SetByEnvVar } from "./SetByEnvVar";

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -13,10 +13,7 @@ import { P, match } from "ts-pattern";
 import { c, t } from "ttag";
 import _ from "underscore";
 
-import { SettingsSection } from "metabase/admin/components/SettingsSection";
-import { SetByEnvVar } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import {
-  skipToken,
   useGetMetabotSettingsQuery,
   useUpdateMetabotSettingsMutation,
   useUpdateSettingsMutation,
@@ -28,10 +25,10 @@ import {
 } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { PLUGIN_METABOT } from "metabase/plugins";
 import {
-  Badge,
   Button,
   type ComboboxItem,
   Flex,
@@ -60,13 +57,14 @@ type MetabotModelOption = ComboboxItem & {
 
 function getModelDescription(provider: MetabotProvider | undefined) {
   if (provider === "metabase") {
+    // eslint-disable-next-line metabase/no-literal-metabase-strings -- "Metabase" is the product name for the managed AI provider option, only shown to admins configuring AI.
     return t`Available models are provided by Metabase.`;
   }
 
   return t`Available models are fetched from the selected provider using its configured API key.`;
 }
 
-const MetabotSetupContext = createContext<{
+const AIProviderConfigurationContext = createContext<{
   connectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
   disconnectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
   isMutating: boolean;
@@ -86,7 +84,7 @@ const MetabotSetupContext = createContext<{
   isModal: false,
 });
 
-export function useMetabotSetupContext(
+export function useAIProviderConfigurationContext(
   onConnect: (() => Promise<void>) | null,
   onDisconnect: (() => Promise<void>) | null = null,
 ) {
@@ -98,7 +96,7 @@ export function useMetabotSetupContext(
     resetProvider,
     handleDisconnect,
     isModal,
-  } = useContext(MetabotSetupContext);
+  } = useContext(AIProviderConfigurationContext);
 
   useEffect(() => {
     if (!connectHandlerRef) {
@@ -129,70 +127,7 @@ export function useMetabotSetupContext(
   return { isMutating, resetProvider, handleDisconnect, isModal };
 }
 
-export function MetabotSetup({ id }: { id?: string }) {
-  const offerMetabaseAiManaged = PLUGIN_METABOT.isEnabled;
-  const { value: savedProviderValue } = useAdminSetting("llm-metabot-provider");
-  const config = useMemo(
-    () => parseProviderAndModel(savedProviderValue),
-    [savedProviderValue],
-  );
-  const isConfigured = !!useSetting("llm-metabot-configured?");
-  const connectedProvider = isConfigured ? config?.provider : undefined;
-  const connectedProviderSettingsQuery = useGetMetabotSettingsQuery(
-    connectedProvider && connectedProvider !== "metabase"
-      ? { provider: connectedProvider }
-      : skipToken,
-  );
-  const hasApiKeyError =
-    !!connectedProviderSettingsQuery.currentData?.["api-key-error"];
-
-  return (
-    <SettingsSection
-      id={id}
-      title={
-        <Flex justify="space-between" align="center">
-          <Group gap="xs" wrap="nowrap">
-            {connectedProvider && (
-              <Badge
-                circle
-                size="12"
-                bg={hasApiKeyError ? "error" : "success"}
-                mr="sm"
-              />
-            )}
-            <div>
-              {match({ connectedProvider, hasApiKeyError })
-                .with(
-                  { connectedProvider: P.nonNullable, hasApiKeyError: true },
-                  ({ connectedProvider }) =>
-                    t`Error connecting to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`,
-                )
-                .with(
-                  { connectedProvider: P.nonNullable },
-                  ({ connectedProvider }) =>
-                    t`Connected to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`,
-                )
-                .with(
-                  { connectedProvider: P.nullish },
-                  () => t`Connect to an AI provider`,
-                )
-                .exhaustive()}
-            </div>
-          </Group>
-        </Flex>
-      }
-      description={
-        !connectedProvider
-          ? t`Select your AI provider to use AI explorations, SQL generation and Metabot.`
-          : undefined
-      }
-    >
-      <MetabotSetupInner />
-    </SettingsSection>
-  );
-}
-
-export function MetabotSetupInner({
+export function AIProviderConfigurationForm({
   isModal = false,
   onClose,
 }: {
@@ -350,7 +285,7 @@ export function MetabotSetupInner({
   const [isConnectButtonEnabled, setIsConnectButtonEnabled] = useState(false);
 
   return (
-    <MetabotSetupContext.Provider
+    <AIProviderConfigurationContext.Provider
       value={{
         connectHandlerRef,
         disconnectHandlerRef,
@@ -400,7 +335,7 @@ export function MetabotSetupInner({
             <MetabaseAIProviderSetup onConnect={onClose} />
           ))
           .with(P.nonNullable, (selectedProvider) => (
-            <AIProviderSetup
+            <ProviderCredentialsFields
               selectedProvider={selectedProvider}
               connectedModel={connectedModel}
               isCurrentConfigured={isCurrentConfigured}
@@ -462,11 +397,11 @@ export function MetabotSetupInner({
           onConfirm={handleConfirmDisconnect}
         />
       </Stack>
-    </MetabotSetupContext.Provider>
+    </AIProviderConfigurationContext.Provider>
   );
 }
 
-const AIProviderSetup = ({
+const ProviderCredentialsFields = ({
   selectedProvider,
   connectedModel,
   isCurrentConfigured,
@@ -501,7 +436,7 @@ const AIProviderSetup = ({
   const connectHandler =
     !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
 
-  const { isMutating } = useMetabotSetupContext(connectHandler);
+  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
 
   const { details: providerApiKeyDetails } = useAdminSettings([
     "llm-anthropic-api-key",

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
@@ -2,3 +2,5 @@ export {
   AIProviderConfigurationForm,
   useAIProviderConfigurationContext,
 } from "./AIProviderConfigurationForm";
+export { getProviderOptions, parseProviderAndModel } from "./utils";
+export type { MetabotApiKeyProvider } from "./utils";

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
@@ -1,0 +1,4 @@
+export {
+  AIProviderConfigurationForm,
+  useAIProviderConfigurationContext,
+} from "./AIProviderConfigurationForm";

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -1,8 +1,3 @@
-import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import type { FormikErrors } from "formik";
-import { P, isMatching } from "ts-pattern";
-
-import { useAdminSetting } from "metabase/api/utils";
 import type { MetabotProvider } from "metabase-types/api";
 
 type ApiKeylessProviders = "metabase";
@@ -34,7 +29,7 @@ export function getProviderOptions(
     ...(hasMetabaseProviderAccess && {
       metabase: {
         value: "metabase" as const,
-
+        // eslint-disable-next-line metabase/no-literal-metabase-strings -- "Metabase" is the product name for the managed AI provider option, only shown to admins configuring AI.
         label: "Metabase",
       },
     }),
@@ -106,60 +101,4 @@ export function parseProviderAndModel(value: string | null | undefined) {
   }
 
   return { provider, model };
-}
-
-// https://redux-toolkit.js.org/rtk-query/usage/error-handling
-// https://redux-toolkit.js.org/rtk-query/usage-with-typescript#type-safe-error-handling
-export const isFetchBaseQueryError = (
-  error: unknown,
-): error is FetchBaseQueryError =>
-  isMatching({ status: P.any, data: P.any }, error);
-
-type IFieldError<Values> =
-  | string
-  | { message: string }
-  | { errors: FormikErrors<Values> };
-
-const isFieldError = <Values>(error: unknown): error is IFieldError<Values> =>
-  isMatching(
-    P.union(
-      P.string,
-      { message: P.string },
-      { errors: P.record(P.string, P.any) },
-    ),
-    error,
-  );
-
-// If `error` is a form field error, throw a structured exception with the shape
-// `{data: {errors: FormikErrors}}` that will be caught as a validation error by
-// [[FormProvider]] in `frontend/src/metabase/forms/components/FormProvider/`.
-export const handleFieldError = <Values>(
-  error: unknown,
-  defaultField: keyof Values,
-) => {
-  if (!isFieldError<Values>(error)) {
-    return;
-  }
-
-  if (typeof error === "string") {
-    throw { data: { errors: { [defaultField]: error } } };
-  }
-
-  if ("message" in error) {
-    throw { data: { errors: { [defaultField]: error.message } } };
-  }
-
-  if ("errors" in error) {
-    throw { data: error };
-  }
-};
-
-export function useMCPServerURL() {
-  const { value: siteUrl } = useAdminSetting("site-url");
-
-  if (!siteUrl) {
-    return null;
-  }
-
-  return `${siteUrl}/api/metabase-mcp`;
 }

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationModal.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationModal.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 
-import { MetabotSetupInner } from "metabase/admin/ai/MetabotSetup";
 import { Modal, type ModalProps } from "metabase/ui";
+
+import { AIProviderConfigurationForm } from "./AIProviderConfigurationForm";
 
 export function AIProviderConfigurationModal({
   opened,
@@ -15,7 +16,7 @@ export function AIProviderConfigurationModal({
       size="lg"
       data-testid="ai-provider-configuration-modal"
     >
-      <MetabotSetupInner isModal onClose={onClose} />
+      <AIProviderConfigurationForm isModal onClose={onClose} />
     </Modal>
   );
 }

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { renderWithProviders, screen, within } from "__support__/ui";
 import type { MetabotAgentChatMessage } from "metabase/metabot/state";
+import { createMockUser } from "metabase-types/api/mocks";
 
 import { AgentMessage, Messages } from "./MetabotChatMessage";
 
@@ -14,6 +15,11 @@ const setup = (message: MetabotAgentChatMessage) =>
       getCopyText={() => ""}
       message={message}
     />,
+    {
+      storeInitialState: {
+        currentUser: createMockUser({ is_superuser: true }),
+      },
+    },
   );
 
 describe("AgentMessage", () => {

--- a/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
@@ -2,11 +2,11 @@ import { useDisclosure } from "@mantine/hooks";
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import { MetabotSetupInner } from "metabase/admin/ai/MetabotSetup";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useStoreUrl } from "metabase/common/hooks";
-import { useDispatch } from "metabase/redux";
+import { useDispatch, useSelector } from "metabase/redux";
 import { dismissUndo } from "metabase/redux/undo";
+import { canAccessSettings } from "metabase/selectors/user";
 import {
   Button,
   Flex,
@@ -15,6 +15,8 @@ import {
   Modal,
   Text,
 } from "metabase/ui";
+
+import { AIProviderConfigurationForm } from "./AIProviderConfigurationForm";
 
 const METABOT_MANAGED_PROVIDER_LIMIT_TOAST_ID =
   "metabot-managed-provider-limit";
@@ -31,6 +33,7 @@ export const MetabotManagedProviderLimitActions = ({
   onConfigureClose,
   ...rest
 }: MetabotManagedProviderLimitActionsProps) => {
+  const canConfigureAi = useSelector(canAccessSettings);
   const [isOpen, { open, close }] = useDisclosure(false, {
     onClose: onConfigureClose,
   });
@@ -45,11 +48,21 @@ export const MetabotManagedProviderLimitActions = ({
       opened={isOpen}
       size="lg"
     >
-      <MetabotSetupInner isModal onClose={close} />
+      <AIProviderConfigurationForm isModal onClose={close} />
     </Modal>
   );
 
   const storeUrl = useStoreUrl("account/manage/plans");
+
+  if (!canConfigureAi) {
+    return (
+      <Flex {...rest}>
+        <Text c="text-secondary" fz="sm" lh="1rem">
+          {t`Ask your admin to switch AI providers or start a paid subscription.`}
+        </Text>
+      </Flex>
+    );
+  }
 
   if (inline) {
     return (

--- a/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
@@ -56,7 +56,11 @@ export const MetabotManagedProviderLimitActions = ({
 
   if (!canConfigureAi) {
     return (
-      <Flex {...rest}>
+      <Flex
+        direction={inline ? "row" : "column"}
+        align={inline ? "center" : "start"}
+        {...rest}
+      >
         <Text c="text-secondary" fz="sm" lh="1rem">
           {t`Ask your admin to switch AI providers or start a paid subscription.`}
         </Text>

--- a/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.unit.spec.tsx
@@ -1,7 +1,8 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import * as metabotSetupModule from "metabase/admin/ai/MetabotSetup";
+import * as aiProviderConfigurationFormModule from "metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm";
+import { createMockUser } from "metabase-types/api/mocks";
 
 import { getMetabotManagedProviderLimitToastProps } from "./MetabotManagedProviderLimit";
 
@@ -9,8 +10,10 @@ describe("getMetabotManagedProviderLimitToastProps", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     jest
-      .spyOn(metabotSetupModule, "MetabotSetupInner")
-      .mockImplementation(() => <div>Mocked Metabot Setup</div>);
+      .spyOn(aiProviderConfigurationFormModule, "AIProviderConfigurationForm")
+      .mockImplementation(() => (
+        <div>Mocked AI provider configuration form</div>
+      ));
   });
 
   it("dismisses the toast only when the configure modal closes", async () => {
@@ -18,6 +21,7 @@ describe("getMetabotManagedProviderLimitToastProps", () => {
       getMetabotManagedProviderLimitToastProps().renderChildren(),
       {
         storeInitialState: {
+          currentUser: createMockUser({ is_superuser: true }),
           undo: [
             {
               id: "metabot-managed-provider-limit",
@@ -32,7 +36,9 @@ describe("getMetabotManagedProviderLimitToastProps", () => {
       screen.getByRole("button", { name: "Use a different AI provider" }),
     );
 
-    expect(screen.getByText("Mocked Metabot Setup")).toBeInTheDocument();
+    expect(
+      screen.getByText("Mocked AI provider configuration form"),
+    ).toBeInTheDocument();
     expect(store.getState().undo).toHaveLength(1);
 
     await userEvent.click(screen.getByRole("button", { name: "Close" }));
@@ -46,13 +52,41 @@ describe("getMetabotManagedProviderLimitToastProps", () => {
     });
   });
 
-  it("renders the paid subscription link in the toast", () => {
+  it("renders the paid subscription link in the toast for admins", () => {
     renderWithProviders(
       getMetabotManagedProviderLimitToastProps().renderChildren(),
+      {
+        storeInitialState: {
+          currentUser: createMockUser({ is_superuser: true }),
+        },
+      },
     );
 
     expect(
       screen.getByRole("link", { name: "Start paid subscription" }),
     ).toHaveAttribute("href", expect.stringContaining("/account/manage/plans"));
+  });
+
+  it("shows an 'ask your admin' message for non-admins instead of the action buttons", () => {
+    renderWithProviders(
+      getMetabotManagedProviderLimitToastProps().renderChildren(),
+      {
+        storeInitialState: {
+          currentUser: createMockUser({ is_superuser: false }),
+        },
+      },
+    );
+
+    expect(
+      screen.getByText(
+        /Ask your admin to switch AI providers or start a paid subscription/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Use a different AI provider" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Start paid subscription" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/metabot/index.tsx
+++ b/frontend/src/metabase/metabot/index.tsx
@@ -1,1 +1,8 @@
 export * from "./context";
+export {
+  AIProviderConfigurationForm,
+  getProviderOptions,
+  parseProviderAndModel,
+  useAIProviderConfigurationContext,
+} from "./components/AIProviderConfigurationForm";
+export type { MetabotApiKeyProvider } from "./components/AIProviderConfigurationForm";


### PR DESCRIPTION
Moves the AI provider configuration form out of metabase/admin into metabase/metabot so that the metabot feature no longer imports from the admin feature module. resolving two shared → feature module-boundary violations. Also gates the managed-provider token-limit actions on canAccessSettings, so non-admins now see an "Ask your admin…" message. Previously, the buttons opened a settings form that 403'd for non-admins anyway.

setByEnvVar had to move because the metabot form depends on it. We need to be careful about making it shared though.

Renamed `MetabotSetup` to `AIProviderConfigurationForm.tsx` because it isn't specific to Metabot (let me know if I'm wrong about that).

Before: 
<img width="1177" height="696" alt="Screenshot 2026-06-08 at 12 00 01 PM" src="https://github.com/user-attachments/assets/98dbc881-a84c-415d-b568-ae6eee3840a5" />

non-admin user is shown the 'Use a different AI Provider button', but clicking it would show an empty modal and the api would error `You don't have permissions to do that.`

After:
<img width="474" height="696" alt="Screenshot 2026-06-08 at 11 37 59 AM" src="https://github.com/user-attachments/assets/9ac82132-0d80-4907-b3ec-1caed2e5a2c5" />

non-admin user is shown 'Ask your admin...' message





