### PR TITLE
Replace cancelDeferred with AbortSignal and honor the signal everywhere

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -205,13 +205,16 @@ describe("issue 12926", () => {
         cy.visit(`/dashboard/${dashboard_id}`);
       });
 
+      // The query is deliberately slowed, so it is still in-flight here.
+      // The API client uses fetch, so cancelling the query aborts its
+      // AbortController rather than calling XMLHttpRequest.abort().
       cy.window().then((win) => {
-        cy.spy(win.XMLHttpRequest.prototype, "abort").as("xhrAbort");
+        cy.spy(win.AbortController.prototype, "abort").as("queryAbort");
       });
 
       removeCard();
 
-      cy.get("@xhrAbort").should("have.been.calledOnce");
+      cy.get("@queryAbort").should("have.been.called");
     });
 
     it("should re-fetch the query when doing undo on the removal", () => {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
@@ -17,7 +17,6 @@ import type {
   SqlParameterValues,
 } from "embedding-sdk-bundle/types/question";
 import { isStaticEmbeddingEntityLoadingError } from "metabase/utils/errors/is-static-embedding-entity-loading-error";
-import { type Deferred, defer } from "metabase/utils/promise";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
@@ -94,19 +93,19 @@ export function useLoadQuestion({
   const tokenRef = useRef(token);
   tokenRef.current = token;
 
-  const deferredRef = useRef<Deferred>();
+  const controllerRef = useRef<AbortController>();
 
-  function deferred() {
+  function nextSignal() {
     // Cancel the previous query when a new one is started.
-    deferredRef.current?.resolve();
-    deferredRef.current = defer();
+    controllerRef.current?.abort();
+    controllerRef.current = new AbortController();
 
-    return deferredRef.current;
+    return controllerRef.current.signal;
   }
 
   // Cancel the running query when the component unmounts.
   useUnmount(() => {
-    deferredRef.current?.resolve();
+    controllerRef.current?.abort();
   });
 
   // Avoid re-running the query if the parameters haven't changed.
@@ -141,7 +140,7 @@ export function useLoadQuestion({
         token: tokenRef.current,
         originalQuestion: questionState.originalQuestion,
         parameterValues: questionState.parameterValues,
-        cancelDeferred: deferred(),
+        signal: nextSignal(),
         dispatch,
       });
 
@@ -152,7 +151,7 @@ export function useLoadQuestion({
     } catch (err) {
       // Ignore cancelled requests (e.g. when the component unmounts, or when a
       // controlled `sqlParameters` push cancels the in-flight load query via the
-      // shared `deferredRef`). React simulates unmounting on strict mode,
+      // shared `controllerRef`). React simulates unmounting on strict mode,
       // therefore "Question not found" will be shown without this.
       if (isCancelledRequestError(err)) {
         setIsQuestionLoading(false);
@@ -199,7 +198,7 @@ export function useLoadQuestion({
       token,
       originalQuestion,
       parameterValues,
-      cancelDeferred: deferred(),
+      signal: nextSignal(),
       dispatch,
     });
 
@@ -229,7 +228,7 @@ export function useLoadQuestion({
           previousQuestion: question,
           originalQuestion,
           nextParameterValues: parameterValues ?? {},
-          cancelDeferred: deferred(),
+          signal: nextSignal(),
           optimisticUpdateQuestion: (question) =>
             mergeQuestionState({ question }),
           shouldRunQueryOnQuestionChange: run,
@@ -267,7 +266,7 @@ export function useLoadQuestion({
           previousQuestion: question,
           originalQuestion,
           nextParameterValues,
-          cancelDeferred: deferred(),
+          signal: nextSignal(),
           optimisticUpdateQuestion: (question) =>
             mergeQuestionState({ question }),
           shouldRunQueryOnQuestionChange: true,
@@ -298,7 +297,7 @@ export function useLoadQuestion({
           token,
           originalQuestion,
           parameterValues,
-          cancelDeferred: deferred(),
+          signal: nextSignal(),
           onQuestionChange: (question) => mergeQuestionState({ question }),
           onClearQueryResults: () =>
             mergeQuestionState({ queryResults: [null] }),

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
@@ -35,7 +35,7 @@ export const runQuestionOnNavigateSdk =
       previousCard,
       originalQuestion,
       parameterValues,
-      cancelDeferred,
+      signal,
       onQuestionChange,
       onClearQueryResults,
     } = params;
@@ -65,7 +65,7 @@ export const runQuestionOnNavigateSdk =
       question: new Question(nextCard, getMetadata(getState())),
       originalQuestion,
       parameterValues,
-      cancelDeferred,
+      signal,
       isGuestEmbed,
       token,
       dispatch,

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
@@ -13,7 +13,6 @@ interface RunQuestionQueryParams {
   token: EntityToken | null | undefined;
   originalQuestion?: Question;
   parameterValues?: ParameterValuesMap;
-  cancelDeferred?: Deferred;
   signal?: AbortSignal;
   dispatch: Dispatch;
 }

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-query.ts
@@ -2,7 +2,6 @@ import { getGuestEmbedFilteredParameters } from "embedding-sdk-bundle/lib/get-gu
 import type { SdkQuestionState } from "embedding-sdk-bundle/types/question";
 import type { Dispatch } from "metabase/redux/store";
 import { runQuestionQuery } from "metabase/services";
-import type { Deferred } from "metabase/utils/promise";
 import { getSensibleDisplays } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
@@ -15,6 +14,7 @@ interface RunQuestionQueryParams {
   originalQuestion?: Question;
   parameterValues?: ParameterValuesMap;
   cancelDeferred?: Deferred;
+  signal?: AbortSignal;
   dispatch: Dispatch;
 }
 
@@ -27,7 +27,7 @@ export async function runQuestionQuerySdk(
     token,
     originalQuestion,
     parameterValues,
-    cancelDeferred,
+    signal,
     dispatch,
   } = params;
 
@@ -53,7 +53,7 @@ export async function runQuestionQuerySdk(
 
     queryResults = await runQuestionQuery(question, {
       dispatch,
-      cancelDeferred,
+      signal,
       ignoreCache: false,
       isDirty: isQueryDirty,
       token,

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
@@ -7,7 +7,6 @@ import { createRawSeries } from "metabase/query_builder/utils";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import { getMetadata } from "metabase/selectors/metadata";
-import type { Deferred } from "metabase/utils/promise";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
@@ -34,7 +33,7 @@ interface UpdateQuestionParams {
   shouldStartAdHocQuestion: boolean;
 
   queryResults?: any[];
-  cancelDeferred?: Deferred;
+  signal?: AbortSignal;
   isGuestEmbed: boolean;
   token: EntityToken | null | undefined;
 
@@ -54,7 +53,7 @@ export const updateQuestionSdk =
       originalQuestion,
       nextParameterValues,
       shouldStartAdHocQuestion,
-      cancelDeferred,
+      signal,
       queryResults,
       optimisticUpdateQuestion: onQuestionChange,
       shouldRunQueryOnQuestionChange = false,
@@ -131,7 +130,7 @@ export const updateQuestionSdk =
         token,
         originalQuestion,
         parameterValues: nextParameterValues,
-        cancelDeferred,
+        signal,
         dispatch,
       });
     }

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 
 import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import type { QueryParams } from "metabase/query_builder/actions";
-import type { Deferred } from "metabase/utils/promise";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import type InternalQuestion from "metabase-lib/v1/Question";
 import type { Card, ParameterValuesMap } from "metabase-types/api";
@@ -117,7 +116,7 @@ export interface NavigateToNewCardParams {
   nextCard: Card;
   previousCard: Card;
   objectId: ObjectId;
-  cancelDeferred?: Deferred;
+  signal?: AbortSignal;
   drillName?: string;
 }
 

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -299,7 +299,7 @@ export class LegacyApi extends EventEmitter {
           (e as { status?: number }).status === 503 &&
           retryCount < maxAttempts
         ) {
-          await delay(retryDelays.pop() ?? 0);
+          await delay(retryDelays.pop() ?? 0, options.signal);
         } else {
           throw e;
         }

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -38,7 +38,6 @@ type RequestOptions = {
   formData?: boolean;
   fetch?: boolean;
   bodyParamName?: string | null;
-  controller?: AbortController;
   signal?: AbortSignal;
 };
 
@@ -415,11 +414,16 @@ export class LegacyApi extends EventEmitter {
       };
       xhr.send(body);
 
-      if (options.cancelled) {
-        options.cancelled.then(() => {
+      if (options.signal) {
+        const onAbort = () => {
           isCancelled = true;
           xhr.abort();
-        });
+        };
+        if (options.signal.aborted) {
+          onAbort();
+        } else {
+          options.signal.addEventListener("abort", onAbort);
+        }
       }
     });
   }
@@ -432,23 +436,21 @@ export class LegacyApi extends EventEmitter {
     data: Record<string, unknown>,
     options: RequestOptions,
   ): Promise<unknown> {
-    const controller = options.controller || new AbortController();
-    const signal = options.signal ?? controller.signal;
-
+    // We bridge `options.signal` through a local controller (rather than
+    // handing it to `fetch` directly) so an already-aborted signal still gets
+    // its request dispatched: the request is sent this microtask, then the
+    // local controller aborts on the next. This matches XHR's `send()` →
+    // `abort()` semantics and keeps superseded-but-parked requests (e.g.
+    // through the embedding-SDK token refresh) going out.
+    const controller = new AbortController();
     const requestUrl = new URL(this.basename + url, location.origin);
     const request = new Request(requestUrl.href, {
       method,
       headers,
       body: requestBody,
-      signal,
+      signal: controller.signal,
     });
 
-    // Propagate aborts from an externally-supplied signal. If the signal is
-    // already aborted (e.g. cancelled while we were awaiting auth-refresh
-    // middleware), defer the propagation to the next microtask so the request
-    // still gets dispatched first — matching XHR's `send()` then-`abort()`
-    // semantics, where `xhr.send()` runs before the cancel handler is wired
-    // up. Otherwise the network never sees the request at all.
     if (options.signal) {
       if (options.signal.aborted) {
         queueMicrotask(() => controller.abort());
@@ -511,7 +513,7 @@ export class LegacyApi extends EventEmitter {
         });
       })
       .catch((error: unknown) => {
-        if (signal.aborted) {
+        if (options.signal?.aborted) {
           throw { isCancelled: true };
         }
         // A raw `fetch` rejection (e.g. the server dropped the connection)

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -300,6 +300,9 @@ export class LegacyApi extends EventEmitter {
           retryCount < maxAttempts
         ) {
           await delay(retryDelays.pop() ?? 0, options.signal);
+          if (options.signal?.aborted) {
+            throw { isCancelled: true };
+          }
         } else {
           throw e;
         }

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -38,7 +38,6 @@ type RequestOptions = {
   formData?: boolean;
   fetch?: boolean;
   bodyParamName?: string | null;
-  cancelled?: Promise<unknown>;
   controller?: AbortController;
   signal?: AbortSignal;
 };
@@ -434,8 +433,7 @@ export class LegacyApi extends EventEmitter {
     options: RequestOptions,
   ): Promise<unknown> {
     const controller = options.controller || new AbortController();
-    const signal = controller.signal;
-    options.cancelled?.then(() => controller.abort());
+    const signal = options.signal ?? controller.signal;
 
     const requestUrl = new URL(this.basename + url, location.origin);
     const request = new Request(requestUrl.href, {

--- a/frontend/src/metabase/common/components/QuestionResultLoader.tsx
+++ b/frontend/src/metabase/common/components/QuestionResultLoader.tsx
@@ -4,8 +4,6 @@ import { useEffectOnce } from "react-use";
 
 import { useDispatch } from "metabase/redux";
 import { runQuestionQuery } from "metabase/services";
-import type { Deferred } from "metabase/utils/promise";
-import { defer } from "metabase/utils/promise";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset, RawSeries } from "metabase-types/api";
 
@@ -57,7 +55,7 @@ export function QuestionResultLoader({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
 
-  const cancelDeferredRef = useRef<Deferred | null>(null);
+  const cancelControllerRef = useRef<AbortController | null>(null);
   const questionRef = useRef<Question | null | undefined>(question);
 
   const loadResult = useCallback(
@@ -74,7 +72,7 @@ export function QuestionResultLoader({
       }
 
       try {
-        cancelDeferredRef.current = defer();
+        cancelControllerRef.current = new AbortController();
 
         setLoading(true);
         setResults((prev) => (keepPrevious ? prev : null));
@@ -82,7 +80,7 @@ export function QuestionResultLoader({
 
         const queryResults = await runQuestionQuery(questionToLoad, {
           dispatch,
-          cancelDeferred: cancelDeferredRef.current,
+          signal: cancelControllerRef.current.signal,
           collectionPreview,
         });
 
@@ -109,7 +107,7 @@ export function QuestionResultLoader({
   const cancel = useCallback(() => {
     if (loading) {
       setLoading(false);
-      cancelDeferredRef.current?.resolve();
+      cancelControllerRef.current?.abort();
     }
   }, [loading]);
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -46,8 +46,6 @@ import {
   isQuestionDashCard,
   isVirtualDashCard,
 } from "metabase/utils/dashboard";
-import type { Deferred } from "metabase/utils/promise";
-import { defer } from "metabase/utils/promise";
 import { uuid } from "metabase/utils/uuid";
 import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -288,7 +286,7 @@ export const fetchCardDataAction = createAsyncThunk<
        * and forth (#70534). When parameters differ (e.g. filter change), we fall through to the cancel-and-restart
        * path below.
        */
-      const inFlight = cardDataCancelDeferreds[`${dashcard.id},${card.id}`];
+      const inFlight = cardDataCancelControllers[`${dashcard.id},${card.id}`];
       if (
         inFlight &&
         _.isEqual(inFlight.queryParams, getDatasetQueryParams(datasetQuery))
@@ -322,22 +320,17 @@ export const fetchCardDataAction = createAsyncThunk<
       }
     }, DASHBOARD_SLOW_TIMEOUT);
 
-    const deferred = defer();
+    const controller = new AbortController();
     setFetchCardDataCancel(
       card.id,
       dashcard.id,
-      deferred,
+      controller,
       getDatasetQueryParams(datasetQuery),
     );
 
-    let cancelled = false;
-    deferred.promise.then(() => {
-      cancelled = true;
-    });
-
     const metadata = getMetadata(getState());
     const queryOptions = {
-      cancelled: deferred.promise,
+      signal: controller.signal,
     };
 
     if (dashboardType === "public") {
@@ -415,7 +408,7 @@ export const fetchCardDataAction = createAsyncThunk<
             { forceRefetch: true },
           ),
         );
-        deferred.promise.then(() => queryAction.abort());
+        controller.signal.addEventListener("abort", () => queryAction.abort());
         try {
           result = (await fetchDataOrError(queryAction.unwrap())) as
             | Dataset
@@ -443,8 +436,8 @@ export const fetchCardDataAction = createAsyncThunk<
       }
     }
 
-    // If the request was not previously cancelled, then clear the defer for the card
-    if (!cancelled) {
+    // If the request was not previously cancelled, then clear the controller for the card
+    if (!controller.signal.aborted) {
       setFetchCardDataCancel(card.id, dashcard.id, null);
     }
     clearTimeout(slowCardTimer);
@@ -452,7 +445,7 @@ export const fetchCardDataAction = createAsyncThunk<
     return {
       dashcard_id: dashcard.id,
       card_id: card.id,
-      result: cancelled ? null : result,
+      result: controller.signal.aborted ? null : result,
       currentTime: performance.now(),
     };
   },
@@ -639,11 +632,11 @@ export const cancelFetchDashboardCardData = createThunkAction(
 );
 
 type InFlightEntry = {
-  deferred: Deferred;
+  controller: AbortController;
   queryParams: ReturnType<typeof getDatasetQueryParams>;
 };
 
-const cardDataCancelDeferreds: Record<
+const cardDataCancelControllers: Record<
   `${DashCardId},${DashboardCard["card_id"]}`,
   InFlightEntry | null
 > = {};
@@ -651,11 +644,11 @@ const cardDataCancelDeferreds: Record<
 function setFetchCardDataCancel(
   card_id: DashboardCard["card_id"],
   dashcard_id: DashCardId,
-  deferred: Deferred | null,
+  controller: AbortController | null,
   queryParams?: ReturnType<typeof getDatasetQueryParams>,
 ) {
-  cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = deferred
-    ? { deferred, queryParams: queryParams! }
+  cardDataCancelControllers[`${dashcard_id},${card_id}`] = controller
+    ? { controller, queryParams: queryParams! }
     : null;
 }
 
@@ -663,10 +656,10 @@ function setFetchCardDataCancel(
 export const cancelFetchCardData = createAction(
   CANCEL_FETCH_CARD_DATA,
   (card_id, dashcard_id) => {
-    const entry = cardDataCancelDeferreds[`${dashcard_id},${card_id}`];
+    const entry = cardDataCancelControllers[`${dashcard_id},${card_id}`];
     if (entry) {
-      entry.deferred.resolve();
-      cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = null;
+      entry.controller.abort();
+      cardDataCancelControllers[`${dashcard_id},${card_id}`] = null;
     }
     return { payload: { dashcard_id, card_id } };
   },
@@ -697,7 +690,7 @@ const dashboardSchema = new schema.Entity("dashboard", {
   dashcards: [dashcardSchema],
 });
 
-let fetchDashboardCancellation: Deferred | null;
+let fetchDashboardCancellation: AbortController | null;
 
 export const fetchDashboard = createAsyncThunk(
   "metabase/dashboard/FETCH_DASHBOARD",
@@ -714,9 +707,9 @@ export const fetchDashboard = createAsyncThunk(
     { getState, dispatch, rejectWithValue },
   ) => {
     if (fetchDashboardCancellation) {
-      fetchDashboardCancellation.resolve();
+      fetchDashboardCancellation.abort();
     }
-    fetchDashboardCancellation = defer();
+    fetchDashboardCancellation = new AbortController();
 
     try {
       let entities;
@@ -740,7 +733,7 @@ export const fetchDashboard = createAsyncThunk(
       } else if (dashboardType === "public") {
         result = await PublicApi.dashboard(
           { uuid: dashId, dashboard_load_id: dashboardLoadId },
-          { cancelled: fetchDashboardCancellation.promise },
+          { signal: fetchDashboardCancellation.signal },
         );
         result = {
           ...result,
@@ -753,7 +746,7 @@ export const fetchDashboard = createAsyncThunk(
       } else if (dashboardType === "embed") {
         result = await EmbedApi.dashboard(
           { token: dashId, dashboard_load_id: dashboardLoadId },
-          { cancelled: fetchDashboardCancellation.promise },
+          { signal: fetchDashboardCancellation.signal },
         );
         result = {
           ...result,
@@ -769,7 +762,7 @@ export const fetchDashboard = createAsyncThunk(
         const [response] = await Promise.all([
           AutoApi.dashboard(
             { subPath, dashboard_load_id: dashboardLoadId },
-            { cancelled: fetchDashboardCancellation.promise },
+            { signal: fetchDashboardCancellation.signal },
           ),
           entityCompatibleQuery(
             {
@@ -802,7 +795,7 @@ export const fetchDashboard = createAsyncThunk(
         const [response] = await Promise.all([
           DashboardApi.get(
             { dashId: dashId, dashboard_load_id: dashboardLoadId },
-            { cancelled: fetchDashboardCancellation.promise },
+            { signal: fetchDashboardCancellation.signal },
           ),
           entityCompatibleQuery(
             { id: dashId, dashboard_load_id: dashboardLoadId },

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -378,7 +378,7 @@ export const fetchCardDataAction = createAsyncThunk<
           card,
           metadata,
           { ...datasetQuery, ignore_cache: ignoreCache },
-          deferred,
+          controller.signal,
         ),
       )) as Dataset | { error: unknown };
     } else {

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -15,7 +15,6 @@ import {
 import type { Dispatch, GetState } from "metabase/redux/store";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
-import { defer } from "metabase/utils/promise";
 import { getSensibleDisplays } from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -158,18 +157,18 @@ export const runQuestionQuery = ({
     }
 
     const startTime = new Date();
-    const cancelQueryDeferred = defer();
+    const cancelQueryController = new AbortController();
 
     apiRunQuestionQuery(question, {
       dispatch,
-      cancelDeferred: cancelQueryDeferred,
+      signal: cancelQueryController.signal,
       ignoreCache: ignoreCache,
       isDirty: isQueryDirty,
     })
       .then((queryResults) => dispatch(queryCompleted(question, queryResults)))
       .catch((error) => dispatch(queryErrored(startTime, error)));
 
-    dispatch({ type: RUN_QUERY_TYPE, payload: { cancelQueryDeferred } });
+    dispatch({ type: RUN_QUERY_TYPE, payload: { cancelQueryController } });
   };
 };
 
@@ -264,9 +263,9 @@ export const queryErrored = createThunkAction(
 export const cancelQuery = () => (dispatch: Dispatch, getState: GetState) => {
   const isRunning = getIsRunning(getState());
   if (isRunning) {
-    const { cancelQueryDeferred } = getState().qb;
-    if (cancelQueryDeferred) {
-      cancelQueryDeferred.resolve();
+    const { cancelQueryController } = getState().qb;
+    if (cancelQueryController) {
+      cancelQueryController.abort();
     }
     dispatch(setDocumentTitle(""));
 

--- a/frontend/src/metabase/query_builder/reducers.ts
+++ b/frontend/src/metabase/query_builder/reducers.ts
@@ -58,7 +58,6 @@ import type {
   Range,
 } from "metabase/redux/store";
 import { clone } from "metabase/utils/clone";
-import type { Deferred } from "metabase/utils/promise";
 import type {
   Card,
   CollectionItemModel,
@@ -488,15 +487,15 @@ export const metadataDiff = createReducer<Record<string, Partial<Field>>>(
   },
 );
 
-// promise used for tracking a query execution in progress. when a query is started we capture this.
-export const cancelQueryDeferred = createReducer<Deferred<void> | null>(
+// AbortController used for tracking a query execution in progress. when a query is started we capture this.
+export const cancelQueryController = createReducer<AbortController | null>(
   null,
   (builder) => {
     builder
       .addCase<
         string,
-        { type: string; payload: { cancelQueryDeferred: Deferred<void> } }
-      >(RUN_QUERY, (_state, action) => action.payload.cancelQueryDeferred)
+        { type: string; payload: { cancelQueryController: AbortController } }
+      >(RUN_QUERY, (_state, action) => action.payload.cancelQueryController)
       .addCase(CANCEL_QUERY, () => null)
       .addCase(QUERY_COMPLETED, () => null)
       .addCase(QUERY_ERRORED, () => null);

--- a/frontend/src/metabase/redux/store/mocks/qb.ts
+++ b/frontend/src/metabase/redux/store/mocks/qb.ts
@@ -64,7 +64,7 @@ export const createMockQueryBuilderState = (
   queryStatus: "complete",
   queryResults: null,
   queryStartTime: null,
-  cancelQueryDeferred: null,
+  cancelQueryController: null,
 
   card: null,
   originalCard: null,

--- a/frontend/src/metabase/redux/store/qb.ts
+++ b/frontend/src/metabase/redux/store/qb.ts
@@ -1,5 +1,4 @@
 import type { QueryModalType } from "metabase/querying/constants";
-import type { Deferred } from "metabase/utils/promise";
 import type { Widget } from "metabase/visualizations/types";
 import type {
   Card,
@@ -93,7 +92,7 @@ export interface QueryBuilderState {
   queryStatus: QueryBuilderQueryStatus;
   queryResults: Dataset[] | null;
   queryStartTime: number | null;
-  cancelQueryDeferred: Deferred<void> | null;
+  cancelQueryController: AbortController | null;
 
   card: Card | null;
   originalCard: Card | null;

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -101,7 +101,7 @@ export function maybeUsePivotEndpoint(api, card, metadata) {
 }
 
 // Dispatches the RTK `datasetApi` ad-hoc query endpoint (pivot or non-pivot)
-// and wires the `cancelDeferred` to RTK Query's `.abort()`. Translates aborts
+// and wires the `signal` to RTK Query's `.abort()`. Translates aborts
 // into the `{ isCancelled: true }` shape that the legacy fetch helper threw,
 // so existing error-handling code (e.g. queryErrored) keeps working.
 let adhocDatasetQueryCounter = 0;
@@ -110,7 +110,7 @@ export async function runAdhocDatasetQuery(
   card,
   metadata,
   body,
-  cancelDeferred,
+  signal,
 ) {
   // Dynamic import to avoid a module-init cycle: `metabase/api/dataset` pulls
   // in `metabase/api` → `metabase/redux/user` → `metabase/redux/query-builder`
@@ -138,7 +138,7 @@ export async function runAdhocDatasetQuery(
   );
 
   let isCancelled = false;
-  cancelDeferred?.promise.then(() => {
+  signal?.addEventListener("abort", () => {
     isCancelled = true;
     action.abort?.();
   });
@@ -162,7 +162,7 @@ export async function runQuestionQuery(
   question,
   {
     dispatch,
-    cancelDeferred,
+    signal,
     isDirty = false,
     token,
     ignoreCache = false,
@@ -197,7 +197,7 @@ export async function runQuestionQuery(
           card,
           question.metadata(),
         )(queryParams, {
-          cancelled: cancelDeferred.promise,
+          signal,
         }),
       ),
     ];
@@ -210,7 +210,7 @@ export async function runQuestionQuery(
         card,
         question.metadata(),
         { ...question.datasetQuery(), parameters },
-        cancelDeferred,
+        signal,
       ),
     ),
   ];

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -138,10 +138,18 @@ export async function runAdhocDatasetQuery(
   );
 
   let isCancelled = false;
-  signal?.addEventListener("abort", () => {
+  const onAbort = () => {
     isCancelled = true;
     action.abort?.();
-  });
+  };
+  // The signal may already be aborted by the time we get here (e.g. the
+  // user cancelled while we were awaiting the dynamic import above). In
+  // that case the "abort" event already fired and a listener won't run.
+  if (signal?.aborted) {
+    onAbort();
+  } else {
+    signal?.addEventListener("abort", onAbort, { once: true });
+  }
 
   return action
     .unwrap()

--- a/frontend/src/metabase/services.unit.spec.ts
+++ b/frontend/src/metabase/services.unit.spec.ts
@@ -6,7 +6,6 @@ import { Api } from "metabase/api";
 import { mainReducers } from "metabase/reducers-main";
 import { createMockState } from "metabase/redux/store/mocks";
 import { getMetadata } from "metabase/selectors/metadata";
-import { defer } from "metabase/utils/promise";
 import Question from "metabase-lib/v1/Question";
 import type {
   Card,
@@ -99,7 +98,7 @@ async function setupRunQuestionQuery(question: Question) {
   fetchMock.post(getQueryEndpointPath(question), mockResult);
   const result = await runQuestionQuery(question, {
     dispatch: getRtkStore().dispatch,
-    cancelDeferred: defer(),
+    signal: new AbortController().signal,
   });
   return { result, mockResult };
 }
@@ -231,7 +230,7 @@ describe("metabase/services > runQuestionQuery", () => {
 
       const result = await runQuestionQuery(question, {
         dispatch: getRtkStore().dispatch,
-        cancelDeferred: defer(),
+        signal: new AbortController().signal,
       });
 
       // 4xx errors should be returned as successful responses with error data
@@ -253,7 +252,7 @@ describe("metabase/services > runQuestionQuery", () => {
 
       const result = await runQuestionQuery(question, {
         dispatch: getRtkStore().dispatch,
-        cancelDeferred: defer(),
+        signal: new AbortController().signal,
       });
 
       // 4xx errors should be returned as successful responses with error data
@@ -272,7 +271,7 @@ describe("metabase/services > runQuestionQuery", () => {
       await expect(
         runQuestionQuery(question, {
           dispatch: getRtkStore().dispatch,
-          cancelDeferred: defer(),
+          signal: new AbortController().signal,
         }),
       ).rejects.toMatchObject({
         status: 500,
@@ -290,13 +289,13 @@ describe("metabase/services > runQuestionQuery", () => {
         new Promise(() => undefined),
       );
 
-      const cancelDeferred = defer();
+      const controller = new AbortController();
       const runPromise = runQuestionQuery(question, {
         dispatch: getRtkStore().dispatch,
-        cancelDeferred,
+        signal: controller.signal,
       });
 
-      cancelDeferred.resolve();
+      controller.abort();
 
       await expect(runPromise).rejects.toEqual({ isCancelled: true });
     });
@@ -317,7 +316,7 @@ describe("metabase/services > runQuestionQuery", () => {
 
       const result = await runQuestionQuery(question, {
         dispatch: getRtkStore().dispatch,
-        cancelDeferred: defer(),
+        signal: new AbortController().signal,
       });
 
       expect(result).toEqual([{ error: errorMessage, status: 400 }]);

--- a/frontend/src/metabase/utils/promise.ts
+++ b/frontend/src/metabase/utils/promise.ts
@@ -24,6 +24,23 @@ export function defer<T>(): Deferred<T> {
   };
 }
 
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, duration(ms)));
+export function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      resolve();
+    };
+
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, duration(ms));
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/frontend/src/metabase/utils/promise.ts
+++ b/frontend/src/metabase/utils/promise.ts
@@ -26,11 +26,6 @@ export function defer<T>(): Deferred<T> {
 
 export function delay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-
     const onAbort = () => {
       clearTimeout(timeoutId);
       resolve();
@@ -42,5 +37,11 @@ export function delay(ms: number, signal?: AbortSignal): Promise<void> {
     }, duration(ms));
 
     signal?.addEventListener("abort", onAbort, { once: true });
+
+    // Register the listener before checking `aborted`, so an abort can never
+    // slip through the gap and leave the timeout running to completion.
+    if (signal?.aborted) {
+      onAbort();
+    }
   });
 }


### PR DESCRIPTION
This PR removes the reliance on `Deferred` for request cancelation in favor of `AbortController` and `AbortSignal`. The latter is standard and designed for this exact purpose.

This cleans up the API client:
- removes the `cancelDeferred` option
- removes the unused `controller` option, `signal` is all we need

It also adds some improvements:
- makes `delay` cancelable. This means that requests that are exponentially backing off can be canceled without waiting for the delay between requests.
- makes the requests actually listen to the abort signal. This means that requests actually get aborted when canceling them. This fixes cases where requests don't get properly cancelled.