### PR TITLE
Table API field order shape

### DIFF
--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -37,7 +37,6 @@ type RequestOptions = {
   retryDelayIntervals: number[];
   formData?: boolean;
   fetch?: boolean;
-  bodyParamName?: string | null;
   signal?: AbortSignal;
 };
 
@@ -227,11 +226,7 @@ export class LegacyApi extends EventEmitter {
         if (options.hasBody) {
           body = options.formData
             ? (rawData["formData"] as FormData)
-            : JSON.stringify(
-                options.bodyParamName != null
-                  ? data[options.bodyParamName!]
-                  : data,
-              );
+            : JSON.stringify(data);
         } else {
           const qs = querystring.stringify(data as Record<string, string>);
           if (qs) {

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -17,7 +17,7 @@ const isAllowedHTTPMethod = (method: any): method is AllowedHTTPMethods => {
 export const apiQuery: BaseQueryFn = async (args, ctx, extraOptions) => {
   const method = typeof args === "string" ? "GET" : (args?.method ?? "GET");
   const url = typeof args === "string" ? args : args.url;
-  const { bodyParamName, noEvent, formData, fetch, transformResponse } = args;
+  const { noEvent, formData, fetch, transformResponse } = args;
 
   if (!isAllowedHTTPMethod(method)) {
     return { error: "Invalid HTTP method" };
@@ -30,7 +30,6 @@ export const apiQuery: BaseQueryFn = async (args, ctx, extraOptions) => {
       { ...args?.body, ...args?.params },
       {
         signal: ctx.signal,
-        bodyParamName,
         noEvent,
         formData,
         fetch,

--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -118,11 +118,10 @@ export const tableApi = Api.injectEndpoints({
       Table,
       UpdateTableFieldsOrderRequest
     >({
-      query: ({ id, ...body }) => ({
+      query: ({ id, field_order }) => ({
         method: "PUT",
         url: `/api/table/${id}/fields/order`,
-        body,
-        bodyParamName: "field_order",
+        body: { field_order },
       }),
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -428,8 +428,12 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
-   field-order :- [:sequential ms/PositiveInt]]
-  (-> (t2/select-one :model/Table :id id) api/write-check (table/custom-order-fields! field-order))
+   ;; Accept either a bare sequential (legacy) or a wrapped {:field_order [...]} body.
+   body :- [:or
+            [:sequential ms/PositiveInt]
+            [:map [:field_order [:sequential ms/PositiveInt]]]]]
+  (let [field-order (if (map? body) (:field_order body) body)]
+    (-> (t2/select-one :model/Table :id id) api/write-check (table/custom-order-fields! field-order)))
   {:success true})
 
 (mu/defn- update-csv!

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1086,6 +1086,16 @@
                  (->> (t2/hydrate (t2/select-one :model/Table :id (mt/id :venues)) :fields)
                       :fields
                       (map u/the-id))))))
+      (testing "Can we set custom field ordering with a wrapped {:field_order [...]} body?"
+        (let [custom-field-order [(mt/id :venues :name) (mt/id :venues :id) (mt/id :venues :price)
+                                  (mt/id :venues :latitude) (mt/id :venues :longitude) (mt/id :venues :category_id)]]
+          (is (=? {:success true}
+                  (mt/user-http-request :crowberto :put 200 (format "table/%s/fields/order" (mt/id :venues))
+                                        {:field_order custom-field-order})))
+          (is (= custom-field-order
+                 (->> (t2/hydrate (t2/select-one :model/Table :id (mt/id :venues)) :fields)
+                      :fields
+                      (map u/the-id))))))
       (finally (mt/user-http-request :crowberto :put 200 (format "table/%s" (mt/id :venues))
                                      {:field_order original-field-order})))))
 


### PR DESCRIPTION
Currently on `master` there's only on API endpoint that does not accept a JSON object:
`/api/table/{id}/fields/order` currently accepts an array of id's: `[1, 2, 3]`.

This changes this endpoint to also accept `{ "field_order": [1, 2, 3] }`.

This simplifies the front end's API client:
- the `bodyParamName` option is removed
- the body is just `JSON.stringify`-ed, not adjusted by the client

The change is backwards compatible (the old way is also still accepted).