### PR TITLE
Replace `raw` option with `:tag*` URL template syntax

### DIFF
--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -2,6 +2,7 @@
 import EventEmitter from "events";
 import querystring from "querystring";
 
+import { substituteUrlTags } from "metabase/api/utils/substitute-url-tags";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isTest } from "metabase/env";
 import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
@@ -30,7 +31,6 @@ type RequestOptions = {
     data?: Record<string, unknown>;
     response?: Response;
   }) => Response | undefined;
-  raw: Record<string, boolean>;
   headers: Record<string, string>;
   retry: boolean;
   retryCount: number;
@@ -48,7 +48,6 @@ const DEFAULT_OPTIONS: RequestOptions = {
   hasBody: false,
   noEvent: false,
   transformResponse: ({ body }) => body as Response,
-  raw: {},
   headers: {},
   retry: false,
   retryCount: MAX_RETRIES,
@@ -205,19 +204,7 @@ export class LegacyApi extends EventEmitter {
           ...middlewareResult.options,
         } as RequestOptions;
         const { data } = middlewareResult;
-        for (const tag of url.match(/:\w+/g) || []) {
-          const paramName = tag.slice(1);
-          let value = data[paramName];
-          delete data[paramName];
-          if (value === undefined) {
-            console.warn("Warning: calling", method, "without", tag);
-            value = "";
-          }
-          if (!options.raw || !options.raw[paramName]) {
-            value = encodeURIComponent(value as string);
-          }
-          url = url.replace(tag, value as string);
-        }
+        url = substituteUrlTags(url, data, method);
         // remove undefined
         for (const name in data) {
           if (data[name] === undefined) {

--- a/frontend/src/metabase/api/utils/index.ts
+++ b/frontend/src/metabase/api/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./errors";
 export * from "./hydrate-legacy-entities";
 export * from "./settings";
+export * from "./substitute-url-tags";
 export * from "./use-token-refresh";

--- a/frontend/src/metabase/api/utils/substitute-url-tags.ts
+++ b/frontend/src/metabase/api/utils/substitute-url-tags.ts
@@ -1,0 +1,28 @@
+// URL template tags:
+// - `:tag`  — value is URL-encoded (default; slashes become %2F).
+// - `:tag*` — value is substituted raw (slashes preserved), for endpoints
+//             whose route includes a multi-segment path parameter.
+const URL_TAG_REGEX = /:\w+\*?/g;
+
+/**
+ * Replace `:tag` / `:tag*` placeholders in a URL template with values pulled
+ * from `data`. Substituted keys are deleted from `data` so the caller can use
+ * any leftovers as querystring params.
+ */
+export function substituteUrlTags(
+  url: string,
+  data: Record<string, unknown>,
+  method: string,
+): string {
+  return url.replace(URL_TAG_REGEX, (tag) => {
+    const isRaw = tag.endsWith("*");
+    const paramName = tag.slice(1, isRaw ? -1 : undefined);
+    const value = data[paramName];
+    delete data[paramName];
+    if (value === undefined) {
+      console.warn("Warning: calling", method, "without", tag);
+      return "";
+    }
+    return isRaw ? String(value) : encodeURIComponent(String(value));
+  });
+}

--- a/frontend/src/metabase/api/utils/substitute-url-tags.unit.spec.ts
+++ b/frontend/src/metabase/api/utils/substitute-url-tags.unit.spec.ts
@@ -1,0 +1,71 @@
+import { substituteUrlTags } from "./substitute-url-tags";
+
+describe("substituteUrlTags", () => {
+  it("returns the URL unchanged when no tags are present", () => {
+    const data = { extra: 1 };
+    const url = substituteUrlTags("/api/foo", data, "GET");
+    expect(url).toBe("/api/foo");
+    expect(data).toEqual({ extra: 1 });
+  });
+
+  it("substitutes a single :tag and consumes it from data", () => {
+    const data = { id: 42, leftover: "x" };
+    const url = substituteUrlTags("/api/foo/:id", data, "GET");
+    expect(url).toBe("/api/foo/42");
+    expect(data).toEqual({ leftover: "x" });
+  });
+
+  it("substitutes multiple :tags in one URL", () => {
+    const data = { dashId: 1, paramId: "p" };
+    const url = substituteUrlTags(
+      "/api/dashboard/:dashId/params/:paramId/values",
+      data,
+      "GET",
+    );
+    expect(url).toBe("/api/dashboard/1/params/p/values");
+    expect(data).toEqual({});
+  });
+
+  it("URL-encodes :tag values by default", () => {
+    const data = { id: "a/b c" };
+    const url = substituteUrlTags("/api/foo/:id", data, "GET");
+    expect(url).toBe("/api/foo/a%2Fb%20c");
+  });
+
+  it("substitutes :tag* values raw (preserves slashes)", () => {
+    const data = { subPath: "table/3/cell/4" };
+    const url = substituteUrlTags(
+      "/api/automagic-dashboards/:subPath*",
+      data,
+      "GET",
+    );
+    expect(url).toBe("/api/automagic-dashboards/table/3/cell/4");
+    expect(data).toEqual({});
+  });
+
+  it("mixes :tag (encoded) and :tag* (raw) in the same URL", () => {
+    const data = { id: "x/y", path: "a/b/c" };
+    const url = substituteUrlTags("/api/:id/sub/:path*", data, "GET");
+    expect(url).toBe("/api/x%2Fy/sub/a/b/c");
+  });
+
+  it("substitutes empty string and warns when a tag has no value in data", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const data = {};
+    const url = substituteUrlTags("/api/foo/:missing", data, "POST");
+    expect(url).toBe("/api/foo/");
+    expect(warn).toHaveBeenCalledWith(
+      "Warning: calling",
+      "POST",
+      "without",
+      ":missing",
+    );
+    warn.mockRestore();
+  });
+
+  it("coerces non-string values to strings before encoding", () => {
+    const data = { id: 7, flag: true };
+    const url = substituteUrlTags("/api/:id/:flag", data, "GET");
+    expect(url).toBe("/api/7/true");
+  });
+});

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -280,10 +280,8 @@ export const EmbedApi = {
 };
 
 export const AutoApi = {
-  dashboard: GET("/api/automagic-dashboards/:subPath", {
-    // this prevents the `subPath` parameter from being URL encoded
-    raw: { subPath: true },
-  }),
+  // `:subPath*` keeps slashes in subPath unencoded (multi-segment path).
+  dashboard: GET("/api/automagic-dashboards/:subPath*"),
 };
 
 export const ParameterApi = {


### PR DESCRIPTION
The legacy API client URL-encodes the `:tag` placeholders that get substituted from the request data. For one endpoint (`/api/automagic-dashboards/:subPath`) the value is a multi-segment path that must NOT be URL-encoded — slashes have to survive. The opt-out was a per-call `raw: { subPath: true }` option, plumbed through `RequestOptions` just for that one case.

This PR replaces it with a custom syntax extension for the template tags that is a bit more straightforward: `:tag*` now gets substituted without URL-encoding.

This allows us to clean up the client:
- the confusing `raw` option is removed
- the code that does the substitution is pulled out and separately tested

