### PR TITLE
Convert the `onResponseError` to use EventEmitter event on API client and add event types

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -39,6 +39,22 @@ const reactSdkEmbedReferrerHandler = async (
   },
 });
 
+const sdkResponseErrorHandler = ({
+  metabaseVersion,
+}: {
+  metabaseVersion: string | null;
+}) => {
+  if (metabaseVersion == null) {
+    return;
+  }
+  // Use ensureMetabaseProviderPropsStore to access the current instance of reduxStore
+  ensureMetabaseProviderPropsStore()
+    .getState()
+    .internalProps.reduxStore?.dispatch(
+      setMetabaseInstanceVersion(metabaseVersion),
+    );
+};
+
 const registerVisualizationsOnce = _.once(registerVisualizations);
 const registerDashboardVisualizationsOnce = _.once(
   registerDashboardVisualizations,
@@ -113,18 +129,11 @@ export const useInitDataInternal = ({
     api.beforeRequestHandlers.push(reactSdkEmbedReferrerHandler);
   }
 
-  if (!api.onResponseError) {
-    api.onResponseError = ({ metabaseVersion }) => {
-      if (metabaseVersion == null) {
-        return;
-      }
-      // Use ensureMetabaseProviderPropsStore to access the current instance of reduxStore
-      ensureMetabaseProviderPropsStore()
-        .getState()
-        .internalProps.reduxStore?.dispatch(
-          setMetabaseInstanceVersion(metabaseVersion),
-        );
-    };
+  // Dedupe by handler identity (matches the `beforeRequestHandlers` pattern
+  // above) rather than total listener count — other code can register its own
+  // `responseError` listeners without disabling ours.
+  if (!api.listeners("responseError").includes(sdkResponseErrorHandler)) {
+    api.on("responseError", sdkResponseErrorHandler);
   }
 
   useEffect(() => {

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -80,12 +80,6 @@ type MethodCreator = (
       }) => Response | undefined),
 ) => ApiMethod;
 
-type ResponseErrorInfo = {
-  body: unknown;
-  status: number;
-  metabaseVersion: string | null;
-};
-
 /**
  * Thrown when the transport itself fails before a response is received —
  * e.g. the server dropped the connection, DNS lookup failed, or the user is
@@ -103,7 +97,6 @@ export class LegacyApi extends EventEmitter {
   basename = "";
   apiKey = "";
   sessionToken: string | undefined;
-  onResponseError: ((info: ResponseErrorInfo) => void) | undefined;
   requestClient: RequestClientInfo | undefined;
 
   beforeRequestHandlers: OnBeforeRequestHandler[] = [];
@@ -396,13 +389,11 @@ export class LegacyApi extends EventEmitter {
             }
             resolve(responseBody);
           } else {
-            if (this.onResponseError) {
-              this.onResponseError({
-                body: responseBody,
-                status,
-                metabaseVersion,
-              });
-            }
+            this.emit("responseError", {
+              body: responseBody,
+              status,
+              metabaseVersion,
+            });
 
             reject({
               status: status,
@@ -507,9 +498,7 @@ export class LegacyApi extends EventEmitter {
             }
             return body;
           } else {
-            if (this.onResponseError) {
-              this.onResponseError({ body, status, metabaseVersion });
-            }
+            this.emit("responseError", { body, status, metabaseVersion });
 
             throw { status: status, data: body };
           }

--- a/frontend/src/metabase/api/legacy-client.ts
+++ b/frontend/src/metabase/api/legacy-client.ts
@@ -93,7 +93,22 @@ export class NetworkError extends Error {
   }
 }
 
-export class LegacyApi extends EventEmitter {
+type ResponseErrorInfo = {
+  body: unknown;
+  status: number;
+  metabaseVersion: string | null;
+};
+
+type EventMap = {
+  // Per-status events. Listeners receive the request URL (with basename
+  // stripped so subscribers see the relative path).
+  [status: number]: [string];
+  // Fired for any non-2xx response. Payload includes the response body so
+  // callers can inspect the failure beyond just its status.
+  responseError: [ResponseErrorInfo];
+};
+
+export class LegacyApi extends EventEmitter<EventMap> {
   basename = "";
   apiKey = "";
   sessionToken: string | undefined;
@@ -402,7 +417,7 @@ export class LegacyApi extends EventEmitter {
             });
           }
           if (!options.noEvent) {
-            this.emit(String(status), url);
+            this.emit(status, url);
           }
         }
       };
@@ -485,7 +500,7 @@ export class LegacyApi extends EventEmitter {
           }
 
           if (!options.noEvent) {
-            this.emit(String(status), url);
+            this.emit(status, url);
           }
 
           if (status >= 200 && status <= 299) {

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -32,7 +32,7 @@ if (isWithinIframe() && !IFRAMED_IN_SELF) {
 
 init(mainReducers, getRoutes, (store) => {
   // received a 401 response
-  api.on("401", (url) => {
+  api.on(401, (url) => {
     if (url.indexOf("/api/user/current") >= 0) {
       return;
     }
@@ -50,7 +50,7 @@ init(mainReducers, getRoutes, (store) => {
   });
 
   // received a 403 response
-  api.on("403", (url) => {
+  api.on(403, (url) => {
     if (NOT_AUTHORIZED_TRIGGERS.some((regex) => regex.test(url))) {
       return store.dispatch(setErrorPage({ status: 403 }));
     }


### PR DESCRIPTION
`LegacyApi` already extends `EventEmitter` (and uses it for the status-code events 401/403/etc), but the response-error notification was a separate parallel mechanism: a public `onResponseError` callback that the embedding SDK assigned at boot. Two ways for callers to subscribe to client events on the same object.

This PR streamlines the API client and used the event emitter everywhere.