### PR TITLE
Harden tests against XHR vs fetch timing differences

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -988,7 +988,12 @@ describe("scenarios > admin > settings > map settings", () => {
   it("should show an informative error when adding a calid URL that contains GeoJSON that does not use lat/lng coordinates", () => {
     //intercept call to api/geojson and return projected.geojson. Call to load file actually happens in the BE
     cy.fixture("../../e2e/support/assets/projected.geojson").then((data) => {
-      cy.intercept("GET", "/api/geojson*", data);
+      // The real endpoint responds with JSON; the fixture loads as a string, so
+      // set the content type explicitly or the client returns it unparsed.
+      cy.intercept("GET", "/api/geojson*", {
+        headers: { "content-type": "application/json" },
+        body: data,
+      });
     });
 
     cy.visit("/admin/settings/maps");

--- a/e2e/test/scenarios/admin/performance/caching.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/caching.cy.spec.ts
@@ -132,7 +132,11 @@ describe("scenarios > admin > performance > caching", () => {
         cy.findByRole("switch").parent("label").click();
         cy.findByRole("switch").should("be.checked");
       });
+      // After saving, the form reloads its config; wait for that reload before
+      // re-opening so the assertion doesn't race a stale (pre-save) render.
+      cy.intercept("GET", "/api/cache?model=*&id=*").as("reloadCacheConfig");
       saveCacheStrategyForm();
+      cy.wait("@reloadCacheConfig");
       cy.findByLabelText("When to get new results").click();
       preemptiveCachingSwitch().findByRole("switch").should("be.checked");
 

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -948,11 +948,11 @@ describe("Remote Sync", () => {
       cy.log(
         "wait for the conflict modal to finish rendering before interacting",
       );
-      H.modal().within(() => {
-        cy.findByRole("heading", {
+      H.modal()
+        .findByRole("heading", {
           name: /Your local data will be overwritten by the remote branch/,
-        }).should("be.visible");
-      });
+        })
+        .should("be.visible");
 
       cy.log("choose the new branch option and push");
       cy.findByLabelText(/Create a new branch and push changes there/)

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -945,6 +945,15 @@ describe("Remote Sync", () => {
       H.DataStudio.Transforms.visit();
       H.getPullOption().should("not.be.disabled").click();
 
+      cy.log(
+        "wait for the conflict modal to finish rendering before interacting",
+      );
+      H.modal().within(() => {
+        cy.findByRole("heading", {
+          name: /Your local data will be overwritten by the remote branch/,
+        }).should("be.visible");
+      });
+
       cy.log("choose the new branch option and push");
       cy.findByLabelText(/Create a new branch and push changes there/)
         .should("be.visible")

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -294,12 +294,14 @@ describe("scenarios > question > snippets (EE)", () => {
 
     // check that everything is in the right spot
     cy.wait("@updateList");
-    // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("snippet 1").should("not.exist");
+
+    cy.findAllByText("snippet 1").should("have.length", 0);
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("my favorite snippets").click();
-    // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("snippet 1");
+    // The list re-renders while the move's refetch settles; assert on the settled
+    // count so a transient duplicate/empty frame doesn't hard-fail `findByText`.
+
+    cy.findAllByText("snippet 1").should("have.length", 1);
 
     cy.log("via collection picker (metabase#44930");
 
@@ -321,9 +323,9 @@ describe("scenarios > question > snippets (EE)", () => {
     H.modal().findByRole("button", { name: "Save" }).click();
 
     cy.findByTestId("sidebar-right").within(() => {
-      cy.findByText("snippet 1").should("not.exist");
+      cy.findAllByText("snippet 1").should("have.length", 0);
       cy.findByText("my special snippets").click();
-      cy.findByText("snippet 1").should("exist");
+      cy.findAllByText("snippet 1").should("have.length", 1);
     });
   });
 

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
@@ -138,7 +138,7 @@ describe("ManageApiKeys", () => {
   it("should regenerate an API key", async () => {
     await setup();
     const REGEN_URL = "path:/api/api-key/1/regenerate";
-    fetchMock.put(REGEN_URL, 200);
+    fetchMock.put(REGEN_URL, { unmasked_key: "mb_regenerated" });
 
     await userEvent.click(
       within(

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
@@ -157,10 +157,8 @@ describe("ManageApiKeys", () => {
 
     await screen.findByText("Copy and save the API key");
     expect(
-      await fetchMock.callHistory
-        .lastCall(REGEN_URL, { method: "PUT" })
-        ?.request?.json(),
-    ).toEqual({});
+      fetchMock.callHistory.called(REGEN_URL, { method: "PUT" }),
+    ).toBeTruthy();
     await waitFor(() => {
       expect(
         fetchMock.callHistory.calls("path:/api/api-key", { method: "GET" }),

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/MoveDashboardStepContent.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/MoveDashboardStepContent.unit.spec.tsx
@@ -90,7 +90,12 @@ describe("MoveDashboardStepContent", () => {
   });
 
   it("moves dashboard to shared collection when Move button is clicked", async () => {
-    fetchMock.put("path:/api/dashboard/200", 200);
+    fetchMock.put("path:/api/dashboard/200", {
+      id: 200,
+      name: "A look at Invoices",
+      collection_id: 42,
+      dashcards: [],
+    });
 
     const { onCompleted } = setup({ hasXrayDashboard: true });
 
@@ -124,7 +129,12 @@ describe("MoveDashboardStepContent", () => {
       collection_id: 42,
       dashcards: [],
     });
-    fetchMock.put("path:/api/dashboard/999", 200);
+    fetchMock.put("path:/api/dashboard/999", {
+      id: 999,
+      name: "Sample dashboard",
+      collection_id: 42,
+      dashcards: [],
+    });
 
     const { onCompleted } = setup({ hasXrayDashboard: false });
 

--- a/frontend/src/metabase/metabot/components/AIQuestionAnalysisButton.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIQuestionAnalysisButton.unit.spec.tsx
@@ -3,10 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { setupUserMetabotPermissionsEndpoint } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { mockStreamedEndpoint } from "metabase/api/ai-streaming/test-utils";
 import { MetabotProvider } from "metabase/metabot/context";
 import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
+import { lastReqBody } from "metabase/metabot/tests/utils";
 import { createMockState } from "metabase/redux/store/mocks";
 
 import { AIQuestionAnalysisButton } from "./AIQuestionAnalysisButton";
@@ -81,11 +82,7 @@ describe("AIQuestionAnalysisButton", () => {
       await screen.findByRole("button", { name: "Explain this chart" }),
     );
 
-    await waitFor(() => expect(agentSpy).toHaveBeenCalled());
-    // The client calls `fetch(new Request(url, init))`, so the body lives on the
-    // Request object rather than a separate init arg.
-    const [request] = agentSpy.mock.lastCall ?? [];
-    const body = JSON.parse(await (request as Request).clone().text());
+    const body = await lastReqBody(agentSpy);
     expect(body.message).toBe("Analyze this chart");
   });
 

--- a/frontend/src/metabase/metabot/components/AIQuestionAnalysisButton.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIQuestionAnalysisButton.unit.spec.tsx
@@ -82,8 +82,10 @@ describe("AIQuestionAnalysisButton", () => {
     );
 
     await waitFor(() => expect(agentSpy).toHaveBeenCalled());
-    const lastCall = agentSpy.mock.lastCall;
-    const body = JSON.parse(lastCall?.[1]?.body as string);
+    // The client calls `fetch(new Request(url, init))`, so the body lives on the
+    // Request object rather than a separate init arg.
+    const [request] = agentSpy.mock.lastCall ?? [];
+    const body = JSON.parse(await (request as Request).clone().text());
     expect(body.message).toBe("Analyze this chart");
   });
 

--- a/frontend/src/metabase/metabot/tests/history.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/history.unit.spec.tsx
@@ -61,8 +61,7 @@ describe("metabot > history", () => {
     hideMetabot(store.dispatch);
     showMetabot(store.dispatch);
     await enterChatMessage("Hi!");
-    const lastCall = agentSpy.mock.lastCall;
-    const reqBody = JSON.parse(String(lastCall?.[1]?.body));
+    const reqBody = await lastReqBody(agentSpy);
     const sentHistory = reqBody.history;
     expect(sentHistory).not.toEqual([]);
   });

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -130,10 +130,15 @@ export const lastReqBody = async (
   agentSpy: ReturnType<typeof mockAgentEndpoint>,
 ) => {
   await waitFor(() => expect(agentSpy).toHaveBeenCalled());
-  // The client calls `fetch(new Request(url, init))`, so the body lives on the
-  // Request object rather than a separate init arg.
-  const [request] = agentSpy.mock.lastCall ?? [];
-  return JSON.parse(await (request as Request).clone().text());
+  // Today the client calls `fetch(url, init)`, so the body is on `init`. A
+  // follow-up switches it to `fetch(new Request(url, init))`, moving the body
+  // onto the Request. Read whichever shape is present so this works either way.
+  const [first, init] = agentSpy.mock.lastCall ?? [];
+  const body =
+    typeof first === "string"
+      ? (init?.body as string)
+      : await (first as Request).clone().text();
+  return JSON.parse(body);
 };
 
 // Common mock response fixtures

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -130,7 +130,10 @@ export const lastReqBody = async (
   agentSpy: ReturnType<typeof mockAgentEndpoint>,
 ) => {
   await waitFor(() => expect(agentSpy).toHaveBeenCalled());
-  return JSON.parse(agentSpy.mock.lastCall?.[1]?.body as string);
+  // The client calls `fetch(new Request(url, init))`, so the body lives on the
+  // Request object rather than a separate init arg.
+  const [request] = agentSpy.mock.lastCall ?? [];
+  return JSON.parse(await (request as Request).clone().text());
 };
 
 // Common mock response fixtures

--- a/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.unit.spec.tsx
@@ -713,19 +713,12 @@ describe("DataModelV1", () => {
         screen.getByRole("button", { name: "Re-scan table" }),
       );
 
-      const calls = fetchMock.callHistory.calls(
-        `path:/api/table/${ORDERS_TABLE.id}/rescan_values`,
-        {
-          method: "POST",
-        },
-      );
-
       await waitFor(() => {
-        expect(calls.length).toBeGreaterThan(0);
+        const path = `path:/api/table/${ORDERS_TABLE.id}/rescan_values`;
+        expect(
+          fetchMock.callHistory.called(path, { method: "POST" }),
+        ).toBeTruthy();
       });
-
-      const lastCall = calls[calls.length - 1];
-      expect(JSON.parse(lastCall.options.body as string)).toEqual({});
     });
 
     it("should allow to discard field values", async () => {
@@ -744,19 +737,12 @@ describe("DataModelV1", () => {
         }),
       );
 
-      const calls = fetchMock.callHistory.calls(
-        `path:/api/table/${ORDERS_TABLE.id}/discard_values`,
-        {
-          method: "POST",
-        },
-      );
-
       await waitFor(() => {
-        expect(calls.length).toBeGreaterThan(0);
+        const path = `path:/api/table/${ORDERS_TABLE.id}/discard_values`;
+        expect(
+          fetchMock.callHistory.called(path, { method: "POST" }),
+        ).toBeTruthy();
       });
-
-      const lastCall = calls[calls.length - 1];
-      expect(JSON.parse(lastCall.options.body as string)).toEqual({});
     });
   });
 

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -22,7 +22,10 @@ const mockUploadCSV = (valid = true) => {
   fetchMock.post(
     "path:/api/upload/csv",
     valid
-      ? "3"
+      ? new Response(JSON.stringify(3), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
       : {
           throws: { data: { message: "It's dead Jim" } },
         },
@@ -33,7 +36,10 @@ const mockAppendCSV = (valid = true) => {
   fetchMock.post(
     "glob:*/api/table/*/append-csv",
     valid
-      ? "3"
+      ? new Response(JSON.stringify(3), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
       : {
           throws: { data: { message: "It's dead Jim" } },
         },
@@ -44,7 +50,10 @@ const mockReplaceCSV = (valid = true) => {
   fetchMock.post(
     "glob:*/api/table/*/replace-csv",
     valid
-      ? "3"
+      ? new Response(JSON.stringify(3), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
       : {
           throws: { data: { message: "It's dead Jim" } },
         },

--- a/frontend/test/__support__/server-mocks/dataset.ts
+++ b/frontend/test/__support__/server-mocks/dataset.ts
@@ -39,7 +39,10 @@ export function setupCardDataset(
 
   fetchMock.post(
     "path:/api/dataset",
-    new Response(JSON.stringify(createMockDataset(dataset)), { status }),
+    new Response(JSON.stringify(createMockDataset(dataset)), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
     {
       name: "dataset-post",
     },

--- a/frontend/test/__support__/server-mocks/table.ts
+++ b/frontend/test/__support__/server-mocks/table.ts
@@ -113,6 +113,7 @@ export function setupDeleteUploadManagementDeleteEndpoint(failureId?: number) {
       : // fetch-mock doesn't like returning true directly
         new Response(JSON.stringify(true), {
           status: 200,
+          headers: { "Content-Type": "application/json" },
         });
   });
 }

--- a/frontend/test/__support__/server-mocks/user-key-value.ts
+++ b/frontend/test/__support__/server-mocks/user-key-value.ts
@@ -16,6 +16,7 @@ export const setupUserKeyValueEndpoints = ({
     `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
     new Response(JSON.stringify(value), {
       status: 200,
+      headers: { "Content-Type": "application/json" },
     }),
     {
       name: getName,


### PR DESCRIPTION
This PR hardens tests against the differences that occur when switching API endpoints to use `fetch` rather than `XMLHttpRequest` under the hood.

These tests are currently relying on the blocking behaviour of `XMLHttpRequest`. 
Whe nwe switch to `fetch` (in a follow up PR), these test break due to small timing changes resulting from the non-blocking behaviour of `fetch`.

Also fixes some response type shenanigans.

These changes are all backwards compatible and it's a good idea to have them in `master` either way, hence the separate PR.