### PR TITLE
[GDGT-2421] field metadata sandboxing

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
@@ -1327,8 +1327,10 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
         `/reference/databases/${SAMPLE_DB_ID}/tables/${PEOPLE_ID}/fields`,
       );
       H.main().within(() => {
+        // Each field renders its display name and its raw column name, so a
+        // visible column like ID appears more than once — use findAllByText.
         PEOPLE_VISIBLE_COLS.forEach((name) =>
-          cy.findByText(name).should("exist"),
+          cy.findAllByText(name).should("exist"),
         );
         ["ADDRESS", "BIRTH_DATE", "LATITUDE", "PASSWORD"].forEach((name) =>
           cy.findByText(name).should("not.exist"),

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
@@ -1290,6 +1290,76 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
       });
     });
   });
+
+  describe("Column-restricting sandbox: hide hidden columns from metadata endpoints", () => {
+    // All tests here use a sandbox source card that exposes only a subset of columns from
+    // the sandboxed table. Future column-leak repros for other endpoints should be added
+    // as it() cases inside this describe.
+
+    const PEOPLE_VISIBLE_COLS = ["ID", "NAME", "EMAIL"];
+
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
+      preparePermissions();
+
+      // Sandbox PEOPLE with a native query exposing only ID, NAME, EMAIL — hides
+      // ADDRESS, BIRTH_DATE, CITY, LATITUDE, LONGITUDE, PASSWORD, SOURCE, STATE, ZIP,
+      // CREATED_AT.
+      H.createNativeQuestion({
+        name: "Sandbox source — people subset",
+        native: { query: "SELECT id, name, email FROM people" },
+      }).then(({ body: card }) => {
+        cy.sandboxTable({
+          table_id: PEOPLE_ID,
+          card_id: card.id,
+          group_id: COLLECTION_GROUP,
+        });
+      });
+
+      cy.signOut();
+      cy.signInAsSandboxedUser();
+    });
+
+    it("Data Reference field list excludes sandbox-hidden columns", () => {
+      cy.visit(
+        `/reference/databases/${SAMPLE_DB_ID}/tables/${PEOPLE_ID}/fields`,
+      );
+      H.main().within(() => {
+        PEOPLE_VISIBLE_COLS.forEach((name) =>
+          cy.findByText(name).should("exist"),
+        );
+        ["ADDRESS", "BIRTH_DATE", "LATITUDE", "PASSWORD"].forEach((name) =>
+          cy.findByText(name).should("not.exist"),
+        );
+      });
+    });
+
+    it("GET /api/database/:id/metadata excludes sandbox-hidden columns", () => {
+      cy.request(`/api/database/${SAMPLE_DB_ID}/metadata`).then(({ body }) => {
+        const people = body.tables.find(
+          (t) => t.name.toUpperCase() === "PEOPLE",
+        );
+        const fieldNames = people.fields.map((f) => f.name.toUpperCase());
+        expect(fieldNames).to.have.members(PEOPLE_VISIBLE_COLS);
+        expect(fieldNames).not.to.include("PASSWORD");
+        expect(fieldNames).not.to.include("ADDRESS");
+      });
+    });
+
+    it("GET /api/database/:id?include=tables.fields excludes sandbox-hidden columns", () => {
+      cy.request(`/api/database/${SAMPLE_DB_ID}?include=tables.fields`).then(
+        ({ body }) => {
+          const people = body.tables.find(
+            (t) => t.name.toUpperCase() === "PEOPLE",
+          );
+          const fieldNames = people.fields.map((f) => f.name.toUpperCase());
+          expect(fieldNames).to.have.members(PEOPLE_VISIBLE_COLS);
+        },
+      );
+    });
+  });
 });
 
 function createJoinedQuestion(name, { visitQuestion = false } = {}) {

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
@@ -1291,12 +1291,15 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
     });
   });
 
-  describe("Column-restricting sandbox: hide hidden columns from metadata endpoints", () => {
-    // All tests here use a sandbox source card that exposes only a subset of columns from
-    // the sandboxed table. Future column-leak repros for other endpoints should be added
-    // as it() cases inside this describe.
+  describe("Column-restricting sandbox: hide hidden columns in the Data Reference UI", () => {
+    // The sandbox source card exposes only a subset of the sandboxed table's columns.
+    // Pure-API assertions for the metadata endpoints live in the backend test
+    // metabase-enterprise.sandbox.api.database-test; add UI repros here as it() cases.
 
     const PEOPLE_VISIBLE_COLS = ["ID", "NAME", "EMAIL"];
+    const PEOPLE_HIDDEN_COLS = new Set(Object.keys(PEOPLE)).difference(
+      new Set(PEOPLE_VISIBLE_COLS),
+    );
 
     beforeEach(() => {
       H.restore();
@@ -1304,12 +1307,13 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
       H.activateToken("pro-self-hosted");
       preparePermissions();
 
-      // Sandbox PEOPLE with a native query exposing only ID, NAME, EMAIL — hides
-      // ADDRESS, BIRTH_DATE, CITY, LATITUDE, LONGITUDE, PASSWORD, SOURCE, STATE, ZIP,
-      // CREATED_AT.
+      // Sandbox PEOPLE with a native query exposing only PEOPLE_VISIBLE_COLS;
+      // every other column (PEOPLE_HIDDEN_COLS) must be hidden everywhere.
       H.createNativeQuestion({
         name: "Sandbox source — people subset",
-        native: { query: "SELECT id, name, email FROM people" },
+        native: {
+          query: `SELECT ${PEOPLE_VISIBLE_COLS.join(", ")} FROM people`,
+        },
       }).then(({ body: card }) => {
         cy.sandboxTable({
           table_id: PEOPLE_ID,
@@ -1332,34 +1336,10 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
         PEOPLE_VISIBLE_COLS.forEach((name) =>
           cy.findAllByText(name).should("exist"),
         );
-        ["ADDRESS", "BIRTH_DATE", "LATITUDE", "PASSWORD"].forEach((name) =>
+        PEOPLE_HIDDEN_COLS.forEach((name) =>
           cy.findByText(name).should("not.exist"),
         );
       });
-    });
-
-    it("GET /api/database/:id/metadata excludes sandbox-hidden columns", () => {
-      cy.request(`/api/database/${SAMPLE_DB_ID}/metadata`).then(({ body }) => {
-        const people = body.tables.find(
-          (t) => t.name.toUpperCase() === "PEOPLE",
-        );
-        const fieldNames = people.fields.map((f) => f.name.toUpperCase());
-        expect(fieldNames).to.have.members(PEOPLE_VISIBLE_COLS);
-        expect(fieldNames).not.to.include("PASSWORD");
-        expect(fieldNames).not.to.include("ADDRESS");
-      });
-    });
-
-    it("GET /api/database/:id?include=tables.fields excludes sandbox-hidden columns", () => {
-      cy.request(`/api/database/${SAMPLE_DB_ID}?include=tables.fields`).then(
-        ({ body }) => {
-          const people = body.tables.find(
-            (t) => t.name.toUpperCase() === "PEOPLE",
-          );
-          const fieldNames = people.fields.map((f) => f.name.toUpperCase());
-          expect(fieldNames).to.have.members(PEOPLE_VISIBLE_COLS);
-        },
-      );
     });
   });
 });

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
@@ -1,0 +1,122 @@
+(ns metabase-enterprise.sandbox.api.column-filter
+  "Centralized helpers for filtering column metadata returned to sandboxed users.
+
+  A sandbox can be backed by a saved question (Card) that selects a subset of the columns
+  in the sandboxed table. When that happens, any UI surface that lists columns must hide
+  the columns the sandbox doesn't expose. This namespace provides the lookup + filter
+  primitives used by every such endpoint.
+
+  ## Fail-closed semantics
+
+  If `find-sandbox-source-cards` returns a card for the given (user, table) but that
+  card's `:result_metadata` is `nil` or `[]`, the allowed-column set is empty and every
+  field is filtered out. This is intentional.
+
+  *Fail-open* (returning all columns when the allowed set is unknowable) would silently
+  degrade a sandbox stuck in failed-metadata-extraction state into no column restriction
+  at all — a security regression. *Fail-loud* (throwing 503) would require every FE
+  surface to handle a new error state. Fail-closed is the conservative middle.
+
+  The vulnerable window for the legitimate case (card was just created, async metadata
+  computation hasn't finished) is bounded by `metabase.queries.models.card.metadata/
+  metadata-sync-wait-ms` (1.5 seconds) for live admin workflows. For permanently failed
+  extractions, sandboxed users will see zero columns until an admin fixes the source card
+  — which is what we want, given the alternative is leaking every column."
+  (:require
+   [metabase.lib.core :as lib]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(mu/defn find-sandbox-source-cards :- [:map-of ms/PositiveInt :map]
+  "For the given `user-id` and `table-ids`, return `{table-id => sandbox-source-card}` for
+  tables that have an MBQL/native sandbox sourced from a Card for that user. Tables
+  without a sandbox, or with attribute-only sandboxes (no card_id), are absent from the
+  map."
+  [user-id   :- [:maybe ms/PositiveInt]
+   table-ids :- [:set ms/PositiveInt]]
+  (if (and user-id (seq table-ids))
+    (let [rows (t2/select :model/Card
+                          {:select [:c.id :c.dataset_query :c.result_metadata :c.card_schema
+                                    [:sandboxes.table_id :_sandbox_table_id]]
+                           :from   [[:sandboxes]]
+                           :join   [[:permissions_group_membership :pgm]
+                                    [:= :sandboxes.group_id :pgm.group_id]
+                                    [:report_card :c] [:= :c.id :sandboxes.card_id]]
+                           :where  [:and
+                                    [:in :sandboxes.table_id table-ids]
+                                    [:= :pgm.user_id user-id]]})]
+      (into {} (map (juxt :_sandbox_table_id #(dissoc % :_sandbox_table_id))) rows))
+    {}))
+
+(defn- allowed-id-set [{result-metadata :result_metadata}]
+  (into #{} (keep u/id) result-metadata))
+
+(defn- allowed-name-set [{result-metadata :result_metadata}]
+  (into #{} (map :name) result-metadata))
+
+(mu/defn filter-fields-by-card
+  "Filter `fields` to those exposed by `card`.
+
+  Uses field id for MBQL sandboxes and field name for native sandboxes. Returns `fields`
+  unchanged if `card` is nil or has no `:dataset_query`. Returns an empty seq if `card`'s
+  `:result_metadata` is nil/empty (fail-closed; see ns docstring)."
+  [card   :- [:maybe :map]
+   fields :- [:sequential :map]]
+  (let [sandbox-query (:dataset_query card)]
+    (cond
+      (nil? card)          fields
+      (nil? sandbox-query) fields
+      (lib/native-only-query? sandbox-query)
+      (let [allowed (allowed-name-set card)]
+        (filter #(contains? allowed (:name %)) fields))
+      :else
+      (let [allowed (allowed-id-set card)]
+        (filter #(contains? allowed (:id %)) fields)))))
+
+(mu/defn filter-fields-for-table
+  "Given a `table-id`, a `user-id`, and a collection of field maps for that table, return
+  only the fields visible to the user under their sandbox configuration. Non-sandboxed
+  tables and superusers receive `fields` unchanged."
+  [table-id :- ms/PositiveInt
+   user-id  :- [:maybe ms/PositiveInt]
+   fields   :- [:sequential :map]]
+  (if-let [card (get (find-sandbox-source-cards user-id #{table-id}) table-id)]
+    (filter-fields-by-card card fields)
+    fields))
+
+(mu/defn batch-filter-fields-by-table
+  "Given a `user-id` and a map of `{table-id => fields}`, return the same map with each
+  table's fields filtered to those visible under the user's sandbox configuration.
+  Performs a single DB query for all sandbox source cards."
+  [user-id         :- [:maybe ms/PositiveInt]
+   fields-by-table :- [:map-of ms/PositiveInt [:sequential :map]]]
+  (let [card-by-table (find-sandbox-source-cards user-id (set (keys fields-by-table)))]
+    (into {}
+          (map (fn [[table-id fields]]
+                 [table-id (if-let [card (get card-by-table table-id)]
+                             (filter-fields-by-card card fields)
+                             fields)]))
+          fields-by-table)))
+
+;;; ----------------------------- defenterprise wrappers -----------------------------
+;;;
+;;; The OSS stubs (no-ops) live in metabase.warehouse-schema.table. Consumers that need
+;;; this filter (db-metadata, /fks, /idfields, etc.) call the OSS stubs; loading EE
+;;; replaces the implementation with the real filtering.
+
+(defenterprise filter-sandboxed-fields
+  "Filter `fields` to those visible to the user under their column-restricting sandbox
+  on `table-id`. No-op for OSS / non-sandboxed users."
+  :feature :sandboxes
+  [table-id user-id fields]
+  (filter-fields-for-table table-id user-id fields))
+
+(defenterprise batch-filter-sandboxed-fields
+  "Filter the `{table-id => fields}` map per the user's sandbox configuration. No-op
+  for OSS / non-sandboxed users."
+  :feature :sandboxes
+  [user-id fields-by-table]
+  (batch-filter-fields-by-table user-id fields-by-table))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
@@ -17,11 +17,10 @@
   at all — a security regression. *Fail-loud* (throwing 503) would require every FE
   surface to handle a new error state. Fail-closed is the conservative middle.
 
-  The vulnerable window for the legitimate case (card was just created, async metadata
-  computation hasn't finished) is bounded by `metabase.queries.models.card.metadata/
-  metadata-sync-wait-ms` (1.5 seconds) for live admin workflows. For permanently failed
-  extractions, sandboxed users will see zero columns until an admin fixes the source card
-  — which is what we want, given the alternative is leaking every column."
+  In the legitimate case (card was just created, async metadata computation hasn't
+  finished) sandboxed users see zero columns until the metadata lands. For permanently
+  failed extractions, sandboxed users will see zero columns until an admin fixes the source
+  card — which is what we want, given the alternative is leaking every column."
   (:require
    [metabase.lib.core :as lib]
    [metabase.permissions.core :as perms]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
@@ -24,6 +24,7 @@
   — which is what we want, given the alternative is leaking every column."
   (:require
    [metabase.lib.core :as lib]
+   [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
@@ -31,25 +32,23 @@
    [toucan2.core :as t2]))
 
 (mu/defn find-sandbox-source-cards :- [:map-of ms/PositiveInt :map]
-  "For the given `user-id` and `table-ids`, return `{table-id => sandbox-source-card}` for
-  tables that have an MBQL/native sandbox sourced from a Card for that user. Tables
-  without a sandbox, or with attribute-only sandboxes (no card_id), are absent from the
-  map."
-  [user-id   :- [:maybe ms/PositiveInt]
-   table-ids :- [:set ms/PositiveInt]]
-  (if (and user-id (seq table-ids))
-    (let [rows (t2/select :model/Card
-                          {:select [:c.id :c.dataset_query :c.result_metadata :c.card_schema
-                                    [:sandboxes.table_id :_sandbox_table_id]]
-                           :from   [[:sandboxes]]
-                           :join   [[:permissions_group_membership :pgm]
-                                    [:= :sandboxes.group_id :pgm.group_id]
-                                    [:report_card :c] [:= :c.id :sandboxes.card_id]]
-                           :where  [:and
-                                    [:in :sandboxes.table_id table-ids]
-                                    [:= :pgm.user_id user-id]]})]
-      (into {} (map (juxt :_sandbox_table_id #(dissoc % :_sandbox_table_id))) rows))
-    {}))
+  "Return `{table-id => sandbox-source-card}` for the `table-ids` that have a Card-backed sandbox for the current user.
+  Tables with no sandbox, or with attribute-only sandboxes (no `card_id`), are absent. Reads `perms/sandboxes-for-user`,
+  the per-request cache, so returns `{}` outside a request (background tasks, REPL) even when sandboxes are configured."
+  [table-ids :- [:set ms/PositiveInt]]
+  (let [sandboxes (filter #(contains? table-ids (:table_id %)) (perms/sandboxes-for-user))
+        card-ids  (into #{} (keep :card_id) sandboxes)]
+    (if (seq card-ids)
+      (let [cards-by-id (into {}
+                              (map (juxt :id identity))
+                              (t2/select [:model/Card :id :dataset_query :result_metadata :card_schema]
+                                         :id [:in card-ids]))]
+        (into {}
+              (keep (fn [{:keys [table_id card_id]}]
+                      (when-let [card (get cards-by-id card_id)]
+                        [table_id card])))
+              sandboxes))
+      {})))
 
 (defn- allowed-id-set [{result-metadata :result_metadata}]
   (into #{} (keep u/id) result-metadata))
@@ -58,10 +57,8 @@
   (into #{} (map :name) result-metadata))
 
 (mu/defn filter-fields-by-card
-  "Filter `fields` to those exposed by `card`.
-
-  Uses field id for MBQL sandboxes and field name for native sandboxes. Returns `fields`
-  unchanged if `card` is nil or has no `:dataset_query`. Returns an empty seq if `card`'s
+  "Filter `fields` to those exposed by `card`, by field id for MBQL sandboxes and by name for native ones.
+  Returns `fields` unchanged when `card` is nil or has no `:dataset_query`, and an empty seq when its
   `:result_metadata` is nil/empty (fail-closed; see ns docstring)."
   [card   :- [:maybe :map]
    fields :- [:sequential :map]]
@@ -77,23 +74,19 @@
         (filter #(contains? allowed (:id %)) fields)))))
 
 (mu/defn filter-fields-for-table
-  "Given a `table-id`, a `user-id`, and a collection of field maps for that table, return
-  only the fields visible to the user under their sandbox configuration. Non-sandboxed
-  tables and superusers receive `fields` unchanged."
+  "Return the `fields` for `table-id` that are visible to the current user under their sandbox configuration.
+  Non-sandboxed tables and superusers receive `fields` unchanged."
   [table-id :- ms/PositiveInt
-   user-id  :- [:maybe ms/PositiveInt]
    fields   :- [:sequential :map]]
-  (if-let [card (get (find-sandbox-source-cards user-id #{table-id}) table-id)]
+  (if-let [card (get (find-sandbox-source-cards #{table-id}) table-id)]
     (filter-fields-by-card card fields)
     fields))
 
 (mu/defn batch-filter-fields-by-table
-  "Given a `user-id` and a map of `{table-id => fields}`, return the same map with each
-  table's fields filtered to those visible under the user's sandbox configuration.
-  Performs a single DB query for all sandbox source cards."
-  [user-id         :- [:maybe ms/PositiveInt]
-   fields-by-table :- [:map-of ms/PositiveInt [:sequential :map]]]
-  (let [card-by-table (find-sandbox-source-cards user-id (set (keys fields-by-table)))]
+  "Return the `{table-id => fields}` map with each table's fields filtered to those visible to the current user.
+  Filters per the user's sandbox configuration, using a single DB query for all sandbox source cards."
+  [fields-by-table :- [:map-of ms/PositiveInt [:sequential :map]]]
+  (let [card-by-table (find-sandbox-source-cards (set (keys fields-by-table)))]
     (into {}
           (map (fn [[table-id fields]]
                  [table-id (if-let [card (get card-by-table table-id)]
@@ -108,15 +101,15 @@
 ;;; replaces the implementation with the real filtering.
 
 (defenterprise filter-sandboxed-fields
-  "Filter `fields` to those visible to the user under their column-restricting sandbox
-  on `table-id`. No-op for OSS / non-sandboxed users."
+  "Filter `fields` to those visible to the current user under their column-restricting sandbox on `table-id`.
+  No-op for OSS / non-sandboxed users."
   :feature :sandboxes
-  [table-id user-id fields]
-  (filter-fields-for-table table-id user-id fields))
+  [table-id fields]
+  (filter-fields-for-table table-id fields))
 
 (defenterprise batch-filter-sandboxed-fields
-  "Filter the `{table-id => fields}` map per the user's sandbox configuration. No-op
-  for OSS / non-sandboxed users."
+  "Filter the `{table-id => fields}` map per the current user's sandbox configuration.
+  No-op for OSS / non-sandboxed users."
   :feature :sandboxes
-  [user-id fields-by-table]
-  (batch-filter-fields-by-table user-id fields-by-table))
+  [fields-by-table]
+  (batch-filter-fields-by-table fields-by-table))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
@@ -38,10 +38,8 @@
   (let [sandboxes (filter (comp table-ids :table_id) (perms/sandboxes-for-user))
         card-ids  (into #{} (keep :card_id) sandboxes)]
     (if (seq card-ids)
-      (let [cards-by-id (into {}
-                              (map (juxt :id identity))
-                              (t2/select [:model/Card :id :dataset_query :result_metadata :card_schema]
-                                         :id [:in card-ids]))]
+      (let [cards-by-id (t2/select-pk->fn identity [:model/Card :id :dataset_query :result_metadata :card_schema]
+                                          :id [:in card-ids])]
         (into {}
               (keep (fn [{:keys [table_id card_id]}]
                       (when-let [card (get cards-by-id card_id)]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/column_filter.clj
@@ -35,7 +35,7 @@
   Tables with no sandbox, or with attribute-only sandboxes (no `card_id`), are absent. Reads `perms/sandboxes-for-user`,
   the per-request cache, so returns `{}` outside a request (background tasks, REPL) even when sandboxes are configured."
   [table-ids :- [:set ms/PositiveInt]]
-  (let [sandboxes (filter #(contains? table-ids (:table_id %)) (perms/sandboxes-for-user))
+  (let [sandboxes (filter (comp table-ids :table_id) (perms/sandboxes-for-user))
         card-ids  (into #{} (keep :card_id) sandboxes)]
     (if (seq card-ids)
       (let [cards-by-id (into {}

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -22,7 +22,7 @@
   ;; Filter the fields list through the centralized column-filter helper. For tables sandboxed via user attribute
   ;; only (no card_id) the helper is a pass-through, preserving the original behavior.
   (update query-metadata-response :fields
-          #(col-filter/filter-fields-for-table (u/the-id table) api/*current-user-id* %)))
+          #(col-filter/filter-fields-for-table (u/the-id table) %)))
 
 (defenterprise fetch-table-query-metadata
   "Returns the query metadata used to power the Query Builder for the given table `id`. `include-sensitive-fields?`,

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -1,9 +1,9 @@
 (ns metabase-enterprise.sandbox.api.table
   (:require
+   [metabase-enterprise.sandbox.api.column-filter :as col-filter]
    [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.lib.core :as lib]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
@@ -12,45 +12,17 @@
    [metabase.warehouse-schema.table :as schema.table]
    [toucan2.core :as t2]))
 
-(mu/defn- find-sandbox-source-card :- [:maybe (ms/InstanceOf :model/Card)]
-  "Find the associated sandboxing card (if there is one) for the given `table-or-table-id` and `user-or-user-id`.
-  Returns nil if no question was found."
-  [table-or-table-id user-or-user-id]
-  (t2/select-one :model/Card
-                 {:select [:c.id :c.dataset_query :c.result_metadata :c.card_schema]
-                  :from   [[:sandboxes]]
-                  :join   [[:permissions_group_membership :pgm] [:= :sandboxes.group_id :pgm.group_id]
-                           [:report_card :c] [:= :c.id :sandboxes.card_id]]
-                  :where  [:and
-                           [:= :sandboxes.table_id (u/the-id table-or-table-id)]
-                           [:= :pgm.user_id (u/the-id user-or-user-id)]]}))
-
 (mu/defn only-sandboxed-perms? :- :boolean
   "Returns true if the user has sandboxed permissions for the given table. If a sandbox policy exists, it overrides
   existing permission on the table."
   [table :- (ms/InstanceOf :model/Table)]
   (boolean (seq (sandbox.api.util/enforced-sandboxes-for-tables #{(:id table)}))))
 
-(defn- filter-fields-by-name [names fields]
-  (filter #(contains? names (:name %))
-          fields))
-
-(defn- filter-fields-by-id [ids fields]
-  (filter #(contains? ids (:id %))
-          fields))
-
 (defn- filter-fields-for-sandboxing [table query-metadata-response]
-  ;; If we have sandboxed permissions and the associated sandbox limits the fields returned, we need to make sure
-  ;; the query_metadata endpoint also excludes any fields the sandbox query would exclude.
-  (if-let [{sandbox-query :dataset_query, :as sandbox-source-card} (find-sandbox-source-card table api/*current-user-id*)]
-    (update query-metadata-response :fields
-            (if (lib/native-only-query? sandbox-query)
-              (partial filter-fields-by-name
-                       (->> sandbox-source-card :result_metadata (map :name) set))
-              (partial filter-fields-by-id
-                       (->> sandbox-source-card :result_metadata (map u/id) set))))
-    ;; Sandboxed via user attribute, not a source question, so no column-level sandboxing is in place
-    query-metadata-response))
+  ;; Filter the fields list through the centralized column-filter helper. For tables sandboxed via user attribute
+  ;; only (no card_id) the helper is a pass-through, preserving the original behavior.
+  (update query-metadata-response :fields
+          #(col-filter/filter-fields-for-table (u/the-id table) api/*current-user-id* %)))
 
 (defenterprise fetch-table-query-metadata
   "Returns the query metadata used to power the Query Builder for the given table `id`. `include-sensitive-fields?`,

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
@@ -14,7 +14,6 @@
   (testing "filter-fields-by-card returns fields unchanged when card is nil"
     (let [fields [{:id 1 :name "A"} {:id 2 :name "B"}]]
       (is (= fields (col-filter/filter-fields-by-card nil fields)))))
-
   (testing "filter-fields-by-card returns fields unchanged when card has no dataset_query"
     (let [fields [{:id 1 :name "A"}]]
       (is (= fields (col-filter/filter-fields-by-card
@@ -113,13 +112,11 @@
                                  :where  [:= :pg.id (u/the-id &group)]})]
         ;; Forcibly clear result_metadata to simulate the async-not-yet-complete or failed-extraction state.
         (t2/update! :model/Card :id (:id card) {:result_metadata nil})
-
         (testing "sandboxed user sees zero fields (fail-closed)"
           (let [{:keys [fields]} (mt/user-http-request :rasta :get 200
                                                        (format "table/%d/query_metadata"
                                                                (mt/id :venues)))]
             (is (= [] fields))))
-
         (testing "admin still sees all fields (sandbox not enforced for admins)"
           (let [{:keys [fields]} (mt/user-http-request :crowberto :get 200
                                                        (format "table/%d/query_metadata"
@@ -141,4 +138,3 @@
           (is (not (contains? result (mt/id :categories)))))
         (testing "the returned card carries the dataset_query needed to determine native vs MBQL"
           (is (some? (:dataset_query (get result (mt/id :venues))))))))))
-

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
@@ -69,8 +69,7 @@
                                     :query      (mt.tu/restricted-column-query (mt/id))}}
                       :attributes {:cat 50}}
       (let [all-fields (t2/select :model/Field :table_id (mt/id :venues))
-            filtered   (col-filter/filter-fields-for-table
-                        (mt/id :venues) (mt/user->id :rasta) all-fields)]
+            filtered   (col-filter/filter-fields-for-table (mt/id :venues) all-fields)]
         (is (= #{"CATEGORY_ID" "ID" "NAME"}
                (set (map (comp u/upper-case-en :name) filtered))))))))
 
@@ -78,8 +77,7 @@
   (testing "filter-fields-for-table returns fields unchanged when no sandbox exists for the user+table"
     (mt/with-current-user (mt/user->id :rasta)
       (let [all-fields (vec (t2/select :model/Field :table_id (mt/id :venues)))
-            filtered   (col-filter/filter-fields-for-table
-                        (mt/id :venues) (mt/user->id :rasta) all-fields)]
+            filtered   (col-filter/filter-fields-for-table (mt/id :venues) all-fields)]
         (is (= (count all-fields) (count filtered))
             "No sandbox configured for this user+table — should be a pass-through")))))
 
@@ -92,7 +90,6 @@
       (let [all-venues-fields   (vec (t2/select :model/Field :table_id (mt/id :venues)))
             all-checkins-fields (vec (t2/select :model/Field :table_id (mt/id :checkins)))
             result (col-filter/batch-filter-fields-by-table
-                    (mt/user->id :rasta)
                     {(mt/id :venues)   all-venues-fields
                      (mt/id :checkins) all-checkins-fields})]
         (testing "sandboxed table is filtered"
@@ -130,13 +127,12 @@
             (is (= 6 (count fields)))))))))
 
 (deftest find-sandbox-source-cards-batch-test
-  (testing "find-sandbox-source-cards returns a {table-id => card} map for the user's sandbox cards"
+  (testing "find-sandbox-source-cards returns a {table-id => card} map for the current user's sandbox cards"
     (met/with-gtaps! {:gtaps      {:venues
                                    {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                                     :query      (mt.tu/restricted-column-query (mt/id))}}
                       :attributes {:cat 50}}
       (let [result (col-filter/find-sandbox-source-cards
-                    (mt/user->id :rasta)
                     #{(mt/id :venues) (mt/id :checkins) (mt/id :categories)})]
         (testing "returns an entry for the sandboxed table"
           (is (contains? result (mt/id :venues))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/column_filter_test.clj
@@ -1,0 +1,148 @@
+(ns metabase-enterprise.sandbox.api.column-filter-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.sandbox.api.column-filter :as col-filter]
+   [metabase-enterprise.sandbox.test-util :as mt.tu]
+   [metabase-enterprise.test :as met]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+;;; -------------------------------- Pure-function tests --------------------------------
+
+(deftest filter-fields-by-card-no-card-test
+  (testing "filter-fields-by-card returns fields unchanged when card is nil"
+    (let [fields [{:id 1 :name "A"} {:id 2 :name "B"}]]
+      (is (= fields (col-filter/filter-fields-by-card nil fields)))))
+
+  (testing "filter-fields-by-card returns fields unchanged when card has no dataset_query"
+    (let [fields [{:id 1 :name "A"}]]
+      (is (= fields (col-filter/filter-fields-by-card
+                     {:dataset_query nil :result_metadata []}
+                     fields))))))
+
+(deftest empty-result-metadata-fails-closed-test
+  (testing "filter-fields-by-card returns NO fields when sandbox card has empty result_metadata.
+
+           DO NOT FLIP THIS TO FAIL-OPEN WITHOUT A SECURITY REVIEW.
+
+           Fail-open would silently degrade a sandbox stuck in failed-metadata-extraction
+           state into no column restriction at all. The acceptable trade-off is that
+           sandboxed users see zero fields during the (sub-second) async metadata window
+           for newly-created cards, and zero fields permanently for cards whose extraction
+           failed — both of which are admin-config issues, not security regressions.
+
+           See the namespace docstring of metabase-enterprise.sandbox.api.column-filter
+           for the full rationale."
+    (let [mbql-card-empty-md  {:dataset_query {:type :query
+                                               :query {:source-table 1}
+                                               :database 1}
+                               :result_metadata []}
+          mbql-card-nil-md    {:dataset_query {:type :query
+                                               :query {:source-table 1}
+                                               :database 1}
+                               :result_metadata nil}
+          native-card-empty   {:dataset_query {:type :native
+                                               :native {:query "SELECT 1"}
+                                               :database 1}
+                               :result_metadata []}
+          native-card-nil     {:dataset_query {:type :native
+                                               :native {:query "SELECT 1"}
+                                               :database 1}
+                               :result_metadata nil}
+          fields              [{:id 1 :name "A"} {:id 2 :name "B"} {:id 3 :name "C"}]]
+      (testing "MBQL card with empty result_metadata filters everything out"
+        (is (= [] (col-filter/filter-fields-by-card mbql-card-empty-md fields))))
+      (testing "MBQL card with nil result_metadata filters everything out"
+        (is (= [] (col-filter/filter-fields-by-card mbql-card-nil-md fields))))
+      (testing "Native card with empty result_metadata filters everything out"
+        (is (= [] (col-filter/filter-fields-by-card native-card-empty fields))))
+      (testing "Native card with nil result_metadata filters everything out"
+        (is (= [] (col-filter/filter-fields-by-card native-card-nil fields)))))))
+
+;;; ----------------------------- Integration tests with a real GTAP -----------------------------
+
+(deftest filter-fields-for-table-mbql-sandbox-test
+  (testing "filter-fields-for-table keeps only columns referenced by an MBQL sandbox source card"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [all-fields (t2/select :model/Field :table_id (mt/id :venues))
+            filtered   (col-filter/filter-fields-for-table
+                        (mt/id :venues) (mt/user->id :rasta) all-fields)]
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (set (map (comp u/upper-case-en :name) filtered))))))))
+
+(deftest filter-fields-for-table-no-sandbox-test
+  (testing "filter-fields-for-table returns fields unchanged when no sandbox exists for the user+table"
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [all-fields (vec (t2/select :model/Field :table_id (mt/id :venues)))
+            filtered   (col-filter/filter-fields-for-table
+                        (mt/id :venues) (mt/user->id :rasta) all-fields)]
+        (is (= (count all-fields) (count filtered))
+            "No sandbox configured for this user+table — should be a pass-through")))))
+
+(deftest batch-filter-fields-by-table-test
+  (testing "batch-filter-fields-by-table filters each table independently in a single DB query"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [all-venues-fields   (vec (t2/select :model/Field :table_id (mt/id :venues)))
+            all-checkins-fields (vec (t2/select :model/Field :table_id (mt/id :checkins)))
+            result (col-filter/batch-filter-fields-by-table
+                    (mt/user->id :rasta)
+                    {(mt/id :venues)   all-venues-fields
+                     (mt/id :checkins) all-checkins-fields})]
+        (testing "sandboxed table is filtered"
+          (is (= #{"CATEGORY_ID" "ID" "NAME"}
+                 (set (map (comp u/upper-case-en :name) (get result (mt/id :venues)))))))
+        (testing "non-sandboxed table is unchanged"
+          (is (= (count all-checkins-fields) (count (get result (mt/id :checkins))))))))))
+
+(deftest empty-result-metadata-integration-test
+  (testing "/api/table/:id/query_metadata returns zero fields when the sandbox source card has nil
+           result_metadata. Pins the fail-closed contract end-to-end through the API surface."
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [card (t2/select-one :model/Card
+                                {:select [:c.id]
+                                 :from   [[:sandboxes :s]]
+                                 :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
+                                          [:report_card :c] [:= :c.id :s.card_id]]
+                                 :where  [:= :pg.id (u/the-id &group)]})]
+        ;; Forcibly clear result_metadata to simulate the async-not-yet-complete or failed-extraction state.
+        (t2/update! :model/Card :id (:id card) {:result_metadata nil})
+
+        (testing "sandboxed user sees zero fields (fail-closed)"
+          (let [{:keys [fields]} (mt/user-http-request :rasta :get 200
+                                                       (format "table/%d/query_metadata"
+                                                               (mt/id :venues)))]
+            (is (= [] fields))))
+
+        (testing "admin still sees all fields (sandbox not enforced for admins)"
+          (let [{:keys [fields]} (mt/user-http-request :crowberto :get 200
+                                                       (format "table/%d/query_metadata"
+                                                               (mt/id :venues)))]
+            (is (= 6 (count fields)))))))))
+
+(deftest find-sandbox-source-cards-batch-test
+  (testing "find-sandbox-source-cards returns a {table-id => card} map for the user's sandbox cards"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [result (col-filter/find-sandbox-source-cards
+                    (mt/user->id :rasta)
+                    #{(mt/id :venues) (mt/id :checkins) (mt/id :categories)})]
+        (testing "returns an entry for the sandboxed table"
+          (is (contains? result (mt/id :venues))))
+        (testing "does not return entries for non-sandboxed tables"
+          (is (not (contains? result (mt/id :checkins))))
+          (is (not (contains? result (mt/id :categories)))))
+        (testing "the returned card carries the dataset_query needed to determine native vs MBQL"
+          (is (some? (:dataset_query (get result (mt/id :venues))))))))))
+

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
@@ -14,6 +14,23 @@
   (let [venues (some #(when (= "VENUES" (u/upper-case-en (:name %))) %) (:tables response))]
     (set (map (comp u/upper-case-en :name) (:fields venues)))))
 
+(defn- recompute-native-sandbox-metadata!
+  "Native sandbox cards populate `result_metadata` asynchronously. Compute + save it synchronously so tests
+  don't race the `metabase.queries.models.card.metadata/metadata-sync-wait-ms` window. Mirrors the dance in
+  metabase-enterprise.sandbox.api.table-test/native-query-metadata-test."
+  [group]
+  (let [card (t2/select-one :model/Card
+                            {:select [:c.id :c.dataset_query :c.entity_id :c.card_schema]
+                             :from   [[:sandboxes :s]]
+                             :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
+                                      [:report_card :c] [:= :c.id :s.card_id]]
+                             :where  [:= :pg.id (u/the-id group)]})
+        {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata
+                                            (:dataset_query card))]
+    (if metadata
+      (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
+      (card.metadata/save-metadata-async! metadata-future card))))
+
 (deftest database-metadata-respects-column-sandbox-test
   (testing "GET /api/database/:id/metadata excludes columns hidden by a column-restricting sandbox."
     (met/with-gtaps! {:gtaps      {:venues
@@ -37,8 +54,7 @@
             "Admin sees every venues column regardless of the GTAP")))))
 
 (deftest database-metadata-without-restricted-columns-test
-  (testing "If a GTAP card exposes ALL columns of the sandboxed table, every column is returned (no over-filtering).
-           Pins the no-restriction code path inside batch-filter-sandboxed-fields."
+  (testing "If a GTAP card exposes ALL columns of the sandboxed table, every column is returned (no over-filtering)."
     (met/with-gtaps! {:gtaps      {:venues {:query      {:database (mt/id)
                                                          :type     :query
                                                          :query    {:source-table (mt/id :venues)}}
@@ -77,20 +93,21 @@
                                     :query      (mt/native-query
                                                  {:query "SELECT CATEGORY_ID, ID, NAME from venues;"})}}
                       :attributes {:cat 50}}
-      ;; Native sandbox cards populate result_metadata asynchronously. Manually compute + save so the test
-      ;; doesn't race the metadata-sync-wait-ms (1.5s) window. Mirrors the dance in
-      ;; metabase-enterprise.sandbox.api.table-test/native-query-metadata-test.
-      (let [card (t2/select-one :model/Card
-                                {:select [:c.id :c.dataset_query :c.entity_id :c.card_schema]
-                                 :from   [[:sandboxes :s]]
-                                 :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
-                                          [:report_card :c] [:= :c.id :s.card_id]]
-                                 :where  [:= :pg.id (u/the-id &group)]})
-            {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata
-                                                (:dataset_query card))]
-        (if metadata
-          (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
-          (card.metadata/save-metadata-async! metadata-future card)))
+      (recompute-native-sandbox-metadata! &group)
       (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (venues-field-names response)))))))
+
+(deftest database-include-tables-fields-native-sandbox-test
+  (testing "GET /api/database/:id?include=tables.fields excludes sandbox-hidden columns for a native sandbox card
+           (native-by-name filtering through the get-database-hydrate-include code path)"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt/native-query
+                                                 {:query "SELECT CATEGORY_ID, ID, NAME from venues;"})}}
+                      :attributes {:cat 50}}
+      (recompute-native-sandbox-metadata! &group)
+      (let [response (mt/user-http-request :rasta :get 200
+                                           (format "database/%d?include=tables.fields" (mt/id)))]
         (is (= #{"CATEGORY_ID" "ID" "NAME"}
                (venues-field-names response)))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
@@ -39,7 +39,9 @@
 (deftest database-metadata-without-restricted-columns-test
   (testing "If a GTAP card exposes ALL columns of the sandboxed table, every column is returned (no over-filtering).
            Pins the no-restriction code path inside batch-filter-sandboxed-fields."
-    (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
+    (met/with-gtaps! {:gtaps      {:venues {:query      {:database (mt/id)
+                                                         :type     :query
+                                                         :query    {:source-table (mt/id :venues)}}
                                             :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
                       :attributes {:cat 50}}
       (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
@@ -89,7 +89,6 @@
         (if metadata
           (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
           (card.metadata/save-metadata-async! metadata-future card)))
-
       (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
         (is (= #{"CATEGORY_ID" "ID" "NAME"}
                (venues-field-names response)))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/database_test.clj
@@ -1,0 +1,95 @@
+(ns metabase-enterprise.sandbox.api.database-test
+  "Tests that `GET /api/database/:id/metadata` and `?include=tables.fields` filter out columns the user's
+  column-restricting sandbox hides."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.sandbox.test-util :as mt.tu]
+   [metabase-enterprise.test :as met]
+   [metabase.queries.models.card.metadata :as card.metadata]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(defn- venues-field-names [response]
+  (let [venues (some #(when (= "VENUES" (u/upper-case-en (:name %))) %) (:tables response))]
+    (set (map (comp u/upper-case-en :name) (:fields venues)))))
+
+(deftest database-metadata-respects-column-sandbox-test
+  (testing "GET /api/database/:id/metadata excludes columns hidden by a column-restricting sandbox."
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (venues-field-names response))
+            "Sandboxed table reports only the columns exposed by the sandbox card")))))
+
+(deftest database-metadata-admin-sees-all-test
+  (testing "Admins are exempt from sandbox enforcement on /api/database/:id/metadata"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [response (mt/user-http-request :crowberto :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "LATITUDE" "LONGITUDE" "NAME" "PRICE"}
+               (venues-field-names response))
+            "Admin sees every venues column regardless of the GTAP")))))
+
+(deftest database-metadata-without-restricted-columns-test
+  (testing "If a GTAP card exposes ALL columns of the sandboxed table, every column is returned (no over-filtering).
+           Pins the no-restriction code path inside batch-filter-sandboxed-fields."
+    (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
+                                            :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                      :attributes {:cat 50}}
+      (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "LATITUDE" "LONGITUDE" "NAME" "PRICE"}
+               (venues-field-names response))
+            "All venues columns returned because the sandbox card SELECTs them all")))))
+
+(deftest database-metadata-row-only-sandbox-test
+  (testing "A row-level sandbox (no card_id, attribute-only) leaves the column list intact —
+           row security doesn't hide columns, only filters rows at query time."
+    (met/with-gtaps! {:gtaps {:venues {}}}
+      (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "LATITUDE" "LONGITUDE" "NAME" "PRICE"}
+               (venues-field-names response))
+            "Row-only sandbox exposes every column to the user (row restriction is enforced by the QP)")))))
+
+(deftest database-include-tables-fields-respects-column-sandbox-test
+  (testing "GET /api/database/:id?include=tables.fields excludes sandbox-hidden columns
+           (this is a separate code path from /metadata in get-database-hydrate-include)"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
+      (let [response (mt/user-http-request :rasta :get 200
+                                           (format "database/%d?include=tables.fields" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (venues-field-names response)))))))
+
+(deftest database-metadata-native-sandbox-test
+  (testing "Native (SQL) sandbox source cards filter by column name. Confirms parity with MBQL sandboxes."
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt/native-query
+                                                 {:query "SELECT CATEGORY_ID, ID, NAME from venues;"})}}
+                      :attributes {:cat 50}}
+      ;; Native sandbox cards populate result_metadata asynchronously. Manually compute + save so the test
+      ;; doesn't race the metadata-sync-wait-ms (1.5s) window. Mirrors the dance in
+      ;; metabase-enterprise.sandbox.api.table-test/native-query-metadata-test.
+      (let [card (t2/select-one :model/Card
+                                {:select [:c.id :c.dataset_query :c.entity_id :c.card_schema]
+                                 :from   [[:sandboxes :s]]
+                                 :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
+                                          [:report_card :c] [:= :c.id :s.card_id]]
+                                 :where  [:= :pg.id (u/the-id &group)]})
+            {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata
+                                                (:dataset_query card))]
+        (if metadata
+          (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
+          (card.metadata/save-metadata-async! metadata-future card)))
+
+      (let [response (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id)))]
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (venues-field-names response)))))))

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -100,6 +100,21 @@
   [ids opts]
   (batch-fetch-query-metadatas* ids opts))
 
+(defenterprise filter-sandboxed-fields
+  "Filter `fields` to those visible to the user under their column-restricting sandbox on `table-id`. OSS no-op.
+  Enterprise implementation lives in `metabase-enterprise.sandbox.api.column-filter` and consults the sandbox source
+  card's `:result_metadata` to remove fields the user shouldn't see."
+  metabase-enterprise.sandbox.api.column-filter
+  [_table-id _user-id fields]
+  fields)
+
+(defenterprise batch-filter-sandboxed-fields
+  "Filter the `{table-id => fields}` map per the user's sandbox configuration. OSS no-op. Enterprise implementation
+  in `metabase-enterprise.sandbox.api.column-filter`."
+  metabase-enterprise.sandbox.api.column-filter
+  [_user-id fields-by-table]
+  fields-by-table)
+
 (defn- card-result-metadata->virtual-fields
   "Return a sequence of 'virtual' fields metadata for the 'virtual' table for a Card in the Saved Questions 'virtual'
    database.

--- a/src/metabase/warehouse_schema/table.clj
+++ b/src/metabase/warehouse_schema/table.clj
@@ -101,18 +101,17 @@
   (batch-fetch-query-metadatas* ids opts))
 
 (defenterprise filter-sandboxed-fields
-  "Filter `fields` to those visible to the user under their column-restricting sandbox on `table-id`. OSS no-op.
-  Enterprise implementation lives in `metabase-enterprise.sandbox.api.column-filter` and consults the sandbox source
-  card's `:result_metadata` to remove fields the user shouldn't see."
+  "Filter `fields` to those visible to the current user under their column-restricting sandbox on `table-id`.
+  OSS no-op; the real implementation lives in `metabase-enterprise.sandbox.api.column-filter`."
   metabase-enterprise.sandbox.api.column-filter
-  [_table-id _user-id fields]
+  [_table-id fields]
   fields)
 
 (defenterprise batch-filter-sandboxed-fields
-  "Filter the `{table-id => fields}` map per the user's sandbox configuration. OSS no-op. Enterprise implementation
-  in `metabase-enterprise.sandbox.api.column-filter`."
+  "Filter the `{table-id => fields}` map per the current user's sandbox configuration.
+  OSS no-op; the real implementation lives in `metabase-enterprise.sandbox.api.column-filter`."
   metabase-enterprise.sandbox.api.column-filter
-  [_user-id fields-by-table]
+  [fields-by-table]
   fields-by-table)
 
 (defn- card-result-metadata->virtual-fields

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -409,11 +409,11 @@
   (remove #(= :sensitive (:visibility_type %)) fields))
 
 (defn- apply-sandbox-column-filter
-  "For each table in `tables`, remove fields that the current user's column-restricting sandbox source card
-  doesn't expose. No-op for OSS instances and for users with no sandbox on a given table."
+  "Remove from each table in `tables` the fields that the current user's column-restricting sandbox hides.
+  No-op for OSS and for users with no sandbox on a given table."
   [tables]
   (let [fields-by-table (into {} (map (juxt :id :fields)) tables)
-        filtered        (schema.table/batch-filter-sandboxed-fields api/*current-user-id* fields-by-table)]
+        filtered        (schema.table/batch-filter-sandboxed-fields fields-by-table)]
     (mapv (fn [t] (assoc t :fields (get filtered (:id t) (:fields t)))) tables)))
 
 (defn- get-database-hydrate-include

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -408,6 +408,14 @@
   [fields]
   (remove #(= :sensitive (:visibility_type %)) fields))
 
+(defn- apply-sandbox-column-filter
+  "For each table in `tables`, remove fields that the current user's column-restricting sandbox source card
+  doesn't expose. No-op for OSS instances and for users with no sandbox on a given table."
+  [tables]
+  (let [fields-by-table (into {} (map (juxt :id :fields)) tables)
+        filtered        (schema.table/batch-filter-sandboxed-fields api/*current-user-id* fields-by-table)]
+    (mapv (fn [t] (assoc t :fields (get filtered (:id t) (:fields t)))) tables)))
+
 (defn- get-database-hydrate-include
   "If URL param `?include=` was passed to `GET /api/database/:id`, hydrate the Database appropriately."
   [db include]
@@ -422,7 +430,9 @@
                             true                        (filter (every-pred (complement :visibility_type) mi/can-read?))
                             true                        (map (fn [table] (update table :schema str)))
                             ; filter hidden fields
-                            (= include "tables.fields") (map #(update % :fields filter-sensitive-fields))))))))
+                            (= include "tables.fields") (map #(update % :fields filter-sensitive-fields))
+                            ; filter columns the user's column-restricting sandbox hides
+                            (= include "tables.fields") apply-sandbox-column-filter))))))
 
 (mu/defn- check-database-exists
   ([id] (check-database-exists id {}))
@@ -571,7 +581,12 @@
              ;; We need to check data model perms after hydrating tables, since this will also filter out tables for
              ;; which the *current-user* does not have data model perms
              (check-db-data-model-perms db)
-             db)]
+             db)
+        ;; Filter out columns hidden by the current user's column-restricting sandbox source card. No-op for
+        ;; non-sandboxed users.
+        db (if skip-fields?
+             db
+             (update db :tables apply-sandbox-column-filter))]
     (-> db
         (update :tables (if include-hidden?
                           identity

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -44,19 +44,16 @@
               (is (= 1 (count timed-out)))
               (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id old-run-id)))
               (is (= :started (t2/select-one-fn :status :model/TransformRun :id fresh-run-id)))))
-
           (testing "counter bumps {type=transform} once for the stale run"
             (is (== 1 (mt/metric-value system
                                        :metabase-transforms/timeouts-total
                                        {:type "transform"}))))
-
           (testing "histogram observes one positive sample for the stale run"
             (let [hist (mt/metric-value system
                                         :metabase-transforms/timeout-detection-latency-ms
                                         {:type "transform"})]
               (is (= 1 (long (:count hist))))
               (is (pos? (:sum hist)))))
-
           (testing "audit event is published with topic transform-run-timeout"
             (let [entry (mt/latest-audit-log-entry :transform-run-timeout old-run-id)]
               (is (some? entry))
@@ -65,7 +62,6 @@
               (is (= old-run-id (:model_id entry)))
               (testing "payload reflects the post-update :timeout status (parity with single-run path)"
                 (is (= "timeout" (some-> entry :details :status))))))))
-
       (testing "no metric activity when there are no stale runs"
         (let [inc-calls     (atom [])
               observe-calls (atom [])]
@@ -82,7 +78,6 @@
                   "sweeper did not increment :metabase-transforms/timeouts-total")
               (is (not-any? #{:metabase-transforms/timeout-detection-latency-ms} @observe-calls)
                   "sweeper did not observe :metabase-transforms/timeout-detection-latency-ms")))))
-
       (testing "single-run timeout-run! bumps counter and publishes audit event"
         (prometheus/clear! :metabase-transforms/timeouts-total)
         (mt/with-temp [:model/Transform    {transform-id :id} {}
@@ -100,7 +95,6 @@
             (is (some? entry))
             (is (= run-id (:model_id entry)))
             (is (= "timeout" (some-> entry :details :status))))))
-
       (testing "job-run sweeper bumps {type=job} counter and observes histogram per timed-out job run"
         (prometheus/clear! :metabase-transforms/timeouts-total)
         (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)


### PR DESCRIPTION
### Description

Row & column security already trims columns in query results; this extends the same trimming to the read-only field listings (Data Reference / table metadata) so a sandboxed group sees a consistent column set everywhere. This is a QoL change for sandboxed viewers, OSS/non-sandboxed users and admins are unaffected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
