### PR TITLE
Update test to reflect label change

### DIFF
--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -114,7 +114,7 @@ describe("impersonated permission", { tags: "@external" }, () => {
         H.openQuestionActions("Edit settings");
         cy.findByLabelText("When to get new results").click();
         H.cacheStrategySidesheet().within(() => {
-          cy.findByText(/Use default/).click();
+          cy.findByText(/Default/).click();
           cy.findByText(/Caching settings/).should("be.visible");
           H.durationRadioButton().click();
           cy.findByRole("button", { name: /Save/ }).click();


### PR DESCRIPTION
Closes [UXW-4285: \[Broken Test\] \[e2e-tests\] impersonated users impersonated permission admins impersonated users caching should not circumvent impersonation permissions](https://linear.app/metabase/issue/UXW-4285/broken-test-e2e-tests-impersonated-users-impersonated-permission)