### PR TITLE
Use request Host header for MCP OAuth discovery URLs

### DIFF
--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -334,7 +334,8 @@
    important when Metabase is reachable via multiple hostnames (e.g. an
    in-cluster address vs. a public domain)."
   [request]
-  (let [host (get-in request [:headers "host"])]
+  (let [host (or (get-in request [:headers "x-forwarded-host"])
+                 (get-in request [:headers "host"]))]
     (if host
       ;; Preserve the request scheme when available; default to the scheme
       ;; implied by the site-url setting, or fall back to "https".

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -327,8 +327,26 @@
 
 ;;; ---------------------------------------------------- Handler ---------------------------------------------------
 
-(defn- www-authenticate-discovery []
-  (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource/api/mcp\""))
+(defn- request-base-url
+  "Derive the base URL from the request's Host header, falling back to the
+   configured site-url. This ensures that the resource_metadata URL in
+   WWW-Authenticate points to the same origin the client used, which is
+   important when Metabase is reachable via multiple hostnames (e.g. an
+   in-cluster address vs. a public domain)."
+  [request]
+  (let [host (get-in request [:headers "host"])]
+    (if host
+      ;; Preserve the request scheme when available; default to the scheme
+      ;; implied by the site-url setting, or fall back to "https".
+      (let [proto (or (get-in request [:headers "x-forwarded-proto"])
+                      (when-let [su (system/site-url)]
+                        (re-find #"^https?" su))
+                      "https")]
+        (str proto "://" host))
+      (system/site-url))))
+
+(defn- www-authenticate-discovery [request]
+  (str "Bearer realm=\"mcp\" resource_metadata=\"" (request-base-url request) "/.well-known/oauth-protected-resource/api/mcp\""))
 
 (def +mcp-enabled
   "Wrap routes so they may only be accessed when the MCP server is enabled."
@@ -380,5 +398,5 @@
            ;; No auth at all — return 401 with discovery
            :else
            (respond (json-response 401 (jsonrpc-error nil -32603 "Authentication required")
-                                   {"WWW-Authenticate" (www-authenticate-discovery)}))))))
+                                   {"WWW-Authenticate" (www-authenticate-discovery request)}))))))
    (constantly nil)))

--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -38,6 +38,19 @@
   (or (discovery-response)
       {:status 404 :body {:error "not_found"}}))
 
+(defn- request-base-url
+  "Derive the base URL from the request's Host header, falling back to the
+   configured site-url."
+  [request]
+  (let [host (get-in request [:headers "host"])]
+    (if host
+      (let [proto (or (get-in request [:headers "x-forwarded-proto"])
+                      (when-let [su (system/site-url)]
+                        (re-find #"^https?" su))
+                      "https")]
+        (str proto "://" host))
+      (system/site-url))))
+
 (api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
   :- [:map
       [:status [:= 200]]
@@ -47,11 +60,12 @@
               [:scopes_supported [:sequential :string]]
               [:bearer_methods_supported [:sequential :string]]]]]
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
-  []
-  (let [site-url (system/site-url)]
+  [_route-params _query-params _body
+   request]
+  (let [base-url (request-base-url request)]
     {:status  200
      :headers {"Content-Type" "application/json"}
-     :body    {:resource                  (str site-url "/api/mcp")
-               :authorization_servers     [site-url]
+     :body    {:resource                  (str base-url "/api/mcp")
+               :authorization_servers     [base-url]
                :scopes_supported          (vec (oauth-server/all-agent-scopes))
                :bearer_methods_supported  ["header"]}}))

--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -42,7 +42,8 @@
   "Derive the base URL from the request's Host header, falling back to the
    configured site-url."
   [request]
-  (let [host (get-in request [:headers "host"])]
+  (let [host (or (get-in request [:headers "x-forwarded-host"])
+                 (get-in request [:headers "host"]))]
     (if host
       (let [proto (or (get-in request [:headers "x-forwarded-proto"])
                       (when-let [su (system/site-url)]

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1035,7 +1035,15 @@
       (let [response (mcp-request-unauthenticated (jsonrpc-request "initialize"))]
         (is (=? {:status  401
                  :headers {"WWW-Authenticate" #(str/includes? % "oauth-protected-resource")}}
-                response))))))
+                response)))))
+  (testing "WWW-Authenticate resource_metadata URL uses the request Host header, not site-url"
+    (mt/with-temporary-setting-values [site-url "https://public.example.com"]
+      (let [response (mcp-request-unauthenticated (jsonrpc-request "initialize")
+                                                  {"host" "internal.local:3000"})]
+        (is (=? {:status 401} response))
+        (is (str/includes? (get-in response [:headers "WWW-Authenticate"])
+                           "https://internal.local:3000/.well-known/oauth-protected-resource/api/mcp")
+            "resource_metadata should reflect the Host header, not site-url")))))
 
 (deftest invalid-bearer-token-returns-401-test
   (testing "POST with invalid bearer token returns 401 with invalid_token error"

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -44,6 +44,14 @@
         (is (=? {:resource                "http://localhost:3000/api/mcp"
                  :authorization_servers   ["http://localhost:3000"]
                  :bearer_methods_supported ["header"]}
+                response)))))
+  (testing "metadata URLs reflect the request Host header instead of site-url"
+    (mt/with-temporary-setting-values [site-url "https://public.example.com"]
+      (let [response (mt/user-http-request :crowberto :get 200
+                                           ".well-known/oauth-protected-resource/api/mcp"
+                                           {:request-options {:headers {"host" "internal.local:3000"}}})]
+        (is (=? {:resource              "https://internal.local:3000/api/mcp"
+                 :authorization_servers ["https://internal.local:3000"]}
                 response))))))
 
 ;;; ----------------------------------------- Dynamic Client Registration ----------------------------------------------


### PR DESCRIPTION
### Description

The `WWW-Authenticate` header returned by `POST /api/mcp` (when unauthenticated) and the OAuth Protected Resource Metadata endpoint (`GET /.well-known/oauth-protected-resource/api/mcp`) both use the `site-url` setting to build discovery URLs. When Metabase is reachable via multiple hostnames (e.g. an in-cluster Kubernetes service address and a public domain), the `resource_metadata` URL points to the configured `site-url` rather than the host the client actually connected to. This breaks the MCP OAuth discovery flow for clients that cannot resolve or reach the configured `site-url`.

This PR derives the base URL from the request's `Host` (or `X-Forwarded-Host`) header instead, with `X-Forwarded-Proto` for the scheme, falling back to `site-url` when no `Host` header is present.

### How to verify

1. Set `site-url` to `https://my-public-domain.example.com`
2. Send an unauthenticated `POST` to `http://localhost:3000/api/mcp` with a JSON-RPC body
3. **Before**: the `WWW-Authenticate` header contains `resource_metadata="https://my-public-domain.example.com/.well-known/oauth-protected-resource/api/mcp"`
4. **After**: the `resource_metadata` URL uses `http://localhost:3000` (matching the request's Host header)
5. Similarly, `GET http://localhost:3000/.well-known/oauth-protected-resource/api/mcp` now returns `resource` and `authorization_servers` based on the request host

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)