### PR TITLE
Fix cljfmt 60

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -4,7 +4,7 @@
  :paths ["mage/src" "mage/test" "bin/lint-migrations-file/src"]
  ;; use Cam's fork temporarily until a new release with https://github.com/weavejester/cljfmt/pull/420 is cut
  ;; (release > 0.16.4)
- :deps {dev.weavejester/cljfmt {:git/sha "05886be17744846685e6a733973fdfbd24e1acd5"
+ :deps {dev.weavejester/cljfmt {:git/sha "d7e7bb9130a8315b4b320823380a172e51657eb3"
                                 :git/url "https://github.com/camsaul/cljfmt"} ;; run cljfmt from bb
         io.github.paintparty/bling {:mvn/version "0.8.8"} ;; printing bells and whistles
         medley/medley {:mvn/version "1.3.0"} ;; utilities

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -614,10 +614,8 @@
                           (-> %
                               (driver-api/assoc-field-options ::sql.qp/wrap-in-case true)
                               (driver-api/assoc-field-options ::sql.qp/add-cast :bit))
-
                           (sql.qp.boolean-to-comparison/boolean-expression-clause? %)
                           (driver-api/assoc-field-options % ::sql.qp/add-cast :bit)
-
                           :else
                           %)]
     (->> (update query :fields #(mapv maybe-add-cast %))

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -266,12 +266,9 @@
     #(cond
        (vector? %) ;; non-literal (checked above)
        true
-
        (not (int? %))
        false
-
        (not (pos? %))
        false
-
        :else
        true)]])


### PR DESCRIPTION
This is backport of https://github.com/metabase/metabase/pull/74892 and https://github.com/metabase/metabase/pull/74885 into `release-x.60.x` to fix CI.

More context:
- https://metaboat.slack.com/archives/CKZEMT1MJ/p1779975055966059
- https://metaboat.slack.com/archives/C5XHN8GLW/p1779923461163749