### PR TITLE
Set oauth dynamic registration to false when MCP is disabled

### DIFF
--- a/src/metabase/mcp/core.clj
+++ b/src/metabase/mcp/core.clj
@@ -14,6 +14,11 @@
   []
   (mcp.settings/mcp-apps-cors-origins))
 
+(defn mcp-enabled?
+  "Whether the MCP server is enabled (composes [[metabase.llm.settings/ai-features-enabled?]])."
+  []
+  (mcp.settings/mcp-enabled?))
+
 (defn vscode-webview-enabled?
   "Returns true if vscode/cursor is enabled in common MCP apps."
   []

--- a/src/metabase/oauth_server/settings.clj
+++ b/src/metabase/oauth_server/settings.clj
@@ -1,6 +1,7 @@
 (ns metabase.oauth-server.settings
   (:require
-   [metabase.settings.core :refer [defsetting]]
+   [metabase.mcp.core :as mcp]
+   [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting oauth-server-access-token-ttl
@@ -30,6 +31,7 @@
   :export?    false
   :audit      :never)
 
+;; Gated on mcp-enabled? so registration is off whenever MCP is; stored override can still force false.
 (defsetting oauth-server-dynamic-registration-enabled
   (deferred-tru "Whether dynamic client registration (RFC 7591) is enabled for the embedded OAuth server.")
   :type       :boolean
@@ -37,4 +39,6 @@
   :visibility :internal
   :doc        false
   :export?    false
-  :audit      :getter)
+  :audit      :getter
+  :getter     #(and (mcp/mcp-enabled?)
+                    (setting/get-value-of-type :boolean :oauth-server-dynamic-registration-enabled)))

--- a/test/metabase/oauth_server/settings_test.clj
+++ b/test/metabase/oauth_server/settings_test.clj
@@ -17,3 +17,22 @@
       (is (= 2592000 (oauth-settings/oauth-server-refresh-token-ttl)))
       (oauth-settings/oauth-server-refresh-token-ttl! 86400)
       (is (= 86400 (oauth-settings/oauth-server-refresh-token-ttl))))))
+
+(deftest dynamic-registration-tracks-mcp-test
+  (testing "oauth-server-dynamic-registration-enabled is AND-composed with mcp-enabled?"
+    (testing "MCP off, override true → false (MCP gate wins)"
+      (mt/with-temporary-setting-values [mcp-enabled?                              false
+                                         oauth-server-dynamic-registration-enabled true]
+        (is (false? (oauth-settings/oauth-server-dynamic-registration-enabled)))))
+    (testing "MCP off, override false → false"
+      (mt/with-temporary-setting-values [mcp-enabled?                              false
+                                         oauth-server-dynamic-registration-enabled false]
+        (is (false? (oauth-settings/oauth-server-dynamic-registration-enabled)))))
+    (testing "MCP on, override true → true"
+      (mt/with-temporary-setting-values [mcp-enabled?                              true
+                                         oauth-server-dynamic-registration-enabled true]
+        (is (true? (oauth-settings/oauth-server-dynamic-registration-enabled)))))
+    (testing "MCP on, override false → false (lockdown override preserved)"
+      (mt/with-temporary-setting-values [mcp-enabled?                              true
+                                         oauth-server-dynamic-registration-enabled false]
+        (is (false? (oauth-settings/oauth-server-dynamic-registration-enabled)))))))


### PR DESCRIPTION
### Description

Updates the `oauth-server-dynamic-registration-enabled` to only actually be true if MCP is enabled. If MCP is not enabled, then the `getter` for this setting will always return false


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
