### PR TITLE
GHY-3372 Update parameter values_source_config.card_id during source swap

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/replacement/source_swap.clj
+++ b/enterprise/backend/src/metabase_enterprise/replacement/source_swap.clj
@@ -38,19 +38,37 @@
           (events/publish-event! :event/transform-update
                                  {:object (merge transform changes) :user-id api/*current-user-id*}))))))
 
+(defn- swap-parameter-source-card-id
+  "For a parameters collection, replace `values_source_config.card_id` references to `old-source-id` with
+  `new-source-id`. Only applies to card-to-card swaps; returns parameters unchanged for any other swap shape
+  (e.g. card-to-table)."
+  [parameters [old-source-type old-source-id] [new-source-type new-source-id]]
+  (letfn [(swap-card-id [card-id]
+            (if (and (= :card old-source-type)
+                     (= :card new-source-type)
+                     (= old-source-id card-id))
+              new-source-id
+              card-id))]
+    (replacement.walk/walk-parameter-source-card-ids (or parameters []) swap-card-id)))
+
 (defn- card-swap-source!
   [card old-source new-source]
   (when (replacement.util/valid-query? (:dataset_query card))
-    (let [query     (:dataset_query card)
-          query'    (source-swap/swap-source-in-query query old-source new-source)
-          table-id  (:table_id card)
-          table-id' (:table-id (queries.query/query->database-and-table-ids query'))
-          changes   (cond-> {}
-                      (not= query query')
-                      (assoc :dataset_query query')
+    (let [query       (:dataset_query card)
+          query'      (source-swap/swap-source-in-query query old-source new-source)
+          table-id    (:table_id card)
+          table-id'   (:table-id (queries.query/query->database-and-table-ids query'))
+          parameters  (or (:parameters card) [])
+          parameters' (swap-parameter-source-card-id parameters old-source new-source)
+          changes     (cond-> {}
+                        (not= query query')
+                        (assoc :dataset_query query')
 
-                      (not= table-id table-id')
-                      (assoc :table_id table-id'))
+                        (not= table-id table-id')
+                        (assoc :table_id table-id')
+
+                        (not= parameters parameters')
+                        (assoc :parameters parameters'))
           ;; `:result_metadata` is set to nil for native queries if not present in changes.
           ;; `verified-result-metadata?` prevents the Card model hooks from clearing it.
           changes   (cond-> changes
@@ -144,13 +162,18 @@
         card-id->card (if (seq all-card-ids)
                         (t2/select-pk->fn identity :model/Card :id [:in all-card-ids])
                         {})
-        any-changed? (reduce (fn [changed? dashcard]
-                               (or
-                                (dashcard-swap-source! dashcard card-id->card old-source new-source)
-                                changed?))
-                             false
-                             dashcards)]
-    (when any-changed?
+        any-dashcard-changed? (reduce (fn [changed? dashcard]
+                                        (or
+                                         (dashcard-swap-source! dashcard card-id->card old-source new-source)
+                                         changed?))
+                                      false
+                                      dashcards)
+        parameters    (or (:parameters dashboard) [])
+        parameters'   (swap-parameter-source-card-id parameters old-source new-source)
+        params-changed? (not= parameters parameters')]
+    (when params-changed?
+      (t2/update! :model/Dashboard (:id dashboard) {:parameters parameters'}))
+    (when (or any-dashcard-changed? params-changed?)
       (events/publish-event!
        :event/dashboard-update {:object  (t2/select-one :model/Dashboard :id (:id dashboard))
                                 :user-id api/*current-user-id*}))))

--- a/enterprise/backend/src/metabase_enterprise/replacement/walk.clj
+++ b/enterprise/backend/src/metabase_enterprise/replacement/walk.clj
@@ -15,6 +15,14 @@
   [parameters :- [:sequential :map]]
   (into #{} (keep #(-> % :values_source_config :card_id)) parameters))
 
+(mu/defn walk-parameter-source-card-ids :- [:sequential :map]
+  "Walk the parameters and update the card IDs in `:values_source_config` using the provided function.
+
+  `card-id-fn` will be called with a card ID and should return a new card ID."
+  [parameters :- [:sequential :map]
+   card-id-fn :- fn?]
+  (mapv #(m/update-existing-in % [:values_source_config :card_id] card-id-fn) parameters))
+
 (mu/defn walk-parameter-source-card-refs :- [:sequential :map]
   "Walk the parameters and update the refs in `:value_field` and `:label_field`
   in the `:values_source_config` using the provided function.

--- a/enterprise/backend/test/metabase_enterprise/replacement/source_swap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/source_swap_test.clj
@@ -101,6 +101,56 @@
                                                   [:table (mt/id :reviews)])
             (is (= {} (:dataset_query (t2/select-one :model/Card card-id))))))))))
 
+(deftest card-swap-source!-updates-parameter-values-source-config-card-id-test
+  (testing "swap-source! should update card_id in card parameter values_source_config for card-to-card swaps"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-test-user :rasta
+        (let [mp (mt/metadata-provider)]
+          (mt/with-temp [:model/Card {old-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                         :model/Card {new-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :reviews)))}
+                         :model/Card {card-id :id}
+                         {:dataset_query (lib/native-query mp "SELECT 1")
+                          :parameters    [{:id                   "cat-param"
+                                           :name                 "category"
+                                           :type                 :string/=
+                                           :values_source_type   "card"
+                                           :values_source_config {:card_id     old-source-id
+                                                                  :value_field [:field "ID" {:base-type :type/Integer}]}}]}]
+            (replacement.source-swap/swap-source! [:card card-id]
+                                                  [:card old-source-id]
+                                                  [:card new-source-id])
+            (testing ":parameters JSONB on the card is updated"
+              (is (= new-source-id
+                     (-> (t2/select-one :model/Card card-id)
+                         :parameters first :values_source_config :card_id))))
+            (testing "parameter_card row is synced"
+              (is (= new-source-id
+                     (t2/select-one-fn :card_id :model/ParameterCard
+                                       :parameterized_object_type "card"
+                                       :parameterized_object_id   card-id
+                                       :parameter_id              "cat-param"))))))))))
+
+(deftest card-swap-source!-card-to-table-leaves-parameter-untouched-test
+  (testing "swap-source! should NOT update parameter values_source_config card_id on card-to-table swaps"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-test-user :rasta
+        (let [mp (mt/metadata-provider)]
+          (mt/with-temp [:model/Card {old-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                         :model/Card {card-id :id}
+                         {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                          :parameters    [{:id                   "cat-param"
+                                           :name                 "category"
+                                           :type                 :string/=
+                                           :values_source_type   "card"
+                                           :values_source_config {:card_id     old-source-id
+                                                                  :value_field [:field "ID" {:base-type :type/Integer}]}}]}]
+            (replacement.source-swap/swap-source! [:card card-id]
+                                                  [:table (mt/id :orders)]
+                                                  [:table (mt/id :reviews)])
+            (is (= old-source-id
+                   (-> (t2/select-one :model/Card card-id)
+                       :parameters first :values_source_config :card_id)))))))))
+
 ;;; ------------------------------------------------ Transform --------------------------------------------------------
 
 (deftest transform-swap-source!-source-table-test
@@ -211,6 +261,54 @@
                                                             [:table (mt/id :reviews)])))))))))
 
 ;;; ------------------------------------------------ Dashboard --------------------------------------------------------
+
+(deftest dashboard-swap-source!-updates-parameter-values-source-config-card-id-test
+  (testing "swap-source! should update card_id in dashboard parameter values_source_config for card-to-card swaps"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-test-user :rasta
+        (let [mp (mt/metadata-provider)]
+          (mt/with-temp [:model/Card      {old-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                         :model/Card      {new-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :reviews)))}
+                         :model/Dashboard {dashboard-id :id}
+                         {:parameters [{:id                   "cat-param"
+                                        :name                 "category"
+                                        :type                 :string/=
+                                        :values_source_type   "card"
+                                        :values_source_config {:card_id     old-source-id
+                                                               :value_field [:field "ID" {:base-type :type/Integer}]}}]}]
+            (replacement.source-swap/swap-source! [:dashboard dashboard-id]
+                                                  [:card old-source-id]
+                                                  [:card new-source-id])
+            (testing ":parameters JSONB on the dashboard is updated"
+              (is (= new-source-id
+                     (-> (t2/select-one :model/Dashboard dashboard-id)
+                         :parameters first :values_source_config :card_id))))
+            (testing "parameter_card row is synced"
+              (is (= new-source-id
+                     (t2/select-one-fn :card_id :model/ParameterCard
+                                       :parameterized_object_type "dashboard"
+                                       :parameterized_object_id   dashboard-id
+                                       :parameter_id              "cat-param"))))))))))
+
+(deftest dashboard-swap-source!-card-to-table-leaves-parameter-untouched-test
+  (testing "swap-source! should NOT update dashboard parameter values_source_config card_id on card-to-table swaps"
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-test-user :rasta
+        (let [mp (mt/metadata-provider)]
+          (mt/with-temp [:model/Card      {old-source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                         :model/Dashboard {dashboard-id :id}
+                         {:parameters [{:id                   "cat-param"
+                                        :name                 "category"
+                                        :type                 :string/=
+                                        :values_source_type   "card"
+                                        :values_source_config {:card_id     old-source-id
+                                                               :value_field [:field "ID" {:base-type :type/Integer}]}}]}]
+            (replacement.source-swap/swap-source! [:dashboard dashboard-id]
+                                                  [:table (mt/id :orders)]
+                                                  [:table (mt/id :reviews)])
+            (is (= old-source-id
+                   (-> (t2/select-one :model/Dashboard dashboard-id)
+                       :parameters first :values_source_config :card_id)))))))))
 
 (deftest dashboard-swap-source!-parameter-mappings-card-to-card-test
   (testing "swap-source! should walk parameter mapping targets without corruption during card-to-card swap"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72280
## Summary

Fixes [GHY-3372](https://linear.app/metabase/issue/GHY-3372/replacing-sources-doesnt-update-parameter-value-source-card-id) / #72280.

When a card-to-card source replacement runs, dashboards and cards whose parameters use the old card as a dropdown source (`parameter.values_source_config.card_id`) were left pointing at the old card. The dependency graph correctly switched to the new card, but parameter dropdowns silently kept the old one — leaving the system inconsistent (dep graph says Q3, runtime says Q2).

This PR rewrites `:parameters values_source_config.card_id` in both `card-swap-source!` and `dashboard-swap-source!` for card-to-card swaps. The existing `before-update` hooks on `Card` and `Dashboard` propagate the change to the `parameter_card` join table automatically — no explicit upsert call needed. Card-to-table swaps are intentionally left untouched (parameter `values_source_config` is card-shaped; the old debate from the issue thread is preserved).

The fix essentially restores `walk-parameter-source-card-ids` (removed in `b12429ac045` on the original feature branch before it shipped) and extends the previously dashboard-only behaviour to cover cards too — Repro-Bot identified that gap.

## Test plan

- [x] Wrote tests **before** implementing; confirmed they fail with `expected: <new-id>, actual: <old-id>` (bug reproduced):
  - `card-swap-source!-updates-parameter-values-source-config-card-id-test`
  - `dashboard-swap-source!-updates-parameter-values-source-config-card-id-test`
- [x] Both pass after fix; each also asserts the `parameter_card` row is synced.
- [x] Added `card-to-table-leaves-parameter-untouched` tests (card and dashboard) to lock in the card-to-card-only scope constraint.
- [x] Full `metabase-enterprise.replacement.source-swap-test` namespace: **26 tests, 42 assertions, 0 failures, 0 errors**.
- [x] kondo on touched files: 0 errors, 0 warnings.
- [ ] Manual repro per the Linear steps (Q1 native SQL with dropdown from Q2 → swap Q2→Q3 → confirm Q1's dropdown now uses Q3).