### PR TITLE
Return 204 No Content from CSV append/replace endpoints

### DIFF
--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -440,10 +440,8 @@
                [:file (ms/InstanceOfClass java.io.File)]
                [:action upload/update-action-schema]]]
   (try
-    (let [_result (upload/update-csv! options)]
-      {:status 200
-       ;; There is scope to return something more interesting.
-       :body   nil})
+    (upload/update-csv! options)
+    api/generic-204-no-content
     (catch Throwable e
       {:status (or (-> e ex-data :status-code)
                    500)

--- a/test/metabase/transforms/timeout_test.clj
+++ b/test/metabase/transforms/timeout_test.clj
@@ -44,19 +44,16 @@
               (is (= 1 (count timed-out)))
               (is (= :timeout (t2/select-one-fn :status :model/TransformRun :id old-run-id)))
               (is (= :started (t2/select-one-fn :status :model/TransformRun :id fresh-run-id)))))
-
           (testing "counter bumps {type=transform} once for the stale run"
             (is (== 1 (mt/metric-value system
                                        :metabase-transforms/timeouts-total
                                        {:type "transform"}))))
-
           (testing "histogram observes one positive sample for the stale run"
             (let [hist (mt/metric-value system
                                         :metabase-transforms/timeout-detection-latency-ms
                                         {:type "transform"})]
               (is (= 1 (long (:count hist))))
               (is (pos? (:sum hist)))))
-
           (testing "audit event is published with topic transform-run-timeout"
             (let [entry (mt/latest-audit-log-entry :transform-run-timeout old-run-id)]
               (is (some? entry))
@@ -65,7 +62,6 @@
               (is (= old-run-id (:model_id entry)))
               (testing "payload reflects the post-update :timeout status (parity with single-run path)"
                 (is (= "timeout" (some-> entry :details :status))))))))
-
       (testing "no metric activity when there are no stale runs"
         (let [inc-calls     (atom [])
               observe-calls (atom [])]
@@ -82,7 +78,6 @@
                   "sweeper did not increment :metabase-transforms/timeouts-total")
               (is (not-any? #{:metabase-transforms/timeout-detection-latency-ms} @observe-calls)
                   "sweeper did not observe :metabase-transforms/timeout-detection-latency-ms")))))
-
       (testing "single-run timeout-run! bumps counter and publishes audit event"
         (prometheus/clear! :metabase-transforms/timeouts-total)
         (mt/with-temp [:model/Transform    {transform-id :id} {}
@@ -100,7 +95,6 @@
             (is (some? entry))
             (is (= run-id (:model_id entry)))
             (is (= "timeout" (some-> entry :details :status))))))
-
       (testing "job-run sweeper bumps {type=job} counter and observes histogram per timed-out job run"
         (prometheus/clear! :metabase-transforms/timeouts-total)
         (prometheus/clear! :metabase-transforms/timeout-detection-latency-ms)

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1115,7 +1115,7 @@
     (mt/with-empty-db
       (testing "Happy path"
         (upload-test/with-uploads-enabled!
-          (is (= {:status 200, :body nil}
+          (is (= {:status 204, :body nil}
                  (update-csv-via-api! :metabase.upload/append)))))
       (testing "Failure paths return an appropriate status code and a message in the body"
         (upload-test/with-uploads-disabled!
@@ -1146,7 +1146,7 @@
     (mt/with-empty-db
       (testing "Happy path"
         (upload-test/with-uploads-enabled!
-          (is (= {:status 200, :body nil}
+          (is (= {:status 204, :body nil}
                  (update-csv-via-api! :metabase.upload/replace)))))
       (testing "Failure paths return an appropriate status code and a message in the body"
         (upload-test/with-uploads-disabled!


### PR DESCRIPTION
The `update-csv!` helper hand-rolled a `{:status 200 :body nil}` response map, which slips through the `wrap-response-if-needed` middleware (see metabase.api.common.internal) and makes it return status 200 even though it should be 204 because there is no content.

This is the only API endpoint that does that and it requires special handling in the API client which isn't free. Getting rid of that is nice.

This PR switched the endpoint to use `api/generic-204-no-content`  so the response carries the correct content type.

The FE callers (`appendTableCsv` and `replaceTableCsv` in `frontend/src/metabase/api/table.ts`) are typed `void` and the consumer in `frontend/src/metabase/redux/uploads.ts` uses `response || modelId`, so neither the old `null` body nor the new empty 204 changes observable behavior.