### PR TITLE
Fix DatePicker css import

### DIFF
--- a/frontend/src/metabase/querying/common/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/metabase/querying/common/components/DatePicker/DatePicker.stories.tsx
@@ -16,7 +16,7 @@ import { Box, Popover } from "metabase/ui";
 
 import { DatePicker } from "./DatePicker";
 
-import "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
+import "metabase/embedding/theme.module.css";
 
 const storeInitialState = createMockState({
   settings: mockSettings(),


### PR DESCRIPTION
The theme styles got moved into shared previously to allow for imports like this