### PR TITLE
Seed suggested prompts for each enabled built-in Metabot

### DIFF
--- a/src/metabase/metabot/task/suggested_prompts_generator.clj
+++ b/src/metabase/metabot/task/suggested_prompts_generator.clj
@@ -4,6 +4,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.metabot.config :as metabot.config]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
    [metabase.metabot.usage :as metabot.usage]
    [metabase.request.core :as request]
@@ -20,36 +21,53 @@
 (def ^:private generator-job-key (jobs/key "metabase.task.metabot.suggested-prompts-generator.job"))
 (def ^:private generator-trigger-key (triggers/key "metabase.task.metabot.suggested-prompts-generator.trigger"))
 
-(defn- maybe-generate-suggested-prompts! []
-  (try
-    (cond
-      (not (metabot.config/any-metabot-enabled?))
-      (log/info "Metabot is disabled. Skipping suggested prompt generation.")
+(defn- enabled-builtin-metabots
+  "Built-in Metabot config IDs to seed, each gated on its own enabled setting."
+  []
+  ;; Internal and embedded both serve prompts from the same per-`metabot_id` endpoint, so each
+  ;; enabled bot needs its own seed.
+  (cond-> []
+    (metabot.settings/metabot-enabled?)          (conj metabot.config/internal-metabot-id)
+    (metabot.settings/embedded-metabot-enabled?) (conj metabot.config/embedded-metabot-id)))
 
-      ;; Pre-check so a locked managed-AI instance logs a clean info-level skip instead of bubbling
-      ;; the 402 from `generate-sample-prompts` up into the catch as a noisy startup error.
-      (metabot.usage/managed-free-limit-reached?)
-      (log/info "Managed AI free limit reached. Skipping suggested prompt generation.")
+(defn- generate-suggested-prompts-for-metabot! [config-id]
+  (let [metabot-eid (get-in metabot.config/metabot-config [config-id :entity-id])
+        metabot-id  (t2/select-one-pk :model/Metabot :entity_id metabot-eid)]
+    (cond
+      (nil? metabot-id)
+      (log/warnf "No Metabot instance found for %s. Skipping suggested prompt generation." config-id)
+
+      (pos? (t2/count :model/MetabotPrompt :metabot_id metabot-id))
+      (log/infof "Suggested prompts are present for %s. Not generating." config-id)
 
       :else
-      ;; Run as admin since this is a system task generating prompts for all content in scope.
-      ;; Users will only see prompts for content they have access to (filtered at query time).
-      (request/as-admin
-        (let [metabot-eid (get-in metabot.config/metabot-config
-                                  [metabot.config/internal-metabot-id :entity-id])
-              metabot-id  (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
-              suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
-          (if (zero? suggested-prompts-cnt)
-            (do
-              (log/info "No suggested prompts found. Generating suggested prompts.")
-              (metabot.suggested-prompts/generate-sample-prompts metabot-id)
-              (log/info "Suggested prompts generated successfully."))
-            (log/info "Suggested prompts are present. Not generating.")))))
+      (do
+        (log/infof "No suggested prompts found for %s. Generating suggested prompts." config-id)
+        (metabot.suggested-prompts/generate-sample-prompts metabot-id)
+        (log/infof "Suggested prompts generated successfully for %s." config-id)))))
+
+(defn- maybe-generate-suggested-prompts! []
+  (try
+    (let [config-ids (enabled-builtin-metabots)]
+      (cond
+        (empty? config-ids)
+        (log/info "Metabot is disabled. Skipping suggested prompt generation.")
+
+        ;; Pre-check so a locked managed-AI instance logs a clean info-level skip instead of bubbling
+        ;; the 402 from `generate-sample-prompts` up into the catch as a noisy startup error.
+        (metabot.usage/managed-free-limit-reached?)
+        (log/info "Managed AI free limit reached. Skipping suggested prompt generation.")
+
+        :else
+        ;; Run as admin since this is a system task generating prompts for all content in scope.
+        ;; Users will only see prompts for content they have access to (filtered at query time).
+        (request/as-admin
+          (run! generate-suggested-prompts-for-metabot! config-ids))))
     (catch Exception e
       (log/errorf "Suggested prompts generation failed: %s" (.getMessage e)))))
 
 (task/defjob ^{DisallowConcurrentExecution true
-               :doc "Initial _suggested prompts_ generation for internal Metabot."}
+               :doc "Initial _suggested prompts_ generation for the enabled built-in Metabot instances."}
   SuggestedPromptsGenerator [_ctx]
   (maybe-generate-suggested-prompts!))
 

--- a/test/metabase/metabot/task/suggested_prompts_generator_test.clj
+++ b/test/metabase/metabot/task/suggested_prompts_generator_test.clj
@@ -15,63 +15,105 @@
 (deftest suggested-prompts-generator-test
   (mt/with-premium-features #{:content-verification}
     (mt/with-empty-h2-app-db!
-      (let [original-metabot (t2/select-one :model/Metabot
-                                            :entity_id (get-in metabot.config/metabot-config
-                                                               [metabot.config/internal-metabot-id :entity-id]))
-            mp (mt/metadata-provider)
-            query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                      lib.convert/->legacy-MBQL)
-            admin-id (:id (mt/fetch-user :crowberto))]
-        (mt/with-model-cleanup [:model/MetabotPrompt]
-          (mt/with-temp
-            [:model/Card
-             {card-id :id}
-             {:type :model
-              :dataset_query query}]
-            (mt/with-dynamic-fn-redefs [metabot.example-question-generator/generate-example-questions
-                                        (fn [input]
-                                          ;; Return fake prompts if we have cards, empty otherwise
-                                          (if (or (seq (:metrics input)) (seq (:tables input)))
-                                            {:table_questions [{:questions ["What is the total for this model?"
-                                                                            "How many items are in this model?"]}]
-                                             :metric_questions [{:questions ["What is the current value of this metric?"
-                                                                             "How has this metric changed over time?"]}]}
-                                            {:table_questions []
-                                             :metric_questions []}))]
-              (testing "Non-verified card with use_verified_content=false generates prompts"
-                (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                  (is (seq prompts))))
-              (testing "Non-verified card with use_verified_content=true generates no prompts"
-                (t2/delete! :model/MetabotPrompt)
-                (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
-                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                  (is (empty? prompts))))
-              (testing "Verified card generates prompts regardless of use_verified_content"
-                (mt/with-temp
-                  [:model/ModerationReview
-                   _
-                   {:moderator_id admin-id
-                    :moderated_item_id card-id
-                    :moderated_item_type "card"
-                    :status "verified"
-                    :most_recent true}]
-                  (testing "with use_verified_content=true"
-                    (t2/delete! :model/MetabotPrompt)
-                    (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
-                    (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                    (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                      (is (seq prompts))))
-                  (testing "with use_verified_content=false"
-                    (t2/delete! :model/MetabotPrompt)
-                    (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-                    (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                    (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                      (is (seq prompts))))))
-              ;; Reset metabot state
-              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false}))))))))
+      ;; Keep this test focused on the internal bot's verified-content gating; the embedded bot is
+      ;; seeded separately (see `enabled-builtin-metabots-test`) and would otherwise add prompts.
+      (mt/with-temporary-setting-values [metabot.settings/embedded-metabot-enabled? false]
+        (let [original-metabot (t2/select-one :model/Metabot
+                                              :entity_id (get-in metabot.config/metabot-config
+                                                                 [metabot.config/internal-metabot-id :entity-id]))
+              mp (mt/metadata-provider)
+              query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                        lib.convert/->legacy-MBQL)
+              admin-id (:id (mt/fetch-user :crowberto))]
+          (mt/with-model-cleanup [:model/MetabotPrompt]
+            (mt/with-temp
+              [:model/Card
+               {card-id :id}
+               {:type :model
+                :dataset_query query}]
+              (mt/with-dynamic-fn-redefs [metabot.example-question-generator/generate-example-questions
+                                          (fn [input]
+                                            ;; Return fake prompts if we have cards, empty otherwise
+                                            (if (or (seq (:metrics input)) (seq (:tables input)))
+                                              {:table_questions [{:questions ["What is the total for this model?"
+                                                                              "How many items are in this model?"]}]
+                                               :metric_questions [{:questions ["What is the current value of this metric?"
+                                                                               "How has this metric changed over time?"]}]}
+                                              {:table_questions []
+                                               :metric_questions []}))]
+                (testing "Non-verified card with use_verified_content=false generates prompts"
+                  (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+                  (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                  (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                    (is (seq prompts))))
+                (testing "Non-verified card with use_verified_content=true generates no prompts"
+                  (t2/delete! :model/MetabotPrompt)
+                  (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
+                  (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                  (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                    (is (empty? prompts))))
+                (testing "Verified card generates prompts regardless of use_verified_content"
+                  (mt/with-temp
+                    [:model/ModerationReview
+                     _
+                     {:moderator_id admin-id
+                      :moderated_item_id card-id
+                      :moderated_item_type "card"
+                      :status "verified"
+                      :most_recent true}]
+                    (testing "with use_verified_content=true"
+                      (t2/delete! :model/MetabotPrompt)
+                      (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
+                      (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                      (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                        (is (seq prompts))))
+                    (testing "with use_verified_content=false"
+                      (t2/delete! :model/MetabotPrompt)
+                      (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+                      (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                      (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                        (is (seq prompts))))))
+                ;; Reset metabot state
+                (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})))))))))
+
+(defn- enabled-builtin-metabots-with [internal? embedded?]
+  (mt/with-dynamic-fn-redefs [metabot.settings/metabot-enabled?          (constantly internal?)
+                              metabot.settings/embedded-metabot-enabled? (constantly embedded?)]
+    (#'metabot.task.suggested-prompts-generator/enabled-builtin-metabots)))
+
+(deftest enabled-builtin-metabots-test
+  (testing "only built-in bots whose own setting is enabled are seeded"
+    (is (= [metabot.config/internal-metabot-id metabot.config/embedded-metabot-id]
+           (enabled-builtin-metabots-with true true)))
+    (testing "internal disabled, embedded enabled -> only embedded (no longer seeds the disabled internal bot)"
+      (is (= [metabot.config/embedded-metabot-id]
+             (enabled-builtin-metabots-with false true))))
+    (testing "both disabled -> none"
+      (is (empty? (enabled-builtin-metabots-with false false))))))
+
+(deftest seeds-each-enabled-builtin-metabot-test
+  (testing "each enabled built-in bot gets its own suggested prompts seeded"
+    (mt/with-premium-features #{:content-verification}
+      (mt/with-empty-h2-app-db!
+        (mt/with-temporary-setting-values [metabot.settings/metabot-enabled?          true
+                                           metabot.settings/embedded-metabot-enabled? true]
+          (let [mp (mt/metadata-provider)
+                query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                          lib.convert/->legacy-MBQL)
+                internal-id (metabot.config/normalize-metabot-id metabot.config/internal-metabot-id)
+                embedded-id (metabot.config/normalize-metabot-id metabot.config/embedded-metabot-id)]
+            (mt/with-model-cleanup [:model/MetabotPrompt]
+              (mt/with-temp [:model/Card {card-id :id} {:type :model, :dataset_query query}]
+                (mt/with-dynamic-fn-redefs [metabot.example-question-generator/generate-example-questions
+                                            (fn [_]
+                                              {:table_questions [{:questions ["What is the total for this model?"]}]
+                                               :metric_questions []})]
+                  (run! #(t2/update! :model/Metabot % {:use_verified_content false}) [internal-id embedded-id])
+                  (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                  (is (seq (t2/select :model/MetabotPrompt :metabot_id internal-id :card_id card-id))
+                      "internal bot is seeded")
+                  (is (seq (t2/select :model/MetabotPrompt :metabot_id embedded-id :card_id card-id))
+                      "embedded bot is seeded"))))))))))
 
 (deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
   (mt/with-premium-features #{:content-verification}


### PR DESCRIPTION
## Summary

Fixes a logic mismatch flagged in [#74406 review](https://github.com/metabase/metabase/pull/74406#discussion_r3313784883).

The task gated on `metabot.config/any-metabot-enabled?` — true if **internal OR embedded** Metabot is enabled — but then unconditionally seeded prompts for the bot only.

1. **Wrong-target generation** — if internal was *disabled* but embedded *enabled*, the task still generated prompts for the disabled internal bot.
2. **Embedded never seeded** — the embedded bot serves prompts from the same per-`metabot_id` endpoint (`GET /api/metabot/metabot/:id/prompt-suggestions`), but it was never seeded under any configuration.

## Behavior change

⚠️ When embedded Metabot is enabled, the startup task will now spend LLM tokens to seed its suggested prompts (previously it never did). This is the intended fix — embedded already served those prompts via the API.

## Tests

- Kept the existing verified-content test focused on the internal bot (embedded disabled so it doesn't add prompts).
- Added `enabled-builtin-metabots-test` — per-instance gating, including the internal-off / embedded-on case.
- Added `seeds-each-enabled-builtin-metabot-test` — both enabled bots get their own prompts.
