### PR TITLE
Fix flaky guest-embed happy path checkbox visibility

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-oss.cy.spec.ts
@@ -168,13 +168,16 @@ describe(
 
         // Options step
         cy.findByLabelText("Allow people to drill through on data points")
+          .scrollIntoView()
           .should("be.visible")
           .should("be.disabled");
         cy.findByLabelText("Allow downloads")
+          .scrollIntoView()
           .should("be.visible")
           .should("be.disabled")
           .should("be.checked");
         cy.findByLabelText("Allow people to save new questions")
+          .scrollIntoView()
           .should("be.visible")
           .should("be.disabled");
 


### PR DESCRIPTION
Closes [EMB-1800: [Flaky Test] Happy path scenarios > embedding > sdk iframe embed setup > guest-embed Happy path Navigates through the guest-embed flow for a question and opens its embed page](https://linear.app/metabase/issue/EMB-1800/flaky-test-e2e-tests-happy-path-scenarios-embedding-sdk-iframe-embed)

### Description

The `should("be.visible")` assertions on the three "Behavior" checkboxes in the guest-embed Happy path test intermittently failed with:

> This element is not visible because its ancestor has `position: fixed` CSS property and it is overflowed by other elements.

The checkboxes live inside `.SidebarContent` (`overflow-y: auto`) nested in `.Sidebar` (`overflow: hidden`). When the layout hadn't fully settled at assertion time, Cypress's visibility heuristic reported the input as overflowed. Adding `.scrollIntoView()` before each visibility check stabilizes the assertion.

### How to verify

100-burn stress test on this branch: https://github.com/metabase/metabase/actions/runs/26628654419

### Checklist

- [x] Tests have been added/updated to cover changes in this PR