### PR TITLE
Replace abandoned verify-pr-label-action with inline gh check

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -12,25 +12,15 @@ jobs:
     name: Decide whether to backport or not
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
+    permissions: {}
     steps:
-      # Replaces jesusvasquez333/verify-pr-label-action (last release 2021), which crashes
-      # with `AttributeError: 'NoneType' object has no attribute 'get'` on transient
-      # GitHub API hiccups during paginated label fetch.
-      - name: Verify backport decision label is present
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+      - name: Fail if backport decision label is missing
+        if: >
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.labels.*.name, 'no-backport') &&
+          !contains(github.event.pull_request.labels.*.name, 'backport') &&
+          !contains(github.event.pull_request.labels.*.name, 'double-backport') &&
+          !contains(github.event.pull_request.labels.*.name, 'triple-backport')
         run: |
-          set -euo pipefail
-          valid='no-backport backport double-backport triple-backport'
-          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
-          for v in $valid; do
-            if printf '%s\n' "$labels" | grep -qFx "$v"; then
-              echo "Found backport label: $v"
-              exit 0
-            fi
-          done
-          echo "::error::PR is missing a backport decision label. Add one of: $valid"
+          echo "::error::PR is missing a backport decision label. Add one of: no-backport, backport, double-backport, triple-backport"
           exit 1

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -13,8 +13,24 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
-      - uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-          valid-labels: 'no-backport, backport, double-backport, triple-backport'
-          disable-reviews: true
+      # Replaces jesusvasquez333/verify-pr-label-action (last release 2021), which crashes
+      # with `AttributeError: 'NoneType' object has no attribute 'get'` on transient
+      # GitHub API hiccups during paginated label fetch.
+      - name: Verify backport decision label is present
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          valid='no-backport backport double-backport triple-backport'
+          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+          for v in $valid; do
+            if printf '%s\n' "$labels" | grep -qFx "$v"; then
+              echo "Found backport label: $v"
+              exit 0
+            fi
+          done
+          echo "::error::PR is missing a backport decision label. Add one of: $valid"
+          exit 1


### PR DESCRIPTION
## Problem

The `Decide whether to backport or not` job uses [`jesusvasquez333/verify-pr-label-action`](https://github.com/jesusvasquez333/verify-pr-label-action), whose last release was March 2021 — effectively abandoned.

It intermittently crashes with:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "/usr/local/lib/python3.6/site-packages/github/Requester.py", line 387, in __createException
    elif status == 404 and output.get('message') == 'Not Found':
```

This happens when the PyGithub paginated label fetch gets a transient response the action's own exception handler doesn't guard against. The job fails red, and downstream jobs that gate on its outcome end up skipped — every retry round burns CI time.

(While we're here: the action's startup log line `Invalid labels are: ['']` is just the default of the unset `invalid-labels` input — benign, not the cause of the crash.)

## Fix

~~Replace with a few lines of `gh` CLI in the workflow:~~

Just use job conditions, neat!