### PR TITLE
Partial rollout of JUnit hook-failure rewriting for select e2e specs

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -158,13 +158,18 @@ jobs:
         # whether to fail or to pass the whole job, based on the quarantine list.
         continue-on-error: true
 
-      - name: Rewrite JUnit hook failures (dry-run)
+      - name: Rewrite JUnit hook failures (partial rollout)
         if: always()
         continue-on-error: true
         shell: bash
         run: |
           if [ -d ./target/junit ]; then
-            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+            bun e2e/support/fix-junit-hooks.ts ./target/junit \
+              --include sharing/public-resource-downloads \
+              --include sharing/sharing-reproductions \
+              --include visualizations-charts/custom-viz \
+              --include metabot/metabot-query-builder \
+              --include dashboard-filters/dashboard-filters-location
           else
             echo "No ./target/junit directory; nothing to process."
           fi


### PR DESCRIPTION
Contributes to [GDGT-2424](https://linear.app/metabase/issue/GDGT-2424)

### Description

Continuing the hook-failure work (investigation: [GDGT-2426](https://linear.app/metabase/issue/GDGT-2426)). `e2e/support/fix-junit-hooks.ts` has been running on CI in `--dry-run` — I spot-checked a random sample of 20 of the last week's records and the rewrite attributes hook failures to the right test, so we're starting a partial rollout. This flips the e2e step from dry-run to a real rewrite, scoped via `--include` to a few specs:

- `sharing/public-resource-downloads`
- `sharing/sharing-reproductions`
- `visualizations-charts/custom-viz`
- `metabot/metabot-query-builder`
- `dashboard-filters/dashboard-filters-location`

**Why these:** these specs have all had hook failures recently. Unlike some other specs (e.g. the mongo suite) that are more thoroughly broken and fail on master, these aren't as broken — so enabling the rewrite for them should at most cause very small disruption until Trunk catches up and quarantines broken/flaky tests.

**Why partial first:** a real rewrite changes what we upload to Trunk, so scoping to a handful of specs keeps the blast radius small while we confirm everything works as expected. Non-matching specs pass through untouched.

**Next steps** (once this is merged and looks good): drop the `--include` flag for a full rollout across all specs, then clean up the existing phantom entries in Trunk.

### How to verify

Hard to verify directly on the PR — the listed specs won't necessarily fail here. The real signal is long-term: after merge we should stop seeing new phantom `… "before each" hook for …` entries in Trunk for these specs, with hook failures attributing to the real test instead.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
