### PR TITLE
Notifications admin include today

### DIFF
--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -101,12 +101,16 @@ export interface RunEntity {
   entity_name?: string;
 }
 
+export type TaskRunStartedAtParam =
+  | TaskRunDateFilterOption
+  | `${TaskRunDateFilterOption}~`;
+
 export type ListTaskRunsRequest = {
   "run-type"?: TaskRunType;
   "entity-type"?: TaskRunEntityType;
   "entity-id"?: number;
   status?: TaskRunStatus;
-  "started-at"?: TaskRunDateFilterOption;
+  "started-at"?: TaskRunStartedAtParam;
 } & PaginationRequest;
 
 export type ListTaskRunsResponse = {
@@ -115,5 +119,5 @@ export type ListTaskRunsResponse = {
 
 export type ListTaskRunEntitiesRequest = {
   "run-type": TaskRunType;
-  "started-at": TaskRunDateFilterOption;
+  "started-at": TaskRunStartedAtParam;
 };

--- a/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
@@ -5,6 +5,8 @@ import { skipToken, useListTaskRunEntitiesQuery } from "metabase/api";
 import { Loader, Select, type SelectProps, Tooltip } from "metabase/ui";
 import type { TaskRunDateFilterOption, TaskRunType } from "metabase-types/api";
 
+import { toBackendStartedAt } from "../../utils";
+
 import type { EntityValue } from "./types";
 import {
   convertEntitiesToSelectOptions,
@@ -18,6 +20,7 @@ type TaskRunEntityPickerProps = Omit<
 > & {
   runType: TaskRunType | null;
   startedAt: TaskRunDateFilterOption | null;
+  includeToday: boolean;
   value: EntityValue | null;
   onChange: (value: EntityValue | null) => void;
 };
@@ -25,16 +28,18 @@ type TaskRunEntityPickerProps = Omit<
 export const TaskRunEntityPicker = ({
   runType,
   startedAt,
+  includeToday,
   value,
   onChange,
   ...props
 }: TaskRunEntityPickerProps) => {
-  const hasAllRequiredParams = runType && startedAt;
+  const effectiveStartedAt = toBackendStartedAt(startedAt, includeToday);
+  const hasAllRequiredParams = runType && effectiveStartedAt;
   const { data: entities, isLoading } = useListTaskRunEntitiesQuery(
     hasAllRequiredParams
       ? {
           "run-type": runType,
-          "started-at": startedAt,
+          "started-at": effectiveStartedAt,
         }
       : skipToken,
   );

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -42,14 +42,13 @@ export const TaskRunDatePicker = ({
   placeholder,
   onChange,
 }: TaskRunDatePickerProps) => {
+  const isIncludeTodayAllowed = (value: TaskRunDateFilterOption | null) =>
+    value !== null && value !== "thisday";
+
   const emit = (
     next: TaskRunDateFilterOption | null,
     nextIncludeToday: boolean,
-  ) =>
-    onChange(
-      next,
-      next === null || next === "thisday" ? false : nextIncludeToday,
-    );
+  ) => onChange(next, isIncludeTodayAllowed(next) && nextIncludeToday);
 
   const [opened, setOpened] = useState<boolean>(false);
   /**
@@ -68,7 +67,7 @@ export const TaskRunDatePicker = ({
   ];
 
   const selectedLabel = options.find((option) => option.value === value)?.label;
-  const includeTodayAllowed = value !== null && value !== "thisday";
+  const includeTodayAllowed = isIncludeTodayAllowed(value);
 
   const displayLabel = (() => {
     if (!selectedLabel) {

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -27,7 +27,6 @@ type TaskRunDatePickerProps = {
 
 type DateOption = {
   label: string;
-  includeTodayLabel?: string;
   value: TaskRunDateFilterOption;
 };
 
@@ -58,42 +57,24 @@ export const TaskRunDatePicker = ({
    */
   const options: DateOption[] = [
     { label: t`Today`, value: "thisday" },
-    {
-      label: t`Yesterday`,
-      includeTodayLabel: t`Yesterday, including today`,
-      value: "past1days",
-    },
-    {
-      label: t`Previous week`,
-      includeTodayLabel: t`Previous week, including today`,
-      value: "past1weeks",
-    },
-    {
-      label: t`Previous 7 days`,
-      includeTodayLabel: t`Previous 7 days, including today`,
-      value: "past7days",
-    },
-    {
-      label: t`Previous 30 days`,
-      includeTodayLabel: t`Previous 30 days, including today`,
-      value: "past30days",
-    },
-    {
-      label: t`Previous month`,
-      includeTodayLabel: t`Previous month, including today`,
-      value: "past1months",
-    },
-    {
-      label: t`Previous 3 months`,
-      includeTodayLabel: t`Previous 3 months, including today`,
-      value: "past3months",
-    },
-    {
-      label: t`Previous 12 months`,
-      includeTodayLabel: t`Previous 12 months, including today`,
-      value: "past12months",
-    },
+    { label: t`Yesterday`, value: "past1days" },
+    { label: t`Previous week`, value: "past1weeks" },
+    { label: t`Previous 7 days`, value: "past7days" },
+    { label: t`Previous 30 days`, value: "past30days" },
+    { label: t`Previous month`, value: "past1months" },
+    { label: t`Previous 3 months`, value: "past3months" },
+    { label: t`Previous 12 months`, value: "past12months" },
   ];
+
+  const includeTodayLabels: Partial<Record<TaskRunDateFilterOption, string>> = {
+    past1days: t`Yesterday, including today`,
+    past1weeks: t`Previous week, including today`,
+    past7days: t`Previous 7 days, including today`,
+    past30days: t`Previous 30 days, including today`,
+    past1months: t`Previous month, including today`,
+    past3months: t`Previous 3 months, including today`,
+    past12months: t`Previous 12 months, including today`,
+  };
 
   const selectedOption = options.find((option) => option.value === value);
   const includeTodayAllowed = isIncludeTodayAllowed(value);
@@ -102,12 +83,10 @@ export const TaskRunDatePicker = ({
     if (!selectedOption) {
       return null;
     }
-    if (
-      includeToday &&
-      includeTodayAllowed &&
-      selectedOption.includeTodayLabel
-    ) {
-      return selectedOption.includeTodayLabel;
+    const includeTodayLabel =
+      value !== null ? includeTodayLabels[value] : undefined;
+    if (includeToday && includeTodayAllowed && includeTodayLabel) {
+      return includeTodayLabel;
     }
     return selectedOption.label;
   })();

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -106,6 +106,7 @@ export const TaskRunDatePicker = ({
         <Input
           component="button"
           type="button"
+          data-testid="task-run-date-picker"
           pointer
           w={PICKER_WIDTH}
           styles={{

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "react";
 import { useState } from "react";
-import { c, t } from "ttag";
+import { t } from "ttag";
 
 import {
   Combobox,
@@ -27,6 +27,7 @@ type TaskRunDatePickerProps = {
 
 type DateOption = {
   label: string;
+  includeTodayLabel?: string;
   value: TaskRunDateFilterOption;
 };
 
@@ -57,27 +58,58 @@ export const TaskRunDatePicker = ({
    */
   const options: DateOption[] = [
     { label: t`Today`, value: "thisday" },
-    { label: t`Yesterday`, value: "past1days" },
-    { label: t`Previous week`, value: "past1weeks" },
-    { label: t`Previous 7 days`, value: "past7days" },
-    { label: t`Previous 30 days`, value: "past30days" },
-    { label: t`Previous month`, value: "past1months" },
-    { label: t`Previous 3 months`, value: "past3months" },
-    { label: t`Previous 12 months`, value: "past12months" },
+    {
+      label: t`Yesterday`,
+      includeTodayLabel: t`Yesterday, including today`,
+      value: "past1days",
+    },
+    {
+      label: t`Previous week`,
+      includeTodayLabel: t`Previous week, including today`,
+      value: "past1weeks",
+    },
+    {
+      label: t`Previous 7 days`,
+      includeTodayLabel: t`Previous 7 days, including today`,
+      value: "past7days",
+    },
+    {
+      label: t`Previous 30 days`,
+      includeTodayLabel: t`Previous 30 days, including today`,
+      value: "past30days",
+    },
+    {
+      label: t`Previous month`,
+      includeTodayLabel: t`Previous month, including today`,
+      value: "past1months",
+    },
+    {
+      label: t`Previous 3 months`,
+      includeTodayLabel: t`Previous 3 months, including today`,
+      value: "past3months",
+    },
+    {
+      label: t`Previous 12 months`,
+      includeTodayLabel: t`Previous 12 months, including today`,
+      value: "past12months",
+    },
   ];
 
-  const selectedLabel = options.find((option) => option.value === value)?.label;
+  const selectedOption = options.find((option) => option.value === value);
   const includeTodayAllowed = isIncludeTodayAllowed(value);
 
   const displayLabel = (() => {
-    if (!selectedLabel) {
+    if (!selectedOption) {
       return null;
     }
-    if (includeToday && includeTodayAllowed) {
-      return c("Date range with include-today suffix")
-        .t`${selectedLabel}, including today`;
+    if (
+      includeToday &&
+      includeTodayAllowed &&
+      selectedOption.includeTodayLabel
+    ) {
+      return selectedOption.includeTodayLabel;
     }
-    return selectedLabel;
+    return selectedOption.label;
   })();
 
   const handleClear = (event: MouseEvent) => {

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.tsx
@@ -1,27 +1,62 @@
-import { t } from "ttag";
+import type { MouseEvent } from "react";
+import { useState } from "react";
+import { c, t } from "ttag";
 
-import { Select, type SelectProps } from "metabase/ui";
-import type { SelectData } from "metabase/ui/components/inputs/Select/Select";
+import {
+  Combobox,
+  Group,
+  Input,
+  Popover,
+  Select,
+  Stack,
+  Switch,
+} from "metabase/ui";
 import type { TaskRunDateFilterOption } from "metabase-types/api";
 
-type TaskRunDatePickerProps = Omit<
-  SelectProps,
-  "data" | "value" | "onChange"
-> & {
+import { guardTaskRunStartedAtRange } from "../../utils";
+
+type TaskRunDatePickerProps = {
   value: TaskRunDateFilterOption | null;
-  onChange: (value: TaskRunDateFilterOption | null) => void;
+  includeToday: boolean;
+  placeholder?: string;
+  onChange: (
+    value: TaskRunDateFilterOption | null,
+    includeToday: boolean,
+  ) => void;
 };
 
+type DateOption = {
+  label: string;
+  value: TaskRunDateFilterOption;
+};
+
+const PICKER_WIDTH = 260;
+const RIGHT_SECTION_FULL_WIDTH = 52;
+
+/**
+ * TODO: this whole component (Select + Switch in a popover with a Select-like trigger) should be generalized.
+ */
 export const TaskRunDatePicker = ({
   value,
+  includeToday,
+  placeholder,
   onChange,
-  ...props
 }: TaskRunDatePickerProps) => {
+  const emit = (
+    next: TaskRunDateFilterOption | null,
+    nextIncludeToday: boolean,
+  ) =>
+    onChange(
+      next,
+      next === null || next === "thisday" ? false : nextIncludeToday,
+    );
+
+  const [opened, setOpened] = useState<boolean>(false);
   /**
    * Using a simple version of TimeFilterWidget here in order to align with a design of admin page.
    * That means no custom date ranges.
    */
-  const data: SelectData<TaskRunDateFilterOption> = [
+  const options: DateOption[] = [
     { label: t`Today`, value: "thisday" },
     { label: t`Yesterday`, value: "past1days" },
     { label: t`Previous week`, value: "past1weeks" },
@@ -32,23 +67,114 @@ export const TaskRunDatePicker = ({
     { label: t`Previous 12 months`, value: "past12months" },
   ];
 
+  const selectedLabel = options.find((option) => option.value === value)?.label;
+  const includeTodayAllowed = value !== null && value !== "thisday";
+
+  const displayLabel = (() => {
+    if (!selectedLabel) {
+      return null;
+    }
+    if (includeToday && includeTodayAllowed) {
+      return c("Date range with include-today suffix")
+        .t`${selectedLabel}, including today`;
+    }
+    return selectedLabel;
+  })();
+
+  const handleClear = (event: MouseEvent) => {
+    event.stopPropagation();
+    emit(null, false);
+  };
+
+  const handleSelectChange = (next: string | null) => {
+    if (next === null) {
+      emit(null, false);
+      return;
+    }
+    if (guardTaskRunStartedAtRange(next)) {
+      emit(next, includeToday);
+    }
+  };
+
   return (
-    <Select
-      comboboxProps={{
-        middlewares: {
-          flip: true,
-          size: {
-            padding: 6,
-          },
-        },
-        position: "bottom-start",
-        width: 300,
-      }}
-      clearable
-      data={data}
-      value={value}
-      onChange={onChange}
-      {...props}
-    />
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      position="bottom-start"
+      withinPortal
+    >
+      <Popover.Target>
+        <Input
+          component="button"
+          type="button"
+          pointer
+          w={PICKER_WIDTH}
+          styles={{
+            input: {
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              textAlign: "left",
+              // Mantine's `rightSectionWidth` only sets a CSS variable that
+              // the layered styles in this bundle don't pick up, so the input
+              // padding doesn't follow the section. Override it directly so
+              // long labels ellipsize instead of sliding under the icons.
+              paddingInlineEnd: RIGHT_SECTION_FULL_WIDTH,
+            },
+            section: {
+              width: "auto",
+              paddingRight: "10px",
+            },
+          }}
+          onClick={() => setOpened((open) => !open)}
+          rightSection={
+            <Group gap="xs" wrap="nowrap">
+              {value !== null && (
+                <Input.ClearButton
+                  size="sm"
+                  aria-label={t`Clear`}
+                  style={{
+                    pointerEvents: "all",
+                    color: "var(--mb-color-text-primary)",
+                  }}
+                  onClick={handleClear}
+                />
+              )}
+              <Combobox.Chevron />
+            </Group>
+          }
+          rightSectionPointerEvents="none"
+        >
+          {displayLabel ?? (
+            <Input.Placeholder c="text-tertiary">
+              {placeholder}
+            </Input.Placeholder>
+          )}
+        </Input>
+      </Popover.Target>
+
+      <Popover.Dropdown p="md">
+        <Stack gap="md" w={PICKER_WIDTH}>
+          <Select
+            data={options}
+            value={value}
+            aria-label={t`Date range`}
+            placeholder={t`Started at`}
+            comboboxProps={{
+              withinPortal: false,
+              floatingStrategy: "fixed",
+              position: "bottom-start",
+            }}
+            onChange={handleSelectChange}
+          />
+          <Switch
+            label={t`Include today`}
+            checked={includeToday && includeTodayAllowed}
+            disabled={!includeTodayAllowed}
+            onChange={(event) => emit(value, event.currentTarget.checked)}
+          />
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
   );
 };

--- a/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunStartedAtPicker/TaskRunDatePicker.unit.spec.tsx
@@ -1,0 +1,121 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { TaskRunDateFilterOption } from "metabase-types/api";
+
+import { TaskRunDatePicker } from "./TaskRunDatePicker";
+
+const PLACEHOLDER = "Filter by started at";
+
+type SetupOpts = {
+  value?: TaskRunDateFilterOption | null;
+  includeToday?: boolean;
+};
+
+const setup = ({ value = null, includeToday = false }: SetupOpts = {}) => {
+  const onChange = jest.fn();
+
+  const Wrapper = () => {
+    const [innerValue, setInnerValue] =
+      useState<TaskRunDateFilterOption | null>(value);
+    const [innerIncludeToday, setInnerIncludeToday] = useState(includeToday);
+
+    return (
+      <TaskRunDatePicker
+        value={innerValue}
+        includeToday={innerIncludeToday}
+        placeholder={PLACEHOLDER}
+        onChange={(nextValue, nextIncludeToday) => {
+          onChange(nextValue, nextIncludeToday);
+          setInnerValue(nextValue);
+          setInnerIncludeToday(nextIncludeToday);
+        }}
+      />
+    );
+  };
+
+  renderWithProviders(<Wrapper />);
+
+  return { onChange };
+};
+
+const openPicker = async () => {
+  await userEvent.click(screen.getByTestId("task-run-date-picker"));
+};
+
+const selectRange = async (label: string) => {
+  await userEvent.click(screen.getByPlaceholderText("Started at"));
+  await userEvent.click(await screen.findByRole("option", { name: label }));
+};
+
+describe("TaskRunDatePicker", () => {
+  it("renders the placeholder when there is no value", () => {
+    setup();
+    expect(screen.getByText(PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it("emits the selected range with the current include-today flag", async () => {
+    const { onChange } = setup();
+
+    await openPicker();
+    await selectRange("Previous week");
+
+    expect(onChange).toHaveBeenCalledWith("past1weeks", false);
+  });
+
+  it("disables the include-today switch when no range is selected", async () => {
+    setup();
+    await openPicker();
+
+    expect(
+      screen.getByRole("switch", { name: "Include today" }),
+    ).toBeDisabled();
+  });
+
+  it("disables the include-today switch and forces it off for Today", async () => {
+    const { onChange } = setup({ includeToday: true });
+
+    await openPicker();
+    await selectRange("Today");
+
+    expect(onChange).toHaveBeenCalledWith("thisday", false);
+    expect(
+      screen.getByRole("switch", { name: "Include today" }),
+    ).toBeDisabled();
+  });
+
+  it("emits the include-today flag when the switch is toggled", async () => {
+    const { onChange } = setup({ value: "past1weeks" });
+
+    await openPicker();
+    await userEvent.click(
+      screen.getByRole("switch", { name: "Include today" }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith("past1weeks", true);
+  });
+
+  it("shows the including-today suffix in the trigger label", async () => {
+    setup({ value: "past1weeks", includeToday: true });
+
+    expect(
+      screen.getByText("Previous week, including today"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the suffix for a range that disallows today", () => {
+    setup({ value: "thisday", includeToday: true });
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.queryByText(/including today/)).not.toBeInTheDocument();
+  });
+
+  it("clears the value through the clear button", async () => {
+    const { onChange } = setup({ value: "past1weeks", includeToday: true });
+
+    await userEvent.click(screen.getByLabelText("Clear"));
+
+    expect(onChange).toHaveBeenCalledWith(null, false);
+  });
+});

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -6,6 +6,7 @@ import { PaginationControls } from "metabase/common/components/PaginationControl
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { Flex } from "metabase/ui";
 
+import { toBackendStartedAt } from "../../utils";
 import { TaskRunTypePicker } from "../RunTypePicker";
 import { TaskRunEntityPicker } from "../TaskRunEntityPicker";
 import { TaskRunDatePicker } from "../TaskRunStartedAtPicker";
@@ -24,6 +25,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
       "entity-type": entityType,
       "entity-id": entityId,
       "started-at": startedAt,
+      "include-today": includeToday,
       status,
     },
     { patchUrlState },
@@ -40,7 +42,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
       "run-type": runType ?? undefined,
       "entity-type": entityType ?? undefined,
       "entity-id": entityId ?? undefined,
-      "started-at": startedAt ?? undefined,
+      "started-at": toBackendStartedAt(startedAt, includeToday),
       status: status ?? undefined,
     },
     {
@@ -71,10 +73,12 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
 
           <TaskRunDatePicker
             value={startedAt}
+            includeToday={includeToday}
             placeholder={t`Filter by started at`}
-            onChange={(startedAt) =>
+            onChange={(startedAt, includeToday) =>
               patchUrlState({
                 "started-at": startedAt,
+                "include-today": includeToday,
                 "entity-type": null,
                 "entity-id": null,
                 page: 0,
@@ -85,6 +89,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
           <TaskRunEntityPicker
             runType={runType}
             startedAt={startedAt}
+            includeToday={includeToday}
             value={entityValue}
             onChange={(entity) =>
               patchUrlState({

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -75,12 +75,14 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
             value={startedAt}
             includeToday={includeToday}
             placeholder={t`Filter by started at`}
-            onChange={(startedAt, includeToday) =>
+            onChange={(nextStartedAt, nextIncludeToday) =>
               patchUrlState({
-                "started-at": startedAt,
-                "include-today": includeToday,
-                "entity-type": null,
-                "entity-id": null,
+                "started-at": nextStartedAt,
+                "include-today": nextIncludeToday,
+                ...(nextStartedAt !== startedAt && {
+                  "entity-type": null,
+                  "entity-id": null,
+                }),
                 page: 0,
               })
             }

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -6,6 +6,7 @@ import { setupTaskRunsEndpoints } from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
+  waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import * as Urls from "metabase/urls";
@@ -19,11 +20,13 @@ const PATHNAME = Urls.adminToolsTasksRuns();
 interface SetupOpts {
   taskRunsResponse?: ListTaskRunsResponse;
   error?: boolean;
+  initialRoute?: string;
 }
 
 const setup = ({
   taskRunsResponse = createMockTaskRunsResponse(),
   error,
+  initialRoute = PATHNAME,
 }: SetupOpts = {}) => {
   if (error) {
     fetchMock.get("path:/api/task/runs", { status: 500 });
@@ -34,10 +37,25 @@ const setup = ({
   return renderWithProviders(
     <Route path={PATHNAME} component={TaskRunsPage} />,
     {
-      initialRoute: PATHNAME,
+      initialRoute,
       withRouter: true,
     },
   );
+};
+
+const getLastRunsParams = () => {
+  const calls = fetchMock.callHistory.calls("path:/api/task/runs");
+  const lastCall = calls[calls.length - 1];
+  return new URL(lastCall.url).searchParams;
+};
+
+const openDatePicker = async () => {
+  await userEvent.click(screen.getByTestId("task-run-date-picker"));
+};
+
+const selectRange = async (label: string) => {
+  await userEvent.click(screen.getByPlaceholderText("Started at"));
+  await userEvent.click(await screen.findByRole("option", { name: label }));
 };
 
 describe("TaskRunsPage", () => {
@@ -80,6 +98,76 @@ describe("TaskRunsPage", () => {
     await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
+
+  describe("started-at filter with include-today", () => {
+    it("requests with the ~ suffix when today is included", async () => {
+      setup();
+      await waitForLoaderToBeRemoved();
+
+      await openDatePicker();
+      await selectRange("Previous week");
+
+      await waitFor(() => {
+        expect(getLastRunsParams().get("started-at")).toBe("past1weeks");
+      });
+
+      await userEvent.click(
+        screen.getByRole("switch", { name: "Include today" }),
+      );
+
+      await waitFor(() => {
+        expect(getLastRunsParams().get("started-at")).toBe("past1weeks~");
+      });
+    });
+
+    it("keeps the selected entity when only include-today changes", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?run-type=alert&started-at=past1weeks&entity-type=card&entity-id=42`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      await openDatePicker();
+      await userEvent.click(
+        screen.getByRole("switch", { name: "Include today" }),
+      );
+
+      await waitFor(() => {
+        const params = getLastRunsParams();
+        expect(params.get("started-at")).toBe("past1weeks~");
+        expect(params.get("entity-type")).toBe("card");
+        expect(params.get("entity-id")).toBe("42");
+      });
+    });
+
+    it("clears the selected entity when the range changes", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?run-type=alert&started-at=past1weeks&entity-type=card&entity-id=42`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      await openDatePicker();
+      await selectRange("Previous 30 days");
+
+      await waitFor(() => {
+        const params = getLastRunsParams();
+        expect(params.get("started-at")).toBe("past30days");
+        expect(params.get("entity-type")).toBeNull();
+        expect(params.get("entity-id")).toBeNull();
+      });
+    });
+
+    it("restores the include-today filter from the URL", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?started-at=past1weeks&include-today=true`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      expect(
+        screen.getByText("Previous week, including today"),
+      ).toBeInTheDocument();
+      expect(getLastRunsParams().get("started-at")).toBe("past1weeks~");
+    });
   });
 });
 

--- a/frontend/src/metabase/admin/tools/components/TaskRunsPage/utils.ts
+++ b/frontend/src/metabase/admin/tools/components/TaskRunsPage/utils.ts
@@ -24,6 +24,7 @@ type UrlState = {
   "entity-id": number | null;
   status: TaskRunStatus | null;
   "started-at": TaskRunDateFilterOption | null;
+  "include-today": boolean;
 };
 
 export const urlStateConfig: UrlStateConfig<UrlState> = {
@@ -34,6 +35,7 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "entity-id": parseTaskRunEntityId(query["entity-id"]),
     status: parseTaskRunStatus(query.status),
     "started-at": parseTaskRunStartedAt(query["started-at"]),
+    "include-today": parseIncludeToday(query["include-today"]),
   }),
   serialize: ({
     page,
@@ -42,6 +44,7 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "entity-id": entityId,
     status,
     "started-at": startedAt,
+    "include-today": includeToday,
   }) => ({
     page: page === 0 ? undefined : String(page),
     "run-type": runType === null ? undefined : runType,
@@ -49,6 +52,7 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "entity-id": entityId === null ? undefined : String(entityId),
     status: status === null ? undefined : status,
     "started-at": startedAt === null ? undefined : startedAt,
+    "include-today": includeToday ? "true" : undefined,
   }),
 };
 
@@ -85,4 +89,8 @@ const parseTaskRunStatus = (param: QueryParam): UrlState["status"] => {
 const parseTaskRunStartedAt = (param: QueryParam): UrlState["started-at"] => {
   const value = getFirstParamValue(param);
   return value && guardTaskRunStartedAtRange(value) ? value : null;
+};
+
+const parseIncludeToday = (param: QueryParam): UrlState["include-today"] => {
+  return getFirstParamValue(param) === "true";
 };

--- a/frontend/src/metabase/admin/tools/notifications/NotificationDetailSidebar/NotificationRunSummaryLog.tsx
+++ b/frontend/src/metabase/admin/tools/notifications/NotificationDetailSidebar/NotificationRunSummaryLog.tsx
@@ -22,6 +22,8 @@ export const NotificationRunSummaryLog = ({
     runType: "alert",
     entityType: "card",
     entityId: cardId,
+    startedAt: "past3months",
+    includeToday: true,
   });
 
   const renderRuns = () => {

--- a/frontend/src/metabase/admin/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -567,6 +567,24 @@ describe("NotificationsAdminPage", () => {
       });
     });
 
+    it("points the run-history 'View all' links at the card runs, including today", async () => {
+      setup({ notifications: [notification1] });
+      await waitForLoaderToBeRemoved();
+
+      await userEvent.click(await screen.findByTestId("notification-row-1"));
+      expect(await screen.findByText("Alert 1")).toBeInTheDocument();
+
+      const [viewAll] = screen.getAllByRole("link", { name: "View all" });
+      const href = viewAll.getAttribute("href") ?? "";
+      const params = new URLSearchParams(href.split("?")[1]);
+
+      expect(params.get("run-type")).toBe("alert");
+      expect(params.get("entity-type")).toBe("card");
+      expect(params.get("entity-id")).toBe("1");
+      expect(params.get("started-at")).toBe("past3months");
+      expect(params.get("include-today")).toBe("true");
+    });
+
     it("shows loaders in the history sections while the alert detail loads", async () => {
       setup({ notifications: [notification1], detailDelay: 10_000 });
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -113,6 +113,8 @@ export const toBackendStartedAt = (
   if (!value) {
     return undefined;
   }
+  // A trailing "~" makes the date range open-ended on the upper bound,
+  // extending it through today so the current day's runs are included.
   return includeToday ? `${value}~` : value;
 };
 

--- a/frontend/src/metabase/admin/tools/utils.ts
+++ b/frontend/src/metabase/admin/tools/utils.ts
@@ -7,6 +7,7 @@ import type {
   TaskRun,
   TaskRunDateFilterOption,
   TaskRunEntityType,
+  TaskRunStartedAtParam,
   TaskRunStatus,
   TaskRunType,
   TaskStatus,
@@ -104,6 +105,16 @@ export const guardTaskRunStatus = (value: string): value is TaskRunStatus =>
   (
     ["started", "success", "failed", "abandoned"] satisfies TaskRunStatus[]
   ).includes(value as TaskRunStatus);
+
+export const toBackendStartedAt = (
+  value: TaskRunDateFilterOption | null,
+  includeToday: boolean,
+): TaskRunStartedAtParam | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  return includeToday ? `${value}~` : value;
+};
 
 export const guardTaskRunStartedAtRange = (
   value: string,

--- a/frontend/src/metabase/urls/admin.ts
+++ b/frontend/src/metabase/urls/admin.ts
@@ -191,6 +191,7 @@ export function adminToolsTasksRunsFor(opts: {
   entityType: TaskRunEntityType;
   entityId: number;
   startedAt?: TaskRunDateFilterOption;
+  includeToday?: boolean;
 }) {
   const params: Record<string, string> = {
     "run-type": opts.runType,
@@ -199,6 +200,9 @@ export function adminToolsTasksRunsFor(opts: {
   };
   if (opts.startedAt) {
     params["started-at"] = opts.startedAt;
+  }
+  if (opts.includeToday) {
+    params["include-today"] = "true";
   }
   return `${adminToolsTasksRuns()}?${new URLSearchParams(params).toString()}`;
 }


### PR DESCRIPTION
### Description

Add an ability to navigate to the Task Runs page with preselected entity-id filter by adding "Including today" option to the started-at filter. 

This is a sub-PR for https://github.com/metabase/metabase/pull/72909
