### PR TITLE
Ignore entities differences in Metabot search

### DIFF
--- a/resources/metabot/prompts/tools/nlq_search.md
+++ b/resources/metabot/prompts/tools/nlq_search.md
@@ -44,8 +44,9 @@ Each search should focus on a single conceptual area to maximize result quality.
 
 `entity_types`:
 - Optionally filter the results to specific data source types (tables, models, metrics, or questions).
-- Leave empty to search across all queryable entity types.
-- Use filtering when the user explicitly requests a specific type or when context makes it clear which types are relevant.
+- Leave empty to search across all queryable entity types — this is almost always the right choice.
+- Users often use terms like "table", "entity", "question", "card", "query", or "data source" loosely and interchangeably. Do NOT filter by entity type just because one of these words appears in the user's query.
+- Only filter entity_types when the user is unambiguously asking to restrict results to a specific type (e.g., "show me only metrics", "I need a question specifically — not a table").
 
 `limit`:
 - Optional. The maximum number of results to return. Defaults to 10 and is capped at 50.

--- a/resources/metabot/prompts/tools/search.md
+++ b/resources/metabot/prompts/tools/search.md
@@ -44,8 +44,9 @@ Each search should focus on a single conceptual area to maximize result quality.
 
 `entity_types`:
 - Optionally filter the results to specific data source types.
-- Leave empty to search broadly across all available entity types.
-- Use filtering when the user explicitly requests a specific type or when context makes it clear which types are relevant.
+- Leave empty to search broadly across all available entity types — this is almost always the right choice.
+- Users often use terms like "table", "entity", "question", "card", "query", or "data source" loosely and interchangeably. Do NOT filter by entity type just because one of these words appears in the user's query.
+- Only filter entity_types when the user is unambiguously asking to restrict results to a specific type (e.g., "show me only dashboards", "list all metrics — nothing else").
 
 `limit`:
 - Optional. The maximum number of results to return. Defaults to 10 and is capped at 50.

--- a/resources/metabot/prompts/tools/sql_search.md
+++ b/resources/metabot/prompts/tools/sql_search.md
@@ -47,8 +47,9 @@ Each search should focus on a single conceptual area to maximize result quality.
 
 `entity_types`:
 - Optionally filter the results to specific data source types (tables or models).
-- Leave empty to search across both tables and models.
-- Use filtering when the user explicitly requests a specific type or when context makes it clear which types are relevant.
+- Leave empty to search across both tables and models — this is almost always the right choice.
+- Users often use "table" loosely to mean any queryable data source, including models. Do NOT filter by entity type just because the word "table" appears in the user's query.
+- Only filter entity_types when the user is unambiguously asking to restrict results to a specific type (e.g., "show me only models", "raw tables only — not models").
 
 `limit`:
 - Optional. The maximum number of results to return. Defaults to 10 and is capped at 50.
@@ -71,14 +72,14 @@ What tables do we have for orders and customers?
 "semantic_queries": ["order data and transactions", "purchase and sales orders"],
 "keyword_queries": ["order", "orders", "purchase", "transaction"],
 "database_id": 123,
-"entity_types": ["table"]
+"entity_types": []
 </search_call_1>
 
 <search_call_2>
 "semantic_queries": ["customer information and profiles", "client and user data"],
 "keyword_queries": ["customer", "client", "user", "account"],
 "database_id": 123,
-"entity_types": ["table"]
+"entity_types": []
 </search_call_2>
 </example>
 


### PR DESCRIPTION
Closes [BOT-1167: Search misses relevant result for cloud default version query](https://linear.app/metabase/issue/BOT-1167/search-misses-relevant-result-for-cloud-default-version-query)

More context in [this thread](https://metaboat.slack.com/archives/C0B5NF5U6RE/p1779961940768919).

The PR changes the prompts so entities are not filtered out when user ask for a specific entity as that may happen by accident.

- [ ] Benchmarks.