### PR TITLE
Auto-backport to supported releases

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -32,40 +32,25 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts
+
       - name: Compute supported backport targets
         id: targets
         uses: actions/github-script@v9
         env:
-          STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
-          STATIC_REGION: ${{ vars.AWS_REGION }}
+          AWS_S3_STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           script: | # js
-            // Backport targets are the supported major lines from version-info.json.
-            // A line is in support — and therefore a backport target — if and only if its EoL is
-            // today or later. `major_version_support` is edition-agnostic (keyed by bare
-            // major), so the OSS file is sufficient. `lts` is display-only and ignored here.
-            const url = `http://${process.env.STATIC_BUCKET}.s3.${process.env.STATIC_REGION}.amazonaws.com/version-info.json`;
-            const resp = await fetch(url);
-            if (!resp.ok) {
-              throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`);
-            }
+            // Backport targets are the supported major lines from version-info.json:
+            // a line is in support — and a backport target — if and only if its EoL is
+            // today or later. `getSupportedMajors` encapsulates that rule (and ignores
+            // the display-only `lts` flag); it is shared with the auto-minor scheduler.
+            const { getSupportedMajors } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            const { major_version_support: lines } = await resp.json();
-            if (!Array.isArray(lines) || lines.length === 0) {
-              throw new Error('version-info.json has no `major_version_support` — cannot determine backport targets');
-            }
-
-            const today = new Date().toISOString().slice(0, 10); // UTC YYYY-MM-DD
-            const targets = [...new Set(
-              lines.filter(line => line.eol >= today).map(line => line.major),
-            )].sort((a, b) => b - a);
-
-            console.log('today', today);
+            const targets = await getSupportedMajors();
             console.log('supported backport targets', targets);
-
-            if (targets.length === 0) {
-              throw new Error('No in-support release lines found — every EoL date is in the past?');
-            }
 
             return targets;
 

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -42,17 +42,17 @@ jobs:
           script: | # js
             // Backport targets are the supported major lines from version-info.json.
             // A line is in support — and therefore a backport target — if and only if its EoL is
-            // today or later. `release_lines` is edition-agnostic (keyed by bare major),
-            // so the OSS file is sufficient. `lts` is display-only and intentionally ignored.
+            // today or later. `major_version_support` is edition-agnostic (keyed by bare
+            // major), so the OSS file is sufficient. `lts` is display-only and ignored here.
             const url = `http://${process.env.STATIC_BUCKET}.s3.${process.env.STATIC_REGION}.amazonaws.com/version-info.json`;
             const resp = await fetch(url);
             if (!resp.ok) {
               throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`);
             }
 
-            const { release_lines: lines } = await resp.json();
+            const { major_version_support: lines } = await resp.json();
             if (!Array.isArray(lines) || lines.length === 0) {
-              throw new Error('version-info.json has no `release_lines` — cannot determine backport targets');
+              throw new Error('version-info.json has no `major_version_support` — cannot determine backport targets');
             }
 
             const today = new Date().toISOString().slice(0, 10); // UTC YYYY-MM-DD
@@ -92,7 +92,7 @@ jobs:
 
   # --- Legacy escape hatch: explicit depth backports -----------------------
   # `double-backport`/`triple-backport` keep their original behavior — backport to
-  # CURRENT_VERSION and the 1–2 lines below it — independent of `release_lines`.
+  # CURRENT_VERSION and the 1–2 lines below it — independent of `major_version_support`.
   # Kept for the short term for one-off manual depth control. If a branch from the
   # primary path above already exists, create-backport simply errors on the duplicate.
   legacy-backport:

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -5,17 +5,105 @@ on:
     types: [closed, labeled]
 
 jobs:
-  create-backport:
+  # --- Primary path: backport to every supported release line --------------
+  # Triggered by the plain `backport` label. `contains(array, 'backport')` is an
+  # exact element match, so this never fires for `double-backport`/`triple-backport`
+  # — those are handled by the legacy escape hatch at the end of this file.
+  prepare:
     if:
-      | # the PR must have a backport label when it's merged, or be labeled with a backport label after merge
+      | # the PR must carry the `backport` label at merge, or be labeled `backport` after merge
+      github.event.pull_request.merged == true && (
+        github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'backport') ||
+        github.event.action == 'labeled' && github.event.label.name == 'backport'
+      )
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    outputs:
+      commit: ${{ steps.find_commit.outputs.commit }}
+      targets: ${{ steps.targets.outputs.result }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - uses: ./.github/actions/find-squashed-commit
+        name: Find commit
+        id: find_commit
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Compute supported backport targets
+        id: targets
+        uses: actions/github-script@v9
+        env:
+          STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
+          STATIC_REGION: ${{ vars.AWS_REGION }}
+        with:
+          script: | # js
+            // Backport targets are the supported major lines from version-info.json.
+            // A line is in support — and therefore a backport target — if and only if its EoL is
+            // today or later. `release_lines` is edition-agnostic (keyed by bare major),
+            // so the OSS file is sufficient. `lts` is display-only and intentionally ignored.
+            const url = `http://${process.env.STATIC_BUCKET}.s3.${process.env.STATIC_REGION}.amazonaws.com/version-info.json`;
+            const resp = await fetch(url);
+            if (!resp.ok) {
+              throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`);
+            }
+
+            const { release_lines: lines } = await resp.json();
+            if (!Array.isArray(lines) || lines.length === 0) {
+              throw new Error('version-info.json has no `release_lines` — cannot determine backport targets');
+            }
+
+            const today = new Date().toISOString().slice(0, 10); // UTC YYYY-MM-DD
+            const targets = [...new Set(
+              lines.filter(line => line.eol >= today).map(line => line.major),
+            )].sort((a, b) => b - a);
+
+            console.log('today', today);
+            console.log('supported backport targets', targets);
+
+            if (targets.length === 0) {
+              throw new Error('No in-support release lines found — every EoL date is in the past?');
+            }
+
+            return targets;
+
+  backport:
+    needs: prepare
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    strategy:
+      fail-fast: false # one conflicting branch must not block the others
+      matrix:
+        target: ${{ fromJson(needs.prepare.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+
+      - name: Backport to v${{ matrix.target }}
+        uses: ./.github/actions/create-backport
+        with:
+          target-version: ${{ matrix.target }}
+          backport-commit: ${{ needs.prepare.outputs.commit }}
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          github-token-2: ${{ secrets.GITHUB_TOKEN }}
+
+  # --- Legacy escape hatch: explicit depth backports -----------------------
+  # `double-backport`/`triple-backport` keep their original behavior — backport to
+  # CURRENT_VERSION and the 1–2 lines below it — independent of `release_lines`.
+  # Kept for the short term for one-off manual depth control. If a branch from the
+  # primary path above already exists, create-backport simply errors on the duplicate.
+  legacy-backport:
+    if:
+      | # triggered only by the legacy depth labels, at merge or when added afterwards
       github.event.pull_request.merged == true && (
         github.event.action == 'closed' && (
-          contains(github.event.pull_request.labels.*.name, 'backport') ||
           contains(github.event.pull_request.labels.*.name, 'double-backport') ||
           contains(github.event.pull_request.labels.*.name, 'triple-backport')
         ) ||
         github.event.action == 'labeled' && (
-          github.event.label.name == 'backport' ||
           github.event.label.name == 'double-backport' ||
           github.event.label.name == 'triple-backport'
         )

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -33,11 +33,19 @@ export interface VersionInfo {
   rollout?: number;
 }
 
+export interface MajorVersionSupport {
+  major: number;
+  released: string;
+  lts: boolean;
+  eol: string;
+}
+
 export interface VersionInfoFile {
   latest: VersionInfo;
   beta?: VersionInfo;
   nightly?: VersionInfo;
   older: VersionInfo[];
+  major_version_support?: MajorVersionSupport[];
 }
 
 export type Issue = {

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 
 import { getChangelogUrl } from "./release-notes";
 import type {
+  MajorVersionSupport,
   ReleaseProps,
   VersionInfo,
   VersionInfoFile,
@@ -125,6 +126,47 @@ export async function getVersionInfo({
   });
 
   return newVersionJson;
+}
+
+// A major version line is in support — and therefore an eligible backport and
+// auto-release target — if and only if its end-of-life date is today or later.
+// `lts` is display-only and intentionally ignored here. `major_version_support`
+// is append-only, so support is computed from `eol`, never from list membership.
+export const getSupportedMajorVersions = (
+  versionInfo: VersionInfoFile,
+  today: string = new Date().toISOString().slice(0, 10),
+): number[] => {
+  const lines: MajorVersionSupport[] | undefined =
+    versionInfo?.major_version_support;
+
+  if (!Array.isArray(lines) || lines.length === 0) {
+    throw new Error(
+      "version-info.json has no `major_version_support` — cannot determine supported major versions",
+    );
+  }
+
+  const supported = [
+    ...new Set(lines.filter(line => line.eol >= today).map(line => line.major)),
+  ].sort((a, b) => b - a);
+
+  if (supported.length === 0) {
+    throw new Error(
+      "No in-support major versions found — every `eol` date is in the past?",
+    );
+  }
+
+  return supported;
+};
+
+// Fetches version-info.json and returns the supported major versions, newest
+// first. `major_version_support` is edition-agnostic, so the OSS file suffices.
+export async function getSupportedMajors(
+  today: string = new Date().toISOString().slice(0, 10),
+): Promise<number[]> {
+  const url = getVersionInfoUrl("v0"); // any non-`v1.` string picks the OSS file
+  const versionInfo = (await fetch(url).then(r => r.json())) as VersionInfoFile;
+
+  return getSupportedMajorVersions(versionInfo, today);
 }
 
 // for promoting a released version to `latest` in version-info.json

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 
 import type { VersionInfoFile } from "./types";
-import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoLatest, updateVersionInfoLatestJson } from "./version-info";
+import { generateVersionInfoJson, getSupportedMajors, getSupportedMajorVersions, getVersionInfoUrl, updateVersionInfoLatest, updateVersionInfoLatestJson } from "./version-info";
 
 jest.mock("node-fetch", () => ({
   __esModule: true,
@@ -321,6 +321,96 @@ describe("version-info", () => {
       const result = await updateVersionInfoLatest({ newVersion: "v0.2.5" });
 
       expect(result.latest.rollout).toEqual(100);
+    });
+  });
+
+  describe("getSupportedMajorVersions", () => {
+    const fileWith = (major_version_support: any) =>
+      ({ latest: {}, older: [], major_version_support }) as unknown as VersionInfoFile;
+
+    it("returns majors whose eol is today or later, newest first", () => {
+      const versionInfo = fileWith([
+        { major: 54, released: "2025-04-15", lts: true, eol: "2025-06-01" },
+        { major: 60, released: "2026-04-01", lts: true, eol: "2027-06-01" },
+        { major: 61, released: "2026-05-01", lts: false, eol: "2026-07-01" },
+      ]);
+
+      expect(getSupportedMajorVersions(versionInfo, "2026-06-04")).toEqual([
+        61, 60,
+      ]);
+    });
+
+    it("treats eol === today as still in support", () => {
+      const versionInfo = fileWith([
+        { major: 60, released: "2026-04-01", lts: true, eol: "2026-06-04" },
+      ]);
+
+      expect(getSupportedMajorVersions(versionInfo, "2026-06-04")).toEqual([60]);
+    });
+
+    it("ignores the lts flag — support is computed from eol only", () => {
+      const versionInfo = fileWith([
+        { major: 60, released: "2026-04-01", lts: false, eol: "2027-06-01" },
+        { major: 54, released: "2025-04-15", lts: true, eol: "2025-06-01" },
+      ]);
+
+      expect(getSupportedMajorVersions(versionInfo, "2026-06-04")).toEqual([60]);
+    });
+
+    it("de-duplicates repeated majors", () => {
+      const versionInfo = fileWith([
+        { major: 60, released: "2026-04-01", lts: true, eol: "2027-06-01" },
+        { major: 60, released: "2026-04-01", lts: true, eol: "2027-12-01" },
+      ]);
+
+      expect(getSupportedMajorVersions(versionInfo, "2026-06-04")).toEqual([60]);
+    });
+
+    it("throws when major_version_support is missing or empty", () => {
+      expect(() => getSupportedMajorVersions(fileWith(undefined))).toThrow(
+        /no `major_version_support`/,
+      );
+      expect(() => getSupportedMajorVersions(fileWith([]))).toThrow(
+        /no `major_version_support`/,
+      );
+    });
+
+    it("throws when every line is past end-of-life", () => {
+      const versionInfo = fileWith([
+        { major: 54, released: "2025-04-15", lts: true, eol: "2025-06-01" },
+      ]);
+
+      expect(() =>
+        getSupportedMajorVersions(versionInfo, "2026-06-04"),
+      ).toThrow(/No in-support major versions/);
+    });
+  });
+
+  describe("getSupportedMajors", () => {
+    beforeEach(() => {
+      process.env.AWS_S3_STATIC_BUCKET = "my.metabase.com";
+      process.env.AWS_REGION = "us-north-9";
+      mockFetch.mockReset();
+    });
+
+    it("fetches the OSS version-info.json and returns supported majors", async () => {
+      mockFetch.mockResolvedValue({
+        json: async () => ({
+          latest: {},
+          older: [],
+          major_version_support: [
+            { major: 60, released: "2026-04-01", lts: true, eol: "2027-06-01" },
+            { major: 54, released: "2025-04-15", lts: true, eol: "2025-06-01" },
+          ],
+        }),
+      } as Awaited<ReturnType<typeof fetch>>);
+
+      const majors = await getSupportedMajors("2026-06-04");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://my.metabase.com.s3.us-north-9.amazonaws.com/version-info.json",
+      );
+      expect(majors).toEqual([60]);
     });
   });
 


### PR DESCRIPTION
Resolves DEV-2013

## Summary

- Adjusts the `auto-backport` workflow logic so that it starts backporting to the currently active releases (eol is newer than today).
- Leaves the old "double-backport" and "triple-backport" logic in as a fallback

## Checklist

- [x] Tests have been added/updated to cover changes in this PR