### PR TITLE
Fix pivot setting comparison when migrating from refs

### DIFF
--- a/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
@@ -119,7 +119,7 @@ function migratePivotSetting(
 ): string[] {
   const columnNameByFieldRef = Object.fromEntries(
     columns.map((column) => [
-      JSON.stringify(getFieldRefForComparisonOrNull(column.field_ref)),
+      JSON.stringify(getFieldRefForComparison(column.field_ref)),
       column.name,
     ]),
   );
@@ -127,7 +127,9 @@ function migratePivotSetting(
   return fieldRefs
     .map(
       (fieldRef) =>
-        columnNameByFieldRef[getFieldRefForComparisonOrNull(fieldRef)],
+        columnNameByFieldRef[
+          JSON.stringify(getFieldRefForComparison(fieldRef))
+        ],
     )
     .filter(isNotNull);
 }
@@ -137,16 +139,12 @@ function migratePivotSetting(
   Sometimes it's present, sometimes it's not. New pivot settings use column
   names only and do not depend on field refs.
  */
-export function getFieldRefForComparison(fieldRef: DimensionReference) {
-  return isDimensionReferenceWithOptions(fieldRef)
-    ? getDimensionReferenceWithoutBaseType(fieldRef)
-    : fieldRef;
-}
-
-function getFieldRefForComparisonOrNull(
+export function getFieldRefForComparison(
   fieldRef: DimensionReference | null | undefined,
 ) {
-  return JSON.stringify(fieldRef ? getFieldRefForComparison(fieldRef) : null);
+  return fieldRef != null && isDimensionReferenceWithOptions(fieldRef)
+    ? getDimensionReferenceWithoutBaseType(fieldRef)
+    : fieldRef;
 }
 
 // Field ref-based visualization settings are considered legacy and are not used

--- a/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
@@ -119,7 +119,7 @@ function migratePivotSetting(
 ): string[] {
   const columnNameByFieldRef = Object.fromEntries(
     columns.map((column) => [
-      getPivotColumnKeyForComparison(column.field_ref),
+      JSON.stringify(getFieldRefForComparisonOrNull(column.field_ref)),
       column.name,
     ]),
   );
@@ -127,7 +127,7 @@ function migratePivotSetting(
   return fieldRefs
     .map(
       (fieldRef) =>
-        columnNameByFieldRef[getPivotColumnKeyForComparison(fieldRef)],
+        columnNameByFieldRef[getFieldRefForComparisonOrNull(fieldRef)],
     )
     .filter(isNotNull);
 }
@@ -137,13 +137,13 @@ function migratePivotSetting(
   Sometimes it's present, sometimes it's not. New pivot settings use column
   names only and do not depend on field refs.
  */
-function getFieldRefForComparison(fieldRef: DimensionReference) {
+export function getFieldRefForComparison(fieldRef: DimensionReference) {
   return isDimensionReferenceWithOptions(fieldRef)
     ? getDimensionReferenceWithoutBaseType(fieldRef)
     : fieldRef;
 }
 
-function getPivotColumnKeyForComparison(
+function getFieldRefForComparisonOrNull(
   fieldRef: DimensionReference | null | undefined,
 ) {
   return JSON.stringify(fieldRef ? getFieldRefForComparison(fieldRef) : null);

--- a/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/pivot.ts
@@ -3,10 +3,15 @@ import _ from "underscore";
 import { isNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
+import {
+  getDimensionReferenceWithoutBaseType,
+  isDimensionReferenceWithOptions,
+} from "metabase-lib/v1/references";
 import type {
   ColumnNameCollapsedRowsSetting,
   ColumnNameColumnSplitSetting,
   DatasetColumn,
+  DimensionReference,
   FieldRefColumnSplitSetting,
   FieldReference,
   PivotTableCollapsedRowsSetting,
@@ -113,12 +118,35 @@ function migratePivotSetting(
   fieldRefs: (FieldReference | null)[] = [],
 ): string[] {
   const columnNameByFieldRef = Object.fromEntries(
-    columns.map((column) => [JSON.stringify(column.field_ref), column.name]),
+    columns.map((column) => [
+      getPivotColumnKeyForComparison(column.field_ref),
+      column.name,
+    ]),
   );
 
   return fieldRefs
-    .map((fieldRef) => columnNameByFieldRef[JSON.stringify(fieldRef)])
+    .map(
+      (fieldRef) =>
+        columnNameByFieldRef[getPivotColumnKeyForComparison(fieldRef)],
+    )
     .filter(isNotNull);
+}
+
+/*
+  When comparing field refs for pivot viz settings, ignore `base-type`.
+  Sometimes it's present, sometimes it's not. New pivot settings use column
+  names only and do not depend on field refs.
+ */
+function getFieldRefForComparison(fieldRef: DimensionReference) {
+  return isDimensionReferenceWithOptions(fieldRef)
+    ? getDimensionReferenceWithoutBaseType(fieldRef)
+    : fieldRef;
+}
+
+function getPivotColumnKeyForComparison(
+  fieldRef: DimensionReference | null | undefined,
+) {
+  return JSON.stringify(fieldRef ? getFieldRefForComparison(fieldRef) : null);
 }
 
 // Field ref-based visualization settings are considered legacy and are not used

--- a/frontend/src/metabase-lib/v1/queries/utils/pivot.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/pivot.unit.spec.ts
@@ -1,0 +1,177 @@
+import type {
+  FieldRefColumnSplitSetting,
+  FieldReference,
+} from "metabase-types/api";
+import { createMockColumn } from "metabase-types/api/mocks";
+
+import { migratePivotColumnSplitSetting } from "./pivot";
+
+describe("migratePivotColumnSplitSetting", () => {
+  it("should return a column-name setting unchanged", () => {
+    const rowColumn = createMockColumn({
+      name: "CATEGORY",
+      field_ref: ["field", 1, null],
+    });
+    const columnColumn = createMockColumn({
+      name: "CREATED_AT",
+      field_ref: ["field", 2, null],
+    });
+    const valueColumn = createMockColumn({
+      name: "COUNT",
+      field_ref: ["aggregation", 0],
+    });
+    const setting = {
+      rows: ["CATEGORY"],
+      columns: ["CREATED_AT"],
+      values: ["COUNT"],
+    };
+    expect(
+      migratePivotColumnSplitSetting(setting, [
+        rowColumn,
+        columnColumn,
+        valueColumn,
+      ]),
+    ).toEqual(setting);
+  });
+
+  it("should migrate matching field refs to column names", () => {
+    const rowColumn = createMockColumn({
+      name: "CATEGORY",
+      field_ref: ["field", 1, null],
+    });
+    const columnColumn = createMockColumn({
+      name: "CREATED_AT",
+      field_ref: ["field", 2, null],
+    });
+    const valueColumn = createMockColumn({
+      name: "COUNT",
+      field_ref: ["aggregation", 0],
+    });
+    const setting: FieldRefColumnSplitSetting = {
+      rows: [["field", 1, null]],
+      columns: [["field", 2, null]],
+      values: [["aggregation", 0]],
+    };
+    expect(
+      migratePivotColumnSplitSetting(setting, [
+        rowColumn,
+        columnColumn,
+        valueColumn,
+      ]),
+    ).toEqual({
+      rows: ["CATEGORY"],
+      columns: ["CREATED_AT"],
+      values: ["COUNT"],
+    });
+  });
+
+  it("should drop field refs that do not match any column", () => {
+    const rowColumn = createMockColumn({
+      name: "CATEGORY",
+      field_ref: ["field", 1, null],
+    });
+    const columnColumn = createMockColumn({
+      name: "CREATED_AT",
+      field_ref: ["field", 2, null],
+    });
+    const setting: FieldRefColumnSplitSetting = {
+      rows: [["field", 999, null]],
+      columns: [["field", 2, null]],
+      values: [],
+    };
+    expect(
+      migratePivotColumnSplitSetting(setting, [rowColumn, columnColumn]),
+    ).toEqual({
+      rows: [],
+      columns: ["CREATED_AT"],
+      values: [],
+    });
+  });
+
+  it("should drop null field refs", () => {
+    const rowColumn = createMockColumn({
+      name: "CATEGORY",
+      field_ref: ["field", 1, null],
+    });
+    const setting: FieldRefColumnSplitSetting = {
+      rows: [null, ["field", 1, null]],
+      columns: [],
+      values: [],
+    };
+    expect(migratePivotColumnSplitSetting(setting, [rowColumn])).toEqual({
+      rows: ["CATEGORY"],
+      columns: [],
+      values: [],
+    });
+  });
+
+  describe("base-type mismatch between settings and columns", () => {
+    it("should match when the setting field ref has base-type and the column field ref has null options", () => {
+      const column = createMockColumn({
+        name: "CATEGORY",
+        field_ref: ["field", 1, null],
+      });
+      const setting: FieldRefColumnSplitSetting = {
+        rows: [["field", 1, { "base-type": "type/Text" }] as FieldReference],
+        columns: [],
+        values: [],
+      };
+      expect(migratePivotColumnSplitSetting(setting, [column])).toEqual({
+        rows: ["CATEGORY"],
+        columns: [],
+        values: [],
+      });
+    });
+
+    it("should match when the setting field ref has base-type and the column field ref has empty options", () => {
+      const column = createMockColumn({
+        name: "CATEGORY",
+        field_ref: ["field", 1, {}],
+      });
+      const setting: FieldRefColumnSplitSetting = {
+        rows: [["field", 1, { "base-type": "type/Text" }] as FieldReference],
+        columns: [],
+        values: [],
+      };
+      expect(migratePivotColumnSplitSetting(setting, [column])).toEqual({
+        rows: ["CATEGORY"],
+        columns: [],
+        values: [],
+      });
+    });
+
+    it("should match when the setting field ref has null options and the column field ref has base-type", () => {
+      const column = createMockColumn({
+        name: "CATEGORY",
+        field_ref: ["field", 1, { "base-type": "type/Text" }],
+      });
+      const setting: FieldRefColumnSplitSetting = {
+        rows: [["field", 1, null]],
+        columns: [],
+        values: [],
+      };
+      expect(migratePivotColumnSplitSetting(setting, [column])).toEqual({
+        rows: ["CATEGORY"],
+        columns: [],
+        values: [],
+      });
+    });
+
+    it("should match when the setting field ref has empty options and the column field ref has base-type", () => {
+      const column = createMockColumn({
+        name: "CATEGORY",
+        field_ref: ["field", 1, { "base-type": "type/Text" }],
+      });
+      const setting: FieldRefColumnSplitSetting = {
+        rows: [["field", 1, {}]],
+        columns: [],
+        values: [],
+      };
+      expect(migratePivotColumnSplitSetting(setting, [column])).toEqual({
+        rows: ["CATEGORY"],
+        columns: [],
+        values: [],
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -17,17 +17,15 @@ import {
 } from "metabase/visualizations/lib/data_grid";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
 import {
-  getDimensionReferenceWithoutBaseType,
-  isDimensionReferenceWithOptions,
-} from "metabase-lib/v1/references";
+  getFieldRefForComparison,
+  migratePivotColumnSplitSetting,
+} from "metabase-lib/v1/queries/utils/pivot";
 import { isDimension } from "metabase-lib/v1/types/utils/isa";
 import type {
   Card,
   DatasetColumn,
   DatasetData,
-  DimensionReference,
   PivotTableColumnSplitSetting,
   RawSeries,
   Series,
@@ -330,14 +328,3 @@ export const _columnSettings = {
     getDefault: displayNameForColumn,
   },
 };
-
-/*
-  When comparing field refs for pivot viz settings, ignore `base-type`.
-  Sometimes it's present, sometimes it's not. New pivot settings use column
-  names only and do not depend on field refs.
- */
-function getFieldRefForComparison(fieldRef: DimensionReference) {
-  return isDimensionReferenceWithOptions(fieldRef)
-    ? getDimensionReferenceWithoutBaseType(fieldRef)
-    : fieldRef;
-}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/74950

When saved pivot setting refs had `base-type` but the refs returned from the QP don't, we failed to migrate and instead reset to default columns. This PR fixes the issue by using the same function to drop `base-type` for comparison as used in other places for pivot settings.