### PR TITLE
Don't move already published tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -144,8 +144,9 @@
                                           (tru "Tables can only be published to Library/Data collections."))
         where              (table-selectors->filter (select-keys body [:database_ids :schema_ids :table_ids]))
         upstream-ids       (all-upstream-table-ids where)
+        ;; Don't move already-published upstream tables; only publish unpublished ones.
         update-where       (if (seq upstream-ids)
-                             [:or where [:in :id upstream-ids]]
+                             [:or where [:and [:in :id upstream-ids] [:= :is_published false]]]
                              where)
         ;; Get table IDs before update for event publishing
         table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})]

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -163,6 +163,38 @@
           (are [table-id] (true? (t2/select-one-fn :is_published :model/Table table-id))
             orders-id products-id))))))
 
+(deftest publish-tables-does-not-move-already-published-upstream-test
+  (mt/with-premium-features #{:library}
+    (testing "POST /api/ee/data-studio/table/publish-tables leaves already-published upstream tables in place (UXW-4169)"
+      (mt/with-temp [:model/Collection {coll-x :id}         {:type collection/library-data-collection-type}
+                     :model/Collection {coll-y :id}         {:type collection/library-data-collection-type}
+                     :model/Database   {db-id :id}          {}
+                     ;; Products already published in collection X
+                     :model/Table      {products-id :id}    {:db_id db-id :name "products"
+                                                             :is_published true :collection_id coll-x}
+                     :model/Field      _                    {:table_id products-id :name "id"
+                                                             :semantic_type :type/PK :base_type :type/Integer}
+                     :model/Field      {prod-name-f :id}    {:table_id products-id :name "name"
+                                                             :semantic_type :type/Name :base_type :type/Text}
+                     ;; Orders (unpublished) remaps to products
+                     :model/Table      {orders-id :id}      {:db_id db-id :name "orders" :is_published false}
+                     :model/Field      _                    {:table_id orders-id :name "id"
+                                                             :semantic_type :type/PK :base_type :type/Integer}
+                     :model/Field      {product-fk :id}     {:table_id orders-id :name "product_id"
+                                                             :semantic_type :type/FK :base_type :type/Integer}
+                     :model/Dimension  _                    {:field_id product-fk
+                                                             :human_readable_field_id prod-name-f
+                                                             :type :external}]
+        (mt/user-http-request :crowberto :post 200 "ee/data-studio/table/publish-tables"
+                              {:table_ids     [orders-id]
+                               :collection_id coll-y})
+        (testing "the selected table is published into the target collection"
+          (is (=? {:is_published true :collection_id coll-y}
+                  (t2/select-one [:model/Table :is_published :collection_id] orders-id))))
+        (testing "the already-published upstream table stays in its original collection"
+          (is (=? {:is_published true :collection_id coll-x}
+                  (t2/select-one [:model/Table :is_published :collection_id] products-id))))))))
+
 (deftest publish-tables-recursive-upstream-test
   (mt/with-premium-features #{:library}
     (testing "POST /api/ee/data-studio/table/publish-tables publishes recursive upstream dependencies"


### PR DESCRIPTION
### Description

Small adjustment to the publish tables API to not move any _upstream tables_ that have already been published. I expect this was originally done like this because there was only 1 collection you could publish to, so it wouldn't matter. 

### How to verify

1. Go to the data studio, and find an unpublished table with FK relationships to a published table (in the sample database, for me this was orders, with people already published)
2. Publish orders to a collection other than where people is published
3. Note that people was not moved

### Checklist

- [x] Tests have been added/updated to cover changes in this PR