### PR TITLE
Prototype schema exports and typed hooks for custom data apps

### DIFF
--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -36,12 +36,12 @@ import schema from "../metabase.data";
    - Use `schema.questions.someQuestion` for saved question results.
    - Use `schema.metrics.someMetric` for metric results.
    - Inspect `columns`, metric `dimensions`, names, descriptions, and `jsType` to design the UI.
-   - Do not copy numeric IDs into constants; pass the schema object directly.
+   - Do not copy numeric IDs into constants. For question queries, pass the generated schema object's `.id` inline.
    - For each hook call, define a local type alias from the exact schema object, for example `type Customers = typeof schema.questions.koiBobaAppCustomersTable;`.
 
 3. Render with SDK data hooks.
    - Wrap the app once in `MetabaseProvider`.
-   - Call `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion)` for question-backed views.
+   - Call `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion.id)` for question-backed views.
    - Call `useMetricQuery<SomeMetric>(schema.metrics.someMetric, { filters, breakouts })` for metric-backed views.
    - Handle `isLoading`, `error`, and empty data explicitly.
    - Use `data.rows` directly. Only do presentation normalization inline when the UI needs labels, badges, numeric coercion, or null fallbacks.
@@ -62,7 +62,7 @@ If no curated schema entry supports the intended UI, leave the UI empty/error st
 
 ## useQuestionQuery
 
-`useQuestionQuery<QuestionType>(schema.questions.someQuestion)` returns keyed rows inferred from the schema. The schema object is both the runtime input and the static type source:
+`useQuestionQuery<QuestionType>(schema.questions.someQuestion.id)` returns keyed rows inferred from the schema. The schema object is the static type source; its `.id` is the runtime input:
 
 ```ts
 import { useQuestionQuery } from "@metabase/embedding-sdk-react";
@@ -71,15 +71,15 @@ import schema from "../metabase.data";
 type Customers = typeof schema.questions.koiBobaAppCustomersTable;
 
 const { data, isLoading, error } = useQuestionQuery<Customers>(
-  schema.questions.koiBobaAppCustomersTable,
+  schema.questions.koiBobaAppCustomersTable.id,
 );
 
 const customers = data?.rows ?? [];
 ```
 
-Rows are objects when a generated schema object is passed. Use `rawRows` only when positional arrays are needed for debugging or low-level rendering.
+Rows are objects when a generated schema type is provided as the generic. Use `rawRows` only when positional arrays are needed for debugging or low-level rendering.
 
-Do not write a wrapper like `useQuestionRows`, and do not map every row through `toOrder` or `toCustomer` just to recover object fields. The schema object is the type source.
+Do not write a wrapper like `useQuestionRows`, and do not map every row through `toOrder` or `toCustomer` just to recover object fields. The schema object is the type source, and `.id` is the runtime argument.
 
 Preferred:
 
@@ -87,7 +87,7 @@ Preferred:
 type Customers = typeof schema.questions.koiBobaAppCustomersTable;
 
 const { data } = useQuestionQuery<Customers>(
-  schema.questions.koiBobaAppCustomersTable,
+  schema.questions.koiBobaAppCustomersTable.id,
 );
 
 const customers = data?.rows ?? [];
@@ -146,9 +146,9 @@ When the UI shows an empty state such as "No orders found":
 ## Common Mistakes
 
 - Searching the Metabase instance or creating saved questions while building the UI. The semantic layer must already be curated.
-- Passing copied numeric IDs instead of generated schema objects.
-- Recreating a `useQuestionRows` wrapper. Use `useQuestionQuery(schema.questions...)` directly.
-- Mapping rows through `toX` adapter functions just to regain typed fields. The hook already returns typed row objects when passed a generated schema object.
+- Copying numeric IDs into constants. Use `schema.questions.someQuestion.id` inline for question queries.
+- Recreating a `useQuestionRows` wrapper. Use `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion.id)` directly.
+- Mapping rows through `toX` adapter functions just to regain typed fields. The hook already returns typed row objects when given the generated schema type.
 - Hard-coding column indexes when keyed rows are available.
 - Inventing fields that are not present in `schema.questions.*.columns` or `schema.metrics.*.dimensions`.
 - Forcing a chart type without checking whether the result has enough rows or categories to support it.

--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: metabase-semantic-schema-data-apps
+description: Use when building React data apps from curated Metabase typed schema exports with Embedding SDK data hooks.
+---
+
+# Metabase Data Hook Custom Visualizations
+
+## Core Rule
+
+Keep the semantic layer and presentation layer separate.
+
+All Metabase instance context must come from the curated generated schema file, usually `src/metabase.data.ts`. Do not discover data, create questions, or edit the semantic layer while building the React UI. Questions and metrics in the schema are curated upstream.
+
+## Workflow
+
+1. Ensure the app has a fresh schema export.
+   - If `src/metabase.data.ts` is missing or stale, ask the user for a Metabase API key.
+   - Generate the schema with e.g.:
+
+```bash
+curl \
+  -o src/metabase.data.ts
+  -H "x-api-key: <YOUR_API_KEY>" \
+  -H "Accept: text/typescript" \
+  http://localhost:3000/api/typed-schemas/v1/typescript
+```
+
+   - Response is saved as `src/metabase.data.ts`.
+   - Import it as `schema` in app code:
+
+```ts
+import schema from "../metabase.data";
+```
+
+2. Choose semantic objects from the schema.
+   - Use `schema.questions.someQuestion` for saved question results.
+   - Use `schema.metrics.someMetric` for metric results.
+   - Inspect `columns`, metric `dimensions`, names, descriptions, and `jsType` to design the UI.
+   - Do not copy numeric IDs into constants; pass the schema object directly.
+   - For each hook call, define a local type alias from the exact schema object, for example `type Customers = typeof schema.questions.koiBobaAppCustomersTable;`.
+
+3. Render with SDK data hooks.
+   - Wrap the app once in `MetabaseProvider`.
+   - Call `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion)` for question-backed views.
+   - Call `useMetricQuery<SomeMetric>(schema.metrics.someMetric, { filters, breakouts })` for metric-backed views.
+   - Handle `isLoading`, `error`, and empty data explicitly.
+   - Use `data.rows` directly. Only do presentation normalization inline when the UI needs labels, badges, numeric coercion, or null fallbacks.
+   - Build visuals from actual result shape and cardinality. If a result has one row, one bucket, or one category, prefer a KPI, ranked list, table, or another honest summary over forcing a trend or distribution chart.
+
+## Presentation Layer
+
+The React app may group, sort, format, and derive display-only values from `data.rows`, but the underlying semantic objects still come only from `schema`.
+
+Good presentation transforms:
+
+- Group rows for visual summaries, such as revenue by franchise or customers by tier.
+- Sort and slice rows for ranked lists, such as top menu items.
+- Format values by domain: currency to at most 2 decimals, counts as whole numbers, dates as short readable labels.
+- Choose chart types from actual data shape: trends need multiple ordered buckets, distributions need multiple categories, and scalar values should stay scalar.
+
+If no curated schema entry supports the intended UI, leave the UI empty/error state or ask for the semantic layer to be curated. Do not invent mock data or create new Metabase questions from the app-building step.
+
+## useQuestionQuery
+
+`useQuestionQuery<QuestionType>(schema.questions.someQuestion)` returns keyed rows inferred from the schema. The schema object is both the runtime input and the static type source:
+
+```ts
+import { useQuestionQuery } from "@metabase/embedding-sdk-react";
+import schema from "../metabase.data";
+
+type Customers = typeof schema.questions.koiBobaAppCustomersTable;
+
+const { data, isLoading, error } = useQuestionQuery<Customers>(
+  schema.questions.koiBobaAppCustomersTable,
+);
+
+const customers = data?.rows ?? [];
+```
+
+Rows are objects when a generated schema object is passed. Use `rawRows` only when positional arrays are needed for debugging or low-level rendering.
+
+Do not write a wrapper like `useQuestionRows`, and do not map every row through `toOrder` or `toCustomer` just to recover object fields. The schema object is the type source.
+
+Preferred:
+
+```ts
+type Customers = typeof schema.questions.koiBobaAppCustomersTable;
+
+const { data } = useQuestionQuery<Customers>(
+  schema.questions.koiBobaAppCustomersTable,
+);
+
+const customers = data?.rows ?? [];
+```
+
+Avoid:
+
+```ts
+function toCustomer(row: Record<string, unknown>) {
+  return {
+    id: Number(row.id),
+    name: String(row.name ?? ""),
+  };
+}
+
+const customers = rows.map(toCustomer);
+```
+
+## useMetricQuery
+
+`useMetricQuery` maps a metric schema to the metric dataset API definition, including `expression`, per-instance `filters`, and `projections` for breakouts.
+
+```ts
+import { useMetricQuery } from "@metabase/embedding-sdk-react";
+import schema from "../metabase.data";
+
+type CustomerLifetimeValue = typeof schema.metrics.customerLifetimeValue;
+
+const { data } = useMetricQuery<CustomerLifetimeValue>(
+  schema.metrics.customerLifetimeValue,
+  {
+    filters: [{ dimension: "orders", operator: ">", value: 0 }],
+    breakouts: [{ dimension: "segment" }],
+  },
+);
+
+const customerSegments = (data?.rows ?? []).map((row) => ({
+  segment: row.segment,
+  count: row.count,
+}));
+```
+
+Metric `dimension` names should come from the metric schema's `dimensions` array.
+
+## Debugging Checklist
+
+When the UI shows an empty state such as "No orders found":
+
+1. Log the hook state: schema object `id`, `isLoading`, `error`, `Boolean(data)`.
+2. Log `data?.columns.map(c => c.name)` and `data?.rows.length`.
+3. Log the first row object and `data?.rawRows[0]` if positional debugging is needed.
+4. Confirm the component is rendered under `MetabaseProvider`.
+5. Confirm the generated schema entry has the expected `id`, `columns`, and metric `dimensions`.
+6. If the schema is stale, ask for an API key and regenerate `src/metabase.data.ts`.
+
+## Common Mistakes
+
+- Searching the Metabase instance or creating saved questions while building the UI. The semantic layer must already be curated.
+- Passing copied numeric IDs instead of generated schema objects.
+- Recreating a `useQuestionRows` wrapper. Use `useQuestionQuery(schema.questions...)` directly.
+- Mapping rows through `toX` adapter functions just to regain typed fields. The hook already returns typed row objects when passed a generated schema object.
+- Hard-coding column indexes when keyed rows are available.
+- Inventing fields that are not present in `schema.questions.*.columns` or `schema.metrics.*.dimensions`.
+- Forcing a chart type without checking whether the result has enough rows or categories to support it.
+- Showing raw floating point values in user-facing UI. Format numbers according to their domain.
+- Keeping mock data or placeholder analytics when a curated schema entry can power the view.
+- Rendering `No data` while the SDK is still authenticating or loading.
+- Creating a nested `MetabaseProvider` per component instead of sharing one provider at the app boundary.

--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: metabase-semantic-schema-data-apps
-description: Use when building React data apps from curated Metabase typed schema exports with Embedding SDK data hooks.
+description: Use when building React data apps from curated Metabase typed schema exports with the Embedding SDK query hook.
 ---
 
-# Metabase Data Hook Custom Visualizations
+# Metabase Semantic Schema Data Apps
 
 ## Core Rule
 
 Keep the semantic layer and presentation layer separate.
 
-All Metabase instance context must come from the curated generated schema file, usually `src/metabase.data.ts`. Do not discover data, create questions, or edit the semantic layer while building the React UI. Questions and metrics in the schema are curated upstream.
+All Metabase instance context must come from the curated generated schema file, usually `src/metabase.data.ts`. Do not discover data, create questions, create metrics, create tables, or edit the semantic layer while building the React UI. Questions, tables, metrics, segments, and measures in the schema are curated upstream.
 
 ## Workflow
 
@@ -25,24 +25,32 @@ curl \
   http://localhost:3000/api/typed-schemas/v1/typescript
 ```
 
-   - Response is saved as `src/metabase.data.ts`.
-   - Import it as `schema` in app code:
+- Response is saved as `src/metabase.data.ts`.
+- To reduce schema size for apps backed by one database, add `?database=<DATABASE_NAME>`, for example `?database=Boba`.
+- Import it as `schema` in app code:
 
 ```ts
 import schema from "../metabase.data";
 ```
 
 2. Choose semantic objects from the schema.
+
    - Use `schema.questions.someQuestion` for saved question results.
+   - Use `schema.tables.someTable` for table-backed exploration with curated segments and measures.
    - Use `schema.metrics.someMetric` for metric results.
-   - Inspect `columns`, metric `dimensions`, names, descriptions, and `jsType` to design the UI.
-   - Do not copy numeric IDs into constants. For question queries, pass the generated schema object's `.id` inline.
+   - Inspect `columns`, table `fields`, table `segments`, table `measures`, metric `dimensions`, names, descriptions, and `jsType` to design the UI.
+   - Reference table fields and metric dimensions through keyed generated schema objects, such as `schema.tables.orders.fields.createdAt` or `schema.metrics.revenue.dimensions.createdAt`.
+   - Do not copy numeric IDs into constants. Pass generated schema object `.id` values inline.
    - For each hook call, define a local type alias from the exact schema object, for example `type Customers = typeof schema.questions.koiBobaAppCustomersTable;`.
 
-3. Render with SDK data hooks.
+3. Render with the SDK query hook.
    - Wrap the app once in `MetabaseProvider`.
-   - Call `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion.id)` for question-backed views.
-   - Call `useMetricQuery<SomeMetric>(schema.metrics.someMetric, { filters, breakouts })` for metric-backed views.
+   - Use `useMetabaseQuery` for schema-backed data fetching.
+   - Do not use the older split hooks for new semantic-schema data apps.
+   - Call `useMetabaseQuery<SomeQuestion>({ questionId: schema.questions.someQuestion.id })` for question-backed views.
+   - Call `useMetabaseQuery<SomeTable>({ tableId: schema.tables.someTable.id, filters, measures, breakouts })` for table-backed views.
+   - Call `useMetabaseQuery<SomeMetric, Schema>({ metricId: schema.metrics.someMetric.id, filters, breakouts })` for metric-backed views when metric filters use table segments.
+   - For metric-backed views that add curated measures as extra series, pass table measures in `measures` and use table fields for `breakouts`.
    - Handle `isLoading`, `error`, and empty data explicitly.
    - Use `data.rows` directly. Only do presentation normalization inline when the UI needs labels, badges, numeric coercion, or null fallbacks.
    - Build visuals from actual result shape and cardinality. If a result has one row, one bucket, or one category, prefer a KPI, ranked list, table, or another honest summary over forcing a trend or distribution chart.
@@ -60,19 +68,33 @@ Good presentation transforms:
 
 If no curated schema entry supports the intended UI, leave the UI empty/error state or ask for the semantic layer to be curated. Do not invent mock data or create new Metabase questions from the app-building step.
 
-## useQuestionQuery
+## Query Result Shape and Charts
 
-`useQuestionQuery<QuestionType>(schema.questions.someQuestion.id)` returns keyed rows inferred from the schema. The schema object is the static type source; its `.id` is the runtime input:
+Always inspect the returned `columns` before mapping low-level `rawRows`.
+
+- Prefer keyed `data.rows` for saved questions and simple table or metric results.
+- Use `rawRows` only when the visualization needs positional access, such as multiple aggregation series.
+- For aggregation results, Metabase may name columns by aggregation aliases like `count`, `sum`, or `avg`, even when the curated measure is named differently. Match columns by `field_ref`, `name`, `display_name`, and `displayName`, then use a clear positional fallback only for a known query shape.
+- Metric-plus-measure queries commonly return `[breakout, metric aggregation, measure aggregation]`.
+- Grouped queries can include a `null` breakout bucket. Decide deliberately whether to render it as "Unknown" or filter it out. Do not accidentally treat it as the latest time bucket.
+- Multi-series charts with different units or magnitudes should use separate y-axes or per-series normalization. A single shared scale can flatten the smaller series even when the query is correct.
+- If an SVG chart uses `preserveAspectRatio="none"`, SVG circles will stretch with the chart. Render dots as CSS circles over the SVG, or use a non-stretched SVG coordinate system.
+
+## useMetabaseQuery
+
+`useMetabaseQuery` returns keyed rows inferred from the schema. The schema object is the static type source; `.id` is the runtime input.
+
+### Saved Questions
 
 ```ts
-import { useQuestionQuery } from "@metabase/embedding-sdk-react";
+import { useMetabaseQuery } from "@metabase/embedding-sdk-react";
 import schema from "../metabase.data";
 
 type Customers = typeof schema.questions.koiBobaAppCustomersTable;
 
-const { data, isLoading, error } = useQuestionQuery<Customers>(
-  schema.questions.koiBobaAppCustomersTable.id,
-);
+const { data, isLoading, error } = useMetabaseQuery<Customers>({
+  questionId: schema.questions.koiBobaAppCustomersTable.id,
+});
 
 const customers = data?.rows ?? [];
 ```
@@ -86,9 +108,9 @@ Preferred:
 ```ts
 type Customers = typeof schema.questions.koiBobaAppCustomersTable;
 
-const { data } = useQuestionQuery<Customers>(
-  schema.questions.koiBobaAppCustomersTable.id,
-);
+const { data } = useMetabaseQuery<Customers>({
+  questionId: schema.questions.koiBobaAppCustomersTable.id,
+});
 
 const customers = data?.rows ?? [];
 ```
@@ -106,23 +128,52 @@ function toCustomer(row: Record<string, unknown>) {
 const customers = rows.map(toCustomer);
 ```
 
-## useMetricQuery
+### Tables
 
-`useMetricQuery` maps a metric schema to the metric dataset API definition, including `expression`, per-instance `filters`, and `projections` for breakouts.
+Table queries can use curated table segments as `filters`, curated table measures as `measures`, and table fields as `breakouts`.
 
 ```ts
-import { useMetricQuery } from "@metabase/embedding-sdk-react";
+import { useMetabaseQuery } from "@metabase/embedding-sdk-react";
 import schema from "../metabase.data";
 
+type Orders = typeof schema.tables.orders;
+
+const { data } = useMetabaseQuery<Orders>({
+  tableId: schema.tables.orders.id,
+  filters: [schema.tables.orders.segments.completedOrders],
+  measures: [schema.tables.orders.measures.revenue],
+  breakouts: [
+    {
+      dimension: schema.tables.orders.fields.createdAt,
+      bucket: "month",
+    },
+  ],
+});
+```
+
+Use segments and measures from the same table as `tableId`. Do not mix segments or measures from another table.
+
+### Metrics
+
+Metric-only queries map to the metric dataset API definition, including `expression`, per-instance `filters`, and `projections` for breakouts.
+
+```ts
+import { useMetabaseQuery } from "@metabase/embedding-sdk-react";
+import schema from "../metabase.data";
+
+type Schema = typeof schema;
 type CustomerLifetimeValue = typeof schema.metrics.customerLifetimeValue;
 
-const { data } = useMetricQuery<CustomerLifetimeValue>(
-  schema.metrics.customerLifetimeValue,
-  {
-    filters: [{ dimension: "orders", operator: ">", value: 0 }],
-    breakouts: [{ dimension: "segment" }],
-  },
-);
+const { data } = useMetabaseQuery<CustomerLifetimeValue, Schema>({
+  metricId: schema.metrics.customerLifetimeValue.id,
+  filters: [schema.tables.customers.segments.hasOrders],
+  breakouts: [
+    {
+      dimension: schema.metrics.customerLifetimeValue.dimensions.createdAt,
+      bucket: "month",
+    },
+  ],
+});
 
 const customerSegments = (data?.rows ?? []).map((row) => ({
   segment: row.segment,
@@ -130,7 +181,48 @@ const customerSegments = (data?.rows ?? []).map((row) => ({
 }));
 ```
 
-Metric `dimension` names should come from the metric schema's `dimensions` array.
+Metric `dimension` values should come from the metric schema's keyed `dimensions` object. Segment filters should come from tables listed in the metric's `mappedTableIds`.
+
+Preferred:
+
+```ts
+breakouts: [
+  {
+    dimension: schema.metrics.customerLifetimeValue.dimensions.segment,
+  },
+];
+```
+
+Avoid:
+
+```ts
+breakouts: [{ dimension: "segment" }];
+```
+
+Do not add local lookup helpers like `getMetricDimension(metric, "segment")` or `getTableField(table, "created_at")`. If a field or dimension is needed in app code, use the generated keyed schema object directly.
+
+Metric queries can also add curated table measures as additional aggregations in the same query stage. In that case, use the metric as the base aggregation, use table measures as extra aggregations, and use fields from the measure's table for breakouts:
+
+```ts
+type Schema = typeof schema;
+type CustomerLifetimeValue = typeof schema.metrics.customerLifetimeValue;
+
+const lifetimeValueTable = schema.tables.customerLifetimeValue;
+const lifetimeValueMetric = schema.metrics.customerLifetimeValue;
+
+const { data } = useMetabaseQuery<CustomerLifetimeValue, Schema>({
+  metricId: lifetimeValueMetric.id,
+  measures: [lifetimeValueTable.measures.totalLtv],
+  breakouts: [
+    {
+      dimension: lifetimeValueTable.fields.lastOrderedAt,
+      bucket: "month",
+    },
+  ],
+});
+```
+
+Use measures from one compatible table. Do not mix measures from unrelated tables in a single metric query.
 
 ## Debugging Checklist
 
@@ -138,19 +230,29 @@ When the UI shows an empty state such as "No orders found":
 
 1. Log the hook state: schema object `id`, `isLoading`, `error`, `Boolean(data)`.
 2. Log `data?.columns.map(c => c.name)` and `data?.rows.length`.
-3. Log the first row object and `data?.rawRows[0]` if positional debugging is needed.
+3. Log the full first column object, first row object, and `data?.rawRows[0]` if positional debugging is needed.
 4. Confirm the component is rendered under `MetabaseProvider`.
-5. Confirm the generated schema entry has the expected `id`, `columns`, and metric `dimensions`.
+5. Confirm the generated schema entry has the expected `id`, `columns`, keyed table `fields`, table `segments`, table `measures`, and keyed metric `dimensions`.
 6. If the schema is stale, ask for an API key and regenerate `src/metabase.data.ts`.
 
 ## Common Mistakes
 
 - Searching the Metabase instance or creating saved questions while building the UI. The semantic layer must already be curated.
-- Copying numeric IDs into constants. Use `schema.questions.someQuestion.id` inline for question queries.
-- Recreating a `useQuestionRows` wrapper. Use `useQuestionQuery<SomeQuestion>(schema.questions.someQuestion.id)` directly.
+- Importing the older split query hooks for new semantic-schema apps. Use `useMetabaseQuery`.
+- Copying numeric IDs into constants. Use generated `.id` values inline in `useMetabaseQuery`.
+- Recreating a `useQuestionRows` wrapper. Use `useMetabaseQuery<SomeQuestion>({ questionId: schema.questions.someQuestion.id })` directly.
 - Mapping rows through `toX` adapter functions just to regain typed fields. The hook already returns typed row objects when given the generated schema type.
 - Hard-coding column indexes when keyed rows are available.
-- Inventing fields that are not present in `schema.questions.*.columns` or `schema.metrics.*.dimensions`.
+- Inventing fields that are not present in `schema.questions.*.columns`, `schema.tables.*.fields`, or `schema.metrics.*.dimensions`.
+- Passing raw strings for metric dimensions. Use `schema.metrics.someMetric.dimensions.someDimension` so the SDK can send the generated dimension id expected by Metabase.
+- Passing raw strings for table fields. Use `schema.tables.someTable.fields.someField` so the SDK can send the generated field id expected by Metabase.
+- Adding local field or dimension lookup helpers in React components instead of using the keyed generated schema objects.
+- Mixing segments or measures from a different table than the queried `tableId`.
+- Mixing measures from multiple tables in one metric query.
+- Assuming measure result columns are named after the curated measure. Check returned aggregation column metadata; the API may use names like `sum`.
+- Letting a `null` breakout bucket become the last point in a time-series chart.
+- Plotting different-unit series on one shared scale when the intended comparison needs separate axes or normalized series.
+- Drawing SVG point markers inside a stretched SVG and accidentally turning circles into ovals.
 - Forcing a chart type without checking whether the result has enough rows or categories to support it.
 - Showing raw floating point values in user-facing UI. Format numbers according to their domain.
 - Keeping mock data or placeholder analytics when a curated schema entry can power the view.

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -28,13 +28,42 @@ export type QuestionSchema = {
 
 export type MetricDimensionSchema = SchemaColumn & {
   id: string | number;
+  tableId?: number;
   fieldId?: number;
+};
+
+export type FieldSchema = SchemaColumn & {
+  id: string | number;
+  fieldId?: number;
+};
+
+export type SegmentSchema<TTableId extends number = number> = {
+  kind: "segment";
+  id: number;
+  tableId: TTableId;
+};
+
+export type MeasureSchema<TTableId extends number = number> = {
+  kind: "measure";
+  id: number;
+  tableId: TTableId;
+  columns: readonly SchemaColumn[];
+};
+
+export type TableSchema = {
+  id: number;
+  databaseId: number;
+  columns?: readonly SchemaColumn[];
+  fields?: Record<string, FieldSchema>;
+  segments?: Record<string, SegmentSchema>;
+  measures?: Record<string, MeasureSchema>;
 };
 
 export type MetricSchema = {
   id: number;
   columns: readonly SchemaColumn[];
-  dimensions?: readonly MetricDimensionSchema[];
+  mappedTableIds?: readonly number[];
+  dimensions?: Record<string, MetricDimensionSchema>;
 };
 
 export type SchemaValue<TColumn extends SchemaColumn> =

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -28,6 +28,7 @@ export type QuestionSchema = {
 
 export type MetricDimensionSchema = SchemaColumn & {
   id: string | number;
+  fieldId?: number;
 };
 
 export type MetricSchema = {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -1,0 +1,109 @@
+import type { QueryQuestionResult } from "embedding-sdk-bundle/lib/query-question";
+import type { DatasetColumn, RowValue, RowValues } from "metabase-types/api";
+
+export type SchemaJavaScriptType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "Date"
+  | "unknown";
+
+export type SchemaColumn = {
+  name: string;
+  description?: string;
+  displayName?: string;
+  jsType?: SchemaJavaScriptType;
+};
+
+export type SchemaParameter = {
+  slug: string;
+  type?: string;
+};
+
+export type QuestionSchema = {
+  id: QueryQuestionResult["id"];
+  columns: readonly SchemaColumn[];
+  parameters?: readonly SchemaParameter[];
+};
+
+export type MetricDimensionSchema = SchemaColumn & {
+  id: string | number;
+};
+
+export type MetricSchema = {
+  id: number;
+  columns: readonly SchemaColumn[];
+  dimensions?: readonly MetricDimensionSchema[];
+};
+
+export type SchemaValue<TColumn extends SchemaColumn> =
+  TColumn["jsType"] extends "string"
+    ? string | null
+    : TColumn["jsType"] extends "number"
+      ? number | null
+      : TColumn["jsType"] extends "boolean"
+        ? boolean | null
+        : TColumn["jsType"] extends "Date"
+          ? string | Date | null
+          : RowValue | null;
+
+export type SchemaRow<TSchema extends { columns: readonly SchemaColumn[] }> = {
+  [TColumn in TSchema["columns"][number] as TColumn["name"]]: SchemaValue<TColumn>;
+};
+
+export type QueryData<TRow> = {
+  id?: QueryQuestionResult["id"] | null;
+  name?: QueryQuestionResult["name"] | null;
+  description?: QueryQuestionResult["description"];
+  entityId?: QueryQuestionResult["entityId"] | null;
+  rowCount: number | null;
+  runningTime: number | null;
+  columns: DatasetColumn[];
+  rows: TRow[];
+  rawRows: RowValues[];
+};
+
+export type InferSchema<TSchema, TFallback> = TSchema extends {
+  columns: readonly SchemaColumn[];
+}
+  ? SchemaRow<TSchema>
+  : TFallback;
+
+export function getSchemaId<TEntity extends { id: unknown }>(
+  entity: TEntity | TEntity["id"] | null,
+): TEntity["id"] | null {
+  if (entity == null) {
+    return null;
+  }
+
+  if (typeof entity === "object" && "id" in entity) {
+    return entity.id as TEntity["id"];
+  }
+
+  return entity as TEntity["id"];
+}
+
+export function mapRowsToObjects<TRow>(
+  columns: DatasetColumn[],
+  rows: RowValues[],
+): TRow[] {
+  return rows.map((row) => {
+    return columns.reduce<Record<string, RowValue>>((acc, column, index) => {
+      const key = column.name || column.display_name || `column_${index}`;
+      acc[key] = row[index];
+      return acc;
+    }, {}) as TRow;
+  });
+}
+
+export function mapQueryData<TRow>(
+  result: QueryQuestionResult,
+): QueryData<TRow> {
+  const rawRows = result.rows;
+
+  return {
+    ...result,
+    rows: mapRowsToObjects<TRow>(result.columns, rawRows),
+    rawRows,
+  };
+}

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
@@ -1,0 +1,6 @@
+export { useMetabaseQuery } from "./use-metabase-query";
+export type {
+  MetabaseBreakout,
+  MetabaseQueryOptions,
+  UseMetabaseQueryResult,
+} from "./use-metabase-query";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -1,0 +1,751 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { QueryDatasetResult } from "embedding-sdk-bundle/lib/query-dataset";
+import type { QueryMetricResult } from "embedding-sdk-bundle/lib/query-metric";
+import type { QueryQuestionResult } from "embedding-sdk-bundle/lib/query-question";
+import type {
+  SdkQuestionId,
+  SqlParameterValues,
+} from "embedding-sdk-bundle/types";
+import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+import type {
+  Aggregation,
+  ConcreteFieldReference,
+  FieldReference,
+  Filter,
+  MetricId,
+  StructuredDatasetQuery,
+} from "metabase-types/api";
+import type {
+  InstanceFilter,
+  JsMetricDefinition,
+  TypedProjection,
+} from "metabase-types/api/metric";
+
+import type {
+  FieldSchema,
+  InferSchema,
+  MeasureSchema,
+  MetricDimensionSchema,
+  MetricSchema,
+  QueryData,
+  QuestionSchema,
+  SchemaColumn,
+  SchemaValue,
+  SegmentSchema,
+  TableSchema,
+} from "../data-schema";
+import { mapQueryData, mapRowsToObjects } from "../data-schema";
+
+type ID = string | number;
+type Values<T> = T[keyof T];
+type UnionToIntersection<TUnion> = (
+  TUnion extends unknown ? (value: TUnion) => void : never
+) extends (value: infer TIntersection) => void
+  ? TIntersection
+  : never;
+
+type SegmentValues<TEntity> = TEntity extends {
+  segments?: infer TSegments;
+}
+  ? Values<NonNullable<TSegments>>
+  : never;
+
+type MeasureValues<TEntity> = TEntity extends {
+  measures?: infer TMeasures;
+}
+  ? Values<NonNullable<TMeasures>>
+  : never;
+
+type FieldValues<TEntity> = TEntity extends {
+  fields?: infer TFields;
+}
+  ? NonNullable<TFields> extends readonly FieldSchema[]
+    ? NonNullable<TFields>[number]
+    : Values<NonNullable<TFields>>
+  : never;
+
+type MetricDimensionValues<TEntity> = TEntity extends {
+  dimensions?: infer TDimensions;
+}
+  ? NonNullable<TDimensions> extends readonly MetricDimensionSchema[]
+    ? NonNullable<TDimensions>[number]
+    : Values<NonNullable<TDimensions>>
+  : never;
+
+type DimensionValues<TEntity> =
+  | FieldValues<TEntity>
+  | MetricDimensionValues<TEntity>;
+
+type DimensionInput<TEntity> = [DimensionValues<TEntity>] extends [never]
+  ? string | FieldSchema | MetricDimensionSchema
+  : DimensionValues<TEntity>;
+
+type MappedTableId<TMetric> = TMetric extends {
+  mappedTableIds?: readonly number[];
+}
+  ? NonNullable<TMetric["mappedTableIds"]>[number]
+  : number;
+
+type MappedTable<TMetric, TSchema> = Extract<
+  TSchema extends { readonly tables: infer TTables } ? Values<TTables> : never,
+  { readonly id: MappedTableId<TMetric> }
+>;
+
+type SegmentForMetric<TMetric, TSchema> = SegmentValues<
+  MappedTable<TMetric, TSchema>
+>;
+
+type MeasureForMetric<TMetric, TSchema> = [
+  MappedTable<TMetric, TSchema>,
+] extends [never]
+  ? MeasureSchema
+  : MeasureValues<MappedTable<TMetric, TSchema>>;
+
+type BreakoutForMetric<TMetric, TSchema> =
+  | MetabaseMetricBreakout
+  | MetabaseBreakout<MappedTable<TMetric, TSchema>>;
+
+type FilterOperator =
+  | "="
+  | "!="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "between"
+  | "contains"
+  | "does-not-contain"
+  | "starts-with"
+  | "ends-with"
+  | "is-empty"
+  | "not-empty"
+  | "is-null"
+  | "not-null"
+  | "time-interval";
+
+export type MetabaseBreakout<TEntity = unknown> =
+  | DimensionInput<TEntity>
+  | {
+      dimension: DimensionInput<TEntity>;
+      bucket?: string;
+      binning?: {
+        strategy: "default" | "bin-width" | "num-bins";
+        "bin-width"?: number;
+        "num-bins"?: number;
+      };
+    };
+
+export type MetabaseDimensionFilter<TEntity = unknown> = {
+  dimension: DimensionInput<TEntity>;
+  operator: FilterOperator;
+  value?: unknown;
+  values?: readonly unknown[];
+};
+
+export type MetabaseMetricBreakout =
+  | MetricDimensionSchema
+  | {
+      dimension: MetricDimensionSchema;
+      bucket?: string;
+      binning?: {
+        strategy: "default" | "bin-width" | "num-bins";
+        "bin-width"?: number;
+        "num-bins"?: number;
+      };
+    };
+
+export type MetabaseMetricDimensionFilter = Omit<
+  MetabaseDimensionFilter,
+  "dimension"
+> & {
+  dimension: MetricDimensionSchema;
+};
+
+type QuestionQuery<TQuestion> = {
+  questionId: SdkQuestionId;
+  tableId?: never;
+  metricId?: never;
+  parameters?: TQuestion extends QuestionSchema
+    ? SqlParameterValues
+    : SqlParameterValues;
+  enabled?: boolean;
+};
+
+type TableQuery<TTable> = {
+  tableId: ID;
+  questionId?: never;
+  metricId?: never;
+  filters?: TTable extends TableSchema
+    ? readonly (SegmentValues<TTable> | MetabaseDimensionFilter<TTable>)[]
+    : readonly unknown[];
+  measures?: TTable extends TableSchema
+    ? readonly MeasureValues<TTable>[]
+    : readonly unknown[];
+  breakouts?: TTable extends TableSchema
+    ? readonly MetabaseBreakout<TTable>[]
+    : readonly MetabaseBreakout[];
+  enabled?: boolean;
+};
+
+type MetricQuery<TMetric, TSchema> = {
+  metricId: ID;
+  questionId?: never;
+  tableId?: never;
+  filters?: TMetric extends MetricSchema
+    ? readonly (
+        | SegmentForMetric<TMetric, TSchema>
+        | MetabaseMetricDimensionFilter
+        | MetabaseDimensionFilter<MappedTable<TMetric, TSchema>>
+      )[]
+    : readonly unknown[];
+  measures?: TMetric extends MetricSchema
+    ? readonly MeasureForMetric<TMetric, TSchema>[]
+    : readonly unknown[];
+  breakouts?: TMetric extends MetricSchema
+    ? readonly BreakoutForMetric<TMetric, TSchema>[]
+    : readonly MetabaseBreakout[];
+  enabled?: boolean;
+};
+
+export type MetabaseQueryOptions<TEntity, TSchema = unknown> =
+  | QuestionQuery<TEntity>
+  | TableQuery<TEntity>
+  | MetricQuery<TEntity, TSchema>;
+
+type EmptyRow = Record<never, never>;
+
+type ColumnRow<TColumn> = TColumn extends SchemaColumn
+  ? { [TName in TColumn["name"]]: SchemaValue<TColumn> }
+  : EmptyRow;
+
+type RowsFromColumns<TColumn> = [TColumn] extends [never]
+  ? EmptyRow
+  : UnionToIntersection<TColumn extends unknown ? ColumnRow<TColumn> : never>;
+
+type BreakoutDimension<TBreakout> = TBreakout extends {
+  dimension: infer TDimension;
+}
+  ? TDimension
+  : TBreakout;
+
+type TupleElement<TValue> = TValue extends readonly unknown[]
+  ? number extends TValue["length"]
+    ? never
+    : TValue[number]
+  : never;
+
+type QueryBreakoutColumns<TQuery> = TQuery extends {
+  breakouts?: infer TBreakouts;
+}
+  ? BreakoutDimension<TupleElement<NonNullable<TBreakouts>>>
+  : never;
+
+type QueryMeasureColumns<TQuery> = TQuery extends {
+  measures?: infer TMeasures;
+}
+  ? TupleElement<NonNullable<TMeasures>> extends {
+      columns: infer TColumns;
+    }
+    ? TupleElement<NonNullable<TColumns>>
+    : never
+  : never;
+
+type InferQuerySchema<TEntity, TQuery> = InferSchema<
+  TEntity,
+  Record<string, unknown>
+> &
+  RowsFromColumns<QueryBreakoutColumns<TQuery> | QueryMeasureColumns<TQuery>>;
+
+export type UseMetabaseQueryResult<TEntity = unknown, TQuery = unknown> = {
+  data: QueryData<InferQuerySchema<TEntity, TQuery>> | null;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => Promise<void>;
+};
+
+export const useMetabaseQuery = <
+  TEntity extends QuestionSchema | TableSchema | MetricSchema | undefined =
+    undefined,
+  TSchema = unknown,
+  TQuery extends MetabaseQueryOptions<TEntity, TSchema> = MetabaseQueryOptions<
+    TEntity,
+    TSchema
+  >,
+>(
+  query: TQuery,
+): UseMetabaseQueryResult<TEntity, TQuery> => {
+  const {
+    state: {
+      internalProps: { reduxStore },
+    },
+  } = useMetabaseProviderPropsStore();
+
+  const loginStatus = useLazySelector(
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.getLoginStatus,
+  );
+
+  const queryQuestion =
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryQuestion;
+  const queryDataset = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryDataset;
+  const queryMetric = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryMetric;
+
+  const [data, setData] =
+    useState<UseMetabaseQueryResult<TEntity, TQuery>["data"]>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const queryKey = useMemo(() => JSON.stringify(query), [query]);
+  const queryRef = useRef(query);
+
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query, queryKey]);
+
+  const refetch = useCallback(async () => {
+    const currentQuery = queryRef.current;
+
+    if (currentQuery.enabled === false) {
+      return;
+    }
+
+    if (!reduxStore) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (isQuestionQuery(currentQuery)) {
+        if (!queryQuestion) {
+          return;
+        }
+
+        const result = await queryQuestion(reduxStore)({
+          questionId: currentQuery.questionId,
+          initialSqlParameters: currentQuery.parameters,
+        });
+
+        setData(mapQueryData(result));
+        return;
+      }
+
+      if (isTableQuery(currentQuery)) {
+        if (!queryDataset) {
+          return;
+        }
+
+        const result = await queryDataset(reduxStore)({
+          datasetQuery: buildTableDatasetQuery(currentQuery),
+        });
+
+        setData(mapDatasetQueryData(result));
+        return;
+      }
+
+      if (isMetricQuery(currentQuery)) {
+        if (hasMeasures(currentQuery)) {
+          if (!queryDataset) {
+            return;
+          }
+
+          const result = await queryDataset(reduxStore)({
+            datasetQuery: buildMetricDatasetQuery(currentQuery),
+          });
+
+          setData(mapDatasetQueryData(result));
+          return;
+        }
+
+        if (!queryMetric) {
+          return;
+        }
+
+        const definition = buildMetricDefinition(currentQuery);
+        const result = await queryMetric(reduxStore)({ definition });
+
+        setData(mapDatasetQueryData(result));
+      }
+    } catch (err) {
+      setError(err);
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [queryDataset, queryMetric, queryQuestion, reduxStore]);
+
+  useEffect(() => {
+    if (loginStatus?.status === "success") {
+      refetch();
+    }
+  }, [loginStatus?.status, queryKey, refetch]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refetch,
+  };
+};
+
+function buildTableDatasetQuery(
+  query: TableQuery<unknown>,
+): Omit<StructuredDatasetQuery, "database"> {
+  const mbql: StructuredDatasetQuery["query"] = {
+    "source-table": Number(query.tableId),
+  };
+
+  const filters = query.filters?.map(buildTableFilter).filter(Boolean);
+  const measures = query.measures?.map(buildMeasureClause).filter(isNotNull);
+  const breakouts = query.breakouts?.map(buildTableBreakout).filter(Boolean);
+
+  if (filters?.length === 1) {
+    mbql.filter = filters[0] as Filter;
+  } else if (filters && filters.length > 1) {
+    mbql.filter = ["and", ...(filters as Filter[])];
+  }
+
+  if (measures?.length) {
+    mbql.aggregation = measures;
+  }
+
+  if (breakouts?.length) {
+    mbql.breakout = breakouts;
+  }
+
+  return {
+    type: "query",
+    query: mbql,
+    parameters: [],
+  };
+}
+
+function isQuestionQuery(
+  query: MetabaseQueryOptions<unknown, unknown>,
+): query is QuestionQuery<unknown> {
+  return query.questionId != null;
+}
+
+function isTableQuery(
+  query: MetabaseQueryOptions<unknown, unknown>,
+): query is TableQuery<unknown> {
+  return query.tableId != null;
+}
+
+function isMetricQuery(
+  query: MetabaseQueryOptions<unknown, unknown>,
+): query is MetricQuery<unknown, unknown> {
+  return query.metricId != null;
+}
+
+function hasMeasures(
+  query: MetricQuery<unknown, unknown>,
+): query is MetricQuery<unknown, unknown> & { measures: readonly unknown[] } {
+  return Array.isArray(query.measures) && query.measures.length > 0;
+}
+
+function buildTableFilter(filter: unknown) {
+  if (isSegmentSchema(filter)) {
+    return ["segment", filter.id];
+  }
+
+  if (isDimensionFilter(filter)) {
+    return buildFieldFilterClause(filter);
+  }
+
+  return null;
+}
+
+function buildMeasureClause(measure: unknown): Aggregation | null {
+  if (!isMeasureSchema(measure)) {
+    return null;
+  }
+
+  return ["measure", {}, measure.id] as Aggregation;
+}
+
+function buildMetricDatasetQuery(
+  query: MetricQuery<unknown, unknown> & { measures: readonly unknown[] },
+): Omit<StructuredDatasetQuery, "database"> {
+  const measures = query.measures.filter(isMeasureSchema);
+  const sourceTableId = getMeasureSourceTableId(measures);
+  const mbql: StructuredDatasetQuery["query"] = {
+    "source-table": sourceTableId,
+    aggregation: [
+      ["metric", Number(query.metricId)] as Aggregation,
+      ...measures.map(buildMeasureClause).filter(isNotNull),
+    ],
+  };
+
+  const filters = query.filters?.map(buildTableFilter).filter(Boolean);
+  const breakouts = query.breakouts?.map(buildTableBreakout).filter(Boolean);
+
+  if (filters?.length === 1) {
+    mbql.filter = filters[0] as Filter;
+  } else if (filters && filters.length > 1) {
+    mbql.filter = ["and", ...(filters as Filter[])];
+  }
+
+  if (breakouts?.length) {
+    mbql.breakout = breakouts;
+  }
+
+  return {
+    type: "query",
+    query: mbql,
+    parameters: [],
+  };
+}
+
+function getMeasureSourceTableId(measures: MeasureSchema[]) {
+  const [firstMeasure] = measures;
+
+  if (!firstMeasure) {
+    throw new Error(
+      "Metric queries with measures require at least one generated measure object.",
+    );
+  }
+
+  const tableId = firstMeasure.tableId;
+  const hasMismatchedMeasure = measures.some((measure) => {
+    return measure.tableId !== tableId;
+  });
+
+  if (hasMismatchedMeasure) {
+    throw new Error("Metric query measures must belong to the same table.");
+  }
+
+  return tableId;
+}
+
+function buildTableBreakout(
+  breakout: MetabaseBreakout,
+): ConcreteFieldReference {
+  const { dimension, options } = normalizeBreakout(breakout);
+
+  return buildFieldReference(dimension, options) as ConcreteFieldReference;
+}
+
+function buildMetricDefinition(query: MetricQuery<unknown, unknown>) {
+  const metricId = Number(query.metricId) as MetricId;
+  const uuid = "metric";
+  const definition: JsMetricDefinition = {
+    expression: ["metric", { "lib/uuid": uuid }, metricId],
+  };
+
+  const filters = query.filters?.map((filter): InstanceFilter | null => {
+    if (isSegmentSchema(filter)) {
+      return {
+        "lib/uuid": uuid,
+        filter: ["segment", {}, filter.id],
+      };
+    }
+
+    if (isMetricDimensionFilter(filter)) {
+      return {
+        "lib/uuid": uuid,
+        filter: buildMetricFilterClause(filter),
+      };
+    }
+
+    return null;
+  });
+
+  const compactFilters = filters?.filter(Boolean) as InstanceFilter[];
+
+  if (compactFilters?.length) {
+    definition.filters = compactFilters;
+  }
+
+  if (query.breakouts?.length) {
+    definition.projections = [
+      {
+        type: "metric",
+        id: metricId,
+        "lib/uuid": uuid,
+        projection: query.breakouts.map((breakout) => {
+          return buildMetricBreakout(toMetricBreakout(breakout));
+        }),
+      } satisfies TypedProjection,
+    ];
+  }
+
+  return definition;
+}
+
+function buildFieldFilterClause(filter: MetabaseDimensionFilter) {
+  const operator = filter.operator;
+  const dimension = buildFieldReference(filter.dimension);
+  const values = filter.values ?? [filter.value];
+
+  if (operator === "between") {
+    return [operator, dimension, ...values.slice(0, 2)];
+  }
+
+  if (isUnaryOperator(operator)) {
+    return [operator, dimension];
+  }
+
+  return [operator, dimension, ...values];
+}
+
+function buildMetricFilterClause(filter: MetabaseMetricDimensionFilter) {
+  const operator = filter.operator;
+  const dimension = buildMetricDimensionReference(filter.dimension);
+  const values = filter.values ?? [filter.value];
+
+  if (operator === "between") {
+    return [operator, {}, dimension, ...values.slice(0, 2)];
+  }
+
+  if (isUnaryOperator(operator)) {
+    return [operator, {}, dimension];
+  }
+
+  return [operator, {}, dimension, ...values];
+}
+
+function buildMetricBreakout(breakout: MetabaseMetricBreakout) {
+  const { dimension, options } = normalizeBreakout(breakout);
+
+  return buildMetricDimensionReference(dimension, options);
+}
+
+function buildFieldReference(
+  field: string | FieldSchema | MetricDimensionSchema,
+  options: Record<string, unknown> = {},
+): FieldReference {
+  if (isFieldSchema(field) && typeof field.fieldId === "number") {
+    return ["field", field.fieldId, options] as FieldReference;
+  }
+
+  if (isFieldSchema(field) && typeof field.id === "number") {
+    return ["field", field.id, options] as FieldReference;
+  }
+
+  return ["field", String(field), options] as FieldReference;
+}
+
+function buildMetricDimensionReference(
+  dimension: string | FieldSchema | MetricDimensionSchema,
+  options: Record<string, unknown> = {},
+) {
+  if (typeof dimension === "string") {
+    throw new Error(
+      "Metric query dimensions must use generated metric dimension objects, not dimension name strings.",
+    );
+  }
+
+  return [
+    "dimension",
+    options,
+    isFieldSchema(dimension) ? dimension.id : dimension,
+  ];
+}
+
+function normalizeBreakout(breakout: MetabaseBreakout) {
+  if (
+    typeof breakout === "string" ||
+    isFieldSchema(breakout) ||
+    isMetricDimensionSchema(breakout)
+  ) {
+    return { dimension: breakout, options: {} };
+  }
+
+  const options: Record<string, unknown> = {};
+
+  if (breakout.bucket) {
+    options["temporal-unit"] = breakout.bucket;
+  }
+
+  if (breakout.binning) {
+    options.binning = breakout.binning;
+  }
+
+  return { dimension: breakout.dimension, options };
+}
+
+function isUnaryOperator(operator: FilterOperator) {
+  return (
+    operator === "is-empty" ||
+    operator === "not-empty" ||
+    operator === "is-null" ||
+    operator === "not-null"
+  );
+}
+
+function isNotNull<TValue>(value: TValue | null): value is TValue {
+  return value !== null;
+}
+
+function isDimensionFilter(value: unknown): value is MetabaseDimensionFilter {
+  return typeof value === "object" && value != null && "dimension" in value;
+}
+
+function isMetricDimensionFilter(
+  value: unknown,
+): value is MetabaseMetricDimensionFilter {
+  return isDimensionFilter(value) && isMetricDimensionSchema(value.dimension);
+}
+
+function toMetricBreakout(breakout: MetabaseBreakout): MetabaseMetricBreakout {
+  if (isMetricDimensionSchema(breakout)) {
+    return breakout;
+  }
+
+  if (
+    typeof breakout === "object" &&
+    breakout != null &&
+    "dimension" in breakout &&
+    isMetricDimensionSchema(breakout.dimension)
+  ) {
+    return breakout as MetabaseMetricBreakout;
+  }
+
+  throw new Error(
+    "Metric query breakouts must use generated metric dimension objects, not dimension name strings.",
+  );
+}
+
+function isSegmentSchema(value: unknown): value is SegmentSchema {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "kind" in value &&
+    value.kind === "segment"
+  );
+}
+
+function isMeasureSchema(value: unknown): value is MeasureSchema {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "kind" in value &&
+    value.kind === "measure"
+  );
+}
+
+function isFieldSchema(
+  value: unknown,
+): value is FieldSchema | MetricDimensionSchema {
+  return typeof value === "object" && value != null && "id" in value;
+}
+
+function isMetricDimensionSchema(
+  value: unknown,
+): value is MetricDimensionSchema {
+  return isFieldSchema(value);
+}
+
+function mapDatasetQueryData<TRow>(
+  result: QueryQuestionResult | QueryDatasetResult | QueryMetricResult,
+): QueryData<TRow> {
+  return {
+    ...result,
+    rows: mapRowsToObjects<TRow>(result.columns, result.rows),
+    rawRows: result.rows,
+  };
+}

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/index.ts
@@ -1,0 +1,7 @@
+export { useMetricQuery } from "./use-metric-query";
+export type {
+  MetricBreakout,
+  MetricFilter,
+  UseMetricQueryOptions,
+  UseMetricQueryResult,
+} from "./use-metric-query";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
@@ -19,6 +19,8 @@ import type {
 } from "../data-schema";
 import { getSchemaId, mapRowsToObjects } from "../data-schema";
 
+type Values<T> = T[keyof T];
+
 type MetricFilterOperator =
   | "="
   | "!="
@@ -38,9 +40,13 @@ type MetricFilterOperator =
   | "time-interval";
 
 type MetricDimensionName<TMetric> = TMetric extends {
-  dimensions: readonly MetricDimensionSchema[];
+  dimensions: infer TDimensions;
 }
-  ? TMetric["dimensions"][number]["name"]
+  ? NonNullable<TDimensions> extends readonly MetricDimensionSchema[]
+    ? NonNullable<TDimensions>[number]["name"]
+    : Values<NonNullable<TDimensions>> extends MetricDimensionSchema
+      ? Values<NonNullable<TDimensions>>["name"]
+      : string
   : string;
 
 export type MetricFilter<TMetric = unknown> = {
@@ -280,11 +286,23 @@ function getDimensionId(
     return dimension.id;
   }
 
-  const schemaDimension = metric?.dimensions?.find(
+  const schemaDimension = getMetricDimensions(metric).find(
     (candidate) => candidate.name === dimension,
   );
 
   return schemaDimension?.id ?? dimension;
+}
+
+function getMetricDimensions(
+  metric: MetricSchema | null,
+): MetricDimensionSchema[] {
+  if (!metric?.dimensions) {
+    return [];
+  }
+
+  return Array.isArray(metric.dimensions)
+    ? [...metric.dimensions]
+    : Object.values(metric.dimensions);
 }
 
 function normalizeFilterOperator(operator: MetricFilterOperator) {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { QueryMetricResult } from "embedding-sdk-bundle/lib/query-metric";
+import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
+import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+import type {
+  InstanceFilter,
+  JsMetricDefinition,
+  MetricId,
+  TypedProjection,
+} from "metabase-types/api/metric";
+
+import type {
+  InferSchema,
+  MetricDimensionSchema,
+  MetricSchema,
+  QueryData,
+} from "../data-schema";
+import { getSchemaId, mapRowsToObjects } from "../data-schema";
+
+type MetricFilterOperator =
+  | "="
+  | "!="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "between"
+  | "contains"
+  | "does-not-contain"
+  | "starts-with"
+  | "ends-with"
+  | "is-empty"
+  | "not-empty"
+  | "is-null"
+  | "not-null"
+  | "time-interval";
+
+type MetricDimensionName<TMetric> = TMetric extends {
+  dimensions: readonly MetricDimensionSchema[];
+}
+  ? TMetric["dimensions"][number]["name"]
+  : string;
+
+export type MetricFilter<TMetric = unknown> = {
+  dimension: MetricDimensionName<TMetric> | MetricDimensionSchema;
+  operator: MetricFilterOperator;
+  value?: unknown;
+  values?: readonly unknown[];
+};
+
+export type MetricBreakout<TMetric = unknown> =
+  | MetricDimensionName<TMetric>
+  | MetricDimensionSchema
+  | {
+      dimension: MetricDimensionName<TMetric> | MetricDimensionSchema;
+      bucket?: string;
+      binning?: {
+        strategy: "default" | "bin-width" | "num-bins";
+        "bin-width"?: number;
+        "num-bins"?: number;
+      };
+    };
+
+export type UseMetricQueryOptions<TMetric = unknown> = {
+  enabled?: boolean;
+  definition?: JsMetricDefinition;
+  filters?: readonly MetricFilter<TMetric>[];
+  breakouts?: readonly MetricBreakout<TMetric>[];
+};
+
+export type UseMetricQueryResult<TMetric = unknown> = {
+  data: QueryData<InferSchema<TMetric, Record<string, unknown>>> | null;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => Promise<void>;
+};
+
+/**
+ * Fetches the result of a metric through the metric dataset API.
+ *
+ * Passing a generated metric schema object enables row and dimension name
+ * inference.
+ *
+ * @function
+ * @category useMetricQuery
+ */
+export const useMetricQuery = <
+  TMetric extends MetricSchema | MetricId = MetricId,
+>(
+  metric: TMetric | null,
+  {
+    enabled = true,
+    definition,
+    filters = [],
+    breakouts = [],
+  }: UseMetricQueryOptions<TMetric> = {},
+): UseMetricQueryResult<TMetric> => {
+  const {
+    state: {
+      internalProps: { reduxStore },
+    },
+  } = useMetabaseProviderPropsStore();
+
+  const loginStatus = useLazySelector(
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.getLoginStatus,
+  );
+
+  const queryMetric = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryMetric;
+
+  const metricId = getSchemaId(metric) as MetricId | null;
+  const metricSchema = isMetricSchema(metric) ? metric : null;
+
+  const [data, setData] = useState<UseMetricQueryResult<TMetric>["data"]>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const definitionKey = useMemo(
+    () => JSON.stringify({ definition, filters, breakouts }),
+    [definition, filters, breakouts],
+  );
+
+  const definitionRef = useRef<JsMetricDefinition | null>(null);
+
+  useEffect(() => {
+    definitionRef.current =
+      definition ??
+      buildMetricDefinition({
+        metricId,
+        metric: metricSchema,
+        filters,
+        breakouts,
+      });
+  }, [definition, metricId, metricSchema, definitionKey, filters, breakouts]);
+
+  const refetch = useCallback(async () => {
+    if (
+      !enabled ||
+      metricId == null ||
+      !reduxStore ||
+      !queryMetric ||
+      !definitionRef.current
+    ) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const nextResult = await queryMetric(reduxStore)({
+        definition: definitionRef.current,
+      });
+
+      setData(mapMetricQueryData(nextResult));
+    } catch (err) {
+      setError(err);
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [enabled, metricId, queryMetric, reduxStore]);
+
+  useEffect(() => {
+    if (loginStatus?.status === "success") {
+      refetch();
+    }
+  }, [loginStatus?.status, definitionKey, refetch]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refetch,
+  };
+};
+
+function buildMetricDefinition({
+  metricId,
+  metric,
+  filters,
+  breakouts,
+}: {
+  metricId: MetricId | null;
+  metric: MetricSchema | null;
+  filters: readonly MetricFilter[];
+  breakouts: readonly MetricBreakout[];
+}): JsMetricDefinition | null {
+  if (metricId == null) {
+    return null;
+  }
+
+  const uuid = "metric";
+  const definition: JsMetricDefinition = {
+    expression: ["metric", { "lib/uuid": uuid }, metricId],
+  };
+
+  const instanceFilters = filters.map((filter): InstanceFilter => {
+    return {
+      "lib/uuid": uuid,
+      filter: buildFilterClause(metric, filter),
+    };
+  });
+
+  if (instanceFilters.length > 0) {
+    definition.filters = instanceFilters;
+  }
+
+  if (breakouts.length > 0) {
+    definition.projections = [
+      {
+        type: "metric",
+        id: metricId,
+        "lib/uuid": uuid,
+        projection: breakouts.map((breakout) =>
+          buildBreakoutClause(metric, breakout),
+        ),
+      } satisfies TypedProjection,
+    ];
+  }
+
+  return definition;
+}
+
+function buildFilterClause(metric: MetricSchema | null, filter: MetricFilter) {
+  const operator = normalizeFilterOperator(filter.operator);
+  const dimension = buildDimensionClause(metric, filter.dimension);
+  const values = filter.values ?? [filter.value];
+
+  if (operator === "between") {
+    return [operator, {}, dimension, ...values.slice(0, 2)];
+  }
+
+  if (
+    operator === "is-empty" ||
+    operator === "not-empty" ||
+    operator === "is-null" ||
+    operator === "not-null"
+  ) {
+    return [operator, {}, dimension];
+  }
+
+  return [operator, {}, dimension, ...values];
+}
+
+function buildBreakoutClause(
+  metric: MetricSchema | null,
+  breakout: MetricBreakout,
+) {
+  if (typeof breakout === "string" || isMetricDimensionSchema(breakout)) {
+    return buildDimensionClause(metric, breakout);
+  }
+
+  const options: Record<string, unknown> = {};
+
+  if (breakout.bucket) {
+    options["temporal-unit"] = breakout.bucket;
+  }
+
+  if (breakout.binning) {
+    options.binning = breakout.binning;
+  }
+
+  return ["dimension", options, getDimensionId(metric, breakout.dimension)];
+}
+
+function buildDimensionClause(
+  metric: MetricSchema | null,
+  dimension: MetricDimensionName<unknown> | MetricDimensionSchema,
+) {
+  return ["dimension", {}, getDimensionId(metric, dimension)];
+}
+
+function getDimensionId(
+  metric: MetricSchema | null,
+  dimension: string | MetricDimensionSchema,
+) {
+  if (isMetricDimensionSchema(dimension)) {
+    return dimension.id;
+  }
+
+  const schemaDimension = metric?.dimensions?.find(
+    (candidate) => candidate.name === dimension,
+  );
+
+  return schemaDimension?.id ?? dimension;
+}
+
+function normalizeFilterOperator(operator: MetricFilterOperator) {
+  return operator === "=" ? "=" : operator;
+}
+
+function isMetricSchema(value: unknown): value is MetricSchema {
+  return typeof value === "object" && value != null && "columns" in value;
+}
+
+function isMetricDimensionSchema(
+  value: unknown,
+): value is MetricDimensionSchema {
+  return typeof value === "object" && value != null && "id" in value;
+}
+
+function mapMetricQueryData<TRow>(result: QueryMetricResult): QueryData<TRow> {
+  return {
+    ...result,
+    rows: mapRowsToObjects<TRow>(result.columns, result.rows),
+    rawRows: result.rows,
+  };
+}

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.unit.spec.tsx
@@ -1,0 +1,170 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { screen } from "__support__/ui";
+import { getLoginStatus } from "embedding-sdk-bundle/store/selectors";
+import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
+import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
+import { createMockColumn } from "metabase-types/api/mocks";
+
+import type { SchemaRow } from "../data-schema";
+
+import { useMetricQuery } from "./use-metric-query";
+
+const TEST_METRIC_ID = 34;
+const TEST_COLUMN = createMockColumn({
+  display_name: "Count",
+  name: "count",
+});
+const TEST_RESULT = {
+  rowCount: 1,
+  runningTime: 1000,
+  columns: [TEST_COLUMN],
+  rows: [[12]],
+};
+const TEST_SCHEMA = {
+  id: TEST_METRIC_ID,
+  name: "Order Count",
+  columns: [{ name: "count", displayName: "Count", jsType: "number" }],
+  dimensions: [
+    {
+      id: "dimension-price",
+      name: "price",
+      displayName: "Price",
+      jsType: "number",
+    },
+    {
+      id: "dimension-created-at",
+      name: "createdAt",
+      displayName: "Created At",
+      jsType: "Date",
+    },
+  ],
+} as const;
+
+type Equals<TLeft, TRight> =
+  (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
+    TValue,
+  >() => TValue extends TRight ? 1 : 2
+    ? true
+    : false;
+type Expect<TValue extends true> = TValue;
+type _MetricRowIsInferred = Expect<
+  Equals<SchemaRow<typeof TEST_SCHEMA>, { count: number | null }>
+>;
+
+describe("useMetricQuery", () => {
+  it("builds a metric definition from filters and breakouts", async () => {
+    const queryMetricApi = jest.fn().mockResolvedValue({
+      ...TEST_RESULT,
+    });
+    const queryMetric = jest.fn(() => queryMetricApi);
+
+    setup({ queryMetric });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("first-row-value")).toHaveTextContent("12");
+    });
+
+    expect(queryMetricApi).toHaveBeenCalledWith({
+      definition: {
+        expression: ["metric", { "lib/uuid": "metric" }, TEST_METRIC_ID],
+        filters: [
+          {
+            "lib/uuid": "metric",
+            filter: [">=", {}, ["dimension", {}, "dimension-price"], 2],
+          },
+        ],
+        projections: [
+          {
+            type: "metric",
+            id: TEST_METRIC_ID,
+            "lib/uuid": "metric",
+            projection: [
+              [
+                "dimension",
+                { "temporal-unit": "month" },
+                "dimension-created-at",
+              ],
+            ],
+          },
+        ],
+      },
+    });
+    expect(queryMetric).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch when disabled", async () => {
+    const queryMetric = jest.fn(() => jest.fn());
+
+    setup({ queryMetric, enabled: false });
+
+    expect(screen.getByTestId("first-row-value")).toHaveTextContent("");
+    expect(queryMetric).not.toHaveBeenCalled();
+  });
+
+  it("can refetch the metric data", async () => {
+    const queryMetricApi = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ...TEST_RESULT,
+      })
+      .mockResolvedValueOnce({
+        ...TEST_RESULT,
+        rows: [[24]],
+      });
+    const queryMetric = jest.fn(() => queryMetricApi);
+
+    setup({ queryMetric });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("first-row-value")).toHaveTextContent("12");
+    });
+
+    await userEvent.click(screen.getByText("Refetch"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("first-row-value")).toHaveTextContent("24");
+    });
+    expect(queryMetricApi).toHaveBeenCalledTimes(2);
+  });
+});
+
+const TestComponent = ({ enabled }: { enabled?: boolean }) => {
+  const result = useMetricQuery(TEST_SCHEMA, {
+    enabled,
+    filters: [{ dimension: "price", operator: ">=", value: 2 }],
+    breakouts: [{ dimension: "createdAt", bucket: "month" }],
+  });
+
+  return (
+    <div>
+      <div data-testid="first-row-value">
+        {String(result.data?.rows[0]?.count ?? "")}
+      </div>
+      <button onClick={() => result.refetch()}>Refetch</button>
+    </div>
+  );
+};
+
+function setup({
+  queryMetric,
+  enabled,
+}: {
+  queryMetric: jest.Mock;
+  enabled?: boolean;
+}) {
+  const { state } = setupSdkState();
+
+  renderWithSDKProviders(<TestComponent enabled={enabled} />, {
+    metabaseEmbeddingSdkBundleExports: {
+      getLoginStatus,
+      queryMetric,
+    },
+    storeInitialState: state,
+    componentProviderProps: {
+      authConfig: createMockSdkConfig(),
+    },
+  });
+}

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.stories.tsx
@@ -2,13 +2,16 @@ import type { StoryFn } from "@storybook/react";
 import type { CSSProperties, JSXElementConstructor } from "react";
 import { useMemo } from "react";
 
-import type { QueryQuestionResult } from "embedding-sdk-bundle/lib/query-question";
 import { getStorybookSdkAuthConfigForUser } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 import type { SdkQuestionId } from "embedding-sdk-bundle/types";
 import { MetabaseProvider } from "embedding-sdk-package/components/public/MetabaseProvider";
 import { getHostedBundleStoryDecorator } from "embedding-sdk-package/test/getHostedBundleStoryDecorator";
 
+import type { QueryData } from "../data-schema";
+
 import { useQuestionQuery } from "./use-question-query";
+
+type StoryQueryData = QueryData<Record<string, unknown>>;
 
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 const config = getStorybookSdkAuthConfigForUser("admin");
@@ -100,7 +103,7 @@ function CustomSalesVisualization({
   data,
   chart,
 }: {
-  data: QueryQuestionResult;
+  data: StoryQueryData;
   chart: ChartModel | null;
 }) {
   if (!chart) {
@@ -164,7 +167,7 @@ function CustomSalesVisualization({
   );
 }
 
-function RowsTable({ data }: { data: QueryQuestionResult }) {
+function RowsTable({ data }: { data: StoryQueryData }) {
   return (
     <section style={panelStyle}>
       <div style={tableIntroStyle}>
@@ -186,7 +189,7 @@ function RowsTable({ data }: { data: QueryQuestionResult }) {
           </tr>
         </thead>
         <tbody>
-          {data.rows.slice(0, 8).map((row, rowIndex) => (
+          {data.rawRows.slice(0, 8).map((row, rowIndex) => (
             <tr key={rowIndex}>
               {row.map((value, valueIndex) => (
                 <td key={valueIndex} style={tableCellStyle}>
@@ -217,7 +220,7 @@ type ChartModel = {
   }[];
 };
 
-function buildChartModel(data: QueryQuestionResult): ChartModel | null {
+function buildChartModel(data: StoryQueryData): ChartModel | null {
   const dateIndex = data.columns.findIndex((column) =>
     [column.base_type, column.effective_type].some((type) =>
       type?.includes("DateTime"),
@@ -243,7 +246,7 @@ function buildChartModel(data: QueryQuestionResult): ChartModel | null {
   const totalsByMonth = new Map<string, Map<string, number>>();
   const categorySet = new Set<string>();
 
-  for (const row of data.rows) {
+  for (const row of data.rawRows) {
     const month = getMonthKey(row[dateIndex]);
     const category = String(row[categoryIndex] ?? "Unknown");
     const value = Number(row[metricIndex] ?? 0);

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { QueryQuestionResult } from "embedding-sdk-bundle/lib/query-question";
 import type {
   SdkQuestionId,
   SqlParameterValues,
@@ -9,13 +8,16 @@ import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
+import type { InferSchema, QueryData, QuestionSchema } from "../data-schema";
+import { getSchemaId, mapQueryData } from "../data-schema";
+
 export type UseQuestionQueryOptions = {
   initialSqlParameters?: SqlParameterValues;
   enabled?: boolean;
 };
 
-export type UseQuestionQueryResult = {
-  data: QueryQuestionResult | null;
+export type UseQuestionQueryResult<TQuestion = unknown> = {
+  data: QueryData<InferSchema<TQuestion, Record<string, unknown>>> | null;
   isLoading: boolean;
   error: unknown;
   refetch: () => Promise<void>;
@@ -30,10 +32,12 @@ export type UseQuestionQueryResult = {
  * @function
  * @category useQuestionQuery
  */
-export const useQuestionQuery = (
-  questionId: SdkQuestionId | null,
+export const useQuestionQuery = <
+  TQuestion extends QuestionSchema | SdkQuestionId = SdkQuestionId,
+>(
+  question: TQuestion | null,
   { initialSqlParameters, enabled = true }: UseQuestionQueryOptions = {},
-): UseQuestionQueryResult => {
+): UseQuestionQueryResult<TQuestion> => {
   const {
     state: {
       internalProps: { reduxStore },
@@ -47,7 +51,10 @@ export const useQuestionQuery = (
   const queryQuestion =
     getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryQuestion;
 
-  const [data, setData] = useState<QueryQuestionResult | null>(null);
+  const questionId = getSchemaId(question) as SdkQuestionId | null;
+
+  const [data, setData] =
+    useState<UseQuestionQueryResult<TQuestion>["data"]>(null);
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
@@ -77,7 +84,7 @@ export const useQuestionQuery = (
         initialSqlParameters: initialSqlParametersRef.current,
       });
 
-      setData(nextResult);
+      setData(mapQueryData(nextResult));
     } catch (err) {
       setError(err);
       setData(null);

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.ts
@@ -9,9 +9,10 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
 import type { InferSchema, QueryData, QuestionSchema } from "../data-schema";
-import { getSchemaId, mapQueryData } from "../data-schema";
+import { mapQueryData } from "../data-schema";
 
 export type UseQuestionQueryOptions = {
+  parameters?: SqlParameterValues;
   initialSqlParameters?: SqlParameterValues;
   enabled?: boolean;
 };
@@ -33,10 +34,14 @@ export type UseQuestionQueryResult<TQuestion = unknown> = {
  * @category useQuestionQuery
  */
 export const useQuestionQuery = <
-  TQuestion extends QuestionSchema | SdkQuestionId = SdkQuestionId,
+  TQuestion extends QuestionSchema | undefined = undefined,
 >(
-  question: TQuestion | null,
-  { initialSqlParameters, enabled = true }: UseQuestionQueryOptions = {},
+  questionId: SdkQuestionId | null,
+  {
+    parameters,
+    initialSqlParameters,
+    enabled = true,
+  }: UseQuestionQueryOptions = {},
 ): UseQuestionQueryResult<TQuestion> => {
   const {
     state: {
@@ -51,24 +56,24 @@ export const useQuestionQuery = <
   const queryQuestion =
     getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.queryQuestion;
 
-  const questionId = getSchemaId(question) as SdkQuestionId | null;
-
   const [data, setData] =
     useState<UseQuestionQueryResult<TQuestion>["data"]>(null);
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
 
+  const sqlParameters = parameters ?? initialSqlParameters;
+
   const parameterKey = useMemo(
-    () => JSON.stringify(initialSqlParameters ?? {}),
-    [initialSqlParameters],
+    () => JSON.stringify(sqlParameters ?? {}),
+    [sqlParameters],
   );
 
-  const initialSqlParametersRef = useRef(initialSqlParameters);
+  const initialSqlParametersRef = useRef(sqlParameters);
 
   useEffect(() => {
-    initialSqlParametersRef.current = initialSqlParameters;
-  }, [initialSqlParameters, parameterKey]);
+    initialSqlParametersRef.current = sqlParameters;
+  }, [sqlParameters, parameterKey]);
 
   const refetch = useCallback(async () => {
     if (!enabled || questionId == null || !reduxStore || !queryQuestion) {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.unit.spec.tsx
@@ -29,12 +29,18 @@ const TEST_RESULT = {
   rows: [[1]],
 };
 
-const TEST_SCHEMA = {
-  id: TEST_QUESTION_ID,
-  name: "Orders",
-  columns: [{ name: "count", displayName: "Count", jsType: "number" }],
-  parameters: [],
-} as const;
+type TestSchema = {
+  readonly id: typeof TEST_QUESTION_ID;
+  readonly name: "Orders";
+  readonly columns: readonly [
+    {
+      readonly name: "count";
+      readonly displayName: "Count";
+      readonly jsType: "number";
+    },
+  ];
+  readonly parameters: readonly [];
+};
 
 type Equals<TLeft, TRight> =
   (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
@@ -44,16 +50,15 @@ type Equals<TLeft, TRight> =
     : false;
 type Expect<TValue extends true> = TValue;
 type _QuestionRowIsInferred = Expect<
-  Equals<SchemaRow<typeof TEST_SCHEMA>, { count: number | null }>
+  Equals<SchemaRow<TestSchema>, { count: number | null }>
 >;
 
 describe("useQuestionQuery", () => {
   it("fetches question data when the SDK is initialized", async () => {
-    const queryQuestion = jest.fn(() =>
-      jest.fn().mockResolvedValue({
-        ...TEST_RESULT,
-      }),
-    );
+    const queryQuestionApi = jest.fn().mockResolvedValue({
+      ...TEST_RESULT,
+    });
+    const queryQuestion = jest.fn(() => queryQuestionApi);
 
     setup({ queryQuestion });
 
@@ -63,6 +68,10 @@ describe("useQuestionQuery", () => {
 
     expect(screen.getByTestId("first-row-value")).toHaveTextContent("1");
     expect(screen.getByTestId("first-raw-row-value")).toHaveTextContent("1");
+    expect(queryQuestionApi).toHaveBeenCalledWith({
+      questionId: TEST_QUESTION_ID,
+      initialSqlParameters: undefined,
+    });
     expect(queryQuestion).toHaveBeenCalledTimes(1);
   });
 
@@ -111,9 +120,7 @@ const TestComponent = ({
   questionId?: SdkQuestionId | null;
   enabled?: boolean;
 }) => {
-  const result = useQuestionQuery(questionId == null ? null : TEST_SCHEMA, {
-    enabled,
-  });
+  const result = useQuestionQuery<TestSchema>(questionId, { enabled });
 
   return (
     <div>

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-question-query/use-question-query.unit.spec.tsx
@@ -9,6 +9,8 @@ import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
 import type { SdkQuestionId } from "embedding-sdk-bundle/types";
 import { createMockColumn } from "metabase-types/api/mocks";
 
+import type { SchemaRow } from "../data-schema";
+
 import { useQuestionQuery } from "./use-question-query";
 
 const TEST_QUESTION_ID = 12;
@@ -27,6 +29,24 @@ const TEST_RESULT = {
   rows: [[1]],
 };
 
+const TEST_SCHEMA = {
+  id: TEST_QUESTION_ID,
+  name: "Orders",
+  columns: [{ name: "count", displayName: "Count", jsType: "number" }],
+  parameters: [],
+} as const;
+
+type Equals<TLeft, TRight> =
+  (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
+    TValue,
+  >() => TValue extends TRight ? 1 : 2
+    ? true
+    : false;
+type Expect<TValue extends true> = TValue;
+type _QuestionRowIsInferred = Expect<
+  Equals<SchemaRow<typeof TEST_SCHEMA>, { count: number | null }>
+>;
+
 describe("useQuestionQuery", () => {
   it("fetches question data when the SDK is initialized", async () => {
     const queryQuestion = jest.fn(() =>
@@ -42,6 +62,7 @@ describe("useQuestionQuery", () => {
     });
 
     expect(screen.getByTestId("first-row-value")).toHaveTextContent("1");
+    expect(screen.getByTestId("first-raw-row-value")).toHaveTextContent("1");
     expect(queryQuestion).toHaveBeenCalledTimes(1);
   });
 
@@ -90,13 +111,18 @@ const TestComponent = ({
   questionId?: SdkQuestionId | null;
   enabled?: boolean;
 }) => {
-  const result = useQuestionQuery(questionId, { enabled });
+  const result = useQuestionQuery(questionId == null ? null : TEST_SCHEMA, {
+    enabled,
+  });
 
   return (
     <div>
       <div data-testid="question-name">{result.data?.name}</div>
       <div data-testid="first-row-value">
-        {String(result.data?.rows[0]?.[0] ?? "")}
+        {String(result.data?.rows[0]?.count ?? "")}
+      </div>
+      <div data-testid="first-raw-row-value">
+        {String(result.data?.rawRows[0]?.[0] ?? "")}
       </div>
       <button onClick={() => result.refetch()}>Refetch</button>
     </div>

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -30,6 +30,7 @@ export { useMetabot } from "./hooks/public/use-metabot";
 export { useCreateDashboardApi } from "./hooks/public/use-create-dashboard-api";
 export { useMetabaseAuthStatus } from "./hooks/public/use-metabase-auth-status";
 export { useQuestionQuery } from "./hooks/public/use-question-query";
+export { useMetricQuery } from "./hooks/public/use-metric-query";
 
 export { defineMetabaseAuthConfig } from "./lib/public/define-metabase-auth-config";
 export { defineMetabaseTheme } from "./lib/public/define-metabase-theme";
@@ -151,7 +152,23 @@ export type {
   UseQuestionQueryOptions,
   UseQuestionQueryResult,
 } from "./hooks/public/use-question-query";
+export type {
+  MetricBreakout,
+  MetricFilter,
+  UseMetricQueryOptions,
+  UseMetricQueryResult,
+} from "./hooks/public/use-metric-query";
+export type {
+  MetricSchema,
+  QuestionSchema,
+  QueryData,
+  SchemaColumn,
+  SchemaJavaScriptType,
+  SchemaParameter,
+  SchemaRow,
+} from "./hooks/public/data-schema";
 export type { QueryQuestionResult } from "embedding-sdk-bundle/lib/query-question";
+export type { QueryMetricResult } from "embedding-sdk-bundle/lib/query-metric";
 
 export type {
   EmbeddingEntityType,

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -31,6 +31,11 @@ export { useCreateDashboardApi } from "./hooks/public/use-create-dashboard-api";
 export { useMetabaseAuthStatus } from "./hooks/public/use-metabase-auth-status";
 export { useQuestionQuery } from "./hooks/public/use-question-query";
 export { useMetricQuery } from "./hooks/public/use-metric-query";
+export { useMetabaseQuery } from "./hooks/public/use-metabase-query";
+export type {
+  MetabaseQueryOptions,
+  UseMetabaseQueryResult,
+} from "./hooks/public/use-metabase-query";
 
 export { defineMetabaseAuthConfig } from "./lib/public/define-metabase-auth-config";
 export { defineMetabaseTheme } from "./lib/public/define-metabase-theme";

--- a/enterprise/frontend/src/metabase-enterprise/data_app_demo/host-sdk-init.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_app_demo/host-sdk-init.ts
@@ -1,3 +1,4 @@
+import { queryDataset } from "embedding-sdk-bundle/lib/query-dataset";
 import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { getSdkStore } from "embedding-sdk-bundle/store";
@@ -36,6 +37,7 @@ export function getHostBackedSdkStore() {
       ...(win.METABASE_EMBEDDING_SDK_BUNDLE ?? {}),
       queryMetric,
       queryQuestion,
+      queryDataset,
       getLoginStatus,
     } as typeof win.METABASE_EMBEDDING_SDK_BUNDLE;
   }

--- a/enterprise/frontend/src/metabase-enterprise/data_app_demo/host-sdk-init.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_app_demo/host-sdk-init.ts
@@ -1,3 +1,4 @@
+import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { getSdkStore } from "embedding-sdk-bundle/store";
 import { initAuth } from "embedding-sdk-bundle/store/auth/auth";
@@ -33,6 +34,7 @@ export function getHostBackedSdkStore() {
   if (win) {
     win.METABASE_EMBEDDING_SDK_BUNDLE = {
       ...(win.METABASE_EMBEDDING_SDK_BUNDLE ?? {}),
+      queryMetric,
       queryQuestion,
       getLoginStatus,
     } as typeof win.METABASE_EMBEDDING_SDK_BUNDLE;

--- a/enterprise/frontend/src/metabase-enterprise/data_app_demo/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_app_demo/sandbox.ts
@@ -14,6 +14,7 @@ import {
   InteractiveDashboard,
   StaticDashboard,
 } from "embedding-sdk-bundle/components/public/dashboard";
+import { useMetabaseQuery } from "embedding-sdk-package/hooks/public/use-metabase-query";
 import { useQuestionQuery } from "embedding-sdk-package/hooks/public/use-question-query";
 import type { MetabaseEmbeddingTheme } from "metabase/embedding-sdk/theme";
 import { MetabaseReduxProvider } from "metabase/redux";
@@ -88,6 +89,7 @@ export function createDataAppSandbox(appId: number = 0) {
       React,
       // Data fetching
       useQuestionQuery,
+      useMetabaseQuery,
       // Provider
       MetabaseProvider,
       // Question components

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -43,6 +43,7 @@ import { getUser } from "metabase/selectors/user";
 import { useInitData } from "./hooks/private/use-init-data";
 import { useLogVersionInfo } from "embedding-sdk-bundle/hooks/private/use-log-version-info";
 import { createDashboard } from "embedding-sdk-bundle/lib/create-dashboard";
+import { queryDataset } from "embedding-sdk-bundle/lib/query-dataset";
 import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { defineBuildInfo } from "metabase/embedding-sdk/lib/define-build-info";
@@ -77,6 +78,7 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   useLogVersionInfo,
   validateFunctionSchema,
   MetabotSubscriber,
+  queryDataset,
   queryMetric,
   queryQuestion,
 };

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -43,6 +43,7 @@ import { getUser } from "metabase/selectors/user";
 import { useInitData } from "./hooks/private/use-init-data";
 import { useLogVersionInfo } from "embedding-sdk-bundle/hooks/private/use-log-version-info";
 import { createDashboard } from "embedding-sdk-bundle/lib/create-dashboard";
+import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { defineBuildInfo } from "metabase/embedding-sdk/lib/define-build-info";
 import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
@@ -76,6 +77,7 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   useLogVersionInfo,
   validateFunctionSchema,
   MetabotSubscriber,
+  queryMetric,
   queryQuestion,
 };
 

--- a/frontend/src/embedding-sdk-bundle/lib/query-dataset.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/query-dataset.ts
@@ -1,0 +1,55 @@
+import { GET, POST } from "metabase/api/legacy-client";
+import type {
+  Dataset,
+  DatasetColumn,
+  RowValues,
+  StructuredDatasetQuery,
+} from "metabase-types/api";
+
+export type QueryDatasetParams = {
+  datasetQuery:
+    | StructuredDatasetQuery
+    | Omit<StructuredDatasetQuery, "database">;
+};
+
+export type QueryDatasetResult = {
+  rowCount: number | null;
+  runningTime: number | null;
+  columns: DatasetColumn[];
+  rows: RowValues[];
+};
+
+export const queryDataset =
+  () =>
+  async ({ datasetQuery }: QueryDatasetParams): Promise<QueryDatasetResult> => {
+    const query =
+      "database" in datasetQuery && datasetQuery.database != null
+        ? datasetQuery
+        : await withTableDatabaseId(datasetQuery);
+
+    const response: Dataset = await POST("/api/dataset")(query);
+
+    return {
+      rowCount: response.row_count ?? null,
+      runningTime: response.running_time ?? null,
+      columns: response.data?.cols ?? [],
+      rows: response.data?.rows ?? [],
+    };
+  };
+
+async function withTableDatabaseId(
+  datasetQuery: Omit<StructuredDatasetQuery, "database">,
+): Promise<StructuredDatasetQuery> {
+  const tableId = datasetQuery.query?.["source-table"];
+
+  if (typeof tableId !== "number") {
+    throw new Error("A database id is required for this dataset query.");
+  }
+
+  const table = await GET(`/api/table/${tableId}`)();
+
+  return {
+    ...datasetQuery,
+    database: table.db_id,
+  };
+}

--- a/frontend/src/embedding-sdk-bundle/lib/query-metric.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/query-metric.ts
@@ -1,0 +1,32 @@
+import { POST } from "metabase/api/legacy-client";
+import type { Dataset, DatasetColumn, RowValues } from "metabase-types/api";
+import type {
+  JsMetricDefinition,
+  MetricDatasetRequest,
+} from "metabase-types/api/metric";
+
+export type QueryMetricParams = {
+  definition: JsMetricDefinition;
+};
+
+export type QueryMetricResult = {
+  rowCount: number | null;
+  runningTime: number | null;
+  columns: DatasetColumn[];
+  rows: RowValues[];
+};
+
+export const queryMetric =
+  () =>
+  async ({ definition }: QueryMetricParams): Promise<QueryMetricResult> => {
+    const response: Dataset = await POST("/api/metric/dataset")({
+      definition,
+    } satisfies MetricDatasetRequest);
+
+    return {
+      rowCount: response.row_count ?? null,
+      runningTime: response.running_time ?? null,
+      columns: response.data?.cols ?? [],
+      rows: response.data?.rows ?? [],
+    };
+  };

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -13,6 +13,10 @@ import type { EditableDashboard } from "embedding-sdk-bundle/components/public/d
 import type { InteractiveDashboard } from "embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard";
 import type { StaticDashboard } from "embedding-sdk-bundle/components/public/dashboard/StaticDashboard";
 import type {
+  QueryMetricParams,
+  QueryMetricResult,
+} from "embedding-sdk-bundle/lib/query-metric";
+import type {
   QueryQuestionParams,
   QueryQuestionResult,
 } from "embedding-sdk-bundle/lib/query-question";
@@ -71,6 +75,9 @@ type ReduxStoreUtilityFunctionExports = {
   >;
   queryQuestion: ReduxStoreUtilityFunction<
     (params: QueryQuestionParams) => Promise<QueryQuestionResult>
+  >;
+  queryMetric: ReduxStoreUtilityFunction<
+    (params: QueryMetricParams) => Promise<QueryMetricResult>
   >;
 };
 

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -13,6 +13,10 @@ import type { EditableDashboard } from "embedding-sdk-bundle/components/public/d
 import type { InteractiveDashboard } from "embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard";
 import type { StaticDashboard } from "embedding-sdk-bundle/components/public/dashboard/StaticDashboard";
 import type {
+  QueryDatasetParams,
+  QueryDatasetResult,
+} from "embedding-sdk-bundle/lib/query-dataset";
+import type {
   QueryMetricParams,
   QueryMetricResult,
 } from "embedding-sdk-bundle/lib/query-metric";
@@ -75,6 +79,9 @@ type ReduxStoreUtilityFunctionExports = {
   >;
   queryQuestion: ReduxStoreUtilityFunction<
     (params: QueryQuestionParams) => Promise<QueryQuestionResult>
+  >;
+  queryDataset: ReduxStoreUtilityFunction<
+    (params: QueryDatasetParams) => Promise<QueryDatasetResult>
   >;
   queryMetric: ReduxStoreUtilityFunction<
     (params: QueryMetricParams) => Promise<QueryMetricResult>

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -64,6 +64,7 @@
    [metabase.transforms-rest.api.transform]
    [metabase.transforms-rest.api.transform-job]
    [metabase.transforms-rest.api.transform-tag]
+   [metabase.typed-schemas.api]
    [metabase.upload.api]
    [metabase.user-key-value.api]
    [metabase.users-rest.api]
@@ -114,6 +115,7 @@
          metabase.transforms-rest.api.transform/keep-me
          metabase.transforms-rest.api.transform-job/keep-me
          metabase.transforms-rest.api.transform-tag/keep-me
+         metabase.typed-schemas.api/keep-me
          metabase.upload.api/keep-me
          metabase.user-key-value.api/keep-me
          metabase.users-rest.api/keep-me
@@ -223,6 +225,7 @@
    "/transform"            (+auth metabase.transforms-rest.api.transform/routes)
    "/transform-job"        (+auth metabase.transforms-rest.api.transform/transform-job-routes)
    "/transform-tag"        (+auth metabase.transforms-rest.api.transform/transform-tag-routes)
+   "/typed-schemas"        (+auth metabase.typed-schemas.api/routes)
    "/upload"               (+auth 'metabase.upload.api)
    "/user"                 (+auth 'metabase.users-rest.api)
    "/user-key-value"       (+auth 'metabase.user-key-value.api)

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.metabot.tools.util :as metabot.tools.u]
+   [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
    [metabase.system.core :as system]
    [metabase.util :as u]
@@ -29,7 +30,7 @@
   (assoc javascript-response-headers "Content-Type" "text/typescript; charset=utf-8"))
 
 (def ^:private js-identifier-key-pattern
-  #"\"([A-Za-z_$][A-Za-z0-9_$]*)\":")
+  #"\"([A-Za-z_$][A-Za-z0-9_$]*)\"\s*:")
 
 (defn- js-type
   [{:keys [type base_type effective_type] :as _column}]
@@ -146,13 +147,34 @@
    :columns     (mapv column-schema result-columns)
    :parameters  []})
 
+(defn- persisted-dimension->column
+  [dimension]
+  (let [field-id (some-> dimension :sources first :field-id)]
+    {:name           (:name dimension)
+     :display_name   (:display-name dimension)
+     :base_type      (some-> (:effective-type dimension) u/qualified-name)
+     :effective_type (some-> (:effective-type dimension) u/qualified-name)
+     :semantic_type  (some-> (:semantic-type dimension) u/qualified-name)
+     :field_id       field-id}))
+
 (defn- dimension-schema
   [{:keys [field_id] :as dimension}]
-  (assoc (column-schema dimension)
-         :key (generated-key (:name dimension) field_id)
-         :id (str field_id)
-         :fieldId (when (integer? field_id) field_id)
-         :operators []))
+  (let [dimension-id (or (:id dimension) field_id)
+        field-id     (or field_id (some-> dimension :sources first :field-id))
+        column       (if (:sources dimension)
+                       (persisted-dimension->column dimension)
+                       dimension)]
+    (assoc (column-schema column)
+           :key (generated-key (:name column) dimension-id)
+           :id (str dimension-id)
+           :fieldId (when (integer? field-id) field-id)
+           :operators [])))
+
+(defn- metric-dimensions
+  [{:keys [id]}]
+  (metrics/sync-dimensions! :metadata/metric id)
+  (-> (t2/select-one [:model/Card :dimensions] :id id)
+      :dimensions))
 
 (defn- source-table-schema
   [[database-name schema-name table-name]]
@@ -171,10 +193,12 @@
    :jsType        "unknown"})
 
 (defn- metric-schema
-  [{:keys [id name description verified portable_entity_id base_table_portable_fk queryable-dimensions] :as details}
+  [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
    card]
   (let [result-column (or (some-> (metric-result-column card) column-schema)
-                          (fallback-metric-column details))]
+                          (fallback-metric-column details))
+        dimensions    (or (seq (metric-dimensions details))
+                          (:queryable-dimensions details))]
     {:kind        "metric"
      :key         (generated-key name id)
      :id          id
@@ -184,7 +208,7 @@
      :verified    (boolean verified)
      :sourceTable (source-table-schema base_table_portable_fk)
      :columns     [result-column]
-     :dimensions  (mapv dimension-schema queryable-dimensions)}))
+     :dimensions  (mapv dimension-schema dimensions)}))
 
 (defn- typed-schema
   []
@@ -209,13 +233,17 @@
   [s]
   (str/replace s js-identifier-key-pattern "$1:"))
 
+(defn- encode-pretty
+  [schema]
+  (json/encode schema {:pretty true}))
+
 (defn- render-javascript
   [schema]
-  (str "export default " (unquote-js-property-names (json/encode schema)) ";\n"))
+  (str "export default " (unquote-js-property-names (encode-pretty schema)) ";\n"))
 
 (defn- render-typescript
   [schema]
-  (str "export default " (unquote-js-property-names (json/encode schema)) " as const;\n"))
+  (str "export default " (unquote-js-property-names (encode-pretty schema)) " as const;\n"))
 
 (api.macros/defendpoint :get "/v1/javascript" :- :any
   "Generate a JavaScript semantic schema module."

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -1,0 +1,241 @@
+(ns metabase.typed-schemas.api
+  "/api/typed-schemas endpoints."
+  (:require
+   [clojure.string :as str]
+   [metabase.api.macros :as api.macros]
+   [metabase.collections.models.collection :as collection]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.metabot.tools.util :as metabot.tools.u]
+   [metabase.models.interface :as mi]
+   [metabase.system.core :as system]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2])
+  (:import
+   (java.time Instant)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private javascript-response-headers
+  {"Content-Type"                 "text/javascript; charset=utf-8"
+   "X-Content-Type-Options"       "nosniff"
+   "Cross-Origin-Resource-Policy" "same-origin"
+   "Referrer-Policy"              "no-referrer"
+   "Cache-Control"                "no-store"})
+
+(def ^:private typescript-response-headers
+  (assoc javascript-response-headers "Content-Type" "text/typescript; charset=utf-8"))
+
+(def ^:private js-identifier-key-pattern
+  #"\"([A-Za-z_$][A-Za-z0-9_$]*)\":")
+
+(defn- js-type
+  [{:keys [type base_type effective_type] :as _column}]
+  (case type
+    :number   "number"
+    :boolean  "boolean"
+    :string   "string"
+    :date     "Date"
+    :datetime "Date"
+    :time     "Date"
+    (let [schema-type (or effective_type base_type)]
+      (cond
+        (some-> schema-type (str/includes? "Boolean")) "boolean"
+        (some-> schema-type (str/includes? "Number"))  "number"
+        (some-> schema-type (str/includes? "Integer")) "number"
+        (some-> schema-type (str/includes? "Float"))   "number"
+        (some-> schema-type (str/includes? "Decimal")) "number"
+        (some-> schema-type (str/includes? "Date"))    "Date"
+        (some-> schema-type (str/includes? "Time"))    "Date"
+        (some-> schema-type (str/includes? "Text"))    "string"
+        (some-> schema-type (str/includes? "UUID"))    "string"
+        :else                                          "unknown"))))
+
+(defn- assoc-some
+  [m & kvs]
+  (reduce (fn [m [k v]]
+            (cond-> m
+              (some? v) (assoc k v)))
+          m
+          (partition 2 kvs)))
+
+(defn- column-schema
+  [{:keys [name display_name base_type effective_type semantic_type description unit] :as column}]
+  (assoc-some
+   {:name          name
+    :displayName   (or display_name name)
+    :baseType      base_type
+    :effectiveType (or effective_type base_type)
+    :semanticType  semantic_type
+    :jsType        (js-type column)}
+   :description description
+   :unit unit))
+
+(defn- generated-key
+  [entity-name id]
+  (let [k (some-> entity-name u/->camelCaseEn)]
+    (if (str/blank? k)
+      (str "entity" id)
+      k)))
+
+(defn- keyed-map
+  [entities]
+  (reduce (fn [m entity]
+            (let [base-key (:key entity)
+                  key      (if (contains? m base-key)
+                             (str base-key (:id entity))
+                             base-key)]
+              (assoc m key (assoc entity :key key))))
+          (sorted-map)
+          entities))
+
+(defn- select-cards
+  [card-type]
+  (->> (t2/select :model/Card
+                  {:where    [:and
+                              [:= :type (name card-type)]
+                              [:= :archived false]
+                              (collection/visible-collection-filter-clause :collection_id)]
+                   :order-by [[:name :asc] [:id :asc]]})
+       (filter mi/can-read?)))
+
+(defn- question-details
+  [card]
+  (-> (entity-details/get-report-details {:report-id             (:id card)
+                                          :with-field-values?    false
+                                          :with-related-tables?  false
+                                          :with-metrics?         false
+                                          :with-measures?        false
+                                          :with-segments?        false})
+      :structured-output))
+
+(defn- metric-result-column
+  [card]
+  (try
+    (let [mp    (lib-be/application-database-metadata-provider (:database_id card))
+          query (lib/query mp (:dataset_query card))
+          col   (->> (lib/returned-columns query)
+                     (filter #(= (:lib/source %) :source/aggregations))
+                     first)]
+      (when col
+        (metabot.tools.u/->result-column query col)))
+    (catch Exception _
+      nil)))
+
+(defn- metric-details
+  [card]
+  (-> (entity-details/get-metric-details {:metric-id                       (:id card)
+                                          :with-default-temporal-breakout? true
+                                          :with-field-values?              false
+                                          :with-queryable-dimensions?      true
+                                          :with-segments?                  false})
+      :structured-output))
+
+(defn- question-schema
+  [{:keys [id name description verified display result-columns portable_entity_id]}]
+  {:kind        "question"
+   :key         (generated-key name id)
+   :id          id
+   :entityId    portable_entity_id
+   :name        name
+   :description description
+   :display     display
+   :verified    (boolean verified)
+   :columns     (mapv column-schema result-columns)
+   :parameters  []})
+
+(defn- dimension-schema
+  [{:keys [field_id] :as dimension}]
+  (assoc (column-schema dimension)
+         :key (generated-key (:name dimension) field_id)
+         :id (str field_id)
+         :fieldId (when (integer? field_id) field_id)
+         :operators []))
+
+(defn- source-table-schema
+  [[database-name schema-name table-name]]
+  (when (and database-name table-name)
+    {:databaseName database-name
+     :schemaName   schema-name
+     :tableName    table-name}))
+
+(defn- fallback-metric-column
+  [{:keys [name]}]
+  {:name          name
+   :displayName   name
+   :baseType      nil
+   :effectiveType nil
+   :semanticType  nil
+   :jsType        "unknown"})
+
+(defn- metric-schema
+  [{:keys [id name description verified portable_entity_id base_table_portable_fk queryable-dimensions] :as details}
+   card]
+  (let [result-column (or (some-> (metric-result-column card) column-schema)
+                          (fallback-metric-column details))]
+    {:kind        "metric"
+     :key         (generated-key name id)
+     :id          id
+     :entityId    portable_entity_id
+     :name        name
+     :description description
+     :verified    (boolean verified)
+     :sourceTable (source-table-schema base_table_portable_fk)
+     :columns     [result-column]
+     :dimensions  (mapv dimension-schema queryable-dimensions)}))
+
+(defn- typed-schema
+  []
+  (let [questions (for [card (select-cards :question)
+                        :let [details (question-details card)]
+                        :when details]
+                    (question-schema details))
+        metrics   (for [card (select-cards :metric)
+                        :let [details (metric-details card)]
+                        :when details]
+                    (metric-schema details card))]
+    (array-map
+     :schemaVersion 1
+     :generatedAt   (str (Instant/now))
+     :metabase      {:instanceUrl (system/site-url)}
+     :questions     (keyed-map questions)
+     :metrics       (keyed-map metrics)
+     :segments      {}
+     :measures      {})))
+
+(defn- unquote-js-property-names
+  [s]
+  (str/replace s js-identifier-key-pattern "$1:"))
+
+(defn- render-javascript
+  [schema]
+  (str "export default " (unquote-js-property-names (json/encode schema)) ";\n"))
+
+(defn- render-typescript
+  [schema]
+  (str "export default " (unquote-js-property-names (json/encode schema)) " as const;\n"))
+
+(api.macros/defendpoint :get "/v1/javascript" :- :any
+  "Generate a JavaScript semantic schema module."
+  [_route-params _query-params _body _request respond _raise]
+  (respond {:status  200
+            :headers javascript-response-headers
+            :body    (render-javascript (typed-schema))}))
+
+(api.macros/defendpoint :get "/v1/typescript" :- :any
+  "Generate a TypeScript semantic schema module."
+  [_route-params _query-params _body _request respond _raise]
+  (respond {:status  200
+            :headers typescript-response-headers
+            :body    (render-typescript (typed-schema))}))
+
+(api.macros/defendpoint :get "/v1/json" :- :any
+  "Generate a JSON semantic schema."
+  []
+  (typed-schema))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/typed-schemas/` routes."
+  (api.macros/ns-handler *ns*))

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -64,15 +64,16 @@
 
 (defn- column-schema
   [{:keys [name display_name base_type effective_type semantic_type description unit] :as column}]
-  (assoc-some
-   {:name          name
-    :displayName   (or display_name name)
-    :baseType      base_type
-    :effectiveType (or effective_type base_type)
-    :semanticType  semantic_type
-    :jsType        (js-type column)}
-   :description description
-   :unit unit))
+  (let [effective-type (or effective_type base_type)]
+    (assoc-some
+     {:name        name
+      :displayName (or display_name name)
+      :jsType      (js-type column)}
+     :baseType base_type
+     :effectiveType (when (not= effective-type base_type) effective-type)
+     :semanticType semantic_type
+     :description description
+     :unit unit)))
 
 (defn- generated-key
   [entity-name id]
@@ -92,13 +93,38 @@
           (sorted-map)
           entities))
 
+(defn- query-database-name
+  [query-params]
+  (some-> (or (:database query-params)
+              (get query-params "database")
+              (:database-name query-params)
+              (get query-params "database-name"))
+          str/trim
+          not-empty))
+
+(defn- database-ids-for-name
+  [database-name]
+  (when database-name
+    (->> (t2/select :model/Database :name database-name)
+         (filter mi/can-read?)
+         (map :id)
+         set)))
+
+(defn- database-id-filter-clause
+  [database-ids column]
+  (when database-ids
+    (if (seq database-ids)
+      [:in column database-ids]
+      [:= column -1])))
+
 (defn- select-cards
-  [card-type]
+  [card-type database-ids]
   (->> (t2/select :model/Card
-                  {:where    [:and
-                              [:= :type (name card-type)]
-                              [:= :archived false]
-                              (collection/visible-collection-filter-clause :collection_id)]
+                  {:where    (cond-> [:and
+                                      [:= :type (name card-type)]
+                                      [:= :archived false]
+                                      (collection/visible-collection-filter-clause :collection_id)]
+                               database-ids (conj (database-id-filter-clause database-ids :database_id)))
                    :order-by [[:name :asc] [:id :asc]]})
        (filter mi/can-read?)))
 
@@ -136,16 +162,16 @@
 
 (defn- question-schema
   [{:keys [id name description verified display result-columns portable_entity_id]}]
-  {:kind        "question"
-   :key         (generated-key name id)
-   :id          id
-   :entityId    portable_entity_id
-   :name        name
+  (assoc-some
+   {:kind    "question"
+    :key     (generated-key name id)
+    :id      id
+    :name    name
+    :display display
+    :columns (mapv column-schema result-columns)}
+   :entityId portable_entity_id
    :description description
-   :display     display
-   :verified    (boolean verified)
-   :columns     (mapv column-schema result-columns)
-   :parameters  []})
+   :verified (when verified true)))
 
 (defn- persisted-dimension->column
   [dimension]
@@ -161,14 +187,26 @@
   [{:keys [field_id] :as dimension}]
   (let [dimension-id (or (:id dimension) field_id)
         field-id     (or field_id (some-> dimension :sources first :field-id))
+        table-id     (or (:table_id dimension) (:table-id dimension))
         column       (if (:sources dimension)
                        (persisted-dimension->column dimension)
                        dimension)]
-    (assoc (column-schema column)
-           :key (generated-key (:name column) dimension-id)
-           :id (str dimension-id)
-           :fieldId (when (integer? field-id) field-id)
-           :operators [])))
+    (assoc-some
+     (assoc (column-schema column)
+            :key (generated-key (:name column) dimension-id)
+            :id (str dimension-id))
+     :tableId (when (integer? table-id) table-id)
+     :fieldId (when (integer? field-id) field-id))))
+
+(defn- field-schema
+  [{:keys [id field_id] :as field}]
+  (let [field-id (or id field_id)]
+    (assoc-some
+     (assoc (column-schema field)
+            :key (generated-key (:name field) field-id)
+            :id field-id)
+     :fieldId (when (integer? field-id) field-id)
+     :defaultTemporalBucket (:unit field))))
 
 (defn- metric-dimensions
   [{:keys [id]}]
@@ -187,10 +225,21 @@
   [{:keys [name]}]
   {:name          name
    :displayName   name
-   :baseType      nil
-   :effectiveType nil
-   :semanticType  nil
    :jsType        "unknown"})
+
+(defn- measure-result-column
+  [database-id measure-id]
+  (try
+    (when-let [definition (t2/select-one-fn :definition :model/Measure :id measure-id)]
+      (let [mp    (lib-be/application-database-metadata-provider database-id)
+            query (lib/query mp definition)
+            col   (->> (lib/returned-columns query)
+                       (filter #(= (:lib/source %) :source/aggregations))
+                       first)]
+        (when col
+          (metabot.tools.u/->result-column query col))))
+    (catch Exception _
+      nil)))
 
 (defn- metric-schema
   [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
@@ -198,36 +247,108 @@
   (let [result-column (or (some-> (metric-result-column card) column-schema)
                           (fallback-metric-column details))
         dimensions    (or (seq (metric-dimensions details))
-                          (:queryable-dimensions details))]
-    {:kind        "metric"
-     :key         (generated-key name id)
-     :id          id
-     :entityId    portable_entity_id
-     :name        name
+                          (:queryable-dimensions details))
+        dimension-schemas (mapv dimension-schema dimensions)
+        mapped-table-ids  (->> dimension-schemas
+                               (keep :tableId)
+                               distinct
+                               sort
+                               vec)]
+    (assoc-some
+     {:kind       "metric"
+      :key        (generated-key name id)
+      :id         id
+      :name       name
+      :columns    [result-column]}
+     :entityId portable_entity_id
      :description description
-     :verified    (boolean verified)
+     :verified (when verified true)
      :sourceTable (source-table-schema base_table_portable_fk)
-     :columns     [result-column]
-     :dimensions  (mapv dimension-schema dimensions)}))
+     :mappedTableIds (not-empty mapped-table-ids)
+     :dimensions (not-empty (keyed-map dimension-schemas)))))
+
+(defn- select-tables
+  [database-ids]
+  (->> (t2/select :model/Table
+                  {:where    (cond-> [:and [:= :active true]]
+                               database-ids (conj (database-id-filter-clause database-ids :db_id)))
+                   :order-by [[:name :asc] [:id :asc]]})
+       (filter mi/can-read?)))
+
+(defn- segment-schema
+  [table-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
+  (assoc-some
+   {:kind    "segment"
+    :key     (generated-key (or display-name name) id)
+    :id      id
+    :tableId table-id
+    :name    name}
+   :entityId (or portable_entity_id portable-entity-id)
+   :description description))
+
+(defn- measure-schema
+  [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
+  (assoc-some
+   {:kind    "measure"
+    :key     (generated-key (or display-name name) id)
+    :id      id
+    :tableId table-id
+    :name    name
+    :columns [(or (some-> (measure-result-column database-id id) column-schema)
+                  (fallback-metric-column {:name (or display-name name)}))]}
+   :entityId (or portable_entity_id portable-entity-id)
+   :description description))
+
+(defn- table-schema
+  [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
+  (let [segments-map (keyed-map (map #(segment-schema id %) segments))
+        measures-map (keyed-map (map #(measure-schema id database_id %) measures))]
+    (assoc-some
+     {:kind         "table"
+      :key          (generated-key (or display_name name) id)
+      :id           id
+      :name         (or display_name name)
+      :databaseId   database_id
+      :databaseName database_name
+      :tableName    name
+      :fields       (keyed-map (map field-schema fields))}
+     :entityId portable_entity_id
+     :description description
+     :schemaName database_schema
+     :segments (not-empty segments-map)
+     :measures (not-empty measures-map))))
 
 (defn- typed-schema
-  []
-  (let [questions (for [card (select-cards :question)
-                        :let [details (question-details card)]
-                        :when details]
-                    (question-schema details))
-        metrics   (for [card (select-cards :metric)
-                        :let [details (metric-details card)]
-                        :when details]
-                    (metric-schema details card))]
+  [query-params]
+  (let [database-ids (database-ids-for-name (query-database-name query-params))
+        questions    (for [card (select-cards :question database-ids)
+                           :let [details (question-details card)]
+                           :when details]
+                       (question-schema details))
+        metrics      (for [card (select-cards :metric database-ids)
+                           :let [details (metric-details card)]
+                           :when details]
+                       (metric-schema details card))
+        tables       (for [table (select-tables database-ids)
+                           :let [details (entity-details/get-table-details
+                                          {:entity-type          :table
+                                           :entity-id            (:id table)
+                                           :with-fields?         true
+                                           :with-field-values?   false
+                                           :with-related-tables? false
+                                           :with-metrics?        false
+                                           :with-measures?       true
+                                           :with-segments?       true})
+                                 details (:structured-output details)]
+                           :when details]
+                       (table-schema details))]
     (array-map
-     :schemaVersion 1
+     :schemaVersion 2
      :generatedAt   (str (Instant/now))
      :metabase      {:instanceUrl (system/site-url)}
      :questions     (keyed-map questions)
-     :metrics       (keyed-map metrics)
-     :segments      {}
-     :measures      {})))
+     :tables        (keyed-map tables)
+     :metrics       (keyed-map metrics))))
 
 (defn- unquote-js-property-names
   [s]
@@ -247,22 +368,22 @@
 
 (api.macros/defendpoint :get "/v1/javascript" :- :any
   "Generate a JavaScript semantic schema module."
-  [_route-params _query-params _body _request respond _raise]
+  [_route-params query-params _body _request respond _raise]
   (respond {:status  200
             :headers javascript-response-headers
-            :body    (render-javascript (typed-schema))}))
+            :body    (render-javascript (typed-schema query-params))}))
 
 (api.macros/defendpoint :get "/v1/typescript" :- :any
   "Generate a TypeScript semantic schema module."
-  [_route-params _query-params _body _request respond _raise]
+  [_route-params query-params _body _request respond _raise]
   (respond {:status  200
             :headers typescript-response-headers
-            :body    (render-typescript (typed-schema))}))
+            :body    (render-typescript (typed-schema query-params))}))
 
 (api.macros/defendpoint :get "/v1/json" :- :any
   "Generate a JSON semantic schema."
-  []
-  (typed-schema))
+  [_route-params query-params]
+  (typed-schema query-params))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/typed-schemas/` routes."

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -21,13 +21,31 @@
                                              :base_type    "type/Text"
                                              :description  "Name of the customer"}))))
 
+(deftest metric-dimension-schema-uses-dimension-id-test
+  (is (= {:name          "category"
+          :displayName   "Category"
+          :baseType      "type/Text"
+          :effectiveType "type/Text"
+          :semanticType  nil
+          :jsType        "string"
+          :key           "category"
+          :id            "550e8400-e29b-41d4-a716-446655440001"
+          :fieldId       3815
+          :operators     []}
+         (#'typed-schemas.api/dimension-schema
+          {:id             "550e8400-e29b-41d4-a716-446655440001"
+           :name           "category"
+           :display-name   "Category"
+           :effective-type :type/Text
+           :sources        [{:type :field, :field-id 3815}]}))))
+
 (deftest javascript-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/javascript")]
     (is (= "text/javascript; charset=utf-8" (get-in response [:headers "Content-Type"])))
     (is (str/starts-with? (:body response) "export default {"))
-    (is (str/includes? (:body response) "schemaVersion:1"))
-    (is (str/includes? (:body response) "questions:{"))
-    (is (str/includes? (:body response) "metrics:{"))
+    (is (str/includes? (:body response) "\n  schemaVersion: 1"))
+    (is (str/includes? (:body response) "\n  questions: {"))
+    (is (str/includes? (:body response) "\n  metrics: {"))
     (is (str/ends-with? (:body response) "};\n"))
     (is (not (str/includes? (:body response) "\"schemaVersion\"")))))
 
@@ -35,7 +53,7 @@
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/typescript")]
     (is (= "text/typescript; charset=utf-8" (get-in response [:headers "Content-Type"])))
     (is (str/starts-with? (:body response) "export default {"))
-    (is (str/includes? (:body response) "schemaVersion:1"))
+    (is (str/includes? (:body response) "\n  schemaVersion: 1"))
     (is (str/ends-with? (:body response) "} as const;\n"))))
 
 (deftest json-endpoint-test

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -1,0 +1,46 @@
+(ns metabase.typed-schemas.api-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.typed-schemas.api :as typed-schemas.api]))
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(deftest column-schema-includes-description-test
+  (is (= {:name          "name"
+          :displayName   "Name"
+          :baseType      "type/Text"
+          :effectiveType "type/Text"
+          :semanticType  nil
+          :jsType        "string"
+          :description   "Name of the customer"}
+         (#'typed-schemas.api/column-schema {:name         "name"
+                                             :display_name "Name"
+                                             :base_type    "type/Text"
+                                             :description  "Name of the customer"}))))
+
+(deftest javascript-endpoint-test
+  (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/javascript")]
+    (is (= "text/javascript; charset=utf-8" (get-in response [:headers "Content-Type"])))
+    (is (str/starts-with? (:body response) "export default {"))
+    (is (str/includes? (:body response) "schemaVersion:1"))
+    (is (str/includes? (:body response) "questions:{"))
+    (is (str/includes? (:body response) "metrics:{"))
+    (is (str/ends-with? (:body response) "};\n"))
+    (is (not (str/includes? (:body response) "\"schemaVersion\"")))))
+
+(deftest typescript-endpoint-test
+  (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/typescript")]
+    (is (= "text/typescript; charset=utf-8" (get-in response [:headers "Content-Type"])))
+    (is (str/starts-with? (:body response) "export default {"))
+    (is (str/includes? (:body response) "schemaVersion:1"))
+    (is (str/ends-with? (:body response) "} as const;\n"))))
+
+(deftest json-endpoint-test
+  (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/json")]
+    (is (= "application/json; charset=utf-8" (get-in response [:headers "Content-Type"])))
+    (is (= 1 (get-in response [:body :schemaVersion])))
+    (is (map? (get-in response [:body :questions])))
+    (is (map? (get-in response [:body :metrics])))))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -12,8 +12,6 @@
   (is (= {:name          "name"
           :displayName   "Name"
           :baseType      "type/Text"
-          :effectiveType "type/Text"
-          :semanticType  nil
           :jsType        "string"
           :description   "Name of the customer"}
          (#'typed-schemas.api/column-schema {:name         "name"
@@ -25,40 +23,157 @@
   (is (= {:name          "category"
           :displayName   "Category"
           :baseType      "type/Text"
-          :effectiveType "type/Text"
-          :semanticType  nil
           :jsType        "string"
           :key           "category"
           :id            "550e8400-e29b-41d4-a716-446655440001"
-          :fieldId       3815
-          :operators     []}
+          :tableId       12
+          :fieldId       3815}
          (#'typed-schemas.api/dimension-schema
           {:id             "550e8400-e29b-41d4-a716-446655440001"
            :name           "category"
            :display-name   "Category"
            :effective-type :type/Text
+           :table-id       12
            :sources        [{:type :field, :field-id 3815}]}))))
+
+(deftest field-schema-uses-field-id-test
+  (is (= {:name          "created_at"
+          :displayName   "Created At"
+          :baseType      "type/DateTime"
+          :jsType        "Date"
+          :key           "createdAt"
+          :id            42
+          :fieldId       42}
+         (#'typed-schemas.api/field-schema {:id             42
+                                            :name           "created_at"
+                                            :display_name   "Created At"
+                                            :base_type      "type/DateTime"}))))
+
+(deftest table-schema-keys-fields-test
+  (is (= {:kind         "table"
+          :key          "orders"
+          :id           10
+          :name         "Orders"
+          :databaseId   1
+          :databaseName "Boba"
+          :tableName    "orders"
+          :fields       {"createdAt" {:name          "created_at"
+                                      :displayName   "Created At"
+                                      :baseType      "type/DateTime"
+                                      :jsType        "Date"
+                                      :key           "createdAt"
+                                      :id            42
+                                      :fieldId       42}}}
+         (#'typed-schemas.api/table-schema
+          {:id            10
+           :name          "orders"
+           :display_name  "Orders"
+           :database_id   1
+           :database_name "Boba"
+           :fields        [{:id           42
+                            :name         "created_at"
+                            :display_name "Created At"
+                            :base_type    "type/DateTime"}]}))))
+
+(deftest metric-schema-keys-dimensions-test
+  (with-redefs [typed-schemas.api/metric-result-column (constantly nil)
+                typed-schemas.api/metric-dimensions
+                (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
+                              :name           "orders"
+                              :display-name   "Orders"
+                              :effective-type :type/Integer
+                              :table-id       10
+                              :sources        [{:type :field, :field-id 42}]}])]
+    (is (= {:kind           "metric"
+            :key            "customerLifetimeValue"
+            :id             247
+            :name           "Customer Lifetime Value"
+            :columns        [{:name "Customer Lifetime Value", :displayName "Customer Lifetime Value", :jsType "unknown"}]
+            :mappedTableIds [10]
+            :dimensions     {"orders" {:name        "orders"
+                                       :displayName "Orders"
+                                       :baseType    "type/Integer"
+                                       :jsType      "number"
+                                       :key         "orders"
+                                       :id          "550e8400-e29b-41d4-a716-446655440001"
+                                       :tableId     10
+                                       :fieldId     42}}}
+           (#'typed-schemas.api/metric-schema
+            {:id   247
+             :name "Customer Lifetime Value"}
+            {:id 247})))))
+
+(deftest measure-schema-uses-result-column-test
+  (testing "measure result columns come from the measure definition when available"
+    (with-redefs [typed-schemas.api/measure-result-column
+                  (constantly {:name         "sum"
+                               :display_name "Sum of Total"
+                               :base_type    "type/Decimal"})]
+      (is (= {:kind    "measure"
+              :key     "totalRevenue"
+              :id      1
+              :tableId 10
+              :name    "Total Revenue"
+              :columns [{:name        "sum"
+                         :displayName "Sum of Total"
+                         :baseType    "type/Decimal"
+                         :jsType      "number"}]}
+             (#'typed-schemas.api/measure-schema
+              10
+              2
+              {:id   1
+               :name "Total Revenue"})))))
+  (testing "measure result columns fall back to the measure name"
+    (with-redefs [typed-schemas.api/measure-result-column (constantly nil)]
+      (is (= {:kind    "measure"
+              :key     "totalRevenue"
+              :id      1
+              :tableId 10
+              :name    "Total Revenue"
+              :columns [{:name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}]}
+             (#'typed-schemas.api/measure-schema
+              10
+              2
+              {:id   1
+               :name "Total Revenue"}))))))
 
 (deftest javascript-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/javascript")]
     (is (= "text/javascript; charset=utf-8" (get-in response [:headers "Content-Type"])))
     (is (str/starts-with? (:body response) "export default {"))
-    (is (str/includes? (:body response) "\n  schemaVersion: 1"))
+    (is (str/includes? (:body response) "\n  schemaVersion: 2"))
     (is (str/includes? (:body response) "\n  questions: {"))
+    (is (str/includes? (:body response) "\n  tables: {"))
     (is (str/includes? (:body response) "\n  metrics: {"))
     (is (str/ends-with? (:body response) "};\n"))
-    (is (not (str/includes? (:body response) "\"schemaVersion\"")))))
+    (is (not (str/includes? (:body response) "\"schemaVersion\"")))
+    (is (not (str/includes? (:body response) "operators: [ ]")))
+    (is (not (str/includes? (:body response) "parameters: [ ]")))
+    (is (not (str/includes? (:body response) "verified: false")))))
 
 (deftest typescript-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/typescript")]
     (is (= "text/typescript; charset=utf-8" (get-in response [:headers "Content-Type"])))
     (is (str/starts-with? (:body response) "export default {"))
-    (is (str/includes? (:body response) "\n  schemaVersion: 1"))
+    (is (str/includes? (:body response) "\n  schemaVersion: 2"))
     (is (str/ends-with? (:body response) "} as const;\n"))))
 
 (deftest json-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/json")]
     (is (= "application/json; charset=utf-8" (get-in response [:headers "Content-Type"])))
-    (is (= 1 (get-in response [:body :schemaVersion])))
+    (is (= 2 (get-in response [:body :schemaVersion])))
     (is (map? (get-in response [:body :questions])))
+    (is (map? (get-in response [:body :tables])))
     (is (map? (get-in response [:body :metrics])))))
+
+(deftest database-filter-test
+  (testing "a non-matching database name returns an empty semantic schema"
+    (let [response (mt/user-http-request-full-response
+                    :crowberto
+                    :get
+                    200
+                    "typed-schemas/v1/json?database=__missing_database__")]
+      (is (= 2 (get-in response [:body :schemaVersion])))
+      (is (= {} (get-in response [:body :questions])))
+      (is (= {} (get-in response [:body :tables])))
+      (is (= {} (get-in response [:body :metrics]))))))


### PR DESCRIPTION
Prototype for schema file generation and custom React hooks for custom data apps.

PR env: https://pr74978.coredev.metabase.com

Use this command to generate your own `metabase.data.ts`, this will be abstracted into MB CLI soon.

```
curl \
  -H "x-api-key: mb_YOUR_API_KEY" \
  -H "Accept: text/typescript" \
  -o metabase.data.ts \
  http://localhost:3000/api/typed-schemas/v1/typescript
```

For usage, read the tech docs on how it's meant to be implemented and used.

[Tech Doc: schema file and SDK hooks for custom data apps](https://linear.app/metabase/document/tech-doc-schema-file-and-sdk-hooks-for-custom-data-apps-f493b7f64ccf)

Examples:

```ts
import schema from "../metabase.data";

type DashboardKpi = typeof schema.questions.koiBobaAppDashboardKpi;
type RecentOrders = typeof schema.questions.koiBobaAppOrdersTable;
type MenuItems = typeof schema.questions.koiBobaAppMenuItems;

// useQuestionQuery takes in just the id, per tech doc
const { data: menuData } = useQuestionQuery<MenuItems>(
  schema.questions.koiBobaAppMenuItems.id,
);

// useMetricQuery needs the full schema for now
// it needs `dimensions` to construct `projections` for querying at RUNTIME
const { data: loyaltyData } = useMetricQuery(
  schema.metrics.customerLifetimeValue,
  {
    filters: [{ dimension: "orders", operator: ">", value: 0 }],
    breakouts: [{ dimension: "segment" }],
  },
);

```