### PR TITLE
Don't invalidate entities on logging activity

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -363,7 +363,6 @@ describe("issue 16559", () => {
       H.visitDashboard(response.body.id);
     });
 
-    cy.intercept("GET", "/api/collection/tree?*").as("getCollections");
     cy.intercept("PUT", "/api/dashboard/*").as("saveDashboard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("GET", "/api/dashboard/*?dashboard_load_id=*").as(
@@ -460,7 +459,7 @@ describe("issue 16559", () => {
     H.entityPickerModal().within(() => {
       cy.findByText("First collection").click();
       cy.button("Move").click();
-      cy.wait(["@saveDashboard", "@getCollections"]);
+      cy.wait(["@saveDashboard"]);
     });
 
     H.openDashboardInfoSidebar().within(() => {

--- a/frontend/src/metabase/api/activity.ts
+++ b/frontend/src/metabase/api/activity.ts
@@ -10,13 +10,7 @@ import type {
 } from "metabase-types/api";
 
 import { Api } from "./api";
-import {
-  TAG_TYPE_MAPPING,
-  idTag,
-  invalidateTags,
-  listTag,
-  provideActivityItemListTags,
-} from "./tags";
+import { invalidateTags, listTag, provideActivityItemListTags } from "./tags";
 
 export const activityApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -69,11 +63,8 @@ export const activityApi = Api.injectEndpoints({
             context: "selection",
           },
         }),
-        invalidatesTags: (_, error, item) =>
-          invalidateTags(error, [
-            listTag(TAG_TYPE_MAPPING[item.model]),
-            idTag(TAG_TYPE_MAPPING[item.model], item.model_id),
-          ]),
+        invalidatesTags: (_, error) =>
+          invalidateTags(error, [listTag("activity")]),
       },
     ),
   }),

--- a/frontend/src/metabase/api/activity.unit.spec.ts
+++ b/frontend/src/metabase/api/activity.unit.spec.ts
@@ -1,0 +1,91 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import {
+  setupCollectionsEndpoints,
+  setupRecentViewsEndpoints,
+} from "__support__/server-mocks";
+import { createMockRecentCollectionItem } from "metabase-types/api/mocks";
+
+import { activityApi } from "./activity";
+import { Api } from "./api";
+import { collectionApi } from "./collection";
+import { listTag } from "./tags";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  setupRecentViewsEndpoints([
+    createMockRecentCollectionItem({ id: 1, model: "card" }),
+  ]);
+  setupCollectionsEndpoints({ collections: [] });
+  fetchMock.post("path:/api/activity/recents", 200);
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  const recentsCalls = () =>
+    fetchMock.callHistory.calls("path:/api/activity/recents", {
+      method: "GET",
+    }).length;
+  const collectionCalls = () =>
+    fetchMock.callHistory.calls("path:/api/collection/tree", {
+      method: "GET",
+    }).length;
+
+  return { store, recentsCalls, collectionCalls };
+}
+
+describe("activityApi", () => {
+  afterEach(() => {
+    // Drop the store's RTK Query subscriptions before pulling the fetch routes,
+    // otherwise orphaned subscriptions refetch against removed routes.
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  describe("logRecentItem invalidation", () => {
+    it("refetches the recents list but leaves sibling entity lists untouched", async () => {
+      const { store, recentsCalls, collectionCalls } = setup();
+
+      // Two active subscribers: the recents list and an unrelated collection list.
+      store.dispatch(activityApi.endpoints.listRecents.initiate());
+      store.dispatch(collectionApi.endpoints.listCollectionsTree.initiate());
+
+      await waitFor(() => expect(recentsCalls()).toBe(1));
+      await waitFor(() => expect(collectionCalls()).toBe(1));
+
+      await store.dispatch(
+        activityApi.endpoints.logRecentItem.initiate({
+          model_id: 1,
+          model: "card",
+        }),
+      );
+
+      // Logging a recent must refetch the recents list...
+      await waitFor(() => expect(recentsCalls()).toBe(2));
+
+      // ...without invalidating the collection list.
+      expect(collectionCalls()).toBe(1);
+    });
+  });
+
+  describe("listRecents provided tags", () => {
+    it("refetches when an entity it surfaced is edited elsewhere", async () => {
+      const { store, recentsCalls } = setup();
+
+      store.dispatch(activityApi.endpoints.listRecents.initiate());
+      await waitFor(() => expect(recentsCalls()).toBe(1));
+
+      // Editing a card/collection invalidates that model's list tag, which
+      // recents provides, so stale names never linger in recent lists.
+      store.dispatch(Api.util.invalidateTags([listTag("collection")]));
+
+      await waitFor(() => expect(recentsCalls()).toBe(2));
+    });
+  });
+});

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -2,6 +2,7 @@ export type TagType = (typeof TAG_TYPES)[number];
 
 export const TAG_TYPES = [
   "action",
+  "activity",
   "alert",
   "api-key",
   "bookmark",

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -114,6 +114,7 @@ export function provideActivityItemListTags(
   return [
     ...ACTIVITY_MODELS.map((model) => listTag(TAG_TYPE_MAPPING[model])),
     ...items.flatMap(provideActivityItemTags),
+    listTag("activity"),
   ];
 }
 


### PR DESCRIPTION
### Description

Updates the provided tags and invalidation logic for the `recents` and `popular items` endpoints. Their tags have fairly complex relationships with other entities
- Listing recents (or popular items) provides list tags for every recents model, plus every individual item. We do this so that if something invalidates a specific item or list (updating the name of a dashboard, for example), we know that we need to refetch recents to show updated information
- logging a recent item previously invalidated the list tag for that specific model, as well as the model itself. This was incorrect, as we don't need to refetch entity lists because of logging, nothing on the list or the entity as changed.

The change here is that we have updated tags to include an `activity` tag, so that we have an independent tag we can invalidate that applies only to listRecents and listPopularItems, without the need to refetch actual entities. This is what was causing the table in the background to rebuild when a user selected a collection.


### How to verify

1. Go to Data Studio -> library
2. Go to publish a table, and open the collection picker
3. Select a collection, the table in the back should not re-build

### Demo

https://github.com/user-attachments/assets/f3fa4b4f-ba39-4dd3-9c15-109d50d73cbe

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
