### PR TITLE
Fix /api/database/:id/schemas when tables have a NULL schema

### DIFF
--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -489,31 +489,32 @@
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a
   single value. The schema-level permission is the *least* restrictive table-level permission within that schema.
 
-  For databases without a schema, the schema name will be nil, but we want to compare that against the empty string instead."
+  Schema names are compared with nil and the empty string treated as equivalent, matching how `database-schemas`
+  presents these databases to the API."
   [user-id perm-type database-id schema-name :- [:maybe :string]]
-  (let [schema-name (or schema-name "")]
-    (when (not= :model/Table (model-by-perm-type perm-type))
-      (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
-                      {perm-type (permissions.schema/data-permissions perm-type)})))
-    (cond
-      (is-superuser? user-id)
-      (most-permissive-value perm-type)
+  (when (not= :model/Table (model-by-perm-type perm-type))
+    (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
+                    {perm-type (permissions.schema/data-permissions perm-type)})))
+  (cond
+    (is-superuser? user-id)
+    (most-permissive-value perm-type)
 
-      (and (= perm-type :perms/manage-table-metadata)
-           (is-data-analyst? user-id))
-      (most-permissive-value perm-type)
+    (and (= perm-type :perms/manage-table-metadata)
+         (is-data-analyst? user-id))
+    (most-permissive-value perm-type)
 
-      :else
-      ;; The schema-level permission is the most-restrictive table-level permission within a schema. So for each group,
-      ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
-      ;; restrictive group permission.
-      (let [perm-values (->> (get-permissions user-id perm-type database-id)
-                             (filter #(or (= (:schema_name %) schema-name)
-                                          (nil? (:table_id %))))
-                             (map :perm_value)
-                             (into #{}))]
-        (or (coalesce perm-type perm-values)
-            (least-permissive-value perm-type))))))
+    :else
+    ;; The schema-level permission is the most-restrictive table-level permission within a schema. So for each group,
+    ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
+    ;; restrictive group permission.
+    (let [schema-name (or schema-name "")
+          perm-values (->> (get-permissions user-id perm-type database-id)
+                           (filter #(or (= (or (:schema_name %) "") schema-name)
+                                        (nil? (:table_id %))))
+                           (map :perm_value)
+                           (into #{}))]
+      (or (coalesce perm-type perm-values)
+          (least-permissive-value perm-type)))))
 
 (mu/defn user-has-permission-for-schema? :- :boolean
   "Returns a Boolean indicating whether the user has the specified permission value for the given database ID and schema,

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -458,6 +458,44 @@
           (is (= :no (data-perms/full-schema-permission-for-user
                       user-id-1 :perms/create-queries database-id-1 "schema_1"))))))))
 
+(deftest schema-permission-for-user-test
+  (testing "schema-permission-for-user returns the most permissive table-level value within the schema"
+    (mt/with-temp [:model/PermissionsGroup           {group-id :id}     {}
+                   :model/User                       {user-id :id}      {}
+                   :model/PermissionsGroupMembership {}                  {:user_id  user-id
+                                                                          :group_id group-id}
+                   :model/Database                   {database-id :id}  {}
+                   :model/Table                      {table-id-1 :id}   {:db_id database-id :schema "schema_1"}
+                   :model/Table                      {table-id-2 :id}   {:db_id database-id :schema "schema_1"}]
+      (mt/with-no-data-perms-for-all-users!
+        (t2/delete! :model/DataPermissions :group_id group-id)
+        (testing "one table at :query-builder + one at :no => :query-builder (least restrictive wins)"
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+          (is (= :query-builder
+                 (data-perms/schema-permission-for-user
+                  user-id :perms/create-queries database-id "schema_1")))))))
+  (testing "databases whose tables have Table.schema = NULL (regression for #46542)"
+    (mt/with-temp [:model/PermissionsGroup           {group-id :id}     {}
+                   :model/User                       {user-id :id}      {}
+                   :model/PermissionsGroupMembership {}                  {:user_id  user-id
+                                                                          :group_id group-id}
+                   :model/Database                   {database-id :id}  {}
+                   :model/Table                      {table-id-1 :id}   {:db_id database-id :schema nil}
+                   :model/Table                      {table-id-2 :id}   {:db_id database-id :schema nil}]
+      (mt/with-no-data-perms-for-all-users!
+        (t2/delete! :model/DataPermissions :group_id group-id)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+        (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+        (testing "called with nil schema-name"
+          (is (= :query-builder
+                 (data-perms/schema-permission-for-user
+                  user-id :perms/create-queries database-id nil))))
+        (testing "called with empty-string schema-name (nil and \"\" are equivalent)"
+          (is (= :query-builder
+                 (data-perms/schema-permission-for-user
+                  user-id :perms/create-queries database-id ""))))))))
+
 (deftest most-permissive-database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
                  :model/User                       {user-id-1 :id}     {}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74956
Fixes [UXW-4301: Removing Create queries permission on 1 Table in MYSQL removes permission to the whole DB](https://linear.app/metabase/issue/UXW-4301/removing-create-queries-permission-on-1-table-in-mysql-removes)

For databases whose tables have Table.schema = NULL  table-level
`:perms/create-queries` grants were being silently
ignored. The endpoint returned an empty 200 even when the user had
query-builder permission on individual tables.

`schema-permission-for-user` was normalizing its `schema-name` argument
from nil to "" before filtering data_permissions rows. But we weren't
normalizing the other side of the `=` - the
`data_permissions.schema_name`. When this was stored as `NULL`, the
comparison failed.

Note that for mysql, both `:model/Table` and `:model/DataPermissions`
store `NULL` for the schema, triggering this bug - we want the schema
permissions for `NULL` but end up checking the schema permissions for
`""`. There aren't any data permissions for that schema name, so we fall
back to the least permissive permission value and `can-read-schema?`
returned false.

`NULL` and `""` schemas can be treated as functionally equivalent - in
general a single database will *either* have `NULL` or `""` values, so I
think it would be safe to just remove the coercion from both sides of
the equality here (like `(= schema-arg schema-from-data-perm)`), but it
should also be safe to just add coercion to *both* sides of the equation
(like `(= (or schema-arg "") (or schema-from-data-perm ""))`), which is
what I've done here.
