### PR TITLE
Harden e2e tests against timing flakiness

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -63,12 +63,16 @@ export const getUnpinnedSection = () => {
 export const openPinnedItemMenu = (name: string) => {
   cy.log(`open pinned item menu: ${name}`);
 
-  getPinnedSection().within(() => {
-    cy.findByText(name)
-      .closest("a")
-      .realHover()
-      .within(() => cy.findByLabelText("Actions").click());
-  });
+  // Hovering a pinned item can trigger an async re-render (e.g. a pinned
+  // metric runs its query), which detaches a chained `.within()` subject. Hover
+  // first, then re-query the actions button so the click acts on a settled
+  // element and Cypress can retry on detach.
+  getPinnedSection().findByText(name).closest("a").realHover();
+  getPinnedSection()
+    .findByText(name)
+    .closest("a")
+    .findByLabelText("Actions")
+    .click();
 };
 
 export const openUnpinnedItemMenu = (name: string) => {

--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -148,7 +148,13 @@ export const DataStudio = {
       libraryPage().findByText("No tables, metrics, or snippets yet"),
     libraryPage,
     metricItem: (name: string) =>
-      cy.findAllByTestId("metric-name").contains(name),
+      // The library page lists items as they come back from /api/ee/library;
+      // on fetch (microtask resolution) the initial render can land before
+      // a freshly-created metric is indexed into the library response. The
+      // outer findAllByTestId retries with its default timeout, but it can
+      // resolve while the named metric is still missing; give `contains`
+      // its own longer timeout to keep retrying for that specific name.
+      cy.findAllByTestId("metric-name").contains(name, { timeout: 10000 }),
     allTableItems: () => libraryPage().findAllByTestId("table-name"),
     tableItem: (name: string) =>
       DataStudio.Library.allTableItems().contains(name),

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -408,8 +408,15 @@ function getTableSectionFieldDescriptionInput(name: string) {
 }
 
 function clickTableSectionField(name: string) {
-  // clicks the icon specifically to avoid issues with clicking the name or description inputs
-  return getTableSectionField(name).findByRole("img").scrollIntoView().click();
+  // Switching tables triggers an async query_metadata fetch; until it resolves
+  // the list still shows the previous table's fields. Wait for this field to
+  // render (cross-database loads can exceed the default 4s timeout) before
+  // clicking. The icon is clicked specifically to avoid the name/description inputs.
+  return getTableSection()
+    .findByRole("listitem", { name, timeout: 15000 })
+    .findByRole("img")
+    .scrollIntoView()
+    .click();
 }
 
 function getTableSectionCloseButton() {

--- a/e2e/support/helpers/e2e-metrics-viewer-helpers.ts
+++ b/e2e/support/helpers/e2e-metrics-viewer-helpers.ts
@@ -6,7 +6,10 @@ export const MetricsViewer = {
     cy.findByTestId("metrics-formula-input").click("right");
     return cy.findByTestId("metrics-viewer-search-input");
   },
-  searchBarPills: () => cy.findAllByTestId("metrics-viewer-search-pill"),
+  // Pills commit asynchronously after the formula is run and its @dataset query
+  // resolves; on a loaded CI this re-render can exceed the default 4s timeout.
+  searchBarPills: () =>
+    cy.findAllByTestId("metrics-viewer-search-pill", { timeout: 15000 }),
   searchResults: () => cy.findByTestId("mini-picker"),
   breakoutLegend: () => cy.findByTestId("metrics-viewer-breakout-legend"),
   getFilterButton: () => cy.findByRole("button", { name: /Filter/ }),
@@ -21,7 +24,10 @@ export const MetricsViewer = {
       MetricsViewer.tablist().findByRole("tab", { name: tab }).should("exist"),
     );
   },
-  getMetricVisualization: () => cy.findByTestId("visualization-root"),
+  // The visualization re-renders after the @dataset query resolves, which can
+  // exceed the default 4s timeout on a loaded CI.
+  getMetricVisualization: () =>
+    cy.findByTestId("visualization-root", { timeout: 15000 }),
   getMetricVisualizationDataPoints: () =>
     MetricsViewer.getMetricVisualization().get(
       "path[fill='hsla(0, 0%, 100%, 1.00)']",

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -238,6 +238,39 @@ export const getSwitchBranchOption = () => {
   return popover().findByRole("option", { name: /Switch branch/ });
 };
 
+// Mantine combobox options can drop a synthetic `.click()` if the dropdown's
+// state machine isn't fully wired yet (e.g. right after the menu opens — the
+// dropdown is visible but the option's handler isn't attached). `realClick`
+// dispatches native mouse events that Mantine processes reliably, and we then
+// verify the menu closed; if not, re-click once with a synthetic click.
+//
+// We detect "menu still open" by looking for the main-menu options
+// (Pull/Push/Switch branch) — neither "any popover visible" nor the controls'
+// `data-expanded` attribute distinguishes the main menu from follow-up popovers
+// like the branch picker that opens after clicking "Switch branch".
+const MAIN_MENU_OPTION_RE = /Pull changes|Push changes|Switch branch/;
+const clickGitSyncOption = (
+  getOption: () => Cypress.Chainable<JQuery<HTMLElement>>,
+) => {
+  getOption().should("not.be.disabled").realClick();
+  cy.get("body").then(($body) => {
+    const mainMenuStillOpen =
+      $body
+        .find('[role="option"]:visible')
+        .filter((_, el) => MAIN_MENU_OPTION_RE.test(el.textContent || ""))
+        .length > 0;
+    if (mainMenuStillOpen) {
+      cy.log("git-sync menu didn't close — re-clicking option");
+      getOption().click();
+    }
+  });
+};
+
+export const clickPullOption = () => clickGitSyncOption(getPullOption);
+export const clickPushOption = () => clickGitSyncOption(getPushOption);
+export const clickSwitchBranchOption = () =>
+  clickGitSyncOption(getSwitchBranchOption);
+
 // Enable tenants feature for testing
 export const enableTenants = () => {
   cy.request("PUT", "/api/setting/use-tenants", { value: true });

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -157,7 +157,14 @@ export function appBar() {
 }
 
 export function openNavigationSidebar() {
-  appBar().findByTestId("sidebar-toggle").click();
+  // The toggle flips the sidebar, so blindly clicking it closes an
+  // already-open sidebar (e.g. right after visiting a dashboard, before it
+  // settles). Only click when it isn't already open so this is idempotent.
+  navigationSidebar().then(($nav) => {
+    if (!$nav.is(":visible")) {
+      appBar().findByTestId("sidebar-toggle").click();
+    }
+  });
   navigationSidebar().should("be.visible");
 }
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -116,6 +116,14 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
 
     it("should be able to create, edit, and delete alerts", () => {
+      // The alerts modal stays in a null-render limbo until
+      // /api/notification?card_id=... resolves and QuestionAlertListModal
+      // picks "create-modal" vs "list-modal". On fetch (microtask resolution
+      // + SDK JWT bootstrap) the click can land before the user-recipients
+      // and channels queries have been issued; wait for the GET so the
+      // create modal is rendered when we assert its heading.
+      cy.intercept("GET", "/api/notification?card_id=*").as("listAlerts");
+
       cy.get<number>("@sqlQuestionId").then((sqlQuestionId) => {
         mountSdkContent(
           <InteractiveQuestion questionId={sqlQuestionId} withAlerts />,
@@ -126,6 +134,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       getSdkRoot().button("Alerts").should("be.visible").click();
 
       cy.log("alerts modal is open");
+      cy.wait("@listAlerts");
       modal().within(() => {
         cy.findByRole("heading", { name: "New alert" }).should("be.visible");
         cy.button("Done").click();

--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -200,6 +200,13 @@ describe("scenarios > embedding-sdk > static-question", () => {
     });
 
     it("should be able to create, edit, and delete alerts", () => {
+      // QuestionAlertListModal stays in null-render limbo until
+      // /api/notification?card_id=... resolves. On fetch (microtask
+      // resolution), the click can land before the recipients/channels
+      // queries have fired; wait for the GET both on first open and on
+      // re-open so the modal has its picked variant by the time we assert.
+      cy.intercept("GET", "/api/notification?card_id=*").as("listAlerts");
+
       mountStaticQuestion({
         withAlerts: true,
       });
@@ -208,6 +215,7 @@ describe("scenarios > embedding-sdk > static-question", () => {
       getSdkRoot().button("Alerts").should("be.visible").click();
 
       cy.log("alerts modal is open");
+      cy.wait("@listAlerts");
       modal().within(() => {
         cy.findByRole("heading", { name: "New alert" }).should("be.visible");
         cy.button("Done").click();
@@ -216,6 +224,7 @@ describe("scenarios > embedding-sdk > static-question", () => {
 
       cy.log("alerts list modal");
       getSdkRoot().button("Alerts").should("be.visible").click();
+      cy.wait("@listAlerts");
       modal().within(() => {
         cy.findByRole("heading", { name: "Edit alerts" }).should("be.visible");
         cy.findByText("Alert when this has results").should("be.visible");

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -752,15 +752,34 @@ describe("formatting > whitelabel", { tags: "@EE" }, () => {
     });
 
     it("should validate the URL and persist only same-origin relative paths", () => {
+      // Clicking "Custom URL" fires a PUT to /api/setting (custom-homepage =
+      // false) AND mounts the URL field. On fetch (microtask resolution) the
+      // mount's landing-page read + the PUT response can land while we're in
+      // the middle of typing; LandingPageUrlField's useEffect would then
+      // overwrite the typed value. Wait for the PUT to land first.
+      cy.intercept("PUT", "/api/setting").as("modeChangePut");
       cy.findByTestId("homepage-setting")
         .findByRole("radio", { name: "Custom URL" })
         .click();
+      cy.wait("@modeChangePut");
 
-      urlInput().click().clear().type("/test-1").blur();
+      urlInput()
+        .click()
+        .clear()
+        .type("/test-1")
+        .should("have.value", "/test-1")
+        .blur();
+      cy.wait("@putLandingPage");
       H.undoToast().findByText("Changes saved").should("be.visible");
 
       // External URLs are rejected and the previous value is preserved.
-      urlInput().click().clear().type("https://google.com").blur();
+      urlInput()
+        .click()
+        .clear()
+        .should("have.value", "")
+        .type("https://google.com")
+        .should("have.value", "https://google.com")
+        .blur();
       cy.findByTestId("admin-layout-content")
         .findByText("This field must be a relative URL.")
         .should("be.visible");

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -54,7 +54,7 @@ describe("Remote Sync", () => {
 
       H.collectionTable().findByText(REMOTE_QUESTION_NAME).should("exist");
 
-      H.getPushOption().click();
+      H.clickPushOption();
 
       H.modal()
         .button(/Push changes/)
@@ -81,7 +81,7 @@ describe("Remote Sync", () => {
         },
       );
 
-      H.getPullOption().click();
+      H.clickPullOption();
 
       H.waitForTask({ taskName: "import" });
       H.expectUnstructuredSnowplowEvent({
@@ -164,7 +164,7 @@ describe("Remote Sync", () => {
         return doc;
       });
 
-      H.getPushOption().click();
+      H.clickPushOption();
 
       // Attempt to push changes
       cy.findByRole("dialog", { name: "Push to Git" })
@@ -191,7 +191,7 @@ describe("Remote Sync", () => {
         cy.findByText("Remote Sync Test Question");
       });
 
-      H.getSwitchBranchOption().click();
+      H.clickSwitchBranchOption();
       H.popover().findByRole("option", { name: "main" }).click();
 
       H.waitForTask({ taskName: "import" });
@@ -211,7 +211,7 @@ describe("Remote Sync", () => {
 
       const createNewBranch = (newBranchName: string) => {
         branchCount++;
-        H.getSwitchBranchOption().click();
+        H.clickSwitchBranchOption();
         H.popover()
           .findByPlaceholderText("Find or create a branch...")
           .type(newBranchName);
@@ -231,7 +231,7 @@ describe("Remote Sync", () => {
       };
 
       const switchToExistingBranch = (branch: string) => {
-        H.getSwitchBranchOption().click();
+        H.clickSwitchBranchOption();
         H.popover()
           .findByPlaceholderText("Find or create a branch...")
           .type(branch);
@@ -239,7 +239,7 @@ describe("Remote Sync", () => {
       };
 
       const pushUpdates = () => {
-        H.getPushOption().click();
+        H.clickPushOption();
 
         H.modal()
           .button(/Push changes/)
@@ -375,7 +375,7 @@ describe("Remote Sync", () => {
         H.moveCollectionItemToSyncedCollection("Orders");
 
         H.goToSyncedCollection();
-        H.getPullOption().click();
+        H.clickPullOption();
       });
 
       it("can force push changes", () => {
@@ -410,7 +410,7 @@ describe("Remote Sync", () => {
 
           H.modal().findByText("Pushing to Git").should("not.exist");
 
-          H.getSwitchBranchOption().click();
+          H.clickSwitchBranchOption();
           H.popover().findByRole("option", { name: "main" }).click();
 
           H.waitForTask({ taskName: "import" }).then(() => {
@@ -821,7 +821,7 @@ describe("Remote Sync", () => {
             H.getSyncStatusIndicators().should("have.length.greaterThan", 0);
 
             // Push changes
-            H.getPushOption().click();
+            H.clickPushOption();
             H.modal()
               .button(/Push changes/)
               .click();
@@ -910,7 +910,7 @@ describe("Remote Sync", () => {
         cy.findByText("Batman's Existing Transform").should("be.visible");
       });
 
-      H.getPullOption().should("not.be.disabled").click();
+      H.clickPullOption();
 
       cy.log("make sure conflict modal is displayed");
       H.modal().within(() => {
@@ -943,7 +943,7 @@ describe("Remote Sync", () => {
     it("can push to a new branch", () => {
       cy.intercept("POST", "/api/ee/remote-sync/export").as("exportChanges");
       H.DataStudio.Transforms.visit();
-      H.getPullOption().should("not.be.disabled").click();
+      H.clickPullOption();
 
       cy.log(
         "wait for the conflict modal to finish rendering before interacting",

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -815,6 +815,17 @@ describe("Dashboard > Dashboard Questions", () => {
         cy.button("Save").click();
       });
 
+      // The modal-save dispatches a dashcard update; the dashboard's
+      // "dirty" flag only flips once that commits. Wait for the modal to
+      // unmount before H.saveDashboard so the edit-bar Save sees the new
+      // dashcard state — otherwise its early-return-if-unchanged path
+      // skips the PUT (no @saveDashboardCards request ever fires).
+      H.modal().should("not.exist");
+      H.getDashboardCard()
+        .findAllByTestId("legend-item")
+        .filter(':contains("Blue Question")')
+        .should("exist");
+
       H.saveDashboard();
       H.getDashboardCard().within(() => {
         H.echartsContainer().should("be.visible").and("not.be.empty");

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -138,7 +138,13 @@ describe("scenarios > dashboard", () => {
 
       H.checkSavedToCollectionQuestionToast(true);
 
-      H.entityPickerModal().findByText("New dashboard").click();
+      // The "New dashboard" button stays disabled until the selected
+      // collection's details (incl. can_write) load; clicking too early is a
+      // no-op, so wait for it to be enabled before clicking.
+      H.entityPickerModal()
+        .findByRole("button", { name: "New dashboard" })
+        .should("be.enabled")
+        .click();
       cy.findByTestId("create-dashboard-on-the-go").within(() => {
         cy.findByPlaceholderText("My new dashboard").type("Foo");
         cy.findByText("Create").click();

--- a/e2e/test/scenarios/data-model/data-model-shared-1.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-1.cy.spec.ts
@@ -720,14 +720,15 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           column: "Total",
           values: ["39.72", "117.03", "49.21", "115.23", "134.91"],
         });
-        // Use trigger("mouseover") instead of realHover() because Chrome v133+
-        // headless hit-tests CDP mouse events differently, preventing the
-        // HoverCard from appearing. mouseover bubbles and React 18 uses it to
-        // simulate onMouseEnter (which Mantine HoverCard.Target relies on).
-        PreviewSection.get()
-          .findByTestId("header-cell")
-          .findByTestId("cell-data")
-          .trigger("mouseover");
+        // realHover is avoided here because Chrome v133+ headless hit-tests
+        // CDP mouse events differently and the HoverCard wouldn't open. We
+        // dispatch synthetic events instead — both `mouseover` (bubbles, so
+        // React 18 turns it into onMouseEnter for any wrapper) and
+        // `mouseenter` (for any native useEventListener-attached handler on
+        // the cell itself). After `cy.wait("@dataset")` the table re-renders
+        // on a microtask (fetch resolution), so re-query the cell each time
+        // to ensure the events land on the post-render DOM node.
+        hoverHeaderCell();
         H.hovercard().should("not.contain.text", "The total billed amount.");
 
         cy.visit(
@@ -770,6 +771,22 @@ function verifyDataStudioFieldSectionEmptyState() {
   H.DataModel.FieldSection.get().should("not.exist");
 }
 
+// Open the preview's column-description hovercard. After `cy.wait("@dataset")`
+// the table re-renders on a microtask (fetch resolution), so a single
+// `.trigger("mouseover")` chained off an earlier find can land on a stale DOM
+// node. Re-query for each dispatch, and fire both `mouseover` (bubbles → React
+// 18 synthetic onMouseEnter for any wrapper) and `mouseenter` (for native
+// useEventListener handlers Mantine attaches directly).
+function hoverHeaderCell() {
+  const headerCell = () =>
+    cy
+      .findByTestId("header-cell")
+      .findByTestId("cell-data")
+      .should("be.visible");
+  headerCell().trigger("mouseenter", { force: true });
+  headerCell().trigger("mouseover", { force: true });
+}
+
 function verifyTablePreview({
   column,
   description,
@@ -789,11 +806,7 @@ function verifyTablePreview({
     });
 
     if (description != null) {
-      // mouseover bubbles and React 18 uses it to simulate onMouseEnter
-      // (which Mantine HoverCard.Target relies on).
-      cy.findByTestId("header-cell")
-        .findByTestId("cell-data")
-        .trigger("mouseover");
+      hoverHeaderCell();
     }
   });
 

--- a/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
@@ -388,7 +388,14 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       cy.log("JSON unfolding");
       TablePicker.getDatabase("Writable Postgres12").click();
+      // Switching tables loads the new table's metadata async; wait for that
+      // specific request so the field interaction doesn't run against the
+      // previously-selected table (a fresh alias avoids matching a stale one).
+      cy.intercept("GET", "/api/table/*/query_metadata*").as(
+        "manyTypesMetadata",
+      );
       TablePicker.getTable("Many Data Types").click();
+      cy.wait("@manyTypesMetadata");
       if (area === "data studio") {
         TableSection.clickFieldsTab();
       }
@@ -399,7 +406,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       FieldSection.getUnfoldJsonInput().should("have.value", "Yes");
 
       cy.log("formatting");
+      cy.intercept("GET", "/api/table/*/query_metadata*").as("ordersMetadata");
       TablePicker.getTable("Orders").click();
+      cy.wait("@ordersMetadata");
       if (area === "data studio") {
         TableSection.clickFieldsTab();
       }

--- a/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
@@ -847,7 +847,10 @@ function pickTarget(targetTableLabel: string) {
 function confirmReplacement() {
   SourceReplacement.getModal()
     .findByRole("tab", {
+      // The affected-items count comes from an async dependents computation
+      // that can exceed the default 4s timeout, so wait longer for the tab.
       name: /\d+ items? will be changed/,
+      timeout: 15000,
     })
     .should("be.visible");
 
@@ -1441,7 +1444,9 @@ function setNestedCardColumnTitle({
 
 function assertTargetRowVisible() {
   H.main()
-    .findAllByText(COMPATIBLE_TARGET_ROW_VALUE)
+    // Visiting the question re-runs its query against the writable DB; allow
+    // more than the default 4s for the result rows to render.
+    .findAllByText(COMPATIBLE_TARGET_ROW_VALUE, { timeout: 15000 })
     .first()
     .should("be.visible");
 }

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -280,8 +280,12 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
+    // The library page lists items as they come back from /api/ee/library;
+    // on fetch (microtask resolution) the initial render can land before
+    // the metric we created in `createLibraryWithItems` has been indexed
+    // into the library response. Allow more time than the default 4s retry.
     H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
+      .findByText("Trusted Orders Metric", { timeout: 10000 })
       .click();
 
     cy.log("Verify metric is loaded");

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1408,8 +1408,41 @@ describe("issue 51934 (EMB-189)", () => {
     const QA_DB_NAME = "QA Postgres12";
     const DATA_SOURCE_NAME = "Orders";
 
+    // The data/join pickers re-render while their collection list loads, AND
+    // clicking a menu item itself triggers a re-render (card metadata fetch +
+    // selection state change) that detaches Cypress's actionability retry on
+    // `.click()`. Wait for the list to be stable (loader gone), then click
+    // with `{ force: true }` to skip the post-find actionability re-check —
+    // we already know the item is visible; we don't want to retry-and-detach
+    // when clicking it causes its own re-render.
+    const clickPickerItem = (name) => {
+      cy.get('[data-testid="mini-picker-list-loader"]').should("not.exist");
+      cy.findByRole("menuitem", { name }).click({ force: true });
+    };
+
+    // Any click that swaps one popover for another (data-source -> join,
+    // notebook-step click -> data-picker) can leave both briefly — or, on a
+    // slow CI runner, for longer than Cypress's default 4 s retry —
+    // visible: the outgoing one is still in its close transition while the
+    // incoming one is already mounted. Cypress's `H.popover().within()`
+    // selects every visible popover, so on a microtask-scheduled fetch
+    // resolution it can match 2 elements and throw.
+    //
+    // `latestPopover()` always returns the most recently mounted visible
+    // popover. Mantine appends portalled popovers to the end of <body>, so
+    // the last DOM match is the newest. Use this in place of
+    // `H.popover()` whenever a click might have just swapped popovers.
+    const latestPopover = () =>
+      cy
+        .get(
+          '.popover[data-state~="visible"],[data-element-id=mantine-popover]',
+        )
+        .filter(":visible")
+        .should("have.length.at.least", 1)
+        .last();
+
     cy.log("select a table as a data source");
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.findByText("Raw Data").click();
       cy.findByRole("heading", { name: QA_DB_NAME }).click();
       cy.findByRole("option", { name: DATA_SOURCE_NAME }).click();
@@ -1419,7 +1452,7 @@ describe("issue 51934 (EMB-189)", () => {
     cy.log(
       'select the "Join" step when the data source is a table will open a table in the same database',
     );
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.findByText(QA_DB_NAME).should("be.visible");
       cy.findByRole("option", { name: "Orders" }).should("be.visible");
     });
@@ -1430,7 +1463,7 @@ describe("issue 51934 (EMB-189)", () => {
     H.getNotebookStep("data").findByText(DATA_SOURCE_NAME).click();
 
     cy.log('go back to the "Bucket" step');
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.icon("chevronleft").click();
       cy.icon("chevronleft").click();
     });
@@ -1438,14 +1471,14 @@ describe("issue 51934 (EMB-189)", () => {
     cy.log(
       "select a question as a data source should open the saved question step in the same collection as the data source (metabase#58357)",
     );
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.findByText("Saved Questions").click();
-      cy.findByRole("menuitem", { name: COLLECTION_NAME }).click();
-      cy.findByRole("menuitem", { name: QUESTION_IN_COLLECTION_NAME }).click();
+      clickPickerItem(COLLECTION_NAME);
+      clickPickerItem(QUESTION_IN_COLLECTION_NAME);
     });
 
     cy.log("the join popover is automatically opened");
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.log("the collection of the data source should be selected");
       cy.findByRole("menuitem", { name: COLLECTION_NAME }).should(
         "have.css",
@@ -1453,9 +1486,7 @@ describe("issue 51934 (EMB-189)", () => {
         // brand color
         "rgb(80, 158, 226)",
       );
-      cy.findByRole("menuitem", { name: QUESTION_IN_COLLECTION_NAME })
-        .should("be.visible")
-        .click();
+      clickPickerItem(QUESTION_IN_COLLECTION_NAME);
     });
 
     cy.log(
@@ -1463,18 +1494,18 @@ describe("issue 51934 (EMB-189)", () => {
     );
     H.getNotebookStep("data").findByText(QUESTION_IN_COLLECTION_NAME).click();
 
-    H.popover().within(() => {
+    latestPopover().within(() => {
       // Go back to the "Bucket" step
       cy.findByText("Saved Questions").click();
 
       // We're now at the "Bucket" step
       cy.findByText("Models").click();
-      cy.findByRole("menuitem", { name: COLLECTION_NAME }).click();
-      cy.findByRole("menuitem", { name: MODEL_IN_COLLECTION_NAME }).click();
+      clickPickerItem(COLLECTION_NAME);
+      clickPickerItem(MODEL_IN_COLLECTION_NAME);
     });
 
     cy.log("the join popover is automatically opened");
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.log("the collection of the data source should be selected");
       cy.findByRole("menuitem", { name: COLLECTION_NAME }).should(
         "have.css",
@@ -1482,21 +1513,19 @@ describe("issue 51934 (EMB-189)", () => {
         // brand color
         "rgb(80, 158, 226)",
       );
-      cy.findByRole("menuitem", { name: MODEL_IN_COLLECTION_NAME })
-        .should("be.visible")
-        .click();
+      clickPickerItem(MODEL_IN_COLLECTION_NAME);
     });
 
     cy.log(
       "select a data source after selecting a join step should refresh the data picker on the join step",
     );
     H.getNotebookStep("data").findByText(MODEL_IN_COLLECTION_NAME).click();
-    H.popover().within(() => {
-      cy.findByRole("menuitem", { name: "Our analytics" }).click();
-      cy.findByRole("menuitem", { name: MODEL_IN_ROOT_NAME }).click();
+    latestPopover().within(() => {
+      clickPickerItem("Our analytics");
+      clickPickerItem(MODEL_IN_ROOT_NAME);
     });
 
-    H.popover().within(() => {
+    latestPopover().within(() => {
       cy.log("the collection of the new data source should be selected");
       cy.findByRole("menuitem", { name: "Our analytics" }).should(
         "have.css",

--- a/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
@@ -91,7 +91,10 @@ describe(
       cy.log("save the theme");
       cy.findByRole("button", { name: /Save theme/ }).click();
 
-      H.undoToast().findByText("Theme saved").should("exist");
+      // An earlier undo toast may still be on screen, so use the toast list
+      // (plural) and filter by text — `undoToast()` (singular) yields
+      // undefined when multiple toasts match.
+      H.undoToastList().contains("Theme saved").should("be.visible");
     });
 
     it("can cancel and navigate back to listing", () => {
@@ -222,7 +225,10 @@ describe(
           expect(settings.fontSize).to.eq("16px");
         });
 
-        H.undoToast().findByText("Theme saved").should("exist");
+        // An earlier undo toast (e.g. "reset to defaults") may still be on
+        // screen, so use the toast list (plural) and filter by text — using
+        // `undoToast()` (singular) yields undefined when multiple toasts match.
+        H.undoToastList().contains("Theme saved").should("be.visible");
       });
     });
 
@@ -269,7 +275,10 @@ describe(
           expect(settings.colors?.brand).to.eq("#ff0000ff");
         });
 
-        H.undoToast().findByText("Theme saved").should("exist");
+        // An earlier undo toast (e.g. "reset to defaults") may still be on
+        // screen, so use the toast list (plural) and filter by text — using
+        // `undoToast()` (singular) yields undefined when multiple toasts match.
+        H.undoToastList().contains("Theme saved").should("be.visible");
       });
     });
 
@@ -347,7 +356,10 @@ describe(
           expect(settings.colors?.filter).to.eq("#2d2d30ff");
         });
 
-        H.undoToast().findByText("Theme saved").should("exist");
+        // An earlier undo toast (e.g. "reset to defaults") may still be on
+        // screen, so use the toast list (plural) and filter by text — using
+        // `undoToast()` (singular) yields undefined when multiple toasts match.
+        H.undoToastList().contains("Theme saved").should("be.visible");
       });
     });
 

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -219,7 +219,14 @@ describe("issue 12581", () => {
       cy.findByText(/You created this/i);
 
       cy.findByTestId("question-revert-button").click(); // Revert to the first revision
+    });
 
+    // Reverting reloads the question, which re-runs its query and resets the
+    // info sidesheet to the Overview tab. Wait for that reload to settle before
+    // re-reading the History tab, otherwise the tab switch races the reset.
+    cy.wait("@cardQuery");
+
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
       cy.findByText(/You reverted to an earlier version/i);
     });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -189,6 +189,7 @@ describe("scenarios > question > saved", () => {
 
   it("should revert a saved question to a previous version", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
+    cy.intercept("POST", "/api/revision/revert").as("revertRevision");
 
     H.visitQuestion(ORDERS_QUESTION_ID);
     H.questionInfoButton().click();
@@ -204,6 +205,13 @@ describe("scenarios > question > saved", () => {
       cy.findByText(/added a description/i);
 
       cy.findByTestId("question-revert-button").click();
+      // The revert mutation invalidates the revision list. On fetch
+      // (microtask resolution) clicking the History tab before that
+      // invalidation lands shows the pre-revert entries — the new
+      // "reverted to an earlier version" row is then never found within
+      // Cypress's default 4s. Wait for the revert request before
+      // re-entering History.
+      cy.wait("@revertRevision");
 
       cy.findByRole("tab", { name: "History" }).click();
       cy.findByText(/reverted to an earlier version/i);

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -571,7 +571,13 @@ function SearchItemList({ query: externalQuery }: { query: string }) {
 }
 
 export const MiniPickerListLoader = () => (
-  <Stack px="1rem" pt="0.5rem" pb="13px" gap="1rem">
+  <Stack
+    data-testid="mini-picker-list-loader"
+    px="1rem"
+    pt="0.5rem"
+    pb="13px"
+    gap="1rem"
+  >
     <Repeat times={3}>
       <Skeleton
         height="1.5rem"

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -46,6 +46,24 @@ const mockAppendCSV = (valid = true) => {
   );
 };
 
+// Asserts the matching request was sent as multipart form data — locks down
+// that table.ts hands the FormData through unwrapped (a JSON-stringified
+// `{ formData }` would set Content-Type: application/json instead).
+const expectMultipartBody = (urlSuffix) => {
+  const call = fetchMock.callHistory
+    .calls()
+    .find((c) => c.url.endsWith(urlSuffix));
+  expect(call).toBeDefined();
+  const headers = call.options?.headers ?? {};
+  const contentType =
+    headers instanceof Headers
+      ? headers.get("content-type")
+      : (headers["content-type"] ?? headers["Content-Type"]);
+  // Either absent (browser sets it with the multipart boundary) or multipart;
+  // application/json would mean FormData got JSON-stringified.
+  expect(contentType ?? "").not.toMatch(/application\/json/);
+};
+
 const mockReplaceCSV = (valid = true) => {
   fetchMock.post(
     "glob:*/api/table/*/replace-csv",
@@ -125,6 +143,8 @@ describe("csv uploads", () => {
       await uploadFile({ file, tableId: 123, uploadMode: "append" })(dispatch);
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
+      expectMultipartBody("append-csv");
+
       expect(dispatch).toHaveBeenCalledWith({
         type: UPLOAD_FILE_START,
         payload: {
@@ -156,6 +176,8 @@ describe("csv uploads", () => {
 
       await uploadFile({ file, tableId: 123, uploadMode: "replace" })(dispatch);
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
+
+      expectMultipartBody("replace-csv");
 
       expect(dispatch).toHaveBeenCalledWith({
         type: UPLOAD_FILE_START,


### PR DESCRIPTION
Basically the same as https://github.com/metabase/metabase/pull/74897, but more tests

More Cypress hardening preempting a class of timing-sensitive flakes that the upcoming XHR→fetch PR. No production-code behavior changes.

Extracted from the `remove-xhr-option-in-api` branch so it can land independently and start paying off on master right away.


**Split chained `.within(() => …)` when the parent subject can detach mid-async.**  Pinned items run their query on hover, Mantine comboboxes mount async, etc. — a chained `.within` holds onto a stale subject and Cypress can't retry on detach. Re-querying the parent inside each step lets the retry-ability kick in.

**`clickPullOption` / `clickPushOption` / `clickSwitchBranchOption` helpers** around the git-sync menu. Mantine combobox state can drop a synthetic `.click()` if invoked before the dropdown's handlers are wired. The helpers do `realClick` → check "did the menu close?" → re-click once with a synthetic click if not.

**`data-testid=\"mini-picker-list-loader\"`** on `MiniPickerListLoader` so specs can `cy.findByTestId` the skeleton instead of relying on text that hasn't rendered yet.

**`expectMultipartBody` assertion in `uploads.unit.spec.js`** that pins down "table.ts hands `FormData` through unwrapped, the browser sets the multipart `Content-Type`." Locks in current behavior so the upcoming client refactor can't silently break it.