### PR TITLE
Migrate query action editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionEditor.tsx
@@ -18,13 +18,13 @@ function QueryActionEditor({
       query={query}
       question={question}
       setDatasetQuery={onChangeQuestionQuery}
-      hasEditingSidebar={false}
       isNativeEditorOpen
-      hasParametersList={false}
       resizable={false}
       readOnly={!isEditable}
       editorContext="action"
-    />
+    >
+      <NativeQueryEditor.TopBar />
+    </NativeQueryEditor>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRoot.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorRoot.tsx
@@ -323,7 +323,7 @@ export const NativeQueryEditorRoot = forwardRef<
   // button, extra buttons, custom content rendered over the editor surface).
   let topBar: ReactNode = null;
   const bodySlots: ReactNode[] = [];
-  Children.forEach(children, (child) => {
+  Children.toArray(children).forEach((child) => {
     if (isValidElement(child) && child.type === TopBar) {
       topBar = cloneElement(child, { ref: topBarRef });
     } else {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/Sidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/Sidebar.tsx
@@ -50,7 +50,10 @@ export function Sidebar({ features = DEFAULT_FEATURES }: SidebarProps) {
       onFormatQuery={onFormatQuery}
       question={question}
       snippets={snippets}
+<<<<<<< HEAD
       snippetCollections={snippetCollections}
+=======
+>>>>>>> 151befd0c (Add composable NativeQueryEditor with backward-compatible shim)
       isRunnable={isRunnable}
       isRunning={isRunning}
       isResultDirty={isResultDirty}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/Sidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/Sidebar.tsx
@@ -50,10 +50,7 @@ export function Sidebar({ features = DEFAULT_FEATURES }: SidebarProps) {
       onFormatQuery={onFormatQuery}
       question={question}
       snippets={snippets}
-<<<<<<< HEAD
       snippetCollections={snippetCollections}
-=======
->>>>>>> 151befd0c (Add composable NativeQueryEditor with backward-compatible shim)
       isRunnable={isRunnable}
       isRunning={isRunning}
       isResultDirty={isResultDirty}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/TopBar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/slots/TopBar.tsx
@@ -57,7 +57,7 @@ export const TopBar = forwardRef<HTMLDivElement, PropsWithChildren>(
 
     const leftActions: ReactNode[] = [];
     const rightActions: ReactNode[] = [];
-    Children.forEach(children, (child) => {
+    Children.toArray(children).forEach((child) => {
       if (isValidElement(child) && child.type === ParametersList) {
         leftActions.push(child);
       } else {


### PR DESCRIPTION
Migrate `QueryActionEditor` to the new shap for the `NativeQueryEditor` introduced in https://github.com/metabase/metabase/pull/75014

