### PR TITLE
Migrate NativeQueryModal to composable NativeQueryEditor

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/NativeQueryModal.tsx
@@ -331,10 +331,6 @@ export const NativeQueryModal = ({
                   query={nativeQuery}
                   isNativeEditorOpen
                   isInitiallyOpen
-                  hasTopBar
-                  hasEditingSidebar
-                  hasParametersList={false}
-                  sidebarFeatures={MODAL_SIDEBAR_FEATURES}
                   availableHeight={totalHeight}
                   isRunnable
                   isRunning={isQueryRunning}
@@ -374,7 +370,14 @@ export const NativeQueryModal = ({
                     setModifiedQuestion(newQuestion);
                   }}
                   resizable
-                />
+                >
+                  <NativeQueryEditor.TopBar>
+                    <NativeQueryEditor.Sidebar
+                      features={MODAL_SIDEBAR_FEATURES}
+                    />
+                  </NativeQueryEditor.TopBar>
+                  <NativeQueryEditor.RunButton />
+                </NativeQueryEditor>
               )}
             </Box>
 


### PR DESCRIPTION
Migrate the `NatieQueryModal` to the new shape of `NativeQueryEditor` introduced in https://github.com/metabase/metabase/pull/75014