### PR TITLE
Add missing honeysql util methods for mbql5 drivers

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -331,6 +331,10 @@
   [driver hsql-form amount unit]
   (h2x/add-interval-honeysql-form driver hsql-form amount unit))
 
+(defmethod sql.qp/add-interval-honeysql-form :h2-mbql5
+  [driver hsql-form amount unit]
+  (h2x/add-interval-honeysql-form driver hsql-form amount unit))
+
 (defmethod driver/humanize-connection-error-message :h2
   [_ messages]
   (let [message (first messages)]
@@ -357,6 +361,10 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod sql.qp/current-datetime-honeysql-form :h2
+  [driver]
+  (h2x/current-datetime-honeysql-form driver))
+
+(defmethod sql.qp/current-datetime-honeysql-form :h2-mbql5
   [driver]
   (h2x/current-datetime-honeysql-form driver))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -490,7 +490,15 @@
   [driver hsql-form amount unit]
   (h2x/add-interval-honeysql-form driver hsql-form amount unit))
 
+(defmethod sql.qp/add-interval-honeysql-form :postgres-mbql5
+  [driver hsql-form amount unit]
+  (h2x/add-interval-honeysql-form driver hsql-form amount unit))
+
 (defmethod sql.qp/current-datetime-honeysql-form :postgres
+  [driver]
+  (h2x/current-datetime-honeysql-form driver))
+
+(defmethod sql.qp/current-datetime-honeysql-form :postgres-mbql5
   [driver]
   (h2x/current-datetime-honeysql-form driver))
 

--- a/src/metabase/sql_tools/sqlglot/core.clj
+++ b/src/metabase/sql_tools/sqlglot/core.clj
@@ -34,6 +34,7 @@
   (case driver
     nil                  nil
     :postgres            "postgres"
+    :postgres-mbql5      "postgres"
     :mysql               "mysql"
     :snowflake           "snowflake"
     :bigquery            "bigquery"

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -438,7 +438,7 @@
   (case db-type
     (:h2 :h2-mbql5) (with-database-type-info :%now "timestamp")
     :mysql    (with-database-type-info [:now [:inline 6]] "timestamp")
-    :postgres (with-database-type-info :%now "timestamptz")))
+    (:postgres :postgres-mbql5) (with-database-type-info :%now "timestamptz")))
 
 (defn- format-postgres-interval
   "Generate a Postgres 'INTERVAL' literal.
@@ -492,6 +492,10 @@
     (let [hsql-form (->pg-timestamp hsql-form)]
       (-> (+ hsql-form (pg-interval amount unit))
           (with-type-info (type-info hsql-form))))))
+
+(defmethod add-interval-honeysql-form :postgres-mbql5
+  [db-type hsql-form amount unit]
+  ((get-method add-interval-honeysql-form :postgres) db-type hsql-form amount unit))
 
 (defmethod add-interval-honeysql-form :mysql
   [db-type hsql-form amount unit]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-2052/fix-failing-postgres-14-tests-on-master

### Description

Adds missing multimethod implementations

These drivers inherit from postgres and h2 so they should just be using those implementations? 

### How to verify



### Demo



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
