### PR TITLE
Migrate action form and implicit action icon from Emotion to Mantine

### DIFF
--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.styled.tsx
@@ -1,8 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const ActionFormButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-`;

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -11,6 +11,7 @@ import { Button } from "metabase/common/components/Button";
 import { FormErrorMessage } from "metabase/common/components/FormErrorMessage";
 import { FormSubmitButton } from "metabase/common/components/FormSubmitButton";
 import { Form, FormProvider } from "metabase/forms";
+import { Flex } from "metabase/ui";
 import type {
   ActionFormInitialValues,
   ParameterId,
@@ -19,8 +20,6 @@ import type {
 } from "metabase-types/api";
 
 import { ActionFormFieldWidget } from "../ActionFormFieldWidget";
-
-import { ActionFormButtonContainer } from "./ActionForm.styled";
 
 interface ActionFormProps {
   action: WritebackAction;
@@ -86,12 +85,12 @@ function ActionForm({
           <ActionFormFieldWidget key={field.name} formField={field} />
         ))}
 
-        <ActionFormButtonContainer>
+        <Flex justify="flex-end" gap="sm">
           {onClose && (
             <Button type="button" onClick={onClose}>{t`Cancel`}</Button>
           )}
           <FormSubmitButton {...submitButtonProps} />
-        </ActionFormButtonContainer>
+        </Flex>
 
         <FormErrorMessage />
       </Form>

--- a/frontend/src/metabase/actions/components/ImplicitActionIcon/ImplicitActionIcon.styled.tsx
+++ b/frontend/src/metabase/actions/components/ImplicitActionIcon/ImplicitActionIcon.styled.tsx
@@ -1,8 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const Root = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`;

--- a/frontend/src/metabase/actions/components/ImplicitActionIcon/ImplicitActionIcon.tsx
+++ b/frontend/src/metabase/actions/components/ImplicitActionIcon/ImplicitActionIcon.tsx
@@ -1,6 +1,4 @@
-import { Icon } from "metabase/ui";
-
-import { Root } from "./ImplicitActionIcon.styled";
+import { Flex, Icon } from "metabase/ui";
 
 interface ImplicitActionIconProps {
   size?: number;
@@ -10,10 +8,10 @@ function ImplicitActionIcon({ size = 14 }: ImplicitActionIconProps) {
   const sizeSmall = size * 0.375;
   const marginLeft = size * 0.75;
   return (
-    <Root>
+    <Flex direction="column" justify="center">
       <Icon name="insight" size={sizeSmall} style={{ marginLeft }} />
       <Icon name="insight" size={size} />
-    </Root>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
### Description

Fixes [UXW-3667](https://linear.app/metabase/issue/UXW-3667/action-components).

Migrates the action form's button container and the implicit-action icon wrapper off Emotion to Mantine `Flex`. Pure styling refactor, no behavior change.

### How to verify

- [ ] Run a model action: the Cancel/submit buttons stay right-aligned with the same gap.
- [ ] In the action creator, the implicit-action icon (stacked insight glyphs) is unchanged.

### Demo

Icon:

<img width="310" height="85" alt="image" src="https://github.com/user-attachments/assets/cd37ad0a-311c-4971-9a60-88c7541ceb5d" />


Form:
<img width="538" height="226" alt="image" src="https://github.com/user-attachments/assets/b32812c5-110a-4c23-829a-d5b64dfd407b" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)