### PR TITLE
Unpublish fk linked tables with archiving a collection with published tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -9,6 +9,7 @@
    [metabase.collections.core :as collection]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -112,6 +113,29 @@
     (if (empty? initial-ids)
       #{}
       (traverse-graph downstream-table-ids initial-ids))))
+
+;;; ------------------------------------------------ Collection lifecycle hook ------------------------------------------------
+
+(defenterprise unpublish-downstream-fk-tables!
+  "When tables are unpublished because their Library collection was archived or deleted, also unpublish any tables that
+  depend on them via FK remapping (Dimensions), so implicit joins are not broken. Mirrors the force-unpublish behavior
+  of the `/unpublish-tables` endpoint. `seed-table-ids` are the tables that were just unpublished."
+  :feature :library
+  [seed-table-ids]
+  (when (seq seed-table-ids)
+    (let [downstream-ids      (all-downstream-table-ids [:in :id seed-table-ids])
+          table-ids-to-update (when (seq downstream-ids)
+                                (t2/select-pks-set :model/Table :id [:in downstream-ids] :is_published true))]
+      (when (seq table-ids-to-update)
+        (t2/query {:update (t2/table-name :model/Table)
+                   :set    {:collection_id nil
+                            :is_published  false}
+                   :where  [:in :id table-ids-to-update]})
+        ;; Publish events for audit log and remote sync tracking
+        (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
+          (doseq [table updated-tables]
+            (events/publish-event! :event/table-unpublish {:object  table
+                                                           :user-id api/*current-user-id*})))))))
 
 ;;; ------------------------------------------------ Response Schemas ------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -272,6 +272,52 @@
           (are [table-id] (false? (t2/select-one-fn :is_published :model/Table table-id))
             customers-id orders-id items-id))))))
 
+(defn- with-fk-linked-published-tables
+  "Sets up two Library/Data collections A and B, with published Table X in A and published Table Y in B, where Y has an
+  FK remapping (Dimension) pointing at X (so X is upstream / Y is downstream). Calls `f` with a map of the ids."
+  [f]
+  (mt/with-temp [:model/Collection {coll-a :id} {:type collection/library-data-collection-type}
+                 :model/Collection {coll-b :id} {:type collection/library-data-collection-type}
+                 :model/Database   {db-id :id}  {}
+                 ;; Table X in collection A (published)
+                 :model/Table      {x-id :id}   {:db_id db-id :name "x" :is_published true :collection_id coll-a}
+                 :model/Field      _            {:table_id x-id :name "id"
+                                                 :semantic_type :type/PK :base_type :type/Integer}
+                 :model/Field      {x-name :id} {:table_id x-id :name "name"
+                                                 :semantic_type :type/Name :base_type :type/Text}
+                 ;; Table Y in collection B (published), FK -> X
+                 :model/Table      {y-id :id}   {:db_id db-id :name "y" :is_published true :collection_id coll-b}
+                 :model/Field      _            {:table_id y-id :name "id"
+                                                 :semantic_type :type/PK :base_type :type/Integer}
+                 :model/Field      {y-fk :id}   {:table_id y-id :name "x_id"
+                                                 :semantic_type :type/FK :base_type :type/Integer}
+                 :model/Dimension  _            {:field_id y-fk :human_readable_field_id x-name :type :external}]
+    (f {:coll-a coll-a :coll-b coll-b :x-id x-id :y-id y-id})))
+
+(deftest unpublish-fk-linked-tables-on-collection-delete-test
+  (mt/with-premium-features #{:library}
+    (testing "deleting a Library collection unpublishes its tables and their FK-linked tables in other collections"
+      (with-fk-linked-published-tables
+        (fn [{:keys [coll-a x-id y-id]}]
+          (t2/delete! :model/Collection :id coll-a)
+          (testing "Table X (in the deleted collection) is unpublished"
+            (is (=? {:is_published false :collection_id nil} (t2/select-one :model/Table x-id))))
+          (testing "Table Y (FK-linked, in another collection) is also unpublished"
+            (is (=? {:is_published false :collection_id nil} (t2/select-one :model/Table y-id)))))))))
+
+(deftest unpublish-fk-linked-tables-on-collection-archive-test
+  (mt/with-premium-features #{:library}
+    (testing "archiving a Library collection unpublishes its tables and their FK-linked tables in other collections"
+      (with-fk-linked-published-tables
+        (fn [{:keys [coll-a x-id y-id]}]
+          (mt/with-current-user (mt/user->id :crowberto)
+            (collection/archive-or-unarchive-collection!
+             (t2/select-one :model/Collection :id coll-a) {:archived true}))
+          (testing "Table X (in the archived collection) is unpublished"
+            (is (=? {:is_published false :collection_id nil} (t2/select-one :model/Table x-id))))
+          (testing "Table Y (FK-linked, in another collection) is also unpublished"
+            (is (=? {:is_published false :collection_id nil} (t2/select-one :model/Table y-id)))))))))
+
 ;;; ------------------------------------------ Publish/Unpublish requires write and query perms ------------------------------------------
 
 (deftest publish-tables-requires-write-and-query-perms-test

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1592,6 +1592,13 @@
   `(binding [*allow-modifying-tenant-root-collections?* true]
      (do ~@body)))
 
+(defenterprise unpublish-downstream-fk-tables!
+  "When Library tables are unpublished because their collection is archived or deleted, also unpublish any tables that
+  depend on them via FK remapping (Dimensions) so implicit joins are not broken. OSS no-op."
+  metabase-enterprise.data-studio.api.table
+  [_seed-table-ids]
+  nil)
+
 (mu/defn archive-collection!
   "Mark a collection as archived, along with all its children."
   [collection :- CollectionWithLocationAndIDOrRoot]
@@ -1630,9 +1637,13 @@
                                                 :id   [:in affected-collection-ids]
                                                 :type library-data-collection-type)]
         (when (seq library-data-ids)
-          (t2/update! :model/Table {:collection_id [:in library-data-ids]}
-                      {:collection_id nil
-                       :is_published  false}))))
+          (let [published-table-ids (t2/select-pks-set :model/Table
+                                                       :collection_id [:in library-data-ids]
+                                                       :is_published  true)]
+            (t2/update! :model/Table {:collection_id [:in library-data-ids]}
+                        {:collection_id nil
+                         :is_published  false})
+            (unpublish-downstream-fk-tables! published-table-ids)))))
     (let [updated-collection (t2/select-one :model/Collection :id (:id collection))]
       (when (:is_remote_synced updated-collection)
         (check-remote-synced-dependents updated-collection)))))
@@ -1999,9 +2010,13 @@
     (throw (ex-info "Fatal error: the trash collection cannot be trashed" {})))
   ;; delete all collection children
   (t2/delete! :model/Collection :location (children-location collection))
-  (let [affected-collection-ids (cons (u/the-id collection) (collection->descendant-ids collection))]
+  (let [affected-collection-ids (cons (u/the-id collection) (collection->descendant-ids collection))
+        published-table-ids     (t2/select-pks-set :model/Table
+                                                   :collection_id [:in affected-collection-ids]
+                                                   :is_published  true)]
     (t2/update! :model/Table :collection_id [:in affected-collection-ids] {:collection_id nil
                                                                            :is_published  false})
+    (unpublish-downstream-fk-tables! published-table-ids)
     (doseq [model [:model/Card
                    :model/Dashboard
                    :model/NativeQuerySnippet


### PR DESCRIPTION
### Description

Updates the `archive-collection!` and `delete-collection!` functions pass a list tables related to any tables published to the collection to `unpublish-downstream-fk-tables!` and have them also unpublished

### How to verify

1. Publish a table with a FK relationship to a collection
2. Both the main table and any related tables should have been published to the same collection. Move the downstream one to another collection
3. archive the collection that the downstream table is published to
4. You should see that the related table has also been unpublished

### Demo


https://github.com/user-attachments/assets/3985f8f5-c8f9-43dc-9032-1fd316ec1724



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
