### PR TITLE
GHY-3727 add network timeout to remote sync git operations

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -89,6 +89,14 @@
   :encryption :no
   :default (* 1000 60 5))
 
+(defsetting remote-sync-git-timeout-seconds
+  (deferred-tru "Network timeout (in seconds) for remote git operations such as fetch, push, clone, and ls-remote. A stalled connection would otherwise hang a sync indefinitely.")
+  :type :integer
+  :visibility :authenticated
+  :export? false
+  :encryption :no
+  :default 60)
+
 (def ^:const transforms-root-id
   "Sentinel value for the virtual Transforms root collection.
    Used to represent the entire transforms feature being enabled/disabled."

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -6,6 +6,7 @@
    [clojure.string :as str]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase.analytics-interface.core :as analytics]
+   [metabase.settings.core :as setting]
    [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
@@ -69,8 +70,10 @@
         credentials-provider (when token (credentials-provider remote-url token))]
     (analytics/inc! :metabase-remote-sync/git-operations analytics-labels)
     (try
-      (-> command
-          (.setCredentialsProvider credentials-provider)
+      (-> (doto command
+            ;; bound the network operation so a stalled connection can't hang the sync forever (GHY-3727)
+            (.setTimeout (int (setting/get :remote-sync-git-timeout-seconds)))
+            (.setCredentialsProvider credentials-provider))
           (.call))
       (catch Exception e
         (analytics/inc! :metabase-remote-sync/git-operations-failed analytics-labels)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -10,7 +10,7 @@
    [metabase.util :as u])
   (:import (java.io File)
            (org.apache.commons.io FileUtils)
-           (org.eclipse.jgit.api Git)
+           (org.eclipse.jgit.api Git TransportCommand)
            (org.eclipse.jgit.lib PersonIdent)
            (org.eclipse.jgit.transport UsernamePasswordCredentialsProvider)))
 
@@ -93,9 +93,38 @@
   (let [remote-repo (apply init-remote! dir config)]
     [(->source! branch remote-repo) remote-repo]))
 
+(defn- command-timeout
+  "Reads the protected `timeout` field (in seconds) that JGit applies to a TransportCommand's
+   network operations. 0 means no timeout (JGit's default), i.e. the operation can hang forever."
+  [^TransportCommand cmd]
+  (let [f (.getDeclaredField TransportCommand "timeout")]
+    (.setAccessible f true)
+    (.getInt f cmd)))
+
 (deftest qualify-branch-test
   (is (= "refs/heads/main" (#'git/qualify-branch "main")))
   (is (= "refs/heads/main" (#'git/qualify-branch "refs/heads/main"))))
+
+(deftest call-remote-command-applies-network-timeout-test
+  (testing "Remote git operations get a positive network timeout so a stalled connection can't hang
+            the sync thread forever (GHY-3727: pull/push gets stuck at progress 0 and 0.3)"
+    (mt/with-temp-dir [remote-dir nil]
+      (let [[source _remote] (init-source! "master" remote-dir :files {"master.txt" "File in master"})
+            ^Git git (:git source)
+            cmd (.lsRemote git)]
+        (#'git/call-remote-command cmd source)
+        (is (pos? (command-timeout cmd))
+            "TransportCommand should have a positive (non-zero) timeout configured before .call")))))
+
+(deftest call-remote-command-respects-timeout-setting-test
+  (testing "The network timeout applied to remote git operations is driven by remote-sync-git-timeout-seconds"
+    (mt/with-temp-dir [remote-dir nil]
+      (let [[source _remote] (init-source! "master" remote-dir :files {"master.txt" "File in master"})
+            ^Git git (:git source)
+            cmd (.lsRemote git)]
+        (mt/with-temporary-setting-values [remote-sync-git-timeout-seconds 17]
+          (#'git/call-remote-command cmd source)
+          (is (= 17 (command-timeout cmd))))))))
 
 (deftest log
   (mt/with-temp-dir [remote-dir nil]


### PR DESCRIPTION
## Summary

Fixes [GHY-3727](https://linear.app/metabase/issue/GHY-3727/remote-sync-pullpush-gets-stuck): remote sync pull/push gets stuck (observed pinned at progress `0` and `0.3`, requiring multiple cancellations).

## Root cause

Remote sync's JGit transport commands (`fetch`, `push`, `clone`, `ls-remote`) all funnel through `call-remote-command` but **never set a network timeout**. JGit defaults to no socket timeout, so when a TCP connection stalls mid-stream, the sync's virtual thread blocks indefinitely.

The two stuck points map exactly to blocking network calls:
- **progress `0`** — import `fetch`/clone (`source.p/snapshot` runs inside the virtual thread before any progress advances)
- **progress `0.3`** — export `push` (after extraction, during `store!` → `write-files!` → `push-branch!`)

Cancelling didn't help because none of the existing safeguards can unblock a wedged socket:
- the cancel flag is only observed inside `update-progress!`, which a hung network call never reaches;
- the diehard `with-timeout {:interrupt? true}` fires only after 50 min, and classic blocking socket I/O ignores `Thread.interrupt()`;
- staleness detection only rewrites the DB row, it doesn't stop the thread.

## Fix

- New `remote-sync-git-timeout-seconds` setting (default `60`).
- `call-remote-command` applies `.setTimeout` to every remote git command before `.call`. A stalled operation now throws `TransportException` and flows into the existing error-handling path that fails the task and releases the lock.

The setting is read via `metabase.settings.core` rather than the remote-sync `settings` namespace to avoid a circular dependency (`settings.clj` already requires `git.clj`).

## Testing

- Added two tests in `git_test.clj` (read JGit's protected `timeout` field via reflection): one asserting a positive timeout is applied, one asserting it honors the setting. Both were confirmed red before the fix.
- All 21 tests in `remote-sync.source.git-test` pass; no reflection warnings; `./bin/mage kondo` clean (0 errors / 0 warnings).
