### PR TITLE
Add missing dimensions in underlying-records drill-thru

### DIFF
--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.drill-thru
-  (:refer-clojure :exclude [select-keys empty? not-empty #?(:clj for)])
+  (:refer-clojure :exclude [select-keys not-empty #?(:clj for)])
   (:require
    [metabase.lib.drill-thru.automatic-insights :as lib.drill-thru.automatic-insights]
    [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
@@ -32,7 +32,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys empty? not-empty #?(:clj for)]]))
+   [metabase.util.performance :refer [select-keys not-empty #?(:clj for)]]))
 
 (comment
   lib.drill-thru.fk-details/keep-me
@@ -83,16 +83,23 @@
          (update :value lib.drill-thru.common/js->drill-value)))))
 
 (mu/defn- context-with-dimensions-or-row-dimensions :- ::lib.schema.drill-thru/context
-  "Return an updated `context` with either the existing `dimensions` or dimensions constructed from the `row`."
+  "Return an updated `context`, supplementing `dimensions` from breakout-sourced `row` entries.
+
+  If no dimensions were provided but the underlying column comes from an aggregation, construct the dimensions from
+  the row data. This is needed in cases where the frontend normally provides dimensions, but will not if it cannot
+  determine that the clicked table cell was from an \"underlying\" aggregation-sourced column. See, e.g. the comment
+  in `getTableCellClickedObject` in `table.js`.
+
+  If dimensions were provided but are missing a breakout-sourced entry that the row has (e.g. a chart whose viz
+  settings only include one of several breakouts as a series breakout — see #73803), append the missing entries so
+  every breakout produced by an earlier stage contributes a filter to the drill output."
   [query                                       :- ::lib.schema/query
    {:keys [column dimensions row] :as context} :- ::lib.schema.drill-thru/context]
-  ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the dimensions
-  ;; from the row data. This is needed in cases where the frontend normally provides dimensions, but will not if it
-  ;; cannot determine that the clicked table cell was from an "underlying" aggregation-sourced column. See, e.g. the
-  ;; comment in getTableCellClickedObject in table.js.
-  (let [row-dimensions (lib.drill-thru.common/dimensions-from-breakout-columns query column row)]
-    (if (and (empty? dimensions) (seq row-dimensions))
-      (assoc context :dimensions row-dimensions)
+  (let [row-dimensions   (lib.drill-thru.common/dimensions-from-breakout-columns query column row)
+        existing-columns (into #{} (keep :column) dimensions)
+        missing-from-row (remove (comp existing-columns :column) row-dimensions)]
+    (if (seq missing-from-row)
+      (update context :dimensions #(into (vec %) missing-from-row))
       context)))
 
 (mu/defn available-drill-thrus :- [:sequential [:ref ::lib.schema.drill-thru/drill-thru]]

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -919,3 +919,57 @@
                              :breakout    (symbol "nil #_\"key is not present.\"")
                              :fields      (symbol "nil #_\"key is not present.\"")}]}
                   second-result)))))))
+
+(deftest ^:parallel partial-dimensions-fill-from-row-test
+  (testing "underlying-records drill fills in missing breakout-sourced row entries when the
+            FE provides only some of the dimensions (#73803)"
+    ;; Models a card where stage 1 has agg+breakouts (count by created-at:month, state); stage 2
+    ;; adds a filter `state = "AK"`. On the FE the scatter only puts CREATED_AT in graph.dimensions,
+    ;; so the click context's :dimensions has just CREATED_AT — STATE is present in :row but, at
+    ;; the last stage, its column metadata shows :source/previous-stage / :source :fields rather
+    ;; than a breakout. The drill must still apply STATE = clicked-value to the underlying records.
+    (let [base       (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (-> (meta/field-metadata :people :created-at)
+                                           (lib/with-temporal-bucket :month)))
+                         (lib/breakout (meta/field-metadata :people :state))
+                         lib/append-stage)
+          base-cols  (lib/returned-columns base)
+          created-at (lib.tu.notebook/find-col-with-spec
+                      base base-cols {} {:display-name "Created At: Month"})
+          state-col  (lib.tu.notebook/find-col-with-spec
+                      base base-cols {} {:display-name "State"})
+          count-col  (lib.tu.notebook/find-col-with-spec
+                      base base-cols {} {:display-name "Count"})
+          query      (lib/filter base (lib/= state-col "AK"))
+          context    {:column     count-col
+                      :column-ref (lib/ref count-col)
+                      :value      4
+                      :row        [{:column     created-at
+                                    :column-ref (lib/ref created-at)
+                                    :value      "2026-07-01T00:00:00Z"}
+                                   {:column     state-col
+                                    :column-ref (lib/ref state-col)
+                                    :value      "AK"}
+                                   {:column     count-col
+                                    :column-ref (lib/ref count-col)
+                                    :value      4}]
+                      :dimensions [{:column     created-at
+                                    :column-ref (lib/ref created-at)
+                                    :value      "2026-07-01T00:00:00Z"}]}
+          drill      (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                   (lib/available-drill-thrus query context))
+          _          (is (some? drill))
+          result     (lib/drill-thru query drill)]
+      (is (=? {:stages [{:source-table (meta/id :people)
+                         :filters      [[:between {}
+                                         [:field {:temporal-unit :month} (meta/id :people :created-at)]
+                                         string?
+                                         string?]
+                                        [:= {}
+                                         [:field {} (meta/id :people :state)]
+                                         "AK"]]
+                         :aggregation  (symbol "nil #_\"key is not present.\"")
+                         :breakout     (symbol "nil #_\"key is not present.\"")
+                         :fields       (symbol "nil #_\"key is not present.\"")}]}
+              result)))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75089
Closes QUE2-635

### Description

The FE can sends a partial set of dimensions when new stages hide the source of a breakout column. This PR relaxes the existing condition that no dimensions should be present and adds the missing ones.

### How to verify

- The repro steps in #75089 should produce the restricted set.
- The repro test should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
