### PR TITLE
GDGT-2213 Update incremental transform label to "Only process new data"

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms-incremental.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-incremental.cy.spec.ts
@@ -67,7 +67,7 @@ describe("scenarios > admin > transforms incremental", () => {
         cy.findByLabelText("Name").type(" transform");
         cy.findByLabelText("Table name").should("have.value", TARGET_TABLE);
         cy.findByRole("switch", {
-          name: /Only process new and changed data/i,
+          name: /Only process new data/i,
         }).click({ force: true });
 
         cy.button("Save").click();
@@ -190,7 +190,7 @@ def transform(animals):
           cy.findByLabelText("Name").clear().type("Python transform");
           cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
           cy.findByRole("switch", {
-            name: /Only process new and changed data/i,
+            name: /Only process new data/i,
           }).click({ force: true });
           cy.button("Save").click();
           cy.wait("@createTransform").then(({ response }) => {
@@ -309,7 +309,7 @@ def transform(animals):
         cy.findByLabelText("Name").clear().type("SQL transform");
         cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
         cy.findByRole("switch", {
-          name: /Only process new and changed data/i,
+          name: /Only process new data/i,
         }).click({ force: true });
         cy.button("Save").click();
         cy.wait("@createTransform");

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -2709,10 +2709,10 @@ LIMIT
       cy.log("'Change target' button is not displayed");
       cy.findByRole("button", { name: /Change target/ }).should("not.exist");
 
-      cy.log("'Only process new and changed data' switch is not displayed");
-      cy.findByRole("switch", {
-        name: /Only process new and changed data/,
-      }).should("be.disabled");
+      cy.log("'Only process new data' switch is not displayed");
+      cy.findByRole("switch", { name: /Only process new data/ }).should(
+        "be.disabled",
+      );
 
       cy.log("visiting edit mode url directly redirects to view-only mode");
       cy.visit("/data-studio/transforms/1/edit");

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -84,7 +84,7 @@ export const IncrementalTransformSettings = ({
       if (!hasCheckpointOptions) {
         return t`Incremental transforms require at least one numeric or temporal source field.`;
       }
-      return t`Only process new and changed data`;
+      return t`Only process new data`;
     };
 
     const transformHasIssues =

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx
@@ -128,7 +128,7 @@ describe("TransformSettingsSection", () => {
 
     it("does not show the change target button", async () => {
       await screen.findByRole("switch", {
-        name: /Only process new and changed data/,
+        name: /Only process new data/,
       });
       expect(
         screen.queryByRole("button", { name: "Change target" }),
@@ -138,7 +138,7 @@ describe("TransformSettingsSection", () => {
     it("makes Incremental transformation switch disabled", async () => {
       expect(
         await screen.findByRole("switch", {
-          name: /Only process new and changed data/,
+          name: /Only process new data/,
         }),
       ).toBeDisabled();
     });

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TransformSettingsSection.unit.spec.tsx
@@ -134,7 +134,7 @@ describe("TransformSettingsSection", () => {
     it("makes Incremental transformation switch disabled", () => {
       expect(
         screen.getByRole("switch", {
-          name: /Only process new and changed data/,
+          name: /Only process new data/,
         }),
       ).toBeDisabled();
     });


### PR DESCRIPTION
Closes [GDGT-2213: Clarify that incremental transforms are append-only](https://linear.app/metabase/issue/GDGT-2213/clarify-that-incremental-transforms-are-append-only)

### Description
Changing the label according in order to make incremental transforms a bit clear.

### Demo
<img width="589" height="116" alt="image" src="https://github.com/user-attachments/assets/229664ae-7a46-4d3d-9bbd-b2fa5c10f81b" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
