### PR TITLE
Default appdb checkoutTimeout to 30s

### DIFF
--- a/src/metabase/app_db/connection_pool_setup.clj
+++ b/src/metabase/app_db/connection_pool_setup.clj
@@ -153,6 +153,18 @@
    (or (config/config-int :mb-application-db-max-connection-pool-size)
        ;; 15 is the c3p0 default but it's always nice to be explicit in case that changes
        15)
+   ;;
+   ;; Milliseconds a thread will wait for a c3p0 Connection to become available when the pool is fully checked out before
+   ;; giving up and throwing.
+   ;; We default to 30s so a stuck checkout fails loudly with a
+   ;; stack trace break cycle deadlocks. Operators who
+   ;; truly want the legacy wait-forever behavior can set the env var to 0.
+   ;;
+   ;; https://www.mchange.com/projects/c3p0/#checkoutTimeout
+   ;;
+   "checkoutTimeout"
+   (or (config/config-int :mb-application-db-checkout-timeout-ms)
+       30000)
 
    "unreturnedConnectionTimeout"
    ;; `MB_APPLICATION_DB_UNRETURNED_CONNECTION_TIMEOUT` is the legacy unsuffixed name (its value has always been

--- a/test/metabase/app_db/connection_pool_setup_test.clj
+++ b/test/metabase/app_db/connection_pool_setup_test.clj
@@ -117,7 +117,8 @@
                                         :mb-application-db-unreturned-connection-timeout-seconds    nil
                                         :mb-application-db-max-connection-age-seconds               nil
                                         :mb-application-db-idle-connection-test-period-seconds      nil
-                                        :mb-application-db-max-idle-time-excess-connections-seconds nil})
+                                        :mb-application-db-max-idle-time-excess-connections-seconds nil
+                                        :mb-application-db-checkout-timeout-ms                       nil})
                   config/config-bool (with-config-overrides config/config-bool
                                        {:mb-application-db-test-connection-on-checkout nil})]
       (let [props (#'mdb.connection-pool-setup/application-db-connection-pool-props)]
@@ -126,6 +127,8 @@
         (is (= 3600 (get props "maxConnectionAge")))
         (is (= 15   (get props "maxPoolSize")))
         (is (= 3600 (get props "unreturnedConnectionTimeout")))
+        (is (= 30000 (get props "checkoutTimeout"))
+            "checkoutTimeout must default to 30s so a saturated pool fails loudly instead of blocking forever")
         (is (false? (get props "testConnectionOnCheckout")))))))
 
 (deftest application-db-connection-pool-props-overrides-test
@@ -149,7 +152,18 @@
     (with-redefs [config/config-bool (with-config-overrides config/config-bool
                                        {:mb-application-db-test-connection-on-checkout true})]
       (is (true? (get (#'mdb.connection-pool-setup/application-db-connection-pool-props)
-                      "testConnectionOnCheckout"))))))
+                      "testConnectionOnCheckout")))))
+  (testing "MB_APPLICATION_DB_CHECKOUT_TIMEOUT_MS overrides checkoutTimeout"
+    (with-redefs [config/config-int (with-config-overrides config/config-int
+                                      {:mb-application-db-checkout-timeout-ms 5000})]
+      (is (= 5000 (get (#'mdb.connection-pool-setup/application-db-connection-pool-props)
+                       "checkoutTimeout")))))
+  (testing "checkoutTimeout of 0 (block forever) can be explicitly restored"
+    (with-redefs [config/config-int (with-config-overrides config/config-int
+                                      {:mb-application-db-checkout-timeout-ms 0})]
+      (is (= 0 (get (#'mdb.connection-pool-setup/application-db-connection-pool-props)
+                    "checkoutTimeout"))
+          "an operator must be able to opt back into the legacy wait-forever behavior"))))
 
 (deftest application-db-unreturned-connection-timeout-aliasing-test
   (testing "the _SECONDS-suffixed name takes precedence over the legacy unsuffixed name"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74954
### Description

Set the checkoutTimeout to 30s rather than the default of "forever".

This will cause attempts to check out a connection from the pool to fail with a stacktrace after waiting for 30 seconds. This will:
- Give us better debugging in cases where the connection pool is filled up and blocking further requests
- If the connection pool filling is caused by a race condition between waiting for a connection and something else, it will break the race condition and the pool may be able to recover

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
