### PR TITLE
Enable all admin users to activate trial up to pro

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-theme-editor/theme-upsell.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-theme-editor/theme-upsell.cy.spec.ts
@@ -47,7 +47,14 @@ describe("scenarios > embedding > themes > upsell", () => {
       H.activateToken("starter");
     });
 
-    it("shows the upsell with a Store Admin contact message instead of a CTA", () => {
+    it("shows the Upgrade to Pro CTA when the current admin is not a Metabase Store Admin", () => {
+      cy.log(
+        "keep the trial check deterministic — no trial, so CTA stays 'Upgrade to Pro'",
+      );
+      cy.intercept("POST", "/api/ee/cloud-proxy/mb-plan-trial-up-available", {
+        body: { available: false, plan_alias: "pro-cloud" },
+      });
+
       cy.visit("/admin/embedding/themes");
 
       cy.log("nav label has an upsell gem");
@@ -67,15 +74,11 @@ describe("scenarios > embedding > themes > upsell", () => {
         ).should("be.visible");
 
         cy.log(
-          "hosted, non-Store-Admin users see the contact-admin message instead of a CTA",
+          "hosted starter admins can upgrade even when they are not Store Admins",
         );
-        cy.findByText(
-          /Please ask a Metabase Store Admin.*to upgrade your plan\./,
-        ).should("be.visible");
-        cy.findByRole("button", { name: "Upgrade to Pro" }).should("not.exist");
-        cy.findByRole("link", { name: "Upgrade to Pro" }).should("not.exist");
-
-        cy.findByRole("button", { name: /New theme/ }).should("not.exist");
+        cy.findByRole("button", { name: "Upgrade to Pro" }).should(
+          "be.visible",
+        );
       });
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PythonTransformsUpsellModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PythonTransformsUpsellModal.tsx
@@ -6,6 +6,7 @@ import { trackUpsellViewed } from "metabase/common/components/upsells/components
 import { useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getIsHosted } from "metabase/setup/selectors";
 import {
   Button,
@@ -45,6 +46,8 @@ export function PythonTransformsUpsell({
 
   const isHosted = useSelector(getIsHosted);
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
+  const isAdmin = useSelector(getUserIsAdmin);
+  const canPurchaseTransforms = isStoreUser || isAdmin;
 
   const { isLoading, error, advancedTransformsAddOn, hadAdvancedTransforms } =
     useTransformsBilling();
@@ -120,14 +123,16 @@ export function PythonTransformsUpsell({
                 </Flex>
               ))}
             </Stack>
-            {!isStoreUser && (
+            {!canPurchaseTransforms && (
               <Text fw="bold" lh="md">
                 {anyStoreUserEmailAddress
                   ? t`Please ask a Store Admin (${anyStoreUserEmailAddress}) to enable this for you.`
                   : t`Please ask a Store Admin to enable this for you.`}
               </Text>
             )}
-            {isStoreUser && !isHosted && <SelfHostedStorePurchaseLink />}
+            {canPurchaseTransforms && !isHosted && (
+              <SelfHostedStorePurchaseLink />
+            )}
           </Stack>
         </Flex>
       )}
@@ -140,7 +145,9 @@ export function PythonTransformsUpsellModal({
 }: PythonTransformsUpsellModalProps) {
   const isHosted = useSelector(getIsHosted);
   const { isStoreUser } = useSelector(getStoreUsers);
-  const shouldShowLeftColumn = isStoreUser && isHosted;
+  const isAdmin = useSelector(getUserIsAdmin);
+  const canPurchaseTransforms = isStoreUser || isAdmin;
+  const shouldShowLeftColumn = canPurchaseTransforms && isHosted;
   const onSuccess = useCallback(() => {
     window.location.href = Urls.transformList(); // On success, do a full-page redirect to transforms list
   }, []);

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
@@ -3,6 +3,7 @@ import { DottedBackground } from "metabase/common/components/upsells/components/
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { useSelector } from "metabase/redux/hooks";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getIsHosted } from "metabase/setup/selectors";
 import { TransformHeader } from "metabase/transforms/components/TransformHeader";
 import { useTransformWithPolling } from "metabase/transforms/hooks/use-transform-with-polling";
@@ -23,7 +24,8 @@ export function TransformInspectorUpsellPage({
   const { transform, isLoading, error } = useTransformWithPolling(transformId);
   const isHosted = useSelector(getIsHosted);
   const { isStoreUser } = useSelector(getStoreUsers);
-  const shouldShowLeftColumn = isStoreUser && isHosted;
+  const isAdmin = useSelector(getUserIsAdmin);
+  const shouldShowLeftColumn = (isStoreUser || isAdmin) && isHosted;
 
   if (isLoading || error || !transform) {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/tests/enterprise.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/tests/enterprise.unit.spec.tsx
@@ -9,8 +9,13 @@ async function waitForLoadingToFinish() {
 }
 
 describe("PythonTransformsUpsellModal", () => {
-  it("renders single-column layout with admin message when hosted and user is not a store user", async () => {
-    setup({ isHosted: true, isStoreUser: false, isEnterprise: true });
+  it("renders single-column layout with admin message when hosted user is not an admin or store user", async () => {
+    setup({
+      isHosted: true,
+      isAdmin: false,
+      isStoreUser: false,
+      isEnterprise: true,
+    });
     await waitForLoadingToFinish();
 
     expect(
@@ -22,10 +27,23 @@ describe("PythonTransformsUpsellModal", () => {
     expect(
       screen.getByText(/Please ask a Store Admin to enable this for you/),
     ).toBeInTheDocument();
+  });
+
+  it("shows cloud purchase content when hosted user is an admin", async () => {
+    setup({
+      isHosted: true,
+      isAdmin: true,
+      isStoreUser: false,
+      isEnterprise: true,
+    });
+    await waitForLoadingToFinish();
 
     expect(
-      screen.queryByRole("button", { name: /Upgrade/ }),
-    ).not.toBeInTheDocument();
+      screen.getByText(
+        "1k advanced transforms included, then 2¢ per transform run.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Upgrade/ })).toBeInTheDocument();
   });
 
   it("shows cloud purchase content when hosted and user is store user", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/tests/setup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/tests/setup.tsx
@@ -21,11 +21,13 @@ import { PythonTransformsUpsellModal } from "../PythonTransformsUpsellModal";
 export const setup = ({
   isHosted,
   isStoreUser,
+  isAdmin = isStoreUser,
   billingPeriodMonths = 12,
   isEnterprise = false,
 }: {
   isOpen?: boolean;
   isHosted: boolean;
+  isAdmin?: boolean;
   isStoreUser: boolean;
   billingPeriodMonths?: number | undefined;
   isEnterprise?: boolean;
@@ -33,9 +35,10 @@ export const setup = ({
   const onClose = jest.fn();
 
   const storeUserEmail = "store-user@example.com";
-  const currentUser = createMockUser(
-    isStoreUser ? { email: storeUserEmail, is_superuser: true } : undefined,
-  );
+  const currentUser = createMockUser({
+    ...(isStoreUser ? { email: storeUserEmail } : {}),
+    is_superuser: isAdmin,
+  });
 
   const settings = {
     "is-hosted?": isHosted,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.setup.spec.tsx
@@ -17,6 +17,7 @@ import { TransformsUpsellPage } from "./TransformsUpsellPage";
 
 type SetupOpts = {
   hadTransforms?: boolean;
+  isAdmin?: boolean;
   isHosted: boolean;
   isStoreUser: boolean;
   isOnTrial?: boolean;
@@ -25,10 +26,11 @@ type SetupOpts = {
 export const setup = ({
   isHosted,
   isStoreUser,
+  isAdmin = isStoreUser,
   hadTransforms = false,
   isOnTrial = false,
 }: SetupOpts) => {
-  const currentUser = createMockUser({ is_superuser: isStoreUser });
+  const currentUser = createMockUser({ is_superuser: isAdmin });
   const settings = createMockSettings({
     "is-hosted?": isHosted,
     "token-status": {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.tsx
@@ -10,6 +10,7 @@ import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
 import { useMetadataToasts } from "metabase/metadata/hooks/useMetadataToasts";
 import { useSelector } from "metabase/redux";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { EnableTransformsCard } from "metabase/transforms/pages/EnableTransformsPage/EnableTransformsCard";
 import { Button, Center, Flex, Text, Title } from "metabase/ui";
 import { reload } from "metabase/utils/dom";
@@ -28,6 +29,8 @@ export function TransformsUpsellPage() {
   const { error, hadTransforms, isLoading, basicTransformsAddOn } =
     useTransformsBilling();
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
+  const isAdmin = useSelector(getUserIsAdmin);
+  const canPurchaseTransforms = isStoreUser || isAdmin;
 
   const [settingUpModalOpened, settingUpModalHandlers] = useDisclosure(false);
   const { sendErrorToast } = useMetadataToasts();
@@ -100,7 +103,7 @@ export function TransformsUpsellPage() {
           <EnableTransformsCard
             onEnableClick={onEnableClick}
             permissionsErrorMessage={
-              !isStoreUser && (
+              !canPurchaseTransforms && (
                 <Text fz="1rem" fw="bold">
                   {t`To enable Transforms, please contact a store administrator`}
                   {anyStoreUserEmailAddress && ` (${anyStoreUserEmailAddress})`}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.unit.spec.tsx
@@ -15,16 +15,24 @@ describe("TransformsUpsellPage", () => {
     jest.spyOn(domUtils, "reload").mockImplementation(() => undefined);
   });
 
-  it("does not render an enable button if the user is not a store user", async () => {
-    setup({ isHosted: true, isStoreUser: false });
+  it("shows the contact message if the user is not an admin or store user", async () => {
+    setup({ isHosted: true, isAdmin: false, isStoreUser: false });
     await waitForLoadingToFinish();
 
     expect(
-      screen.queryByRole("button", { name: "Enable transforms" }),
-    ).not.toBeInTheDocument();
-    expect(
       screen.getByText(/contact a store administrator/i),
     ).toBeInTheDocument();
+  });
+
+  it("proceeds to an agree step when the user is an admin", async () => {
+    setup({ isHosted: true, isAdmin: true, isStoreUser: false });
+    await waitForLoadingToFinish();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Enable transforms" }),
+    );
+
+    expect(screen.getByText("1,000 free transform runs")).toBeInTheDocument();
   });
 
   it("proceeds to an agree step with an overview of the free bucket", async () => {
@@ -66,9 +74,6 @@ describe("TransformsUpsellPage", () => {
     setup({ isHosted: true, isStoreUser: true, hadTransforms: true });
     await waitForLoadingToFinish();
 
-    expect(
-      screen.queryByText("1,000 free transform runs"),
-    ).not.toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls(
         "path:/api/ee/cloud-add-ons/transforms-basic-metered",

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/TransformsUpsellPage.unit.spec.tsx
@@ -20,6 +20,9 @@ describe("TransformsUpsellPage", () => {
     await waitForLoadingToFinish();
 
     expect(
+      screen.queryByRole("button", { name: "Enable transforms" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByText(/contact a store administrator/i),
     ).toBeInTheDocument();
   });
@@ -74,6 +77,9 @@ describe("TransformsUpsellPage", () => {
     setup({ isHosted: true, isStoreUser: true, hadTransforms: true });
     await waitForLoadingToFinish();
 
+    expect(
+      screen.queryByText("1,000 free transform runs"),
+    ).not.toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls(
         "path:/api/ee/cloud-add-ons/transforms-basic-metered",

--- a/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.tsx
+++ b/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.tsx
@@ -10,6 +10,7 @@ import {
 } from "metabase/common/components/upsells/components/analytics";
 import { useSelector } from "metabase/redux";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getIsHosted } from "metabase/setup/selectors";
 import {
   Box,
@@ -141,9 +142,10 @@ const UpsellCardLeftColumnContent = ({
   isTrialAvailable: boolean;
 }) => {
   const isHosted = useSelector(getIsHosted);
+  const isAdmin = useSelector(getUserIsAdmin);
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
 
-  const shouldShowContactAdmin = isHosted && !isStoreUser;
+  const shouldShowContactAdmin = isHosted && !isStoreUser && !isAdmin;
 
   return (
     <Stack gap="sm" w="100%">

--- a/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.unit.spec.tsx
@@ -18,22 +18,40 @@ const defaultProps: UpsellCardContentProps = {
 
 interface SetupOpts {
   isHosted: boolean;
+  isAdmin?: boolean;
+  isStoreUser?: boolean;
 }
 
-function setup({ isHosted }: SetupOpts) {
+function setup({ isHosted, isAdmin = true, isStoreUser = false }: SetupOpts) {
   setupTrialAvailableEndpoint({
     available: true,
     plan_alias: "pro-cloud",
   });
 
-  renderWithProviders(<UpsellCardContent {...defaultProps} />, {
-    storeInitialState: createMockState({
-      currentUser: createMockUser({ is_superuser: true }),
-      settings: mockSettings({
-        "is-hosted?": isHosted,
-      }),
-    }),
+  const currentUser = createMockUser({
+    email: "user@example.com",
+    is_superuser: isAdmin,
   });
+
+  renderWithProviders(
+    <UpsellCardContent {...defaultProps} upgradeOnClick={jest.fn()} />,
+    {
+      storeInitialState: createMockState({
+        currentUser,
+        settings: mockSettings({
+          "is-hosted?": isHosted,
+          "token-status": {
+            valid: true,
+            status: "",
+            features: [],
+            "store-users": [
+              { email: isStoreUser ? currentUser.email : "store@example.com" },
+            ],
+          },
+        }),
+      }),
+    },
+  );
 }
 
 describe("UpsellCardContent", () => {
@@ -60,6 +78,34 @@ describe("UpsellCardContent", () => {
           "path:/api/ee/cloud-proxy/mb-plan-trial-up-available",
         ),
       ).toBe(false);
+    });
+  });
+
+  describe("upgrade action", () => {
+    it("shows the trial CTA when hosted user is an admin", async () => {
+      setup({ isHosted: true, isAdmin: true, isStoreUser: false });
+
+      expect(
+        await screen.findByRole("button", { name: "Try for free" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the trial CTA when hosted user is a store user", async () => {
+      setup({ isHosted: true, isAdmin: false, isStoreUser: true });
+
+      expect(
+        await screen.findByRole("button", { name: "Try for free" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the contact admin message when hosted user is not an admin or store user", async () => {
+      setup({ isHosted: true, isAdmin: false, isStoreUser: false });
+
+      expect(
+        await screen.findByText(
+          "Please ask a Metabase Store Admin (store@example.com) to upgrade your plan.",
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner.tsx
+++ b/frontend/src/metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner.tsx
@@ -4,10 +4,13 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux/hooks";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Button, Flex, Stack, Text } from "metabase/ui";
 
 export const LockedTransformsBanner = () => {
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
+  const isAdmin = useSelector(getUserIsAdmin);
+  const canPurchaseTransforms = isStoreUser || isAdmin;
   const storeUrl = useStoreUrl("account/manage/plans");
 
   return (
@@ -27,7 +30,7 @@ export const LockedTransformsBanner = () => {
         <Text c="text-secondary" lh="inherit">
           {t`To keep using transforms you can end your trial early and start your subscription.`}
         </Text>
-        {!isStoreUser && (
+        {!canPurchaseTransforms && (
           <Text c="text-secondary" fw="bold" lh="inherit">
             {anyStoreUserEmailAddress
               ? t`Please ask a Store Admin (${anyStoreUserEmailAddress}) to enable this for you.`
@@ -35,7 +38,7 @@ export const LockedTransformsBanner = () => {
           </Text>
         )}
       </Stack>
-      {isStoreUser && (
+      {canPurchaseTransforms && (
         <Box ml="md">
           <Button
             component={ExternalLink}

--- a/frontend/src/metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner.unit.spec.tsx
@@ -1,0 +1,63 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockUser } from "metabase-types/api/mocks";
+
+import { LockedTransformsBanner } from "./LockedTransformsBanner";
+
+function setup({
+  isAdmin = false,
+  isStoreUser = false,
+}: {
+  isAdmin?: boolean;
+  isStoreUser?: boolean;
+} = {}) {
+  const currentUser = createMockUser({
+    email: "user@example.com",
+    is_superuser: isAdmin,
+  });
+
+  renderWithProviders(<LockedTransformsBanner />, {
+    storeInitialState: createMockState({
+      currentUser,
+      settings: mockSettings({
+        "token-status": {
+          status: "valid",
+          valid: true,
+          "store-users": [
+            { email: isStoreUser ? currentUser.email : "store@example.com" },
+          ],
+          features: [],
+        },
+      }),
+    }),
+  });
+}
+
+describe("LockedTransformsBanner", () => {
+  it("shows the paid subscription link when the user is an admin", () => {
+    setup({ isAdmin: true, isStoreUser: false });
+
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the paid subscription link when the user is a store user", () => {
+    setup({ isAdmin: false, isStoreUser: true });
+
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Store Admin message when the user is not an admin or store user", () => {
+    setup({ isAdmin: false, isStoreUser: false });
+
+    expect(
+      screen.getByText(
+        "Please ask a Store Admin (store@example.com) to enable this for you.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/components/LockedTransformsHoverCard/LockedTransformsHoverCard.tsx
+++ b/frontend/src/metabase/transforms/components/LockedTransformsHoverCard/LockedTransformsHoverCard.tsx
@@ -5,10 +5,13 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux/hooks";
 import { getStoreUsers } from "metabase/selectors/store-users";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button, HoverCard, Text } from "metabase/ui";
 
 export const LockedTransformsHoverCard = ({ children }: PropsWithChildren) => {
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
+  const isAdmin = useSelector(getUserIsAdmin);
+  const canPurchaseTransforms = isStoreUser || isAdmin;
   const storeUrl = useStoreUrl("account/manage/plans");
 
   return (
@@ -26,7 +29,7 @@ export const LockedTransformsHoverCard = ({ children }: PropsWithChildren) => {
         <Text lh="inherit" mt="sm" c="text-secondary">
           {t`To keep using transforms you can end your trial early and start your subscription.`}
         </Text>
-        {!isStoreUser ? (
+        {!canPurchaseTransforms ? (
           <Text lh="inherit" mt="sm" c="text-secondary" fw="bold">
             {anyStoreUserEmailAddress
               ? t`Please ask a Store Admin (${anyStoreUserEmailAddress}) to enable this for you.`

--- a/frontend/src/metabase/transforms/components/LockedTransformsHoverCard/LockedTransformsHoverCard.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/components/LockedTransformsHoverCard/LockedTransformsHoverCard.unit.spec.tsx
@@ -1,0 +1,78 @@
+import { mockSettings } from "__support__/settings";
+import { act, fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockUser } from "metabase-types/api/mocks";
+
+import { LockedTransformsHoverCard } from "./LockedTransformsHoverCard";
+
+function setup({
+  isAdmin = false,
+  isStoreUser = false,
+}: {
+  isAdmin?: boolean;
+  isStoreUser?: boolean;
+} = {}) {
+  jest.useFakeTimers();
+
+  const currentUser = createMockUser({
+    email: "user@example.com",
+    is_superuser: isAdmin,
+  });
+
+  renderWithProviders(
+    <LockedTransformsHoverCard>
+      <button>Run transform</button>
+    </LockedTransformsHoverCard>,
+    {
+      storeInitialState: createMockState({
+        currentUser,
+        settings: mockSettings({
+          "token-status": {
+            status: "valid",
+            valid: true,
+            "store-users": [
+              { email: isStoreUser ? currentUser.email : "store@example.com" },
+            ],
+            features: [],
+          },
+        }),
+      }),
+    },
+  );
+
+  fireEvent.mouseEnter(screen.getByRole("button", { name: "Run transform" }));
+  act(() => jest.runAllTimers());
+}
+
+describe("LockedTransformsHoverCard", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("shows the paid subscription link when the user is an admin", () => {
+    setup({ isAdmin: true, isStoreUser: false });
+
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the paid subscription link when the user is a store user", () => {
+    setup({ isAdmin: false, isStoreUser: true });
+
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Store Admin message when the user is not an admin or store user", () => {
+    setup({ isAdmin: false, isStoreUser: false });
+
+    expect(
+      screen.getByText(
+        "Please ask a Store Admin (store@example.com) to enable this for you.",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes GRO-449, GRO-450

### Description

This PR enables all admin roles in the application to go through upsells. This is, upgrading to Pro, trialing up, and purchasing transforms.

### How to verify

1. On a new instance that has upsells available (e.g. a starter instance), add a new non-store admin user.
2. Go to any upsell, and verify that you're able to go through the upsell all the way.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
