### PR TITLE
refactor(embedding): Convert SavedEntityPicker to TypeScript

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
@@ -10,7 +10,7 @@ import { useTranslateContent } from "metabase/i18n/hooks";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Box } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { CardType, Collection, DatabaseId } from "metabase-types/api";
+import type { CardType, CollectionId, DatabaseId } from "metabase-types/api";
 
 import SavedEntityListS from "./SavedEntityList.module.css";
 import { CARD_INFO } from "./constants";
@@ -19,7 +19,7 @@ interface SavedEntityListProps {
   type: Extract<CardType, "model" | "question">;
   selectedId?: string;
   databaseId?: DatabaseId;
-  collection?: Collection;
+  collectionId?: CollectionId;
   onSelect: (tableOrModelId: string) => void;
 }
 
@@ -27,7 +27,7 @@ const SavedEntityList = ({
   type,
   selectedId,
   databaseId,
-  collection,
+  collectionId,
   onSelect,
 }: SavedEntityListProps): JSX.Element => {
   const tc = useTranslateContent();
@@ -37,12 +37,12 @@ const SavedEntityList = ({
     </Box>
   );
 
-  const isVirtualCollection = collection?.id === PERSONAL_COLLECTIONS.id;
+  const isVirtualCollection = collectionId === PERSONAL_COLLECTIONS.id;
 
   const { data, error, isFetching } = useListCollectionItemsQuery(
-    collection && !isVirtualCollection
+    collectionId != null && !isVirtualCollection
       ? {
-          id: collection.id,
+          id: collectionId,
           models: [CARD_INFO[type].model],
           sort_column: "name",
           sort_direction: "asc",
@@ -60,7 +60,7 @@ const SavedEntityList = ({
       <SelectList className={SavedEntityListS.SavedEntityListRoot}>
         <LoadingAndErrorWrapper
           className={SavedEntityListS.LoadingWrapper}
-          loading={!collection || isFetching}
+          loading={collectionId == null || isFetching}
           error={error}
         >
           <Fragment>

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
@@ -17,8 +17,8 @@ import { CARD_INFO } from "./constants";
 
 interface SavedEntityListProps {
   type: Extract<CardType, "model" | "question">;
-  selectedId: string;
-  databaseId: DatabaseId;
+  selectedId?: string;
+  databaseId?: DatabaseId;
   collection?: Collection;
   onSelect: (tableOrModelId: string) => void;
 }

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
@@ -23,6 +23,7 @@ import type {
   Collection,
   CollectionId,
   DatabaseId,
+  User,
 } from "metabase-types/api";
 
 import SavedEntityList from "./SavedEntityList";
@@ -45,6 +46,9 @@ const getOurAnalyticsCollection = (
   collectionEntity: Collection,
 ): CollectionTreeItem => ({
   ...collectionEntity,
+  // "Our analytics" is shown here as a flat clickable target; its real children
+  // are already listed by buildCollectionTree below, so we explicitly empty
+  // them to avoid duplicating the tree.
   children: [],
   schemaName: "Everything else",
   icon: "folder",
@@ -62,14 +66,18 @@ export function SavedEntityPicker(props: SavedEntityPickerProps) {
     namespaces: ["", "shared-tenant-collection", "tenant-specific"],
   });
   const { data: rootCollection } = useGetCollectionQuery({ id: "root" });
-  if (!collections) {
+  const currentUser = useSelector(getUser);
+
+  if (!collections || !currentUser) {
     return null;
   }
+
   return (
     <InnerSavedEntityPicker
       {...props}
       collections={collections}
       rootCollection={rootCollection}
+      currentUser={currentUser}
     />
   );
 }
@@ -77,6 +85,7 @@ export function SavedEntityPicker(props: SavedEntityPickerProps) {
 interface InnerSavedEntityPickerProps extends SavedEntityPickerProps {
   collections: Collection[];
   rootCollection?: Collection;
+  currentUser: User;
 }
 
 function InnerSavedEntityPicker({
@@ -88,14 +97,9 @@ function InnerSavedEntityPicker({
   onBack,
   collections,
   rootCollection,
+  currentUser,
 }: InnerSavedEntityPickerProps) {
-  const currentUser = useSelector(getUser);
-
   const collectionTree = useMemo<CollectionTreeItem[]>(() => {
-    if (!currentUser) {
-      return [];
-    }
-
     const modelFilter = (model: string) => CARD_INFO[type].model === model;
 
     const preparedCollections: Collection[] = [];

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
@@ -131,25 +131,25 @@ function InnerSavedEntityPicker({
     ];
   }, [collections, rootCollection, currentUser, type]);
 
-  const initialCollection = useMemo(
-    () =>
-      (collectionId != null
-        ? findCollectionById(collectionTree, collectionId)
-        : null) ?? collectionTree[0],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
-  const [selectedCollection, setSelectedCollection] =
-    useState(initialCollection);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<
+    CollectionId | undefined
+  >(() => {
+    if (collectionId != null) {
+      const collection = findCollectionById(collectionTree, collectionId);
+      if (collection) {
+        return collection.id;
+      }
+    }
+    return collectionTree[0]?.id;
+  });
 
   const handleSelect = useCallback((collection: ITreeNodeItem) => {
     if (collection.id === PERSONAL_COLLECTIONS.id) {
       return;
     }
-    // Tree erases the concrete item type to ITreeNodeItem, but at runtime the
-    // selected node is one of the CollectionTreeItem entries we passed in.
-    setSelectedCollection(collection as CollectionTreeItem);
+    // Tree erases node ids to string | number, but a selected collection
+    // node's id is always a CollectionId.
+    setSelectedCollectionId(collection.id as CollectionId);
   }, []);
 
   return (
@@ -167,13 +167,13 @@ function InnerSavedEntityPicker({
           <Tree
             data={collectionTree}
             onSelect={handleSelect}
-            selectedId={selectedCollection?.id}
+            selectedId={selectedCollectionId}
           />
         </Box>
       </Box>
       <SavedEntityList
         type={type}
-        collection={selectedCollection}
+        collectionId={selectedCollectionId}
         selectedId={tableId}
         databaseId={databaseId}
         onSelect={onSelect}

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import { useCallback, useMemo, useState } from "react";
 
 import {
@@ -6,6 +5,7 @@ import {
   useListCollectionsTreeQuery,
 } from "metabase/api";
 import { PERSONAL_COLLECTIONS } from "metabase/collections/constants";
+import type { CollectionTreeItem } from "metabase/collections/utils";
 import {
   buildCollectionTree,
   currentUserPersonalCollections,
@@ -13,54 +13,50 @@ import {
   nonPersonalOrArchivedCollection,
 } from "metabase/collections/utils";
 import { Tree } from "metabase/common/components/tree";
+import type { ITreeNodeItem } from "metabase/common/components/tree/types";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/redux";
 import { getUser } from "metabase/selectors/user";
 import { Box, Icon } from "metabase/ui";
+import type {
+  CardType,
+  Collection,
+  CollectionId,
+  DatabaseId,
+} from "metabase-types/api";
 
 import SavedEntityList from "./SavedEntityList";
 import SavedEntityPickerS from "./SavedEntityPicker.module.css";
 import { CARD_INFO } from "./constants";
 import { findCollectionById } from "./utils";
 
-const propTypes = {
-  type: PropTypes.string,
-  onSelect: PropTypes.func.isRequired,
-  onBack: PropTypes.func.isRequired,
-  databaseId: PropTypes.string,
-  tableId: PropTypes.string,
-  collectionId: PropTypes.number,
-};
+type SavedEntityType = Extract<CardType, "model" | "question">;
 
-const getOurAnalyticsCollection = (collectionEntity) => {
-  return {
-    ...collectionEntity,
-    schemaName: "Everything else",
-    icon: "folder",
-  };
-};
+interface SavedEntityPickerProps {
+  type: SavedEntityType;
+  collectionId?: CollectionId;
+  tableId?: string;
+  databaseId?: DatabaseId;
+  onSelect: (cardId: string) => void;
+  onBack: () => void;
+}
 
+const getOurAnalyticsCollection = (
+  collectionEntity: Collection,
+): CollectionTreeItem => ({
+  ...collectionEntity,
+  children: [],
+  schemaName: "Everything else",
+  icon: "folder",
+});
+
+// A sentinel root node that buildCollectionTree special-cases by id; it isn't a
+// real Collection, so we assert the type here rather than fabricate every field.
 const ALL_PERSONAL_COLLECTIONS_ROOT = {
   ...PERSONAL_COLLECTIONS,
-};
+} as Collection;
 
-/**
- * @typedef {import("metabase/embedding-sdk/types/components/data-picker").DataSourceSelectorProps} DataSourceSelectorProps
- *
- * @typedef {object} SavedEntityPickerOwnProps
- * @property {DataSourceSelectorProps['selectedCollectionId']} collectionId
- * @property {Extract<import("metabase-types/api").CardType, 'model' | 'question'>} type
- * @property {string} tableId
- * @property {DataSourceSelectorProps['selectedDatabaseId']} databaseId
- * @property {(cardId: string) => void} onSelect
- * @property {() => void} onBack
- */
-
-/**
- * @param {SavedEntityPickerOwnProps} props
- * @returns {JSX.Element | null}
- */
-export function SavedEntityPicker(props) {
+export function SavedEntityPicker(props: SavedEntityPickerProps) {
   const { data: collections } = useListCollectionsTreeQuery({
     "exclude-archived": true,
     namespaces: ["", "shared-tenant-collection", "tenant-specific"],
@@ -78,6 +74,11 @@ export function SavedEntityPicker(props) {
   );
 }
 
+interface InnerSavedEntityPickerProps extends SavedEntityPickerProps {
+  collections: Collection[];
+  rootCollection?: Collection;
+}
+
 function InnerSavedEntityPicker({
   collectionId,
   type,
@@ -87,13 +88,17 @@ function InnerSavedEntityPicker({
   onBack,
   collections,
   rootCollection,
-}) {
+}: InnerSavedEntityPickerProps) {
   const currentUser = useSelector(getUser);
 
-  const collectionTree = useMemo(() => {
-    const modelFilter = (model) => CARD_INFO[type].model === model;
+  const collectionTree = useMemo<CollectionTreeItem[]>(() => {
+    if (!currentUser) {
+      return [];
+    }
 
-    const preparedCollections = [];
+    const modelFilter = (model: string) => CARD_INFO[type].model === model;
+
+    const preparedCollections: Collection[] = [];
     const userPersonalCollections = currentUserPersonalCollections(
       collections,
       currentUser.id,
@@ -127,7 +132,10 @@ function InnerSavedEntityPicker({
   }, [collections, rootCollection, currentUser, type]);
 
   const initialCollection = useMemo(
-    () => findCollectionById(collectionTree, collectionId) ?? collectionTree[0],
+    () =>
+      (collectionId != null
+        ? findCollectionById(collectionTree, collectionId)
+        : null) ?? collectionTree[0],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
@@ -135,11 +143,13 @@ function InnerSavedEntityPicker({
   const [selectedCollection, setSelectedCollection] =
     useState(initialCollection);
 
-  const handleSelect = useCallback((collection) => {
+  const handleSelect = useCallback((collection: ITreeNodeItem) => {
     if (collection.id === PERSONAL_COLLECTIONS.id) {
       return;
     }
-    setSelectedCollection(collection);
+    // Tree erases the concrete item type to ITreeNodeItem, but at runtime the
+    // selected node is one of the CollectionTreeItem entries we passed in.
+    setSelectedCollection(collection as CollectionTreeItem);
   }, []);
 
   return (
@@ -171,10 +181,3 @@ function InnerSavedEntityPicker({
     </Box>
   );
 }
-
-SavedEntityPicker.propTypes = propTypes;
-InnerSavedEntityPicker.propTypes = {
-  ...propTypes,
-  collections: PropTypes.array.isRequired,
-  rootCollection: PropTypes.object,
-};

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.tsx
@@ -34,15 +34,13 @@ const COLLECTIONS = {
 };
 
 function mockCollectionItemsEndpoint() {
-  fetchMock.get(
-    {
-      url: "path:/api/collection/root/items",
-      query: {
-        sort_column: "name",
-        sort_direction: "asc",
-      },
+  fetchMock.get({
+    url: "path:/api/collection/root/items",
+    query: {
+      sort_column: "name",
+      sort_direction: "asc",
     },
-    {
+    response: {
       total: 3,
       data: [
         createMockCollectionItem({
@@ -62,7 +60,7 @@ function mockCollectionItemsEndpoint() {
       limit: null,
       offset: null,
     },
-  );
+  });
 }
 
 async function setup() {


### PR DESCRIPTION
### Description

[UXW-4317](https://linear.app/metabase/issue/UXW-4317).

Converts the embedding data picker's `SavedEntityPicker` from JSX to TypeScript. Behavior-preserving.

- The new prop types aren't yet enforced at the only caller (`embedding/data-picker/DataSelector`), which is still `.jsx`. Follow-up: convert that file so the types actually guard the call site.
- Two type assertions are retained on purpose: the "all personal collections" sentinel node (not a real `Collection`) and the `Tree` `onSelect` item (the `Tree` API erases the concrete item type, same pattern other tree consumers use).
- Incidental: loosened `SavedEntityList`'s `selectedId`/`databaseId` to optional to match what the picker actually passes. 
Fixes [UXW-4317: Convert remaining `SavedEntityPicker.jsx` files to TS](https://linear.app/metabase/issue/UXW-4317/convert-remaining-savedentitypickerjsx-files-to-ts)

### How to verify

- [ ] In interactive embedding, open the data picker, switch to Saved Questions / Models, and confirm the collection tree, personal-collection ordering, and selection still work.

### Demo

n/a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)