### PR TITLE
Reclassify entry-point composition files as app tier

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -175,6 +175,10 @@ const elements = [
     pattern: "frontend/src/metabase/app/nav/**",
     enforceOutgoing: true,
   }),
+  // static-viz must come after the app entries rather than in the
+  // alphabetical shared list: its entry point (static-viz/index.tsx) is app
+  // tier, and the first matching element wins.
+  createElement({ type: "shared", name: "static-viz" }),
   // catch-all for unmoduled files - must be last
   createElement({
     type: "shared",

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -150,12 +150,17 @@ const elements = [
     "frontend/src/metabase/App.styled.tsx",
     "frontend/src/metabase/AppKBarProvider.tsx",
     "frontend/src/metabase/reducers-main.ts",
+    "frontend/src/metabase/reducers-common.ts",
+    "frontend/src/metabase/reducers-public.ts",
     "frontend/src/metabase/routes.jsx",
     "frontend/src/metabase/routes-embed.tsx",
     "frontend/src/metabase/route-guards.tsx",
     "frontend/src/metabase/routes-public.tsx",
     "frontend/src/metabase/AppThemeProvider.tsx",
     "frontend/src/metabase/AppColorSchemeProvider.tsx",
+    // Entry point for the static-viz bundle (server-side chart rendering in
+    // GraalJS) - like app.js, it composes OSS + EE code for a build artifact.
+    "frontend/src/metabase/static-viz/index.tsx",
   ].map((path) =>
     createElement({
       type: "app",


### PR DESCRIPTION
Disclaimer: This PR was AI generated but I certify that I approve of the contents:

Fixes 2 module boundary violations by classifying entry-point composition files as app tier in `module-boundaries.mjs`, and **enforces the `static-viz` module**.

| Violation | Strategy |
|---|---|
| `reducers-common.ts` → `feature/dashboard` (dashboardReducers) | Reclassify as `app/misc` — it's entry-point reducer composition, same role as `reducers-main.ts` which is already app tier. `reducers-public.ts` added too for the same reason.
| `static-viz/index.tsx` → `feature/enterprise` (ee-overrides) | Reclassify as `app/misc` — it's the static-viz bundle entry point (server-side chart rendering in GraalJS) that composes OSS + EE code.

Enforces static-viz module

**Known trade-off:** `embedding-sdk-bundle/store/index.ts` gains one technical violation (shared/other → app/misc), since it imports `reducers-common`. The SDK bundle is unclassified (catch-all `shared/other`) and already has 47 violations. This whole class of violations will be fixed when we position it correctly in the module graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)