### PR TITLE
Manual Backport "GDGT-2515: Fix FK field name crop in Schema Viewer info popup"

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/InfoPanelField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/InfoPanelField.tsx
@@ -46,23 +46,27 @@ export function InfoPanelField({
   const isExternalFk = field.fk_target_table_id != null && targetNode == null;
 
   const fieldName = (
-    <Ellipsified className={S.fieldName}>{field.name}</Ellipsified>
+    <Ellipsified className={S.fieldName} maw={targetNode ? "50%" : "100%"}>
+      {field.name}
+    </Ellipsified>
   );
 
   return (
     <Group className={cx(S.fieldRow, CS.textWrap)} gap="sm" wrap="nowrap">
       <FixedSizeIcon name={fieldIcon} c="text-secondary" />
       {isExternalFk ? (
-        <Tooltip label={t`Fetch external table`} disabled={isExpanding}>
+        <Tooltip
+          label={t`Fetch external table`}
+          disabled={isExpanding}
+          position="left"
+        >
           <UnstyledButton
             className={S.fkLink}
             c="brand"
             disabled={isExpanding}
             onClick={onFetchExternal}
-            flex="1 1 auto"
-            lh={1}
+            flex="0 1 auto"
             h="100%"
-            style={{ overflow: "visible" }}
           >
             {fieldName}
           </UnstyledButton>

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
@@ -29,12 +29,8 @@
     }
   }
 
-  .fieldName,
-  .targetName {
+  .fieldName {
     flex: 0 1 auto;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     display: inline-block;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
@@ -20,7 +20,6 @@
 
   .fkLink {
     overflow: hidden;
-    line-height: 1;
 
     &:hover span {
       text-decoration: underline;
@@ -33,9 +32,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .fieldName {
-    max-width: 50%;
+    display: inline-block;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/SelectedNodeInfoPanel.module.css
@@ -1,8 +1,10 @@
 .infoPanel {
+  --max-content-height: calc(100vh - 2rem - var(--minimap-height));
+
   position: absolute;
   top: 1rem;
-  bottom: 1rem;
-  max-height: calc(100% - var(--minimap-height));
+  height: auto;
+  max-height: var(--max-content-height);
   z-index: var(--canvas-element-z-index);
 
   .card {
@@ -10,7 +12,8 @@
     flex-direction: column;
     padding: 0;
     width: 32rem;
-    max-height: 100%;
+    min-height: 0;
+    max-height: var(--max-content-height);
     pointer-events: all;
   }
 


### PR DESCRIPTION
[GDGT-2515](https://linear.app/metabase/issue/GDGT-2515/related-table-name-is-cut-in-info-popup)

### Description

Styling adjustments for Schema Viewer info popup

1. In the Schema Viewer's selected-node info popup, foreign-key field rows rendered the related table name clipped at the bottom — descenders (`g`, `y`, `p`) were cut off because `line-height: 1` combined with `overflow: hidden` shrank the line box below the glyph height.

This fixes the layout of the FK field row.

Also, minor adjustments:
- max width of field name – if there's no adjacent target table link, allow the field name to take whole popup width.
- move the "Fetch external table" tooltip on the left to not overlap with long ellipsified field names

2. The container of InfoPanel popup always took `screen height - minimap height` space even when the internal content needed less. This made the visible canvas under the popup unaccessible due to elements overlap. This is now also fixed.

### How to verify

1. Data Studio → open a table with foreign-key fields in the Schema Viewer (ERD).
2. Click a table node to open the info popup.
3. Confirm related/FK table names are no longer cut off at the bottom, and long field/table names ellipsize cleanly within the row.

### Demo

FK link names are not cropped, node under the popup can be selected:

<img width="568" height="915" alt="image" src="https://github.com/user-attachments/assets/62b123db-db8f-45b6-90e2-b837c3ec93f6" />
