### PR TITLE
DEV-2088: Skip milestone check when there's no prior release to compare

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -21,6 +21,7 @@ import {
   getVersionFromReleaseBranch,
   ignorePatches,
   isPatchVersion,
+  isPreReleaseVersion,
   versionSort,
 } from "./version-helpers";
 
@@ -301,10 +302,33 @@ export async function checkMilestoneForRelease({
   version,
   commitHash,
 }: GithubProps & { version: string, commitHash: string }) {
-  // Patches don't have their own milestones — they share the parent minor's.
-  // There's nothing to check pre-release; skip cleanly.
-  if (isPatchVersion(version)) {
-    console.log(`Skipping milestone check for patch version ${version}`);
+  // Nothing to audit pre-release, for two reasons:
+  //  - Patches don't have their own milestone — they share the parent minor's.
+  //  - A major's `.0` is, by convention, only ever cut as a pre-release
+  //    (beta/RC); we never tag a `.0` as a standalone stable build. So a
+  //    pre-release is always the first build of a new major and has no prior
+  //    stable release *in the same major* to diff against — and we never
+  //    compare across majors.
+  // Bail here so we skip the milestone API calls entirely (and never compare
+  // against an `undefined` base ref).
+  if (isPatchVersion(version) || isPreReleaseVersion(version)) {
+    console.log(`Skipping milestone check for ${version}`);
+    return;
+  }
+
+  const lastTag = await getLastReleaseTag({
+    github,
+    owner,
+    repo,
+    version,
+    ignorePatches: true, // ignore patch versions since we don't release notes for them
+    ignorePreReleases: true, // ignore pre-releases because we want cumulative notes for them
+  });
+
+  // Safety net: by convention, a `.0` should never be a standalone release.
+  // If someone breaks that, this check exits early.
+  if (!lastTag) {
+    console.log(`No prior release tag found for ${version}, skipping milestone check`);
     return;
   }
 
@@ -319,15 +343,6 @@ export async function checkMilestoneForRelease({
   });
   const openMilestoneIssues = await getMilestoneIssues({
     github, owner, repo, version, state: 'open', milestoneStatus: 'open',
-  });
-
-  const lastTag = await getLastReleaseTag({
-    github,
-    owner,
-    repo,
-    version,
-    ignorePatches: true, // ignore patch versions since we don't release notes for them
-    ignorePreReleases: true, // ignore pre-releases because we want cumulative notes for them
   });
 
   const compareResponse = await github.rest.repos.compareCommitsWithBasehead({

--- a/release/src/milestones.unit.spec.ts
+++ b/release/src/milestones.unit.spec.ts
@@ -1,4 +1,8 @@
-import { getNextMilestone, setMilestoneForCommits } from "./milestones";
+import {
+  checkMilestoneForRelease,
+  getNextMilestone,
+  setMilestoneForCommits,
+} from "./milestones";
 import type { Milestone } from "./types";
 
 describe('milestones', () => {
@@ -96,6 +100,72 @@ describe('milestones', () => {
       })).resolves.toBeUndefined();
 
       expect(github.rest.issues.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkMilestoneForRelease', () => {
+    // string sentinels so paginate can dispatch on which rest endpoint it got
+    const listMilestones = 'listMilestones';
+    const listForRepo = 'listForRepo';
+    const listMatchingRefs = 'listMatchingRefs';
+
+    const buildGithub = ({
+      milestones = [{ number: 620, title: '0.62' }] as Milestone[],
+      tags = [] as { ref: string }[],
+    } = {}) => {
+      const rest = {
+        issues: { listMilestones, listForRepo },
+        git: { listMatchingRefs },
+        repos: { compareCommitsWithBasehead: jest.fn() },
+      };
+      const paginate = jest.fn((fn: unknown) => {
+        if (fn === listMilestones) return Promise.resolve(milestones);
+        if (fn === listMatchingRefs) return Promise.resolve(tags);
+        return Promise.resolve([]); // listForRepo -> no milestone issues
+      });
+      return { paginate, rest };
+    };
+
+    it('is a no-op for a pre-release, bailing before any API calls (a major .0 is always cut as a beta/RC)', async () => {
+      const github = buildGithub();
+
+      await expect(checkMilestoneForRelease({
+        github: github as any,
+        owner: 'metabase',
+        repo: 'metabase',
+        version: 'v0.62.0-beta',
+        commitHash: 'b36890cda1b4bd8009b3c416c071937273fe87dc',
+      })).resolves.toBeUndefined();
+
+      // never attempt the compare with an `undefined` base ref
+      expect(github.rest.repos.compareCommitsWithBasehead).not.toHaveBeenCalled();
+      // and bail before touching the API at all — not even the tag list
+      expect(github.paginate).not.toHaveBeenCalled();
+    });
+
+    it('safety net: skips when there is no prior stable tag in this major, without comparing against `undefined`', async () => {
+      // A stable .0 shouldn't happen by convention, but if one ever reaches
+      // here, getLastReleaseTag finds no stable base and we must not feed
+      // `undefined` into the compare API.
+      const github = buildGithub({
+        tags: [
+          { ref: 'refs/tags/v0.62.0-beta' },
+          { ref: 'refs/tags/v0.62.0-RC1' },
+        ],
+      });
+
+      await expect(checkMilestoneForRelease({
+        github: github as any,
+        owner: 'metabase',
+        repo: 'metabase',
+        version: 'v0.62.0',
+        commitHash: 'b36890cda1b4bd8009b3c416c071937273fe87dc',
+      })).resolves.toBeUndefined();
+
+      expect(github.rest.repos.compareCommitsWithBasehead).not.toHaveBeenCalled();
+      // only the tag list was queried, then we bailed before milestone lookups
+      expect(github.paginate).toHaveBeenCalledWith(listMatchingRefs, expect.anything());
+      expect(github.paginate).not.toHaveBeenCalledWith(listMilestones, expect.anything());
     });
   });
 });


### PR DESCRIPTION
Resolves DEV-2088

## Summary

The trigger-milestone-check job crashed when cutting the first build of a new major (e.g. v0.62.0-beta): `getLastReleaseTag` only looks within the same major, finds no prior stable tag, and the resulting `undefined` base ref was fed into the compare API (`compare/undefined...<sha>`), 404ing the job.

Bail early for patches (which share their parent minor's milestone) and pre-releases (by convention a major's `.0` is always cut as a beta/RC, so a pre-release is always the first build of a new major with no same-major baseline). A `!lastTag` guard remains after `getLastReleaseTag` as a safety net in case that convention is ever broken.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
