### PR TITLE
fix: retry message on gsheets transient failure

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -117,7 +117,7 @@ function SyncNowButton({ disabled }: { disabled: boolean }) {
         await doSync();
       }}
     >
-      {t`Sync now`}
+      {t`Sync`}
     </Menu.Item>
   );
 }
@@ -161,6 +161,18 @@ function MenuSyncStatus() {
     : t`soon` + "™";
 
   if (folderStatus === "error") {
+    // transient error, will be automatically retried
+    if (!folderError && lastSync) {
+      const isDelayed = dayjs
+        .unix(lastSync)
+        .isBefore(dayjs().subtract(1, "hour"));
+      return (
+        <GdriveRecoveringMenuItem
+          lastSyncRelative={lastSyncRelative ?? ""}
+          isDelayed={isDelayed}
+        />
+      );
+    }
     return <GdriveErrorMenuItem error={folderError ?? folderInfo} />;
   }
 
@@ -184,3 +196,27 @@ const SyncingText = () => (
     <Loader size="xs" />
   </Flex>
 );
+
+function GdriveRecoveringMenuItem({
+  lastSyncRelative,
+  isDelayed,
+}: {
+  lastSyncRelative: string;
+  isDelayed: boolean;
+}) {
+  if (isDelayed) {
+    return (
+      <>
+        <Text fw="bold">{t`Sync delayed`}</Text>
+        <Text fz="sm">{t`Last synced ${lastSyncRelative}. Your data may be a bit behind. We're retrying the sync.`}</Text>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Text fw="bold">{t`Retrying shortly`}</Text>
+      <Text fz="sm">{t`Last synced ${lastSyncRelative}. Your data is up to date as of the last sync.`}</Text>
+    </>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
@@ -100,15 +100,55 @@ describe("Google Drive > DB Menu", () => {
     expect(screen.getByLabelText("chevrondown icon")).toBeInTheDocument();
   });
 
-  it("shows a menu in error state", async () => {
+  it("shows the hard error when erroring and never synced", async () => {
+    // No last_sync_at => never synced successfully => a real setup error.
     setup({ status: "error" });
 
     await openMenu();
+    expect(
+      await screen.findByText("Couldn't sync Google Sheets"),
+    ).toBeInTheDocument();
     expect(
       await screen.findByText(
         "Please check that the folder is shared with the Metabase Service Account.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("retrying when erroring but synced within the last hour", async () => {
+    setup({
+      status: "error",
+      last_sync_at: dayjs().subtract(10, "minute").unix(),
+    });
+
+    await openMenu();
+    expect(await screen.findByText("Retrying shortly")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Last synced 10 minutes ago. Your data is up to date as of the last sync.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Couldn't sync Google Sheets"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("delay warning when erroring and last synced over an hour ago", async () => {
+    setup({
+      status: "error",
+      last_sync_at: dayjs().subtract(2, "hour").unix(),
+    });
+
+    await openMenu();
+    expect(await screen.findByText("Sync delayed")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Last synced 2 hours ago. Your data may be a bit behind. We're retrying the sync.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Couldn't sync Google Sheets"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a menu when loading", async () => {
@@ -191,13 +231,13 @@ describe("Google Drive > DB Menu", () => {
     expect(await screen.findByText("Next sync soon™")).toBeInTheDocument();
   });
 
-  it("should call the sync API when clicking sync now", async () => {
+  it("should call the sync API when clicking sync", async () => {
     setup({ status: "active" });
 
     await openMenu();
 
     const syncButton = await screen.findByRole("menuitem", {
-      name: /sync now/i,
+      name: /sync icon sync/i,
     });
     expect(syncButton).toBeEnabled();
 


### PR DESCRIPTION
Fix https://linear.app/metabase/issue/CLO-5546/review-google-sheets-sync-error-ux