### PR TITLE
Fix flaky theme editor main colors test on release-61

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
@@ -269,7 +269,10 @@ describe(
           expect(settings.colors?.brand).to.eq("#ff0000ff");
         });
 
-        H.undoToast().findByText("Theme saved").should("exist");
+        // An earlier undo toast (e.g. "reset to defaults") may still be on
+        // screen, so use the toast list (plural) and filter by text — using
+        // `undoToast()` (singular) yields undefined when multiple toasts match.
+        H.undoToastList().contains("Theme saved").should("be.visible");
       });
     });
 


### PR DESCRIPTION
Fixes EMB-1820

### Description

On 61, the "shows, edits, saves, and reverts main colors" test is flaky. The fix already landed on 62 and master via #75004. This PR backports it to 61.

### How to verify

Stress-tested via the E2E Stress Test Flake Fix workflow (50 burns, ee, network throttling on):

- This PR (61 + fix) -> ✅ **50 / 50** pass: [run 26814759361](https://github.com/metabase/metabase/actions/runs/26814759361)
- `release-x.61.x` (no fix) -> ❌ **1 pass / 49 fail**: [run 26809132459](https://github.com/metabase/metabase/actions/runs/26809132459)
- master (already fixed) -> ✅ **50 / 50** pass: [run 26808914442](https://github.com/metabase/metabase/actions/runs/26808914442)