### PR TITLE
Fix "Promise was collected" error in Storybook play functions

### DIFF
--- a/frontend/src/metabase/palette/components/Palette.stories.tsx
+++ b/frontend/src/metabase/palette/components/Palette.stories.tsx
@@ -111,11 +111,13 @@ export const Recents = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    const canvas = within(canvasElement);
+    try {
+      const canvas = within(canvasElement);
 
-    await canvas.findByRole("option", { name: "Recents" });
-
-    asyncCallback();
+      await canvas.findByRole("option", { name: "Recents" });
+    } finally {
+      asyncCallback();
+    }
   },
 };
 
@@ -124,21 +126,23 @@ export const Search = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    const canvas = within(canvasElement);
+    try {
+      const canvas = within(canvasElement);
 
-    await userEvent.type(
-      await canvas.findByPlaceholderText(/Search for anything/),
-      "ord",
-    );
+      await userEvent.type(
+        await canvas.findByPlaceholderText(/Search for anything/),
+        "ord",
+      );
 
-    await canvas.findByRole("option", { name: "Results" });
+      await canvas.findByRole("option", { name: "Results" });
 
-    // Wait for the result to all show up because "Results" will be
-    // present when the search query is still loading
-    await expect(
-      await canvas.findByText("Product breakdown"),
-    ).toBeInTheDocument();
-
-    asyncCallback();
+      // Wait for the result to all show up because "Results" will be
+      // present when the search query is still loading
+      await expect(
+        await canvas.findByText("Product breakdown"),
+      ).toBeInTheDocument();
+    } finally {
+      asyncCallback();
+    }
   },
 };

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.stories.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.stories.tsx
@@ -45,15 +45,17 @@ export const Default = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    const canvas = within(canvasElement);
+    try {
+      const canvas = within(canvasElement);
 
-    // To force the tooltip to show up
-    await userEvent.hover(
-      (await canvas.findByText("December 16, 2025 - December 19, 2025"))
-        .parentElement!,
-    );
-
-    asyncCallback();
+      // To force the tooltip to show up
+      await userEvent.hover(
+        (await canvas.findByText("December 16, 2025 - December 19, 2025"))
+          .parentElement!,
+      );
+    } finally {
+      asyncCallback();
+    }
   },
 };
 
@@ -78,14 +80,19 @@ export const LongPlaceholder = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    const canvas = within(canvasElement);
+    try {
+      const canvas = within(canvasElement);
 
-    // To force the tooltip to show up
-    await userEvent.hover(
-      (await canvas.findByText("Longggg String Longggg String Longggg String"))
-        .parentElement!,
-    );
-
-    asyncCallback();
+      // To force the tooltip to show up
+      await userEvent.hover(
+        (
+          await canvas.findByText(
+            "Longggg String Longggg String Longggg String",
+          )
+        ).parentElement!,
+      );
+    } finally {
+      asyncCallback();
+    }
   },
 };

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-pdf-export.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView-pdf-export.stories.tsx
@@ -176,10 +176,7 @@ const defaultArgs: Partial<MockDashboardContextProps> = {
   withFooter: true,
 };
 
-const triggerPdfExport = async (
-  canvasElement: HTMLElement,
-  asyncCallback: () => void,
-) => {
+const triggerPdfExport = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
 
   // Wait for the embed frame to render
@@ -196,7 +193,6 @@ const triggerPdfExport = async (
 
   // Wait for the image to be rendered (this is set by openImageBlobOnStorybook)
   await canvas.findByTestId("image-downloaded", {}, { timeout: 30000 });
-  asyncCallback();
 };
 
 export const GridMapPdfExport = {
@@ -205,7 +201,11 @@ export const GridMapPdfExport = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    await triggerPdfExport(canvasElement, asyncCallback);
+    try {
+      await triggerPdfExport(canvasElement);
+    } finally {
+      asyncCallback();
+    }
   },
   parameters: {
     loki: { skip: true },

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
@@ -148,7 +148,11 @@ export const LightThemeDownload = {
 
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const asyncCallback = createAsyncCallback();
-    await downloadQuestionAsPng(canvasElement, asyncCallback);
+    try {
+      await downloadQuestionAsPng(canvasElement);
+    } finally {
+      asyncCallback();
+    }
   },
 };
 
@@ -404,10 +408,7 @@ function NarrowContainer(Story: StoryFn) {
   );
 }
 
-const downloadQuestionAsPng = async (
-  canvasElement: HTMLElement,
-  asyncCallback: () => void,
-) => {
+const downloadQuestionAsPng = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
 
   const downloadButton = await canvas.findByTestId(
@@ -422,5 +423,4 @@ const downloadQuestionAsPng = async (
     await documentElement.findByTestId("download-results-button"),
   );
   await canvas.findByTestId("image-downloaded");
-  asyncCallback();
 };

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.stories.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.stories.tsx
@@ -82,14 +82,16 @@ WithFormattingAndHover.play = async ({
   canvasElement: HTMLCanvasElement;
 }) => {
   const asyncCallback = createAsyncCallback();
-  const canvas = within(canvasElement.parentElement as HTMLElement);
-  const value = (await canvas.findAllByTestId("scalar-value"))[2];
+  try {
+    const canvas = within(canvasElement.parentElement as HTMLElement);
+    const value = (await canvas.findAllByTestId("scalar-value"))[2];
 
-  await userEvent.hover(value);
-  value.classList.add("pseudo-hover");
+    await userEvent.hover(value);
+    value.classList.add("pseudo-hover");
 
-  await expect(await canvas.findByRole("tooltip")).toBeInTheDocument();
-  expect(value.classList.contains("pseudo-hover")).toBe(true);
-
-  asyncCallback();
+    await expect(await canvas.findByRole("tooltip")).toBeInTheDocument();
+    expect(value.classList.contains("pseudo-hover")).toBe(true);
+  } finally {
+    asyncCallback();
+  }
 };


### PR DESCRIPTION
### Description

_Hiding whitespace changes recommended._

Similar to #53889, but for Storybook `play` functions.

Example failure: https://github.com/metabase/metabase/actions/runs/26815943289/job/79057658183?pr=75035

When a step inside a story's `play` function `throw`s, `asyncCallback` would never be called, and the story would fail with "Promise was collected" error. It would prevent a screenshot for that story from being produced.

The fix is to wrap all steps in story's `play` function with `try`/`finally` block to ensure `asyncCallback` is always called.
