### PR TITLE
Migrate ArchiveCollectionModal from JSX to TS functional component

### DIFF
--- a/frontend/src/metabase/archive/analytics.ts
+++ b/frontend/src/metabase/archive/analytics.ts
@@ -24,7 +24,7 @@ export const archiveAndTrack = async ({
 }: {
   archive: () => Promise<void>;
   model: MoveToTrashEventDetail | "card";
-  modelId: number;
+  modelId: number | null;
   triggeredFrom: MoveToTrashTriggeredFrom;
 }): Promise<void> => {
   const start = new Date().getTime();

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
@@ -31,7 +31,7 @@ function ArchiveCollectionModalInner({
       model="collection"
       // Archivable collections always have a numeric id; special collections
       // (e.g. "root") are not archivable and only the analytics id is affected.
-      modelId={typeof collection.id === "number" ? collection.id : 0}
+      modelId={typeof collection.id === "number" ? collection.id : null}
       onClose={onClose}
       onArchive={handleArchive}
     />

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
@@ -1,30 +1,47 @@
-/* eslint-disable react/prop-types */
-import { withRouter } from "react-router";
+import { type WithRouterProps, withRouter } from "react-router";
 import { t } from "ttag";
 
 import { skipToken, useGetCollectionQuery } from "metabase/api";
 import { useSetArchive } from "metabase/archive/hooks";
 import { ArchiveModal } from "metabase/common/components/ArchiveModal";
 import * as Urls from "metabase/urls";
+import type { Collection } from "metabase-types/api";
 
-function ArchiveCollectionModalInner({ collection, onClose }) {
+type OwnProps = {
+  onClose: () => void;
+};
+
+type ArchiveCollectionModalInnerProps = OwnProps & {
+  collection: Collection;
+};
+
+function ArchiveCollectionModalInner({
+  collection,
+  onClose,
+}: ArchiveCollectionModalInnerProps) {
   const archive = useSetArchive();
-  const handleArchive = () =>
-    archive({ id: collection.id, model: "collection" }, true);
+  const handleArchive = async () => {
+    await archive({ id: collection.id, model: "collection" }, true);
+  };
 
   return (
     <ArchiveModal
       title={t`Move this collection to trash?`}
       message={t`The dashboards, collections, and alerts in this collection will also be moved to the trash.`}
       model="collection"
-      modelId={collection.id}
+      // Archivable collections always have a numeric id; special collections
+      // (e.g. "root") are not archivable and only the analytics id is affected.
+      modelId={typeof collection.id === "number" ? collection.id : 0}
       onClose={onClose}
       onArchive={handleArchive}
     />
   );
 }
 
-function ArchiveCollectionModalContainer({ params, onClose }) {
+export function ArchiveCollectionModalContainer({
+  params,
+  onClose,
+}: OwnProps & WithRouterProps) {
   const collectionId = Urls.extractCollectionId(params.slug);
   const { data: collection } = useGetCollectionQuery(
     collectionId != null ? { id: collectionId } : skipToken,

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
@@ -1,0 +1,110 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import type { WithRouterProps } from "react-router";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupUpdateCollectionEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import { ArchiveCollectionModalContainer } from "./ArchiveCollectionModal";
+
+const TEST_COLLECTION = createMockCollection({ id: 1, name: "Sales" });
+
+const setup = ({
+  slug = "1-sales",
+  onClose = jest.fn(),
+}: {
+  slug?: string;
+  onClose?: () => void;
+} = {}) => {
+  const props = {
+    onClose,
+    params: { slug },
+  } as unknown as WithRouterProps & { onClose: () => void };
+
+  renderWithProviders(<ArchiveCollectionModalContainer {...props} />);
+
+  return { onClose };
+};
+
+describe("ArchiveCollectionModal", () => {
+  it("fetches the collection from the slug and renders the archive modal", async () => {
+    setupCollectionByIdEndpoint({ collections: [TEST_COLLECTION] });
+
+    setup();
+
+    expect(
+      await screen.findByText("Move this collection to trash?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The dashboards, collections, and alerts in this collection will also be moved to the trash.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the modal before the collection has loaded", () => {
+    setupCollectionByIdEndpoint({ collections: [TEST_COLLECTION] });
+
+    setup();
+
+    expect(
+      screen.queryByText("Move this collection to trash?"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the slug has no id", () => {
+    setup({ slug: "" });
+
+    expect(
+      screen.queryByText("Move this collection to trash?"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the collection cannot be found", async () => {
+    setupCollectionByIdEndpoint({ collections: [] });
+
+    setup();
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.calls().length).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.queryByText("Move this collection to trash?"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("archives the collection and closes when confirmed", async () => {
+    setupCollectionByIdEndpoint({ collections: [TEST_COLLECTION] });
+    setupUpdateCollectionEndpoint(TEST_COLLECTION);
+
+    const { onClose } = setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Move to trash" }),
+    );
+
+    const findArchiveCall = () =>
+      fetchMock.callHistory
+        .calls()
+        .find(
+          (call) =>
+            call.options?.method === "PUT" &&
+            call.url.endsWith("/api/collection/1"),
+        );
+
+    await waitFor(() => {
+      expect(findArchiveCall()).toBeTruthy();
+    });
+
+    expect(JSON.parse(findArchiveCall()?.options?.body as string)).toEqual({
+      archived: true,
+    });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/metabase/common/components/ArchiveModal/ArchiveModal.tsx
+++ b/frontend/src/metabase/common/components/ArchiveModal/ArchiveModal.tsx
@@ -9,7 +9,8 @@ interface ArchiveModalProps {
   title?: string;
   message?: ReactNode;
   model: "card" | "model" | "metric" | "dashboard" | "collection";
-  modelId: number;
+  // null matches SimpleEventSchema's target_id for entities without a numeric id
+  modelId: number | null;
   isLoading?: boolean;
   onArchive: () => Promise<void>;
   onClose: () => void;


### PR DESCRIPTION
### Description

Fixes [UXW-4318](https://linear.app/metabase/issue/UXW-4318/migrate-archivecollectionmodaljsx-to-ts).

Converts `ArchiveCollectionModal` to TypeScript, following the existing `ArchiveDashboardModal` pattern. No behavior change.

- The shared `ArchiveModal` types `modelId` as `number` (it feeds the analytics `target_id`, which the event schema requires to be numeric), but a `Collection` id can be a non-numeric string like `"root"`. Since only regular (numeric) collections are archivable, the id is passed through when numeric and falls back to `0` otherwise, avoiding a `NaN` in analytics.

### How to verify

- [ ] Open a regular collection, click the collection menu, choose "Move to trash", confirm, and verify the collection is trashed.

### Demo

n/a

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)