### PR TITLE
Add Data Layer column to table, fix update on undo

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -118,18 +118,37 @@ describe("Table editing", () => {
       .blur();
     cy.wait("@updateTable");
     TablePicker.getTable("Renamed Orders").should("be.visible");
+    H.undoToast().findByRole("img", { name: /Close/i }).click();
 
     H.selectHasValue("Owner", "No owner").click();
     H.selectDropdown().contains("Bobby Tables").click();
+
     H.undoToastListContainer()
       .findByText("Table owner updated")
       .should("be.visible");
+    H.undoToast().findByRole("img", { name: /Close/i }).click();
 
     H.selectHasValue("Visibility layer", "Internal").click();
     H.selectDropdown().contains("Final").click();
     H.undoToastListContainer()
       .findByText("Table visibility layer updated")
       .should("be.visible");
+
+    cy.log(
+      "undo the change and verify the table updates to the reverted value",
+    );
+    H.undoToastListContainer()
+      .findByText("Table visibility layer updated")
+      .closest("[data-testid='toast-undo']")
+      .button("Undo")
+      .click();
+    cy.wait("@updateTable");
+    H.undoToastListContainer().findByText("Change undone").should("be.visible");
+    H.undoToast().findByRole("img", { name: /Close/i }).click();
+    H.selectHasValue("Visibility layer", "Internal");
+    TablePicker.getTable("Orders")
+      .findByTestId("table-data-layer")
+      .should("have.text", "Internal");
 
     H.selectHasValue("Entity type", "Transaction").click();
     H.selectDropdown().contains("Person").click();
@@ -148,7 +167,7 @@ describe("Table editing", () => {
     TablePicker.getTable("Renamed Orders").click();
 
     H.selectHasValue("Owner", "Bobby Tables");
-    H.selectHasValue("Visibility layer", "Final");
+    H.selectHasValue("Visibility layer", "Internal");
     H.selectHasValue("Entity type", "Person");
     H.selectHasValue("Source", "Ingested");
   });

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
@@ -382,6 +382,46 @@ describe("TablePicker", () => {
         databaseId: DATABASE_WITH_SINGLE_SCHEMA.id,
       });
     });
+
+    it("shows the visibility layer for each table", async () => {
+      const hiddenTable = createMockTable({
+        id: nextId(),
+        name: "HIDDEN_TABLE",
+        display_name: "Hidden Table",
+        schema: "public",
+        data_layer: "hidden",
+        fields: [],
+      });
+      const finalTable = createMockTable({
+        id: nextId(),
+        name: "FINAL_TABLE",
+        display_name: "Final Table",
+        schema: "public",
+        data_layer: "final",
+        fields: [],
+      });
+      const layerDatabase = createMockDatabase({
+        id: nextId(),
+        name: "LAYER_DATABASE",
+        tables: [hiddenTable, finalTable],
+      });
+
+      setup({ databases: [layerDatabase] });
+      await waitLoading();
+
+      // single-schema databases auto-expand to their tables on click
+      await clickItem(layerDatabase);
+      await waitLoading();
+
+      expect(item(hiddenTable)).toBeInTheDocument();
+      expect(item(finalTable)).toBeInTheDocument();
+
+      const labels = screen
+        .getAllByTestId("table-data-layer")
+        .map((cell) => cell.textContent);
+      expect(labels).toContain("Hidden");
+      expect(labels).toContain("Final");
+    });
   });
 
   describe("Search view", () => {

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePickerTreeTable.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePickerTreeTable.tsx
@@ -11,11 +11,16 @@ import { t } from "ttag";
 
 import { useListUsersQuery } from "metabase/api";
 import { useNumberFormatter } from "metabase/common/hooks/use-number-formatter";
+import {
+  DATA_LAYER_ICONS,
+  getDataLayerLabel,
+} from "metabase/metadata/utils/data-layer";
 import type { SelectionState, TreeTableColumnDef } from "metabase/ui";
 import {
   Box,
   Center,
   EntityNameCell,
+  Group,
   Icon,
   TreeTable,
   useTreeTableInstance,
@@ -236,6 +241,26 @@ export function TablePickerTreeTable({
           return ownerName ? (
             <Box data-testid="table-owner">{ownerName}</Box>
           ) : null;
+        },
+      },
+      {
+        id: "data-layer",
+        header: t`Visibility layer`,
+        width: 150,
+        cell: ({ row }) => {
+          if (row.original.type !== "table" || !row.original.table) {
+            return null;
+          }
+          const dataLayer = row.original.table.data_layer;
+          if (dataLayer == null) {
+            return null;
+          }
+          return (
+            <Group gap="sm" wrap="nowrap" data-testid="table-data-layer">
+              <Icon name={DATA_LAYER_ICONS[dataLayer]} c="text-secondary" />
+              <Box>{getDataLayerLabel(dataLayer)}</Box>
+            </Group>
+          );
         },
       },
       {

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableAttributesEditSingle.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableAttributesEditSingle.tsx
@@ -48,6 +48,9 @@ export function TableAttributesEditSingle({ table, onUpdate }: Props) {
           owner_email: table.owner_email,
           owner_user_id: table.owner_user_id,
         });
+        if (!error) {
+          onUpdate();
+        }
         sendUndoToast(error);
       });
     }
@@ -74,6 +77,9 @@ export function TableAttributesEditSingle({ table, onUpdate }: Props) {
           owner_email: table.owner_email,
           owner_user_id: table.owner_user_id,
         });
+        if (!error) {
+          onUpdate();
+        }
         sendUndoToast(error);
       });
     }
@@ -92,11 +98,15 @@ export function TableAttributesEditSingle({ table, onUpdate }: Props) {
     if (error) {
       sendErrorToast(t`Failed to update table visibility layer`);
     } else {
+      onUpdate();
       sendSuccessToast(t`Table visibility layer updated`, async () => {
         const { error } = await updateTable({
           id: table.id,
           data_layer: table.data_layer,
         });
+        if (!error) {
+          onUpdate();
+        }
         sendUndoToast(error);
       });
     }

--- a/frontend/src/metabase/metadata/components/LayerInput.tsx
+++ b/frontend/src/metabase/metadata/components/LayerInput.tsx
@@ -1,5 +1,10 @@
 import { t } from "ttag";
 
+import {
+  DATA_LAYER_ICONS,
+  getDataLayerOptions,
+  isDataLayer,
+} from "metabase/metadata/utils/data-layer";
 import { Group, Icon, Select, SelectItem, type SelectProps } from "metabase/ui";
 import type { TableDataLayer } from "metabase-types/api";
 
@@ -7,8 +12,6 @@ interface Props extends Omit<SelectProps, "data" | "value" | "onChange"> {
   value: TableDataLayer | null;
   onChange: (value: TableDataLayer | null) => void;
 }
-
-const dataLayers = ["hidden", "internal", "final"] as const;
 
 export const LayerInput = ({
   comboboxProps,
@@ -28,11 +31,7 @@ export const LayerInput = ({
         position: "bottom-start",
         ...comboboxProps,
       }}
-      data={[
-        { value: "hidden" as const, label: t`Hidden` },
-        { value: "internal" as const, label: t`Internal` },
-        { value: "final" as const, label: t`Final` },
-      ]}
+      data={getDataLayerOptions()}
       label={t`Visibility layer`}
       renderOption={(item) => {
         const selected = item.option.value === value;
@@ -55,24 +54,14 @@ export const LayerInput = ({
   );
 };
 
-function isDataLayer(value: string): value is TableDataLayer {
-  return dataLayers.some((layer) => layer === value);
-}
-
 function VisibilityIcon({ value }: { value: string | null }): React.ReactNode {
   if (value == null) {
     return null;
   }
 
   if (isDataLayer(value)) {
-    return <Icon name={VISIBILITY_ICONS[value]} />;
+    return <Icon name={DATA_LAYER_ICONS[value]} />;
   }
 
   return null;
 }
-
-const VISIBILITY_ICONS = {
-  hidden: "eye_filled",
-  internal: "database",
-  final: "published",
-} as const;

--- a/frontend/src/metabase/metadata/utils/data-layer.ts
+++ b/frontend/src/metabase/metadata/utils/data-layer.ts
@@ -1,0 +1,36 @@
+import { t } from "ttag";
+
+import type { IconName, TableDataLayer } from "metabase-types/api";
+
+export const DATA_LAYERS: TableDataLayer[] = ["hidden", "internal", "final"];
+
+export const DATA_LAYER_ICONS: Record<TableDataLayer, IconName> = {
+  hidden: "eye_filled",
+  internal: "database",
+  final: "published",
+};
+
+export function getDataLayerLabel(layer: TableDataLayer): string {
+  switch (layer) {
+    case "hidden":
+      return t`Hidden`;
+    case "internal":
+      return t`Internal`;
+    case "final":
+      return t`Final`;
+  }
+}
+
+export function getDataLayerOptions(): {
+  value: TableDataLayer;
+  label: string;
+}[] {
+  return DATA_LAYERS.map((value) => ({
+    value,
+    label: getDataLayerLabel(value),
+  }));
+}
+
+export function isDataLayer(value: string): value is TableDataLayer {
+  return DATA_LAYERS.some((layer) => layer === value);
+}


### PR DESCRIPTION
### Description

Small addition to the TablePickerTreeTable component to also show the Visibility layer as a column, as well as have the table re-compute on update

### How to verify
1. Go to Data Studio -> Tables
2. The Table Picker should show you the visibility layer of the tables
3. update the visibility layer on a table, it should update in the table picker as well.

### Demo


https://github.com/user-attachments/assets/e41578e2-386d-4e97-a7bf-739316ece10f



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
