### PR TITLE
Ignore .Team/Querying label from slack issue notifications

### DIFF
--- a/.github/workflows/team-issues-slack-notification.yml
+++ b/.github/workflows/team-issues-slack-notification.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 5
     if: |
       contains(github.event.label.name, '.Team/') &&
+       github.event.label.name != '.Team/Querying' &&
        ( contains(github.event.issue.labels.*.name, 'Type:Bug') ||
          contains(github.event.issue.labels.*.name, 'flaky-test-fix') )
     steps:


### PR DESCRIPTION
### Description

Ignores `.Team/Querying` label from slack notifications. `.Team/QueryingPlatform` is used instead now.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
