### PR TITLE
Fix set -e abort in e2e-prepare-containers when last service is disabled

### DIFF
--- a/.github/actions/e2e-prepare-containers/action.yml
+++ b/.github/actions/e2e-prepare-containers/action.yml
@@ -67,19 +67,18 @@ runs:
 
         cd e2e/test/scenarios/
 
-        SERVICES="\
-          $([ ${{ inputs.postgres }} = true ] && echo 'postgres-sample') \
-          $([ ${{ inputs.mysql }} = true ] && echo 'mysql-sample') \
-          $([ ${{ inputs.mongo }} = true ] && echo 'mongo-sample') \
-          $([ ${{ inputs.maildev }} = true ] && echo 'maildev') \
-          $([ ${{ inputs.maildev }} = true ] && echo 'maildev-ssl') \
-          $([ ${{ inputs.openldap }} = true ] && echo 'ldap') \
-          $([ ${{ inputs.webhook }} = true ] && echo 'webhook-tester') \
-          $([ ${{ inputs.snowplow }} = true ] && echo 'snowplow-micro')"
+        SERVICES=()
+        [ "${{ inputs.postgres }}" = true ] && SERVICES+=(postgres-sample)
+        [ "${{ inputs.mysql }}" = true ] && SERVICES+=(mysql-sample)
+        [ "${{ inputs.mongo }}" = true ] && SERVICES+=(mongo-sample)
+        [ "${{ inputs.maildev }}" = true ] && SERVICES+=(maildev maildev-ssl)
+        [ "${{ inputs.openldap }}" = true ] && SERVICES+=(ldap)
+        [ "${{ inputs.webhook }}" = true ] && SERVICES+=(webhook-tester)
+        [ "${{ inputs.snowplow }}" = true ] && SERVICES+=(snowplow-micro)
 
         for attempt in 1 2 3; do
           echo "Docker compose up attempt $attempt of 3..."
-          if docker compose up $SERVICES -d; then
+          if docker compose up "${SERVICES[@]}" -d; then
             echo "Docker compose up succeeded on attempt $attempt"
             break
           fi


### PR DESCRIPTION
Resolves DEV-2099

PR #75096 extracted the docker compose service list into a SERVICES="..." variable assignment built from command substitutions. Under GitHub Actions' default bash -e, a variable assignment inherits the exit status of its last command substitution, so when the last-listed service (snowplow) is disabled, [ false = true ] && echo ... returns 1, the assignment returns 1, and errexit aborts the Start Containers step before the retry loop runs. This broke jobs with snowplow=false (e.g. SDK component tests); e2e-group jobs passed only because they run snowplow=true.

Build SERVICES as a bash array via standalone test && append statements (exempt from errexit) and expand with "${SERVICES[@]}", which also fixes the unquoted-word-splitting on $SERVICES.
