### PR TITLE
Increase warn time for long tests from 3 seconds to 60 seconds.

### DIFF
--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -91,7 +91,7 @@
 (defn- default-options []
   {:namespace-pattern   #"^(?:(?:metabase.*)|(?:hooks\..*))" ; anything starting with `metabase*` (including `metabase-enterprise`) or `hooks.*`
    :exclude-directories excluded-directories
-   :test-warn-time      3000})
+   :test-warn-time      60000})
 
 (defn module-folders
   [modules]


### PR DESCRIPTION
While in theory it's helpful to know about which tests are "slow", in practice an awful lot of them are, and no one is working to address the slow tests, so there is no need to clutter up the CI logs with information no one is using.

Instead, let's warn when tests go longer than a minute.