### PR TITLE
Add brute-force vector search strategy for semantic search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -644,19 +644,20 @@
 (defn- brute-force-search-query
   "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
   [index embedding-literal filters]
-  ;; Apply the filters first, inside a MATERIALIZED CTE. Materializing fences the planner off the HNSW
-  ;; index, so cosine distance is computed for every surviving row, then ordered and limited -- exact, at
-  ;; the cost of a sequential scan over the rows that pass the filters.
-  (let [filtered-query {:select (into common-search-columns
-                                      [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
-                        :from   [(keyword (:table-name index))]
-                        :where  (if filters filters [:= 1 1])}]
+  ;; Apply the filters and the distance cutoff first, inside a MATERIALIZED CTE. Materializing fences the
+  ;; planner off the HNSW index, so cosine distance is computed for every surviving row -- exact, at the
+  ;; cost of a sequential scan over the rows that pass the filters. Filtering by the cutoff here (rather
+  ;; than in the outer query) keeps the materialized set down to rows that can actually be returned.
+  (let [distance-cutoff [:<= [:raw (str "embedding <=> " embedding-literal)] max-cosine-distance]
+        filtered-query  {:select (into common-search-columns
+                                       [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
+                         :from   [(keyword (:table-name index))]
+                         :where  (if filters [:and filters distance-cutoff] distance-cutoff)}]
     {:with     [[:vector_candidates filtered-query :materialized]]
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
                       [:distance :semantic_score]])
      :from     [:vector_candidates]
-     :where    [:<= :distance max-cosine-distance]
      :order-by [[:semantic_rank :asc]]
      :limit    (semantic-settings/semantic-search-results-limit)}))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -617,14 +617,16 @@
 
 (def ^:private ^:const max-cosine-distance "Cut-off used to filter semantic search results" 0.7)
 
-(defn- semantic-search-query
-  "Build a semantic search query using vector similarity with post-filtering to enable HNSW index usage."
-  [index embedding search-context]
-  (let [filters (search-filters search-context)
-        embedding-literal (format-embedding embedding)
-        ;; Inner query: pure vector search to better trigger HNSW index vs. seqscan
-        ;; TODO: only pull in necessary extra columns from configured filters
-        hnsw-query {:select (into common-search-columns
+(defn- hnsw-search-query
+  "Build a semantic search query using vector similarity with post-filtering to enable HNSW index usage.
+
+  The inner `vector_candidates` CTE does a pure vector search so the planner uses the HNSW index; the
+  non-vector filters are applied afterwards in the outer query. This is fast but approximate: when the
+  globally-closest rows are dominated by a cluster that the filters reject, the slightly-further-away rows
+  that would have survived the filters never make it into the candidate set."
+  [index embedding-literal filters]
+  ;; TODO: only pull in necessary extra columns from configured filters
+  (let [hnsw-query {:select (into common-search-columns
                                   [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
                     :from   [(keyword (:table-name index))]
                     :order-by [[[:raw (str "embedding <=> " embedding-literal)] :asc]]
@@ -640,6 +642,45 @@
       (update base-query :where #(into [:and] [% filters]))
       base-query)))
 
+(defn- brute-force-search-query
+  "Build a semantic search query that computes exact cosine distance over the filtered rows.
+
+  The non-vector filters are applied first, inside a MATERIALIZED CTE. Materializing fences the planner off
+  the HNSW index, so distance is computed for every surviving row, then ordered and limited. This is exact
+  (it always returns the closest results among the filtered set) at the cost of a sequential scan over the
+  rows that pass the filters."
+  [index embedding-literal filters]
+  (let [filtered-query {:select (into common-search-columns
+                                      [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
+                        :from   [(keyword (:table-name index))]
+                        :where  (if filters filters [:= 1 1])}]
+    {:with     [[:vector_candidates filtered-query :materialized]]
+     :select   (into common-search-columns
+                     [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                      [:distance :semantic_score]])
+     :from     [:vector_candidates]
+     :where    [:<= :distance max-cosine-distance]
+     :order-by [[:semantic_rank :asc]]
+     :limit    (semantic-settings/semantic-search-results-limit)}))
+
+(defn- vector-search-strategy
+  "Resolve the vector-search strategy for `search-context`, falling back to the configured default setting."
+  [search-context]
+  (or (:vector-search-strategy search-context)
+      (semantic-settings/semantic-search-vector-strategy)))
+
+(defn- semantic-search-query
+  "Build a semantic search query using vector similarity.
+
+  Dispatches on the resolved [[vector-search-strategy]]: `:brute-force` for exact filter-first search,
+  `:hnsw` (the default) for approximate index-backed search."
+  [index embedding search-context]
+  (let [filters           (search-filters search-context)
+        embedding-literal (format-embedding embedding)]
+    (case (vector-search-strategy search-context)
+      :brute-force (brute-force-search-query index embedding-literal filters)
+      (hnsw-search-query index embedding-literal filters))))
+
 (defn- flatten-ctes
   "Flatten nested :with clauses into a single top-level :with.
   PostgreSQL doesn't support nested CTEs, so we need to extract all nested :with clauses
@@ -650,9 +691,10 @@
   (if-not (:with query)
     {:ctes [] :query query}
     (let [ctes (reduce
-                (fn [acc [cte-name cte-query]]
+                ;; `opts` carries any trailing CTE options (e.g. `:materialized`) so they survive hoisting.
+                (fn [acc [cte-name cte-query & opts]]
                   (let [{:keys [ctes query]} (flatten-ctes cte-query)]
-                    (into acc (conj ctes [cte-name query]))))
+                    (into acc (conj ctes (into [cte-name query] opts)))))
                 []
                 (:with query))]
       {:ctes ctes

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -644,22 +644,23 @@
 (defn- brute-force-search-query
   "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
   [index embedding-literal filters]
-  ;; Compute the cosine distance once, in `with-distance`; the wrapping query applies the cutoff against the
-  ;; `:distance` alias so the (dominant) distance computation isn't repeated for the filter. The whole thing
-  ;; is a MATERIALIZED CTE: that fences the planner off the HNSW index (so the scan is exact), and applying
-  ;; the cutoff before materializing keeps the stored set down to rows that can actually be returned.
-  (let [with-distance  (cond-> {:select (into common-search-columns
+  ;; The filtered rows and their cosine distance are computed once, inside a MATERIALIZED CTE: that fences
+  ;; the planner off the HNSW index (so the scan is exact) and stores the `distance` column, so the outer
+  ;; query reads it rather than recomputing it. The cutoff and ranking run in the outer query.
+  ;; We deliberately don't push the cutoff into the CTE to avoid materializing rows beyond it: that would
+  ;; either recompute the distance for the qual, or need a subquery optimization fence (Postgres pulls a
+  ;; plain subquery back up and re-inlines the expression) -- not worth it for an exact scan that already
+  ;; touches every filtered row.
+  (let [filtered-query (cond-> {:select (into common-search-columns
                                               [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
                                 :from   [(keyword (:table-name index))]}
-                         filters (assoc :where filters))
-        filtered-query {:select [:*]
-                        :from   [[with-distance :candidates]]
-                        :where  [:<= :distance max-cosine-distance]}]
+                         filters (assoc :where filters))]
     {:with     [[:vector_candidates filtered-query :materialized]]
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
                       [:distance :semantic_score]])
      :from     [:vector_candidates]
+     :where    [:<= :distance max-cosine-distance]
      :order-by [[:semantic_rank :asc]]
      :limit    (semantic-settings/semantic-search-results-limit)}))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -644,15 +644,17 @@
 (defn- brute-force-search-query
   "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
   [index embedding-literal filters]
-  ;; Apply the filters and the distance cutoff first, inside a MATERIALIZED CTE. Materializing fences the
-  ;; planner off the HNSW index, so cosine distance is computed for every surviving row -- exact, at the
-  ;; cost of a sequential scan over the rows that pass the filters. Filtering by the cutoff here (rather
-  ;; than in the outer query) keeps the materialized set down to rows that can actually be returned.
-  (let [distance-cutoff [:<= [:raw (str "embedding <=> " embedding-literal)] max-cosine-distance]
-        filtered-query  {:select (into common-search-columns
-                                       [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
-                         :from   [(keyword (:table-name index))]
-                         :where  (if filters [:and filters distance-cutoff] distance-cutoff)}]
+  ;; Compute the cosine distance once, in `with-distance`; the wrapping query applies the cutoff against the
+  ;; `:distance` alias so the (dominant) distance computation isn't repeated for the filter. The whole thing
+  ;; is a MATERIALIZED CTE: that fences the planner off the HNSW index (so the scan is exact), and applying
+  ;; the cutoff before materializing keeps the stored set down to rows that can actually be returned.
+  (let [with-distance  (cond-> {:select (into common-search-columns
+                                              [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
+                                :from   [(keyword (:table-name index))]}
+                         filters (assoc :where filters))
+        filtered-query {:select [:*]
+                        :from   [[with-distance :candidates]]
+                        :where  [:<= :distance max-cosine-distance]}]
     {:with     [[:vector_candidates filtered-query :materialized]]
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -618,13 +618,12 @@
 (def ^:private ^:const max-cosine-distance "Cut-off used to filter semantic search results" 0.7)
 
 (defn- hnsw-search-query
-  "Build a semantic search query using vector similarity with post-filtering to enable HNSW index usage.
-
-  The inner `vector_candidates` CTE does a pure vector search so the planner uses the HNSW index; the
-  non-vector filters are applied afterwards in the outer query. This is fast but approximate: when the
-  globally-closest rows are dominated by a cluster that the filters reject, the slightly-further-away rows
-  that would have survived the filters never make it into the candidate set."
+  "Build the semantic vector subquery using the HNSW index, applying `filters` after candidate selection."
   [index embedding-literal filters]
+  ;; The inner `vector_candidates` CTE is a pure vector search (ORDER BY distance LIMIT) so the planner
+  ;; uses the HNSW index. The filters only run in the outer query, so this is approximate: when the
+  ;; globally-closest rows are dominated by a cluster the filters reject, slightly-further survivors that
+  ;; would have passed the filters never enter the candidate set. `brute-force-search-query` is exact.
   ;; TODO: only pull in necessary extra columns from configured filters
   (let [hnsw-query {:select (into common-search-columns
                                   [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
@@ -643,13 +642,11 @@
       base-query)))
 
 (defn- brute-force-search-query
-  "Build a semantic search query that computes exact cosine distance over the filtered rows.
-
-  The non-vector filters are applied first, inside a MATERIALIZED CTE. Materializing fences the planner off
-  the HNSW index, so distance is computed for every surviving row, then ordered and limited. This is exact
-  (it always returns the closest results among the filtered set) at the cost of a sequential scan over the
-  rows that pass the filters."
+  "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
   [index embedding-literal filters]
+  ;; Apply the filters first, inside a MATERIALIZED CTE. Materializing fences the planner off the HNSW
+  ;; index, so cosine distance is computed for every surviving row, then ordered and limited -- exact, at
+  ;; the cost of a sequential scan over the rows that pass the filters.
   (let [filtered-query {:select (into common-search-columns
                                       [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
                         :from   [(keyword (:table-name index))]
@@ -670,10 +667,8 @@
       (semantic-settings/semantic-search-vector-strategy)))
 
 (defn- semantic-search-query
-  "Build a semantic search query using vector similarity.
-
-  Dispatches on the resolved [[vector-search-strategy]]: `:brute-force` for exact filter-first search,
-  `:hnsw` (the default) for approximate index-backed search."
+  "Build the semantic vector subquery, dispatching on the resolved [[vector-search-strategy]].
+  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
         embedding-literal (format-embedding embedding)]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -98,6 +98,30 @@
   :visibility :internal
   :doc false)
 
+(def ^:private valid-vector-search-strategies
+  "Valid semantic-search vector-search strategies."
+  #{:hnsw :brute-force})
+
+(defsetting semantic-search-vector-strategy
+  (deferred-tru
+   (str "Default vector-search strategy for semantic search: `hnsw` (approximate, HNSW-index-backed) or "
+        "`brute-force` (exact, applies non-vector filters first then computes cosine distance over the "
+        "survivors). Individual requests may override this via the `vector_search_strategy` API parameter."))
+  :type       :keyword
+  :default    :hnsw
+  :encryption :no
+  :export?    false
+  :visibility :internal
+  :doc        false
+  :setter     (fn [new-value]
+                (let [kw (some-> new-value keyword)]
+                  (when (and kw (not (contains? valid-vector-search-strategies kw)))
+                    (throw (ex-info (str "Invalid vector-search strategy: " (pr-str new-value)
+                                         ". Valid strategies are: " (pr-str valid-vector-search-strategies))
+                                    {:invalid-value new-value
+                                     :valid-values  valid-vector-search-strategies})))
+                  (setting/set-value-of-type! :keyword :semantic-search-vector-strategy kw))))
+
 (defsetting semantic-search-min-results-threshold
   (deferred-tru "Minimum number of semantic search results required before falling back to other engines.")
   :type :integer

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -99,7 +99,10 @@
   :doc false)
 
 (def ^:private valid-vector-search-strategies
-  "Valid semantic-search vector-search strategies."
+  "Valid semantic-search vector-search strategies.
+  Keep in sync with the `vector_search_strategy` enum in [[metabase.search.api]] (the OSS API layer can't
+  reference this EE set across the module boundary) and the dispatch in
+  [[metabase-enterprise.semantic-search.index/semantic-search-query]]."
   #{:hnsw :brute-force})
 
 (defsetting semantic-search-vector-strategy

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.llm.settings :as llm-settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.search.config :as search.config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 
@@ -99,11 +100,9 @@
   :doc false)
 
 (def ^:private valid-vector-search-strategies
-  "Valid semantic-search vector-search strategies.
-  Keep in sync with the `vector_search_strategy` enum in [[metabase.search.api]] (the OSS API layer can't
-  reference this EE set across the module boundary) and the dispatch in
-  [[metabase-enterprise.semantic-search.index/semantic-search-query]]."
-  #{:hnsw :brute-force})
+  "Valid semantic-search vector-search strategies, mastered in
+  [[metabase.search.config/vector-search-strategies]]."
+  (set search.config/vector-search-strategies))
 
 (defsetting semantic-search-vector-strategy
   (deferred-tru

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -49,6 +49,33 @@
     (is (= (vector-search-sql (semantic.settings/semantic-search-vector-strategy))
            (vector-search-sql nil)))))
 
+(defn- flattened-vector-candidates-cte
+  "Build the brute-force/hnsw hybrid query, flatten it the way `scored-search-query` does, and return the
+  hoisted `:vector_candidates` CTE binding (e.g. `[:vector_candidates <query> :materialized]`)."
+  [strategy]
+  (let [index  {:table-name "idx_tbl"}
+        ctx    {:search-string "pasta" :archived? false :vector-search-strategy strategy}
+        hybrid (#'semantic.index/hybrid-search-query index [0.1 0.2 0.3] ctx)
+        {:keys [ctes]} (#'semantic.index/flatten-ctes hybrid)]
+    (first (filter #(= :vector_candidates (first %)) ctes))))
+
+(deftest flatten-ctes-preserves-materialized-test
+  (testing "the :materialized opt survives CTE hoisting (the path every real query takes via scored-search-query)"
+    ;; A regression that dropped the opt would change only the query plan, not the results, so the
+    ;; results-based end-to-end tests can't catch it -- assert on the hoisted binding directly.
+    (is (= :materialized (last (flattened-vector-candidates-cte :brute-force)))))
+  (testing ":hnsw hoists a plain CTE binding with no opts"
+    (is (= 2 (count (flattened-vector-candidates-cte :hnsw))))))
+
+(deftest semantic-search-vector-strategy-setting-test
+  (testing "the setting rejects an unknown strategy"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid vector-search strategy"
+                          (semantic.settings/semantic-search-vector-strategy! :nonsense))))
+  (testing "valid strategies round-trip"
+    (doseq [strategy [:hnsw :brute-force]]
+      (mt/with-temporary-setting-values [semantic.settings/semantic-search-vector-strategy strategy]
+        (is (= strategy (semantic.settings/semantic-search-vector-strategy)))))))
+
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -3,9 +3,11 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [honey.sql :as sql]
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
@@ -19,6 +21,33 @@
 (set! *warn-on-reflection* true)
 
 (use-fixtures :once #'semantic.tu/once-fixture)
+
+(defn- vector-search-sql
+  "Format the private vector subquery for `strategy` against a stub index, returning the SQL string."
+  [strategy]
+  (let [index   {:table-name "idx_tbl"}
+        ctx     (cond-> {:search-string "pasta" :archived? false}
+                  strategy (assoc :vector-search-strategy strategy))
+        embedding [0.1 0.2 0.3]]
+    (first (sql/format (#'semantic.index/semantic-search-query index embedding ctx) :quoted true))))
+
+(deftest semantic-search-query-strategy-test
+  (testing ":brute-force applies the non-vector filters inside a MATERIALIZED CTE (filter-first, exact)"
+    (let [sql (vector-search-sql :brute-force)]
+      (is (str/includes? sql "AS MATERIALIZED"))
+      ;; filter lives inside the CTE, before distance is computed/ordered
+      (is (re-find #"AS MATERIALIZED \(SELECT.*\"archived\" = FALSE.*\)" sql))
+      ;; no pure-vector ORDER BY ... LIMIT that would trigger the HNSW index
+      (is (not (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql)))))
+  (testing ":hnsw does a pure vector search in the inner CTE then post-filters (approximate)"
+    (let [sql (vector-search-sql :hnsw)]
+      (is (not (str/includes? sql "MATERIALIZED")))
+      (is (re-find #"ORDER BY embedding <=>" sql))
+      ;; the filter is applied in the outer query, after the candidate set is chosen
+      (is (str/includes? sql "\"archived\" = FALSE"))))
+  (testing "no explicit strategy falls back to the configured default setting"
+    (is (= (vector-search-sql (semantic.settings/semantic-search-vector-strategy))
+           (vector-search-sql nil)))))
 
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -37,6 +37,8 @@
       (is (str/includes? sql "AS MATERIALIZED"))
       ;; filter lives inside the CTE, before distance is computed/ordered
       (is (re-find #"AS MATERIALIZED \(SELECT.*\"archived\" = FALSE.*\)" sql))
+      ;; the (dominant) distance expression is computed exactly once -- the cutoff filters the alias
+      (is (= 1 (count (re-seq #"embedding <=>" sql))))
       ;; no pure-vector ORDER BY ... LIMIT that would trigger the HNSW index
       (is (not (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql)))))
   (testing ":hnsw does a pure vector search in the inner CTE then post-filters (approximate)"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -35,9 +35,10 @@
   (testing ":brute-force applies the non-vector filters inside a MATERIALIZED CTE (filter-first, exact)"
     (let [sql (vector-search-sql :brute-force)]
       (is (str/includes? sql "AS MATERIALIZED"))
-      ;; filter lives inside the CTE, before distance is computed/ordered
+      ;; filter lives inside the CTE, alongside the distance computation
       (is (re-find #"AS MATERIALIZED \(SELECT.*\"archived\" = FALSE.*\)" sql))
-      ;; the (dominant) distance expression is computed exactly once -- the cutoff filters the alias
+      ;; the distance expression appears once -- it is computed and stored in the materialized CTE, and the
+      ;; outer query reads that column rather than recomputing it
       (is (= 1 (count (re-seq #"embedding <=>" sql))))
       ;; no pure-vector ORDER BY ... LIMIT that would trigger the HNSW index
       (is (not (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql)))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -26,6 +26,28 @@
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Bird Watching Tips" (-> results first :name)))))))))))
 
+(deftest brute-force-strategy-test
+  (testing "Brute-force vector search returns the same closest results as HNSW for these queries"
+    (mt/with-premium-features #{:semantic-search}
+      (mt/as-admin
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
+          (semantic.tu/with-only-semantic-weights
+            (testing "Dog-related query finds dog content"
+              (let [results (-> (semantic.tu/query-index {:search-string "puppy"
+                                                          :vector-search-strategy :brute-force})
+                                semantic.tu/filter-for-mock-embeddings)]
+                (is (= "Dog Training Guide" (-> results first :name)))))
+            (testing "Filters are honored under brute-force search"
+              (let [active   (semantic.tu/query-index {:search-string "feline"
+                                                       :archived? false
+                                                       :vector-search-strategy :brute-force})
+                    archived (semantic.tu/query-index {:search-string "feline"
+                                                       :archived? true
+                                                       :vector-search-strategy :brute-force})]
+                (is (every? #(not (:archived %)) active))
+                (is (pos? (count (semantic.tu/filter-for-mock-embeddings archived))))
+                (is (every? :archived archived))))))))))
+
 (defn- index-of-name
   "Return the index of the item with :name `name` in `coll`"
   [coll name]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -239,11 +239,14 @@
                                       (:archived %)
                                       (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
                 (testing "Verified items with additional filters"
-                  (let [results (q {:search-string "marine mammal"
-                                    :models ["dashboard"]
+                  ;; The fixture's only verified entity is a card ("Dog Training Guide"), so filter on
+                  ;; cards here -- a verified-dashboard query would return nothing and assert vacuously.
+                  (let [results (q {:search-string "puppy"
+                                    :models ["card"]
                                     :verified true
                                     :archived? false})]
-                    (is (every? #(and (= "dashboard" (:model %))
+                    (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                    (is (every? #(and (= "card" (:model %))
                                       (:verified %)
                                       (not (:archived %))) results))))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -26,27 +26,38 @@
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Bird Watching Tips" (-> results first :name)))))))))))
 
-(deftest brute-force-strategy-test
-  (testing "Brute-force vector search returns the same closest results as HNSW for these queries"
+(deftest vector-search-strategy-test
+  (testing "Both vector-search strategies find the closest content and honor the same filters"
+    ;; The existing query tests exercise the default :hnsw path; this runs the same kind of filter
+    ;; battery under both strategies, since :brute-force applies the filters in a different SQL position
+    ;; (inside the materialized CTE) than :hnsw (post-candidate-selection).
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
-            (testing "Dog-related query finds dog content"
-              (let [results (-> (semantic.tu/query-index {:search-string "puppy"
-                                                          :vector-search-strategy :brute-force})
-                                semantic.tu/filter-for-mock-embeddings)]
-                (is (= "Dog Training Guide" (-> results first :name)))))
-            (testing "Filters are honored under brute-force search"
-              (let [active   (semantic.tu/query-index {:search-string "feline"
-                                                       :archived? false
-                                                       :vector-search-strategy :brute-force})
-                    archived (semantic.tu/query-index {:search-string "feline"
-                                                       :archived? true
-                                                       :vector-search-strategy :brute-force})]
-                (is (every? #(not (:archived %)) active))
-                (is (pos? (count (semantic.tu/filter-for-mock-embeddings archived))))
-                (is (every? :archived archived))))))))))
+            (doseq [strategy [:hnsw :brute-force]]
+              (let [q (fn [ctx] (semantic.tu/query-index (assoc ctx :vector-search-strategy strategy)))]
+                (testing (str "strategy = " strategy)
+                  (testing "finds the closest content"
+                    (is (= "Dog Training Guide"
+                           (-> (q {:search-string "puppy"}) semantic.tu/filter-for-mock-embeddings first :name))))
+                  (testing "model filter"
+                    (let [results (q {:search-string "avian" :models ["card"]})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? #(= "card" (:model %)) results))))
+                  (testing "archived filter"
+                    (is (every? #(not (:archived %)) (q {:search-string "feline" :archived? false})))
+                    (let [archived (q {:search-string "feline" :archived? true})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings archived))))
+                      (is (every? :archived archived))))
+                  (testing "verified filter"
+                    (let [results (q {:search-string "puppy" :verified true})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? :verified results))))
+                  (testing "creator filter"
+                    (let [results (q {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? #(= (mt/user->id :crowberto) (:creator_id %)) results)))))))))))))
 
 (defn- index-of-name
   "Return the index of the item with :name `name` in `coll`"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -46,7 +46,9 @@
                       (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
                       (is (every? #(= "card" (:model %)) results))))
                   (testing "archived filter"
-                    (is (every? #(not (:archived %)) (q {:search-string "feline" :archived? false})))
+                    (let [active (q {:search-string "feline" :archived? false})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings active))))
+                      (is (every? #(not (:archived %)) active)))
                     (let [archived (q {:search-string "feline" :archived? true})]
                       (is (pos? (count (semantic.tu/filter-for-mock-embeddings archived))))
                       (is (every? :archived archived))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -74,7 +74,8 @@
         (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
             (let [not-top-10? #(or (nil? %) (< 10 %))]
-              (doseq [{:keys [name desc search-string search-native-query? expected-index?]}
+              (doseq [strategy [:hnsw :brute-force]
+                      {:keys [name desc search-string search-native-query? expected-index?]}
                       [{:name "Dog Training Guide"
                         :desc "contains"
                         :search-string "AVG(tricks)"
@@ -130,9 +131,10 @@
                         :search-string "Watching"
                         :search-native-query? true
                         :expected-index? zero?}]]
-                (testing (format "\n%s %s %s %s" name desc search-string search-native-query?)
+                (testing (format "\n[%s] %s %s %s %s" strategy name desc search-string search-native-query?)
                   (is (-> (semantic.tu/query-index {:search-string search-string
-                                                    :search-native-query search-native-query?})
+                                                    :search-native-query search-native-query?
+                                                    :vector-search-strategy strategy})
                           (index-of-name name)
                           expected-index?)))))))))))
 
@@ -211,40 +213,42 @@
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (semantic.tu/with-test-db! {:mode :mock-indexed}
-          (testing "Non-archived cards by specific creator"
-            (let [results (semantic.tu/query-index {:search-string "equine"
-                                                    :models ["card"]
-                                                    :archived? false
-                                                    :created-by [(mt/user->id :rasta)]})
-                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-              (is (pos? (count filtered-results)))
-              (is (every? #(and (= "card" (:model %))
-                                (not (:archived %))
-                                (= (mt/user->id :rasta) (:creator_id %))) results))))
-          (testing "Archived dashboards by multiple creators"
-            (let [results (semantic.tu/query-index {:search-string "Antarctic wildlife"
-                                                    :models ["dashboard"]
-                                                    :archived? true
-                                                    :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
-                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-              (is (pos? (count filtered-results)))
-              (is (every? #(and (= "dashboard" (:model %))
-                                (:archived %)
-                                (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
-          (testing "Verified items with additional filters"
-            (let [results (semantic.tu/query-index {:search-string "marine mammal"
-                                                    :models ["dashboard"]
-                                                    :verified true
-                                                    :archived? false})]
-              (is (every? #(and (= "dashboard" (:model %))
-                                (:verified %)
-                                (not (:archived %))) results)))))))))
+          (doseq [strategy [:hnsw :brute-force]]
+            (let [q (fn [ctx] (semantic.tu/query-index (assoc ctx :vector-search-strategy strategy)))]
+              (testing (str "strategy = " strategy)
+                (testing "Non-archived cards by specific creator"
+                  (let [results (q {:search-string "equine"
+                                    :models ["card"]
+                                    :archived? false
+                                    :created-by [(mt/user->id :rasta)]})
+                        filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+                    (is (pos? (count filtered-results)))
+                    (is (every? #(and (= "card" (:model %))
+                                      (not (:archived %))
+                                      (= (mt/user->id :rasta) (:creator_id %))) results))))
+                (testing "Archived dashboards by multiple creators"
+                  (let [results (q {:search-string "Antarctic wildlife"
+                                    :models ["dashboard"]
+                                    :archived? true
+                                    :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
+                        filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+                    (is (pos? (count filtered-results)))
+                    (is (every? #(and (= "dashboard" (:model %))
+                                      (:archived %)
+                                      (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
+                (testing "Verified items with additional filters"
+                  (let [results (q {:search-string "marine mammal"
+                                    :models ["dashboard"]
+                                    :verified true
+                                    :archived? false})]
+                    (is (every? #(and (= "dashboard" (:model %))
+                                      (:verified %)
+                                      (not (:archived %))) results))))))))))))
 
 (deftest permissions-test
   (mt/with-premium-features #{:semantic-search}
     (semantic.tu/with-test-db! {:mode :mock-indexed}
       (let [monsters-table (t2/select-one-pk :model/Table :name "Monsters Table")
-            q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]})))
             all-users (perms-group/all-users)
             unrestrict-table (fn [table-id]
                                (data-perms/set-table-permission! all-users table-id :perms/create-queries :query-builder)
@@ -252,26 +256,32 @@
             restrict-table (fn [table-id]
                              (data-perms/set-table-permission! all-users table-id :perms/create-queries :no)
                              (data-perms/set-table-permission! all-users table-id :perms/view-data :blocked))]
-        (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
-        (restrict-table monsters-table)
-        (testing "admin"
-          (mt/with-test-user :crowberto
-            (testing "collection permissions"
-              (is (some #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
-              (is (some #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
-            (testing "data permissions"
-              (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
-        (testing "all-users"
-          (mt/with-test-user :rasta
-            (testing "collection permissions"
-              (is (not-any? #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
-              (is (not-any? #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
-            (testing "data permissions"
-              (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
-            (testing "give data permissions"
-              (unrestrict-table monsters-table)
-              (data-perms/disable-perms-cache
-               (is (some #{"Monsters Table"} (q "table" "monster facts")))))))))))
+        (doseq [strategy [:hnsw :brute-force]]
+          (let [q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]
+                                                                     :vector-search-strategy strategy})))]
+            ;; Re-establish the restricted baseline each iteration: the give-data-permissions block below
+            ;; unrestricts the table, which would otherwise leak into the next strategy's iteration.
+            (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
+            (restrict-table monsters-table)
+            (testing (str "strategy = " strategy)
+              (testing "admin"
+                (mt/with-test-user :crowberto
+                  (testing "collection permissions"
+                    (is (some #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+                    (is (some #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+                  (testing "data permissions"
+                    (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
+              (testing "all-users"
+                (mt/with-test-user :rasta
+                  (testing "collection permissions"
+                    (is (not-any? #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+                    (is (not-any? #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+                  (testing "data permissions"
+                    (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
+                  (testing "give data permissions"
+                    (unrestrict-table monsters-table)
+                    (data-perms/disable-perms-cache
+                     (is (some #{"Monsters Table"} (q "table" "monster facts"))))))))))))))
 
 (deftest basic-batched-query-test
   (testing "Small-batch reindexing"

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -219,6 +219,7 @@
        [:last_edited_by                      {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
+       ;; keep in sync with `valid-vector-search-strategies` in metabase-enterprise.semantic-search.settings
        [:vector_search_strategy              {:optional true} [:maybe [:enum "hnsw" "brute-force"]]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -171,6 +171,7 @@
   - `last_edited_at`: search for items last edited at a specific timestamp
   - `last_edited_by`: search for items last edited by a specific user
   - `search_native_query`: set to true to search the content of native queries
+  - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -197,6 +198,7 @@
     last-edited-by                      :last_edited_by
     model-ancestors                     :model_ancestors
     search-engine                       :search_engine
+    vector-search-strategy              :vector_search_strategy
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -217,6 +219,7 @@
        [:last_edited_by                      {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
+       [:vector_search_strategy              {:optional true} [:maybe [:enum "hnsw" "brute-force"]]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -247,6 +250,7 @@
                 :models                              (not-empty (set models))
                 :offset                              (request/offset)
                 :search-engine                       search-engine
+                :vector-search-strategy              vector-search-strategy
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -219,8 +219,7 @@
        [:last_edited_by                      {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
-       ;; keep in sync with `valid-vector-search-strategies` in metabase-enterprise.semantic-search.settings
-       [:vector_search_strategy              {:optional true} [:maybe [:enum "hnsw" "brute-force"]]]
+       [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -253,8 +253,8 @@
    [:models             [:set SearchableModel]]
    ;; TODO this is optional only for tests, clean those up!
    [:search-engine      {:optional true} keyword?]
-   ;; Vector-search strategy for the semantic engine: :hnsw (approximate, index-backed) or :brute-force
-   ;; (exact, filter-first). When absent, the engine falls back to its configured default setting.
+   ;; Semantic-engine vector-search strategy (:hnsw or :brute-force). When absent, the engine uses its
+   ;; configured default setting.
    [:vector-search-strategy {:optional true} [:maybe keyword?]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -232,6 +232,11 @@
   "Schema for searchable models"
   (into [:enum] all-models))
 
+(def vector-search-strategies
+  "Valid semantic-search vector-search strategies, as keywords. Mastered here (rather than in the EE module)
+  so the OSS search API param and the EE semantic-search setting/dispatch share one definition."
+  [:hnsw :brute-force])
+
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   [:map {:closed true}

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -253,6 +253,9 @@
    [:models             [:set SearchableModel]]
    ;; TODO this is optional only for tests, clean those up!
    [:search-engine      {:optional true} keyword?]
+   ;; Vector-search strategy for the semantic engine: :hnsw (approximate, index-backed) or :brute-force
+   ;; (exact, filter-first). When absent, the engine falls back to its configured default setting.
+   [:vector-search-strategy {:optional true} [:maybe keyword?]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -234,7 +234,9 @@
 
 (def vector-search-strategies
   "Valid semantic-search vector-search strategies, as keywords. Mastered here (rather than in the EE module)
-  so the OSS search API param and the EE semantic-search setting/dispatch share one definition."
+  so the OSS search API param and the EE semantic-search setting validation share one definition.
+  Note: the per-strategy dispatch in [[metabase-enterprise.semantic-search.index/semantic-search-query]] is a
+  separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
   [:hnsw :brute-force])
 
 (def SearchContext

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -264,6 +264,7 @@
    [:offset                              {:optional true} [:maybe ms/Int]]
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
    [:search-engine                       {:optional true} [:maybe string?]]
+   [:vector-search-strategy              {:optional true} [:maybe string?]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -302,6 +303,7 @@
            models
            offset
            search-engine
+           vector-search-strategy
            search-native-query
            search-string
            table-db-id
@@ -344,6 +346,7 @@
                  (some? table-db-id)                         (assoc :table-db-id table-db-id)
                  (some? limit)                               (assoc :limit-int limit)
                  (some? offset)                              (assoc :offset-int offset)
+                 (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)


### PR DESCRIPTION
### Description

Our HNSW-based semantic search heuristic gets stuck in large clusters: the approximate index picks the globally-closest rows *first* and applies the non-vector filters (archived, model, verified, creator, etc.) *afterwards*, so when the closest cluster is dominated by rows the filters reject, the slightly-further-away rows that would have survived the filters never make it into the candidate set.

This PR adds an opt-in **brute-force** vector-search strategy alongside the default `:hnsw`:

- **`:brute-force`** applies the non-vector filters *first*, inside a `MATERIALIZED` CTE that computes cosine distance once per surviving row, then orders by distance and limits. Materializing fences the planner off the HNSW index, so the scan is exact — it always returns the closest results *within the filtered set*. The cost is a sequential scan over the rows that pass the filters (acceptable for an opt-in exact path).
- **`:hnsw`** (default) is unchanged — approximate, index-backed.

Wiring:
- New API parameter `vector_search_strategy` (`hnsw` | `brute-force`) on `GET /api/search`.
- New `defsetting semantic-search-vector-strategy` (default `:hnsw`) for the instance-wide default; the request param overrides it per call.
- The valid strategy list is mastered once in `metabase.search.config/vector-search-strategies` (OSS); the API Malli enum and the EE setting's validation both derive from it.

**Scope note:** this fixes filtering for everything expressible in SQL. Permission and collection-descendant filtering still happen in application code *after* the query (unchanged), so brute-force doesn't help the case where the closest filtered rows are rejected by *permissions* — same boundary HNSW has. Pushing permissions into SQL would be a separate, larger change.

### How to verify

1. Ensure semantic search is enabled (EE, pgvector + embedding service configured) and the index is populated.
2. Find a query where HNSW returns too few / wrong results because the nearest cluster is filtered out (e.g. a heavily-filtered search like `models=card` + a creator filter).
3. Call `GET /api/search?q=...&vector_search_strategy=brute-force` and confirm it returns the closest results *within the filtered set*, where `...&vector_search_strategy=hnsw` (or the default) misses them.
4. Flip the instance default with the `semantic-search-vector-strategy` setting and confirm requests without the param follow it.

Backend tests run the full filter battery (basic, model, archived, verified, creator, native-query, complex, permissions) under **both** strategies; the SQL-builder/flatten/setting-validation paths have unit coverage.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
