### PR TITLE
Make metabase-lib a separate chunk

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -237,6 +237,12 @@ const config = {
           name: "vendor",
           priority: -10,
         },
+        metabaseLib: {
+          test: /[\\/]target[\\/]cljs_(dev|release)[\\/]/,
+          chunks: "all",
+          name: "metabase-lib",
+          priority: 20,
+        },
         sqlFormatter: {
           test: /[\\/]sql-formatter[\\/]/,
           chunks: "all",


### PR DESCRIPTION
Puts `metabase-lib` into a separate chunk.

This is a large part of our FE budget, but generally changes quite little. Putting it in it's own chunk means it can be cached more effectively and it can be fetched in parallel with our other FE code.