### PR TITLE
Use rtk for dashboard data-fetching

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -299,6 +299,7 @@ export type ListDashboardsResponse = Omit<
 export type GetDashboardRequest = {
   id: DashboardId;
   ignore_error?: boolean;
+  dashboard_load_id?: string;
 };
 
 export type CreateDashboardRequest = {

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -1,3 +1,5 @@
+import { defaultSerializeQueryArgs } from "@reduxjs/toolkit/query/react";
+
 import { PLUGIN_API } from "metabase/plugins";
 import { DashboardSchema, QueryMetadataSchema } from "metabase/schema";
 import type {
@@ -73,11 +75,20 @@ export const dashboardApi = Api.injectEndpoints({
         onQueryStarted: hydrateMetadataStore([DashboardSchema]),
       }),
       getDashboard: builder.query<Dashboard, GetDashboardRequest>({
-        query: ({ id, ignore_error }) => ({
+        query: ({ id, ignore_error, dashboard_load_id }) => ({
           method: "GET",
           url: `/api/dashboard/${id}`,
+          params: dashboard_load_id ? { dashboard_load_id } : undefined,
           noEvent: ignore_error,
         }),
+        // `dashboard_load_id` is a per-load correlation id, not part of the
+        // resource identity — exclude it from the cache key so the dashboard
+        // page (which passes one) shares a cache entry, and a single request,
+        // with callers that don't (e.g. the nav sidebar's useGetDashboardQuery).
+        serializeQueryArgs: ({
+          queryArgs: { dashboard_load_id: _dashboard_load_id, ...queryArgs },
+          ...rest
+        }) => defaultSerializeQueryArgs({ queryArgs, ...rest }),
         providesTags: (dashboard) =>
           dashboard ? provideDashboardTags(dashboard) : [],
         onQueryStarted: hydrateMetadataStore(DashboardSchema),

--- a/frontend/src/metabase/app/nav/Navbar.tsx
+++ b/frontend/src/metabase/app/nav/Navbar.tsx
@@ -2,11 +2,10 @@ import { useMemo } from "react";
 import { type WithRouterProps, withRouter } from "react-router";
 
 import { useListDatabasesQuery } from "metabase/api";
-import { getDashboard } from "metabase/dashboard/selectors";
 import { AdminNavbar } from "metabase/nav/components/AdminNavbar";
 import { MainNavbar } from "metabase/nav/containers/MainNavbar";
 import { connect } from "metabase/redux";
-import type { AdminPath, State, StoreDashboard } from "metabase/redux/store";
+import type { AdminPath, State } from "metabase/redux/store";
 import { getAdminPaths } from "metabase/selectors/admin";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getUser } from "metabase/selectors/user";
@@ -16,17 +15,12 @@ type NavbarProps = WithRouterProps & {
   isOpen: boolean;
   user: User | null;
   adminPaths: AdminPath[];
-  dashboard?: StoreDashboard;
 };
 
 const mapStateToProps = (state: State) => ({
   isOpen: getIsNavbarOpen(state),
   user: getUser(state),
   adminPaths: getAdminPaths(state),
-  // Can't use the dashboard entity loader instead.
-  // The dashboard page uses DashboardsApi.get directly,
-  // so we can't re-use data between these components.
-  dashboard: getDashboard(state),
 });
 
 function NavbarInner({
@@ -35,7 +29,6 @@ function NavbarInner({
   location,
   params,
   adminPaths,
-  dashboard,
 }: NavbarProps) {
   useListDatabasesQuery();
   const isAdminApp = useMemo(
@@ -50,12 +43,7 @@ function NavbarInner({
   return isAdminApp ? (
     <AdminNavbar path={location.pathname} adminPaths={adminPaths} />
   ) : (
-    <MainNavbar
-      isOpen={isOpen}
-      location={location}
-      params={params}
-      dashboard={dashboard}
-    />
+    <MainNavbar isOpen={isOpen} location={location} params={params} />
   );
 }
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -793,19 +793,33 @@ export const fetchDashboard = createAsyncThunk(
         result = expandInlineDashboard(dashId);
         dashId = result.id = String(dashId);
       } else {
-        const [response] = await Promise.all([
-          DashboardApi.get(
-            { dashId: dashId, dashboard_load_id: dashboardLoadId },
-            { signal: fetchDashboardCancellation.signal },
-          ),
-          runRtkEndpoint(
+        // dashboard_load_id`is excluded from the cache key, so the requests dedupe
+        // `forceRefetch: clearCache` preserves the fresh-load default.
+        const dashboardRequest = dispatch(
+          dashboardApi.endpoints.getDashboard.initiate(
             { id: dashId, dashboard_load_id: dashboardLoadId },
-            dispatch,
-            dashboardApi.endpoints.getDashboardQueryMetadata,
-            { forceRefetch: false },
+            { forceRefetch: clearCache },
           ),
-        ]);
-        result = response;
+        );
+        // Preserve the abort-previous-fetch behavior (metabase#35959): when a
+        // newer fetchDashboard aborts the shared controller, abort this request.
+        fetchDashboardCancellation.signal.addEventListener("abort", () =>
+          dashboardRequest.abort(),
+        );
+        try {
+          const [response] = await Promise.all([
+            dashboardRequest.unwrap(),
+            runRtkEndpoint(
+              { id: dashId, dashboard_load_id: dashboardLoadId },
+              dispatch,
+              dashboardApi.endpoints.getDashboardQueryMetadata,
+              { forceRefetch: false },
+            ),
+          ]);
+          result = response;
+        } finally {
+          dashboardRequest.unsubscribe?.();
+        }
       }
 
       fetchDashboardCancellation = null;

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -131,7 +131,9 @@ describe("fetchDashboard", () => {
 
     await Promise.all([pageFetch, navFetch.unwrap()]);
 
-    expect(fetchMock.callHistory.calls("path:/api/dashboard/1")).toHaveLength(1);
+    expect(fetchMock.callHistory.calls("path:/api/dashboard/1")).toHaveLength(
+      1,
+    );
   });
 
   it("should not cancel an in-flight request when re-dispatched with the same parameters (#70534)", async () => {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -7,7 +7,7 @@ import {
   setupDatabaseEndpoints,
 } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
-import { Api } from "metabase/api";
+import { Api, dashboardApi } from "metabase/api";
 import type { DashboardState, State } from "metabase/redux/store";
 import {
   createMockDashboardState,
@@ -114,6 +114,24 @@ describe("fetchDashboard", () => {
         },
       },
     });
+  });
+
+  it("shares a single dashboard request with useGetDashboardQuery callers (no double fetch)", async () => {
+    const store = setup({ dashboards: [createMockDashboard({ id: 1 })] });
+
+    // Simulate the dashboard page and the nav sidebar loading concurrently:
+    // the page passes a dashboard_load_id, the sidebar (useGetDashboardQuery)
+    // does not. They should dedupe onto one GET /api/dashboard/1.
+    const pageFetch = store.dispatch(
+      fetchDashboard({ dashId: 1, queryParams: {}, options: {} }),
+    );
+    const navFetch = store.dispatch(
+      dashboardApi.endpoints.getDashboard.initiate({ id: 1 }),
+    );
+
+    await Promise.all([pageFetch, navFetch.unwrap()]);
+
+    expect(fetchMock.callHistory.calls("path:/api/dashboard/1")).toHaveLength(1);
   });
 
   it("should not cancel an in-flight request when re-dispatched with the same parameters (#70534)", async () => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -6,6 +6,7 @@ import {
   skipToken,
   useGetCardQuery,
   useGetCollectionQuery,
+  useGetDashboardQuery,
 } from "metabase/api";
 import { NavbarPromoSlot } from "metabase/nav/components/NavbarPromoSlot";
 import { connect } from "metabase/redux";
@@ -20,6 +21,7 @@ import MainNavbarContainer from "./MainNavbarContainer";
 import {
   getSelectedItems,
   isCollectionPath,
+  isDashboardPath,
   isMetricPath,
   isModelPath,
   isQuestionPath,
@@ -37,6 +39,7 @@ interface EntityLoaderProps {
 interface StateProps {
   questionId?: number | null;
   collectionId?: CollectionId | null;
+  dashboardId?: number | null;
 }
 
 interface DispatchProps extends MainNavbarDispatchProps {
@@ -52,6 +55,7 @@ function mapStateToProps(state: State, props: MainNavbarOwnProps) {
   return {
     questionId: maybeGetQuestionId(state, props),
     collectionId: maybeGetCollectionId(state, props),
+    dashboardId: maybeGetDashboardId(state, props),
   };
 }
 
@@ -67,7 +71,7 @@ function MainNavbarInner({
   params,
   questionId,
   collectionId,
-  dashboard,
+  dashboardId,
   openNavbar,
   closeNavbar,
   onChangeLocation,
@@ -83,6 +87,10 @@ function MainNavbarInner({
 
   const { currentData: collection } = useGetCollectionQuery(
     collectionId ? { id: collectionId } : skipToken,
+  );
+
+  const { currentData: dashboard } = useGetDashboardQuery(
+    dashboardId ? { id: dashboardId } : skipToken,
   );
 
   useEffect(() => {
@@ -156,6 +164,14 @@ function maybeGetCollectionId(
   const { pathname } = location;
   const canFetchQuestion = isCollectionPath(pathname);
   return canFetchQuestion ? Urls.extractEntityId(params.slug) : null;
+}
+
+function maybeGetDashboardId(
+  state: State,
+  { location, params }: MainNavbarOwnProps,
+) {
+  const { pathname } = location;
+  return isDashboardPath(pathname) ? Urls.extractEntityId(params.slug) : null;
 }
 
 export const MainNavbar = connect(

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -1,8 +1,7 @@
 import { coerceCollectionId } from "metabase/collections/utils";
-import type { StoreDashboard } from "metabase/redux/store";
 import * as Urls from "metabase/urls";
 import type Question from "metabase-lib/v1/Question";
-import type { Collection } from "metabase-types/api";
+import type { Collection, Dashboard } from "metabase-types/api";
 
 import type { SelectedItem } from "./types";
 
@@ -13,7 +12,7 @@ type Opts = {
     pageId?: string;
   };
   question?: Question;
-  dashboard?: StoreDashboard;
+  dashboard?: Dashboard;
   collection?: Collection;
 };
 
@@ -64,7 +63,7 @@ export function isMetricPath(pathname: string): boolean {
   return pathname.startsWith("/metric");
 }
 
-function isDashboardPath(pathname: string): boolean {
+export function isDashboardPath(pathname: string): boolean {
   return (
     pathname.startsWith("/dashboard") &&
     // `/${resource}/entity/${entity_id}` paths should only do a redirect, without triggering any other logic

--- a/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
@@ -8,6 +8,7 @@ import {
   setupCollectionByIdEndpoint,
   setupCollectionItemsEndpoint,
   setupCollectionsEndpoints,
+  setupDashboardEndpoints,
   setupDatabasesEndpoints,
   setupSearchEndpoints,
   setupSettingEndpoint,
@@ -21,7 +22,7 @@ import {
 } from "__support__/ui";
 import type { ModelResult } from "metabase/browse/models";
 import { ROOT_COLLECTION } from "metabase/collections/constants";
-import type { DashboardState, StoreDashboard } from "metabase/redux/store";
+import type { DashboardState } from "metabase/redux/store";
 import {
   createMockDashboardState,
   createMockQueryBuilderState,
@@ -172,15 +173,15 @@ export async function setup({
   let dashboardId: DashboardId | null = null;
   const dashboardsForState: DashboardState["dashboards"] = {};
   const dashboardsForEntities: Dashboard[] = [];
-  let storeDashboard: StoreDashboard | undefined;
   if (openDashboard) {
     dashboardId = openDashboard.id;
-    storeDashboard = {
+    dashboardsForState[openDashboard.id] = {
       ...openDashboard,
       dashcards: openDashboard.dashcards.map((c) => c.id),
     };
-    dashboardsForState[openDashboard.id] = storeDashboard;
     dashboardsForEntities.push(openDashboard);
+    // MainNavbar reads the open dashboard via useGetDashboardQuery.
+    setupDashboardEndpoints(openDashboard);
   }
 
   const storeInitialState = createMockState({
@@ -220,9 +221,7 @@ export async function setup({
   renderWithProviders(
     <Route
       path={route}
-      component={(props) => (
-        <MainNavbar {...props} isOpen dashboard={storeDashboard} />
-      )}
+      component={(props) => <MainNavbar {...props} isOpen />}
     />,
     {
       storeInitialState,

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,7 +1,5 @@
 import type { Location } from "history";
 
-import type { StoreDashboard } from "metabase/redux/store";
-
 export interface MainNavbarOwnProps {
   isOpen: boolean;
   location: Location;
@@ -9,7 +7,6 @@ export interface MainNavbarOwnProps {
     slug?: string;
     pageId?: string;
   };
-  dashboard?: StoreDashboard;
 }
 
 export interface MainNavbarDispatchProps {


### PR DESCRIPTION
 Load the nav sidebar's dashboard via RTK (share one request with the dashboard page)
  
  The nav sidebar read the open dashboard from the legacy dashboard redux slice (a module-boundary smell). It now loads it via useGetDashboardQuery, and fetchDashboard fetches through the same RTK getDashboard
  endpoint — so the page and sidebar share one cache entry and a single network request instead of two.

  Changes
  - fetchDashboard fetches the dashboard via the RTK getDashboard endpoint instead of legacy DashboardApi.get, preserving abort-on-navigation (#35959).
  - getDashboard excludes dashboard_load_id from its cache key (it's a per-load correlation id, not resource identity), so callers that don't pass one still dedupe.
  - MainNavbar reads the dashboard with useGetDashboardQuery keyed off the route id; drops the dashboard prop-threading through app/nav/Navbar.

  Testing
  Existing dashboard-load + cancellation tests pass; added a test asserting one GET /api/dashboard/:id when the page and sidebar load concurrently.