### PR TITLE
docs: standardize upload setup link labels

### DIFF
--- a/docs/exploration-and-organization/uploads.md
+++ b/docs/exploration-and-organization/uploads.md
@@ -11,7 +11,7 @@ You can upload CSV files to Metabase to query, visualize, and share.
 
 To upload CSV data, you'll need:
 
-- Uploads [enabled](../databases/uploads.md) by an admin.
+- Uploads [set up](../databases/uploads.md) by an admin.
 - [Data permissions](../permissions/data.md): your group needs **Can view** data access and **Create queries** access (query builder or higher) for the upload schema. (Unless you're an admin, you can't see what groups you're in; just noting this here so you know groups are a thing. Ask your admin to put you in a group with these privileges).
 - [Curate access](../permissions/collections.md#curate-access) to the collection you want to upload to.
 
@@ -160,4 +160,4 @@ When you delete the table, Metabase will give you the option to **Also send all 
 
 ## Further reading
 
-- [Enabling uploads](../databases/uploads.md)
+- [Setting up uploads](../databases/uploads.md)


### PR DESCRIPTION
Closes #71452.

### What changed
- Updated the upload requirements link text from `enabled` to `set up`.
- Updated the further reading link from `Enabling uploads` to `Setting up uploads`.

### Why
Both links point to the same setup page, so using consistent wording makes the uploads documentation less jarring to read.

### Testing
- Docs-only change; reviewed the rendered Markdown source for the two updated links.