### PR TITLE
Add Prometheus metric for search result counts

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -331,6 +331,10 @@
                        {:description "Number of successful search requests."})
    (prometheus/counter :metabase-search/response-error
                        {:description "Number of errors when responding to search requests."})
+   (prometheus/histogram :metabase-search/response-results
+                         {:description "Distribution of the total number of results matched by a search request."
+                          ;; `:total` is capped at *db-max-results* (1000).
+                          :buckets [0 1 2 5 10 25 50 100 250 500 1000]})
    (prometheus/gauge :metabase-search/engine-default
                      {:description "Whether a given engine is being used as the default. User can override via cookie."
                       :labels [:engine]})

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -258,7 +258,8 @@
                 :non-temporal-dim-ids                (process-non-temporal-dim-ids non-temporal-dim-ids)
                 :has-temporal-dim                    has-temporal-dim
                 :display-type                        (set display-type)}))
-      (analytics/inc! :metabase-search/response-ok))
+      (analytics/inc! :metabase-search/response-ok)
+      (analytics/observe! :metabase-search/response-results (:total <>)))
     (catch Exception e
       (let [status-code (:status-code (ex-data e))]
         (when (or (not status-code) (= 5 (quot status-code 100)))

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1886,12 +1886,17 @@
 
 (deftest ^:synchronized prometheus-response-metrics-test
   (testing "Prometheus counters get incremented for error responses"
-    (let [calls (atom nil)]
-      (mt/with-dynamic-fn-redefs [analytics/inc! #(swap! calls conj %)]
+    (let [calls    (atom nil)
+          observed (atom [])]
+      (mt/with-dynamic-fn-redefs [analytics/inc!     (fn [metric & _] (swap! calls conj metric))
+                                  analytics/observe! (fn [& args] (swap! observed conj (vec args)))]
         (testing "Success response"
-          (search-request :crowberto :q "test")
-          (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
-          (is (= 0 (count (filter #{:metabase-search/response-error} @calls)))))
+          (let [response (search-request :crowberto :q "test")]
+            (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
+            (is (= 0 (count (filter #{:metabase-search/response-error} @calls))))
+            (testing "result count is observed and matches the response :total"
+              (is (= [[:metabase-search/response-results (:total response)]]
+                     (filter (comp #{:metabase-search/response-results} first) @observed))))))
         (testing "Bad request (400)"
           (mt/user-http-request :crowberto :get 400 "/search" :archived "meow")
           (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1901,12 +1901,16 @@
           (mt/user-http-request :crowberto :get 400 "/search" :archived "meow")
           (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
           ;; We do not treat client side errors as errors for our alerts.
-          (is (= 0 (count (filter #{:metabase-search/response-error} @calls)))))
+          (is (= 0 (count (filter #{:metabase-search/response-error} @calls))))
+          (is (= 1 (count (filter (comp #{:metabase-search/response-results} first) @observed)))
+              "result count is not observed on error responses"))
         (testing "Unexpected server error (500)"
           (mt/with-dynamic-fn-redefs [search/search (fn [& _] (throw (Exception.)))]
             (mt/user-http-request :crowberto :get 500 "/search" :q "test")
             (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
-            (is (= 1 (count (filter #{:metabase-search/response-error} @calls))))))))))
+            (is (= 1 (count (filter #{:metabase-search/response-error} @calls))))
+            (is (= 1 (count (filter (comp #{:metabase-search/response-results} first) @observed)))
+                "result count is not observed on error responses")))))))
 
 (deftest ^:synchronized multiple-limits-test
   (when (search/supports-index?)


### PR DESCRIPTION
## Summary

Adds a backend Prometheus metric that records **how many results a search query matched** — something we currently only capture client-side via the Snowplow `search_query.total_results` event.

The Snowplow event is frontend-only and fires solely for searches with a UI `context` (`search-app`, `search-bar`, `command-palette`, `entity-picker`). 

Context-less, internal, and Metabot-driven searches produce no signal today. This metric closes that gap on the server.

## Changes

- **New histogram** `:metabase-search/response-results` (`src/metabase/analytics/prometheus.clj`) — "Distribution of the total number of results matched by a search request." Buckets `[0 1 2 5 10 25 50 100 250 500 1000]`, since `:total` is capped at `*db-max-results*` (1000).
- **Emission** in the search API handler (`src/metabase/search/api.clj`) — observes `(:total <>)` (the full ranked-result count, pre-pagination) on every successful response, right alongside the existing `:metabase-search/response-ok` counter.

Being a histogram, it yields count, sum, and a bucketed distribution — so you can derive average results-per-query (`sum/count`) and percentiles.

## Testing

Extended `prometheus-response-metrics-test` to assert the metric is observed on a successful search and that the observed value equals the response `:total`. All assertions pass.
