### PR TITLE
Clear setup-token after use

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -203,12 +203,15 @@
     ;; initialize Metabase from an `config.yml` file if present (Enterprise Edition™ only)
     (config-from-file/init-from-file-if-code-available!)
     (init-status/set-progress! 0.6)
-    (when new-install?
-      (log/info "Looks like this is a new installation ... preparing setup wizard")
-      ;; create setup token
-      (create-setup-token-and-log-setup-url!)
-      ;; publish install event
-      (events/publish-event! :event/install {}))
+    (if new-install?
+      (do
+        (log/info "Looks like this is a new installation ... preparing setup wizard")
+        ;; create setup token
+        (create-setup-token-and-log-setup-url!)
+        ;; publish install event
+        (events/publish-event! :event/install {}))
+      ;; The instance is already set up. Clear out any stale setup token.
+      (setup/clear-token!))
     (init-status/set-progress! 0.7)
     ;; deal with our sample database as needed
     (when (config/load-sample-content?)

--- a/src/metabase/setup/core.clj
+++ b/src/metabase/setup/core.clj
@@ -25,3 +25,9 @@
       ;; I guess we can't use `setup-token!` because it's marked as `:setter :none` even tho we are literally setting it
       ;; right here. `:setter :none` is meant for settings whose values are programmatically generated -- Cam
       (setting/set-value-of-type! :string :setup-token (str (random-uuid)))))
+
+(defn clear-token!
+  "Clear out the setup token. Called once the first User has been created -- the token can never be used again, so we
+  don't keep an unusable token-like value around in (public) Settings responses."
+  []
+  (setting/set-value-of-type! :string :setup-token nil))

--- a/src/metabase/setup/settings.clj
+++ b/src/metabase/setup/settings.clj
@@ -6,14 +6,14 @@
    [metabase.util.i18n :refer [deferred-tru tru]]
    [toucan2.core :as t2]))
 
-;;; TODO -- we actually do set this so it probably shouldn't be `:setter :none`. `:setter :none` is meant for settings
-;;; whose values are programmatically generated -- Cam
 (defsetting setup-token
   "A token used to signify that an instance has permissions to create the initial User. This is created upon the first
-  launch of Metabase, by the first instance; once used, it is cleared out, never to be used again."
-  :visibility :public
-  :setter     :none
-  :audit      :never)
+  launch of Metabase, by the first instance; once used, it is cleared out, never to be used again.
+  Setter is none so users cannot overwrite or re-set the setup-token from the generated value"
+  :visibility         :public
+  :setter             :none
+  :audit              :never
+  :can-read-from-env? false)
 
 (let [app-db-id->user-exists? (atom {})]
   (defn- -has-user-setup []

--- a/src/metabase/setup_rest/api.clj
+++ b/src/metabase/setup_rest/api.clj
@@ -94,6 +94,9 @@
                                                      :password password
                                                      :device-info (request/device-info request)})]
                   (setup-set-settings! {:email email :site-name site-name :site-locale site-locale})
+                  ;; the setup token can never be used again now that the first User exists -- clear it out so we don't
+                  ;; keep an unusable token-like value around in (public) Settings responses.
+                  (setup/clear-token!)
                   user-info))
               (catch Throwable e
                 ;; if the transaction fails, restore the Settings cache from the DB again so any changes made in this

--- a/test/metabase/setup/core_test.clj
+++ b/test/metabase/setup/core_test.clj
@@ -59,6 +59,25 @@
            (setup/has-user-setup)))
       (is (zero? (call-count))))))
 
+(deftest clear-token-test
+  (testing "clear-token! removes the setup token so an unusable value isn't left in (public) Settings (UXW-4359)"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (let [token (setup/create-token!)]
+        (testing "a token exists and validates before it is cleared"
+          (is (string? token))
+          (is (= token (setup/setup-token)))
+          (is (true? (setup/token-match? token))))
+        (testing "after clearing, the token is gone and no longer validates"
+          (setup/clear-token!)
+          (is (nil? (setup/setup-token)))
+          (is (false? (setup/token-match? token))))
+        (testing "create-token! mints a fresh token after clearing"
+          (let [new-token (setup/create-token!)]
+            (is (string? new-token))
+            (is (not= token new-token))
+            (is (= new-token (setup/setup-token)))))))))
+
 (deftest has-example-dashboard-id-setting-test
   (mt/with-temp-empty-app-db [_conn :h2]
     (mdb/setup-db! :create-sample-content? true)

--- a/test/metabase/setup_rest/api_test.clj
+++ b/test/metabase/setup_rest/api_test.clj
@@ -18,7 +18,6 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
-   [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -88,6 +87,24 @@
                         :model    "User"
                         :details  {}}
                        (mt/latest-audit-log-entry :user-joined user-id)))))))))))
+
+(deftest setup-token-cleared-after-use-test
+  (testing "POST /api/setup clears the setup token once the first user is created (UXW-4359)"
+    (let [body {:token (setup/create-token!)
+                :prefs {:site_locale "en"
+                        :site_name   (mt/random-name)}
+                :user  {:first_name (mt/random-name)
+                        :last_name  (mt/random-name)
+                        :email      (mt/random-email)
+                        :password   "p@ssword1"}}]
+      (do-with-setup!*
+       body
+       (fn []
+         (with-redefs [api.setup/*allow-api-setup-after-first-user-is-created* true]
+           (is (=? {:id string/valid-uuid?}
+                   (client/client :post 200 "setup" body)))
+           (testing "the now-unusable token is cleared out of Settings"
+             (is (nil? (setup/setup-token))))))))))
 
 (deftest setup-settings-test
   (testing "POST /api/setup"
@@ -228,28 +245,21 @@
 
 (deftest create-superuser-only-once-test
   (testing "POST /api/setup"
-    (testing "Check that we cannot create a new superuser via setup-token when a user exists"
-      (let [token          (setup/create-token!)
-            body           {:token token
-                            :prefs {:site_locale "es_MX"
-                                    :site_name   (mt/random-name)}
-                            :user  {:first_name (mt/random-name)
-                                    :last_name  (mt/random-name)
-                                    :email      (mt/random-email)
-                                    :password   "p@ssword1"}}
-            has-user-setup (atom false)]
-        (mt/with-dynamic-fn-redefs [setup/has-user-setup (fn [] @has-user-setup)]
-          (is (not (setup/has-user-setup)))
-          (mt/discard-setting-changes [site-name site-locale anon-tracking-enabled admin-email]
-            (is (malli= [:map {:closed true} [:id ms/NonBlankString]]
-                        (client/client :post 200 "setup" body))))
-          ;; In the non-test context, this is 'set' iff there is one or more users, and doesn't have to be toggled
-          (reset! has-user-setup true)
-          (is (setup/has-user-setup))
-          ;; use do-with-setup!* to delete the random user that was created
-          (do-with-setup!* body
-                           #(is (= "The /api/setup route can only be used to create the first user, however a user currently exists."
-                                   (client/client :post 403 "setup" (assoc-in body [:user :email] (mt/random-email)))))))))))
+    (testing "A second superuser cannot be created once a user exists -- even if the caller presents a valid setup token"
+      ;; Simulate the attacker's ideal preconditions directly: a user already exists, and the supplied token passes
+      ;; validation (i.e. they somehow got hold of a valid setup token). The "a user already exists" guard must still
+      ;; reject the request -- this is the real safeguard, independent of whether a token happens to exist.
+      (mt/with-dynamic-fn-redefs [setup/has-user-setup (constantly true)
+                                  setup/token-match?   (constantly true)]
+        (let [body {:token "any-valid-looking-token"
+                    :prefs {:site_locale "es_MX"
+                            :site_name   (mt/random-name)}
+                    :user  {:first_name (mt/random-name)
+                            :last_name  (mt/random-name)
+                            :email      (mt/random-email)
+                            :password   "p@ssword1"}}]
+          (is (= "The /api/setup route can only be used to create the first user, however a user currently exists."
+                 (client/client :post 403 "setup" body))))))))
 
 (deftest transaction-test
   (testing "POST /api/setup/"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72908
### Description

After we create the first user, the setup-token is no longer needed. We already had code in place to not allow it to be used again, but this change removes it from the settings so it doesn't confuse people on what it could be used for.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
