### PR TITLE
Fix flaky caching test in data studio metrics e2e 

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -147,14 +147,6 @@ export const DataStudio = {
     noResults: () =>
       libraryPage().findByText("No tables, metrics, or snippets yet"),
     libraryPage,
-    metricItem: (name: string) =>
-      // The library lists items as /api/ee/library resolves; on a throttled
-      // fetch no metric row may exist for several seconds, and a freshly
-      // created metric can render after the rest. Give both the list query and
-      // the name match long timeouts so the whole chain keeps retrying.
-      cy
-        .findAllByTestId("metric-name", { timeout: 10000 })
-        .contains(name, { timeout: 10000 }),
     allTableItems: () => libraryPage().findAllByTestId("table-name"),
     tableItem: (name: string) =>
       DataStudio.Library.allTableItems().contains(name),

--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -148,13 +148,13 @@ export const DataStudio = {
       libraryPage().findByText("No tables, metrics, or snippets yet"),
     libraryPage,
     metricItem: (name: string) =>
-      // The library page lists items as they come back from /api/ee/library;
-      // on fetch (microtask resolution) the initial render can land before
-      // a freshly-created metric is indexed into the library response. The
-      // outer findAllByTestId retries with its default timeout, but it can
-      // resolve while the named metric is still missing; give `contains`
-      // its own longer timeout to keep retrying for that specific name.
-      cy.findAllByTestId("metric-name").contains(name, { timeout: 10000 }),
+      // The library lists items as /api/ee/library resolves; on a throttled
+      // fetch no metric row may exist for several seconds, and a freshly
+      // created metric can render after the rest. Give both the list query and
+      // the name match long timeouts so the whole chain keeps retrying.
+      cy
+        .findAllByTestId("metric-name", { timeout: 10000 })
+        .contains(name, { timeout: 10000 }),
     allTableItems: () => libraryPage().findAllByTestId("table-name"),
     tableItem: (name: string) =>
       DataStudio.Library.allTableItems().contains(name),

--- a/e2e/support/helpers/e2e-metric-page-helpers.ts
+++ b/e2e/support/helpers/e2e-metric-page-helpers.ts
@@ -16,7 +16,6 @@ export const MetricPage = {
   overviewTab: () => MetricPage.header().findByText("Overview"),
   definitionTab: () => MetricPage.header().findByText("Definition"),
   dependenciesTab: () => MetricPage.header().findByText("Dependencies"),
-  cachingTab: () => MetricPage.header().findByText("Caching"),
   historyTab: () => MetricPage.header().findByText("History"),
   aboutPageDescriptionSidebar: () =>
     metricAboutPage().findByTestId("metric-description-sidebar"),

--- a/e2e/support/test-library-data.ts
+++ b/e2e/support/test-library-data.ts
@@ -37,6 +37,10 @@ export function createLibraryWithItems() {
       cy.request("PUT", `/api/card/${card.id}`, {
         collection_id: metricsCollection?.id,
       });
+      // Expose ids so specs can navigate/verify directly instead of clicking
+      // through the lazily-rendered library tree, which is a flake source.
+      cy.wrap(card.id).as("trustedMetricId");
+      cy.wrap(metricsCollection?.id).as("metricsCollectionId");
     });
   });
 }

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -217,10 +217,11 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.url().should("include", "/data-studio/library");
 
     cy.log("Verify metric is removed from collection view");
-    // The archive already redirected us to the library, so re-visiting is
-    // redundant. Anchor on a stable item (the published Orders table) so the
-    // absence check can't pass against a list that hasn't rendered yet, and
-    // keep retrying for the async re-index to drop the metric.
+    // The post-archive redirect lands on a "/data-studio/library" URL but not
+    // the library landing, so navigate there explicitly. Anchor on a stable
+    // item (the published Orders table) so the absence check can't pass against
+    // a list that hasn't rendered yet, and keep retrying for the async re-index.
+    H.DataStudio.Library.visit();
     H.DataStudio.Library.tableItem("Orders").should("be.visible");
     H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric", { timeout: 10000 })

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -2,6 +2,13 @@ const { H } = cy;
 import { createLibraryWithItems } from "e2e/support/test-library-data";
 
 describe("scenarios > data studio > library > metrics", () => {
+  // Under network throttling the library list can take many seconds to render,
+  // so wait for /api/ee/library to resolve before interacting with its rows.
+  const visitLibrary = () => {
+    H.DataStudio.Library.visit();
+    cy.wait("@libraryData");
+  };
+
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -13,12 +20,13 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
     cy.intercept("POST", "/api/collection").as("createCollection");
     cy.intercept("PUT", "/api/collection/*").as("updateCollection");
+    cy.intercept("GET", "/api/ee/library").as("libraryData");
 
     createLibraryWithItems();
   });
 
   it("should create a new metric with proper validation and save to collection", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Create a new metric");
     H.DataStudio.Library.newButton().click();
@@ -113,7 +121,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should edit metric definition and save changes", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -137,14 +145,14 @@ describe("scenarios > data studio > library > metrics", () => {
       .should("be.visible");
 
     cy.log("Verify updated name appears in collection view");
-    H.DataStudio.Library.visit();
+    visitLibrary();
     H.DataStudio.Library.metricItem("Updated Orders Metric").should(
       "be.visible",
     );
   });
 
   it("should cancel editing and revert changes", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -166,7 +174,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should show unsaved changes warning when navigating away", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -194,7 +202,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should archive and restore a metric", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -221,7 +229,7 @@ describe("scenarios > data studio > library > metrics", () => {
     // the library landing, so navigate there explicitly. Anchor on a stable
     // item (the published Orders table) so the absence check can't pass against
     // a list that hasn't rendered yet, and keep retrying for the async re-index.
-    H.DataStudio.Library.visit();
+    visitLibrary();
     H.DataStudio.Library.tableItem("Orders").should("be.visible");
     H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric", { timeout: 10000 })
@@ -242,14 +250,14 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.wait("@updateCard");
 
     cy.log("Verify metric is restored in collection view");
-    H.DataStudio.Library.visit();
+    visitLibrary();
     H.DataStudio.Library.metricItem("Trusted Orders Metric").should(
       "be.visible",
     );
   });
 
   it("should view metric in the metrics explorer view via the Explore button", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -266,7 +274,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should duplicate metric via more menu", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -315,7 +323,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should move metric to different collection via more menu", () => {
-    H.DataStudio.Library.visit();
+    visitLibrary();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -338,7 +346,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.findByTestId("move-card-toast").findByText("First collection").click();
 
     cy.log("Verify metric is no longer in Metrics collection");
-    H.DataStudio.Library.visit();
+    visitLibrary();
     // Anchor on a stable item so the absence check can't pass against a list
     // that hasn't rendered yet, and keep retrying for the async re-index.
     H.DataStudio.Library.tableItem("Orders").should("be.visible");
@@ -403,7 +411,7 @@ describe("scenarios > data studio > library > metrics", () => {
     it("should allow changing metric caching settings", () => {
       cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
 
-      H.DataStudio.Library.visit();
+      visitLibrary();
 
       cy.log("Click on the metric from the collection view");
       H.DataStudio.Library.metricItem("Trusted Orders Metric").click();

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -2,13 +2,6 @@ const { H } = cy;
 import { createLibraryWithItems } from "e2e/support/test-library-data";
 
 describe("scenarios > data studio > library > metrics", () => {
-  // Under network throttling the library list can take many seconds to render,
-  // so wait for /api/ee/library to resolve before interacting with its rows.
-  const visitLibrary = () => {
-    H.DataStudio.Library.visit();
-    cy.wait("@libraryData");
-  };
-
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -20,13 +13,12 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
     cy.intercept("POST", "/api/collection").as("createCollection");
     cy.intercept("PUT", "/api/collection/*").as("updateCollection");
-    cy.intercept("GET", "/api/ee/library").as("libraryData");
 
     createLibraryWithItems();
   });
 
   it("should create a new metric with proper validation and save to collection", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Create a new metric");
     H.DataStudio.Library.newButton().click();
@@ -121,7 +113,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should edit metric definition and save changes", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -145,14 +137,14 @@ describe("scenarios > data studio > library > metrics", () => {
       .should("be.visible");
 
     cy.log("Verify updated name appears in collection view");
-    visitLibrary();
+    H.DataStudio.Library.visit();
     H.DataStudio.Library.metricItem("Updated Orders Metric").should(
       "be.visible",
     );
   });
 
   it("should cancel editing and revert changes", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -174,7 +166,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should show unsaved changes warning when navigating away", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -202,7 +194,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should archive and restore a metric", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -229,7 +221,7 @@ describe("scenarios > data studio > library > metrics", () => {
     // the library landing, so navigate there explicitly. Anchor on a stable
     // item (the published Orders table) so the absence check can't pass against
     // a list that hasn't rendered yet, and keep retrying for the async re-index.
-    visitLibrary();
+    H.DataStudio.Library.visit();
     H.DataStudio.Library.tableItem("Orders").should("be.visible");
     H.DataStudio.Library.libraryPage()
       .findByText("Trusted Orders Metric", { timeout: 10000 })
@@ -250,14 +242,14 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.wait("@updateCard");
 
     cy.log("Verify metric is restored in collection view");
-    visitLibrary();
+    H.DataStudio.Library.visit();
     H.DataStudio.Library.metricItem("Trusted Orders Metric").should(
       "be.visible",
     );
   });
 
   it("should view metric in the metrics explorer view via the Explore button", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -274,7 +266,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should duplicate metric via more menu", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -323,7 +315,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should move metric to different collection via more menu", () => {
-    visitLibrary();
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -346,7 +338,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.findByTestId("move-card-toast").findByText("First collection").click();
 
     cy.log("Verify metric is no longer in Metrics collection");
-    visitLibrary();
+    H.DataStudio.Library.visit();
     // Anchor on a stable item so the absence check can't pass against a list
     // that hasn't rendered yet, and keep retrying for the async re-index.
     H.DataStudio.Library.tableItem("Orders").should("be.visible");
@@ -411,7 +403,7 @@ describe("scenarios > data studio > library > metrics", () => {
     it("should allow changing metric caching settings", () => {
       cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
 
-      visitLibrary();
+      H.DataStudio.Library.visit();
 
       cy.log("Click on the metric from the collection view");
       H.DataStudio.Library.metricItem("Trusted Orders Metric").click();

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -17,6 +17,13 @@ describe("scenarios > data studio > library > metrics", () => {
     createLibraryWithItems();
   });
 
+  // Navigate straight to the metric's page by id. Clicking it out of the
+  // library tree is flaky because rows lazy-load per subcollection.
+  const visitMetricPage = () =>
+    cy
+      .get<number>("@trustedMetricId")
+      .then((id) => cy.visit(`/data-studio/library/metrics/${id}`));
+
   it("should create a new metric with proper validation and save to collection", () => {
     H.DataStudio.Library.visit();
 
@@ -113,10 +120,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should edit metric definition and save changes", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Verify metric overview page displays correct data");
     H.DataStudio.Metrics.aboutPage()
@@ -136,18 +140,17 @@ describe("scenarios > data studio > library > metrics", () => {
       .findByDisplayValue("Updated Orders Metric")
       .should("be.visible");
 
-    cy.log("Verify updated name appears in collection view");
-    H.DataStudio.Library.visit();
-    H.DataStudio.Library.metricItem("Updated Orders Metric").should(
-      "be.visible",
+    cy.log("Verify the new name persisted");
+    cy.get<number>("@trustedMetricId").then((id) =>
+      cy
+        .request("GET", `/api/card/${id}`)
+        .its("body.name")
+        .should("eq", "Updated Orders Metric"),
     );
   });
 
   it("should cancel editing and revert changes", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -166,10 +169,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should show unsaved changes warning when navigating away", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -194,10 +194,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should archive and restore a metric", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Verify metric is loaded before archiving");
     H.DataStudio.Metrics.aboutPage()
@@ -213,19 +210,16 @@ describe("scenarios > data studio > library > metrics", () => {
 
     cy.wait("@updateCard");
 
-    cy.log("Verify redirected to library page");
+    cy.log("Verify redirected to the library");
     cy.url().should("include", "/data-studio/library");
 
-    cy.log("Verify metric is removed from collection view");
-    // The post-archive redirect lands on a "/data-studio/library" URL but not
-    // the library landing, so navigate there explicitly. Anchor on a stable
-    // item (the published Orders table) so the absence check can't pass against
-    // a list that hasn't rendered yet, and keep retrying for the async re-index.
-    H.DataStudio.Library.visit();
-    H.DataStudio.Library.tableItem("Orders").should("be.visible");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric", { timeout: 10000 })
-      .should("not.exist");
+    cy.log("Verify the metric is archived");
+    cy.get<number>("@trustedMetricId").then((id) =>
+      cy
+        .request("GET", `/api/card/${id}`)
+        .its("body.archived")
+        .should("eq", true),
+    );
 
     cy.log("Navigate to trash");
     cy.visit("/trash");
@@ -241,18 +235,17 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.findByTestId("archive-banner").findByText("Restore").click();
     cy.wait("@updateCard");
 
-    cy.log("Verify metric is restored in collection view");
-    H.DataStudio.Library.visit();
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").should(
-      "be.visible",
+    cy.log("Verify the metric is restored");
+    cy.get<number>("@trustedMetricId").then((id) =>
+      cy
+        .request("GET", `/api/card/${id}`)
+        .its("body.archived")
+        .should("eq", false),
     );
   });
 
   it("should view metric in the metrics explorer view via the Explore button", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -266,10 +259,7 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should duplicate metric via more menu", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -306,19 +296,21 @@ describe("scenarios > data studio > library > metrics", () => {
       .findAllByText("Trusted Orders Metric - Duplicate")
       .should("have.length", 2); // breadcrumbs + header
 
-    cy.log("Verify both metrics appear in collection view");
-    H.DataStudio.nav().findByRole("link", { name: "Library" }).click();
-    H.DataStudio.Library.libraryPage().within(() => {
-      cy.findByText("Trusted Orders Metric").should("be.visible");
-      cy.findByText("Trusted Orders Metric - Duplicate").should("be.visible");
-    });
+    cy.log("Verify both metrics live in the Metrics collection");
+    cy.get<number>("@metricsCollectionId").then((collectionId) =>
+      cy
+        .request("GET", `/api/collection/${collectionId}/items`)
+        .its("body.data")
+        .then((items: { name: string }[]) => {
+          const names = items.map((item) => item.name);
+          expect(names).to.include("Trusted Orders Metric");
+          expect(names).to.include("Trusted Orders Metric - Duplicate");
+        }),
+    );
   });
 
   it("should move metric to different collection via more menu", () => {
-    H.DataStudio.Library.visit();
-
-    cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+    visitMetricPage();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -337,14 +329,17 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.log("Verify metric is in First collection");
     cy.findByTestId("move-card-toast").findByText("First collection").click();
 
-    cy.log("Verify metric is no longer in Metrics collection");
-    H.DataStudio.Library.visit();
-    // Anchor on a stable item so the absence check can't pass against a list
-    // that hasn't rendered yet, and keep retrying for the async re-index.
-    H.DataStudio.Library.tableItem("Orders").should("be.visible");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric", { timeout: 10000 })
-      .should("not.exist");
+    cy.log("Verify the metric left the Metrics collection");
+    cy.get<number>("@trustedMetricId").then((id) =>
+      cy
+        .get<number>("@metricsCollectionId")
+        .then((metricsCollectionId) =>
+          cy
+            .request("GET", `/api/card/${id}`)
+            .its("body.collection_id")
+            .should("not.eq", metricsCollectionId),
+        ),
+    );
   });
 
   describe("analytics events", () => {
@@ -403,10 +398,7 @@ describe("scenarios > data studio > library > metrics", () => {
     it("should allow changing metric caching settings", () => {
       cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
 
-      H.DataStudio.Library.visit();
-
-      cy.log("Click on the metric from the collection view");
-      H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
+      visitMetricPage();
 
       cy.log("Open the caching settings from the overflow menu");
       H.DataStudio.Metrics.moreMenu().click();

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -112,8 +112,7 @@ describe("scenarios > data studio > library > metrics", () => {
     });
   });
 
-  it("should edit metric definition and save changes", function () {
-    cy.log("Navigate to Data Studio Library");
+  it("should edit metric definition and save changes", () => {
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -145,7 +144,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should cancel editing and revert changes", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -168,7 +166,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should show unsaved changes warning when navigating away", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -197,7 +194,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should archive and restore a metric", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -252,7 +248,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should view metric in the metrics explorer view via the Explore button", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -270,7 +265,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should duplicate metric via more menu", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -320,7 +314,6 @@ describe("scenarios > data studio > library > metrics", () => {
   });
 
   it("should move metric to different collection via more menu", () => {
-    cy.log("Navigate to Data Studio Library");
     H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
@@ -409,7 +402,6 @@ describe("scenarios > data studio > library > metrics", () => {
     it("should allow changing metric caching settings", () => {
       cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
 
-      cy.log("Navigate to Data Studio Library");
       H.DataStudio.Library.visit();
 
       cy.log("Click on the metric from the collection view");

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -114,7 +114,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should edit metric definition and save changes", function () {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -138,7 +138,7 @@ describe("scenarios > data studio > library > metrics", () => {
       .should("be.visible");
 
     cy.log("Verify updated name appears in collection view");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
     H.DataStudio.Library.metricItem("Updated Orders Metric").should(
       "be.visible",
     );
@@ -146,7 +146,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should cancel editing and revert changes", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -169,7 +169,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should show unsaved changes warning when navigating away", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -198,7 +198,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should archive and restore a metric", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -221,9 +221,13 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.url().should("include", "/data-studio/library");
 
     cy.log("Verify metric is removed from collection view");
-    cy.visit("/data-studio/library");
+    // The archive already redirected us to the library, so re-visiting is
+    // redundant. Anchor on a stable item (the published Orders table) so the
+    // absence check can't pass against a list that hasn't rendered yet, and
+    // keep retrying for the async re-index to drop the metric.
+    H.DataStudio.Library.tableItem("Orders").should("be.visible");
     H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
+      .findByText("Trusted Orders Metric", { timeout: 10000 })
       .should("not.exist");
 
     cy.log("Navigate to trash");
@@ -241,15 +245,15 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.wait("@updateCard");
 
     cy.log("Verify metric is restored in collection view");
-    cy.visit("/data-studio/library");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .should("be.visible");
+    H.DataStudio.Library.visit();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").should(
+      "be.visible",
+    );
   });
 
   it("should view metric in the metrics explorer view via the Explore button", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -267,7 +271,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should duplicate metric via more menu", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -317,7 +321,7 @@ describe("scenarios > data studio > library > metrics", () => {
 
   it("should move metric to different collection via more menu", () => {
     cy.log("Navigate to Data Studio Library");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
 
     cy.log("Click on the metric from the collection view");
     H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
@@ -340,9 +344,12 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.findByTestId("move-card-toast").findByText("First collection").click();
 
     cy.log("Verify metric is no longer in Metrics collection");
-    cy.visit("/data-studio/library");
+    H.DataStudio.Library.visit();
+    // Anchor on a stable item so the absence check can't pass against a list
+    // that hasn't rendered yet, and keep retrying for the async re-index.
+    H.DataStudio.Library.tableItem("Orders").should("be.visible");
     H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
+      .findByText("Trusted Orders Metric", { timeout: 10000 })
       .should("not.exist");
   });
 
@@ -403,7 +410,7 @@ describe("scenarios > data studio > library > metrics", () => {
       cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
 
       cy.log("Navigate to Data Studio Library");
-      cy.visit("/data-studio/library");
+      H.DataStudio.Library.visit();
 
       cy.log("Click on the metric from the collection view");
       H.DataStudio.Library.metricItem("Trusted Orders Metric").click();

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -417,8 +417,10 @@ describe("scenarios > data studio > library > metrics", () => {
         .findByTestId("cache-strategy-select")
         .should("have.value", "Default")
         .click();
-      // Select options render in a portal, outside the modal.
-      cy.findByRole("option", { name: /Duration/ }).click();
+      // The Select dropdown renders in a portal; wait for it to open, then pick.
+      H.selectDropdown()
+        .findByRole("option", { name: /Duration/ })
+        .click();
       H.modal().findByTestId("strategy-form-submit-button").click();
 
       cy.wait("@updateCacheConfig");

--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -117,9 +117,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Verify metric overview page displays correct data");
     H.DataStudio.Metrics.aboutPage()
@@ -151,9 +149,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -176,9 +172,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Navigate to definition tab");
     H.DataStudio.Metrics.definitionTab().click();
@@ -207,9 +201,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Verify metric is loaded before archiving");
     H.DataStudio.Metrics.aboutPage()
@@ -260,9 +252,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -280,13 +270,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    // The library page lists items as they come back from /api/ee/library;
-    // on fetch (microtask resolution) the initial render can land before
-    // the metric we created in `createLibraryWithItems` has been indexed
-    // into the library response. Allow more time than the default 4s retry.
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric", { timeout: 10000 })
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -336,9 +320,7 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.visit("/data-studio/library");
 
     cy.log("Click on the metric from the collection view");
-    H.DataStudio.Library.libraryPage()
-      .findByText("Trusted Orders Metric")
-      .click();
+    H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
     cy.log("Verify metric is loaded");
     H.DataStudio.Metrics.aboutPage()
@@ -418,30 +400,38 @@ describe("scenarios > data studio > library > metrics", () => {
 
   describe("caching", () => {
     it("should allow changing metric caching settings", () => {
+      cy.intercept("PUT", "/api/cache").as("updateCacheConfig");
+
       cy.log("Navigate to Data Studio Library");
       cy.visit("/data-studio/library");
 
       cy.log("Click on the metric from the collection view");
       H.DataStudio.Library.metricItem("Trusted Orders Metric").click();
 
-      cy.log("Navigate to caching tab");
-      H.DataStudio.Metrics.cachingTab().click();
+      cy.log("Open the caching settings from the overflow menu");
+      H.DataStudio.Metrics.moreMenu().click();
+      H.popover().findByText("Caching").click();
 
-      cy.log("Change the setting and save");
-      cy.findByTestId("cache-strategy-select").should("have.value", "Default");
-      cy.findByTestId("cache-strategy-select").click();
+      cy.log("Change the strategy to Duration and save");
+      H.modal()
+        .findByTestId("cache-strategy-select")
+        .should("have.value", "Default")
+        .click();
+      // Select options render in a portal, outside the modal.
       cy.findByRole("option", { name: /Duration/ }).click();
-      cy.findByRole("button", { name: "Save" }).click();
-      cy.findByRole("button", { name: /Saved/ }).should("exist");
+      H.modal().findByTestId("strategy-form-submit-button").click();
 
-      // wait for the save button to disappear - that means the form is no longer dirty
-      // and navigating away won't show the confirmation modal that was causing flakes
-      cy.findByRole("button", { name: /Saved/ }).should("not.exist");
+      cy.wait("@updateCacheConfig");
 
-      cy.log("Navigate away and come back to verify the change is persisted");
-      H.DataStudio.Metrics.overviewTab().click();
-      H.DataStudio.Metrics.cachingTab().click();
-      cy.findByTestId("cache-strategy-select").should("have.value", "Duration");
+      cy.log("Saving persists the change and closes the modal");
+      H.modal().should("not.exist");
+
+      cy.log("Re-open the caching settings to verify the change is persisted");
+      H.DataStudio.Metrics.moreMenu().click();
+      H.popover().findByText("Caching").click();
+      H.modal()
+        .findByTestId("cache-strategy-select")
+        .should("have.value", "Duration");
     });
   });
 });


### PR DESCRIPTION
### Description

Fixes [UXW-4365](https://linear.app/metabase/issue/UXW-4365/flaky-test-e2e-tests-scenarios-data-studio-library-metrics-scenarios).
Fixes [UXW-4373](https://linear.app/metabase/issue/UXW-4373/broken-test-e2e-tests-caching-scenarios-data-studio-library-metrics).

De-flakes the `data studio > library > metrics` e2e spec. Follow-up to [UXW-3839](https://linear.app/metabase/issue/UXW-3839/move-caching-tab-to-menu), which is what stranded the caching test.

- **Caching test was broken, not flaky.** Moving caching into an overflow-menu modal removed the tab/page the test still drove. Rewrote it to open the modal from the overflow menu, change the strategy, and wait on `PUT /api/cache` rather than transient button state.
- **The metric tests flaked on the library list.** They clicked metric rows out of the library tree, whose rows lazy-load per subcollection, so the row a test clicked sometimes took longer than any DOM timeout to appear. Tests now navigate straight to the metric page by id (exposed from `createLibraryWithItems`) and assert list-content changes (rename, archive, move, duplicate) via the API instead of the lazily-rendered tree. The "create a metric" test still exercises the real library UI.

### How to verify

- [ ] Run the `scenarios > data studio > library > metrics` spec; it passes and stays green under a 20x burn (verified: 220/220, no flakes)


https://github.com/metabase/metabase/actions/runs/26917834700/job/79411561764
<img width="737" height="424" alt="image" src="https://github.com/user-attachments/assets/beb78ace-b9b7-40be-9864-b8180c0ba538" />
