### PR TITLE
Add timeout and diagnostic logging to the JUnit hook-rewrite CI step

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -183,9 +183,11 @@ jobs:
       - name: Rewrite JUnit hook failures (partial rollout)
         if: always()
         continue-on-error: true
+        timeout-minutes: 1
         shell: bash
         run: |
           if [ -d ./target/junit ]; then
+            echo "fix-junit-hooks: invoking bun"
             bun e2e/support/fix-junit-hooks.ts ./target/junit \
               --include sharing/public-resource-downloads \
               --include sharing/sharing-reproductions \

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -90,9 +90,11 @@ jobs:
       - name: Rewrite JUnit hook failures (dry-run)
         if: always()
         continue-on-error: true
+        timeout-minutes: 1
         shell: bash
         run: |
           if [ -d ./target/junit ]; then
+            echo "fix-junit-hooks: invoking bun"
             bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
           else
             echo "No ./target/junit directory; nothing to process."
@@ -254,9 +256,11 @@ jobs:
       - name: Rewrite JUnit hook failures (dry-run)
         if: always()
         continue-on-error: true
+        timeout-minutes: 1
         shell: bash
         run: |
           if [ -d ./target/junit ]; then
+            echo "fix-junit-hooks: invoking bun"
             bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
           else
             echo "No ./target/junit directory; nothing to process."

--- a/e2e/support/fix-junit-hooks.ts
+++ b/e2e/support/fix-junit-hooks.ts
@@ -49,6 +49,8 @@ type Result = {
   rewrites: Rewrite[];
 };
 
+console.error("fix-junit-hooks: parsing arguments");
+
 const program = new Command();
 program
   .name("fix-junit-hooks")
@@ -71,6 +73,10 @@ program
 
 const [inDir, outDir = inDir] = program.processedArgs as [string, string?];
 const { dryRun = false, include: includes } = program.opts<Options>();
+
+console.error(
+  `fix-junit-hooks: start (in=${inDir}, out=${outDir}, dryRun=${dryRun}, includes=[${includes.join(", ")}])`,
+);
 
 if (!statSync(inDir).isDirectory()) {
   console.error(`error: <input-dir> must be a directory, got ${inDir}`);
@@ -226,11 +232,17 @@ const files = readdirSync(inDir)
   .filter((f) => f.endsWith(".xml"))
   .sort();
 
+console.error(`fix-junit-hooks: found ${files.length} XML file(s)`);
+
 let totalScanned = 0;
 let totalRewritten = 0;
 for (const f of files) {
   const inP = join(inDir, f);
   const outP = inDir === outDir ? inP : join(outDir, f);
+  // Log before processing so a hang points at the exact culprit file.
+  console.error(
+    `fix-junit-hooks: processing ${f} (${statSync(inP).size} bytes)`,
+  );
   const r = processFile(inP, outP);
   console.error(summarize(inP, r));
   totalScanned += r.scanned;

--- a/e2e/support/fix-junit-hooks.ts
+++ b/e2e/support/fix-junit-hooks.ts
@@ -239,7 +239,6 @@ let totalRewritten = 0;
 for (const f of files) {
   const inP = join(inDir, f);
   const outP = inDir === outDir ? inP : join(outDir, f);
-  // Log before processing so a hang points at the exact culprit file.
   console.error(
     `fix-junit-hooks: processing ${f} (${statSync(inP).size} bytes)`,
   );


### PR DESCRIPTION
Closes [DEV-2121](https://linear.app/metabase/issue/DEV-2121)

### Description

The "Rewrite JUnit hook failures" e2e step hung once on `master`, stalling the job until it hit the 40-minute timeout and cancelling the whole run. The step already has `continue-on-error: true`, but that only ignores a non-zero exit, not a hang.

I couldn't pin down the root cause, so this adds a defensive `timeout-minutes: 1` to the step (and to the two dry-run usages of the same script in `embedding-sdk-component-tests.yml`) so a future stall fails just the step instead of taking down the run. It also adds staged logging to `fix-junit-hooks.ts` so if it happens again we can see which phase is stuck.

### How to verify

### Checklist

- [x] Tests have been added/updated to cover changes in this PR