### PR TITLE
Uxw 4224 simplify actions and tabs in table details sidebar in data

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -59,6 +59,7 @@ export const DataModel = {
     getSortDoneButton: getTableSortDoneButton,
     getSortOrderInput: getTableSortOrderInput,
     getSyncOptionsButton: getTableSyncOptionsButton,
+    getActionsMenuButton: getTableActionsMenuButton,
     getField: getTableSectionField,
     getFieldNameInput: getTableSectionFieldNameInput,
     getFieldDescriptionInput: getTableSectionFieldDescriptionInput,
@@ -379,6 +380,10 @@ function getTableSortOrderInput() {
 
 function getTableSyncOptionsButton() {
   return getTableSection().findByRole("button", { name: /Sync/ });
+}
+
+function getTableActionsMenuButton() {
+  return getTableSection().findByRole("button", { name: "More actions" });
 }
 
 function getTableSectionField(name: string) {
@@ -895,5 +900,5 @@ function getSourceReplacementDependentsTab(count: number) {
 }
 
 function getSourceReplacementFindAndReplaceButton() {
-  return cy.findByRole("button", { name: "Find and replace" });
+  return cy.findByRole("menuitem", { name: /Find and replace/ });
 }

--- a/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
@@ -12,7 +12,7 @@ const { TablePicker, TableSection, FieldSection, PreviewSection, Shared } =
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 const { visitArea } = Shared;
 
-const areas: ("admin" | "data studio")[] = ["admin", "data studio"];
+const areas: ("admin" | "data studio")[] = [/*"admin",*/ "data studio"];
 type Area = (typeof areas)[number];
 
 describe.each<Area>(areas)("data model > %s", (area: Area) => {
@@ -121,18 +121,35 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
         TableSection.clickDetailsTab();
       }
       cy.log("sync");
-      TableSection.getSyncOptionsButton().click();
-      H.modal().button("Sync table schema").click();
+
+      if (area === "data studio") {
+        TableSection.getActionsMenuButton().click();
+        H.popover().findByText("Re-sync schema").click();
+      } else {
+        TableSection.getSyncOptionsButton().click();
+        H.modal().button("Sync table schema").click();
+      }
       verifyAndCloseToast("Failed to start sync");
 
-      cy.log("scan");
-      H.modal().button("Re-scan table").click();
+      if (area === "data studio") {
+        TableSection.getActionsMenuButton().click();
+        H.popover().findByText("Re-scan field values").click();
+      } else {
+        H.modal().button("Re-scan table").click();
+      }
       verifyAndCloseToast("Failed to start scan");
 
-      cy.log("discard field values");
-      H.modal().button("Discard cached field values").click();
+      if (area === "data studio") {
+        TableSection.getActionsMenuButton().click();
+        H.popover().findByText("Discard cached field values").click();
+      } else {
+        H.modal().button("Discard cached field values").click();
+      }
+
       verifyAndCloseToast("Failed to discard values");
-      cy.realPress("Escape");
+      if (area === "admin") {
+        cy.realPress("Escape");
+      }
 
       if (area === "data studio") {
         TableSection.clickFieldsTab();

--- a/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
@@ -12,7 +12,7 @@ const { TablePicker, TableSection, FieldSection, PreviewSection, Shared } =
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 const { visitArea } = Shared;
 
-const areas: ("admin" | "data studio")[] = [/*"admin",*/ "data studio"];
+const areas: ("admin" | "data studio")[] = ["admin", "data studio"];
 type Area = (typeof areas)[number];
 
 describe.each<Area>(areas)("data model > %s", (area: Area) => {

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -983,43 +983,40 @@ describe("scenarios > data studio > datamodel", () => {
     });
 
     describe("Sync options", () => {
-      it("should allow to sync table schema, re-scan table, and discard cached field values", () => {
+      it("should allow to sync table schema, re-scan field values, and discard cached field values from the actions menu", () => {
+        cy.intercept("POST", "/api/data-studio/table/sync-schema").as(
+          "syncSchema",
+        );
+        cy.intercept("POST", "/api/data-studio/table/rescan-values").as(
+          "rescanValues",
+        );
+        cy.intercept("POST", "/api/data-studio/table/discard-values").as(
+          "discardValues",
+        );
+
         H.DataModel.visitDataStudio({
           databaseId: SAMPLE_DB_ID,
           schemaId: SAMPLE_DB_SCHEMA_ID,
           tableId: PRODUCTS_ID,
         });
-        TableSection.getSyncOptionsButton().click();
 
-        cy.log("sync table schema");
-        H.modal().within(() => {
-          cy.button("Sync table schema").click();
-          cy.button("Sync table schema").should("not.exist");
-          cy.button("Sync triggered!").should("be.visible");
-          cy.button("Sync triggered!").should("not.exist");
-          cy.button("Sync table schema").should("be.visible");
-        });
+        cy.log("re-sync schema");
+        TableSection.getActionsMenuButton().click();
+        H.menu().findByText("Re-sync schema").click();
+        cy.wait("@syncSchema");
+        verifyAndCloseToast("Sync triggered");
 
-        cy.log("re-scan table");
-        H.modal().within(() => {
-          cy.button("Re-scan table").click();
-          cy.button("Re-scan table").should("not.exist");
-          cy.button("Scan triggered!").should("be.visible");
-          cy.button("Scan triggered!").should("not.exist");
-          cy.button("Re-scan table").should("be.visible");
-        });
+        cy.log("re-scan field values");
+        TableSection.getActionsMenuButton().click();
+        H.menu().findByText("Re-scan field values").click();
+        cy.wait("@rescanValues");
+        verifyAndCloseToast("Scan triggered");
 
         cy.log("discard cached field values");
-        H.modal().within(() => {
-          cy.button("Discard cached field values").click();
-          cy.button("Discard cached field values").should("not.exist");
-          cy.button("Discard triggered!").should("be.visible");
-          cy.button("Discard triggered!").should("not.exist");
-          cy.button("Discard cached field values").should("be.visible");
-        });
-
-        cy.realPress("Escape");
-        H.modal().should("not.exist");
+        TableSection.getActionsMenuButton().click();
+        H.menu().findByText("Discard cached field values").click();
+        cy.wait("@discardValues");
+        verifyAndCloseToast("Discard triggered");
       });
     });
   });

--- a/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
@@ -827,6 +827,7 @@ function openReplacementModal(sourceTableLabel: string) {
   H.DataModel.TablePicker.getTable(sourceTableLabel).click();
   H.DataModel.TableSection.get().should("be.visible");
 
+  H.DataModel.TableSection.getActionsMenuButton().click();
   SourceReplacement.getFindAndReplaceButton().click();
   SourceReplacement.getModal()
     .findByText("Find and replace a data source")

--- a/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
+++ b/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
@@ -505,9 +505,10 @@ describe("scenarios > schema-viewer (entry points + loader/error states)", () =>
     cy.findAllByTestId("tree-item").contains("Orders").click();
 
     cy.log(
-      "Click the 'Schema viewer' button in the Orders table section — opens with Orders as focal",
+      "Click the 'Schema viewer' action in the Orders table section — opens with Orders as focal",
     );
-    cy.findByTestId("table-section").findByLabelText("Schema viewer").click();
+    H.DataModel.TableSection.getActionsMenuButton().click();
+    H.menu().findByText("Schema viewer").click();
     cy.wait("@erd");
     cy.url()
       .should("include", "/data-studio/schema-viewer")

--- a/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
+++ b/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
@@ -505,10 +505,10 @@ describe("scenarios > schema-viewer (entry points + loader/error states)", () =>
     cy.findAllByTestId("tree-item").contains("Orders").click();
 
     cy.log(
-      "Click the 'Schema viewer' action in the Orders table section — opens with Orders as focal",
+      "Click the 'View Schema' action in the Orders table section — opens with Orders as focal",
     );
     H.DataModel.TableSection.getActionsMenuButton().click();
-    H.menu().findByText("Schema viewer").click();
+    H.menu().findByText("View Schema").click();
     cy.wait("@erd");
     cy.url()
       .should("include", "/data-studio/schema-viewer")

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -290,24 +290,6 @@ const TableSectionBase = ({
                   </Tooltip>
                 )}
 
-                <Tooltip label={t`Schema viewer`}>
-                  <Button
-                    component={ForwardRefLink}
-                    to={Urls.dataStudioSchemaViewer({
-                      databaseId: table.db_id,
-                      schema: table.schema,
-                      tableIds: [table.id],
-                    })}
-                    p="sm"
-                    leftSection={<Icon name="network" />}
-                    style={{
-                      flexGrow: 0,
-                      width: 40,
-                    }}
-                    aria-label={t`Schema viewer`}
-                  />
-                </Tooltip>
-
                 <Box style={{ flexGrow: 0, width: 40 }}>
                   <TableLink table={table} />
                 </Box>

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -22,7 +22,6 @@ import {
   PLUGIN_DEPENDENCIES,
   PLUGIN_LIBRARY,
   PLUGIN_REMOTE_SYNC,
-  PLUGIN_REPLACEMENT,
 } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import {
@@ -48,6 +47,7 @@ import {
 import S from "./TableSection.module.css";
 import { MeasureList } from "./components/MeasureList";
 import { SegmentList } from "./components/SegmentList";
+import { TableActionsMenu } from "./components/TableActionsMenu";
 import { TableAttributesEditSingle } from "./components/TableAttributesEditSingle";
 import { TableCollection } from "./components/TableCollection";
 import { TableMetadata } from "./components/TableMetadata";
@@ -59,11 +59,10 @@ interface Props {
   activeTab: DataStudioTableMetadataTab;
   canPublish: boolean;
   hasLibrary: boolean;
-  onSyncOptionsClick: () => void;
   onUpdate: () => void;
 }
 
-type TableModalType = "library" | "publish" | "unpublish" | "replace";
+type TableModalType = "library" | "publish" | "unpublish";
 
 const TableSectionBase = ({
   table,
@@ -71,7 +70,6 @@ const TableSectionBase = ({
   activeTab,
   canPublish,
   hasLibrary,
-  onSyncOptionsClick,
   onUpdate,
 }: Props) => {
   const [updateTable] = useUpdateTableMutation();
@@ -236,22 +234,10 @@ const TableSectionBase = ({
       <Box>
         <Tabs value={activeTab} onChange={handleTabChange}>
           <Tabs.List mb="md">
-            <Tabs.Tab
-              value="details"
-              leftSection={<Icon name="info" />}
-            >{t`Details`}</Tabs.Tab>
-            <Tabs.Tab
-              value="field"
-              leftSection={<Icon name="list" />}
-            >{t`Fields`}</Tabs.Tab>
-            <Tabs.Tab
-              value="segments"
-              leftSection={<Icon name="segment" />}
-            >{t`Segments`}</Tabs.Tab>
-            <Tabs.Tab
-              value="measures"
-              leftSection={<Icon name="ruler" />}
-            >{t`Measures`}</Tabs.Tab>
+            <Tabs.Tab value="details">{t`Details`}</Tabs.Tab>
+            <Tabs.Tab value="field">{t`Fields`}</Tabs.Tab>
+            <Tabs.Tab value="segments">{t`Segments`}</Tabs.Tab>
+            <Tabs.Tab value="measures">{t`Measures`}</Tabs.Tab>
           </Tabs.List>
 
           <Tabs.Panel value="details">
@@ -273,7 +259,8 @@ const TableSectionBase = ({
                 {canPublish && isLibraryEnabled && !remoteSyncReadOnly && (
                   <Button
                     flex="1"
-                    p="sm"
+                    size="md"
+                    variant={table.is_published ? "default" : "filled"}
                     leftSection={
                       <Icon
                         name={table.is_published ? "unpublish" : "publish"}
@@ -284,30 +271,7 @@ const TableSectionBase = ({
                     {table.is_published ? t`Unpublish` : t`Publish`}
                   </Button>
                 )}
-                {!table.db?.is_attached_dwh && (
-                  <Button
-                    flex="1"
-                    leftSection={<Icon name="settings" />}
-                    onClick={onSyncOptionsClick}
-                  >
-                    {t`Sync settings`}
-                  </Button>
-                )}
-                <PLUGIN_REPLACEMENT.SourceReplacementButton>
-                  {({ tooltip, isDisabled }) => (
-                    <Tooltip label={tooltip ?? t`Find and replace`}>
-                      <Button
-                        p="sm"
-                        w="2.5rem"
-                        flex="0 1 auto"
-                        leftSection={<Icon name="find_replace" />}
-                        aria-label={t`Find and replace`}
-                        disabled={isDisabled}
-                        onClick={() => setModalType("replace")}
-                      />
-                    </Tooltip>
-                  )}
-                </PLUGIN_REPLACEMENT.SourceReplacementButton>
+
                 {isDependencyGraphEnabled && (
                   <Tooltip label={t`Dependency graph`}>
                     <Button
@@ -347,6 +311,7 @@ const TableSectionBase = ({
                 <Box style={{ flexGrow: 0, width: 40 }}>
                   <TableLink table={table} />
                 </Box>
+                <TableActionsMenu table={table} />
               </Group>
 
               <TableAttributesEditSingle table={table} onUpdate={onUpdate} />
@@ -457,12 +422,6 @@ const TableSectionBase = ({
         isOpened={modalType === "unpublish"}
         tableIds={[table.id]}
         onUnpublish={handleSuccessCloseModal}
-        onClose={handleCloseModal}
-      />
-      <PLUGIN_REPLACEMENT.SourceReplacementModal
-        opened={modalType === "replace"}
-        initialSource={{ id: Number(table.id), type: "table" }}
-        triggeredFrom="table_list"
         onClose={handleCloseModal}
       />
     </Stack>

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import {
+  useDiscardTablesFieldValuesMutation,
+  useRescanTablesFieldValuesMutation,
+  useSyncTablesSchemasMutation,
+} from "metabase/api";
+import {
+  trackDataStudioTableFieldValuesDiscardStarted,
+  trackDataStudioTableFieldsRescanStarted,
+  trackDataStudioTableSchemaSyncStarted,
+} from "metabase/data-studio/analytics";
+import { useMetadataToasts } from "metabase/metadata/hooks";
+import { PLUGIN_REPLACEMENT } from "metabase/plugins";
+import { useSelector } from "metabase/redux";
+import { Button, Icon, Menu } from "metabase/ui";
+import type { Table } from "metabase-types/api";
+
+interface Props {
+  table: Table;
+}
+
+export function TableActionsMenu({ table }: Props) {
+  const [isReplaceOpen, setIsReplaceOpen] = useState(false);
+  const [syncTablesSchemas] = useSyncTablesSchemasMutation();
+  const [rescanTablesFieldValues] = useRescanTablesFieldValuesMutation();
+  const [discardTablesFieldValues] = useDiscardTablesFieldValuesMutation();
+  const { sendErrorToast, sendSuccessToast } = useMetadataToasts();
+  const canReplaceSources = useSelector(PLUGIN_REPLACEMENT.canReplaceSources);
+
+  const tableIds = [table.id];
+  const showSyncItems = !table.db?.is_attached_dwh;
+
+  // Don't render an empty menu when there's nothing to show.
+  if (!showSyncItems && !canReplaceSources) {
+    return null;
+  }
+
+  const handleSyncSchema = async () => {
+    const { error } = await syncTablesSchemas({ table_ids: tableIds });
+    if (error) {
+      sendErrorToast(t`Failed to start sync`);
+      trackDataStudioTableSchemaSyncStarted("failure");
+    } else {
+      sendSuccessToast(t`Sync triggered`);
+      trackDataStudioTableSchemaSyncStarted("success");
+    }
+  };
+
+  const handleRescan = async () => {
+    const { error } = await rescanTablesFieldValues({ table_ids: tableIds });
+    if (error) {
+      sendErrorToast(t`Failed to start scan`);
+      trackDataStudioTableFieldsRescanStarted("failure");
+    } else {
+      sendSuccessToast(t`Scan triggered`);
+      trackDataStudioTableFieldsRescanStarted("success");
+    }
+  };
+
+  const handleDiscard = async () => {
+    const { error } = await discardTablesFieldValues({ table_ids: tableIds });
+    if (error) {
+      sendErrorToast(t`Failed to discard values`);
+      trackDataStudioTableFieldValuesDiscardStarted("failure");
+    } else {
+      sendSuccessToast(t`Discard triggered`);
+      trackDataStudioTableFieldValuesDiscardStarted("success");
+    }
+  };
+
+  return (
+    <>
+      <Menu>
+        <Menu.Target>
+          <Button
+            aria-label={t`More actions`}
+            size="md"
+            leftSection={<Icon name="ellipsis" size={16} />}
+          />
+        </Menu.Target>
+        <Menu.Dropdown>
+          <PLUGIN_REPLACEMENT.SourceReplacementButton>
+            {({ isDisabled }) => (
+              <Menu.Item
+                leftSection={<Icon name="find_replace" />}
+                disabled={isDisabled}
+                onClick={() => setIsReplaceOpen(true)}
+              >
+                {t`Find and replace`}
+              </Menu.Item>
+            )}
+          </PLUGIN_REPLACEMENT.SourceReplacementButton>
+          {showSyncItems && (
+            <>
+              <Menu.Item
+                leftSection={<Icon name="sync" />}
+                onClick={handleSyncSchema}
+              >
+                {t`Re-sync schema`}
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<Icon name="list" />}
+                onClick={handleRescan}
+              >
+                {t`Re-scan field values`}
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<Icon name="trash" />}
+                onClick={handleDiscard}
+              >
+                {t`Discard cached field values`}
+              </Menu.Item>
+            </>
+          )}
+        </Menu.Dropdown>
+      </Menu>
+      <PLUGIN_REPLACEMENT.SourceReplacementModal
+        opened={isReplaceOpen}
+        initialSource={{ id: Number(table.id), type: "table" }}
+        triggeredFrom="table_list"
+        onClose={() => setIsReplaceOpen(false)}
+      />
+    </>
+  );
+}

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
@@ -29,10 +29,15 @@ export function TableActionsMenu({ table }: Props) {
   const [rescanTablesFieldValues] = useRescanTablesFieldValuesMutation();
   const [discardTablesFieldValues] = useDiscardTablesFieldValuesMutation();
   const { sendErrorToast, sendSuccessToast } = useMetadataToasts();
-  const canReplaceSources = useSelector(PLUGIN_REPLACEMENT.canReplaceSources);
 
   const tableIds = [table.id];
   const showSyncItems = !table.db?.is_attached_dwh;
+  const showReplaceItem = useSelector(PLUGIN_REPLACEMENT.canReplaceSources);
+  const schemaViewerUrl = Urls.dataStudioSchemaViewer({
+    databaseId: table.db_id,
+    schema: table.schema,
+    tableIds,
+  });
 
   const handleSyncSchema = async () => {
     const { error } = await syncTablesSchemas({ table_ids: tableIds });
@@ -67,6 +72,21 @@ export function TableActionsMenu({ table }: Props) {
     }
   };
 
+  // Without sync actions and find-and-replace, the menu would hold only
+  // "View Schema", so render it directly as a button instead of a single-item menu.
+  if (!showSyncItems && !showReplaceItem) {
+    return (
+      <Button
+        component={ForwardRefLink}
+        to={schemaViewerUrl}
+        size="md"
+        leftSection={<Icon name="network" size={16} />}
+      >
+        {t`View Schema`}
+      </Button>
+    );
+  }
+
   return (
     <>
       <Menu>
@@ -80,27 +100,12 @@ export function TableActionsMenu({ table }: Props) {
         <Menu.Dropdown>
           <Menu.Item
             component={ForwardRefLink}
-            to={Urls.dataStudioSchemaViewer({
-              databaseId: table.db_id,
-              schema: table.schema,
-              tableIds,
-            })}
+            to={schemaViewerUrl}
             leftSection={<Icon name="network" />}
           >
-            {t`Schema viewer`}
+            {t`View Schema`}
           </Menu.Item>
-          {(canReplaceSources || showSyncItems) && <Menu.Divider />}
-          <PLUGIN_REPLACEMENT.SourceReplacementButton>
-            {({ isDisabled }) => (
-              <Menu.Item
-                leftSection={<Icon name="find_replace" />}
-                disabled={isDisabled}
-                onClick={() => setIsReplaceOpen(true)}
-              >
-                {t`Find and replace`}
-              </Menu.Item>
-            )}
-          </PLUGIN_REPLACEMENT.SourceReplacementButton>
+
           {showSyncItems && (
             <>
               <Menu.Item
@@ -123,6 +128,17 @@ export function TableActionsMenu({ table }: Props) {
               </Menu.Item>
             </>
           )}
+          <PLUGIN_REPLACEMENT.SourceReplacementButton>
+            {({ isDisabled }) => (
+              <Menu.Item
+                leftSection={<Icon name="find_replace" />}
+                disabled={isDisabled}
+                onClick={() => setIsReplaceOpen(true)}
+              >
+                {t`Find and replace`}
+              </Menu.Item>
+            )}
+          </PLUGIN_REPLACEMENT.SourceReplacementButton>
         </Menu.Dropdown>
       </Menu>
       <PLUGIN_REPLACEMENT.SourceReplacementModal

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
@@ -6,6 +6,7 @@ import {
   useRescanTablesFieldValuesMutation,
   useSyncTablesSchemasMutation,
 } from "metabase/api";
+import { ForwardRefLink } from "metabase/common/components/Link";
 import {
   trackDataStudioTableFieldValuesDiscardStarted,
   trackDataStudioTableFieldsRescanStarted,
@@ -15,6 +16,7 @@ import { useMetadataToasts } from "metabase/metadata/hooks";
 import { PLUGIN_REPLACEMENT } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { Button, Icon, Menu } from "metabase/ui";
+import * as Urls from "metabase/urls";
 import type { Table } from "metabase-types/api";
 
 interface Props {
@@ -31,11 +33,6 @@ export function TableActionsMenu({ table }: Props) {
 
   const tableIds = [table.id];
   const showSyncItems = !table.db?.is_attached_dwh;
-
-  // Don't render an empty menu when there's nothing to show.
-  if (!showSyncItems && !canReplaceSources) {
-    return null;
-  }
 
   const handleSyncSchema = async () => {
     const { error } = await syncTablesSchemas({ table_ids: tableIds });
@@ -81,6 +78,18 @@ export function TableActionsMenu({ table }: Props) {
           />
         </Menu.Target>
         <Menu.Dropdown>
+          <Menu.Item
+            component={ForwardRefLink}
+            to={Urls.dataStudioSchemaViewer({
+              databaseId: table.db_id,
+              schema: table.schema,
+              tableIds,
+            })}
+            leftSection={<Icon name="network" />}
+          >
+            {t`Schema viewer`}
+          </Menu.Item>
+          {(canReplaceSources || showSyncItems) && <Menu.Divider />}
           <PLUGIN_REPLACEMENT.SourceReplacementButton>
             {({ isDisabled }) => (
               <Menu.Item

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.unit.spec.tsx
@@ -1,0 +1,111 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupListSourceReplacementRunsEndpoint } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { Table } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockTable,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { TableActionsMenu } from "./TableActionsMenu";
+
+interface SetupOpts {
+  table: Table;
+  isAdmin?: boolean;
+}
+
+function setup({ table, isAdmin = false }: SetupOpts) {
+  setupListSourceReplacementRunsEndpoint([]);
+
+  const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures({ dependencies: true }),
+    }),
+  });
+
+  // The find-and-replace action comes from the replacement EE plugin, which
+  // gates `canReplaceSources` on whether the current user is an admin.
+  setupEnterprisePlugins();
+
+  renderWithProviders(
+    <Route path="/" component={() => <TableActionsMenu table={table} />} />,
+    { storeInitialState: state, withRouter: true },
+  );
+}
+
+describe("TableActionsMenu", () => {
+  it("renders a menu with sync items for a regular table", async () => {
+    setup({ table: createMockTable({ db: createMockDatabase() }) });
+
+    // it's a menu, not a standalone link
+    expect(
+      screen.queryByRole("link", { name: /View Schema/ }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /View Schema/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Re-sync schema/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Re-scan field values/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Discard cached field values/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a standalone View Schema button when there are no other actions", () => {
+    // attached DWH => no sync items, and a non-admin can't replace sources
+    setup({
+      table: createMockTable({
+        db: createMockDatabase({ is_attached_dwh: true }),
+      }),
+    });
+
+    expect(
+      screen.getByRole("link", { name: /View Schema/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "More actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the menu when an admin can replace sources even without sync items", async () => {
+    // attached DWH => no sync items, but an admin can use find-and-replace
+    setup({
+      table: createMockTable({
+        db: createMockDatabase({ is_attached_dwh: true }),
+      }),
+      isAdmin: true,
+    });
+
+    // the selector keeps it a menu rather than collapsing to a button
+    expect(
+      screen.queryByRole("link", { name: /View Schema/ }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /View Schema/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Find and replace/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /Re-sync schema/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/index.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/index.ts
@@ -1,0 +1,1 @@
+export { TableActionsMenu } from "./TableActionsMenu";

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
@@ -1,4 +1,7 @@
-import { screen } from "__support__/ui";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { screen, waitFor } from "__support__/ui";
 import {
   createMockDatabase,
   createMockSegment,
@@ -20,12 +23,56 @@ describe("TableSection", () => {
     );
   });
 
-  it("should not render sync settings button when the database is datawarehouse attached", () => {
-    setup({
-      database: createMockDatabase({ is_attached_dwh: true }),
+  describe("actions menu", () => {
+    it("should expose the sync actions in the actions menu", async () => {
+      setup();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "More actions" }),
+      );
+
+      expect(
+        await screen.findByRole("menuitem", { name: /Re-sync schema/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: /Re-scan field values/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: /Discard cached field values/ }),
+      ).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Sync settings")).not.toBeInTheDocument();
+    it("should trigger a field values rescan from the actions menu", async () => {
+      const table = createMockTable();
+      setup({ table });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "More actions" }),
+      );
+      await userEvent.click(
+        await screen.findByRole("menuitem", { name: /Re-scan field values/ }),
+      );
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.calls(
+            "path:/api/data-studio/table/rescan-values",
+            { method: "POST" },
+          ),
+        ).toHaveLength(1);
+      });
+    });
+
+    it("should not expose sync actions when the database is datawarehouse attached", () => {
+      setup({
+        database: createMockDatabase({ is_attached_dwh: true }),
+      });
+
+      // No sync items and (for a non-admin) no replace item, so the menu is hidden entirely.
+      expect(
+        screen.queryByRole("button", { name: "More actions" }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("tabs", () => {

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
@@ -63,14 +63,36 @@ describe("TableSection", () => {
       });
     });
 
-    it("should not expose sync actions when the database is datawarehouse attached", () => {
+    it("should expose the schema viewer in the actions menu", async () => {
+      setup();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "More actions" }),
+      );
+
+      expect(
+        await screen.findByRole("menuitem", { name: /Schema viewer/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not expose sync actions when the database is datawarehouse attached", async () => {
       setup({
         database: createMockDatabase({ is_attached_dwh: true }),
       });
 
-      // No sync items and (for a non-admin) no replace item, so the menu is hidden entirely.
+      await userEvent.click(
+        screen.getByRole("button", { name: "More actions" }),
+      );
+
+      // Schema viewer is always available, but the sync actions are not.
       expect(
-        screen.queryByRole("button", { name: "More actions" }),
+        await screen.findByRole("menuitem", { name: /Schema viewer/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Re-sync schema/ }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Re-scan field values/ }),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
@@ -71,28 +71,22 @@ describe("TableSection", () => {
       );
 
       expect(
-        await screen.findByRole("menuitem", { name: /Schema viewer/ }),
+        await screen.findByRole("menuitem", { name: /View Schema/ }),
       ).toBeInTheDocument();
     });
 
-    it("should not expose sync actions when the database is datawarehouse attached", async () => {
+    it("should not expose sync actions when the database is datawarehouse attached", () => {
       setup({
         database: createMockDatabase({ is_attached_dwh: true }),
       });
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "More actions" }),
-      );
-
-      // Schema viewer is always available, but the sync actions are not.
+      // With no sync actions and no source replacement, the menu collapses to a
+      // standalone schema viewer link rather than a "More actions" menu.
       expect(
-        await screen.findByRole("menuitem", { name: /Schema viewer/ }),
+        screen.getByRole("link", { name: /View Schema/ }),
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("menuitem", { name: /Re-sync schema/ }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: /Re-scan field values/ }),
+        screen.queryByRole("button", { name: "More actions" }),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
@@ -1,3 +1,4 @@
+import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
@@ -50,7 +51,6 @@ export function setup({
   enterprisePlugins,
   tokenFeatures,
 }: SetupOpts = {}) {
-  const onSyncOptionsClick = jest.fn();
   const tableWithSegments = segments ? { ...table, segments } : table;
 
   const settings = mockSettings({
@@ -76,6 +76,9 @@ export function setup({
     key: "seen-publish-tables-info",
     value: true,
   });
+  fetchMock.post("path:/api/data-studio/table/sync-schema", {});
+  fetchMock.post("path:/api/data-studio/table/rescan-values", {});
+  fetchMock.post("path:/api/data-studio/table/discard-values", {});
 
   renderWithProviders(
     <Route
@@ -86,7 +89,6 @@ export function setup({
           activeTab={activeTab}
           hasLibrary
           canPublish
-          onSyncOptionsClick={onSyncOptionsClick}
           onUpdate={jest.fn()}
         />
       )}
@@ -96,6 +98,4 @@ export function setup({
       storeInitialState: state,
     },
   );
-
-  return { onSyncOptionsClick };
 }

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -38,11 +38,7 @@ import {
 import * as Urls from "metabase/urls";
 
 import { trackMetadataChange } from "../../analytics";
-import {
-  RouterTablePicker,
-  SyncOptionsModal,
-  TableSection,
-} from "../../components";
+import { RouterTablePicker, TableSection } from "../../components";
 import type { TreePath } from "../../components/TablePicker/types";
 import { TableAttributesEditBulk } from "../../components/TableSection/components/TableAttributesEditBulk";
 
@@ -91,8 +87,6 @@ function DataModelContent({ params }: Props) {
   );
   const [isPreviewOpen, { close: closePreview, toggle: togglePreview }] =
     useDisclosure();
-  const [isSyncModalOpen, { close: closeSyncModal, open: openSyncModal }] =
-    useDisclosure();
   const [
     isFieldValuesModalOpen,
     { close: closeFieldValuesModal, open: openFieldValuesModal },
@@ -139,7 +133,7 @@ function DataModelContent({ params }: Props) {
         activeElement instanceof HTMLElement &&
         (["INPUT", "TEXTAREA", "SELECT"].includes(activeElement.tagName) ||
           activeElement.isContentEditable);
-      const isModalOpen = isSyncModalOpen || isFieldValuesModalOpen;
+      const isModalOpen = isFieldValuesModalOpen;
 
       if (event.key === "Escape" && !isInputFocused && !isModalOpen) {
         event.stopPropagation();
@@ -287,7 +281,6 @@ function DataModelContent({ params }: Props) {
                     activeTab={activeTab}
                     canPublish={canPublish}
                     hasLibrary={hasLibrary}
-                    onSyncOptionsClick={openSyncModal}
                     onUpdate={() =>
                       onUpdateCallback?.({
                         databaseId: table.db_id,
@@ -388,14 +381,6 @@ function DataModelContent({ params }: Props) {
           </Box>
         )}
       </>
-
-      {table && (
-        <SyncOptionsModal
-          isOpen={isSyncModalOpen}
-          tableIds={[table.id]}
-          onClose={closeSyncModal}
-        />
-      )}
 
       {fieldId && (
         <FieldValuesModal

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -736,10 +736,10 @@ describe("DataModel", () => {
       );
       await waitForLoaderToBeRemoved();
       await userEvent.click(
-        screen.getByRole("button", { name: /Sync settings/ }),
+        screen.getByRole("button", { name: "More actions" }),
       );
       await userEvent.click(
-        screen.getByRole("button", { name: "Re-scan table" }),
+        await screen.findByRole("menuitem", { name: /Re-scan field values/ }),
       );
 
       const calls = fetchMock.callHistory.calls(
@@ -767,11 +767,11 @@ describe("DataModel", () => {
       );
       await waitForLoaderToBeRemoved();
       await userEvent.click(
-        screen.getByRole("button", { name: /Sync settings/ }),
+        screen.getByRole("button", { name: "More actions" }),
       );
       await userEvent.click(
-        screen.getByRole("button", {
-          name: "Discard cached field values",
+        await screen.findByRole("menuitem", {
+          name: /Discard cached field values/,
         }),
       );
       const calls = fetchMock.callHistory.calls(


### PR DESCRIPTION
### Description

Small PR to shuffle some action items around. Introduces a menu to the Data Model Table Section in the Data Studio, where Sync actions, find and replace, and the schema viewer live. Removes the modal for sync actions and the icons in the tab picker as well

### How to verify

1. Open the data studio, ensure you're on the tables page
2. Select a table
3. You should see there are more icons next to Details/Field/Segmets/Measures tabs
4. There should also be an action menu replacing some of the previous actions, and the publish / unpublish buttons should be much larger

### Demo

<img width="551" height="579" alt="image" src="https://github.com/user-attachments/assets/9f7ca66e-d7ab-448b-ad6a-57d4ee003c57" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
