### PR TITLE
Override driver type in certain cases

### DIFF
--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -295,3 +295,22 @@
                     (lib/query mp)
                     (qp/process-query)
                     (mt/rows))))))))
+
+(deftest ^:parallel date-bucketed-breakout-preserves-temporal-type-test
+  (testing (str "SQLite has no date type: a :month-bucketed breakout compiles to date()/strftime() whose JDBC "
+                "type is reported as TEXT. The returned column must still be typed temporally, not :type/Text, so "
+                "that date drills, date filters, and date dimension mapping are offered (GHY-3790).")
+    (mt/test-driver :sqlite
+      (let [mp       (mt/metadata-provider)
+            date-col (lib.metadata/field mp (mt/id :checkins :date))
+            query    (-> (lib/query mp (lib.metadata/table mp (mt/id :checkins)))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-temporal-bucket date-col :month)))
+            col      (-> (qp/process-query query) mt/cols first)]
+        (testing "driver reports a non-temporal JDBC storage type for the truncation output"
+          (is (= "TEXT" (:database_type col))))
+        (testing "but the column carries a temporal unit"
+          (is (= :month (:unit col))))
+        (testing "so its base/effective type stays temporal (Lib's type wins over the storage affinity)"
+          (is (isa? (:base_type col) :type/Temporal))
+          (is (isa? (:effective_type col) :type/Temporal)))))))

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -70,23 +70,36 @@
   from the driver to values calculated by Lib."
   [driver-col :- [:maybe ::col]
    lib-col    :- [:maybe ::col]]
-  (let [driver-col (update-keys driver-col u/->kebab-case-en)]
+  (let [type-overrides   [;; A driver may report a non-temporal type (e.g. SQLite's TEXT affinity) for a column Lib knows
+                          ;; is temporal, such as a date-bucketed breakout. The driver type is a storage-affinity
+                          ;; artifact, not the semantic type, so trust Lib's (concrete) type. Mirrors coercion, which
+                          ;; already maps a `:type/Text` storage type to a `:type/Date` effective type.
+                          [:type/Temporal :type/Text]]
+        driver-col       (update-keys driver-col u/->kebab-case-en)
+        driver-base-type (:base-type driver-col)
+        lib-base-type    (:base-type lib-col)
+        override?        (and lib-base-type driver-base-type
+                              (some (fn [[lib-t drv-t]]
+                                      (and (isa? lib-base-type lib-t)
+                                           (isa? driver-base-type drv-t)))
+                                    type-overrides))]
     (merge lib-col
            (m/filter-vals some? driver-col)
-           ;; Prefer our inferred base type if the driver returned `:type/*` and ours is more specific
-           (when (#{nil :type/*} (:base-type driver-col))
-             (when-let [lib-base-type (:base-type lib-col)]
+           ;; Prefer our inferred base type if the driver returned `:type/*` and ours is more specific, or if Lib's type
+           ;; is more authoritative than the driver's storage type (see `type-overrides`)
+           (when (or override? (#{nil :type/*} driver-base-type))
+             (when lib-base-type
                {:base-type lib-base-type}))
            ;; Prefer our `:name` if it's something different that what's returned by the driver (e.g. for named
            ;; aggregations). Same for `:lib/source`
            (u/select-non-nil-keys lib-col [:name :lib/source])
            ;; whatever type comes back from the query is by definition the effective type, otherwise fall back to the
            ;; type calculated by Lib
-           {:effective-type (or (when-let [driver-base-type (:base-type driver-col)]
-                                  (when-not (= driver-base-type :type/*)
-                                    driver-base-type))
+           {:effective-type (or (when override? lib-base-type)
+                                (when (and driver-base-type (not= driver-base-type :type/*))
+                                  driver-base-type)
                                 (:effective-type lib-col)
-                                (:base-type lib-col)
+                                lib-base-type
                                 :type/*)})))
 
 (mu/defn- merge-cols :- [:sequential ::kebab-cased-map]

--- a/test/metabase/query_processor/cast_test.clj
+++ b/test/metabase/query_processor/cast_test.clj
@@ -526,7 +526,7 @@
 
 (defmethod date-type-expected :sqlite
   [_]
-  :type/Text)
+  :type/Date)
 
 (defmethod date-type-expected :mongo
   [_]


### PR DESCRIPTION
Closes [GHY-3790: Make SQLite temporal-bucketing aggregate carry date type info](https://linear.app/metabase/issue/GHY-3790/make-sqlite-temporal-bucketing-aggregate-carry-date-type-info)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
