### PR TITLE
Fix boundaries/ignore glob so nested stories are exempt

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -293,7 +293,7 @@ const configs = [
       "boundaries/ignore": [
         "**/*.unit.spec.*",
         "**/e2e/**",
-        "*.stories.*",
+        "**/*.stories.*",
         "test/**",
       ],
     },


### PR DESCRIPTION
## Problem

CI `lint-eslint-pure` is failing on `master` (and therefore every open PR) with ~11 errors like:

```
shared/common cannot import from app/misc      boundaries/element-types
feature/public cannot import from app/misc     boundaries/element-types
```

all in nested `*.stories.tsx` files that import `metabase/reducers-public` to build a Redux store for the story.

## Cause

The `boundaries/element-types` rule already intends to exempt Storybook files — `boundaries/ignore` lists `*.stories.*`. But unlike the sibling `**/*.unit.spec.*` and `**/e2e/**` entries, that pattern has no `**/` prefix, and the `boundaries/ignore` setting micromatches the **full path**, so it only matches stories at the repo root. Nested stories were never actually exempt.

This stayed invisible until #75073 reclassified entry-point composition files (`reducers-public.ts`, `reducers-main.ts`, …) into the `app` tier. Stories that import `reducers-public` then became `shared|feature → app/misc` violations.

## Fix

`"*.stories.*"` → `"**/*.stories.*"` in the `boundaries/ignore` list, matching the convention of the other patterns and the intent that stories (non-production code) are exempt from boundary checks. One line; unblocks the lint on master and all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)