### PR TITLE
Fix stories boundary-ignore glob in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -293,7 +293,7 @@ const configs = [
       "boundaries/ignore": [
         "**/*.unit.spec.*",
         "**/e2e/**",
-        "*.stories.*",
+        "**/*.stories.*",
         "test/**",
       ],
     },


### PR DESCRIPTION
#75073 reclassified reducers-common.ts to app/misc. Stories that import it (to set up the redux store) became shared/feature → app/misc boundary violations.

This PR fixes the ignore glob for stories.