### PR TITLE
Lazy load `echarts` module

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,6 +14,13 @@ require("metabase/css/core/index.css");
 require("metabase/css/index.module.css");
 require("metabase/utils/dayjs");
 
+// EChartsRenderer is loaded as an on-demand chunk in the app (see
+// EChartsRenderer/lazy.ts). Force it into the Storybook bundle so chart stories
+// render echarts synchronously and visual snapshots are deterministic (no
+// lazy-chunk skeleton flash). The dynamic `import()` then resolves from the
+// already-loaded module.
+require("metabase/visualizations/components/EChartsRenderer/EChartsRenderer");
+
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-specific-imports.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-specific-imports.ts
@@ -30,3 +30,13 @@ import "metabase/visualizations/visualizations/Map/MapRenderer";
 // main app. The SDK bundle can't fetch on-demand chunks at runtime, so force the
 // pivot table module to be included eagerly here.
 import "metabase/visualizations/visualizations/PivotTable/PivotTableInner";
+
+/**
+ * EChartsRenderer (and all of echarts) is loaded as an on-demand chunk in the
+ * main app (see EChartsRenderer/lazy.ts) to keep echarts out of the initial
+ * bundle. The SDK loads its code eagerly via a build-time manifest and can't
+ * fetch on-demand chunks in a host app (they'd fail with a ChunkLoadError), so
+ * we force EChartsRenderer into the bundle here. The dynamic `import()` then
+ * resolves from the already-loaded module instead of fetching a chunk.
+ */
+import "metabase/visualizations/components/EChartsRenderer/EChartsRenderer";

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
@@ -1,10 +1,24 @@
-import { forwardRef, useLayoutEffect } from "react";
+import { Suspense, forwardRef, lazy, useLayoutEffect } from "react";
 
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
+import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
 import { isNumber } from "metabase/utils/types";
 import type { EChartsRendererProps } from "metabase/visualizations/components/EChartsRenderer/EChartsRenderer";
-import { EChartsRenderer } from "metabase/visualizations/components/EChartsRenderer/EChartsRenderer";
 import { ResponsiveEChartsRendererStyled } from "metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.styled";
+
+// echarts (its chart classes, components, the core SVG renderer and zrender) is
+// the single largest dependency in the app bundle. Loading EChartsRenderer
+// lazily moves all of it into its own async chunk so it is not part of the
+// initial page load. `webpackPrefetch` lets the browser warm that chunk during
+// idle time after the app shell loads, so by the time a chart needs to render
+// the code is usually already available.
+const EChartsRenderer = lazy(() =>
+  import(
+    /* webpackPrefetch: true */
+    /* webpackChunkName: "echarts-renderer" */
+    "metabase/visualizations/components/EChartsRenderer/EChartsRenderer"
+  ).then((module) => ({ default: module.EChartsRenderer })),
+);
 
 export interface ResponsiveEChartsRendererProps extends React.PropsWithChildren<EChartsRendererProps> {
   onResize?: (width: number, height: number) => void;
@@ -35,12 +49,14 @@ const ResponsiveEChartsRendererInner = forwardRef<
 
   return (
     <ResponsiveEChartsRendererStyled>
-      <EChartsRenderer
-        ref={ref}
-        {...echartsRenderedProps}
-        width={width}
-        height={height}
-      />
+      <Suspense fallback={<LoadingSpinner />}>
+        <EChartsRenderer
+          ref={ref}
+          {...echartsRenderedProps}
+          width={width}
+          height={height}
+        />
+      </Suspense>
       {children}
     </ResponsiveEChartsRendererStyled>
   );

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
@@ -45,7 +45,13 @@ const ResponsiveEChartsRendererInner = forwardRef<
       <Suspense
         fallback={
           <Flex h="100%" w="100%" direction="column">
-            {getChartSkeletonImage(display)}
+            {getChartSkeletonImage(
+              display === "boxplot"
+                ? "scatter"
+                : display === "combo"
+                  ? "bar"
+                  : display,
+            )}
           </Flex>
         }
       >

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
@@ -1,24 +1,11 @@
-import { Suspense, forwardRef, lazy, useLayoutEffect } from "react";
+import { Suspense, forwardRef, useLayoutEffect } from "react";
 
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
 import { isNumber } from "metabase/utils/types";
 import type { EChartsRendererProps } from "metabase/visualizations/components/EChartsRenderer/EChartsRenderer";
 import { ResponsiveEChartsRendererStyled } from "metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.styled";
-
-// echarts (its chart classes, components, the core SVG renderer and zrender) is
-// the single largest dependency in the app bundle. Loading EChartsRenderer
-// lazily moves all of it into its own async chunk so it is not part of the
-// initial page load. `webpackPrefetch` lets the browser warm that chunk during
-// idle time after the app shell loads, so by the time a chart needs to render
-// the code is usually already available.
-const EChartsRenderer = lazy(() =>
-  import(
-    /* webpackPrefetch: true */
-    /* webpackChunkName: "echarts-renderer" */
-    "metabase/visualizations/components/EChartsRenderer/EChartsRenderer"
-  ).then((module) => ({ default: module.EChartsRenderer })),
-);
+import { LazyEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer/lazy";
 
 export interface ResponsiveEChartsRendererProps extends React.PropsWithChildren<EChartsRendererProps> {
   onResize?: (width: number, height: number) => void;
@@ -50,7 +37,7 @@ const ResponsiveEChartsRendererInner = forwardRef<
   return (
     <ResponsiveEChartsRendererStyled>
       <Suspense fallback={<LoadingSpinner />}>
-        <EChartsRenderer
+        <LazyEChartsRenderer
           ref={ref}
           {...echartsRenderedProps}
           width={width}

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.tsx
@@ -1,14 +1,19 @@
 import { Suspense, forwardRef, useLayoutEffect } from "react";
 
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
-import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
+import { Flex } from "metabase/ui";
 import { isNumber } from "metabase/utils/types";
 import type { EChartsRendererProps } from "metabase/visualizations/components/EChartsRenderer/EChartsRenderer";
 import { ResponsiveEChartsRendererStyled } from "metabase/visualizations/components/EChartsRenderer/ResponsiveEChartsRenderer.styled";
 import { LazyEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer/lazy";
+import { getChartSkeletonImage } from "metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton";
+import type { VisualizationDisplay } from "metabase-types/api";
 
 export interface ResponsiveEChartsRendererProps extends React.PropsWithChildren<EChartsRendererProps> {
   onResize?: (width: number, height: number) => void;
+  // Display type of the chart, used to show a matching skeleton while the
+  // echarts chunk is loading.
+  display?: VisualizationDisplay;
 }
 
 const ResponsiveEChartsRendererInner = forwardRef<
@@ -20,6 +25,7 @@ const ResponsiveEChartsRendererInner = forwardRef<
     width,
     height,
     children,
+    display,
     ...echartsRenderedProps
   }: ResponsiveEChartsRendererProps,
   ref,
@@ -36,7 +42,13 @@ const ResponsiveEChartsRendererInner = forwardRef<
 
   return (
     <ResponsiveEChartsRendererStyled>
-      <Suspense fallback={<LoadingSpinner />}>
+      <Suspense
+        fallback={
+          <Flex h="100%" w="100%" direction="column">
+            {getChartSkeletonImage(display)}
+          </Flex>
+        }
+      >
         <LazyEChartsRenderer
           ref={ref}
           {...echartsRenderedProps}

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/index.ts
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/index.ts
@@ -4,4 +4,5 @@
 // bundle. Types are erased at build time, so re-exporting them is safe.
 export type { EChartsRendererProps } from "./EChartsRenderer";
 export type { ResponsiveEChartsRendererProps } from "./ResponsiveEChartsRenderer";
+export { prefetchEChartsRenderer } from "./lazy";
 export { ResponsiveEChartsRenderer } from "./ResponsiveEChartsRenderer.styled";

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/index.ts
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/index.ts
@@ -1,3 +1,7 @@
-export * from "./EChartsRenderer";
+// NOTE: do not statically re-export the EChartsRenderer *value* here. It is
+// loaded lazily (see ResponsiveEChartsRenderer) so that echarts lands in its
+// own async chunk; a static `export *` would pull it back into the initial
+// bundle. Types are erased at build time, so re-exporting them is safe.
+export type { EChartsRendererProps } from "./EChartsRenderer";
 export type { ResponsiveEChartsRendererProps } from "./ResponsiveEChartsRenderer";
 export { ResponsiveEChartsRenderer } from "./ResponsiveEChartsRenderer.styled";

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/lazy.ts
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/lazy.ts
@@ -1,0 +1,31 @@
+import { lazy } from "react";
+
+// echarts (its chart classes, components, the core SVG renderer and zrender) is
+// the single largest dependency in the app bundle. Loading EChartsRenderer
+// lazily moves all of it into its own async chunk so it is not part of the
+// initial page load.
+//
+// This lives in its own module (rather than next to ResponsiveEChartsRenderer)
+// to avoid a module-load-order cycle: ResponsiveEChartsRenderer and its styled
+// component import each other, so importing the prefetch helper from there would
+// force that pair to evaluate in the wrong order.
+const importEChartsRenderer = () =>
+  import(
+    /* webpackChunkName: "echarts-renderer" */
+    "metabase/visualizations/components/EChartsRenderer/EChartsRenderer"
+  );
+
+// Start downloading the echarts chunk ahead of render — e.g. as soon as a chart
+// card mounts, while its data query is still in flight — so the library loads
+// in parallel with the data instead of only after the chart is ready to render.
+// rspack de-duplicates the request, so this shares the same chunk as the lazy
+// component below.
+export const prefetchEChartsRenderer = () => {
+  void importEChartsRenderer();
+};
+
+export const LazyEChartsRenderer = lazy(() =>
+  importEChartsRenderer().then((module) => ({
+    default: module.EChartsRenderer,
+  })),
+);

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -40,6 +40,7 @@ import { getMode } from "metabase/visualizations/click-actions/lib/modes";
 import ChartCaption from "metabase/visualizations/components/ChartCaption";
 import ChartTooltip from "metabase/visualizations/components/ChartTooltip";
 import { ConnectedClickActionsPopover } from "metabase/visualizations/components/ClickActions";
+import { prefetchEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer/lazy";
 import { performDefaultAction } from "metabase/visualizations/lib/action";
 import {
   ChartSettingsError,
@@ -353,10 +354,24 @@ class Visualization extends PureComponent<
     ) {
       this.updateWarnings();
     }
+    if (prevState.visualization !== this.state.visualization) {
+      this.maybePrefetchEChartsRenderer();
+    }
   }
 
   componentDidMount() {
     this.updateWarnings();
+    this.maybePrefetchEChartsRenderer();
+  }
+
+  // Kick off loading the (lazy) echarts chunk as soon as an echarts-based chart
+  // mounts — typically while its data query is still in flight — so the library
+  // downloads in parallel with the data rather than only once the chart is
+  // ready to render.
+  maybePrefetchEChartsRenderer() {
+    if (this.state.visualization?.usesEChartsRenderer) {
+      prefetchEChartsRenderer();
+    }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.tsx
@@ -16,7 +16,7 @@ import SkeletonCaption from "metabase/visualizations/components/skeletons/Skelet
 import TableSkeleton from "metabase/visualizations/components/skeletons/TableSkeleton";
 import { VisualizationSkeleton } from "metabase/visualizations/components/skeletons/VisualizationSkeleton/VisualizationSkeleton";
 import WaterfallSkeleton from "metabase/visualizations/components/skeletons/WaterfallSkeleton";
-import type { CardDisplayType } from "metabase-types/api";
+import type { CardDisplayType, VisualizationDisplay } from "metabase-types/api";
 
 export type ChartSkeletonProps = HTMLAttributes<HTMLDivElement> & {
   display?: CardDisplayType;
@@ -25,9 +25,12 @@ export type ChartSkeletonProps = HTMLAttributes<HTMLDivElement> & {
   actionMenu?: JSX.Element | null;
 };
 
-const skeletonComponent: (display?: CardDisplayType) => JSX.Element | null = (
-  display?: CardDisplayType,
-) => {
+// Returns just the chart-shaped skeleton image for a display type (no caption
+// or surrounding chrome), suitable for embedding inside a chart's own render
+// area — e.g. as the Suspense fallback while the echarts chunk loads.
+export const getChartSkeletonImage: (
+  display?: VisualizationDisplay,
+) => JSX.Element | null = (display?: VisualizationDisplay) => {
   if (!display) {
     return null;
   }
@@ -92,7 +95,7 @@ const ChartSkeleton = ({
       description={description}
       actionMenu={actionMenu}
     >
-      {skeletonComponent(display)}
+      {getChartSkeletonImage(display)}
     </VisualizationSkeleton>
   );
 };

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -640,6 +640,10 @@ export type VisualizationDefinition = {
   disableClickBehavior?: boolean;
   canSavePng?: boolean;
   noHeader?: boolean;
+  // True for visualizations that render through the (lazily loaded)
+  // EChartsRenderer. Used to prefetch the echarts chunk while the chart's data
+  // is still loading. See prefetchEChartsRenderer.
+  usesEChartsRenderer?: boolean;
   hidden?: boolean;
   disableSettingsConfig?: boolean;
   supportPreviewing?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/BoxPlot/BoxPlot.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BoxPlot/BoxPlot.tsx
@@ -227,6 +227,7 @@ function BoxPlotInner({
         <ResponsiveEChartsRenderer
           key={hasValidOption ? "chart" : "measuring"}
           ref={containerRef}
+          display="boxplot"
           option={option ?? {}}
           eventHandlers={hasValidOption ? eventHandlers : undefined}
           onInit={handleInit}

--- a/frontend/src/metabase/visualizations/visualizations/BoxPlot/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/BoxPlot/chart-definition.ts
@@ -23,6 +23,7 @@ export const BOXPLOT_CHART_DEFINITION: VisualizationDefinition = {
   getUiName: () => t`Box Plot`,
   identifier: "boxplot",
   iconName: "boxplot",
+  usesEChartsRenderer: true,
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   noun: t`box plot`,
   minSize: getMinSize("boxplot"),

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -186,6 +186,7 @@ function CartesianChartInner(props: VisualizationProps) {
       >
         <ResponsiveEChartsRenderer
           ref={containerRef}
+          display={card.display}
           option={option}
           eventHandlers={eventHandlers}
           onResize={handleResize}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -84,6 +84,11 @@ function CartesianChartInner(props: VisualizationProps) {
   useChartDebug({ isQueryBuilder, rawSeries, option, chartModel });
 
   const chartRef = useRef<EChartsType>();
+  // Mirror the ECharts instance into state so that effects depending on it
+  // (e.g. brush setup) re-run once it becomes available. With the lazily loaded
+  // EChartsRenderer, `onInit` fires after the surrounding effects have already
+  // run, and a ref assignment alone would not re-trigger them.
+  const [chartInstance, setChartInstance] = useState<EChartsType>();
 
   const description = settings["card.description"];
 
@@ -95,6 +100,7 @@ function CartesianChartInner(props: VisualizationProps) {
 
   const handleInit = useCallback((chart: EChartsType) => {
     chartRef.current = chart;
+    setChartInstance(chart);
 
     // HACK: clip paths cause glitches in Safari on multiseries line charts on dashboards (metabase#51383)
     if (isWebkit()) {
@@ -129,6 +135,7 @@ function CartesianChartInner(props: VisualizationProps) {
     option,
     renderingContext,
     props,
+    chartInstance,
   );
 
   const handleResize = useCallback((width: number, height: number) => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
@@ -48,6 +48,7 @@ export const getCartesianChartDefinition = (
 ): Partial<Visualization> => {
   return {
     noHeader: true,
+    usesEChartsRenderer: true,
     supportsVisualizer: true,
 
     isSensible: ({ cols, rows }) => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -66,6 +66,11 @@ export const useBrush = (
   // ECharts option object — used as a signal dep to re-enable brush after
   // chart model changes (ECharts resets the cursor state on re-render).
   option?: unknown,
+  // ECharts instance — used as a signal dep so the brush is (re-)enabled once
+  // the (lazily loaded) renderer has initialized the chart. `onInit` fires
+  // after this hook's effects first run, so without this the brush would never
+  // be enabled on desktop.
+  chartInstance?: unknown,
 ) => {
   const isTouch = useRef(isTouchDevice()).current;
 
@@ -81,7 +86,14 @@ export const useBrush = (
     chartRef.current?.dispatchAction({ type: "takeGlobalCursor" });
   }, [chartRef]);
 
-  useDesktopBrush({ isTouch, isBrushable, enableBrush, disableBrush, option });
+  useDesktopBrush({
+    isTouch,
+    isBrushable,
+    enableBrush,
+    disableBrush,
+    option,
+    chartInstance,
+  });
   useTouchBrush({
     chartRef,
     containerRef,
@@ -99,12 +111,14 @@ function useDesktopBrush({
   enableBrush,
   disableBrush,
   option,
+  chartInstance,
 }: {
   isTouch: boolean;
   isBrushable: boolean;
   enableBrush: () => void;
   disableBrush: () => void;
   option?: unknown;
+  chartInstance?: unknown;
 }) {
   useEffect(() => {
     if (isTouch) {
@@ -120,7 +134,7 @@ function useDesktopBrush({
     }, 0);
 
     return () => clearTimeout(timeout);
-  }, [isBrushable, isTouch, enableBrush, disableBrush, option]);
+  }, [isBrushable, isTouch, enableBrush, disableBrush, option, chartInstance]);
 }
 
 /**

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -224,6 +224,48 @@ describe("use-brush", () => {
 
         expectBrushDisabled(dispatchAction);
       });
+
+      it("enables brush once the chart instance becomes available (lazy renderer)", () => {
+        // Simulates the lazily loaded EChartsRenderer: the chart instance is
+        // only set (via onInit) after this hook's effects have already run, so
+        // the first attempt to enable the brush is a no-op. Surfacing the chart
+        // instance as a signal must re-run the effect and enable the brush.
+        const dispatchAction = jest.fn();
+        const chartRef = {
+          current: undefined,
+        } as MutableRefObject<EChartsType | undefined>;
+        const { containerRef } = createMockContainerRef();
+
+        const { rerender } = renderHook(
+          ({ chartInstance }) =>
+            useBrush(
+              chartRef,
+              containerRef,
+              true,
+              true,
+              undefined,
+              chartInstance,
+            ),
+          {
+            initialProps: {
+              chartInstance: undefined as EChartsType | undefined,
+            },
+          },
+        );
+        act(() => jest.runAllTimers());
+
+        // Chart not initialized yet → brush cannot be enabled.
+        expectBrushNotEnabled(dispatchAction);
+
+        // Chart initializes: ref is populated and the instance is surfaced as a
+        // signal, mirroring CartesianChart's handleInit.
+        const chart = { dispatchAction } as unknown as EChartsType;
+        chartRef.current = chart;
+        rerender({ chartInstance: chart });
+        act(() => jest.runAllTimers());
+
+        expectBrushEnabled(dispatchAction);
+      });
     });
 
     describe("touch", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -79,6 +79,10 @@ export const useChartEvents = (
     metadata,
     isDashboard,
   }: VisualizationProps,
+  // The ECharts instance, mirrored into state by the caller. Used as a signal
+  // to re-run chart-instance-dependent effects (e.g. brush) once it is ready,
+  // which matters because the lazily loaded renderer calls `onInit` late.
+  chartInstance?: EChartsType,
 ) => {
   const isBrushing = useRef<boolean>();
   useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
@@ -367,7 +371,14 @@ export const useChartEvents = (
   );
   const isBrushable = canBrushChart && !hovered && !clicked;
 
-  useBrush(chartRef, containerRef, canBrushChart, isBrushable, option);
+  useBrush(
+    chartRef,
+    containerRef,
+    canBrushChart,
+    isBrushable,
+    option,
+    chartInstance,
+  );
 
   const onSelectSeries = useCallback(
     (event: React.MouseEvent, seriesIndex: number) => {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
@@ -193,6 +193,7 @@ export function PieChart(props: VisualizationProps) {
     >
       <ResponsiveEChartsRenderer
         ref={containerRef}
+        display="pie"
         option={option}
         onInit={handleInit}
         onResize={handleResize}

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -48,6 +48,7 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
   getUiName: () => t`Pie`,
   identifier: "pie",
   iconName: "pie",
+  usesEChartsRenderer: true,
   minSize: getMinSize("pie"),
   defaultSize: getDefaultSize("pie"),
   supportsVisualizer: true,

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
@@ -75,6 +75,7 @@ export const SankeyChart = ({
     <>
       <ResponsiveEChartsRenderer
         ref={containerRef}
+        display="sankey"
         option={option}
         eventHandlers={eventHandlers}
         onInit={handleInit}

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -124,6 +124,7 @@ export const SANKEY_CHART_DEFINITION: VisualizationDefinition = {
   getUiName: () => t`Sankey`,
   identifier: "sankey",
   iconName: "sankey",
+  usesEChartsRenderer: true,
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   noun: t`sankey chart`,
   minSize: getMinSize("sankey"),


### PR DESCRIPTION
Lazy load the `echarts` module so that it's not part of the initial bundle.

This PR adds:
- Pass the correct `display` as a prop to the `EchartsRenderer` so it can pick the correct fallback to render,
- prefetches the `echarts` module (through `webpackPrefetch`), but also
- imperatively import `echarts` in parallel with the data fetch for the vizualization to force it being fetched when it's needed

This removes about 6% of the initial bundle size.
