### PR TITLE
fix: pin commons-configuration2 2.15.1 in Databricks driver

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -11,4 +11,6 @@
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}
   ;; pinned: databricks-jdbc-thin pulls older transitive versions
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}
-  org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.3.5"}}}
+  org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.3.5"}
+  ;; pinned: databricks-jdbc-thin 3.3.1 pulls commons-configuration2 2.11.0 (CVE-2026-45205)
+  org.apache.commons/commons-configuration2 {:mvn/version "2.15.1"}}}


### PR DESCRIPTION
Fixes EMB-1834 when https://github.com/metabase/metabase/pull/75229 is also merged

fixes:
- https://github.com/metabase/metabase/security/code-scanning/alerts/759: commons-configuration2 2.11.0 (transitive via databricks-jdbc-thin 3.3.1) has CVE-2026-45205. Pinned to 2.15.1 in databricks/deps.edn.
- https://github.com/metabase/metabase/security/code-scanning/alerts/761: Same CVE in the built uberjar (Trivy). Same pin resolves it — confirmed version 2.15.1 in metabase.jar after build.