### PR TITLE
fix: pin netty 4.1.135.Final in Snowflake driver

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -21,4 +21,9 @@
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.84"}
   ;; pinned: snowflake-jdbc-thin 4.1.0 pulls jackson-core 2.18.4.1 which has resource exhaustion vulns
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}
+  ;; pinned: AWS SDK (transitive via snowflake-jdbc-thin) pulls netty 4.1.126.Final
+  ;; (SNYK-JAVA-IONETTY-16438930, SNYK-JAVA-IONETTY-16438322). Pin the full family to avoid mixed-version classpath.
+  io.netty/netty-codec                    {:mvn/version "4.1.135.Final"}
+  io.netty/netty-handler                  {:mvn/version "4.1.135.Final"}
+  io.netty/netty-transport-classes-epoll  {:mvn/version "4.1.135.Final"}}}


### PR DESCRIPTION
Fixes EMB-1834 when https://github.com/metabase/metabase/pull/75228 is also merged

fixes:
- https://github.com/metabase/metabase/security/code-scanning/alerts/747: netty-codec 4.1.126.Final (transitive via AWS SDK in snowflake-jdbc-thin) has SNYK-JAVA-IONETTY-16438930 and SNYK-JAVA-IONETTY-16438322. Pinned netty-codec, netty-handler, and netty-transport-classes-epoll to 4.1.135.Final in snowflake/deps.edn.
- https://github.com/metabase/metabase/security/code-scanning/alerts/748: Same vulnerabilities in the built uberjar (Trivy). Same pins resolve it.