### PR TITLE
chore: prepare SDK release workflow for 62 beta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,12 +12,12 @@ enterprise/backend/src/metabase_enterprise/dependencies @metabase/graphy
 enterprise/frontend/src/metabase-enterprise/dependencies @metabase/graphy
 
 # @metabase/embedding
-enterprise/frontend/src/embedding-sdk-package @metabase/embedding
-enterprise/frontend/src/embedding-sdk-bundle @metabase/embedding
-enterprise/frontend/src/embedding-sdk-shared @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
+# enterprise/frontend/src/embedding-sdk-package @metabase/embedding
+# enterprise/frontend/src/embedding-sdk-bundle @metabase/embedding
+# enterprise/frontend/src/embedding-sdk-shared @metabase/embedding
+# frontend/src/metabase/embedding-sdk @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
 
 # @metabase/tech-writers
 docs @metabase/tech-writers

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -8,9 +8,9 @@ on:
         description: "Branch we want to release the SDK from (to release from other branches use the workflow from those branches)"
         type: choice
         required: true
-        default: "master"
+        default: "release-x.62.x"
         options:
-          - master
+          - release-x.62.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -375,15 +375,6 @@ jobs:
           name: metabase-sdk
           path: sdk
 
-      - name: Compute master tag
-        id: compute-tag
-        run: |
-          if [ -n "${{ needs.determine-sdk-version.outputs.pre_release_label }}" ]; then
-            echo "masterTag=${{ needs.determine-sdk-version.outputs.pre_release_label }}" >> $GITHUB_OUTPUT
-          else
-            echo "masterTag=nightly" >> $GITHUB_OUTPUT
-          fi
-
       # Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
       # Node 22.x line bundles npm 10.x, so pin Node 24.x which ships npm 11.x.
       - name: Setup Node.js for npm publish with trusted publishing
@@ -395,9 +386,7 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          TAG="${{ steps.compute-tag.outputs.masterTag }}"
-          echo "Resolved npm tag: $TAG"
-          npm publish --tag "$TAG"
+          npm publish --tag 62-beta
       # ⚠️ This step should only be executed on the latest stable (gold) release branch.
       # Only uncomment this when the new release branch becomes stable (gold).
       # - name: Add `latest` tag to the latest release branch (e.g. `release-x.61.x`) deployment

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.62.0-alpha",
+  "version": "0.62.0-beta",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
## Summary

Beta checklist for `release-x.62.x` per the [Embedding Checklist](https://app.notion.com/p/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d#20269354c9018049a6d9ea26b14750f4).

- Update release workflow `branch` input: default and options changed from `master` to `release-x.62.x`
- Remove `Compute master tag` step (only needed for master/nightly releases)
- Hardcode npm publish tag to `62-beta`
- Bump `package.template.json` version from `0.62.0-alpha` to `0.62.0-beta`
- Comment out `@metabase/embedding` CODEOWNERS entries so the team doesn't get pinged on bot-approved PRs in this branch

## Notes

- Did **not** re-add `.npmrc`/`NPM_RELEASE_TOKEN` — this branch already uses OIDC trusted publishing
- After this merges, trigger the SDK release from `release-x.62.x` (step 6 in the checklist)