### PR TITLE
Fix section layout preview key warning

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
@@ -35,9 +35,9 @@ export function SectionLayoutPreview({ layout }: SectionLayoutPreviewProps) {
   return (
     <Flex align="center" justify="center">
       <Box pos="relative" w={WIDTH} mih={height}>
-        {layoutItems.map((item) => (
+        {layoutItems.map((item, index) => (
           <PreviewCard
-            key={item.id}
+            key={`${item.col}:${item.row}:${item.size_x}:${item.size_y}:${index}`}
             layout={item}
             cellWidth={CELL_WIDTH}
             cellHeight={CELL_HEIGHT}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.unit.spec.tsx
@@ -1,0 +1,75 @@
+import { render } from "@testing-library/react";
+
+import { ThemeProvider } from "metabase/ui";
+
+import { SectionLayoutPreview } from "./SectionLayoutPreview";
+
+const createPreviewItem = ({
+  col,
+  row,
+  size_x,
+  size_y,
+}: {
+  col: number;
+  row: number;
+  size_x: number;
+  size_y: number;
+}) => {
+  const virtualCard = {
+    name: null,
+    display: "heading" as const,
+    visualization_settings: {},
+    archived: false,
+  };
+
+  return {
+    col,
+    row,
+    size_x,
+    size_y,
+    card: virtualCard,
+    visualization_settings: { virtual_card: virtualCard },
+  };
+};
+
+const TEST_LAYOUT: Parameters<typeof SectionLayoutPreview>[0]["layout"] = {
+  id: "kpi_grid",
+  label: "KPI grid",
+  getLayout: () => [
+    createPreviewItem({
+      col: 0,
+      row: 0,
+      size_x: 24,
+      size_y: 1,
+    }),
+    createPreviewItem({
+      col: 0,
+      row: 1,
+      size_x: 12,
+      size_y: 5,
+    }),
+  ],
+};
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe("SectionLayoutPreview", () => {
+  it("renders layout options without React key warnings", () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    renderWithTheme(<SectionLayoutPreview layout={TEST_LAYOUT} />);
+
+    const hasKeyWarning = consoleErrorSpy.mock.calls.some((call) =>
+      call.some(
+        (message) =>
+          typeof message === "string" && message.includes('unique "key" prop'),
+      ),
+    );
+
+    expect(hasKeyWarning).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75112

### Description

Section layout preview cards are rendered before real dashcard IDs exist, so keying them with `item.id` logs React's unique key warning. This changes the preview key to use the rendered preview geometry and adds a regression test that covers virtual section cards without IDs.

### How to verify

1. Open a dashboard, edit it, and click **Add section**.
2. Confirm the browser console does not log `Each child in a list should have a unique "key" prop` for the section layout previews.
3. Run the focused unit test:
   `./node_modules/.bin/jest --no-cache --runInBand frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.unit.spec.tsx`

### Demo

N/A - console warning fix covered by unit test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
