### PR TITLE
feat: add embedding-sdk-tag-latest workflow for npm dist-tag

### DIFF
--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -1,0 +1,32 @@
+name: Tag Embedding SDK npm release as latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm version to tag as latest, e.g. 0.61.5"
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      version:
+        description: "npm version to tag as latest, e.g. 0.61.5"
+        type: string
+        required: true
+    secrets:
+      NPM_RELEASE_TOKEN:
+        required: true
+
+jobs:
+  tag-latest:
+    name: Tag npm release as latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add `latest` dist-tag to npm release
+        run: |
+          echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
+          npm dist-tag add @metabase/embedding-sdk-react@${{ inputs.version }} latest
+          echo "Tagged @metabase/embedding-sdk-react@${{ inputs.version }} as latest" >> $GITHUB_STEP_SUMMARY
+        env:
+          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -23,10 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
       - name: Add `latest` dist-tag to npm release
         run: |
-          echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
           npm dist-tag add @metabase/embedding-sdk-react@${{ inputs.version }} latest
           echo "Tagged @metabase/embedding-sdk-react@${{ inputs.version }} as latest" >> "$GITHUB_STEP_SUMMARY"
         env:
-          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -27,6 +27,6 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
           npm dist-tag add @metabase/embedding-sdk-react@${{ inputs.version }} latest
-          echo "Tagged @metabase/embedding-sdk-react@${{ inputs.version }} as latest" >> $GITHUB_STEP_SUMMARY
+          echo "Tagged @metabase/embedding-sdk-react@${{ inputs.version }} as latest" >> "$GITHUB_STEP_SUMMARY"
         env:
           NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -13,9 +13,6 @@ on:
         description: "npm version to tag as latest, e.g. 0.61.5"
         type: string
         required: true
-    secrets:
-      NPM_RELEASE_TOKEN:
-        required: true
 
 jobs:
   tag-latest:

--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   tag-latest:
     name: Tag npm release as latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
       - name: Setup Node.js

--- a/.github/workflows/embedding-sdk-tag-latest.yml
+++ b/.github/workflows/embedding-sdk-tag-latest.yml
@@ -14,11 +14,19 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: npm-dist-tag-latest
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   tag-latest:
     name: Tag npm release as latest
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
@@ -26,9 +34,12 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Verify version exists on npm
+        run: npm view "@metabase/embedding-sdk-react@$VERSION" version
+
       - name: Add `latest` dist-tag to npm release
         run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ inputs.version }} latest
-          echo "Tagged @metabase/embedding-sdk-react@${{ inputs.version }} as latest" >> "$GITHUB_STEP_SUMMARY"
+          npm dist-tag add "@metabase/embedding-sdk-react@$VERSION" latest
+          echo "Tagged @metabase/embedding-sdk-react@$VERSION as latest" >> "$GITHUB_STEP_SUMMARY"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -94,6 +94,7 @@ jobs:
         "test",
         "build-sdk",
         "publish-npm",
+        "tag-latest",
         "git-tag",
       ]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -398,12 +399,18 @@ jobs:
           TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
-      # ⚠️ This step should only be executed on the latest stable (gold) release branch.
-      # Only uncomment this when the new release branch becomes stable (gold).
-      # - name: Add `latest` tag to the latest release branch (e.g. `release-x.61.x`) deployment
-      #   working-directory: sdk
-      #   run: |
-      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+
+  tag-latest:
+    name: Tag npm release as latest
+    # ⚠️ This should only run on the most recent release branch (e.g. `release-x.61.x`),
+    # and only once it becomes stable (gold). Delete this line when gold — do not delete during the pre-gold window.
+    if: false
+    needs: [publish-npm, determine-sdk-version]
+    uses: ./.github/workflows/embedding-sdk-tag-latest.yml
+    with:
+      version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
+    secrets:
+      NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -409,8 +409,7 @@ jobs:
     uses: ./.github/workflows/embedding-sdk-tag-latest.yml
     with:
       version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
-    secrets:
-      NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+    secrets: inherit
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]


### PR DESCRIPTION
Fixes EMB-1765

### Backport reason
We need to backport this to 62, so when 62 goes gold, we can use this change.

### Description

Adds `.github/workflows/embedding-sdk-tag-latest.yml` — a standalone workflow that sets the `latest` dist-tag on a published `@metabase/embedding-sdk-react` version using a classic npm token (`NPM_RELEASE_TOKEN`). Trusted publishing (OIDC) cannot set dist-tags, hence the separate workflow.

The workflow supports `workflow_dispatch` (manual trigger with a `version` input) and `workflow_call` (called from `release-embedding-sdk.yml`).

Wires the new workflow into `release-embedding-sdk.yml` as a `tag-latest` job between `publish-npm` and `git-tag`:
- Disabled via `if: false` until the release branch becomes gold
- Always present in `send-slack-notification-failure.needs` so failures are caught once enabled
- One edit to enable: delete the `if: false` line

Removes the old commented-out inline `npm dist-tag` step from `publish-npm`.

### Demo

Both files have been linted with `actionlint`. Existing warnings/errors are kept as is.

`0.61.0` was published in https://github.com/metabase/metabase/actions/runs/25928598976 but `latest` still points to `0.60.0`. The plan is to verify by running:

```bash
gh workflow run embedding-sdk-tag-latest.yml \
  --ref master \
  -f version=0.61.0
```

GitHub requires the workflow to exist on the default branch before `workflow_dispatch` can be triggered — so this can only be tested post-merge. Will update with the run result after merge.