### PR TITLE
fix flaky test https://app.trunk.io/metabase/flaky-tests/repo/56d8e0a…

### DIFF
--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -1808,12 +1808,14 @@
               seed-runs    (fn [data] (filter (comp run-id? :id) data))]
           (testing "desc — longest completed runs first; in-progress (null duration) sinks to the bottom"
             (let [resp (mt/user-http-request :crowberto :get 200 "transform/run"
+                                             :transform-ids [tid]
                                              :sort-column "duration"
                                              :sort-direction "desc")
                   ids  (map :id (seed-runs (:data resp)))]
               (is (= [long-id short-id running-id] ids))))
           (testing "asc — shortest completed runs first; in-progress run still last"
             (let [resp (mt/user-http-request :crowberto :get 200 "transform/run"
+                                             :transform-ids [tid]
                                              :sort-column "duration"
                                              :sort-direction "asc")
                   ids  (map :id (seed-runs (:data resp)))]


### PR DESCRIPTION
Fixes https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/44ef37ca-1d2c-5e0f-9e51-a9c64654159d

### Description
The duration-sort runs test didn't scope its requests to the seeded transform, so the endpoint returned every `transform_run` in the DB. On the shared Postgres CI database, leftover rows from other tests pushed the in-progress run (always sorted last for `duration`) past the default `limit 20`, so it fell off page one and the post-fetch `seed-runs` filter couldn't recover it. Adding `:transform-ids [tid]` scopes each request to the three seeded runs, matching every other run test in the file.
