### PR TITLE
Disable bigquery from workspace-full-e2e-test so we can unquarantine

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
@@ -71,7 +71,11 @@
    `{:tables #{}}` even when USAGE/SELECT grants are intact (root cause
    pending investigation; see that test's docstring). Don't add drivers
    to the smaller test without first fixing the underlying sync visibility."
-  #{:postgres :sqlserver :clickhouse :mysql :redshift :bigquery-cloud-sdk})
+  #{:postgres :sqlserver :clickhouse :mysql :redshift
+    ;; currently this is very flaky in CI causing the entire bigquery driver
+    ;; to be quarantined. for now we disable just this one test so we can
+    ;; bring back the rest of it, but this still needs investigation.
+    #_:bigquery-cloud-sdk})
 
 (defn- three-slot-driver?
   "True when the driver emits `db.schema.table` (SQL Server / BigQuery).


### PR DESCRIPTION
This test is responsible for almost every bigquery CI failure recorded in the past 7 days. If we drop this, we can start unquarantining bigquery. This will probably cause additional failures, because at that point we'll start having concurrent runs, which we haven't had for over 30 days. But while those failures will cause a red X, they will not block delivery. We need at least a few days worth of data around what those failures look like so we can start addressing them. Currently all the data we had about those failures has aged out of the CI logs.