### PR TITLE
GHY-3801 preserve result_metadata for native cards on serdes export

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -962,30 +962,31 @@
                                                                                                               [:field %products.category {:join-alias "Products"}]]}]})}]
             ;; Populate the native source card's result_metadata the way the app does when a user runs and
             ;; saves the query. This is the state serdes must preserve across the round-trip.
-            (let [cols (-> (qp/process-query (t2/select-one-fn :dataset_query [:model/Card :dataset_query] native-id))
-                           (get-in [:data :results_metadata :columns]))]
-              (t2/update! :model/Card native-id {:result_metadata cols}))
-            (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
-              (storage/store! (seq extraction) (storage.files/file-writer dump-dir)))
-            (ts/with-db dest-db
-              (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
-                  "serdes ingest succeeded")
-              (let [imported-native (t2/select-one :model/Card :entity_id native-eid)
-                    imported-gui    (t2/select-one :model/Card :entity_id gui-eid)]
-                (testing "imported GUI question's query compiles without 'add alias info to join' errors"
-                  ;; Compile (not execute): the bug surfaces in add-alias-info during compilation, and serdes
-                  ;; strips warehouse connection details so the imported card can't actually be run here.
-                  (let [result (try
-                                 (qp.compile/compile (:dataset_query imported-gui))
-                                 (catch Throwable e
-                                   {:error (ex-message e)
-                                    :data  (ex-data e)}))]
-                    (is (not (and (map? result) (:error result)))
-                        (str "Expected query to compile but got error: "
-                             (when (map? result) (:error result))))))
-                (testing "(diagnostic) imported native card has result_metadata after import"
-                  (is (seq (:result_metadata imported-native))
-                      "Native source card lost result_metadata during serdes round-trip"))))))))))
+            (let [source-cols  (-> (qp/process-query (t2/select-one-fn :dataset_query [:model/Card :dataset_query] native-id))
+                                   (get-in [:data :results_metadata :columns]))
+                  source-names (mapv :name source-cols)]
+              (t2/update! :model/Card native-id {:result_metadata source-cols})
+              (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
+                (storage/store! (seq extraction) (storage.files/file-writer dump-dir)))
+              (ts/with-db dest-db
+                (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
+                    "serdes ingest succeeded")
+                (let [imported-native (t2/select-one :model/Card :entity_id native-eid)
+                      imported-gui    (t2/select-one :model/Card :entity_id gui-eid)]
+                  (testing "imported native card preserves its result_metadata columns"
+                    (is (= source-names (mapv :name (:result_metadata imported-native)))
+                        "Native source card lost result_metadata columns during serdes round-trip"))
+                  (testing "imported GUI question's query compiles without 'add alias info to join' errors"
+                    ;; Compile (not execute): the bug surfaces in add-alias-info during compilation, and serdes
+                    ;; strips warehouse connection details so the imported card can't actually be run here.
+                    (let [result (try
+                                   (qp.compile/compile (:dataset_query imported-gui))
+                                   (catch Throwable e
+                                     {:error (ex-message e)
+                                      :data  (ex-data e)}))]
+                      (is (not (and (map? result) (:error result)))
+                          (str "Expected query to compile but got error: "
+                               (when (map? result) (:error result)))))))))))))))
 
 (deftest schema-coercion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -16,6 +16,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.serialization :as serdes]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
@@ -929,6 +931,61 @@
                            :dataset_query {:stages [{:aggregation [[:metric {} (:id new-metric)]]
                                                      :breakout    [[:field {} (mt/id :orders :user_id)]]}]}}
                           (t2/select-one :model/Card :name "Metric Consuming Question Card"))))))))))))
+
+(deftest gui-question-joined-to-native-source-card-survives-roundtrip-test
+  (testing "GUI question joining a native source-card should still run after serdes export+import (GHY-3801)"
+    (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+      (ts/with-dbs [source-db dest-db]
+        (ts/with-db source-db
+          (mt/with-temp
+            [:model/Collection {coll-id :id}                {:name "GHY-3801"}
+             :model/Card       {native-id :id
+                                native-eid :entity_id}      {:name          "Native Products"
+                                                             :collection_id coll-id
+                                                             :type          :question
+                                                             :display       :table
+                                                             :dataset_query {:type     :native
+                                                                             :database (mt/id)
+                                                                             :native   {:query "SELECT * FROM PRODUCTS"}}}
+             :model/Card       {gui-eid :entity_id}         {:name          "GUI Joins Native"
+                                                             :collection_id coll-id
+                                                             :type          :question
+                                                             :display       :table
+                                                             :dataset_query (mt/mbql-query nil
+                                                                              {:source-table (str "card__" native-id)
+                                                                               :joins        [{:fields       :all
+                                                                                               :strategy     :left-join
+                                                                                               :alias        "Products"
+                                                                                               :source-table $$products
+                                                                                               :condition    [:=
+                                                                                                              [:field "CATEGORY" {:base-type :type/Text}]
+                                                                                                              [:field %products.category {:join-alias "Products"}]]}]})}]
+            ;; Populate the native source card's result_metadata the way the app does when a user runs and
+            ;; saves the query. This is the state serdes must preserve across the round-trip.
+            (let [cols (-> (qp/process-query (t2/select-one-fn :dataset_query [:model/Card :dataset_query] native-id))
+                           (get-in [:data :results_metadata :columns]))]
+              (t2/update! :model/Card native-id {:result_metadata cols}))
+            (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
+              (storage/store! (seq extraction) (storage.files/file-writer dump-dir)))
+            (ts/with-db dest-db
+              (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
+                  "serdes ingest succeeded")
+              (let [imported-native (t2/select-one :model/Card :entity_id native-eid)
+                    imported-gui    (t2/select-one :model/Card :entity_id gui-eid)]
+                (testing "imported GUI question's query compiles without 'add alias info to join' errors"
+                  ;; Compile (not execute): the bug surfaces in add-alias-info during compilation, and serdes
+                  ;; strips warehouse connection details so the imported card can't actually be run here.
+                  (let [result (try
+                                 (qp.compile/compile (:dataset_query imported-gui))
+                                 (catch Throwable e
+                                   {:error (ex-message e)
+                                    :data  (ex-data e)}))]
+                    (is (not (and (map? result) (:error result)))
+                        (str "Expected query to compile but got error: "
+                             (when (map? result) (:error result))))))
+                (testing "(diagnostic) imported native card has result_metadata after import"
+                  (is (seq (:result_metadata imported-native))
+                      "Native source card lost result_metadata during serdes round-trip"))))))))))
 
 (deftest schema-coercion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1259,7 +1259,11 @@
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
 (defn- export-result-metadata [card _k metadata]
-  (if (and (seq metadata) (model? card))
+  (cond
+    (empty? metadata)
+    ::serdes/skip
+
+    (model? card)
     (let [native?   (lib/native? (:dataset_query card))
           keep-keys (into #{:name}
                           (map u/->snake_case_en)
@@ -1269,6 +1273,20 @@
                   (m/update-existing :fk_target_field_id serdes/*export-field-fk*)
                   (m/update-existing :id serdes/*export-field-fk*)))
             metadata))
+
+    ;; Native non-model cards keep their full result_metadata. Unlike MBQL cards, their columns can't be
+    ;; re-derived from the query at import time without executing the SQL, and downstream questions that join
+    ;; them depend on this metadata to resolve join columns.
+    (lib/native? (:dataset_query card))
+    (mapv (fn [m]
+            (-> (dissoc m :fingerprint)
+                (m/update-existing :table_id           serdes/*export-table-fk*)
+                (m/update-existing :id                 serdes/*export-field-fk*)
+                (m/update-existing :field_ref          serdes/export-mbql)
+                (m/update-existing :fk_target_field_id serdes/*export-field-fk*)))
+          metadata)
+
+    :else
     ::serdes/skip))
 
 (defn- import-result-metadata [metadata]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1274,17 +1274,22 @@
                   (m/update-existing :id serdes/*export-field-fk*)))
             metadata))
 
-    ;; Native non-model cards keep their full result_metadata. Unlike MBQL cards, their columns can't be
-    ;; re-derived from the query at import time without executing the SQL, and downstream questions that join
-    ;; them depend on this metadata to resolve join columns.
+    ;; Native non-model cards keep their result_metadata. Unlike MBQL cards, their columns can't be re-derived
+    ;; from the query at import time without executing the SQL, and downstream questions that join them depend
+    ;; on this metadata to resolve join columns. We whitelist the portable keys (dropping computed `:lib/*`,
+    ;; `:fingerprint`, etc.) rather than the model soft-key set, since native columns also need their structural
+    ;; type info preserved.
     (lib/native? (:dataset_query card))
-    (mapv (fn [m]
-            (-> (dissoc m :fingerprint)
-                (m/update-existing :table_id           serdes/*export-table-fk*)
-                (m/update-existing :id                 serdes/*export-field-fk*)
-                (m/update-existing :field_ref          serdes/export-mbql)
-                (m/update-existing :fk_target_field_id serdes/*export-field-fk*)))
-          metadata)
+    (let [keep-keys #{:name :base_type :effective_type :field_ref :database_type
+                      :display_name :semantic_type :description :visibility_type :settings
+                      :fk_target_field_id :id :table_id}]
+      (mapv (fn [m]
+              (-> (select-keys m keep-keys)
+                  (m/update-existing :table_id           serdes/*export-table-fk*)
+                  (m/update-existing :id                 serdes/*export-field-fk*)
+                  (m/update-existing :field_ref          serdes/export-mbql)
+                  (m/update-existing :fk_target_field_id serdes/*export-field-fk*)))
+            metadata))
 
     :else
     ::serdes/skip))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75230
## Problem

After a serdes export→import, **native source-cards land with `result_metadata = nil`**. Any GUI question that joins such a native card by an unqualified column name then fails at query-compile time with:

> `Error adding alias info to join: Join condition refers to a column from outside this join, but it was incorrectly resolved to a column from this join.`

(The customer's other variant — `Missing ::desired-alias->escaped for "..."` — is the same root cause for a different join shape.) The user's workaround is to manually re-run the native query, which repopulates the metadata.

## Root cause

GHY-3339 dropped `result_metadata` from all non-model serdes exports, on the premise that import re-derives it from `dataset_query` via `qp.preprocess/query->expected-cols`. That premise holds for **MBQL** cards — their columns are computed statically from synced metadata, no warehouse access needed. It does **not** hold for **native** cards: a native query is opaque SQL whose columns can only be observed by executing it. So `populate-result-metadata` deliberately sets native metadata to `nil` on import, and downstream joins that rely on the source card's columns break.

## Fix

Export the **full** `result_metadata` for native non-model cards, mirroring the pre-GHY-3339 transforms (`dissoc :fingerprint` + `:table_id`/`:id`/`:field_ref`/`:fk_target_field_id` FK transforms) that `import-result-metadata` already inverts symmetrically. Models keep their lean soft-key export; MBQL non-models still skip (they re-derive fine at import). The metadata was already observed once when the card was saved, so this carries it across without executing anything at import — avoiding the warehouse-connectivity and permission problems of an import-time re-execution approach (serdes also strips warehouse connection details on export).

## Test

Adds `gui-question-joined-to-native-source-card-survives-roundtrip-test` in `e2e_test.clj`: creates a native card (with populated metadata) + a GUI card joining it, runs serdes extract/load between two H2 app DBs, then **compiles** the imported GUI query. Compilation is where the bug surfaces (`add-alias-info` runs during `mbql->native`), and it's the connection-free way to assert the fix — serdes strips warehouse details, so the imported card can't actually be executed in the test. The test fails on master with the exact reported error and passes with this change.