### PR TITLE
allow collection creation when publishing tables

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/components/PublishTablesModal/PublishTablesModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/components/PublishTablesModal/PublishTablesModal.tsx
@@ -181,7 +181,7 @@ function ModalBody({
                 hasSearch: true,
                 hasRecents: false,
                 hasConfirmButtons: true,
-                canCreateCollections: false,
+                canCreateCollections: true,
               },
             }}
           />

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/components/PublishTablesModal/PublishTablesModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/components/PublishTablesModal/PublishTablesModal.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   setupLibraryEndpoints,
   setupPublishTablesEndpoint,
   setupPublishTablesEndpointError,
+  setupRootCollectionItemsEndpoint,
   setupTableSelectionInfoEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
@@ -74,6 +75,23 @@ function setup({
     ],
   });
   setupCollectionByIdEndpoint({ collections: [dataCollection] });
+  setupCollectionItemsEndpoint({
+    collection: { id: dataCollection.id as number },
+    collectionItems: [],
+  });
+  setupRootCollectionItemsEndpoint({
+    rootCollectionItems: [
+      createMockCollectionItem({
+        id: dataCollection.id as number,
+        name: dataCollection.name,
+        model: "collection",
+        type: dataCollection.type,
+        can_write: true,
+        here: ["table", "collection"],
+        below: ["table", "collection"],
+      }),
+    ],
+  });
 
   setupTableSelectionInfoEndpoint(selectionInfo);
   if (hasPublishError) {
@@ -178,6 +196,26 @@ describe("PublishTablesModal", () => {
     expect(await screen.findByText("People")).toBeInTheDocument();
     await userEvent.click(await screen.findByText("Publish these tables"));
     await waitFor(() => expect(onPublish).toHaveBeenCalled());
+  });
+
+  it("should allow creating a new collection from the collection picker (UXW-4167)", async () => {
+    setup({
+      selectionInfo: createMockBulkTableSelectionInfo({
+        selected_table: createMockBulkTableInfo({
+          id: 1,
+          display_name: "Orders",
+        }),
+      }),
+    });
+    expect(await screen.findByText("Publish Orders?")).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId("collection-picker-button"),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "New collection" }),
+    ).toBeInTheDocument();
   });
 
   it("should show a publish error", async () => {


### PR DESCRIPTION
### Description

Small change to allow collection creation when publishing tables

### How to verify
1. Go to Data studio -> tables
2. Select an unpublished table and hit publish
3. Open the entity picker and see the create collection butotn


### Demo

https://github.com/user-attachments/assets/f04e598d-445a-4f2c-9104-460fa8683c50



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
