### PR TITLE
Remove Our Analytics from library snippet header

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/components/SnippetHeader/SnippetHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/components/SnippetHeader/SnippetHeader.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 
 import { useUpdateSnippetMutation } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
+import { isRootCollection } from "metabase/collections/utils";
 import { useToast } from "metabase/common/hooks";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import {
@@ -41,6 +42,11 @@ export function SnippetHeader({
     collectionId: snippet.collection_id,
   });
 
+  // Drop the root collection; the "SQL snippets" link already represents it.
+  const folderPath = path?.filter(
+    (collection) => !isRootCollection(collection),
+  );
+
   return (
     <PaneHeader
       title={
@@ -59,7 +65,7 @@ export function SnippetHeader({
           <Link key="snippet-root-collection" to={Urls.dataStudioLibrary()}>
             {t`SQL snippets`}
           </Link>
-          {path?.map((collection, i) => (
+          {folderPath?.map((collection, i) => (
             <Link
               key={collection.id}
               to={
@@ -68,7 +74,7 @@ export function SnippetHeader({
                   : Urls.dataStudioLibrary({
                       expandedIds: [
                         "root",
-                        ...path.slice(0, i + 1).map((c) => c.id),
+                        ...folderPath.slice(0, i + 1).map((c) => c.id),
                       ],
                     })
               }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/components/SnippetHeader/SnippetHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/snippets/components/SnippetHeader/SnippetHeader.unit.spec.tsx
@@ -28,7 +28,14 @@ const setup = ({ snippet = {}, remoteSyncType }: SetupOps) => {
   const mockSnippet = createMockNativeQuerySnippet(snippet);
 
   setupCollectionByIdEndpoint({
-    collections: [createMockCollection({ id: "root" })],
+    collections: [
+      createMockCollection({ id: "root", name: "Our analytics" }),
+      createMockCollection({
+        id: 10,
+        name: "My folder",
+        effective_ancestors: [createMockCollection({ id: "root" })],
+      }),
+    ],
   });
 
   const tokenFeatures: Partial<TokenFeatures> = {
@@ -73,6 +80,33 @@ describe("SnippetHeader", () => {
       screen.getByRole("button", { name: "Snippet menu options" }),
     ).toBeInTheDocument();
     expect(screen.getByTestId("custom-actions")).toBeInTheDocument();
+  });
+
+  describe("breadcrumbs", () => {
+    it("does not show 'Our analytics' for a snippet in the root folder (metabase#UXW-4170)", async () => {
+      setup({ snippet: { name: "My Snippet", collection_id: null } });
+
+      expect(
+        await screen.findByRole("link", { name: "SQL snippets" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "Our analytics" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the folder path for a snippet inside a folder", async () => {
+      setup({ snippet: { name: "My Snippet", collection_id: 10 } });
+
+      expect(
+        await screen.findByRole("link", { name: "SQL snippets" }),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole("link", { name: "My folder" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "Our analytics" }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("when remote sync is set to read-only", () => {


### PR DESCRIPTION
### Description

Updates the snippet header to remove the root collection from the breadcrumbs.

### How to verify
1. Go to the data studio -> library
2. Open a snippet
3. You should not see "Our Analytics" in the breadcrumbs


### Demo

<img width="533" height="448" alt="image" src="https://github.com/user-attachments/assets/62eb79fb-5347-4ed5-b841-43a039908d3c" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR