### PR TITLE
Update transitively dependent cards when card database changes

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1665,6 +1665,7 @@
            dashboards
            documents
            events
+           graph
            lib
            lib-be
            metrics

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -16,6 +16,7 @@
    [metabase.content-verification.core :as moderation]
    [metabase.dashboards.autoplace :as autoplace]
    [metabase.events.core :as events]
+   [metabase.graph.core :as graph]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -1177,6 +1178,37 @@
             (doseq [[id update] updates]
               (t2/update! :model/DashboardCard :id id update))))))))
 
+(deftype SourceCardDependentsGraph []
+  graph/Graph
+  (children-of [_this key-seq]
+    (if (empty? key-seq)
+      {}
+      (let [deps (t2/select [:model/Card :id :source_card_id :card_schema] :source_card_id [:in key-seq])]
+        (u/group-by :source_card_id :id conj #{} deps)))))
+
+(defn- dependent-cards-to-update
+  [root-card-id old-db-id]
+  (let [all-dep-ids (graph/transitive (->SourceCardDependentsGraph) [root-card-id])]
+    (when (seq all-dep-ids)
+      (into []
+            (filter (fn [{:keys [dataset_query]}]
+                      (and (map? dataset_query) (= (:database dataset_query) old-db-id))))
+            (t2/select [:model/Card :id :dataset_query :card_schema] :id [:in all-dep-ids])))))
+
+(defn- cascade-database-change-to-dependents!
+  "When a card's `database_id` changes, update all cards that use it as a `:source-card` (transitively) so their
+  `dataset_query` `:database` key stays in sync. Without this dependent cards would fail with 'Card does not exist'
+   because the metadata provider filters cards by database (#74561)."
+  [card-before-update]
+  (let [card-id   (:id card-before-update)
+        old-db-id (:database_id card-before-update)
+        new-db-id (t2/select-one-fn :database_id :model/Card :id card-id)]
+    (when (not= old-db-id new-db-id)
+      (let [cards-to-update (dependent-cards-to-update card-id old-db-id)]
+        (when (seq cards-to-update)
+          (doseq [{dep-id :id, dep-query :dataset_query} cards-to-update]
+            (t2/update! :model/Card dep-id {:dataset_query (assoc dep-query :database new-db-id)})))))))
+
 (defn update-card!
   "Update a Card. Metadata is fetched asynchronously. If it is ready before [[metadata-sync-wait-ms]] elapses it will be
   included, otherwise the metadata will be saved to the database asynchronously."
@@ -1207,6 +1239,8 @@
                                  :with-overrides? true})
       ;; ok, now save the Card
       (t2/update! :model/Card (:id card-before-update) updated-fields))
+    ;; Update all transitively dependent cards if the database was changed (#74561)
+    (cascade-database-change-to-dependents! card-before-update)
     ;; ok, now update dependent dashcard parameters
     (try
       (update-associated-parameters! card-before-update card-updates)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1191,23 +1191,21 @@
   (let [all-dep-ids (graph/transitive (->SourceCardDependentsGraph) [root-card-id])]
     (when (seq all-dep-ids)
       (into []
-            (filter (fn [{:keys [dataset_query]}]
-                      (and (map? dataset_query) (= (:database dataset_query) old-db-id))))
+            (filter (fn [{:keys [dataset_query]}] (= (:database dataset_query) old-db-id)))
             (t2/select [:model/Card :id :dataset_query :card_schema] :id [:in all-dep-ids])))))
 
 (defn- cascade-database-change-to-dependents!
   "When a card's `database_id` changes, update all cards that use it as a `:source-card` (transitively) so their
   `dataset_query` `:database` key stays in sync. Without this dependent cards would fail with 'Card does not exist'
    because the metadata provider filters cards by database (#74561)."
-  [card-before-update]
+  [card-before-update card-updates]
   (let [card-id   (:id card-before-update)
-        old-db-id (:database_id card-before-update)
-        new-db-id (t2/select-one-fn :database_id :model/Card :id card-id)]
+        old-db-id (-> card-before-update :dataset_query :database)
+        new-db-id (-> card-updates :dataset_query :database)]
     (when (not= old-db-id new-db-id)
       (let [cards-to-update (dependent-cards-to-update card-id old-db-id)]
-        (when (seq cards-to-update)
-          (doseq [{dep-id :id, dep-query :dataset_query} cards-to-update]
-            (t2/update! :model/Card dep-id {:dataset_query (assoc dep-query :database new-db-id)})))))))
+        (doseq [{dep-id :id, dep-query :dataset_query} cards-to-update]
+          (t2/update! :model/Card dep-id {:dataset_query (assoc dep-query :database new-db-id)}))))))
 
 (defn update-card!
   "Update a Card. Metadata is fetched asynchronously. If it is ready before [[metadata-sync-wait-ms]] elapses it will be
@@ -1240,7 +1238,7 @@
       ;; ok, now save the Card
       (t2/update! :model/Card (:id card-before-update) updated-fields))
     ;; Update all transitively dependent cards if the database was changed (#74561)
-    (cascade-database-change-to-dependents! card-before-update)
+    (cascade-database-change-to-dependents! card-before-update card-updates)
     ;; ok, now update dependent dashcard parameters
     (try
       (update-associated-parameters! card-before-update card-updates)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1202,7 +1202,7 @@
   (let [card-id   (:id card-before-update)
         old-db-id (-> card-before-update :dataset_query :database)
         new-db-id (-> card-updates :dataset_query :database)]
-    (when (not= old-db-id new-db-id)
+    (when (and old-db-id new-db-id (not= old-db-id new-db-id))
       (let [cards-to-update (dependent-cards-to-update card-id old-db-id)]
         (doseq [{dep-id :id, dep-query :dataset_query} cards-to-update]
           (t2/update! :model/Card dep-id {:dataset_query (assoc dep-query :database new-db-id)}))))))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1561,3 +1561,35 @@
               (testing "remapped values appear correctly"
                 (is (= ["Zero" "A" "B" "C" "D"]
                        (map last rows)))))))))))
+
+(defn- dependent-card [db-id source-card]
+  {:database_id   db-id
+   :dataset_query {:lib/type :mbql/query
+                   :database db-id
+                   :stages   [{:lib/type    :mbql.stage/mbql
+                               :source-card (:id source-card)}]}})
+
+(deftest cascade-database-change-to-transitive-dependents-test
+  (testing "Recursive cascade through chains of dependent cards (#74561)"
+    (mt/with-temp [:model/Database {db1-id :id} {:name "db1" :engine :h2}
+                   :model/Database {db2-id :id} {:name "db2" :engine :h2}
+                   :model/Card     model        {:type          :model
+                                                 :database_id   db1-id
+                                                 :dataset_query {:lib/type :mbql/query
+                                                                 :database db1-id
+                                                                 :stages   [{:lib/type :mbql.stage/native
+                                                                             :native   "SELECT 1"}]}}
+                   :model/Card     question1    (dependent-card db1-id model)
+                   :model/Card     question2    (dependent-card db1-id model)
+                   :model/Card     question3    (dependent-card db1-id question1)
+                   :model/Card     question4    (dependent-card db1-id question2)]
+      (mt/with-test-user :crowberto
+        (card/update-card! {:card-before-update model
+                            :card-updates       {:dataset_query {:lib/type :mbql/query
+                                                                 :database db2-id
+                                                                 :stages   [{:lib/type :mbql.stage/native
+                                                                             :native   "SELECT 1"}]}}}))
+      (doseq [question [question1 question2 question3 question4]]
+        (let [updated-question (t2/select-one :model/Card :id (:id question))]
+          (is (= db2-id (get-in updated-question [:dataset_query :database])))
+          (is (= db2-id (:database_id updated-question))))))))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1582,14 +1582,15 @@
                    :model/Card     question1    (dependent-card db1-id model)
                    :model/Card     question2    (dependent-card db1-id model)
                    :model/Card     question3    (dependent-card db1-id question1)
-                   :model/Card     question4    (dependent-card db1-id question2)]
+                   :model/Card     question4    (dependent-card db1-id question2)
+                   :model/Card     question5    (dependent-card db1-id question4)]
       (mt/with-test-user :crowberto
         (card/update-card! {:card-before-update model
                             :card-updates       {:dataset_query {:lib/type :mbql/query
                                                                  :database db2-id
                                                                  :stages   [{:lib/type :mbql.stage/native
                                                                              :native   "SELECT 1"}]}}}))
-      (doseq [question [question1 question2 question3 question4]]
-        (let [updated-question (t2/select-one :model/Card :id (:id question))]
-          (is (= db2-id (get-in updated-question [:dataset_query :database])))
-          (is (= db2-id (:database_id updated-question))))))))
+      (doseq [question [question1 question2 question3 question4 question5]]
+        (let [updated-card (t2/select-one :model/Card :id (:id question))]
+          (is (= db2-id (get-in updated-card [:dataset_query :database])))
+          (is (= db2-id (:database_id updated-card))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74561

### Description

When we update a card's database, downstream cards are now broken as when we try to resolve the source card's metadata we filter by the (now outdated) database id of the downstream card. The fix in this PR is to synchronously update all transitively dependent cards when we update a cards database. I considered trying to fix the outdated db lazily on read but that would mean an extra app db call before we start the qp setup. Also considered doing this asynchronously but preferred the atomicity of this since its in a transaction, and it's simpler. 

**NB**: This can result in a (potentially large) number of card updates if the card has many downstream dependents. I'm not sure if that's enough of a concern to warrant moving to a lazy or async approach, so input on that would be appreciated.

### How to verify

See repro steps in original issue. You should be able to query the card and get the expected results.

### Demo

https://github.com/user-attachments/assets/8aed3747-ac5e-4758-b183-0e5c9e4ea97f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
