### PR TITLE
Hide collection CTA if user doesn't have publish permisisons

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/index.ts
@@ -12,6 +12,7 @@ import {
   getEntityPickerSyntheticLibraryItem,
   getLibraryCollectionEmptyStateMessages,
   isLibraryCollectionType,
+  isLibraryDataCollectionType,
   isLibrarySubCollectionType,
   useGetLibraryChildCollectionByType,
   useGetLibraryCollection,
@@ -39,5 +40,6 @@ export function initializePlugin() {
       getLibraryCollectionEmptyStateMessages;
     PLUGIN_LIBRARY.isLibraryCollectionType = isLibraryCollectionType;
     PLUGIN_LIBRARY.isLibrarySubCollectionType = isLibrarySubCollectionType;
+    PLUGIN_LIBRARY.isLibraryDataCollectionType = isLibraryDataCollectionType;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/utils.ts
@@ -195,6 +195,12 @@ export const isLibrarySubCollectionType = (
   return type === "library-data" || type === "library-metrics";
 };
 
+export const isLibraryDataCollectionType = (
+  type?: string | null,
+): type is "library-data" => {
+  return type === "library-data";
+};
+
 export const isLibraryCollectionType = (
   type?: string | null,
 ): type is LibrarySubCollectionType => {

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -7,7 +7,9 @@ import {
   isRootTrashCollection,
 } from "metabase/collections/utils";
 import { NewItemMenu } from "metabase/common/components/NewItemMenu";
+import { canAccessDataStudio } from "metabase/data-studio/selectors";
 import { PLUGIN_LIBRARY } from "metabase/plugins";
+import { useSelector } from "metabase/redux";
 import { Box, Button, Icon, Stack, Text, useMantineTheme } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
@@ -23,12 +25,24 @@ const CollectionEmptyState = ({
   const isTrashCollection = !!collection && isRootTrashCollection(collection);
   const isArchived = !!collection?.archived;
 
+  // The library-data description is a "publish tables" CTA; hide it from users who can't publish.
+  const canPublish = useSelector(canAccessDataStudio);
+  const isLibraryDataCollection = PLUGIN_LIBRARY.isLibraryDataCollectionType(
+    collection?.type,
+  );
+  const showDescription = !isLibraryDataCollection || canPublish;
+
   if (isTrashCollection) {
     return <TrashEmptyState />;
   } else if (isArchived) {
     return <ArchivedCollectionEmptyState />;
   } else {
-    return <DefaultCollectionEmptyState collection={collection} />;
+    return (
+      <DefaultCollectionEmptyState
+        collection={collection}
+        showDescription={showDescription}
+      />
+    );
   }
 };
 
@@ -55,7 +69,8 @@ const ArchivedCollectionEmptyState = () => {
 
 const DefaultCollectionEmptyState = ({
   collection,
-}: CollectionEmptyStateProps) => {
+  showDescription,
+}: CollectionEmptyStateProps & { showDescription: boolean }) => {
   const { title, description } = getDefaultEmptyStateMessages(collection);
   const canWrite = !!collection?.can_write;
   const isSemanticLayer = collection != null && isLibraryCollection(collection);
@@ -65,7 +80,9 @@ const DefaultCollectionEmptyState = ({
     <EmptyStateWrapper>
       <CollectionEmptyIcon />
       <EmptyStateTitle>{title}</EmptyStateTitle>
-      <EmptyStateSubtitle>{description}</EmptyStateSubtitle>
+      {showDescription && (
+        <EmptyStateSubtitle>{description}</EmptyStateSubtitle>
+      )}
       {showAddButton && (
         <NewItemMenu
           trigger={

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
@@ -1,15 +1,20 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
   setupUserMetabotPermissionsEndpoint,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import CollectionEmptyState from "metabase/collections/components/CollectionEmptyState";
+import { createMockState } from "metabase/redux/store/mocks";
 import type { Collection } from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
   createMockDatabase,
+  createMockTokenFeatures,
+  createMockUser,
 } from "metabase-types/api/mocks";
 
 console.warn = jest.fn();
@@ -25,14 +30,38 @@ const TEST_COLLECTION_ITEM = createMockCollectionItem({
 
 async function setup({
   collection,
-}: { collection?: Partial<Collection> } = {}) {
+  isAdmin = false,
+  isAnalyst = false,
+  hasEnterprisePlugins = false,
+}: {
+  collection?: Partial<Collection>;
+  isAdmin?: boolean;
+  isAnalyst?: boolean;
+  hasEnterprisePlugins?: boolean;
+} = {}) {
   const mockCollection = createMockCollection(collection);
 
   setupUserMetabotPermissionsEndpoint();
   setupDatabasesEndpoints([TEST_DATABASE]);
   setupSearchEndpoints([TEST_COLLECTION_ITEM]);
 
-  renderWithProviders(<CollectionEmptyState collection={mockCollection} />);
+  const state = createMockState({
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures({ library: true }),
+    }),
+    currentUser: createMockUser({
+      is_superuser: isAdmin,
+      is_data_analyst: isAnalyst,
+    }),
+  });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+
+  renderWithProviders(<CollectionEmptyState collection={mockCollection} />, {
+    storeInitialState: state,
+  });
 }
 
 describe("empty collection", () => {
@@ -46,5 +75,52 @@ describe("empty collection", () => {
     await setup({ collection: { can_write: false } });
 
     expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+});
+
+describe("library sub-collection empty state", () => {
+  const PUBLISH_CTA = "Publish tables in the Library to see them here.";
+  const LIBRARY_DATA_COLLECTION = { type: "library-data" as const };
+
+  it("shows the publish CTA to admins", async () => {
+    await setup({
+      collection: LIBRARY_DATA_COLLECTION,
+      isAdmin: true,
+      hasEnterprisePlugins: true,
+    });
+
+    expect(screen.getByText("No published tables yet")).toBeInTheDocument();
+    expect(screen.getByText(PUBLISH_CTA)).toBeInTheDocument();
+  });
+
+  it("shows the publish CTA to data analysts", async () => {
+    await setup({
+      collection: LIBRARY_DATA_COLLECTION,
+      isAnalyst: true,
+      hasEnterprisePlugins: true,
+    });
+
+    expect(screen.getByText(PUBLISH_CTA)).toBeInTheDocument();
+  });
+
+  it("hides the publish CTA from users who cannot publish, but keeps the title (metabase#UXW-4243)", async () => {
+    await setup({
+      collection: LIBRARY_DATA_COLLECTION,
+      hasEnterprisePlugins: true,
+    });
+
+    expect(screen.getByText("No published tables yet")).toBeInTheDocument();
+    expect(screen.queryByText(PUBLISH_CTA)).not.toBeInTheDocument();
+  });
+
+  it("keeps the metrics description visible to users who cannot publish", async () => {
+    await setup({
+      collection: { type: "library-metrics" as const },
+      hasEnterprisePlugins: true,
+    });
+
+    expect(
+      screen.getByText("Put metrics in the Library to see them here."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/plugins/oss/library.ts
+++ b/frontend/src/metabase/plugins/oss/library.ts
@@ -117,6 +117,7 @@ type LibraryPlugin = {
   isLibrarySubCollectionType: (
     type?: string | null,
   ) => type is LibrarySubCollectionType;
+  isLibraryDataCollectionType: (type?: string | null) => type is "library-data";
 };
 
 const getDefaultPluginLibrary = (): LibraryPlugin => ({
@@ -150,6 +151,9 @@ const getDefaultPluginLibrary = (): LibraryPlugin => ({
   isLibrarySubCollectionType: (
     _type?: string | null,
   ): _type is LibrarySubCollectionType => false,
+  isLibraryDataCollectionType: (
+    _type?: string | null,
+  ): _type is "library-data" => false,
 });
 
 export const PLUGIN_LIBRARY = getDefaultPluginLibrary();


### PR DESCRIPTION
### Description

Removes the Empty Collection CTA for library data collections. Note that this does not impact the CTA for metric folders

### How to verify

1. Log in as a normie user and navigate to an empty librart data folder
2. Note that there is no CTA to publish a table.

### Demo

<img width="1173" height="932" alt="image" src="https://github.com/user-attachments/assets/27309f29-617b-4782-a4f0-ef7627a3fa1b" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
