### PR TITLE
GHY-3804 require superuser for remote-sync current-task endpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -130,12 +130,14 @@
 (api.macros/defendpoint :get "/current-task" :- [:maybe remote-sync.schema/SyncTask]
   "Get the current sync task"
   []
+  (api/check-superuser)
   (when-let [task (remote-sync.task/most-recent-task)]
     (t2/hydrate task :status)))
 
 (api.macros/defendpoint :post "/current-task/cancel" :- remote-sync.schema/SyncTask
   "Cancels the current task if one is running"
   []
+  (api/check-superuser)
   (let [task (remote-sync.task/most-recent-task)]
     (api/check-400 (and (some? task) (remote-sync.task/running? task)) "No active task to cancel")
     (remote-sync.task/cancel-sync-task! (:id task))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -391,6 +391,11 @@
 
 ;;; ------------------------------------------------- Current Task Endpoint -------------------------------------------------
 
+(deftest current-task-requires-superuser-test
+  (testing "GET /api/ee/remote-sync/current-task requires superuser permissions (GHY-3804)"
+    (is (= "You don't have permissions to do that."
+           (mt/user-http-request :rasta :get 403 "ee/remote-sync/current-task")))))
+
 (deftest current-task-returns-nil-when-no-tasks-test
   (testing "GET /api/ee/remote-sync/current-task returns nil when there are no tasks"
     (is (nil? (mt/user-http-request :crowberto :get 204 "ee/remote-sync/current-task")))))
@@ -436,6 +441,16 @@
               (mt/user-http-request :crowberto :get 200 "ee/remote-sync/current-task"))))))
 
 ;;; ------------------------------------------------- Cancel Task Endpoint -------------------------------------------------
+
+(deftest cancel-task-requires-superuser-test
+  (testing "POST /api/ee/remote-sync/current-task/cancel requires superuser permissions (GHY-3804)"
+    (mt/with-temp [:model/RemoteSyncTask {id :id} {:sync_task_type "export"
+                                                   :last_progress_report_at :%now
+                                                   :started_at :%now}]
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "ee/remote-sync/current-task/cancel")))
+      (testing "task is not cancelled by the non-superuser request"
+        (is (not (remote-sync.task/cancelled? (t2/select-one :model/RemoteSyncTask :id id))))))))
 
 (deftest cancel-task-errors-when-no-tasks-test
   (testing "POST /api/ee/remote-sync/current-task/cancel errors when there are no tasks"


### PR DESCRIPTION
## Summary

The remote sync `GET /api/ee/remote-sync/current-task` and `POST /api/ee/remote-sync/current-task/cancel` endpoints were protected only by `+auth`, so any authenticated user could read sync task details (including errors/conflicts) and cancel active sync operations — a denial-of-service against admin sync workflows.

This adds `(api/check-superuser)` to both endpoints, aligning them with every other endpoint in the remote-sync API (`/import`, `/export`, `/is-dirty`, etc.).

Fixes GHY-3804.

## Changes

- `enterprise/backend/src/metabase_enterprise/remote_sync/api.clj` — add `api/check-superuser` to `/current-task` and `/current-task/cancel`.
- `enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj` — add tests asserting non-admin users get 403 on both endpoints, and that a rejected cancel leaves the active task untouched.

## Testing

- New superuser tests pass (5 assertions, 0 failures).
- Kondo clean (0 errors, 0 warnings).