### PR TITLE
Send Cypress failure screenshots to ci-conductor

### DIFF
--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -120,89 +120,46 @@ function baseName(p: string): string {
   return p.split(/[\\/]/).pop() ?? "";
 }
 
-// First-failure screenshot paths captured for the current spec via Cypress'
-// after:screenshot hook. Populated by recordFailureScreenshot and drained by
-// takeRecordedScreenshotPaths (per spec, in after:spec). Module-level state, but
-// specs run serially so a spec only ever sees its own shots.
-const recordedFailureScreenshots: string[] = [];
-
 /**
- * Record a screenshot from Cypress' after:screenshot hook (see config.js). The
- * hook's details carry `testFailure` and `testAttemptIndex`, which the after:spec
- * results don't — so we keep exactly the first failure shot per test
- * (`testFailure === true && testAttemptIndex === 0`) and ignore manual
- * screenshots and retry shots ("(attempt 2)", ...). Defensive: ignores anything
- * malformed and never throws into the run. See DEV-2000.
- */
-export function recordFailureScreenshot(details: {
-  path?: string;
-  testFailure?: boolean;
-  testAttemptIndex?: number;
-}): void {
-  try {
-    if (
-      details?.testFailure === true &&
-      details?.testAttemptIndex === 0 &&
-      typeof details?.path === "string" &&
-      details.path
-    ) {
-      recordedFailureScreenshots.push(details.path);
-    }
-  } catch (error) {
-    // Recording is best-effort; log but never throw into the run.
-    console.error("[ci-conductor] failed to record screenshot", error);
-  }
-}
-
-/**
- * Return the first-failure screenshot paths captured for the current spec and
- * reset the buffer for the next one (snapshot-and-clear, so a spec only ever
- * sees its own shots even if reporting later throws). Called once per spec.
- */
-export function takeRecordedScreenshotPaths(): string[] {
-  // splice(0) returns all elements and empties the buffer in one step.
-  return recordedFailureScreenshots.splice(0);
-}
-
-/**
- * Match a test to its (already filtered to first-failure) screenshot path. The
- * after:screenshot hook gives us paths but no test title, so the only link is
- * the path itself — Cypress derives the filename from the test's full title. We
- * normalize the title and each path's basename down to [a-z0-9] (dropping spaces,
- * the " -- " separators, the "(failed)" suffix, the extension and any filesystem
- * sanitization) and test containment.
+ * Match a failed test to its first-failure screenshot from after:spec's
+ * `results.screenshots` — a flat, spec-level list with no link back to the test.
+ * Cypress derives each screenshot filename from the test's full title (joined
+ * with " -- ", sanitized) followed by " (failed)" (plus "(attempt N)" for
+ * retries). We normalize the title and each basename down to [a-z0-9] — which
+ * cancels every sanitization rule (">", " -- ", "/", ":", ...) on both sides, so
+ * we never reconstruct the filename — and anchor on the title immediately
+ * followed by "failed":
  *
- * `recordedPaths` already holds only first-failure shots (one per test), so the
- * sole remaining ambiguity is a title that's a prefix of another test's — we
- * keep the most specific (shortest normalized basename that still contains the
- * title) so a short title can't steal a longer test's shot.
+ *   normalize(basename) === normalize(title.join("")) + "failed" + [attempt…] + ext
+ *
+ * Anchoring on "failed" (a) excludes manual cy.screenshot() shots, which have no
+ * "(failed)" suffix, and (b) is collision-proof: a title that's a prefix of
+ * another's won't match, because "failed" must follow the key exactly. The first
+ * shot and its retries both anchor-match, so we take the shortest basename — the
+ * one without an "(attempt N)" suffix, i.e. the first attempt.
  *
  * Pure and defensive: returns undefined on any missing/odd input, never throws.
  * See DEV-2000.
  */
 export function resolveScreenshotPath(
   titlePath: string[] | undefined,
-  recordedPaths: string[] | undefined,
+  screenshots: Array<{ path?: string }> | undefined,
 ): string | undefined {
   try {
     const key = normalizeForMatch((titlePath ?? []).join(""));
-    if (!key || !Array.isArray(recordedPaths)) {
+    if (!key || !Array.isArray(screenshots)) {
       return undefined;
     }
 
-    // Most specific wins (shortest basename still containing the title); ties
-    // keep the earlier, first-captured match.
-    return recordedPaths
-      .filter((path): path is string => typeof path === "string" && path !== "")
-      .map((path) => ({ path, hay: normalizeForMatch(baseName(path)) }))
-      .filter(({ hay }) => hay.includes(key))
-      .reduce<{ path: string; hay: string } | undefined>(
-        (best, match) =>
-          best === undefined || match.hay.length < best.hay.length
-            ? match
-            : best,
-        undefined,
-      )?.path;
+    const anchor = `${key}failed`;
+    return (
+      screenshots
+        .map((shot) => (typeof shot?.path === "string" ? shot.path : ""))
+        .filter((path) => path !== "")
+        .filter((path) => normalizeForMatch(baseName(path)).startsWith(anchor))
+        // Shortest basename = the first attempt (no "(attempt N)" suffix).
+        .sort((a, b) => baseName(a).length - baseName(b).length)[0]
+    );
   } catch (error) {
     console.error("[ci-conductor] failed to resolve screenshot path", error);
     return undefined;
@@ -256,7 +213,6 @@ function encodeScreenshot(filePath: string): string | undefined {
 export function extractFailedTests(
   spec: Cypress.Spec,
   results: CypressCommandLine.RunResult,
-  failureScreenshotPaths: string[] = [],
 ): ConductorTest[] {
   const file = spec?.relative;
 
@@ -282,12 +238,12 @@ export function extractFailedTests(
       const suite = titlePath.slice(0, -1).join(" > ");
       const attempts = test.attempts ?? [];
       // Resolve (but don't yet read) the test's first failure screenshot from
-      // the paths captured by the after:screenshot hook. The file is encoded
-      // into `failure_screenshot` at send time so the matching logic here stays
-      // pure. Returns undefined on any miss — best-effort.
+      // this spec's `results.screenshots`. The file is encoded into
+      // `failure_screenshot` at send time so the matching logic here stays pure.
+      // Returns undefined on any miss — best-effort.
       const screenshotPath = resolveScreenshotPath(
         titlePath,
-        failureScreenshotPaths,
+        results?.screenshots,
       );
       return {
         name,

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,3 +1,5 @@
+import { readFileSync, statSync } from "node:fs";
+
 import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
 // `Cypress` and `CypressCommandLine` are global namespaces provided by the
@@ -57,6 +59,19 @@ type ConductorTest = {
    * value. Conductor schema isn't final — fields it doesn't store are ignored.
    */
   message?: string | null;
+  /**
+   * The test's first failure screenshot as a base64 PNG data URI. ci-conductor
+   * uploads it to S3 and stores the public URL. Attached at send time by
+   * `reportFailedTestsToConductor`; absent when there's no screenshot or it
+   * can't be read. See DEV-2000.
+   */
+  failure_screenshot?: string;
+  /**
+   * Transient (never sent on the wire): absolute path to the resolved first
+   * failure screenshot, set by `extractFailedTests`. It's read and encoded into
+   * `failure_screenshot` just before the POST, then dropped. See DEV-2000.
+   */
+  screenshotPath?: string;
 };
 
 /**
@@ -95,6 +110,132 @@ function toNumber(value: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+/** Normalize a string to just [a-z0-9] for sanitization-proof matching. */
+function normalizeForMatch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Basename of a path, tolerant of both POSIX and Windows separators. */
+function baseName(p: string): string {
+  return p.split(/[\\/]/).pop() ?? "";
+}
+
+// First-failure screenshot paths captured for the current spec via Cypress'
+// after:screenshot hook. Populated by recordFailureScreenshot and drained by
+// takeRecordedScreenshotPaths (per spec, in after:spec). Module-level state, but
+// specs run serially so a spec only ever sees its own shots.
+const recordedFailureScreenshots: string[] = [];
+
+/**
+ * Record a screenshot from Cypress' after:screenshot hook (see config.js). The
+ * hook's details carry `testFailure` and `testAttemptIndex`, which the after:spec
+ * results don't — so we keep exactly the first failure shot per test
+ * (`testFailure === true && testAttemptIndex === 0`) and ignore manual
+ * screenshots and retry shots ("(attempt 2)", ...). Defensive: ignores anything
+ * malformed and never throws into the run. See DEV-2000.
+ */
+export function recordFailureScreenshot(details: {
+  path?: string;
+  testFailure?: boolean;
+  testAttemptIndex?: number;
+}): void {
+  try {
+    if (
+      details?.testFailure === true &&
+      details?.testAttemptIndex === 0 &&
+      typeof details?.path === "string" &&
+      details.path
+    ) {
+      recordedFailureScreenshots.push(details.path);
+    }
+  } catch (error) {
+    // Recording is best-effort; log but never throw into the run.
+    console.error("[ci-conductor] failed to record screenshot", error);
+  }
+}
+
+/**
+ * Return the first-failure screenshot paths captured for the current spec and
+ * reset the buffer for the next one (snapshot-and-clear, so a spec only ever
+ * sees its own shots even if reporting later throws). Called once per spec.
+ */
+export function takeRecordedScreenshotPaths(): string[] {
+  // splice(0) returns all elements and empties the buffer in one step.
+  return recordedFailureScreenshots.splice(0);
+}
+
+/**
+ * Match a test to its (already filtered to first-failure) screenshot path. The
+ * after:screenshot hook gives us paths but no test title, so the only link is
+ * the path itself — Cypress derives the filename from the test's full title. We
+ * normalize the title and each path's basename down to [a-z0-9] (dropping spaces,
+ * the " -- " separators, the "(failed)" suffix, the extension and any filesystem
+ * sanitization) and test containment.
+ *
+ * `recordedPaths` already holds only first-failure shots (one per test), so the
+ * sole remaining ambiguity is a title that's a prefix of another test's — we
+ * keep the most specific (shortest normalized basename that still contains the
+ * title) so a short title can't steal a longer test's shot.
+ *
+ * Pure and defensive: returns undefined on any missing/odd input, never throws.
+ * See DEV-2000.
+ */
+export function resolveScreenshotPath(
+  titlePath: string[] | undefined,
+  recordedPaths: string[] | undefined,
+): string | undefined {
+  try {
+    const key = normalizeForMatch((titlePath ?? []).join(""));
+    if (!key || !Array.isArray(recordedPaths)) {
+      return undefined;
+    }
+
+    // Most specific wins (shortest basename still containing the title); ties
+    // keep the earlier, first-captured match.
+    return recordedPaths
+      .filter((path): path is string => typeof path === "string" && path !== "")
+      .map((path) => ({ path, hay: normalizeForMatch(baseName(path)) }))
+      .filter(({ hay }) => hay.includes(key))
+      .reduce<{ path: string; hay: string } | undefined>(
+        (best, match) =>
+          best === undefined || match.hay.length < best.hay.length
+            ? match
+            : best,
+        undefined,
+      )?.path;
+  } catch (error) {
+    console.error("[ci-conductor] failed to resolve screenshot path", error);
+    return undefined;
+  }
+}
+
+// ci-conductor rejects screenshots over 10 MB decoded; base64 inflates ~33%, so
+// we cap the raw file well under that (see its lib/screenshots MAX_SCREENSHOT_BYTES).
+const MAX_SCREENSHOT_RAW_BYTES = 7 * 1024 * 1024;
+
+/**
+ * Read a screenshot file and return it as a base64 PNG data URI, or undefined if
+ * the file is missing, empty, too large, or unreadable. Best-effort and never
+ * throws — a screenshot problem must not break reporting. See DEV-2000.
+ */
+function encodeScreenshot(filePath: string): string | undefined {
+  try {
+    const stat = statSync(filePath);
+    if (
+      !stat.isFile() ||
+      stat.size === 0 ||
+      stat.size > MAX_SCREENSHOT_RAW_BYTES
+    ) {
+      return undefined;
+    }
+    const b64 = readFileSync(filePath).toString("base64");
+    return b64 ? `data:image/png;base64,${b64}` : undefined;
+  } catch (error) {
+    console.error("[ci-conductor] failed to read screenshot", filePath, error);
+    return undefined;
+  }
+}
+
 /**
  * Pull the reportable tests out of a single spec's run results. We always
  * include any test that had at least one failed attempt — so both "broken"
@@ -115,6 +256,7 @@ function toNumber(value: string | undefined): number | null {
 export function extractFailedTests(
   spec: Cypress.Spec,
   results: CypressCommandLine.RunResult,
+  failureScreenshotPaths: string[] = [],
 ): ConductorTest[] {
   const file = spec?.relative;
 
@@ -139,6 +281,14 @@ export function extractFailedTests(
       const name = titlePath[titlePath.length - 1] ?? "(unknown test)";
       const suite = titlePath.slice(0, -1).join(" > ");
       const attempts = test.attempts ?? [];
+      // Resolve (but don't yet read) the test's first failure screenshot from
+      // the paths captured by the after:screenshot hook. The file is encoded
+      // into `failure_screenshot` at send time so the matching logic here stays
+      // pure. Returns undefined on any miss — best-effort.
+      const screenshotPath = resolveScreenshotPath(
+        titlePath,
+        failureScreenshotPaths,
+      );
       return {
         name,
         path: suite || undefined,
@@ -147,6 +297,7 @@ export function extractFailedTests(
         attempts,
         status: classifyStatus(attempts),
         message: test.displayError ?? null,
+        ...(screenshotPath ? { screenshotPath } : {}),
       };
     });
 
@@ -181,6 +332,17 @@ export async function reportFailedTestsToConductor(
   // Everything below is wrapped so the reporter can never throw into the test
   // run, regardless of payload contents or network behavior.
   try {
+    // Best-effort: read each resolved screenshot and inline it as base64 for
+    // ci-conductor to upload. encodeScreenshot never throws — a test simply goes
+    // without a screenshot if it can't be read. The transient `screenshotPath`
+    // is dropped here so it never reaches the wire.
+    const outgoing = tests.map(({ screenshotPath, ...rest }) => {
+      const failure_screenshot = screenshotPath
+        ? encodeScreenshot(screenshotPath)
+        : undefined;
+      return failure_screenshot ? { ...rest, failure_screenshot } : rest;
+    });
+
     const body = {
       repo_id: toNumber(REPO_ID),
       run_id: toNumber(GITHUB_RUN_ID),
@@ -195,13 +357,25 @@ export async function reportFailedTestsToConductor(
       // CYPRESS_RETRIES isn't set in CI by default; e2e/support/config.js
       // surfaces the resolved Cypress config value into this env at startup.
       retries: toNumber(process.env.CYPRESS_RETRIES),
-      tests,
+      tests: outgoing,
     };
 
     if (isDryRun) {
+      // Don't dump base64 blobs into the log — replace each with a size marker.
+      const screenshotCount = outgoing.filter(
+        (t) => t.failure_screenshot,
+      ).length;
+      const redactedTests = outgoing.map((t) =>
+        t.failure_screenshot
+          ? {
+              ...t,
+              failure_screenshot: `<base64 ${t.failure_screenshot.length} chars>`,
+            }
+          : t,
+      );
       console.log(
-        `[ci-conductor] (dry run) would POST ${tests.length} failure(s):`,
-        JSON.stringify(body),
+        `[ci-conductor] (dry run) would POST ${outgoing.length} failure(s), ${screenshotCount} with screenshot(s):`,
+        JSON.stringify({ ...body, tests: redactedTests }),
       );
       return;
     }

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -1,9 +1,4 @@
-import {
-  extractFailedTests,
-  recordFailureScreenshot,
-  resolveScreenshotPath,
-  takeRecordedScreenshotPaths,
-} from "./ci_conductor";
+import { extractFailedTests, resolveScreenshotPath } from "./ci_conductor";
 
 // jest.mock is hoisted; the mocked default must be referenced via a `mock`-
 // prefixed variable. node-fetch is unused by extractFailedTests, so mocking it
@@ -73,6 +68,13 @@ const test = (
   duration,
   attempts: attemptStates.map((state) => ({ state })),
 });
+
+// Build a `results.screenshots`-shaped array from bare paths (the only field we
+// read). Cypress leaves `name` null for automatic failure shots.
+const screenshotsFromPaths = (...paths: string[]) =>
+  paths.map((path) => ({
+    path,
+  })) as unknown as CypressCommandLine.RunResult["screenshots"];
 
 describe("extractFailedTests", () => {
   // Pin the default to "first attempt" so these tests are deterministic even
@@ -249,32 +251,34 @@ describe("extractFailedTests", () => {
     expect(extractFailedTests(spec, results)).toEqual([]);
   });
 
-  it("attaches screenshotPath for a failed test with a matching recorded shot", () => {
+  it("attaches screenshotPath for a failed test with a matching screenshot", () => {
     const path =
       "/cy/screenshots/foo.cy.spec.js/a -- shows an error (failed).png";
     const results = makeResults({
       tests: [test(["a", "shows an error"], ["failed"], "boom")],
+      screenshots: screenshotsFromPaths(path),
     });
 
-    expect(extractFailedTests(spec, results, [path])[0]).toMatchObject({
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
       name: "shows an error",
       screenshotPath: path,
     });
   });
 
-  it("omits screenshotPath when no recorded shot matches the test", () => {
-    const results = makeResults({
-      tests: [test(["a", "shows an error"], ["failed"], "boom")],
-    });
+  it("omits screenshotPath when no screenshot matches the test", () => {
     const unrelated =
       "/cy/screenshots/foo/a -- a totally different test (failed).png";
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+      screenshots: screenshotsFromPaths(unrelated),
+    });
 
-    expect(
-      extractFailedTests(spec, results, [unrelated])[0],
-    ).not.toHaveProperty("screenshotPath");
+    expect(extractFailedTests(spec, results)[0]).not.toHaveProperty(
+      "screenshotPath",
+    );
   });
 
-  it("omits screenshotPath when no screenshots were recorded", () => {
+  it("omits screenshotPath when the spec produced no screenshots", () => {
     const results = makeResults({
       tests: [test(["a", "shows an error"], ["failed"], "boom")],
     });
@@ -286,79 +290,61 @@ describe("extractFailedTests", () => {
 });
 
 describe("resolveScreenshotPath", () => {
-  it("returns undefined with no paths, no title, or no match", () => {
+  const shots = (...paths: string[]) => paths.map((path) => ({ path }));
+
+  it("returns undefined with no screenshots, no title, or no match", () => {
     expect(resolveScreenshotPath(["a", "b"], undefined)).toBeUndefined();
     expect(resolveScreenshotPath(["a", "b"], [])).toBeUndefined();
-    expect(resolveScreenshotPath(undefined, ["/x.png"])).toBeUndefined();
     expect(
-      resolveScreenshotPath(["a", "b"], ["/x/unrelated (failed).png"]),
+      resolveScreenshotPath(undefined, shots("/x/a (failed).png")),
+    ).toBeUndefined();
+    expect(
+      resolveScreenshotPath(["a", "b"], shots("/x/unrelated (failed).png")),
     ).toBeUndefined();
   });
 
-  it("matches by path basename despite spaces, separators and suffixes", () => {
+  it("matches the real on-disk basename despite spaces, ` -- ` and `>` stripping", () => {
+    // Verbatim from a local run: describe("scenarios > models > create") →
+    // Cypress writes "scenarios  models  create -- <test> (failed).png".
     const path =
-      "/cy/screenshots/foo.cy.spec.js/scenarios  dashboard  filters -- static list source (dropdown) -- should be able to use a static list source when embedded (failed).png";
+      "/home/dev/code/metabase/cypress/screenshots/create.cy.spec.js/scenarios  models  create -- user without a collection access should still be able to create and save a model in his own personal collection (failed).png";
     expect(
       resolveScreenshotPath(
         [
-          "scenarios",
-          "dashboard",
-          "filters static list source (dropdown)",
-          "should be able to use a static list source when embedded",
+          "scenarios > models > create",
+          "user without a collection access should still be able to create and save a model in his own personal collection",
         ],
-        [path],
+        shots(path),
       ),
     ).toBe(path);
   });
 
-  it("does not let a prefix title steal a longer test's screenshot", () => {
+  it("excludes manual screenshots (no `(failed)` anchor)", () => {
+    // A manual cy.screenshot() is named "<title>.png" — no "(failed)".
+    const manual = "/x/a -- renders the chart.png";
+    expect(
+      resolveScreenshotPath(["a", "renders the chart"], shots(manual)),
+    ).toBeUndefined();
+  });
+
+  it("picks the first attempt over its retry", () => {
+    const first = "/x/a -- flaky (failed).png";
+    const retry = "/x/a -- flaky (failed) (attempt 2).png";
+    expect(resolveScreenshotPath(["a", "flaky"], shots(retry, first))).toBe(
+      first,
+    );
+  });
+
+  it("anchors on `(failed)`, so a prefix title can't steal a longer test's shot", () => {
     const shortShot = "/x/a -- loads (failed).png";
     const longShot = "/x/a -- loads quickly (failed).png";
-    // "loads" is a substring of "loads quickly"; the shorter, more specific
-    // basename wins for the short title regardless of order.
-    expect(resolveScreenshotPath(["a", "loads"], [longShot, shortShot])).toBe(
-      shortShot,
-    );
-  });
-});
-
-describe("recordFailureScreenshot / takeRecordedScreenshotPaths", () => {
-  // Drain any leftover state so each test starts clean (module state persists
-  // across the shared top-level import).
-  beforeEach(() => {
-    takeRecordedScreenshotPaths();
-  });
-
-  const detail = (
-    path: string,
-    testFailure: boolean,
-    testAttemptIndex: number,
-  ) => ({ path, testFailure, testAttemptIndex });
-
-  it("keeps only first-attempt failure screenshots", () => {
-    recordFailureScreenshot(detail("/x/first (failed).png", true, 0));
-    recordFailureScreenshot(
-      detail("/x/retry (failed) (attempt 2).png", true, 1),
-    );
-    recordFailureScreenshot(detail("/x/manual.png", false, 0));
-
-    expect(takeRecordedScreenshotPaths()).toEqual(["/x/first (failed).png"]);
-  });
-
-  it("drains and resets, so a spec only ever sees its own shots", () => {
-    recordFailureScreenshot(detail("/x/spec-a (failed).png", true, 0));
-    expect(takeRecordedScreenshotPaths()).toEqual(["/x/spec-a (failed).png"]);
-    // Second drain is empty — the buffer was cleared.
-    expect(takeRecordedScreenshotPaths()).toEqual([]);
-  });
-
-  it("ignores malformed details and never throws", () => {
-    expect(() => {
-      recordFailureScreenshot({});
-      recordFailureScreenshot(detail("", true, 0));
-      recordFailureScreenshot(undefined as unknown as { path: string });
-    }).not.toThrow();
-    expect(takeRecordedScreenshotPaths()).toEqual([]);
+    // "loads" anchors on "loadsfailed"; "loadsquickly…" can't match it.
+    expect(
+      resolveScreenshotPath(["a", "loads"], shots(longShot, shortShot)),
+    ).toBe(shortShot);
+    expect(
+      resolveScreenshotPath(["a", "loads quickly"], shots(longShot, shortShot)),
+    ).toBe(longShot);
   });
 });
 

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -1,4 +1,9 @@
-import { extractFailedTests } from "./ci_conductor";
+import {
+  extractFailedTests,
+  recordFailureScreenshot,
+  resolveScreenshotPath,
+  takeRecordedScreenshotPaths,
+} from "./ci_conductor";
 
 // jest.mock is hoisted; the mocked default must be referenced via a `mock`-
 // prefixed variable. node-fetch is unused by extractFailedTests, so mocking it
@@ -243,6 +248,118 @@ describe("extractFailedTests", () => {
 
     expect(extractFailedTests(spec, results)).toEqual([]);
   });
+
+  it("attaches screenshotPath for a failed test with a matching recorded shot", () => {
+    const path =
+      "/cy/screenshots/foo.cy.spec.js/a -- shows an error (failed).png";
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+    });
+
+    expect(extractFailedTests(spec, results, [path])[0]).toMatchObject({
+      name: "shows an error",
+      screenshotPath: path,
+    });
+  });
+
+  it("omits screenshotPath when no recorded shot matches the test", () => {
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+    });
+    const unrelated =
+      "/cy/screenshots/foo/a -- a totally different test (failed).png";
+
+    expect(
+      extractFailedTests(spec, results, [unrelated])[0],
+    ).not.toHaveProperty("screenshotPath");
+  });
+
+  it("omits screenshotPath when no screenshots were recorded", () => {
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+    });
+
+    expect(extractFailedTests(spec, results)[0]).not.toHaveProperty(
+      "screenshotPath",
+    );
+  });
+});
+
+describe("resolveScreenshotPath", () => {
+  it("returns undefined with no paths, no title, or no match", () => {
+    expect(resolveScreenshotPath(["a", "b"], undefined)).toBeUndefined();
+    expect(resolveScreenshotPath(["a", "b"], [])).toBeUndefined();
+    expect(resolveScreenshotPath(undefined, ["/x.png"])).toBeUndefined();
+    expect(
+      resolveScreenshotPath(["a", "b"], ["/x/unrelated (failed).png"]),
+    ).toBeUndefined();
+  });
+
+  it("matches by path basename despite spaces, separators and suffixes", () => {
+    const path =
+      "/cy/screenshots/foo.cy.spec.js/scenarios  dashboard  filters -- static list source (dropdown) -- should be able to use a static list source when embedded (failed).png";
+    expect(
+      resolveScreenshotPath(
+        [
+          "scenarios",
+          "dashboard",
+          "filters static list source (dropdown)",
+          "should be able to use a static list source when embedded",
+        ],
+        [path],
+      ),
+    ).toBe(path);
+  });
+
+  it("does not let a prefix title steal a longer test's screenshot", () => {
+    const shortShot = "/x/a -- loads (failed).png";
+    const longShot = "/x/a -- loads quickly (failed).png";
+    // "loads" is a substring of "loads quickly"; the shorter, more specific
+    // basename wins for the short title regardless of order.
+    expect(resolveScreenshotPath(["a", "loads"], [longShot, shortShot])).toBe(
+      shortShot,
+    );
+  });
+});
+
+describe("recordFailureScreenshot / takeRecordedScreenshotPaths", () => {
+  // Drain any leftover state so each test starts clean (module state persists
+  // across the shared top-level import).
+  beforeEach(() => {
+    takeRecordedScreenshotPaths();
+  });
+
+  const detail = (
+    path: string,
+    testFailure: boolean,
+    testAttemptIndex: number,
+  ) => ({ path, testFailure, testAttemptIndex });
+
+  it("keeps only first-attempt failure screenshots", () => {
+    recordFailureScreenshot(detail("/x/first (failed).png", true, 0));
+    recordFailureScreenshot(
+      detail("/x/retry (failed) (attempt 2).png", true, 1),
+    );
+    recordFailureScreenshot(detail("/x/manual.png", false, 0));
+
+    expect(takeRecordedScreenshotPaths()).toEqual(["/x/first (failed).png"]);
+  });
+
+  it("drains and resets, so a spec only ever sees its own shots", () => {
+    recordFailureScreenshot(detail("/x/spec-a (failed).png", true, 0));
+    expect(takeRecordedScreenshotPaths()).toEqual(["/x/spec-a (failed).png"]);
+    // Second drain is empty — the buffer was cleared.
+    expect(takeRecordedScreenshotPaths()).toEqual([]);
+  });
+
+  it("ignores malformed details and never throws", () => {
+    expect(() => {
+      recordFailureScreenshot({});
+      recordFailureScreenshot(detail("", true, 0));
+      recordFailureScreenshot(undefined as unknown as { path: string });
+    }).not.toThrow();
+    expect(takeRecordedScreenshotPaths()).toEqual([]);
+  });
 });
 
 describe("reportFailedTestsToConductor", () => {
@@ -475,6 +592,52 @@ describe("reportFailedTestsToConductor", () => {
     await reportFailedTestsToConductor(oneTest);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("500"));
     (console.error as jest.Mock).mockRestore();
+  });
+
+  it("inlines a resolved screenshot as base64 and drops screenshotPath", async () => {
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const pathMod = await import("node:path");
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]); // PNG magic
+    const file = pathMod.join(os.tmpdir(), "ci-conductor-shot.png");
+    fs.writeFileSync(file, bytes);
+    try {
+      const { reportFailedTestsToConductor } = await loadConductor({
+        CI_CONDUCTOR_WEBHOOK_URL: url,
+      });
+      await reportFailedTestsToConductor([
+        { name: "t", file: "f.cy.spec.ts", screenshotPath: file },
+      ]);
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body).tests[0];
+      expect(sent.failure_screenshot).toBe(
+        `data:image/png;base64,${bytes.toString("base64")}`,
+      );
+      expect(sent).not.toHaveProperty("screenshotPath");
+    } finally {
+      fs.unlinkSync(file);
+    }
+  });
+
+  it("omits the screenshot (and screenshotPath) when the file can't be read", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_WEBHOOK_URL: url,
+    });
+
+    await reportFailedTestsToConductor([
+      { name: "t", file: "f.cy.spec.ts", screenshotPath: "/no/such/file.png" },
+    ]);
+
+    const sent = JSON.parse(mockFetch.mock.calls[0][1].body).tests[0];
+    expect(sent).not.toHaveProperty("failure_screenshot");
+    expect(sent).not.toHaveProperty("screenshotPath");
+    // The read failure is logged (best-effort), not thrown.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to read screenshot"),
+      "/no/such/file.png",
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
   });
 
   it("never throws even when fetch throws synchronously", async () => {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -10,9 +10,7 @@ import { BACKEND_HOST, BACKEND_PORT } from "../runner/constants/backend-port";
 
 import {
   extractFailedTests,
-  recordFailureScreenshot,
   reportFailedTestsToConductor,
-  takeRecordedScreenshotPaths,
 } from "./ci_conductor";
 import * as ciTasks from "./ci_tasks";
 import { collectFailingTests } from "./collectFailedTests";
@@ -193,14 +191,6 @@ const defaultConfig = {
         : (config.retries?.runMode ?? 0);
     process.env.CYPRESS_RETRIES = String(resolvedRetries);
 
-    // Capture each test's first failure screenshot for ci-conductor. The
-    // after:screenshot hook is the only place Cypress exposes `testFailure` and
-    // `testAttemptIndex`, which let us keep just the first failure shot per test
-    // (see recordFailureScreenshot). after:spec then drains and reports them.
-    if (isCI) {
-      on("after:screenshot", (details) => recordFailureScreenshot(details));
-    }
-
     on("after:spec", async (spec, results) => {
       // Report failures to ci-conductor mid-run (no-ops unless configured).
       if (isCI) {
@@ -208,9 +198,7 @@ const defaultConfig = {
         // a hard backstop around everything — extraction, payload build, and
         // the request. The reporter also handles its own errors internally.
         try {
-          await reportFailedTestsToConductor(
-            extractFailedTests(spec, results, takeRecordedScreenshotPaths()),
-          );
+          await reportFailedTestsToConductor(extractFailedTests(spec, results));
         } catch (error) {
           console.error("[ci-conductor] reporting failed (ignored)", error);
         }

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -10,7 +10,9 @@ import { BACKEND_HOST, BACKEND_PORT } from "../runner/constants/backend-port";
 
 import {
   extractFailedTests,
+  recordFailureScreenshot,
   reportFailedTestsToConductor,
+  takeRecordedScreenshotPaths,
 } from "./ci_conductor";
 import * as ciTasks from "./ci_tasks";
 import { collectFailingTests } from "./collectFailedTests";
@@ -191,6 +193,14 @@ const defaultConfig = {
         : (config.retries?.runMode ?? 0);
     process.env.CYPRESS_RETRIES = String(resolvedRetries);
 
+    // Capture each test's first failure screenshot for ci-conductor. The
+    // after:screenshot hook is the only place Cypress exposes `testFailure` and
+    // `testAttemptIndex`, which let us keep just the first failure shot per test
+    // (see recordFailureScreenshot). after:spec then drains and reports them.
+    if (isCI) {
+      on("after:screenshot", (details) => recordFailureScreenshot(details));
+    }
+
     on("after:spec", async (spec, results) => {
       // Report failures to ci-conductor mid-run (no-ops unless configured).
       if (isCI) {
@@ -198,7 +208,9 @@ const defaultConfig = {
         // a hard backstop around everything — extraction, payload build, and
         // the request. The reporter also handles its own errors internally.
         try {
-          await reportFailedTestsToConductor(extractFailedTests(spec, results));
+          await reportFailedTestsToConductor(
+            extractFailedTests(spec, results, takeRecordedScreenshotPaths()),
+          );
         } catch (error) {
           console.error("[ci-conductor] reporting failed (ignored)", error);
         }


### PR DESCRIPTION
Attach each failed test's first failure screenshot to the failed-tests payload so ci-conductor can upload it to S3 and link it to the run.

- Capture in the after:screenshot hook, the only place Cypress exposes testFailure + testAttemptIndex; keep exactly the first failure shot per test (testFailure && testAttemptIndex === 0), excluding retries and manual cy.screenshot() at the source.
- Drain the per-spec buffer in after:spec and match each failing test to its shot by normalized title↔filename containment (after:screenshot gives a path but no title; name is null for auto-failure shots).
- Read + base64-inline the file at send time as a data URI; ci-conductor stores null when absent.

Best-effort throughout: every step is wrapped, logs on failure, and can never throw into or interrupt the test run.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
