### PR TITLE
Add metric labels to dimension picker selects / Add expr metric occurrence counts

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.tsx
@@ -75,7 +75,8 @@ export function DimensionPickerSidebar(props: DimensionPickerSidebarProps) {
     categories,
     activeDimensionBreakout,
   );
-  const showAllFields = mode === "all" || searchText.trim() !== "";
+  const isSearching = searchText.trim() !== "";
+  const showAllFields = mode === "all" || isSearching;
   const hasAllFields = sections.length > 0;
   const showSeeAll = !showAllFields && hasAllFields;
   let defaultEmptyStateText = t`No dimensions found`;
@@ -302,6 +303,7 @@ export function DimensionPickerSidebar(props: DimensionPickerSidebarProps) {
             metricSourceDataById={sourceDataById}
             sourceColors={sourceColors}
             metricSlots={metricSlots}
+            expandAllMetricGroups={isSearching}
             onSelect={handleAllFieldsSelect}
           />
         )}

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
@@ -1153,6 +1153,69 @@ describe("DimensionPickerSidebar", () => {
     expect(
       screen.getByLabelText("Select dimension for Feedback, Count"),
     ).toHaveValue("Time");
+    expect(screen.getByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("Feedback, Count")).toBeInTheDocument();
+  });
+
+  it("shows expression occurrence counts in dropdown rows and See all accordions", async () => {
+    setup({
+      dimensionBreakout: {
+        ...timeDimensionBreakout,
+        dimensionMapping: {
+          0: "dim-first-revenue-created-at",
+          1: "dim-second-revenue-created-at",
+        },
+      },
+      dimensions: {
+        shared: [],
+        bySource: {
+          [SOURCE_ID]: [
+            {
+              icon: "calendar",
+              dimensionBreakoutInfo: {
+                type: "time",
+                label: "Time",
+                dimensionMapping: {
+                  0: "dim-first-revenue-created-at",
+                  1: "dim-second-revenue-created-at",
+                },
+              },
+            },
+          ],
+        },
+      },
+      slots: [
+        {
+          slotIndex: 0,
+          entityIndex: 0,
+          sourceId: SOURCE_ID,
+          tokenPosition: 0,
+          occurrenceCount: 1,
+        },
+        {
+          slotIndex: 1,
+          entityIndex: 0,
+          sourceId: SOURCE_ID,
+          tokenPosition: 2,
+          occurrenceCount: 2,
+        },
+      ],
+      sourceOrder: [SOURCE_ID],
+      sources: {
+        [SOURCE_ID]: { type: "metric", name: "Revenue" },
+      },
+    });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Configure Time" }),
+    );
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "See all" }));
+
+    expect(screen.getAllByText("Revenue")).toHaveLength(2);
+    expect(screen.getByText("2")).toBeInTheDocument();
   });
 
   it("uses the active time mapping for column select values", async () => {

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/DimensionPickerSidebar.unit.spec.tsx
@@ -773,6 +773,71 @@ describe("DimensionPickerSidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("expands all metric accordions while searching all fields", async () => {
+    setup({
+      dimensions: {
+        shared: [],
+        bySource: {
+          [SOURCE_ID]: [
+            {
+              icon: "calendar",
+              dimensionBreakoutInfo: {
+                type: "time",
+                label: "Created At",
+                dimensionMapping: { 0: "dim-created-at" },
+              },
+            },
+          ],
+          [SECOND_SOURCE_ID]: [
+            {
+              icon: "calendar",
+              dimensionBreakoutInfo: {
+                type: "time",
+                label: "Created At",
+                dimensionMapping: { 1: "second-dim-created-at" },
+              },
+            },
+          ],
+        },
+      },
+      slots: [
+        { slotIndex: 0, entityIndex: 0, sourceId: SOURCE_ID },
+        { slotIndex: 1, entityIndex: 1, sourceId: SECOND_SOURCE_ID },
+      ],
+      sourceOrder: [SOURCE_ID, SECOND_SOURCE_ID],
+      sources: {
+        [SOURCE_ID]: { type: "metric", name: "Revenue" },
+        [SECOND_SOURCE_ID]: { type: "metric", name: "Total Orders" },
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "See all" }));
+
+    expect(screen.getByRole("button", { name: "Revenue" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Total Orders" }),
+    ).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Search fields"),
+      "created",
+    );
+
+    expect(screen.getByRole("button", { name: "Revenue" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Total Orders" }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getAllByRole("button", { name: "Created At" })).toHaveLength(
+      2,
+    );
+  });
+
   it("shows one See all accordion per metric slot when the same metric is selected twice", async () => {
     setup({
       dimensions: {

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/AllFieldsList.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/AllFieldsList.tsx
@@ -23,6 +23,7 @@ type AllFieldsListProps = {
   metricSourceDataById: Record<MetricSourceId, SourceDisplayInfo>;
   sourceColors: SourceColorMap;
   metricSlots: MetricSlot[];
+  expandAllMetricGroups: boolean;
   onSelect: (item: DimensionPickerItem) => void;
 };
 
@@ -32,6 +33,7 @@ export function AllFieldsList({
   metricSourceDataById,
   sourceColors,
   metricSlots,
+  expandAllMetricGroups,
   onSelect,
 }: AllFieldsListProps) {
   if (sections.length === 0) {
@@ -48,12 +50,15 @@ export function AllFieldsList({
   });
 
   if (metricSlots.length > 1 && metricGroups.length > 1) {
+    const defaultExpandedGroupKeys = expandAllMetricGroups
+      ? metricGroups.map((group) => group.key)
+      : metricGroups.slice(0, 1).map((group) => group.key);
+
     return (
       <MetricAccordionList
+        key={defaultExpandedGroupKeys.join("|")}
         activeDimensionBreakout={activeDimensionBreakout}
-        defaultExpandedGroupKeys={metricGroups
-          .slice(0, 1)
-          .map((group) => group.key)}
+        defaultExpandedGroupKeys={defaultExpandedGroupKeys}
         groups={metricGroups}
         onSelect={onSelect}
       />

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.module.css
@@ -28,3 +28,7 @@
 .metricAccordionPanel {
   padding: 1rem;
 }
+
+.occurrenceCountBadge {
+  box-shadow: 0 0 0 1px var(--mb-color-border);
+}

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.module.css
@@ -5,7 +5,7 @@
 
 .metricAccordionControl {
   align-items: center;
-  background-color: var(--mb-color-background-hover);
+  background-color: var(--mb-color-background-secondary);
   border-radius: 0.5rem;
   color: var(--mb-color-text-primary);
   display: flex;

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/MetricAccordionItem.tsx
@@ -1,7 +1,7 @@
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import type { MetricsViewerDimensionBreakoutState } from "metabase/metrics-viewer/types";
 import type { DimensionPickerItem } from "metabase/metrics-viewer/utils";
-import { Box, Flex, Icon, Text, UnstyledButton } from "metabase/ui";
+import { Badge, Box, Flex, Icon, Text, UnstyledButton } from "metabase/ui";
 
 import { AllFieldsSectionList } from "./AllFieldsSectionList";
 import S from "./MetricAccordionItem.module.css";
@@ -20,6 +20,9 @@ export function MetricAccordionItem({
   onToggle: () => void;
   onSelect: (item: DimensionPickerItem) => void;
 }) {
+  const showOccurrenceCount =
+    group.occurrenceCount != null && group.occurrenceCount > 1;
+
   return (
     <Box className={S.metricAccordionItem}>
       <UnstyledButton
@@ -37,6 +40,11 @@ export function MetricAccordionItem({
           <Text className={S.metricAccordionLabel} component="span">
             {group.name}
           </Text>
+          {showOccurrenceCount && (
+            <Badge className={S.occurrenceCountBadge} circle c="text-hover">
+              {group.occurrenceCount}
+            </Badge>
+          )}
         </Flex>
         <Icon name={isExpanded ? "chevronup" : "chevrondown"} size={12} />
       </UnstyledButton>

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/buildAllFieldsMetricGroups.ts
@@ -149,6 +149,9 @@ export function buildAllFieldsMetricGroups({
           name: sourceDataById[slot.sourceId]?.name ?? slot.sourceId,
           colors: sourceColors[slot.entityIndex],
           isExpressionToken: slot.tokenPosition != null,
+          ...(slot.occurrenceCount != null
+            ? { occurrenceCount: slot.occurrenceCount }
+            : {}),
           sections: mergeSectionsByName(scopedSections),
         };
       })

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/types.ts
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/AllFieldsList/types.ts
@@ -5,5 +5,6 @@ export type AllFieldsMetricGroup = {
   name: string;
   colors?: string[];
   isExpressionToken: boolean;
+  occurrenceCount?: number;
   sections: DimensionPickerSection[];
 };

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/MetricDimensionSelect.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/MetricDimensionSelect.module.css
@@ -3,10 +3,20 @@
   height: 2rem;
   border-color: var(--mb-color-border);
   border-radius: 0.5rem;
-  font-size: 0.875rem;
+  font-size: var(--mantine-font-size-md);
   line-height: 1rem;
 }
 
 .metricSelectInput:not(:focus) {
   cursor: pointer;
+}
+
+.metricLabel {
+  color: var(--mb-color-text-primary);
+  font-size: var(--mantine-font-size-md);
+  font-weight: 600;
+  line-height: 1.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/MetricDimensionSelect.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPickerSidebar/components/MetricDimensionSelect.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import type { DimensionPickerSidebarCategorySelectRow } from "metabase/metrics-viewer/utils";
-import { Select } from "metabase/ui";
+import { Badge, Flex, Select, Text } from "metabase/ui";
 
 import S from "./MetricDimensionSelect.module.css";
 
@@ -13,8 +13,23 @@ export function MetricDimensionSelect({
   row: DimensionPickerSidebarCategorySelectRow;
   onChange: (dimensionId: string) => void;
 }) {
+  const showOccurrenceCount =
+    row.occurrenceCount != null && row.occurrenceCount > 1;
+
   return (
     <Select
+      label={
+        <Flex align="center" gap="xs" miw={0} pt="0.5rem">
+          <Text fz="md" lh="md" component="span">
+            {row.metricName}
+          </Text>
+          {showOccurrenceCount && (
+            <Badge circle c="text-hover">
+              {row.occurrenceCount}
+            </Badge>
+          )}
+        </Flex>
+      }
       classNames={{ input: S.metricSelectInput }}
       aria-label={t`Select dimension for ${row.metricName}`}
       data={row.options}

--- a/frontend/src/metabase/metrics-viewer/components/FilterPopover/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/FilterPopover/utils.ts
@@ -95,7 +95,7 @@ export function getMetricGroups(
     return {
       id: definitionSource.index,
       metricName: getDefinitionSourceName(definitionSource),
-      metricCount: definitionSource.token?.count,
+      metricCount: definitionSource.token?.occurrenceCount,
       icon: getDefinitionSourceIcon(definitionSource),
       colors: metricColors[definitionSource.entityIndex],
       sections,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.unit.spec.tsx
@@ -16,9 +16,9 @@ function buildEntry(
     type: "expression",
     name: "A + B",
     tokens: [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ],
     ...overrides,
   };
@@ -61,11 +61,11 @@ describe("MetricExpressionPill expression rendering", () => {
       type: "expression",
       name: "",
       tokens: [
-        { type: "metric", sourceId: "metric:1", count: 1 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
         { type: "operator", op: "+" },
-        { type: "metric", sourceId: "metric:1", count: 2 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 2 },
         { type: "operator", op: "+" },
-        { type: "metric", sourceId: "metric:1", count: 3 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 3 },
       ],
     };
 
@@ -90,11 +90,11 @@ describe("MetricExpressionPill expression rendering", () => {
       type: "expression",
       name: "A + A + A",
       tokens: [
-        { type: "metric", sourceId: "metric:1", count: 1 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
         { type: "operator", op: "+" },
-        { type: "metric", sourceId: "metric:1", count: 2 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 2 },
         { type: "operator", op: "+" },
-        { type: "metric", sourceId: "metric:1", count: 3 },
+        { type: "metric", sourceId: "metric:1", occurrenceCount: 3 },
       ],
     };
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.unit.spec.tsx
@@ -167,7 +167,7 @@ const costsEntry = makeMetricEntry(costs);
 const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
   type: "metric",
   sourceId,
-  count: 1,
+  occurrenceCount: 1,
 });
 const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
   type: "operator",
@@ -559,12 +559,12 @@ describe("expression pill display after committing a formula", () => {
     const expr = exprDefs[0];
     expect(expr.tokens).toEqual([
       { type: "open-paren" },
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "close-paren" },
       { type: "operator", op: "/" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
     ]);
     expect(expr.name).toBe("(MetricA + MetricB) / MetricC");
   });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -46,10 +46,10 @@ export function buildExpressionForPill(
     } else if (token.type === "metric") {
       const name = metricNames[token.sourceId];
       curr += name ?? "";
-      if (token.count > 1) {
+      if (token.occurrenceCount > 1) {
         result.push(curr);
         curr = "";
-        result.push(token.count);
+        result.push(token.occurrenceCount);
       }
     } else if (token.type === "constant") {
       curr += String(token.value);
@@ -487,7 +487,7 @@ export function traverseMetricTokens(
 function stripPositions(token: PositionedToken): ExpressionSubToken | null {
   switch (token.type) {
     case "metric":
-      return { type: "metric", sourceId: token.sourceId, count: 0 };
+      return { type: "metric", sourceId: token.sourceId, occurrenceCount: 0 };
     case "operator":
       return { type: "operator", op: token.op };
     case "constant":
@@ -713,7 +713,7 @@ export function parseFullTextWithPositions(
       tokens.push({
         type: "metric",
         sourceId: identity.sourceId,
-        count: 0,
+        occurrenceCount: 0,
         from: identity.from,
         to: identity.to,
       });
@@ -805,7 +805,7 @@ export function parseFullTextWithPositions(
           tokens.push({
             type: "metric",
             sourceId: id,
-            count: 0,
+            occurrenceCount: 0,
             from: i,
             to: nextI,
           });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -63,7 +63,7 @@ describe("cleanupParens", () => {
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
-    count: 1,
+    occurrenceCount: 1,
   });
   const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
     type: "operator",
@@ -177,7 +177,7 @@ describe("buildExpressionText", () => {
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
-    count: 1,
+    occurrenceCount: 1,
   });
   const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
     type: "operator",
@@ -232,7 +232,7 @@ describe("parseFullText — numeric literal parsing", () => {
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
-    count: 1,
+    occurrenceCount: 1,
   });
   const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
     type: "operator",
@@ -399,7 +399,7 @@ describe("parseFullText — negative numbers", () => {
   const metric = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
-    count: 1,
+    occurrenceCount: 1,
   });
   const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
     type: "operator",
@@ -580,7 +580,7 @@ describe("parseFullText — metric names with commas", () => {
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
-    count: 1,
+    occurrenceCount: 1,
   });
   const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
     type: "operator",
@@ -1639,9 +1639,9 @@ describe("buildFullTextWithIdentities", () => {
         type: "expression",
         name: "Revenue + Costs",
         tokens: [
-          { type: "metric", sourceId: "metric:1" as const, count: 1 },
+          { type: "metric", sourceId: "metric:1" as const, occurrenceCount: 1 },
           { type: "operator", op: "+" as const },
-          { type: "metric", sourceId: "metric:2" as const, count: 1 },
+          { type: "metric", sourceId: "metric:2" as const, occurrenceCount: 1 },
         ],
       },
     ];
@@ -1691,7 +1691,7 @@ describe("buildFullTextWithIdentities", () => {
         type: "expression",
         name: "123 + 456",
         tokens: [
-          { type: "metric", sourceId: "metric:3" as const, count: 1 },
+          { type: "metric", sourceId: "metric:3" as const, occurrenceCount: 1 },
           { type: "operator", op: "+" as const },
           { type: "constant", value: 456 },
         ],
@@ -1746,7 +1746,7 @@ describe("parseFullText with identities", () => {
         type: "expression",
         name: "123 + 456",
         tokens: [
-          { type: "metric", sourceId: "metric:3", count: 1 },
+          { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
           { type: "operator", op: "+" },
           { type: "constant", value: 456 },
         ],

--- a/frontend/src/metabase/metrics-viewer/components/MetricsFilterPills/MetricsFilterPills.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsFilterPills/MetricsFilterPills.tsx
@@ -148,7 +148,7 @@ function getFlatFilters(
         metricName: shouldDisplayMetricName
           ? getDefinitionSourceName(source)
           : undefined,
-        metricCount: source.token?.count,
+        metricCount: source.token?.occurrenceCount,
         isSegment,
         segmentName,
       };

--- a/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
@@ -46,7 +46,7 @@ export interface StoredMetricsViewerDimensionBreakout {
 export type ExpressionMetricSubToken = {
   type: "metric";
   sourceId: MetricSourceId;
-  count: number;
+  occurrenceCount: number;
   definition?: MetricDefinition;
   serializedDefinitionInfo?: SerializedDefinitionInfo;
 };

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
@@ -241,6 +241,7 @@ export type DimensionPickerSidebarCategorySelectRow = {
   metricName: string;
   colors?: string[];
   isExpressionToken: boolean;
+  occurrenceCount?: number;
   value: string | null;
   options: DimensionPickerSidebarCategorySelectOption[];
 };
@@ -423,6 +424,9 @@ export function buildDimensionPickerSidebarCategorySelectRows({
         metricName: sourceDataById[slot.sourceId]?.name ?? slot.sourceId,
         colors: sourceColors[slot.entityIndex],
         isExpressionToken: slot.tokenPosition != null,
+        ...(slot.occurrenceCount != null
+          ? { occurrenceCount: slot.occurrenceCount }
+          : {}),
         value: options.some((option) => option.value === activeDimensionId)
           ? activeDimensionId
           : null,

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
@@ -500,6 +500,91 @@ describe("buildDimensionPickerSidebarCategorySelectRows", () => {
 
     expect(rows.map((row) => row.isExpressionToken)).toEqual([true, true]);
   });
+
+  it("preserves expression token occurrence counts", () => {
+    const categories = buildDimensionPickerSidebarCategories({
+      availableDimensions: {
+        shared: [],
+        bySource: {
+          [REVENUE_SOURCE_ID]: [
+            {
+              icon: "calendar",
+              dimensionBreakoutInfo: {
+                type: "time",
+                label: "Time",
+                dimensionMapping: {
+                  0: "dim-first-revenue-created-at",
+                  1: "dim-second-revenue-created-at",
+                },
+              },
+            },
+          ],
+        },
+      },
+      sourceOrder: [REVENUE_SOURCE_ID],
+      sourceDataById: {
+        [REVENUE_SOURCE_ID]: { type: "metric", name: "Revenue" },
+      },
+      metricSlots: [
+        {
+          slotIndex: 0,
+          entityIndex: 0,
+          sourceId: REVENUE_SOURCE_ID,
+          tokenPosition: 0,
+          occurrenceCount: 1,
+        },
+        {
+          slotIndex: 1,
+          entityIndex: 0,
+          sourceId: REVENUE_SOURCE_ID,
+          tokenPosition: 2,
+          occurrenceCount: 2,
+        },
+      ],
+    });
+    const timeCategory = categories.find(
+      (category) => category.name === "Time",
+    );
+
+    expect(timeCategory).toBeDefined();
+
+    const rows = buildDimensionPickerSidebarCategorySelectRows({
+      category: timeCategory!,
+      activeDimensionBreakout: {
+        id: "time",
+        type: "time",
+        label: "Time",
+        display: "line",
+        dimensionMapping: {
+          0: "dim-first-revenue-created-at",
+          1: "dim-second-revenue-created-at",
+        },
+        projectionConfig: {},
+      },
+      metricSlots: [
+        {
+          slotIndex: 0,
+          entityIndex: 0,
+          sourceId: REVENUE_SOURCE_ID,
+          tokenPosition: 0,
+          occurrenceCount: 1,
+        },
+        {
+          slotIndex: 1,
+          entityIndex: 0,
+          sourceId: REVENUE_SOURCE_ID,
+          tokenPosition: 2,
+          occurrenceCount: 2,
+        },
+      ],
+      sourceDataById: {
+        [REVENUE_SOURCE_ID]: { type: "metric", name: "Revenue" },
+      },
+      sourceColors: { 0: ["#509ee3"] },
+    });
+
+    expect(rows.map((row) => row.occurrenceCount)).toEqual([1, 2]);
+  });
 });
 
 describe("getComparableDimensionMapping", () => {

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
@@ -502,54 +502,37 @@ describe("buildDimensionPickerSidebarCategorySelectRows", () => {
   });
 
   it("preserves expression token occurrence counts", () => {
-    const categories = buildDimensionPickerSidebarCategories({
-      availableDimensions: {
-        shared: [],
-        bySource: {
-          [REVENUE_SOURCE_ID]: [
-            {
-              icon: "calendar",
-              dimensionBreakoutInfo: {
-                type: "time",
-                label: "Time",
-                dimensionMapping: {
-                  0: "dim-first-revenue-created-at",
-                  1: "dim-second-revenue-created-at",
-                },
-              },
+    const timeCategory: DimensionPickerSidebarCategory = {
+      key: "type:time",
+      name: "Time",
+      icon: "calendar",
+      dimensionBreakoutInfo: {
+        id: "time",
+        type: "time",
+        label: "Time",
+        dimensionMapping: {
+          0: "dim-first-revenue-created-at",
+          1: "dim-second-revenue-created-at",
+        },
+      },
+      targetItems: [
+        {
+          name: "Time",
+          icon: "calendar",
+          dimensionBreakoutInfo: {
+            type: "time",
+            label: "Time",
+            dimensionMapping: {
+              0: "dim-first-revenue-created-at",
+              1: "dim-second-revenue-created-at",
             },
-          ],
-        },
-      },
-      sourceOrder: [REVENUE_SOURCE_ID],
-      sourceDataById: {
-        [REVENUE_SOURCE_ID]: { type: "metric", name: "Revenue" },
-      },
-      metricSlots: [
-        {
-          slotIndex: 0,
-          entityIndex: 0,
-          sourceId: REVENUE_SOURCE_ID,
-          tokenPosition: 0,
-          occurrenceCount: 1,
-        },
-        {
-          slotIndex: 1,
-          entityIndex: 0,
-          sourceId: REVENUE_SOURCE_ID,
-          tokenPosition: 2,
-          occurrenceCount: 2,
+          },
         },
       ],
-    });
-    const timeCategory = categories.find(
-      (category) => category.name === "Time",
-    );
-
-    expect(timeCategory).toBeDefined();
+    };
 
     const rows = buildDimensionPickerSidebarCategorySelectRows({
-      category: timeCategory!,
+      category: timeCategory,
       activeDimensionBreakout: {
         id: "time",
         type: "time",

--- a/frontend/src/metabase/metrics-viewer/utils/expression.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/expression.ts
@@ -14,9 +14,9 @@ export function stampMetricCounts(
   const counts = new Map<MetricSourceId, number>();
   return tokens.map((token) => {
     if (token.type === "metric") {
-      const count = (counts.get(token.sourceId) ?? 0) + 1;
-      counts.set(token.sourceId, count);
-      return { ...token, count };
+      const occurrenceCount = (counts.get(token.sourceId) ?? 0) + 1;
+      counts.set(token.sourceId, occurrenceCount);
+      return { ...token, occurrenceCount } satisfies ExpressionSubToken;
     }
     return token;
   });

--- a/frontend/src/metabase/metrics-viewer/utils/metric-slots.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/metric-slots.ts
@@ -54,7 +54,7 @@ export function computeMetricSlots(
             entityIndex: i,
             sourceId: token.sourceId,
             tokenPosition: j,
-            occurrenceCount: token.count,
+            occurrenceCount: token.occurrenceCount,
           });
         }
       }

--- a/frontend/src/metabase/metrics-viewer/utils/metric-slots.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/metric-slots.ts
@@ -24,6 +24,7 @@ export type MetricSlot = {
    * `undefined` for standalone metric slots.
    */
   tokenPosition?: number;
+  occurrenceCount?: number;
 };
 
 /**
@@ -53,6 +54,7 @@ export function computeMetricSlots(
             entityIndex: i,
             sourceId: token.sourceId,
             tokenPosition: j,
+            occurrenceCount: token.count,
           });
         }
       }

--- a/frontend/src/metabase/metrics-viewer/utils/metric-slots.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/metric-slots.unit.spec.ts
@@ -10,9 +10,9 @@ describe("computeMetricSlots", () => {
         type: "expression",
         name: "Repeated Revenue",
         tokens: [
-          { type: "metric", sourceId: "metric:1", count: 1 },
+          { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
           { type: "operator", op: "+" },
-          { type: "metric", sourceId: "metric:1", count: 2 },
+          { type: "metric", sourceId: "metric:1", occurrenceCount: 2 },
         ],
       },
     ];

--- a/frontend/src/metabase/metrics-viewer/utils/metric-slots.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/metric-slots.unit.spec.ts
@@ -1,0 +1,37 @@
+import type { MetricsViewerFormulaEntity } from "metabase/metrics-viewer/types";
+
+import { computeMetricSlots } from "./metric-slots";
+
+describe("computeMetricSlots", () => {
+  it("preserves expression metric occurrence counts", () => {
+    const formulaEntities: MetricsViewerFormulaEntity[] = [
+      {
+        id: "expression:repeated-revenue",
+        type: "expression",
+        name: "Repeated Revenue",
+        tokens: [
+          { type: "metric", sourceId: "metric:1", count: 1 },
+          { type: "operator", op: "+" },
+          { type: "metric", sourceId: "metric:1", count: 2 },
+        ],
+      },
+    ];
+
+    expect(computeMetricSlots(formulaEntities)).toEqual([
+      {
+        slotIndex: 0,
+        entityIndex: 0,
+        sourceId: "metric:1",
+        tokenPosition: 0,
+        occurrenceCount: 1,
+      },
+      {
+        slotIndex: 1,
+        entityIndex: 0,
+        sourceId: "metric:1",
+        tokenPosition: 2,
+        occurrenceCount: 2,
+      },
+    ]);
+  });
+});

--- a/frontend/src/metabase/metrics-viewer/utils/parse-expression.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/parse-expression.unit.spec.ts
@@ -39,9 +39,9 @@ function stripOptions(expr: ExpressionRef | number | null): any {
 describe("parseExpression", () => {
   it("should parse a simple expression", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual(["+", ["metric", 1], ["metric", 2]]);
@@ -49,12 +49,12 @@ describe("parseExpression", () => {
 
   it("should handle parens", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "-" },
       { type: "open-paren" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "measure:3", count: 1 },
+      { type: "metric", sourceId: "measure:3", occurrenceCount: 1 },
       { type: "close-paren" },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
@@ -67,7 +67,7 @@ describe("parseExpression", () => {
 
   it("should handle a single metric", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual(["metric", 1]);
@@ -75,7 +75,7 @@ describe("parseExpression", () => {
 
   it("should return null for invalid input", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
@@ -85,11 +85,11 @@ describe("parseExpression", () => {
   // A + B * C  =>  A + (B * C)
   it("should respect precedence: + before *", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -102,11 +102,11 @@ describe("parseExpression", () => {
   // A * B + C  =>  (A * B) + C
   it("should respect precedence: * before +", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -119,11 +119,11 @@ describe("parseExpression", () => {
   // A - B / C  =>  A - (B / C)
   it("should respect precedence: - before /", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "-" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "operator", op: "/" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -136,13 +136,13 @@ describe("parseExpression", () => {
   // A * B + C * D  =>  (A * B) + (C * D)
   it("should handle multiple high-precedence groups", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:4", count: 1 },
+      { type: "metric", sourceId: "metric:4", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -156,12 +156,12 @@ describe("parseExpression", () => {
   it("should allow parens to override precedence", () => {
     const tokens: ExpressionSubToken[] = [
       { type: "open-paren" },
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
       { type: "close-paren" },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:3", count: 1 },
+      { type: "metric", sourceId: "metric:3", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -174,11 +174,11 @@ describe("parseExpression", () => {
   it("should handle constants in precedence expressions", () => {
     // A + 2 * B  =>  A + (2 * B)
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "+" },
       { type: "constant", value: 2 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -193,9 +193,9 @@ describe("parseExpression", () => {
     const tokens: ExpressionSubToken[] = [
       { type: "constant", value: 8 },
       { type: "operator", op: "-" },
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "-" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -210,9 +210,9 @@ describe("parseExpression", () => {
     const tokens: ExpressionSubToken[] = [
       { type: "constant", value: 8 },
       { type: "operator", op: "/" },
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "/" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([
@@ -225,7 +225,7 @@ describe("parseExpression", () => {
   it("should return null when tokens are not fully consumed", () => {
     // "Metric1 2" — two operands with no operator
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "constant", value: 2 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
@@ -234,8 +234,8 @@ describe("parseExpression", () => {
 
   it("should return null for metric followed by another metric without operator", () => {
     const tokens: ExpressionSubToken[] = [
-      { type: "metric", sourceId: "metric:1", count: 1 },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(expr).toBeNull();
@@ -246,9 +246,9 @@ describe("parseExpression", () => {
     const tokens: ExpressionSubToken[] = [
       { type: "constant", value: 6 },
       { type: "operator", op: "/" },
-      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
       { type: "operator", op: "*" },
-      { type: "metric", sourceId: "metric:2", count: 1 },
+      { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
     ];
     const expr = parseExpression(tokens, createLeafRefs(tokens));
     expect(stripOptions(expr)).toEqual([

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -777,7 +777,7 @@ function buildExpressionMetricSources(
             return undefined;
           }
           const token = entity.tokens[slot.tokenPosition];
-          return token?.type === "metric" ? token.count : undefined;
+          return token?.type === "metric" ? token.occurrenceCount : undefined;
         })(),
         colors: entryColors,
         currentDimension,

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -612,7 +612,7 @@ describe("buildDimensionItemsFromDefinitions", () => {
           {
             type: "metric",
             sourceId: revenueSourceId,
-            count: 1,
+            occurrenceCount: 1,
           },
           {
             type: "operator",
@@ -621,7 +621,7 @@ describe("buildDimensionItemsFromDefinitions", () => {
           {
             type: "metric",
             sourceId: geoSourceId,
-            count: 1,
+            occurrenceCount: 1,
           },
         ],
       },

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
@@ -252,7 +252,7 @@ function deserializeSubToken(
     return {
       type: "metric",
       sourceId: token.sourceId as MetricSourceId,
-      count: 0,
+      occurrenceCount: 0,
       serializedDefinitionInfo: hasInfo
         ? {
             filters: token.filters,

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
@@ -1016,9 +1016,9 @@ describe("url-serialization", () => {
           type: "expression",
           name: "test",
           tokens: [
-            { type: "metric", sourceId: "metric:1", count: 1 },
+            { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
             { type: "operator", op: "+" },
-            { type: "metric", sourceId: "metric:2", count: 1 },
+            { type: "metric", sourceId: "metric:2", occurrenceCount: 1 },
           ],
         },
       ]);
@@ -1102,7 +1102,7 @@ describe("url-serialization", () => {
           type: "expression",
           name: "Total",
           tokens: [
-            { type: "metric", sourceId: "metric:1", count: 1 },
+            { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
             { type: "operator", op: "+" },
             { type: "constant", value: 10 },
           ],
@@ -1136,7 +1136,7 @@ describe("url-serialization", () => {
           type: "expression",
           name: "Total",
           tokens: [
-            { type: "metric", sourceId: "metric:1", count: 1 },
+            { type: "metric", sourceId: "metric:1", occurrenceCount: 1 },
             { type: "operator", op: "*" },
             { type: "constant", value: 2 },
           ],


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4397/small-additional-improvements-on-the-dimension-picking-sidebar

### Description

Shows metric labels above multi-metric dimension picker selects so expression rows are easier to identify.
Also carries expression duplicate counts into the sidebar and See all accordions.

### How to verify

1. Open Metrics Viewer with a formula expression that repeats the same metric.
2. Open the dimension picker sidebar and configure a shared dimension.
3. Confirm each column select has a metric label above it, and the repeated metric shows its duplicate count badge.
4. Click See all and confirm the repeated expression metric accordion also shows the duplicate count badge.

### Demo
Before:
<img width="1903" height="782" alt="image" src="https://github.com/user-attachments/assets/52cd24ed-4ce6-4f7c-9f85-4531088ffb39" />

After:
<img width="1903" height="782" alt="image" src="https://github.com/user-attachments/assets/c6b34fa9-cefa-47dd-bc06-41273ed55e6c" />
<img width="1903" height="782" alt="image" src="https://github.com/user-attachments/assets/3be76647-d0a8-4369-9877-8aede6bbc57f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)