### PR TITLE
Fix metabot self-test app-db init flake (app-db tests)

### DIFF
--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -11,11 +11,14 @@
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.test-util :as test-util]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util.json :as json]
    [metabase.util.log.capture :as log.capture]
    [ring.adapter.jetty :as jetty]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 ;;; provider resolution tests
 


### PR DESCRIPTION
### Description

App DB Tests (Part 2) fail with:

```
Table 'mb_test.metabot_instance_limit' doesn't exist
  reported as "Uncaught exception, not in assertion".
```
[Example](https://github.com/metabase/metabase/actions/runs/26981637804/job/79627783842?pr=75262)
[Example 2](https://github.com/metabase/metabase/actions/runs/26468613562/job/77935648091)

`metabot/self_test.clj` hits the `call-llm` → `check-usage-limits!` path (queries `metabot_instance_limit`), but had
  no `:db` fixture. Its `^:parallel` tests could run before the app DB was migrated → missing table.

[The fix](https://github.com/metabase/metabase/pull/74467/changes/8c52807bad0b78d60ebea7f74fc953d83673c679) has been merged to the master after the release branch was cut.