### PR TITLE
GHY-3805: Make check-card dependency response order deterministic

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -53,12 +53,14 @@
 (mu/defn- broken-cards-response :- ::broken-cards-response
   [{:keys [card transform]}]
   (let [broken-card-ids (keys card)
+        ;; Order by id so the response is deterministic; `(keys card)` and an `IN` query without
+        ;; an `:order-by` would otherwise return cards in an arbitrary order.
         broken-cards (when (seq broken-card-ids)
-                       (-> (t2/select :model/Card :id [:in broken-card-ids])
+                       (-> (t2/select :model/Card :id [:in broken-card-ids] {:order-by [[:id :asc]]})
                            (t2/hydrate [:collection :effective_ancestors] :dashboard :document)))
         broken-transform-ids (keys transform)
         broken-transforms (when (seq broken-transform-ids)
-                            (t2/select :model/Transform :id [:in broken-transform-ids]))]
+                            (t2/select :model/Transform :id [:in broken-transform-ids] {:order-by [[:id :asc]]}))]
     {:success (and (empty? broken-card-ids)
                    (empty? broken-transform-ids))
      :bad_cards (into [] (comp (filter mi/can-read?)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -71,7 +71,7 @@
                                 collection.root/hydrate-root-collection
                                 (update :dashboard #(some-> % (select-keys [:id :name])))
                                 (update :document #(some-> % (select-keys [:id :name]))))))
-                     (sort-by :id)
+                     (sort-by (juxt :created_at :id))
                      vec)
      :bad_transforms (->> broken-transforms
                           (filter mi/can-read?)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -52,6 +52,7 @@
 
 (mu/defn- broken-cards-response :- ::broken-cards-response
   "Build the `check-*` response from a breakage map.
+
   `bad_cards` and `bad_transforms` are sorted to ensure the stable response order."
   [{:keys [card transform]}]
   (let [broken-card-ids (keys card)
@@ -80,8 +81,7 @@
 (api.macros/defendpoint :post "/check-card" :- ::broken-cards-response
   "Check a proposed edit to a card, and return the cards/transforms this edit will break.
 
-  `bad_cards` and `bad_transforms` are sorted by `id` ascending. This order is stable and may be
-  relied upon (the FE renders the entities in this order)."
+  `broken-cards-response` ensures the stable response order."
   [_route-params
    _query-params
    body :- ::card-body]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -51,29 +51,42 @@
    [:bad_transforms {:optional true} [:sequential ::transforms.schema/transform]]])
 
 (mu/defn- broken-cards-response :- ::broken-cards-response
+  "Build the `check-*` response from a breakage map.
+
+  `bad_cards` and `bad_transforms` are sorted by `id` ascending so the response order is stable.
+  The FE renders these entities in the order the BE returns them, so the ordering is part of the
+  contract, not an implementation detail. We sort here, after the `filter`/`map` passes (rather than
+  via an `:order-by` on the query), so the guarantee can't be silently broken by an upstream
+  transformation that doesn't preserve order."
   [{:keys [card transform]}]
   (let [broken-card-ids (keys card)
-        ;; Order by id so the response is deterministic; `(keys card)` and an `IN` query without
-        ;; an `:order-by` would otherwise return cards in an arbitrary order.
         broken-cards (when (seq broken-card-ids)
-                       (-> (t2/select :model/Card :id [:in broken-card-ids] {:order-by [[:id :asc]]})
+                       (-> (t2/select :model/Card :id [:in broken-card-ids])
                            (t2/hydrate [:collection :effective_ancestors] :dashboard :document)))
         broken-transform-ids (keys transform)
         broken-transforms (when (seq broken-transform-ids)
-                            (t2/select :model/Transform :id [:in broken-transform-ids] {:order-by [[:id :asc]]}))]
+                            (t2/select :model/Transform :id [:in broken-transform-ids]))]
     {:success (and (empty? broken-card-ids)
                    (empty? broken-transform-ids))
-     :bad_cards (into [] (comp (filter mi/can-read?)
-                               (map (fn [card]
-                                      (-> card
-                                          collection.root/hydrate-root-collection
-                                          (update :dashboard #(some-> % (select-keys [:id :name])))
-                                          (update :document #(some-> % (select-keys [:id :name])))))))
-                      broken-cards)
-     :bad_transforms (into [] (filter mi/can-read?) broken-transforms)}))
+     :bad_cards (->> broken-cards
+                     (filter mi/can-read?)
+                     (map (fn [card]
+                            (-> card
+                                collection.root/hydrate-root-collection
+                                (update :dashboard #(some-> % (select-keys [:id :name])))
+                                (update :document #(some-> % (select-keys [:id :name]))))))
+                     (sort-by :id)
+                     vec)
+     :bad_transforms (->> broken-transforms
+                          (filter mi/can-read?)
+                          (sort-by :id)
+                          vec)}))
 
 (api.macros/defendpoint :post "/check-card" :- ::broken-cards-response
-  "Check a proposed edit to a card, and return the card IDs for those cards this edit will break."
+  "Check a proposed edit to a card, and return the cards/transforms this edit will break.
+
+  `bad_cards` and `bad_transforms` are sorted by `id` ascending. This order is stable and may be
+  relied upon (the FE renders the entities in this order)."
   [_route-params
    _query-params
    body :- ::card-body]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -52,12 +52,7 @@
 
 (mu/defn- broken-cards-response :- ::broken-cards-response
   "Build the `check-*` response from a breakage map.
-
-  `bad_cards` and `bad_transforms` are sorted by `id` ascending so the response order is stable.
-  The FE renders these entities in the order the BE returns them, so the ordering is part of the
-  contract, not an implementation detail. We sort here, after the `filter`/`map` passes (rather than
-  via an `:order-by` on the query), so the guarantee can't be silently broken by an upstream
-  transformation that doesn't preserve order."
+  `bad_cards` and `bad_transforms` are sorted to ensure the stable response order."
   [{:keys [card transform]}]
   (let [broken-card-ids (keys card)
         broken-cards (when (seq broken-card-ids)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -75,7 +75,7 @@
                      vec)
      :bad_transforms (->> broken-transforms
                           (filter mi/can-read?)
-                          (sort-by :id)
+                          (sort-by (juxt :created_at :id))
                           vec)}))
 
 (api.macros/defendpoint :post "/check-card" :- ::broken-cards-response


### PR DESCRIPTION
Resolves GHY-3805

## Summary

`broken-cards-response` built `:bad_cards`/`:bad_transforms` from `(keys card)` and an `IN` query with no `:order-by`, so the response order was nondeterministic. This flaked check-card-hydrates-dashboard-and-document-test, which matches `:bad_cards` positionally via `=?`.

Order both selects by `:id` so the response is stable.

