### PR TITLE
fix: adding proper keys for PreviewCard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
@@ -37,7 +37,7 @@ export function SectionLayoutPreview({ layout }: SectionLayoutPreviewProps) {
       <Box pos="relative" w={WIDTH} mih={height}>
         {layoutItems.map((item) => (
           <PreviewCard
-            key={item.id}
+            key={`${item.row}-${item.col}`}
             layout={item}
             cellWidth={CELL_WIDTH}
             cellHeight={CELL_HEIGHT}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75112

### Description

The ids rendered are all undefined, So we get the `require unique key` warning

The fix is using a composite key of row - col as they will be unique for that particular section layout

### How to verify

Describe the steps to verify that the changes are working as expected.

1.     Open a dashboard
2.     Edit it
3.     Click "Add section" button

No `Each child in a list should have a unique "key" prop` warning in JS console

### Demo

<img width="2559" height="541" alt="image" src="https://github.com/user-attachments/assets/29998fdd-0563-4199-9934-e9bd38b07649" />

