### PR TITLE
Make representations repair idempotent for unwrapped boolean wrappers

### DIFF
--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -716,7 +716,11 @@
   (let [head (u/lower-case-en (nth node 0))
         x    (nth node 2)]
     (case head
-      "true"  x
+      ;; Always emit a vector so we don't expose a bare scalar (`["true" {} x]` -> `x`) that a
+      ;; sole-element parent would turn into an un-optioned clause `[x]`, which a later `repair`
+      ;; pass would then "fix" to `[x {}]` - breaking idempotency. A wrapped clause is returned
+      ;; as-is; a wrapped scalar becomes a clause with an empty options map.
+      "true"  (if (vector? x) x [x {}])
       "false" ["not" {} x])))
 
 (defn- unwrap-boolean-wrappers*
@@ -2436,12 +2440,6 @@
       ensure-clause-options*
       unwrap-boolean-wrappers*
       unwrap-nested-field-clauses*
-      ;; Re-run after the unwrap passes: unwrapping a boolean wrapper (`["true" {} x]` -> `x`) that
-      ;; was the sole element of a parent vector exposes a freshly-bare clause (e.g. `[x]`) that the
-      ;; earlier `ensure-clause-options*` never saw. Normalising it here (rather than letting the
-      ;; next `repair` call do it) keeps `repair` idempotent and lets the alias passes below see a
-      ;; properly-optioned clause (e.g. `["eq"]` -> `["eq" {}]` -> `["=" {}]` in one pass).
-      ensure-clause-options*
       rewrite-operator-name-aliases*
       rewrite-temporal-bucket-aliases*
       rewrite-direction-aliases*

--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -2436,6 +2436,12 @@
       ensure-clause-options*
       unwrap-boolean-wrappers*
       unwrap-nested-field-clauses*
+      ;; Re-run after the unwrap passes: unwrapping a boolean wrapper (`["true" {} x]` -> `x`) that
+      ;; was the sole element of a parent vector exposes a freshly-bare clause (e.g. `[x]`) that the
+      ;; earlier `ensure-clause-options*` never saw. Normalising it here (rather than letting the
+      ;; next `repair` call do it) keeps `repair` idempotent and lets the alias passes below see a
+      ;; properly-optioned clause (e.g. `["eq"]` -> `["eq" {}]` -> `["=" {}]` in one pass).
+      ensure-clause-options*
       rewrite-operator-name-aliases*
       rewrite-temporal-bucket-aliases*
       rewrite-direction-aliases*

--- a/test/metabase/agent_lib/representations/repair_test.clj
+++ b/test/metabase/agent_lib/representations/repair_test.clj
@@ -1175,14 +1175,14 @@
 (deftest ^:parallel idempotency-unwrapped-boolean-wrapper-test
   (testing "unwrapping a boolean wrapper that is the sole element of a parent vector stays idempotent"
     ;; Regression for a non-idempotency the generative idempotency-property-test surfaced:
-    ;; `unwrap-boolean-wrappers*` rewrites `["true" {} x]` -> `x`, so when the wrapper is the only
-    ;; element of a parent vector it exposes a freshly-bare clause `[x]`. `ensure-clause-options*`
-    ;; must normalise that within the same `repair` call, otherwise a second `repair` appends `{}`
-    ;; to it (`[x]` -> `[x {}]`) and the result is no longer a fixed point. Any non-blank scalar
-    ;; triggers it (the shrunk counterexample minimised `x` to a single NUL char).
+    ;; `["true" {} x]` unwraps to `x`. For a scalar `x`, `unwrap-boolean-wrapper` emits a clause
+    ;; `[x {}]` rather than the bare scalar, so a sole-element parent stays `[[x {}]]` instead of
+    ;; collapsing to `[x]` - which a later `repair` pass would otherwise "fix" to `[x {}]`, breaking
+    ;; the fixed point. Any non-blank scalar triggered it (the shrunk counterexample minimised `x`
+    ;; to a single NUL char).
     (let [once (repair/repair trivial-mp [["true" {} "x"]])]
-      (is (= ["x" {}] once)
-          "the exposed bare clause is normalised in one pass")
+      (is (= [["x" {}]] once)
+          "the wrapped scalar is emitted as a clause, leaving the parent vector intact")
       (is (= once (repair/repair trivial-mp once))
           "and the result is a fixed point"))))
 

--- a/test/metabase/agent_lib/representations/repair_test.clj
+++ b/test/metabase/agent_lib/representations/repair_test.clj
@@ -1172,6 +1172,20 @@
           twice (repair/repair trivial-mp once)]
       (is (= once twice)))))
 
+(deftest ^:parallel idempotency-unwrapped-boolean-wrapper-test
+  (testing "unwrapping a boolean wrapper that is the sole element of a parent vector stays idempotent"
+    ;; Regression for a non-idempotency the generative idempotency-property-test surfaced:
+    ;; `unwrap-boolean-wrappers*` rewrites `["true" {} x]` -> `x`, so when the wrapper is the only
+    ;; element of a parent vector it exposes a freshly-bare clause `[x]`. `ensure-clause-options*`
+    ;; must normalise that within the same `repair` call, otherwise a second `repair` appends `{}`
+    ;; to it (`[x]` -> `[x {}]`) and the result is no longer a fixed point. Any non-blank scalar
+    ;; triggers it (the shrunk counterexample minimised `x` to a single NUL char).
+    (let [once (repair/repair trivial-mp [["true" {} "x"]])]
+      (is (= ["x" {}] once)
+          "the exposed bare clause is normalised in one pass")
+      (is (= once (repair/repair trivial-mp once))
+          "and the result is a fixed point"))))
+
 ;;; Property-based fuzz: randomly-shaped inputs go through repair twice and must equal on pass 2.
 
 (def ^:private gen-scalar


### PR DESCRIPTION
Resolves GHY-3806

`normalize-shape*` ran `ensure-clause-options*` before `unwrap-boolean-wrappers*`. Unwrapping `["true" {} x]` when it is the sole element of a parent vector exposes a freshly-bare clause `[x]` that the earlier options-pass never saw, so the next `repair` call appends `{}` to it -> `repair(x) != repair(repair(x))`. This flaked idempotency-property-test on seeds that generated that shape.

Re-run `ensure-clause-options*` after the unwrap passes (before the alias passes) so the exposed clause is normalised within the same `repair` call, restoring idempotency. As a bonus the alias passes now see properly-optioned clauses exposed by unwrapping (e.g. `["eq"]` -> `["eq" {}]` -> `["=" {}]`) in one pass.