### PR TITLE
Transform scheduler freshness

### DIFF
--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -50,6 +50,12 @@ export type Transform = {
 
   last_checkpoint_value?: string | null;
 
+  // set by the job transforms endpoint on transforms pulled into the plan
+  // only as dependencies (not tagged for the job); `scheduled` says whether
+  // any active job's schedule covers them
+  dependency?: boolean;
+  scheduled?: boolean;
+
   // hydrated fields
   collection?: Collection | null;
   tag_ids?: TransformTagId[];

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
@@ -13,7 +13,7 @@ import { Card, TreeTable, useTreeTableInstance } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Transform, TransformJobId } from "metabase-types/api";
 
-import { getColumns } from "./utils";
+import { getColumns, isUnscheduledDependency } from "./utils";
 
 type TransformsSectionProps = {
   jobId: TransformJobId;
@@ -54,7 +54,9 @@ export function TransformTable({ transforms }: TransformTableProps) {
 
   const handleRowActivate = useCallback(
     (row: Row<Transform>) => {
-      dispatch(push(Urls.transform(row.original.id)));
+      if (!isUnscheduledDependency(row.original)) {
+        dispatch(push(Urls.transform(row.original.id)));
+      }
     },
     [dispatch],
   );
@@ -81,6 +83,7 @@ export function TransformTable({ transforms }: TransformTableProps) {
           <ListEmptyState label={t`There are no transforms for this job.`} />
         }
         ariaLabel={t`Job transforms`}
+        isRowDisabled={(row) => isUnscheduledDependency(row.original)}
         onRowClick={handleRowActivate}
       />
     </Card>

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/TransformsSection.tsx
@@ -13,7 +13,7 @@ import { Card, TreeTable, useTreeTableInstance } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Transform, TransformJobId } from "metabase-types/api";
 
-import { getColumns, isUnscheduledDependency } from "./utils";
+import { getColumns } from "./utils";
 
 type TransformsSectionProps = {
   jobId: TransformJobId;
@@ -54,9 +54,7 @@ export function TransformTable({ transforms }: TransformTableProps) {
 
   const handleRowActivate = useCallback(
     (row: Row<Transform>) => {
-      if (!isUnscheduledDependency(row.original)) {
-        dispatch(push(Urls.transform(row.original.id)));
-      }
+      dispatch(push(Urls.transform(row.original.id)));
     },
     [dispatch],
   );
@@ -83,7 +81,6 @@ export function TransformTable({ transforms }: TransformTableProps) {
           <ListEmptyState label={t`There are no transforms for this job.`} />
         }
         ariaLabel={t`Job transforms`}
-        isRowDisabled={(row) => isUnscheduledDependency(row.original)}
         onRowClick={handleRowActivate}
       />
     </Card>

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
@@ -1,31 +1,34 @@
 import { t } from "ttag";
 
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified, Flex, Icon, Text } from "metabase/ui";
+import { Ellipsified, Flex, Icon } from "metabase/ui";
 import type { Transform } from "metabase-types/api";
 
-export function isUnscheduledDependency(transform: Transform) {
+function isUnscheduledDependency(transform: Transform) {
   return transform.dependency === true && transform.scheduled === false;
 }
 
-function FreshnessNote({ transform }: { transform: Transform }) {
+function getFreshnessNoteText(transform: Transform): string | null {
   if (!transform.dependency) {
     return null;
   }
-  if (isUnscheduledDependency(transform)) {
-    return (
-      <Flex align="center" c="warning" flex="0 0 auto" gap="xs">
-        <Icon name="warning" size={12} />
-        <Text c="warning" size="sm">
-          {t`Will not be re-run because it doesn't have a schedule`}
-        </Text>
-      </Flex>
-    );
+  return isUnscheduledDependency(transform)
+    ? t`Will not be re-run because it doesn't have a schedule`
+    : t`Will only re-run if it is stale according to its own schedule`;
+}
+
+function FreshnessNote({ transform }: { transform: Transform }) {
+  const note = getFreshnessNoteText(transform);
+  if (note == null) {
+    return null;
   }
   return (
-    <Text c="text-secondary" flex="0 0 auto" size="sm">
-      {t`Will only re-run if it is stale according to its own schedule`}
-    </Text>
+    <Flex align="center" c="text-secondary" fz="sm" gap="xs" miw={0}>
+      {isUnscheduledDependency(transform) && (
+        <Icon c="warning" name="warning" size={12} />
+      )}
+      <Ellipsified>{note}</Ellipsified>
+    </Flex>
   );
 }
 
@@ -37,13 +40,8 @@ function getTransformColumn(): TreeTableColumnDef<Transform> {
     maxAutoWidth: 520,
     enableSorting: true,
     accessorFn: (transform) => transform.name,
-    cell: ({ getValue, row }) => {
-      return (
-        <Flex align="center" gap="sm" miw={0}>
-          <Ellipsified>{String(getValue())}</Ellipsified>
-          <FreshnessNote transform={row.original} />
-        </Flex>
-      );
+    cell: ({ getValue }) => {
+      return <Ellipsified>{String(getValue())}</Ellipsified>;
     },
   };
 }
@@ -62,6 +60,19 @@ function getTargetColumn(): TreeTableColumnDef<Transform> {
   };
 }
 
+function getFreshnessNoteColumn(): TreeTableColumnDef<Transform> {
+  return {
+    id: "freshness-note",
+    header: t`Notes`,
+    width: "auto",
+    maxAutoWidth: 520,
+    accessorFn: getFreshnessNoteText,
+    cell: ({ row }) => {
+      return <FreshnessNote transform={row.original} />;
+    },
+  };
+}
+
 export function getColumns(): TreeTableColumnDef<Transform>[] {
-  return [getTransformColumn(), getTargetColumn()];
+  return [getTransformColumn(), getTargetColumn(), getFreshnessNoteColumn()];
 }

--- a/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/TransformsSection/utils.tsx
@@ -1,8 +1,33 @@
 import { t } from "ttag";
 
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified } from "metabase/ui";
+import { Ellipsified, Flex, Icon, Text } from "metabase/ui";
 import type { Transform } from "metabase-types/api";
+
+export function isUnscheduledDependency(transform: Transform) {
+  return transform.dependency === true && transform.scheduled === false;
+}
+
+function FreshnessNote({ transform }: { transform: Transform }) {
+  if (!transform.dependency) {
+    return null;
+  }
+  if (isUnscheduledDependency(transform)) {
+    return (
+      <Flex align="center" c="warning" flex="0 0 auto" gap="xs">
+        <Icon name="warning" size={12} />
+        <Text c="warning" size="sm">
+          {t`Will not be re-run because it doesn't have a schedule`}
+        </Text>
+      </Flex>
+    );
+  }
+  return (
+    <Text c="text-secondary" flex="0 0 auto" size="sm">
+      {t`Will only re-run if it is stale according to its own schedule`}
+    </Text>
+  );
+}
 
 function getTransformColumn(): TreeTableColumnDef<Transform> {
   return {
@@ -12,8 +37,13 @@ function getTransformColumn(): TreeTableColumnDef<Transform> {
     maxAutoWidth: 520,
     enableSorting: true,
     accessorFn: (transform) => transform.name,
-    cell: ({ getValue }) => {
-      return <Ellipsified>{String(getValue())}</Ellipsified>;
+    cell: ({ getValue, row }) => {
+      return (
+        <Flex align="center" gap="sm" miw={0}>
+          <Ellipsified>{String(getValue())}</Ellipsified>
+          <FreshnessNote transform={row.original} />
+        </Flex>
+      );
     },
   };
 }

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -35,7 +35,8 @@
        first))
 
 (defn fresh-dep-ids
-  "Subset of `dep-ids` whose most recent succeeded run is within their cadence as of `now`."
+  "Subset of `dep-ids` safe to skip as of `now`: a dep that has never succeeded is never fresh; a
+  scheduled one is fresh within its cadence; an unscheduled one is fresh once it has succeeded."
   [now dep-ids]
   (when (seq dep-ids)
     (let [schedules-by-id (transform-tag/schedules-for-transforms dep-ids)
@@ -43,8 +44,8 @@
           now-date        (Date/from (t/instant now))]
       (into #{}
             (keep (fn [id]
-                    (when-let [w (window now-date (schedules-by-id id))]
-                      (when-let [ran (last-success id)]
-                        (when (t/after? ran (t/minus now w))
-                          id)))))
+                    (when-let [ran (last-success id)]
+                      (if-let [w (window now-date (schedules-by-id id))]
+                        (when (t/after? ran (t/minus now w)) id)
+                        id))))
             dep-ids))))

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -1,42 +1,32 @@
 (ns metabase.transforms.freshness
-  "Decides which transforms pulled into a job's plan only as dependencies are already fresh — have a
-  recent enough successful run for their own cadence — and can be skipped."
+  "Decides which transforms pulled into a job's plan only as dependencies are already fresh — no
+  scheduled fire time has passed since their last successful run — and can be skipped."
   (:require
    [java-time.api :as t]
    [metabase.transforms.models.transform-run :as transform-run]
    [metabase.transforms.models.transform-tag :as transform-tag]
    [metabase.util.log :as log])
   (:import
-   (java.time Duration)
    (java.util Date)
    (org.quartz CronExpression)))
 
 (set! *warn-on-reflection* true)
 
-(defn- cron-interval
-  "Duration between the next two fire times of `cron` after `now`, or nil if it can't fire twice or is
-  unparseable."
-  ^Duration [cron ^Date now]
+(defn- fired-since?
+  "True if `cron` has a fire time after `last-success` and at or before `now` — i.e. a scheduled run
+  was due since the last success. Unparseable crons are ignored."
+  [cron ^Date last-success ^Date now]
   (try
-    (let [expr (CronExpression. ^String cron)]
-      (when-let [t1 (.getNextValidTimeAfter expr now)]
-        (when-let [t2 (.getNextValidTimeAfter expr t1)]
-          (Duration/ofMillis (- (.getTime t2) (.getTime t1))))))
+    (when-let [next-fire (.getNextValidTimeAfter (CronExpression. ^String cron) last-success)]
+      (not (.after next-fire now)))
     (catch Exception e
       (log/warnf e "Ignoring unparseable transform job schedule %s" (pr-str cron))
-      nil)))
-
-(defn- window
-  "A transform's cadence as of `now`: the shortest fire interval among `schedules`, or nil if none apply."
-  ^Duration [^Date now schedules]
-  (->> schedules
-       (keep #(cron-interval % now))
-       (sort-by #(.toMillis ^Duration %))
-       first))
+      false)))
 
 (defn fresh-dep-ids
   "Subset of `dep-ids` safe to skip as of `now`: a dep that has never succeeded is never fresh; a
-  scheduled one is fresh within its cadence; an unscheduled one is fresh once it has succeeded."
+  scheduled one is fresh while none of its schedules has fired since its last success; an unscheduled
+  one is fresh once it has succeeded."
   [now dep-ids]
   (when (seq dep-ids)
     (let [schedules-by-id (transform-tag/schedules-for-transforms dep-ids)
@@ -45,7 +35,8 @@
       (into #{}
             (keep (fn [id]
                     (when-let [ran (last-success id)]
-                      (if-let [w (window now-date (schedules-by-id id))]
-                        (when (t/after? ran (t/minus now w)) id)
-                        id))))
+                      (let [ran-date (Date/from (t/instant ran))]
+                        (when (not-any? #(fired-since? % ran-date now-date)
+                                        (schedules-by-id id))
+                          id)))))
             dep-ids))))

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -1,0 +1,50 @@
+(ns metabase.transforms.freshness
+  "Decides which transforms pulled into a job's plan only as dependencies are already fresh — have a
+  recent enough successful run for their own cadence — and can be skipped."
+  (:require
+   [java-time.api :as t]
+   [metabase.transforms.models.transform-run :as transform-run]
+   [metabase.transforms.models.transform-tag :as transform-tag]
+   [metabase.util.log :as log])
+  (:import
+   (java.time Duration)
+   (java.util Date)
+   (org.quartz CronExpression)))
+
+(set! *warn-on-reflection* true)
+
+(defn- cron-interval
+  "Duration between the next two fire times of `cron` after `now`, or nil if it can't fire twice or is
+  unparseable."
+  ^Duration [cron ^Date now]
+  (try
+    (let [expr (CronExpression. ^String cron)]
+      (when-let [t1 (.getNextValidTimeAfter expr now)]
+        (when-let [t2 (.getNextValidTimeAfter expr t1)]
+          (Duration/ofMillis (- (.getTime t2) (.getTime t1))))))
+    (catch Exception e
+      (log/warnf e "Ignoring unparseable transform job schedule %s" (pr-str cron))
+      nil)))
+
+(defn- window
+  "A transform's cadence as of `now`: the shortest fire interval among `schedules`, or nil if none apply."
+  ^Duration [^Date now schedules]
+  (->> schedules
+       (keep #(cron-interval % now))
+       (sort-by #(.toMillis ^Duration %))
+       first))
+
+(defn fresh-dep-ids
+  "Subset of `dep-ids` whose most recent succeeded run is within their cadence as of `now`."
+  [now dep-ids]
+  (when (seq dep-ids)
+    (let [schedules-by-id (transform-tag/schedules-for-transforms dep-ids)
+          last-success    (transform-run/last-successful-run-times dep-ids)
+          now-date        (Date/from (t/instant now))]
+      (into #{}
+            (keep (fn [id]
+                    (when-let [w (window now-date (schedules-by-id id))]
+                      (when-let [ran (last-success id)]
+                        (when (t/after? ran (t/minus now w))
+                          id)))))
+            dep-ids))))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -1,10 +1,12 @@
 (ns metabase.transforms.jobs
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.calendar-interval :as calendar-interval]
    [clojurewerkz.quartzite.triggers :as triggers]
    [flatland.ordered.set :as ordered-set]
+   [java-time.api :as t]
    [metabase.channel.urls :as urls]
    [metabase.events.core :as events]
    [metabase.revisions.core :as revisions]
@@ -13,6 +15,7 @@
    [metabase.transforms-base.ordering :as transforms-base.ordering]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.freshness :as freshness]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
@@ -172,8 +175,16 @@
 
   Updates the transform-job-run specified by run-id after every completion.
   Returns a map with :status and a collection of :failures if failed."
-  [run-id transform-ids-to-run {:keys [run-method start-promise user-id]}]
+  [run-id transform-ids-to-run {:keys [run-method start-promise user-id skip-fresh-deps?]
+                                :or   {skip-fresh-deps? true}}]
   (let [{plan :order deps :deps} (get-plan transform-ids-to-run)
+        requested    (set transform-ids-to-run)
+        closure      (into #{} (map :id) plan)
+        ;; Only deps pulled into the plan (not directly requested) are freshness-gated. Seeding them
+        ;; as :succeeded lets their dependents dispatch while they themselves are never submitted.
+        skip         (if skip-fresh-deps?
+                       (freshness/fresh-dep-ids (t/offset-date-time) (set/difference closure requested))
+                       #{})
         n            (max 1 (transforms.settings/transform-run-job-sql-concurrency))
         sql-executor (Executors/newFixedThreadPool n (named-thread-factory "transforms-sql-worker-%d"))
         py-executor  (Executors/newSingleThreadExecutor (named-thread-factory "transforms-python-worker-%d"))
@@ -181,7 +192,7 @@
                       :py  {:executor py-executor  :capacity 1}}
         lane-for     (fn [t] (if (transforms-base.u/python-transform? t) :py :sql))
         completions  (ArrayBlockingQueue. (max 2 (inc n)))
-        state        (volatile! {:succeeded         #{}
+        state        (volatile! {:succeeded         skip
                                  :failed            #{}
                                  :failures          []
                                  :in-flight         {:sql #{} :py #{}}
@@ -239,6 +250,8 @@
                               :else st)))
                         st
                         plan))]
+    (when (seq skip)
+      (log/infof "Skipping %d fresh pulled-in dependency transform(s): %s" (count skip) (pr-str skip)))
     (when start-promise (deliver start-promise :started))
     (try
       (vreset! state (dispatch! @state))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -185,9 +185,9 @@
         closure      (into #{} (map :id) plan)
         ;; Only deps pulled into the plan (not directly requested) are freshness-gated. Seeding them
         ;; as :succeeded lets their dependents dispatch while they themselves are never submitted.
-        skip         (if skip-fresh-deps?
-                       (freshness/fresh-dep-ids (app-db-now) (set/difference closure requested))
-                       #{})
+        skip         (or (when skip-fresh-deps?
+                           (freshness/fresh-dep-ids (app-db-now) (set/difference closure requested)))
+                         #{})
         n            (max 1 (transforms.settings/transform-run-job-sql-concurrency))
         sql-executor (Executors/newFixedThreadPool n (named-thread-factory "transforms-sql-worker-%d"))
         py-executor  (Executors/newSingleThreadExecutor (named-thread-factory "transforms-python-worker-%d"))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -6,7 +6,6 @@
    [clojurewerkz.quartzite.schedule.calendar-interval :as calendar-interval]
    [clojurewerkz.quartzite.triggers :as triggers]
    [flatland.ordered.set :as ordered-set]
-   [java-time.api :as t]
    [metabase.channel.urls :as urls]
    [metabase.events.core :as events]
    [metabase.revisions.core :as revisions]
@@ -160,6 +159,10 @@
   (when-let [{:keys [database schema name]} (:target transform)]
     [database schema name]))
 
+(defn- app-db-now
+  []
+  (:now (t2/query-one {:select [[[:raw "current_timestamp"] :now]]})))
+
 (defn run-transforms!
   "Run a series of transforms and their dependencies.
 
@@ -183,7 +186,7 @@
         ;; Only deps pulled into the plan (not directly requested) are freshness-gated. Seeding them
         ;; as :succeeded lets their dependents dispatch while they themselves are never submitted.
         skip         (if skip-fresh-deps?
-                       (freshness/fresh-dep-ids (t/offset-date-time) (set/difference closure requested))
+                       (freshness/fresh-dep-ids (app-db-now) (set/difference closure requested))
                        #{})
         n            (max 1 (transforms.settings/transform-run-job-sql-concurrency))
         sql-executor (Executors/newFixedThreadPool n (named-thread-factory "transforms-sql-worker-%d"))

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -18,6 +18,7 @@
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
+   [metabase.transforms.models.transform-tag :as transform-tag]
    [metabase.transforms.settings :as transforms.settings]
    [metabase.transforms.usage :as transforms.usage]
    [metabase.transforms.util :as transforms.u]
@@ -296,11 +297,20 @@
       #{})))
 
 (defn job-transforms
-  "Return the transforms that are executed when running the job with ID `job-id`.
+  "Return the transforms that are executed when running the job with ID `job-id`, in execution order.
 
-  The transforms are returned in the order of their execution."
+  Transforms pulled into the plan only as dependencies are marked with `:dependency true`
+  and `:scheduled` (whether any active job's schedule covers them)."
   [job-id]
-  (:order (get-plan (job-transform-ids job-id))))
+  (let [tagged    (job-transform-ids job-id)
+        plan      (:order (get-plan tagged))
+        dep-ids   (into #{} (comp (map :id) (remove tagged)) plan)
+        scheduled (set (keys (transform-tag/schedules-for-transforms dep-ids)))]
+    (map (fn [{:keys [id] :as transform}]
+           (cond-> transform
+             (contains? dep-ids id) (assoc :dependency true
+                                           :scheduled  (contains? scheduled id))))
+         plan)))
 
 (defn- compile-transform-failure-messages [failures]
   (->> failures

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -219,6 +219,20 @@
                  :transform_id transform-id
                  :is_active true))
 
+(defn last-successful-run-times
+  "Map each id in `transform-ids` with a succeeded run to its most recent run's `end_time`. Ids with
+  no succeeded run are absent."
+  [transform-ids]
+  (when (seq transform-ids)
+    (into {}
+          (map (juxt :transform_id :last_success))
+          (t2/select :model/TransformRun
+                     {:select   [:transform_id [[:max :end_time] :last_success]]
+                      :where    [:and
+                                 [:in :transform_id transform-ids]
+                                 [:= :status [:inline "succeeded"]]]
+                      :group-by [:transform_id]}))))
+
 (defn- timestamp-constraint
   [field-name date-string]
   (let [{:keys [start end]}

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -37,8 +37,8 @@
   (api/is-data-analyst?))
 
 (defn schedules-for-transforms
-  "Map each id in `transform-ids` to the cron schedules of the jobs that run it via shared tags. Ids
-  with no scheduling job are absent."
+  "Map each id in `transform-ids` to the cron schedules of the active jobs that run it via shared tags.
+  Ids with no such job are absent."
   [transform-ids]
   (when (seq transform-ids)
     (reduce (fn [m {:keys [transform_id schedule]}]
@@ -49,7 +49,9 @@
                         :from   [[:transform_transform_tag :ttt]]
                         :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
                                  [:transform_job :job] [:= :jtt.job_id :job.id]]
-                        :where  [:in :ttt.transform_id transform-ids]}))))
+                        :where  [:and
+                                 [:in :ttt.transform_id transform-ids]
+                                 [:= :job.active true]]}))))
 
 (defn tag-name-exists?
   "Check if a tag with the given name already exists"

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -36,6 +36,21 @@
   [_model _instance]
   (api/is-data-analyst?))
 
+(defn schedules-for-transforms
+  "Map each id in `transform-ids` to the cron schedules of the jobs that run it via shared tags. Ids
+  with no scheduling job are absent."
+  [transform-ids]
+  (when (seq transform-ids)
+    (reduce (fn [m {:keys [transform_id schedule]}]
+              (update m transform_id (fnil conj #{}) schedule))
+            {}
+            (t2/select :model/TransformTransformTag
+                       {:select [:ttt.transform_id [:job.schedule :schedule]]
+                        :from   [[:transform_transform_tag :ttt]]
+                        :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
+                                 [:transform_job :job] [:= :jtt.job_id :job.id]]
+                        :where  [:in :ttt.transform_id transform-ids]}))))
+
 (defn tag-name-exists?
   "Check if a tag with the given name already exists"
   [tag-name]

--- a/src/metabase/transforms_rest/api/transform_job.clj
+++ b/src/metabase/transforms_rest/api/transform_job.clj
@@ -215,14 +215,19 @@
 (api.macros/defendpoint :post "/:job-id/run" :- [:map {:closed true}
                                                  [:message :string]
                                                  [:job_run_id :string]]
-  "Run a transform job manually."
-  [{:keys [job-id]} :- [:map [:job-id ms/PositiveInt]]]
+  "Run a transform job manually. By default, fresh pulled-in dependencies are skipped; pass `run_all`
+  to force-refresh the whole plan."
+  [{:keys [job-id]} :- [:map [:job-id ms/PositiveInt]]
+   _query-params
+   {:keys [run_all]} :- [:map
+                         [:run_all {:default false} :boolean]]]
   (log/info "Manual run of transform job" job-id)
   (api/write-check (t2/select-one :model/TransformJob :id job-id))
   (u.jvm/in-virtual-thread*
    (try
-     (transforms.core/run-job! job-id {:run-method :manual
-                                       :user-id api/*current-user-id*})
+     (transforms.core/run-job! job-id {:run-method       :manual
+                                       :user-id          api/*current-user-id*
+                                       :skip-fresh-deps? (not run_all)})
      (catch Throwable t
        (log/error "Error executing transform job" job-id)
        (log/error t))))

--- a/src/metabase/transforms_rest/api/transform_job.clj
+++ b/src/metabase/transforms_rest/api/transform_job.clj
@@ -80,6 +80,8 @@
    [:creator_id pos-int?]
    [:collection_id [:maybe pos-int?]]
    [:run_trigger {:optional true} [:maybe :keyword]]
+   [:dependency {:optional true} :boolean]
+   [:scheduled {:optional true} :boolean]
    [:creator CreatorResponse]])
 
 (api.macros/defendpoint :post "/" :- TransformJobResponse

--- a/test/metabase/transforms/freshness_test.clj
+++ b/test/metabase/transforms/freshness_test.clj
@@ -54,12 +54,26 @@
         (testing "a success 30m ago is within the hourly window"
           (insert-succeeded-run! (:id t) (t/minus now (t/minutes 30)))
           (is (= #{(:id t)} (freshness/fresh-dep-ids now #{(:id t)}))))))
-    (testing "a dep with a tag but no scheduling job is never skipped, even with a recent success"
-      (mt/with-temp [:model/TransformTag          tag {:name "unscheduled-tag"}
-                     :model/Transform             t   {:name "unscheduled-dep"}
+    (testing "a dep with no active scheduling job is fresh once it has succeeded at least once"
+      (mt/with-temp [:model/TransformTag          tag   {:name "unscheduled-tag"}
+                     :model/Transform             ran   {:name "unscheduled-ran"}
+                     :model/TransformTransformTag _      {:transform_id (:id ran) :tag_id (:id tag) :position 0}
+                     :model/Transform             never {:name "unscheduled-never"}
+                     :model/TransformTransformTag _      {:transform_id (:id never) :tag_id (:id tag) :position 0}]
+        ;; old success — would be stale under any cadence, but there is no cadence asking to refresh it
+        (insert-succeeded-run! (:id ran) (t/minus now (t/days 365)))
+        (is (= #{(:id ran)}
+               (freshness/fresh-dep-ids now #{(:id ran) (:id never)}))
+            "the one that has run is skipped; the one that never has is not")))
+    (testing "an inactive job does not establish a cadence (so the dep is fresh once it has run)"
+      (mt/with-temp [:model/TransformTag          tag {:name "inactive-tag"}
+                     :model/TransformJob          job {:name "inactive-job" :schedule daily-cron :active false}
+                     :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             t   {:name "inactively-scheduled"}
                      :model/TransformTransformTag _   {:transform_id (:id t) :tag_id (:id tag) :position 0}]
-        (insert-succeeded-run! (:id t) (t/minus now (t/minutes 1)))
-        (is (= #{} (freshness/fresh-dep-ids now #{(:id t)})))))
+        ;; stale for the daily cadence, but the only job is inactive → treated as unscheduled
+        (insert-succeeded-run! (:id t) (t/minus now (t/days 2)))
+        (is (= #{(:id t)} (freshness/fresh-dep-ids now #{(:id t)})))))
     (testing "a scheduled dep with no successful run is not skipped"
       (mt/with-temp [:model/TransformTag          tag {:name "daily-tag-3"}
                      :model/TransformJob          job {:name "daily-job-3" :schedule daily-cron}

--- a/test/metabase/transforms/freshness_test.clj
+++ b/test/metabase/transforms/freshness_test.clj
@@ -10,6 +10,7 @@
 
 (def ^:private hourly-cron "0 0 * * * ? *")
 (def ^:private daily-cron "0 0 0 * * ? *")
+(def ^:private weekend-cron "0 0 2 ? * SAT,SUN *")
 
 (defn- insert-succeeded-run!
   "Insert a succeeded transform run completing at `end-time`."
@@ -22,11 +23,13 @@
                                   :end_time     end-time}))
 
 (deftest fresh-dep-ids-test
-  (let [now (t/offset-date-time)]
+  ;; pinned to a Wednesday at 10:30 (local) so cron fire boundaries are deterministic: the hourly
+  ;; cron last fired at 10:00, the daily one at midnight, the weekend one on Sunday at 02:00
+  (let [now (t/offset-date-time 2025 6 18 10 30)]
     (testing "nil/empty input"
       (is (nil? (freshness/fresh-dep-ids now nil)))
       (is (nil? (freshness/fresh-dep-ids now #{}))))
-    (testing "a daily-scheduled dep is fresh when its last success is within a day, stale otherwise"
+    (testing "a daily-scheduled dep is fresh while no daily fire has come due since its last success"
       (mt/with-temp [:model/TransformTag          tag   {:name "daily-tag"}
                      :model/TransformJob          job   {:name "daily-job" :schedule daily-cron}
                      :model/TransformJobTransformTag _   {:job_id (:id job) :tag_id (:id tag) :position 0}
@@ -34,11 +37,12 @@
                      :model/TransformTransformTag _      {:transform_id (:id fresh) :tag_id (:id tag) :position 0}
                      :model/Transform             stale {:name "stale-daily"}
                      :model/TransformTransformTag _      {:transform_id (:id stale) :tag_id (:id tag) :position 0}]
+        ;; 08:30 — after today's midnight fire → fresh; two days ago → two midnights have passed → stale
         (insert-succeeded-run! (:id fresh) (t/minus now (t/hours 2)))
         (insert-succeeded-run! (:id stale) (t/minus now (t/days 2)))
         (is (= #{(:id fresh)}
                (freshness/fresh-dep-ids now #{(:id fresh) (:id stale)})))))
-    (testing "the shortest schedule wins: a dep run by both an hourly and a daily job uses the 1h window"
+    (testing "with multiple schedules, any one firing since the last success makes the dep stale"
       (mt/with-temp [:model/TransformTag          hourly-tag {:name "hourly-tag"}
                      :model/TransformTag          daily-tag  {:name "daily-tag-2"}
                      :model/TransformJob          hourly-job {:name "hourly-job" :schedule hourly-cron}
@@ -48,12 +52,26 @@
                      :model/Transform             t          {:name "hourly-and-daily"}
                      :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id hourly-tag) :position 0}
                      :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id daily-tag) :position 1}]
-        (testing "a success 2h ago is within the daily window but not the (shorter) hourly one"
+        (testing "a success 2h ago (08:30): the hourly job has fired since (09:00, 10:00), the daily one hasn't"
           (insert-succeeded-run! (:id t) (t/minus now (t/hours 2)))
           (is (= #{} (freshness/fresh-dep-ids now #{(:id t)}))))
-        (testing "a success 30m ago is within the hourly window"
-          (insert-succeeded-run! (:id t) (t/minus now (t/minutes 30)))
+        (testing "a success 25m ago (10:05): no schedule has fired since"
+          (insert-succeeded-run! (:id t) (t/minus now (t/minutes 25)))
           (is (= #{(:id t)} (freshness/fresh-dep-ids now #{(:id t)}))))))
+    (testing "an irregular weekend-only schedule stays fresh all week off a Sunday success"
+      (mt/with-temp [:model/TransformTag          tag   {:name "weekend-tag"}
+                     :model/TransformJob          job   {:name "weekend-job" :schedule weekend-cron}
+                     :model/TransformJobTransformTag _   {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             fresh {:name "fresh-weekend"}
+                     :model/TransformTransformTag _      {:transform_id (:id fresh) :tag_id (:id tag) :position 0}
+                     :model/Transform             stale {:name "stale-weekend"}
+                     :model/TransformTransformTag _      {:transform_id (:id stale) :tag_id (:id tag) :position 0}]
+        ;; Sunday 02:30, just after the weekend job's last fire; next fire is Saturday → fresh on Wednesday
+        (insert-succeeded-run! (:id fresh) (t/minus now (t/days 3) (t/hours 8)))
+        ;; last Thursday: both weekend fires have come due since → stale
+        (insert-succeeded-run! (:id stale) (t/minus now (t/days 6)))
+        (is (= #{(:id fresh)}
+               (freshness/fresh-dep-ids now #{(:id fresh) (:id stale)})))))
     (testing "a dep with no active scheduling job is fresh once it has succeeded at least once"
       (mt/with-temp [:model/TransformTag          tag   {:name "unscheduled-tag"}
                      :model/Transform             ran   {:name "unscheduled-ran"}
@@ -71,7 +89,7 @@
                      :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}
                      :model/Transform             t   {:name "inactively-scheduled"}
                      :model/TransformTransformTag _   {:transform_id (:id t) :tag_id (:id tag) :position 0}]
-        ;; stale for the daily cadence, but the only job is inactive → treated as unscheduled
+        ;; the daily schedule would have fired since, but the only job is inactive → treated as unscheduled
         (insert-succeeded-run! (:id t) (t/minus now (t/days 2)))
         (is (= #{(:id t)} (freshness/fresh-dep-ids now #{(:id t)})))))
     (testing "a scheduled dep with no successful run is not skipped"

--- a/test/metabase/transforms/freshness_test.clj
+++ b/test/metabase/transforms/freshness_test.clj
@@ -1,0 +1,77 @@
+(ns metabase.transforms.freshness-test
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase.test :as mt]
+   [metabase.transforms.freshness :as freshness]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private hourly-cron "0 0 * * * ? *")
+(def ^:private daily-cron "0 0 0 * * ? *")
+
+(defn- insert-succeeded-run!
+  "Insert a succeeded transform run completing at `end-time`."
+  [transform-id end-time]
+  (t2/insert-returning-instance! :model/TransformRun
+                                 {:transform_id transform-id
+                                  :run_method   :cron
+                                  :status       :succeeded
+                                  :is_active    nil
+                                  :end_time     end-time}))
+
+(deftest fresh-dep-ids-test
+  (let [now (t/offset-date-time)]
+    (testing "nil/empty input"
+      (is (nil? (freshness/fresh-dep-ids now nil)))
+      (is (nil? (freshness/fresh-dep-ids now #{}))))
+    (testing "a daily-scheduled dep is fresh when its last success is within a day, stale otherwise"
+      (mt/with-temp [:model/TransformTag          tag   {:name "daily-tag"}
+                     :model/TransformJob          job   {:name "daily-job" :schedule daily-cron}
+                     :model/TransformJobTransformTag _   {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             fresh {:name "fresh-daily"}
+                     :model/TransformTransformTag _      {:transform_id (:id fresh) :tag_id (:id tag) :position 0}
+                     :model/Transform             stale {:name "stale-daily"}
+                     :model/TransformTransformTag _      {:transform_id (:id stale) :tag_id (:id tag) :position 0}]
+        (insert-succeeded-run! (:id fresh) (t/minus now (t/hours 2)))
+        (insert-succeeded-run! (:id stale) (t/minus now (t/days 2)))
+        (is (= #{(:id fresh)}
+               (freshness/fresh-dep-ids now #{(:id fresh) (:id stale)})))))
+    (testing "the shortest schedule wins: a dep run by both an hourly and a daily job uses the 1h window"
+      (mt/with-temp [:model/TransformTag          hourly-tag {:name "hourly-tag"}
+                     :model/TransformTag          daily-tag  {:name "daily-tag-2"}
+                     :model/TransformJob          hourly-job {:name "hourly-job" :schedule hourly-cron}
+                     :model/TransformJob          daily-job  {:name "daily-job-2" :schedule daily-cron}
+                     :model/TransformJobTransformTag _        {:job_id (:id hourly-job) :tag_id (:id hourly-tag) :position 0}
+                     :model/TransformJobTransformTag _        {:job_id (:id daily-job) :tag_id (:id daily-tag) :position 0}
+                     :model/Transform             t          {:name "hourly-and-daily"}
+                     :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id hourly-tag) :position 0}
+                     :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id daily-tag) :position 1}]
+        (testing "a success 2h ago is within the daily window but not the (shorter) hourly one"
+          (insert-succeeded-run! (:id t) (t/minus now (t/hours 2)))
+          (is (= #{} (freshness/fresh-dep-ids now #{(:id t)}))))
+        (testing "a success 30m ago is within the hourly window"
+          (insert-succeeded-run! (:id t) (t/minus now (t/minutes 30)))
+          (is (= #{(:id t)} (freshness/fresh-dep-ids now #{(:id t)}))))))
+    (testing "a dep with a tag but no scheduling job is never skipped, even with a recent success"
+      (mt/with-temp [:model/TransformTag          tag {:name "unscheduled-tag"}
+                     :model/Transform             t   {:name "unscheduled-dep"}
+                     :model/TransformTransformTag _   {:transform_id (:id t) :tag_id (:id tag) :position 0}]
+        (insert-succeeded-run! (:id t) (t/minus now (t/minutes 1)))
+        (is (= #{} (freshness/fresh-dep-ids now #{(:id t)})))))
+    (testing "a scheduled dep with no successful run is not skipped"
+      (mt/with-temp [:model/TransformTag          tag {:name "daily-tag-3"}
+                     :model/TransformJob          job {:name "daily-job-3" :schedule daily-cron}
+                     :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             t   {:name "never-succeeded"}
+                     :model/TransformTransformTag _   {:transform_id (:id t) :tag_id (:id tag) :position 0}]
+        (testing "no runs at all"
+          (is (= #{} (freshness/fresh-dep-ids now #{(:id t)}))))
+        (testing "only a failed run does not count as fresh"
+          (t2/insert! :model/TransformRun {:transform_id (:id t)
+                                           :run_method   :cron
+                                           :status       :failed
+                                           :is_active    nil
+                                           :end_time     (t/minus now (t/minutes 1))})
+          (is (= #{} (freshness/fresh-dep-ids now #{(:id t)}))))))))

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -14,6 +14,7 @@
    [metabase.test :as mt]
    [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.freshness :as freshness]
    [metabase.transforms.jobs :as jobs]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
@@ -501,6 +502,39 @@
                                                                           :name     "zombie_out"}}]
             (testing "get-plan with empty transform-ids must not throw on unrelated zombies"
               (is (empty? (:order (#'jobs/get-plan #{})))))))))))
+
+(deftest run-transforms-skips-fresh-pulled-in-deps-test
+  (mt/with-premium-features #{:transforms-basic}
+    ;; b (2) depends on a (1), plus independent c (3); only b and c are requested, so a is pulled in.
+    (let [plan [{:id 1} {:id 2} {:id 3}]
+          deps {1 #{} 2 #{1} 3 #{}}
+          ran  (atom #{})]
+      (testing "a fresh pulled-in dep is not executed, but its dependent still runs"
+        (with-redefs [jobs/get-plan           (fn [_] {:order plan :deps deps})
+                      freshness/fresh-dep-ids (fn [_now dep-ids]
+                                                ;; only pulled-in deps are offered for gating
+                                                (is (= #{1} (set dep-ids)))
+                                                #{1})
+                      jobs/run-transform!     (fn [_ _ _ t] (swap! ran conj (:id t)))]
+          (is (= {::jobs/status :succeeded}
+                 (jobs/run-transforms! 0 #{2 3} {:run-method :cron})))
+          (is (= #{2 3} @ran) "transform 1 (fresh dep) was skipped; 2 and 3 ran")))
+      (testing "skip-fresh-deps? false (manual run_all) force-refreshes the whole plan"
+        (reset! ran #{})
+        (with-redefs [jobs/get-plan           (fn [_] {:order plan :deps deps})
+                      freshness/fresh-dep-ids (fn [& _] (throw (ex-info "must not gate when disabled" {})))
+                      jobs/run-transform!     (fn [_ _ _ t] (swap! ran conj (:id t)))]
+          (is (= {::jobs/status :succeeded}
+                 (jobs/run-transforms! 0 #{2 3} {:run-method :manual :skip-fresh-deps? false})))
+          (is (= #{1 2 3} @ran) "with skipping disabled, the dep runs too"))))
+    (testing "a plan that is entirely skipped exits cleanly as succeeded with nothing run"
+      (let [ran (atom #{})]
+        (with-redefs [jobs/get-plan           (fn [_] {:order [{:id 1}] :deps {1 #{}}})
+                      freshness/fresh-dep-ids (fn [_now _dep-ids] #{1})
+                      jobs/run-transform!     (fn [_ _ _ t] (swap! ran conj (:id t)))]
+          (is (= {::jobs/status :succeeded}
+                 (jobs/run-transforms! 0 #{} {:run-method :cron})))
+          (is (= #{} @ran)))))))
 
 (deftest run-transforms!-race-condition-test
   ;; Previously a race would ensure one transform run got the duplicate key error and aborted.

--- a/test/metabase/transforms/models_test.clj
+++ b/test/metabase/transforms/models_test.clj
@@ -355,3 +355,19 @@
                                                               :checkpoint-filter-field-id 200}}})
           (let [t (t2/select-one :model/Transform transform-id)]
             (is (= "99" (:last_checkpoint_value t)))))))))
+
+(deftest schedules-for-transforms-test
+  (testing "returns the schedules of the active jobs that run a transform via shared tags"
+    (mt/with-temp [:model/TransformTag          tag      {}
+                   :model/TransformJob          active   {:schedule "0 0 * * * ? *" :active true}
+                   :model/TransformJob          inactive {:schedule "0 0 0 * * ? *" :active false}
+                   :model/TransformJobTransformTag _      {:job_id (:id active) :tag_id (:id tag) :position 0}
+                   :model/TransformJobTransformTag _      {:job_id (:id inactive) :tag_id (:id tag) :position 1}
+                   :model/Transform             t        {}
+                   :model/TransformTransformTag _         {:transform_id (:id t) :tag_id (:id tag) :position 0}
+                   :model/Transform             untagged {}]
+      (is (= {(:id t) #{"0 0 * * * ? *"}}
+             (transform-tag/schedules-for-transforms #{(:id t)}))
+          "only the active job's schedule is included")
+      (is (= {} (transform-tag/schedules-for-transforms #{(:id untagged)}))
+          "a transform with no scheduling job is absent"))))


### PR DESCRIPTION
Closes [GDGT-2550: Skip fresh dependency transforms in scheduler plans](https://linear.app/metabase/issue/GDGT-2550/skip-fresh-dependency-transforms-in-scheduler-plans)

When a transform job runs, the scheduler expands the requested transforms to their full dependency closure. Today that means a dependency dragged into a frequent job (e.g. an  hourly job depending on a daily-cadence transform) is re-run on every trigger, even when its own output is still fresh.

This PR skips re-running a transform that's pulled into a job's plan only as a dependency when it's already fresh.
A dependency transform is considered fresh when: 
- if it's scheduled,  its most recent successful run falls within the cadence of its shortest cron interval
- if it's unscheduled, it has a successful run

Added notes on the jobs page about freshness implications
<img width="962" height="420" alt="image" src="https://github.com/user-attachments/assets/f96b61c8-b260-4b89-9015-6b59dfa138e8" />
