### PR TITLE
Migrate app routes to TypeScript

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -150,7 +150,7 @@ const elements = [
     "frontend/src/metabase/App.styled.tsx",
     "frontend/src/metabase/AppKBarProvider.tsx",
     "frontend/src/metabase/reducers-main.ts",
-    "frontend/src/metabase/routes.jsx",
+    "frontend/src/metabase/routes.tsx",
     "frontend/src/metabase/routes-embed.tsx",
     "frontend/src/metabase/route-guards.tsx",
     "frontend/src/metabase/routes-public.tsx",

--- a/frontend/lint/tests/no-analytics-import-outside-analytics-files.unit.spec.js
+++ b/frontend/lint/tests/no-analytics-import-outside-analytics-files.unit.spec.js
@@ -21,7 +21,7 @@ const VALID_CASES = [
   },
   {
     code: `import { trackPageView } from "metabase/analytics";`,
-    filename: "/path/to/routes.jsx",
+    filename: "/path/to/routes.tsx",
   },
   // Restricted specifiers are fine in analytics.* files.
   {

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -1,6 +1,5 @@
 import type { Store } from "@reduxjs/toolkit";
-import type { ComponentType } from "react";
-import { IndexRedirect, Route } from "react-router";
+import { IndexRedirect, Route, type RouteComponent } from "react-router";
 
 import type { State } from "metabase/redux/store";
 
@@ -12,7 +11,7 @@ import UserProfileApp from "./profile/containers/UserProfileApp";
 
 export const getAccountRoutes = (
   _store: Store<State>,
-  IsAuthenticated: ComponentType,
+  IsAuthenticated: RouteComponent,
 ) => {
   return (
     <Route path="/account" component={IsAuthenticated}>

--- a/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.tsx
+++ b/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.tsx
@@ -31,14 +31,14 @@ import { PermissionsTable } from "../PermissionsTable";
 
 import S from "./CollectionPermissionsModal.module.css";
 
-const getDefaultTitle = (namespace: CollectionNamespace) =>
+const getDefaultTitle = (namespace?: CollectionNamespace) =>
   namespace === "snippets"
     ? t`Permissions for this folder`
     : t`Permissions for this collection`;
 
 const mapStateToProps = (
   state: State,
-  props: { params: { slug?: string }; namespace: CollectionNamespace },
+  props: { params: { slug?: string }; namespace?: CollectionNamespace },
 ) => {
   const collectionId = Urls.extractCollectionId(props.params.slug);
   if (!collectionId) {
@@ -70,7 +70,7 @@ interface CollectionPermissionsModalProps {
   permissionEditor: PermissionEditorType | null;
   isDirty: boolean;
   onClose: () => void;
-  namespace: CollectionNamespace;
+  namespace?: CollectionNamespace;
   collection?: Collection;
   initialize: (namespace: CollectionNamespace) => void;
   updateCollectionPermission: (
@@ -83,7 +83,7 @@ const CollectionPermissionsModal = ({
   permissionEditor,
   isDirty,
   onClose,
-  namespace,
+  namespace = null,
   collection,
 
   initialize,

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
@@ -41,7 +41,7 @@ function ArchiveCollectionModalInner({
   );
 }
 
-export function ArchiveCollectionModalContainer({
+export function ArchiveCollectionModal({
   params,
   onClose,
 }: ArchiveCollectionModalRouteProps) {
@@ -56,5 +56,3 @@ export function ArchiveCollectionModalContainer({
     <ArchiveCollectionModalInner collection={collection} onClose={onClose} />
   );
 }
-
-export const ArchiveCollectionModal = ArchiveCollectionModalContainer;

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.tsx
@@ -1,4 +1,3 @@
-import { type WithRouterProps, withRouter } from "react-router";
 import { t } from "ttag";
 
 import { skipToken, useGetCollectionQuery } from "metabase/api";
@@ -9,6 +8,10 @@ import type { Collection } from "metabase-types/api";
 
 type OwnProps = {
   onClose: () => void;
+};
+
+type ArchiveCollectionModalRouteProps = OwnProps & {
+  params: { slug?: string };
 };
 
 type ArchiveCollectionModalInnerProps = OwnProps & {
@@ -41,7 +44,7 @@ function ArchiveCollectionModalInner({
 export function ArchiveCollectionModalContainer({
   params,
   onClose,
-}: OwnProps & WithRouterProps) {
+}: ArchiveCollectionModalRouteProps) {
   const collectionId = Urls.extractCollectionId(params.slug);
   const { data: collection } = useGetCollectionQuery(
     collectionId != null ? { id: collectionId } : skipToken,
@@ -54,6 +57,4 @@ export function ArchiveCollectionModalContainer({
   );
 }
 
-export const ArchiveCollectionModal = withRouter(
-  ArchiveCollectionModalContainer,
-);
+export const ArchiveCollectionModal = ArchiveCollectionModalContainer;

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
-import type { WithRouterProps } from "react-router";
 
 import {
   setupCollectionByIdEndpoint,
@@ -23,7 +22,7 @@ const setup = ({
   const props = {
     onClose,
     params: { slug },
-  } as unknown as WithRouterProps & { onClose: () => void };
+  };
 
   renderWithProviders(<ArchiveCollectionModalContainer {...props} />);
 

--- a/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ArchiveCollectionModal/ArchiveCollectionModal.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockCollection } from "metabase-types/api/mocks";
 
-import { ArchiveCollectionModalContainer } from "./ArchiveCollectionModal";
+import { ArchiveCollectionModal } from "./ArchiveCollectionModal";
 
 const TEST_COLLECTION = createMockCollection({ id: 1, name: "Sales" });
 
@@ -24,7 +24,7 @@ const setup = ({
     params: { slug },
   };
 
-  renderWithProviders(<ArchiveCollectionModalContainer {...props} />);
+  renderWithProviders(<ArchiveCollectionModal {...props} />);
 
   return { onClose };
 };

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -56,7 +56,7 @@ export const MoveCollectionModal = ({
   onClose,
 }: {
   collectionId?: CollectionId;
-  params?: { slug: string };
+  params?: { slug?: string };
   onClose: () => void;
 }) => {
   const setCollection = useSetCollection();

--- a/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
+++ b/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
@@ -21,7 +21,7 @@ import { MoveQuestionsIntoDashboardsInfoModal } from "./MoveQuestionsIntoDashboa
 
 interface MoveQuestionsIntoDashboardsModalProps {
   onClose: () => void;
-  params: { slug: string };
+  params: { slug?: string };
   location: Location<unknown>;
 }
 

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
@@ -1,6 +1,7 @@
+import type { Location } from "history";
 import { dissoc } from "icepick";
 import { useState } from "react";
-import { type WithRouterProps, withRouter } from "react-router";
+import { withRouter } from "react-router";
 import { replace } from "react-router-redux";
 import { t } from "ttag";
 
@@ -16,7 +17,9 @@ import { getDashboardComplete } from "../selectors";
 
 type DashboardCopyModalProps = {
   onClose: () => void;
-} & WithRouterProps;
+  params: { slug?: string };
+  location: Location;
+};
 
 const getTitle = (
   dashboard: Dashboard | null,

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
@@ -94,7 +94,7 @@ export const DashboardMoveModalConnected = ({
   params,
   onClose,
 }: {
-  params: { slug: string };
+  params: { slug?: string };
   onClose: () => void;
 }) => {
   const id = Urls.extractCollectionId(params.slug);

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { type WithRouterProps, withRouter } from "react-router";
+import { withRouter } from "react-router";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -57,7 +57,7 @@ const ArchiveDashboardModal = ({
 };
 
 export const ArchiveDashboardModalConnectedInner = (
-  props: OwnProps & WithRouterProps,
+  props: OwnProps & { params: { slug?: string } },
 ) => {
   const id = Urls.extractCollectionId(props.params?.slug);
   const { currentData: dashboard, error } = useGetDashboardQuery(

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -1,6 +1,5 @@
 import type { Store } from "@reduxjs/toolkit";
-import type { ComponentType } from "react";
-import { IndexRoute, Route } from "react-router";
+import { IndexRoute, Route, type RouteComponent } from "react-router";
 
 import {
   PLUGIN_DEPENDENCIES,
@@ -32,10 +31,10 @@ import {
 
 export function getDataStudioRoutes(
   store: Store<State>,
-  CanAccessDataStudio: ComponentType,
-  CanAccessDataModel: ComponentType,
-  _CanAccessTransforms: ComponentType,
-  IsAdmin: ComponentType,
+  CanAccessDataStudio: RouteComponent,
+  CanAccessDataModel: RouteComponent,
+  _CanAccessTransforms: RouteComponent,
+  IsAdmin: RouteComponent,
 ) {
   return (
     <Route component={CanAccessDataStudio}>

--- a/frontend/src/metabase/documents/components/CommentsSidesheet/CommentsSidesheet.tsx
+++ b/frontend/src/metabase/documents/components/CommentsSidesheet/CommentsSidesheet.tsx
@@ -36,7 +36,7 @@ type SidesheetTab = "open" | "resolved";
 
 interface Props {
   params?: {
-    childTargetId: string;
+    childTargetId?: string;
   };
   onClose: () => void;
 }

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -16,13 +16,17 @@ import { HydratedKBarSearch } from "./HydratedKBarSearch";
 import S from "./Palette.module.css";
 import { PaletteResults } from "./PaletteResults";
 
+type CommandPaletteRouteProps = {
+  disableCommandPalette?: boolean;
+};
+
 /** Command palette */
 export const Palette = withRouter((props) => {
   const isLoggedIn = useSelector((state) => !!getUser(state));
 
   const disableCommandPaletteForRoute = props.routes.some(
-    (route: PlainRoute & { disableCommandPalette?: boolean }) =>
-      route.disableCommandPalette,
+    (route: PlainRoute<CommandPaletteRouteProps>) =>
+      route.props?.disableCommandPalette,
   );
 
   useCommandPaletteBasicActions({ ...props, isLoggedIn });

--- a/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/Palette.unit.spec.tsx
@@ -40,7 +40,7 @@ const setup = ({
     <Route
       path={initialRoute ? "*" : "/"}
       component={Palette}
-      {...routeProps}
+      props={routeProps}
     />,
     {
       withKBar: true,

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -1,4 +1,4 @@
-import type { AnyAction, Store, ThunkDispatch } from "@reduxjs/toolkit";
+import type { Store, ThunkDispatch, UnknownAction } from "@reduxjs/toolkit";
 import { IndexRedirect, IndexRoute, Redirect, Route } from "react-router";
 
 import App from "metabase/App";
@@ -84,8 +84,8 @@ import {
 import { createEntityIdRedirect } from "./routes-stable-id-aware";
 import { getSetting } from "./selectors/settings";
 
-type AppStore = Store<State, AnyAction> & {
-  dispatch: ThunkDispatch<State, void, AnyAction>;
+type AppStore = Store<State> & {
+  dispatch: ThunkDispatch<State, void, UnknownAction>;
 };
 
 export const getRoutes = (store: AppStore) => {
@@ -106,7 +106,7 @@ export const getRoutes = (store: AppStore) => {
         onChange={(prevState, nextState) => {
           trackPageView(nextState.location.pathname);
         }}
-        disableCommandPalette
+        props={{ disableCommandPalette: true }}
       />
 
       {/* For compatibility: use the standard setup for embedding */}

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -1,6 +1,7 @@
+import type { AnyAction, Store, ThunkDispatch } from "@reduxjs/toolkit";
 import { IndexRedirect, IndexRoute, Redirect, Route } from "react-router";
 
-import App from "metabase/App.tsx";
+import App from "metabase/App";
 import { getAccountRoutes } from "metabase/account/routes";
 import CollectionPermissionsModal from "metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal";
 import { getRoutes as getAdminRoutes } from "metabase/admin/routes";
@@ -49,6 +50,7 @@ import {
   PLUGIN_TENANTS,
 } from "metabase/plugins";
 import { QueryBuilder } from "metabase/query_builder/containers/QueryBuilder";
+import type { State } from "metabase/redux/store";
 import { loadCurrentUser } from "metabase/redux/user";
 import DatabaseDetailContainer from "metabase/reference/databases/DatabaseDetailContainer";
 import DatabaseListContainer from "metabase/reference/databases/DatabaseListContainer";
@@ -82,7 +84,11 @@ import {
 import { createEntityIdRedirect } from "./routes-stable-id-aware";
 import { getSetting } from "./selectors/settings";
 
-export const getRoutes = (store) => {
+type AppStore = Store<State, AnyAction> & {
+  dispatch: ThunkDispatch<State, void, AnyAction>;
+};
+
+export const getRoutes = (store: AppStore) => {
   const hasUserSetup = getSetting(store.getState(), "has-user-setup");
 
   return (
@@ -111,7 +117,7 @@ export const getRoutes = (store) => {
         onEnter={async (nextState, replace, done) => {
           await store.dispatch(loadCurrentUser());
           trackPageView(nextState.location.pathname);
-          done();
+          done?.();
         }}
         onChange={(prevState, nextState) => {
           if (nextState.location.pathname !== prevState.location.pathname) {
@@ -163,7 +169,7 @@ export const getRoutes = (store) => {
 
           <Route path="search" component={SearchApp} />
           {/* Send historical /archive route to trash - can remove in v52 */}
-          <Redirect from="archive" to="trash" replace />
+          <Redirect from="archive" to="trash" />
           <Route path="trash" component={TrashCollectionLanding} />
 
           <Route path="document/:entityId" component={DocumentPageOuter}>

--- a/frontend/src/types/react-router.d.ts
+++ b/frontend/src/types/react-router.d.ts
@@ -1,0 +1,9 @@
+import "react-router/lib/Route";
+
+declare module "react-router/lib/Route" {
+  // Metabase-specific custom Route prop, read in Palette.tsx from `props.routes`
+  // to suppress the command palette on certain routes (e.g. setup).
+  interface RouteProps<Props> {
+    disableCommandPalette?: boolean;
+  }
+}

--- a/frontend/src/types/react-router.d.ts
+++ b/frontend/src/types/react-router.d.ts
@@ -1,9 +1,0 @@
-import "react-router/lib/Route";
-
-declare module "react-router/lib/Route" {
-  // Metabase-specific custom Route prop, read in Palette.tsx from `props.routes`
-  // to suppress the command palette on certain routes (e.g. setup).
-  interface RouteProps<Props> {
-    disableCommandPalette?: boolean;
-  }
-}


### PR DESCRIPTION
### Description
Migrate `frontend/src/metabase/routes.jsx` to TypeScript and type the app route store.
