### PR TITLE
Fix self join column remapping

### DIFF
--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -453,17 +453,19 @@
             ;; if this is a column we're remapping FROM, we need to add information about which column we're remapping
             ;; TO
             (when (= dimension-id original-field-dimension-id)
-              {:remapped_to (or (some (fn [{{::keys [new-field-dimension-id]} :options, target-name :name}]
-                                        (when (= new-field-dimension-id dimension-id)
-                                          target-name))
+              {:remapped_to (or (some (fn [{{::keys [new-field-dimension-id]} :options, :as target-col}]
+                                        (when (and (= new-field-dimension-id dimension-id)
+                                                   (= (:lib/join-alias target-col) (:lib/join-alias column)))
+                                          (:name target-col)))
                                       columns)
                                 to-name)})
             ;; if this is a column we're remapping TO, we need to add information about which column we're remapping
             ;; FROM
             (when (= dimension-id new-field-dimension-id)
-              {:remapped_from (or (some (fn [{{::keys [original-field-dimension-id]} :options, source-name :name}]
-                                          (when (= original-field-dimension-id dimension-id)
-                                            source-name))
+              {:remapped_from (or (some (fn [{{::keys [original-field-dimension-id]} :options, :as source-col}]
+                                          (when (and (= original-field-dimension-id dimension-id)
+                                                     (= (:lib/join-alias source-col) (:lib/join-alias column)))
+                                            (:name source-col)))
                                         columns)
                                   from-name)
                :display_name  from-display-name}))

--- a/test/metabase/query_processor/middleware/add_remaps_test.clj
+++ b/test/metabase/query_processor/middleware/add_remaps_test.clj
@@ -832,3 +832,32 @@
         (is (= ["ID"
                 "Orders → ID"]
                (map :display_name (qp.preprocess/query->expected-cols query))))))))
+
+(deftest ^:parallel self-join-with-remapped-columns-uses-remapping-test
+  (let [mp (mt/metadata-provider)
+        orders (lib.metadata/table mp (mt/id :orders))
+        order-id (lib.metadata/field mp (mt/id :orders :id))
+        user-id (lib.metadata/field mp (mt/id :orders :user_id))
+        user-email (lib.metadata/field mp (mt/id :people :email))
+        rm-mp (lib.tu/remap-metadata-provider mp user-id user-email)
+        query (-> (lib/query rm-mp orders)
+                  (lib/with-fields [order-id user-id])
+                  (lib/join (-> (lib/join-clause orders [(lib/= order-id order-id)])
+                                (lib/with-join-fields [order-id user-id])))
+                  (lib/limit 3))
+        result (qp/process-query query)]
+    (is (= [[1 1 1 1 "borer-hudson@yahoo.com" "borer-hudson@yahoo.com"]
+            [2 1 2 1 "borer-hudson@yahoo.com" "borer-hudson@yahoo.com"]
+            [3 1 3 1 "borer-hudson@yahoo.com" "borer-hudson@yahoo.com"]]
+           (mt/rows result)))
+    (is (= [{:name "ID"}
+            {:name "USER_ID", :remapped_to "EMAIL"}
+            {:name "ID_2"}
+            {:name "USER_ID_2", :remapped_to "EMAIL_2"}
+            {:name "EMAIL", :remapped_from "USER_ID"}
+            {:name "EMAIL_2", :remapped_from "USER_ID_2"}]
+           (->> result
+                :data
+                :results_metadata
+                :columns
+                (mapv #(select-keys % [:name :remapped_to :remapped_from])))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67808

### Description

When we are trying to construct the `remapped_to` and `remapped_from` of a self joined column, we were using the column name from the original table instead of the joined table. This was happening because we use `some` to look for`(= new-field-dimension-id dimension-id)`, which matched with the original table column first. The fix in this PR is to also check that the `:lib/join-alias` matches to distinguish which table the column is matching. 

**NB**: Not super familiar with remapping so there might be a better approach. 

### How to verify

See repro steps in original issue. It should show the remapped value now. 

### Demo

<details>

<summary>screen recording</summary>

https://github.com/user-attachments/assets/4568fd5e-b9f0-4f25-89a6-2a90afb7090b

</details>

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
