### PR TITLE
Connection credentials != intent: remove behavioral switches based on connection-type

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1106,3 +1106,22 @@
           (is (some? thrown) "expected validate-impersonated-query* to throw")
           (is (= qp.error-type/invalid-query (:type (ex-data thrown))))
           (is (re-find #"single select statement" (ex-message thrown))))))))
+
+(deftest ^:parallel validate-impersonated-query-keys-on-allow-write-flag-test
+  (testing "validate-impersonated-query* derives read-vs-write from :impersonation/allow-write?"
+    (let [query   (fn [sql allow-write?]
+                    (cond-> {:stages [{:lib/type :mbql.stage/native :native sql}]}
+                      allow-write? (assoc :impersonation/allow-write? true)))
+          outcome (fn [q]
+                    (try
+                      (driver.sql/validate-impersonated-query* :postgres q)
+                      :ok
+                      (catch clojure.lang.ExceptionInfo _ :rejected)))
+          select  "SELECT 1 AS x"
+          write   "UPDATE t SET x = 1 WHERE id = -1"]
+      (testing "without :impersonation/allow-write?: SELECT allowed, write rejected"
+        (is (= :ok       (outcome (query select false))))
+        (is (= :rejected (outcome (query write  false)))))
+      (testing "with :impersonation/allow-write? true: write allowed, SELECT rejected"
+        (is (= :ok       (outcome (query write  true))))
+        (is (= :rejected (outcome (query select true))))))))

--- a/src/metabase/driver/connection.clj
+++ b/src/metabase/driver/connection.clj
@@ -68,7 +68,7 @@
 (mr/def ::connection-type
   (into [:enum] connection-types))
 
-(def ^:dynamic *connection-type*
+(def ^:dynamic ^:private *connection-type*
   "Which connection details [[effective-details]] should resolve.
 
    - `:default` — primary `:details`
@@ -173,7 +173,7 @@
 
    `:transform` resolves the same `:write-data-details` as `:write-data` — transforms write,
    so they get write-data credentials when set. The two still resolve to *different* pool keys
-   (see [[effective-connection-type]]) so the pool properties can differ."
+   (see [[connection-pool-type]]) so the pool properties can differ."
   [database connection-type]
   (case connection-type
     :default    nil
@@ -221,7 +221,7 @@
                              {:connection-type (name *connection-type*)})
              (catch Exception _ nil)))
       (-> (driver.w/maybe-swap-details (:id database) base)
-          (assoc ::effective-connection-type eff-type)
+          (assoc ::connection-pool-type eff-type)
           (assoc ::database-id (u/id database))))))
 
 (defn details-for-exact-type
@@ -238,17 +238,14 @@
       :transform  (:details database)
       :admin      (database-admin-details database))))
 
-(defn write-connection-requested?
-  "True if currently executing within a [[with-write-connection]] scope."
+(defn connection-telemetry-info
+  "A human-readable description of the current connection context, for logging only. Prose, not a
+   token — interpolate it into log messages, never branch on it. If you need a value to act on, use
+   [[connection-pool-type]]."
   []
-  (= *connection-type* :write-data))
+  (str "the " (name *connection-type*) " connection"))
 
-(defn admin-connection-requested?
-  "True if currently executing within a [[with-admin-connection]] scope."
-  []
-  (= *connection-type* :admin))
-
-(defn effective-connection-type
+(defn connection-pool-type
   "Returns the effective pool key for the given database. Return value matches malli schema
   [[::connection-type]].
 
@@ -273,7 +270,7 @@
    Call at the point where a driver actually obtains a connection (e.g., pool checkout).
    Non-JDBC drivers that manage their own connections should call this explicitly."
   [connection-details]
-  (if-let [conn-type (::effective-connection-type connection-details)]
+  (if-let [conn-type (::connection-pool-type connection-details)]
     (do
       (log/debugf "Acquiring %s connection for db %s" conn-type (::database-id connection-details))
       (try (analytics/inc! :metabase-db-connection/write-op {:connection-type (name conn-type)})

--- a/src/metabase/driver/connection.clj
+++ b/src/metabase/driver/connection.clj
@@ -83,14 +83,29 @@
    not directly."
   :default)
 
+(defn do-with-write-connection
+  "Functional core of [[with-write-connection]]. Public so the macro can delegate here instead of
+   expanding `binding` at call sites — that keeps `*connection-type*` referenced only within this namespace."
+  [thunk]
+  (binding [*connection-type* :write-data]
+    (thunk)))
+
 (defmacro with-write-connection
   "Establishes a write-connection context for body.
 
    [[effective-details]] calls within this scope resolve to take `:write-data-details`
    into account (if configured) instead of only primary `:details`."
   [& body]
-  `(binding [*connection-type* :write-data]
-     ~@body))
+  `(do-with-write-connection (fn [] ~@body)))
+
+(defn do-with-admin-connection
+  "Functional core of [[with-admin-connection]]."
+  [thunk]
+  (let [prior *connection-type*]
+    (when (not= prior :admin)
+      (log/infof "Entering :admin connection scope (from %s)" prior))
+    (binding [*connection-type* :admin]
+      (thunk))))
 
 (defmacro with-admin-connection
   "Establishes an admin-connection context for body.
@@ -101,11 +116,13 @@
    ownership, schema management). Code that needs admin access must opt in
    explicitly."
   [& body]
-  `(let [prior# *connection-type*]
-     (when (not= prior# :admin)
-       (log/infof "Entering :admin connection scope (from %s)" prior#))
-     (binding [*connection-type* :admin]
-       ~@body)))
+  `(do-with-admin-connection (fn [] ~@body)))
+
+(defn do-with-transform-connection
+  "Functional core of [[with-transform-connection]]."
+  [thunk]
+  (binding [*connection-type* :transform]
+    (thunk)))
 
 (defmacro with-transform-connection
   "Establishes a transform-connection context for body.
@@ -115,8 +132,7 @@
    through a separate connection pool keyed on `:transform` so the pool can carry its own
    c3p0 properties. See [[*connection-type*]] for the rationale."
   [& body]
-  `(binding [*connection-type* :transform]
-     ~@body))
+  `(do-with-transform-connection (fn [] ~@body)))
 
 (def ^:dynamic ^:private *suppress-resolution-telemetry*
   false)

--- a/src/metabase/driver/connection.clj
+++ b/src/metabase/driver/connection.clj
@@ -79,8 +79,8 @@
      whose c3p0 leak-detector tolerates transform-length runtimes. Set by
      [[with-transform-connection]] from the transform runner.
 
-   Bind via [[with-write-connection]], [[with-default-connection]], [[with-admin-connection]], or
-   [[with-transform-connection]], not directly."
+   Bind via [[with-write-connection]], [[with-admin-connection]], or [[with-transform-connection]],
+   not directly."
   :default)
 
 (defmacro with-write-connection
@@ -106,14 +106,6 @@
        (log/infof "Entering :admin connection scope (from %s)" prior#))
      (binding [*connection-type* :admin]
        ~@body)))
-
-(defmacro with-default-connection
-  "Establishes a default-connection context for body.
-
-   Use this to compile or execute a read query from inside a broader write-connection context."
-  [& body]
-  `(binding [*connection-type* :default]
-     ~@body))
 
 (defmacro with-transform-connection
   "Establishes a transform-connection context for body.

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -68,36 +68,37 @@
 
 (defmethod ddl.i/refresh! :mysql
   [driver database definition dataset-query]
-  (let [{:keys [query params]} (driver.conn/with-default-connection
-                                 (driver-api/compile dataset-query))
-        db-spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+  (let [{:keys [query params]} (driver-api/compile dataset-query)]
+    (driver.conn/with-write-connection
+      (let [db-spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+        (sql-jdbc.execute/do-with-connection-with-options
+         driver
+         database
+         {:write? true}
+         (fn [conn]
+           (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table-name definition))])
+           ;; It is possible that this fails and rollback would not restore the table.
+           ;; That is ok, the persisted-info will be marked inactive and the next refresh will try again.
+           (execute-with-timeout! driver
+                                  conn
+                                  db-spec
+                                  (.toMillis (t/minutes 10))
+                                  (into [(sql.ddl/create-table-sql database definition query)] params))
+           {:state :success}))))))
+
+(defmethod ddl.i/unpersist! :mysql
+  [driver database persisted-info]
+  (driver.conn/with-write-connection
     (sql-jdbc.execute/do-with-connection-with-options
      driver
      database
      {:write? true}
-     (fn [conn]
-       (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table-name definition))])
-       ;; It is possible that this fails and rollback would not restore the table.
-       ;; That is ok, the persisted-info will be marked inactive and the next refresh will try again.
-       (execute-with-timeout! driver
-                              conn
-                              db-spec
-                              (.toMillis (t/minutes 10))
-                              (into [(sql.ddl/create-table-sql database definition query)] params))
-       {:state :success}))))
-
-(defmethod ddl.i/unpersist! :mysql
-  [driver database persisted-info]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   database
-   {:write? true}
-   (fn [^java.sql.Connection conn]
-     (try
-       (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table_name persisted-info))])
-       (catch Exception e
-         (log/warn e)
-         (throw e))))))
+     (fn [^java.sql.Connection conn]
+       (try
+         (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table_name persisted-info))])
+         (catch Exception e
+           (log/warn e)
+           (throw e)))))))
 
 (defmethod ddl.i/check-can-persist :mysql
   [{driver :engine, :as database}]

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -37,31 +37,32 @@
 
 (defmethod ddl.i/refresh! :postgres
   [driver database definition dataset-query]
-  (let [{:keys [query params]} (driver.conn/with-default-connection
-                                 (driver-api/compile dataset-query))]
+  (let [{:keys [query params]} (driver-api/compile dataset-query)]
+    (driver.conn/with-write-connection
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver
+       database
+       {:write? true}
+       (fn [^java.sql.Connection conn]
+         (jdbc/with-db-transaction [tx {:connection conn}]
+           (set-statement-timeout! tx)
+           (sql.ddl/execute! tx [(sql.ddl/drop-table-sql database (:table-name definition))])
+           (sql.ddl/execute! tx (into [(sql.ddl/create-table-sql database definition query)] params)))
+         {:state :success})))))
+
+(defmethod ddl.i/unpersist! :postgres
+  [driver database persisted-info]
+  (driver.conn/with-write-connection
     (sql-jdbc.execute/do-with-connection-with-options
      driver
      database
      {:write? true}
-     (fn [^java.sql.Connection conn]
-       (jdbc/with-db-transaction [tx {:connection conn}]
-         (set-statement-timeout! tx)
-         (sql.ddl/execute! tx [(sql.ddl/drop-table-sql database (:table-name definition))])
-         (sql.ddl/execute! tx (into [(sql.ddl/create-table-sql database definition query)] params)))
-       {:state :success}))))
-
-(defmethod ddl.i/unpersist! :postgres
-  [driver database persisted-info]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   database
-   {:write? true}
-   (fn [conn]
-     (try
-       (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table_name persisted-info))])
-       (catch Exception e
-         (log/warn e)
-         (throw e))))))
+     (fn [conn]
+       (try
+         (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table_name persisted-info))])
+         (catch Exception e
+           (log/warn e)
+           (throw e)))))))
 
 (defmethod ddl.i/check-can-persist :postgres
   [{driver :engine, :as database}]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -5,7 +5,6 @@
    [clojure.set :as set]
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
-   [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql.normalize]
    [metabase.driver.sql.parameters.substitute :as sql.params.substitute]
    [metabase.driver.sql.parameters.substitution]
@@ -280,15 +279,15 @@
 
 (defn validate-impersonated-query*
   "Validates a native query by parsing it and ensuring that it is a single statement.
-   Checks driver.conn/*connection-type* to determine if it is a regular impersonated query or a custom action.
-   For regular impersonated queries, ensure that it is a single select statement.
-   For custom actions, ensure that it is a single write statement (insert, update, delete)."
+   Reads `:impersonation/allow-write?` on the query to decide what to require: when truthy (set by
+   [[metabase.query-processor.writeback/execute-write-query!]] for custom write actions) require a single
+   write statement (insert, update, delete); otherwise require a single select statement."
   [driver query]
   (update query :stages
           (fn [stages]
             (mapv (fn [stage]
                     (if (lib.util/native-stage? stage)
-                      (let [[stmt-type allowed-stmts] (if (= driver.conn/*connection-type* :write-data)
+                      (let [[stmt-type allowed-stmts] (if (:impersonation/allow-write? query)
                                                         ["write" (tru "insert, update, or delete")]
                                                         ["read" (tru "select")])
                             {:keys [is-single-stmt? sql error]}

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -187,11 +187,11 @@
 (defn- create-pool!
   "Create a new C3P0 `ComboPooledDataSource` for connecting to the given `database`.
    Uses [[driver.conn/effective-details]] to select the appropriate connection details
-   based on the current [[driver.conn/*connection-type*]]."
+   for the current connection context."
   [{:keys [id], driver :engine, :as database}]
   {:pre [(map? database)]}
-  (log/debug (u/format-color :cyan "Creating new connection pool for %s database %s (connection-type: %s) ..."
-                             driver id driver.conn/*connection-type*))
+  (log/debug (u/format-color :cyan "Creating new connection pool for %s database %s (%s) ..."
+                             driver id (driver.conn/connection-telemetry-info)))
   (let [details             (driver.conn/effective-details database)
         details-with-tunnel (driver/incorporate-ssh-tunnel-details ;; If the tunnel is disabled this returned unchanged
                              driver
@@ -250,16 +250,16 @@
 
 (defn- pool-cache-key
   "Returns the cache key for connection pools: `[database-id, connection-type]`.
-   Uses [[driver.conn/effective-connection-type]] so that a requested write connection
+   Uses [[driver.conn/connection-pool-type]] so that a requested write connection
    without configured `:write-data-details` resolves to `:default`, reusing the
    existing pool instead of creating a duplicate."
   [database]
-  [(u/the-id database) (driver.conn/effective-connection-type database)])
+  [(u/the-id database) (driver.conn/connection-pool-type database)])
 
 (mu/defn- jdbc-spec-hash
   "Computes a hash value for the JDBC connection spec based on the effective connection details, for the purpose of
   determining if details changed and therefore the existing connection pool needs to be invalidated.
-  Uses [[driver.conn/effective-details]] to select the appropriate details based on [[driver.conn/*connection-type*]]."
+  Uses [[driver.conn/effective-details]] to select the appropriate details for the current connection context."
   [{driver :engine, :as database} :- [:maybe :map]]
   (when (some? database)
     (hash (connection-details->spec driver (driver.conn/effective-details database)))))
@@ -439,8 +439,8 @@
 
 (defn db->pooled-connection-spec
   "Return a JDBC connection spec that includes a c3p0 `ComboPooledDataSource`. These connection pools are cached so we
-  don't create multiple ones for the same DB and connection type. The connection type is determined by
-  [[driver.conn/*connection-type*]] - use [[driver.conn/with-write-connection]] to get a write connection pool.
+  don't create multiple ones for the same DB and connection type. The connection type follows the current
+  connection context — use [[driver.conn/with-write-connection]] to get a write connection pool.
 
   When [[metabase.driver/with-swapped-connection-details]] is active for a database, the database details are
   modified before creating the connection pool. Swapped pools are stored in a separate Guava cache with TTL-based

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -8,7 +8,6 @@
    [medley.core :as m]
    [metabase.app-db.core :as mdb]
    [metabase.driver :as driver]
-   [metabase.driver.connection :as driver.conn]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.events.core :as events]
    [metabase.model-persistence.models.persisted-info :as persisted-info]
@@ -55,41 +54,40 @@
 
 (defn- refresh-with-stats! [refresher database stats persisted-info]
   ;; Since this could be long running, double check state just before refreshing
-  (driver.conn/with-write-connection
-    (when (contains? (persisted-info/refreshable-states) (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info)))
-      (tracing/with-span :tasks "task.persist.refresh-model" {:db/id           (u/the-id database)
-                                                              :persist/card-id (:card_id persisted-info)
-                                                              :persist/table   (:table_name persisted-info)}
-        (log/infof "Attempting to refresh persisted model %s." (:card_id persisted-info))
-        (let [card                  (t2/select-one :model/Card :id (:card_id persisted-info))
-              definition            (persisted-info/metadata->definition (:result_metadata card)
-                                                                         (:table_name persisted-info))
-              _                     (t2/update! :model/PersistedInfo (u/the-id persisted-info)
-                                                {:definition      definition,
-                                                 :query_hash      (persisted-info/query-hash (:dataset_query card))
-                                                 :active          false,
-                                                 :refresh_begin   :%now,
-                                                 :refresh_end     nil,
-                                                 :state           "refreshing"
-                                                 :state_change_at :%now})
-              {:keys [state error]} (try
-                                      (refresh! refresher database definition card)
-                                      (catch Exception e
-                                        (log/infof e "Error refreshing persisting model with card-id %s"
-                                                   (:card_id persisted-info))
-                                        {:state :error :error (ex-message e)}))]
-          (t2/update! :model/PersistedInfo (u/the-id persisted-info)
-                      {:active          (= state :success),
-                       :refresh_end     :%now,
-                       :state           (if (= state :success) "persisted" "error")
-                       :state_change_at :%now
-                       :error           (when (= state :error) error)})
-          (if (= :success state)
-            (update stats :success inc)
-            (-> stats
-                (update :error-details conj {:persisted-info-id (:id persisted-info)
-                                             :error             error})
-                (update :error inc))))))))
+  (when (contains? (persisted-info/refreshable-states) (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info)))
+    (tracing/with-span :tasks "task.persist.refresh-model" {:db/id           (u/the-id database)
+                                                            :persist/card-id (:card_id persisted-info)
+                                                            :persist/table   (:table_name persisted-info)}
+      (log/infof "Attempting to refresh persisted model %s." (:card_id persisted-info))
+      (let [card                  (t2/select-one :model/Card :id (:card_id persisted-info))
+            definition            (persisted-info/metadata->definition (:result_metadata card)
+                                                                       (:table_name persisted-info))
+            _                     (t2/update! :model/PersistedInfo (u/the-id persisted-info)
+                                              {:definition      definition,
+                                               :query_hash      (persisted-info/query-hash (:dataset_query card))
+                                               :active          false,
+                                               :refresh_begin   :%now,
+                                               :refresh_end     nil,
+                                               :state           "refreshing"
+                                               :state_change_at :%now})
+            {:keys [state error]} (try
+                                    (refresh! refresher database definition card)
+                                    (catch Exception e
+                                      (log/infof e "Error refreshing persisting model with card-id %s"
+                                                 (:card_id persisted-info))
+                                      {:state :error :error (ex-message e)}))]
+        (t2/update! :model/PersistedInfo (u/the-id persisted-info)
+                    {:active          (= state :success),
+                     :refresh_end     :%now,
+                     :state           (if (= state :success) "persisted" "error")
+                     :state_change_at :%now
+                     :error           (when (= state :error) error)})
+        (if (= :success state)
+          (update stats :success inc)
+          (-> stats
+              (update :error-details conj {:persisted-info-id (:id persisted-info)
+                                           :error             error})
+              (update :error inc)))))))
 
 (defn- error-details
   [results]
@@ -130,33 +128,32 @@
   "Seam for tests to pass in specific deletables to drop."
   [refresher deletables]
   (when (seq deletables)
-    (driver.conn/with-write-connection
-      (let [db-id->db    (m/index-by :id (t2/select :model/Database :id [:in (map :database_id deletables)]))
-            unpersist-fn (fn []
-                           (reduce (fn [stats persisted-info]
-                                     ;; Since this could be long running, double check state just before deleting
-                                     (let [current-state (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info))
-                                           card-info     (t2/select-one [:model/Card :archived :type :card_schema]
-                                                                        :id (:card_id persisted-info))]
-                                       (if (or (contains? (persisted-info/prunable-states) current-state)
-                                               (:archived card-info)
-                                               (not= (:type card-info) :model))
-                                         (let [database (-> persisted-info :database_id db-id->db)]
-                                           (log/infof "Unpersisting model with card-id %s" (:card_id persisted-info))
-                                           (tracing/with-span :tasks "task.persist.unpersist-model" {:db/id           (:database_id persisted-info)
-                                                                                                     :persist/card-id (:card_id persisted-info)}
-                                             (try
-                                               (unpersist! refresher database persisted-info)
-                                               (when-not (= "off" current-state)
-                                                 (t2/delete! :model/PersistedInfo :id (:id persisted-info)))
-                                               (update stats :success inc)
-                                               (catch Exception e
-                                                 (log/infof e "Error unpersisting model with card-id %s" (:card_id persisted-info))
-                                                 (update stats :error inc)))))
-                                         (update stats :skipped inc))))
-                                   {:success 0, :error 0, :skipped 0}
-                                   deletables))]
-        (save-task-history! "unpersist-tables" nil unpersist-fn)))))
+    (let [db-id->db    (m/index-by :id (t2/select :model/Database :id [:in (map :database_id deletables)]))
+          unpersist-fn (fn []
+                         (reduce (fn [stats persisted-info]
+                                   ;; Since this could be long running, double check state just before deleting
+                                   (let [current-state (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info))
+                                         card-info     (t2/select-one [:model/Card :archived :type :card_schema]
+                                                                      :id (:card_id persisted-info))]
+                                     (if (or (contains? (persisted-info/prunable-states) current-state)
+                                             (:archived card-info)
+                                             (not= (:type card-info) :model))
+                                       (let [database (-> persisted-info :database_id db-id->db)]
+                                         (log/infof "Unpersisting model with card-id %s" (:card_id persisted-info))
+                                         (tracing/with-span :tasks "task.persist.unpersist-model" {:db/id           (:database_id persisted-info)
+                                                                                                   :persist/card-id (:card_id persisted-info)}
+                                           (try
+                                             (unpersist! refresher database persisted-info)
+                                             (when-not (= "off" current-state)
+                                               (t2/delete! :model/PersistedInfo :id (:id persisted-info)))
+                                             (update stats :success inc)
+                                             (catch Exception e
+                                               (log/infof e "Error unpersisting model with card-id %s" (:card_id persisted-info))
+                                               (update stats :error inc)))))
+                                       (update stats :skipped inc))))
+                                 {:success 0, :error 0, :skipped 0}
+                                 deletables))]
+      (save-task-history! "unpersist-tables" nil unpersist-fn))))
 
 (defn- deletable-models
   "Returns persisted info records that can be unpersisted. Will select records that have moved into a deletable state

--- a/src/metabase/query_processor/writeback.clj
+++ b/src/metabase/query_processor/writeback.clj
@@ -54,7 +54,7 @@
 (mu/defn execute-write-query!
   "Execute an writeback query (which currently has to be an MBQL 4 native query) from an action."
   [query :- ::lib.schema/native-only-query]
-  (qp.setup/with-qp-setup [query query]
+  (qp.setup/with-qp-setup [query (assoc query :impersonation/allow-write? true)]
     (let [query (qp.preprocess/preprocess query)]
       ;; make sure this is a native query.
       (when-not (lib/native-only-query? query)

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -46,7 +46,7 @@
        (when start-promise (deliver start-promise [:started run-id]))
        (driver.conn/with-write-connection
          (log/info "Executing transform" id "with target" (pr-str target)
-                   (when (driver.conn/write-connection-requested?) " using write connection"))
+                   "using" (driver.conn/connection-telemetry-info))
          (let [target-type (keyword (:type target))]
            (tracing/with-span :tasks "task.transform.query"
              {:transform/id                   id

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -837,9 +837,9 @@
     (mt/with-actions-test-data-and-actions-enabled
       (let [db-id           (mt/id)
             write-cache-key [db-id :write-data]]
-        (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
+        (mt/with-dynamic-fn-redefs [driver.conn/connection-pool-type
                                     (fn [_database]
-                                      (if (= driver.conn/*connection-type* :write-data)
+                                      (if (= @#'driver.conn/*connection-type* :write-data)
                                         :write-data
                                         :default))]
           (try

--- a/test/metabase/actions/execution_write_pool_test.clj
+++ b/test/metabase/actions/execution_write_pool_test.clj
@@ -13,9 +13,9 @@
     (mt/with-actions-test-data-and-actions-enabled
       (let [db-id           (mt/id)
             write-cache-key [db-id :write-data]]
-        (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
+        (mt/with-dynamic-fn-redefs [driver.conn/connection-pool-type
                                     (fn [_database]
-                                      (if (= driver.conn/*connection-type* :write-data)
+                                      (if (= @#'driver.conn/*connection-type* :write-data)
                                         :write-data
                                         :default))]
           (try

--- a/test/metabase/driver/connection_test.clj
+++ b/test/metabase/driver/connection_test.clj
@@ -78,13 +78,15 @@
       (driver.conn/with-write-connection
         (is (nil? (driver.conn/effective-details nil)))))))
 
-(deftest write-connection-requested?-test
-  (testing "write-connection-requested? returns false by default"
-    (is (false? (driver.conn/write-connection-requested?))))
-  (testing "write-connection-requested? returns true inside with-write-connection"
-    (mt/with-premium-features #{:writable-connection}
-      (driver.conn/with-write-connection
-        (is (true? (driver.conn/write-connection-requested?)))))))
+(deftest connection-telemetry-info-test
+  (testing "connection-telemetry-info describes the current connection context as prose, for logging only"
+    (is (= "the default connection" (driver.conn/connection-telemetry-info)))
+    (driver.conn/with-write-connection
+      (is (= "the write-data connection" (driver.conn/connection-telemetry-info))))
+    (driver.conn/with-admin-connection
+      (is (= "the admin connection" (driver.conn/connection-telemetry-info))))
+    (driver.conn/with-transform-connection
+      (is (= "the transform connection" (driver.conn/connection-telemetry-info))))))
 
 (deftest effective-details-default-with-admin-details-test
   (testing "effective-details returns :details when *connection-type* is :default, even when :admin-details present"
@@ -147,23 +149,7 @@
           (is (=? details
                   (driver.conn/effective-details database))))))))
 
-(deftest admin-connection-requested?-test
-  (testing "admin-connection-requested? returns false by default"
-    (is (false? (driver.conn/admin-connection-requested?))))
-  (testing "admin-connection-requested? returns true inside with-admin-connection"
-    (mt/with-premium-features #{:workspaces}
-      (driver.conn/with-admin-connection
-        (is (true? (driver.conn/admin-connection-requested?))))))
-  (testing "admin-connection-requested? does not leak across to write-connection"
-    (mt/with-premium-features #{:writable-connection}
-      (driver.conn/with-write-connection
-        (is (false? (driver.conn/admin-connection-requested?))))))
-  (testing "write-connection-requested? does not leak across to admin-connection"
-    (mt/with-premium-features #{:workspaces}
-      (driver.conn/with-admin-connection
-        (is (false? (driver.conn/write-connection-requested?)))))))
-
-(deftest effective-connection-type-admin-test
+(deftest connection-pool-type-admin-test
   (mt/when-ee-evailable
    (mt/with-premium-features #{:workspaces}
      (let [details       {:host "read-host"}
@@ -173,12 +159,12 @@
            unconfigured  {:lib/type :metadata/database :id 1 :details details}]
        (testing "returns :admin when both requested and configured"
          (driver.conn/with-admin-connection
-           (is (= :admin (driver.conn/effective-connection-type configured)))))
+           (is (= :admin (driver.conn/connection-pool-type configured)))))
        (testing "returns :default when requested but not configured (avoids duplicate pool)"
          (driver.conn/with-admin-connection
-           (is (= :default (driver.conn/effective-connection-type unconfigured)))))
+           (is (= :default (driver.conn/connection-pool-type unconfigured)))))
        (testing "returns :default when not requested even if configured"
-         (is (= :default (driver.conn/effective-connection-type configured))))))))
+         (is (= :default (driver.conn/connection-pool-type configured))))))))
 
 (deftest effective-details-admin-with-workspace-swap-test
   (mt/when-ee-evailable

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -68,7 +68,7 @@
         (mt/with-dynamic-fn-redefs [sql-jdbc.execute/do-with-resolved-connection-data-source
                                     (fn [driver db opts]
                                       (when (and (= db test-db-id) (:keep-open? opts))
-                                        (vreset! captured-connection-type driver.conn/*connection-type*))
+                                        (vreset! captured-connection-type @#'driver.conn/*connection-type*))
                                       (orig-fn driver db opts))]
           (let [closed-conn (doto (.getConnection ^DataSource
                                    (orig-fn driver/*driver* test-db-id {}))

--- a/test/metabase/model_persistence/task/persist_refresh_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_test.clj
@@ -4,6 +4,7 @@
    [clojurewerkz.quartzite.conversion :as qc]
    [java-time.api :as t]
    [medley.core :as m]
+   [metabase.driver.connection :as driver.conn]
    [metabase.model-persistence.init]
    [metabase.model-persistence.task.persist-refresh :as task.persist-refresh]
    [metabase.query-processor.timezone :as qp.timezone]
@@ -140,6 +141,38 @@
             (testing "but a subsequent refresh run will refresh the table"
               (#'task.persist-refresh/refresh-tables! (u/the-id db) test-refresher)
               (is (= "persisted" (t2/select-one-fn :state :model/PersistedInfo :id (u/the-id persisted-info)))))))))))
+
+(deftest task-establishes-no-write-connection-context-test
+  (testing "The persist-refresh task layer leaves *connection-type* at :default; refresh! and unpersist!
+            implementations are responsible for declaring write themselves (so a read sub-step like query
+            compilation is not forced into a write context)."
+    (mt/with-model-cleanup [:model/TaskHistory]
+      (mt/with-temp [:model/Database     db {:settings {:persist-models-enabled true}}
+                     :model/Card         model {:type :model :database_id (u/the-id db)}
+                     :model/PersistedInfo _refreshable {:card_id (u/the-id model) :database_id (u/the-id db)}
+                     :model/Card         model2 {:type :model :database_id (u/the-id db)}
+                     :model/PersistedInfo deletable {:card_id         (u/the-id model2)
+                                                     :database_id     (u/the-id db)
+                                                     :state           "deletable"
+                                                     ;; old enough to be prunable
+                                                     :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
+        (testing "refresh! receives :default"
+          (let [seen      (atom ::unset)
+                refresher (reify task.persist-refresh/Refresher
+                            (refresh! [_ _database _definition _card]
+                              (reset! seen driver.conn/*connection-type*)
+                              {:state :success})
+                            (unpersist! [_ _database _persisted-info]))]
+            (#'task.persist-refresh/refresh-tables! (u/the-id db) refresher)
+            (is (= :default @seen))))
+        (testing "unpersist! receives :default"
+          (let [seen      (atom ::unset)
+                refresher (reify task.persist-refresh/Refresher
+                            (refresh! [_ _database _definition _card] {:state :success})
+                            (unpersist! [_ _database _persisted-info]
+                              (reset! seen driver.conn/*connection-type*)))]
+            (#'task.persist-refresh/prune-deletables! refresher [deletable])
+            (is (= :default @seen))))))))
 
 (deftest refresh-tables!'-test
   (mt/with-model-cleanup [:model/TaskHistory]

--- a/test/metabase/model_persistence/task/persist_refresh_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_test.clj
@@ -160,7 +160,7 @@
           (let [seen      (atom ::unset)
                 refresher (reify task.persist-refresh/Refresher
                             (refresh! [_ _database _definition _card]
-                              (reset! seen driver.conn/*connection-type*)
+                              (reset! seen @#'driver.conn/*connection-type*)
                               {:state :success})
                             (unpersist! [_ _database _persisted-info]))]
             (#'task.persist-refresh/refresh-tables! (u/the-id db) refresher)
@@ -170,7 +170,7 @@
                 refresher (reify task.persist-refresh/Refresher
                             (refresh! [_ _database _definition _card] {:state :success})
                             (unpersist! [_ _database _persisted-info]
-                              (reset! seen driver.conn/*connection-type*)))]
+                              (reset! seen @#'driver.conn/*connection-type*)))]
             (#'task.persist-refresh/prune-deletables! refresher [deletable])
             (is (= :default @seen))))))))
 

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -28,7 +28,7 @@
             (with-redefs [driver-api/compile                               (fn [_query] {:query "SELECT 1" :params []})
                           sql-jdbc.conn/db->pooled-connection-spec         (fn [_database] {:fake :spec})
                           sql-jdbc.execute/do-with-connection-with-options (fn [_driver _database _opts _f]
-                                                                             (reset! ddl-ctx driver.conn/*connection-type*)
+                                                                             (reset! ddl-ctx @#'driver.conn/*connection-type*)
                                                                              {:state :success})]
               (#'task.persist-refresh/refresh-tables! (:id db) @#'task.persist-refresh/dispatching-refresher))
             (is (= :write-data @ddl-ctx))))))))
@@ -46,7 +46,7 @@
                                                 :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
           (let [ddl-ctx (atom ::unset)]
             (with-redefs [sql-jdbc.execute/do-with-connection-with-options (fn [_driver _database _opts _f]
-                                                                             (reset! ddl-ctx driver.conn/*connection-type*)
+                                                                             (reset! ddl-ctx @#'driver.conn/*connection-type*)
                                                                              nil)]
               (#'task.persist-refresh/prune-deletables! @#'task.persist-refresh/dispatching-refresher [pi]))
             (is (= :write-data @ddl-ctx))))))))

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -1,65 +1,52 @@
-(ns ^:mb/driver-tests metabase.model-persistence.task.persist-refresh-write-pool-test
+(ns metabase.model-persistence.task.persist-refresh-write-pool-test
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.driver :as driver]
+   [metabase.driver-api.core :as driver-api]
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.model-persistence.task.persist-refresh :as task.persist-refresh]
    [metabase.test :as mt]))
 
-(deftest refresh-creates-write-pool-test
-  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
-    (let [db-id           (mt/id)
-          write-cache-key [db-id :write-data]]
-      (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
-                                  (fn [_database]
-                                    (if (= driver.conn/*connection-type* :write-data)
-                                      :write-data
-                                      :default))]
-        (try
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-          (testing "write pool does not exist before refresh"
-            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-          (let [test-refresher (reify task.persist-refresh/Refresher
-                                 (refresh! [_ database _definition _card]
-                                   (driver.conn/with-write-connection
-                                     (sql-jdbc.conn/db->pooled-connection-spec (:id database)))
-                                   {:state :success})
-                                 (unpersist! [_ _database _persisted-info]))]
-            (mt/with-temp [:model/Card model {:type :model :database_id db-id}
-                           :model/PersistedInfo _pi {:card_id (:id model) :database_id db-id}]
-              (#'task.persist-refresh/refresh-tables! db-id test-refresher)))
-          (testing "write pool is created during refresh"
-            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-          (finally
-            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))
+;; The write context for persistence DDL is established by the driver's refresh!/unpersist!, not by the
+;; task layer (see persist-refresh-test/task-establishes-no-write-connection-context-test for the other half).
+;; These tests drive the real dispatching-refresher and capture *connection-type* at the DDL boundary; the
+;; warehouse calls (compile, db->pooled-connection-spec, do-with-connection-with-options) are stubbed so no
+;; real connection is opened.
 
-(deftest prune-creates-write-pool-test
-  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
-    (let [db-id           (mt/id)
-          write-cache-key [db-id :write-data]]
-      (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
-                                  (fn [_database]
-                                    (if (= driver.conn/*connection-type* :write-data)
-                                      :write-data
-                                      :default))]
-        (try
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-          (testing "write pool does not exist before prune"
-            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-          (let [test-refresher (reify task.persist-refresh/Refresher
-                                 (refresh! [_ _database _definition _card]
-                                   {:state :success})
-                                 (unpersist! [_ database _persisted-info]
-                                   (driver.conn/with-write-connection
-                                     (sql-jdbc.conn/db->pooled-connection-spec (:id database)))))]
-            (mt/with-temp [:model/Card model {:type :model :database_id db-id}
-                           :model/PersistedInfo pi {:card_id         (:id model)
-                                                    :database_id     db-id
-                                                    :state           "deletable"
-                                                    :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
-              (#'task.persist-refresh/prune-deletables! test-refresher [pi])))
-          (testing "write pool is created during prune"
-            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-          (finally
-            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))
+(deftest refresh-runs-ddl-under-write-connection-test
+  (doseq [engine [:postgres :mysql]]
+    (driver/the-initialized-driver engine)
+    (testing (str engine " refresh! runs its DDL under a write-connection context")
+      (mt/with-model-cleanup [:model/TaskHistory]
+        (mt/with-temp [:model/Database     db {:engine engine :settings {:persist-models-enabled true}}
+                       :model/Card         model {:type :model :database_id (:id db)}
+                       :model/PersistedInfo _pi {:card_id (:id model) :database_id (:id db)}]
+          (let [ddl-ctx (atom ::unset)]
+            (with-redefs [driver-api/compile                               (fn [_query] {:query "SELECT 1" :params []})
+                          sql-jdbc.conn/db->pooled-connection-spec         (fn [_database] {:fake :spec})
+                          sql-jdbc.execute/do-with-connection-with-options (fn [_driver _database _opts _f]
+                                                                             (reset! ddl-ctx driver.conn/*connection-type*)
+                                                                             {:state :success})]
+              (#'task.persist-refresh/refresh-tables! (:id db) @#'task.persist-refresh/dispatching-refresher))
+            (is (= :write-data @ddl-ctx))))))))
+
+(deftest unpersist-runs-ddl-under-write-connection-test
+  (doseq [engine [:postgres :mysql]]
+    (driver/the-initialized-driver engine)
+    (testing (str engine " unpersist! runs its DDL under a write-connection context")
+      (mt/with-model-cleanup [:model/TaskHistory]
+        (mt/with-temp [:model/Database     db {:engine engine :settings {:persist-models-enabled true}}
+                       :model/Card         model {:type :model :database_id (:id db)}
+                       :model/PersistedInfo pi {:card_id         (:id model)
+                                                :database_id     (:id db)
+                                                :state           "deletable"
+                                                :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
+          (let [ddl-ctx (atom ::unset)]
+            (with-redefs [sql-jdbc.execute/do-with-connection-with-options (fn [_driver _database _opts _f]
+                                                                             (reset! ddl-ctx driver.conn/*connection-type*)
+                                                                             nil)]
+              (#'task.persist-refresh/prune-deletables! @#'task.persist-refresh/dispatching-refresher [pi]))
+            (is (= :write-data @ddl-ctx))))))))

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -22,7 +22,8 @@
             (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
           (let [test-refresher (reify task.persist-refresh/Refresher
                                  (refresh! [_ database _definition _card]
-                                   (sql-jdbc.conn/db->pooled-connection-spec (:id database))
+                                   (driver.conn/with-write-connection
+                                     (sql-jdbc.conn/db->pooled-connection-spec (:id database)))
                                    {:state :success})
                                  (unpersist! [_ _database _persisted-info]))]
             (mt/with-temp [:model/Card model {:type :model :database_id db-id}
@@ -50,7 +51,8 @@
                                  (refresh! [_ _database _definition _card]
                                    {:state :success})
                                  (unpersist! [_ database _persisted-info]
-                                   (sql-jdbc.conn/db->pooled-connection-spec (:id database))))]
+                                   (driver.conn/with-write-connection
+                                     (sql-jdbc.conn/db->pooled-connection-spec (:id database)))))]
             (mt/with-temp [:model/Card model {:type :model :database_id db-id}
                            :model/PersistedInfo pi {:card_id         (:id model)
                                                     :database_id     db-id

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -10,11 +10,8 @@
    [metabase.model-persistence.task.persist-refresh :as task.persist-refresh]
    [metabase.test :as mt]))
 
-;; The write context for persistence DDL is established by the driver's refresh!/unpersist!, not by the
-;; task layer (see persist-refresh-test/task-establishes-no-write-connection-context-test for the other half).
-;; These tests drive the real dispatching-refresher and capture *connection-type* at the DDL boundary; the
-;; warehouse calls (compile, db->pooled-connection-spec, do-with-connection-with-options) are stubbed so no
-;; real connection is opened.
+;; Verify that the driver's refresh!/unpersist! establish a write-connection context for their DDL: drive the
+;; real refresher with the warehouse calls stubbed, and capture *connection-type* at the DDL boundary.
 
 (deftest refresh-runs-ddl-under-write-connection-test
   (doseq [engine [:postgres :mysql]]

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -420,10 +420,10 @@
             default pool's leak detector tight on non-transform instances."
     (mt/with-temp [:model/Database db {:engine :h2}]
       (is (= :default
-             (driver.conn/effective-connection-type db)))
+             (driver.conn/connection-pool-type db)))
       (driver.conn/with-transform-connection
         (is (= :transform
-               (driver.conn/effective-connection-type db)))))))
+               (driver.conn/connection-pool-type db)))))))
 
 ;; Not ^:parallel: the kondo linter flags `set-statement-query-timeout!` (`!`-suffixed, so classified "destructive")
 ;; when used inside a parallel test. The call site here only mutates a local proxy Statement and is safe, but marking

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2633,9 +2633,9 @@
     (with-uploads-enabled!
       (let [db-id           (mt/id)
             write-cache-key [db-id :write-data]]
-        (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
+        (mt/with-dynamic-fn-redefs [driver.conn/connection-pool-type
                                     (fn [_database]
-                                      (if (= driver.conn/*connection-type* :write-data)
+                                      (if (= @#'driver.conn/*connection-type* :write-data)
                                         :write-data
                                         :default))]
           (try
@@ -2653,9 +2653,9 @@
     (with-uploads-enabled!
       (let [db-id           (mt/id)
             write-cache-key [db-id :write-data]]
-        (mt/with-dynamic-fn-redefs [driver.conn/effective-connection-type
+        (mt/with-dynamic-fn-redefs [driver.conn/connection-pool-type
                                     (fn [_database]
-                                      (if (= driver.conn/*connection-type* :write-data)
+                                      (if (= @#'driver.conn/*connection-type* :write-data)
                                         :write-data
                                         :default))]
           (try


### PR DESCRIPTION
Closes GHY-3809.

### Description

Principles:
1. All database operations should use the default (read) credentials, unless the programmer explicitly upgrades to write credentials.
2. Upgrading to write credentials should not implicitly upgrade downstream code (write-connection should also be able to read, and read operations shouldn't change to write -- or be expected to).

Scenario:
- Refreshing a cached model performs three data-warehouse operations, two of which *require* writes. Its body was wrapped in `with-write-connection`.
- Separately, the impersonation native-query validator was changed to require a different statement type based on which credentials were active. This broke impersonated native-model caching, as the validator rejected the model's SELECT for not being a write.
- `with-default-connection` was introduced to locally downgrade back to read credentials, to patch this up.

Because we don't ever want to accidentally escalate credentials, the system should be rock-solid simple to reason about, and downstream code changing its behavior based on which credentials happen to be active "because it can" is *not that*.

### Approach

1. Introduced a flag that tells the impersonation native-query validator whether or not a write is intended.
2. Deleted `with-default-connection`.
3. Made `*connection-type*` private.
4. Renamed `effective-connection-type` to `connection-pool-type` to try to signal semantically that its only intended purpose is for pool-construction logic.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
