### PR TITLE
Fix password-disable when using OIDC

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
@@ -37,7 +37,7 @@
   [provider-key request]
   (premium-features/assert-has-feature :sso-oidc (tru "OIDC authentication"))
 
-  (api/check-400 (sso-settings/oidc-enabled?) "OIDC is not enabled")
+  (api/check-400 (sso-settings/oidc-enabled) "OIDC is not enabled")
 
   (let [provider-config (sso-settings/get-oidc-provider provider-key)]
     (when-not provider-config

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -377,7 +377,7 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
             provider))
         (oidc-providers)))
 
-(defsetting oidc-configured?
+(defsetting oidc-configured
   (deferred-tru "Are any OIDC providers configured with required fields?")
   :type    :boolean
   :default false
@@ -391,7 +391,7 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
                          (oidc-providers))))
   :export?     false)
 
-(defsetting oidc-enabled?
+(defsetting oidc-enabled
   (deferred-tru "Is any OIDC provider enabled?")
   :type    :boolean
   :default false

--- a/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
@@ -107,10 +107,10 @@
     (mt/with-additional-premium-features #{:sso-oidc}
       (mt/with-temporary-setting-values [oidc-providers []]
         (testing "oidc-enabled is false with no providers"
-          (is (false? (sso-settings/oidc-enabled?)))))
+          (is (false? (sso-settings/oidc-enabled)))))
       (mt/with-temporary-setting-values [oidc-providers [(assoc test-provider :enabled true)]]
         (testing "oidc-configured is true when provider has required fields"
-          (is (true? (sso-settings/oidc-enabled?)))))
+          (is (true? (sso-settings/oidc-enabled)))))
       (mt/with-temporary-setting-values [oidc-providers [(assoc test-provider :enabled false)]]
         (testing "oidc-enabled is false when no provider is enabled"
-          (is (false? (sso-settings/oidc-enabled?))))))))
+          (is (false? (sso-settings/oidc-enabled))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -301,4 +301,30 @@
       ;; not flip on the SAML/JWT login button. See UXW-3940.
       (sso.test-helpers/with-slack-default-setup!
         (is (true? (sso.settings/slack-connect-enabled)))
-        (is (false? (sso-settings/other-sso-enabled?)))))))
+        (is (false? (sso-settings/other-sso-enabled?)))))
+    (testing "false when only OIDC is enabled (OIDC uses /auth/sso/oidc, not /auth/sso)"
+      (mt/with-premium-features #{:sso-oidc}
+        (tu/with-temporary-setting-values [oidc-providers [{:key           "test-idp"
+                                                            :login-prompt  "Test IdP"
+                                                            :issuer-uri    "https://test.idp.example.com"
+                                                            :client-id     "test-client-id"
+                                                            :client-secret "test-client-secret"
+                                                            :scopes        ["openid" "email" "profile"]
+                                                            :enabled       true}]]
+          (is (false? (sso-settings/other-sso-enabled?))))))))
+
+(deftest enable-password-login-honors-oidc-as-sso-test
+  (testing "enable-password-login is honored when OIDC is the only SSO provider"
+    (mt/with-premium-features #{:sso-oidc :disable-password-login}
+      (tu/with-temporary-setting-values [oidc-providers [{:key           "test-idp"
+                                                          :login-prompt  "Test IdP"
+                                                          :issuer-uri    "https://test.idp.example.com"
+                                                          :client-id     "test-client-id"
+                                                          :client-secret "test-client-secret"
+                                                          :scopes        ["openid" "email" "profile"]
+                                                          :enabled       true}]
+                                         enable-password-login false]
+        (is (true? (sso.settings/sso-enabled?))
+            "sso-enabled? should be true when OIDC is the only provider")
+        (is (false? (session/enable-password-login))
+            "enable-password-login should be honored when OIDC is enabled")))))

--- a/enterprise/frontend/src/metabase-enterprise/auth/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/utils.unit.spec.tsx
@@ -1,0 +1,35 @@
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { useHasSsoEnabled } from "./utils";
+
+describe("useHasSsoEnabled", () => {
+  it("returns true when OIDC is the only enabled SSO provider", async () => {
+    setupPropertiesEndpoints(createMockSettings({ "oidc-enabled": true }));
+
+    const { result } = renderHookWithProviders(() => useHasSsoEnabled(), {});
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy();
+    });
+  });
+
+  it("returns false when no SSO providers are enabled", async () => {
+    setupPropertiesEndpoints(
+      createMockSettings({
+        "oidc-enabled": false,
+        "saml-enabled": false,
+        "jwt-enabled": false,
+        "ldap-enabled": false,
+        "google-auth-enabled": false,
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useHasSsoEnabled(), {});
+
+    await waitFor(() => {
+      expect(result.current).toBeFalsy();
+    });
+  });
+});

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -283,7 +283,8 @@
 
 (defn- ee-sso-configured? []
   (when config/ee-available?
-    (setting/get :other-sso-enabled?)))
+    (or (setting/get :other-sso-enabled?)
+        (setting/get :oidc-enabled))))
 
 (defn sso-enabled?
   "Any SSO provider is configured and enabled"
@@ -308,7 +309,7 @@
      ;; regardless of license status.
      :saml   (setting/get :saml-enabled)
      :jwt    (setting/get :jwt-enabled)
-     :oidc   (setting/get :oidc-enabled?)
+     :oidc   (setting/get :oidc-enabled)
      :slack  (setting/get :slack-connect-enabled)
      :scim   (setting/get :scim-enabled)
      ;; Unknown sso_source -- treat as disabled to allow password reset


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75252
### Description

With OIDC configured as the only SSO provider, there is no way to disable password authentication:

- MB_ENABLE_PASSWORD_LOGIN=false is ignored — password login stays enabled.
- The "Enable password authentication" toggle in Admin → Authentication doesn't appear.

Previously, the `oidc-enabled` setting was `oidc-enabled?` which didn't match the no-? version the UI was using to enable the "Enable password authentication" toggle in admin. Switched off the `?` version to match the other sso enabled settings.

Separately, the `sso-enabled?` used by the mb-enabled-password-login config was not checking the new OIDC option.

This PR fixes both

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
