### PR TITLE
fix: dashboard name is stale in breadcrumb after renaming

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -103,6 +103,8 @@ export interface Dashboard {
   more?: string | null;
 }
 
+export type DashboardCrumb = Pick<Dashboard, "id" | "name">;
+
 export type RelatedDashboardXRays = {
   related?: RelatedDashboardXRayItem[];
   "zoom-in"?: RelatedDashboardXRayItem[];

--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -2,6 +2,7 @@ import { withRouter } from "react-router";
 import { push } from "react-router-redux";
 
 import { useInitialCollectionId } from "metabase/collections/hooks";
+import { getDashboardCrumb } from "metabase/dashboard/selectors";
 import {
   getCommentSidebarOpen,
   getSidebarOpen,
@@ -88,7 +89,8 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
 
   const { pathname } = props.location;
   const dashboard =
-    pathname && isQuestionPath(pathname) ? question?.dashboard() : undefined;
+    useSelector(getDashboardCrumb) ??
+    (pathname && isQuestionPath(pathname) ? question?.dashboard() : undefined);
 
   const locationState = props.location.state as { cardId?: number } | undefined;
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -754,3 +754,25 @@ export const getCanResetFilters = createSelector(
   [getFiltersToReset],
   (filtersToReset) => filtersToReset.length > 0,
 );
+
+export const getCardFromQueryBuilder = (state: State) => state.qb.card;
+
+export const getDashboardCrumb = createSelector(
+  [getCardFromQueryBuilder, getDashboards],
+  (card, dashboards) => {
+    const id = card?.dashboard?.id;
+    if (!id) {
+      return undefined;
+    }
+
+    const dashboard = dashboards[id];
+    if (!dashboard) {
+      return undefined;
+    }
+
+    return {
+      id,
+      name: dashboard.name,
+    };
+  },
+);

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.ts
@@ -4,6 +4,7 @@ import { createMockEntitiesState } from "__support__/store";
 import {
   getClickBehaviorSidebarDashcard,
   getDashboardComplete,
+  getDashboardCrumb,
   getDashboardHeaderParameters,
   getEditingParameterId,
   getIsEditingParameter,
@@ -460,6 +461,58 @@ describe("dashboard/selectors", () => {
       expect(cards[2].card.id).toBe(0);
       expect(cards[1].card.id).toBe(1);
       expect(cards[0].card.id).toBe(2);
+    });
+  });
+
+  describe("getDashboardCrumb", () => {
+    it("should return undefined when the current card has no dashboard", () => {
+      const state = chain(STATE)
+        .assocIn(["qb", "card"], createMockCard())
+        .value();
+
+      expect(getDashboardCrumb(state)).toBeUndefined();
+    });
+
+    it("should return undefined when the dashboard does not exist", () => {
+      const state = chain(STATE)
+        .assocIn(
+          ["qb", "card"],
+          createMockCard({
+            dashboard: {
+              id: 123,
+              name: "stale name",
+            },
+          }),
+        )
+        .value();
+
+      expect(getDashboardCrumb(state)).toBeUndefined();
+    });
+
+    it("should use the dashboard name from entities", () => {
+      const state = chain(STATE)
+        .assocIn(
+          ["qb", "card"],
+          createMockCard({
+            dashboard: {
+              id: 123,
+              name: "stale name",
+            },
+          }),
+        )
+        .assocIn(
+          ["dashboard", "dashboards", 123],
+          createMockDashboard({
+            id: 123,
+            name: "Updated Dashboard Name",
+          }),
+        )
+        .value();
+
+      expect(getDashboardCrumb(state)).toEqual({
+        id: 123,
+        name: "Updated Dashboard Name",
+      });
     });
   });
 });

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -11,14 +11,14 @@ import type {
   Collection,
   CollectionEssentials,
   CollectionId,
-  Dashboard,
+  DashboardCrumb,
 } from "metabase-types/api";
 
 import { getCollectionList } from "./utils";
 
 export interface CollectionBreadcrumbsProps {
   collection?: Collection;
-  dashboard?: Dashboard;
+  dashboard?: DashboardCrumb;
   onClick?: (collection: CollectionEssentials) => void;
   baseCollectionId: CollectionId | null;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75184

### Description

When a dashboard is renamed, the card data that is already cached still contains the previous dashboard name. As a result, when reopening a previously visited card, the UI displays a stale dashboard name in the breadcrumb instead of the updated one.

Describe the overall approach and the problem being solved.

I considered few approaches
- Invalidating api
    - Calls all the cards that were cached, causes big load time
- Updating cache
    - While it made sense, if multiple cards were already cached looping through them all to update it didn't seem like a better idea 
- use card + dashboard id as a selector
    - Went with this approach as this is the simplest and we don't have to worry about any race condition or cache invalidation 


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question and save it in a dashboard
2. Open the question
3. Go back to the dashboard
4. Rename dashboard
5. Open the question again
6. Bread Crumb should have the updated name

### Demo

https://github.com/user-attachments/assets/074ff46d-6e26-4f52-a82b-fae52af0fe9a



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
