### PR TITLE
Fix tooltips rendering under popovers and menus

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
@@ -1,7 +1,8 @@
-import { type MantineThemeOverride, Tooltip } from "@mantine/core";
-import cx from "classnames";
-
-import ZIndex from "metabase/css/core/z-index.module.css";
+import {
+  type MantineThemeOverride,
+  Tooltip,
+  getDefaultZIndex,
+} from "@mantine/core";
 
 import { PORTAL_CONTAINER_ID } from "../PortalContainer/constants";
 
@@ -13,6 +14,10 @@ export const tooltipOverrides: MantineThemeOverride["components"] = {
       arrowSize: 10,
       withArrow: true,
       withinPortal: true,
+      // Mantine puts Tooltip, Popover and Menu on the same "popover" tier, so a
+      // tooltip ties with them and loses on portal DOM order. +1 keeps it in its
+      // tier but always renders above same-tier overlays.
+      zIndex: getDefaultZIndex("popover") + 1,
       portalProps: {
         target: `#${PORTAL_CONTAINER_ID}`,
       },
@@ -28,7 +33,7 @@ export const tooltipOverrides: MantineThemeOverride["components"] = {
       color: "tooltip-background",
     },
     classNames: {
-      tooltip: cx(TooltipStyles.tooltip, ZIndex.Overlay),
+      tooltip: TooltipStyles.tooltip,
       arrow: TooltipStyles.arrow,
     },
   }),


### PR DESCRIPTION
Fixes a regression probably from https://github.com/metabase/metabase/pull/75103

### Description

Mantine assigns Tooltip, Popover and Menu the same "popover" z-index tier (300), so a tooltip tied with them and the winner was decided by portal DOM order. Once tooltips moved into the fixed PortalContainer near the top of <body>, later-mounted overlays began painting over them. Bumping the tooltip z-index to popover+1 keeps it in its tier while always rendering above same-tier overlays, independent of DOM order.

### How to verify

Open any modal/popover with a tooltip inside. For example, the tree-dot menu on a model with DB actions allowed. Or the actions modal for the same model (e.g. `https://stats.metabase.com/model/33375-accounts-analytic-events-invoices-model/detail/actions/new`)

### Demo
Before
<img width="392" height="329" alt="SCR-20260607-pcrg" src="https://github.com/user-attachments/assets/22eedef5-d6d0-4631-96ca-ae7724b5251c" />
<img width="1182" height="313" alt="SCR-20260607-pdop" src="https://github.com/user-attachments/assets/420baa23-bab1-467c-b797-2faa5870ba32" />
After
<img width="402" height="370" alt="SCR-20260607-pept" src="https://github.com/user-attachments/assets/33e2ea25-0ac7-48f4-a8b1-015794af6116" />
<img width="840" height="338" alt="SCR-20260607-peyg" src="https://github.com/user-attachments/assets/b2c02b06-6c3a-4646-9dcc-324270fe7d33" />
