### PR TITLE
Enable JUnit hook-failure rewriting for all e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -180,7 +180,7 @@ jobs:
         # whether to fail or to pass the whole job, based on the quarantine list.
         continue-on-error: true
 
-      - name: Rewrite JUnit hook failures (partial rollout)
+      - name: Rewrite JUnit hook failures
         if: always()
         continue-on-error: true
         timeout-minutes: 1
@@ -188,12 +188,7 @@ jobs:
         run: |
           if [ -d ./target/junit ]; then
             echo "fix-junit-hooks: invoking bun"
-            bun e2e/support/fix-junit-hooks.ts ./target/junit \
-              --include sharing/public-resource-downloads \
-              --include sharing/sharing-reproductions \
-              --include visualizations-charts/custom-viz \
-              --include metabot/metabot-query-builder \
-              --include dashboard-filters/dashboard-filters-location
+            bun e2e/support/fix-junit-hooks.ts ./target/junit
           else
             echo "No ./target/junit directory; nothing to process."
           fi

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -87,7 +87,7 @@ jobs:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: node e2e/runner/run_cypress_ci.js component
 
-      - name: Rewrite JUnit hook failures (dry-run)
+      - name: Rewrite JUnit hook failures
         if: always()
         continue-on-error: true
         timeout-minutes: 1
@@ -95,7 +95,7 @@ jobs:
         run: |
           if [ -d ./target/junit ]; then
             echo "fix-junit-hooks: invoking bun"
-            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+            bun e2e/support/fix-junit-hooks.ts ./target/junit
           else
             echo "No ./target/junit directory; nothing to process."
           fi
@@ -253,7 +253,7 @@ jobs:
           node e2e/runner/run_cypress_ci.js component \
             --expose grepTags="-@skip-backward-compatibility"
 
-      - name: Rewrite JUnit hook failures (dry-run)
+      - name: Rewrite JUnit hook failures
         if: always()
         continue-on-error: true
         timeout-minutes: 1
@@ -261,7 +261,7 @@ jobs:
         run: |
           if [ -d ./target/junit ]; then
             echo "fix-junit-hooks: invoking bun"
-            bun e2e/support/fix-junit-hooks.ts --dry-run ./target/junit
+            bun e2e/support/fix-junit-hooks.ts ./target/junit
           else
             echo "No ./target/junit directory; nothing to process."
           fi


### PR DESCRIPTION
Contributes to [GDGT-2424](https://linear.app/metabase/issue/GDGT-2424)

### Description

Finishes the hook-failure rewrite rollout (partial rollout was #74958). `e2e/support/fix-junit-hooks.ts` rewrites the JUnit XML so a `before/after each|all` hook failure is attributed to the underlying test, instead of becoming a separate `… "before each" hook for …` entry that Trunk treats as a brand-new test which — since it only ever appears on failure — can never recover from "broken".

The partial rollout ran live for ~a week on five specs with no surprises: failures landed on the real test and the phantom entries went quiet. So this drops the `--include` allowlist in `e2e-test.yml` and the `--dry-run` flag in `embedding-sdk-component-tests.yml`, enabling the rewrite for every spec.

### How to verify

CI is green and we don't see new phantom `… "before each" hook for …` tests in Trunk anymore.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR