### PR TITLE
Relax schema in security center

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
@@ -7,7 +7,7 @@
   [:string {:min 1}])
 
 (mr/def ::semver
-  [:re #"^\d+\.\d+\.\d+$"])
+  [:re #"^\d+(?:\.\d+)*$"])
 
 (mr/def ::severity
   [:enum :critical :high :medium :low])

--- a/enterprise/backend/test/metabase_enterprise/security_center/schema_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/schema_test.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.security-center.schema-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.security-center.schema :as schema]
+   [metabase.util.malli.registry :as mr]))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:parallel semver-test
+  (testing "accepts versions with any number of dot-separated numeric segments"
+    (doseq [v ["1.57" "1.57.19" "0.50.2" "1.58.14" "10.0.0"
+               "1.57.19.1" "1.58.14.1" "1.57.19.1.2"]]
+      (is (mr/validate ::schema/semver v)
+          v)))
+  (testing "rejects non-versions"
+    (doseq [v ["1." ".1" "1..2" "foo" "1.57.x"]]
+      (is (not (mr/validate ::schema/semver v))
+          v))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75334

Accept patch versions
Closes [GDGT-2562: Security center won't work advisories with patch versions](https://linear.app/metabase/issue/GDGT-2562/security-center-wont-work-advisories-with-patch-versions)