### PR TITLE
feat: add embedding-devs Slack group to github-slack-map

### DIFF
--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -120,5 +120,6 @@
   "successengineers": "S05AAL8PUA1",
   "growth": "S056LQCRQG5",
   "core-release": "S02UJK9DN59",
-  "engineering": "S03BXTD2PCJ"
+  "engineering": "S03BXTD2PCJ",
+  "embedding-devs": "S07A51ATQLD"
 }


### PR DESCRIPTION
Fixes EMB-1833

### Description

The `cut-release-branch.yml` workflow calls `mentionSlackTeam('embedding-devs')` to ping the embedding team after a new release branch is cut. However, `embedding-devs` was missing from `release/github-slack-map.json`, causing the Slack message to render `<!subteam^undefined|embedding-devs>` — a broken mention that notifies nobody.

Fix: add `"embedding-devs": "S07A51ATQLD"` to the map.

### How to verify

Search `<@S07A51ATQLD>` (from this PR) in Slack — it should resolve to the `@embedding-devs` user group (Kelvin, Nicolò, Poom, Sébastien, Timofei).

### Demo

<img width="741" height="283" alt="image" src="https://github.com/user-attachments/assets/b70f7f05-6dc7-4bec-b5cc-bf0c33428ec3" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~