### PR TITLE
feat(search): add a search context enum, default it to api

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -83,7 +83,11 @@ describe(
       cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("POST", "/api/action").as("createAction");
       cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
-      cy.intercept("GET", "/api/search?archived=true").as("getArchived");
+      cy.intercept({
+        method: "GET",
+        pathname: "/api/search",
+        query: { archived: "true" },
+      }).as("getArchived");
       cy.intercept("GET", "/api/search?*").as("getSearchResults");
       cy.intercept("GET", "/api/database?*").as("getDatabase");
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -230,10 +230,17 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
   });
 
   it("should not include entity-types when model count is 1", () => {
-    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
-      data: [],
-      total: 1,
-    }).as("searchModels");
+    cy.intercept(
+      {
+        method: "GET",
+        pathname: "/api/search",
+        query: { limit: "0", models: "dataset" },
+      },
+      {
+        data: [],
+        total: 1,
+      },
+    ).as("searchModels");
 
     navigateToGetCodeStep({ experience: "exploration" });
 
@@ -252,10 +259,17 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
   });
 
   it("should include entity-types when model count is 3", () => {
-    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
-      data: [],
-      total: 3,
-    }).as("searchModels");
+    cy.intercept(
+      {
+        method: "GET",
+        pathname: "/api/search",
+        query: { limit: "0", models: "dataset" },
+      },
+      {
+        data: [],
+        total: 3,
+      },
+    ).as("searchModels");
 
     navigateToGetCodeStep({ experience: "exploration" });
 

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -903,6 +903,7 @@ function withAvailableModels(WrappedComponent) {
       calculate_available_models: true,
       limit: 0,
       models: ["dataset"],
+      context: "data-picker",
     });
     const { data: _data, ...metadata } = response ?? {};
     return (

--- a/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
@@ -25,6 +25,7 @@ export function SimpleDataPicker({
   const { data, isLoading, error } = useSearchQuery({
     table_db_id: filterByDatabaseId ? filterByDatabaseId : undefined,
     models: translateEntityTypesToSearchModels(entityTypes),
+    context: "data-picker",
   });
 
   const options = useMemo(() => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibrarySearch.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibrarySearch.ts
@@ -29,6 +29,7 @@ export function useLibrarySearch(
           q: debouncedQuery,
           collection: libraryCollectionId,
           models: ["table", "metric"],
+          context: "library",
         }
       : skipToken,
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/EntrySearchInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/EntrySearchInput.tsx
@@ -54,6 +54,7 @@ export function EntrySearchInput({
     {
       q: searchQuery,
       models: searchModels,
+      context: "dependencies",
     },
     {
       skip: !isSearchEnabled,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/SearchModelPicker/SearchModelPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/SearchModelPicker/SearchModelPicker.tsx
@@ -62,6 +62,7 @@ function SearchModelPopover({
     models: ["card"],
     limit: 0,
     calculate_available_models: true,
+    context: "dependencies",
   });
   const items = data ? getSearchModelItems(data) : [];
 

--- a/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/MigrateModelsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/MigrateModelsPage.tsx
@@ -17,6 +17,7 @@ import { PageHeader } from "./PageHeader";
 export function MigrateModelsPage() {
   const { data, isLoading, error } = useSearchQuery({
     models: ["dataset"],
+    context: "model-migration",
   });
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [isResizing, { open: startResizing, close: stopResizing }] =

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -122,10 +122,8 @@ export interface SearchResult<
   collection_id?: CollectionId;
 }
 
-// The frontend surface that issued a search request, used by the backend to select ranking weights and
-// filter defaults. Required on every frontend request; keep in sync with
-// `metabase.search.config/ui-contexts`. The backend-only contexts (`api`, `metabot`) are deliberately
-// excluded so the frontend cannot use them: `api` is for programmatic callers and `metabot` is internal.
+// The frontend surface that issued a search request; the backend uses it to pick ranking weights and
+// filter defaults. Keep in sync with `metabase.search.config/ui-contexts`.
 export type SearchContext =
   | "search-bar"
   | "search-app"

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -122,11 +122,23 @@ export interface SearchResult<
   collection_id?: CollectionId;
 }
 
+// The frontend surface that issued a search request, used by the backend to select ranking weights and
+// filter defaults. Required on every frontend request; keep in sync with
+// `metabase.search.config/ui-contexts`. The backend-only contexts (`api`, `metabot`) are deliberately
+// excluded so the frontend cannot use them: `api` is for programmatic callers and `metabot` is internal.
 export type SearchContext =
   | "search-bar"
   | "search-app"
   | "command-palette"
-  | "entity-picker";
+  | "entity-picker"
+  | "data-picker"
+  | "type-filter"
+  | "browse"
+  | "embedding-setup"
+  | "document"
+  | "library"
+  | "dependencies"
+  | "model-migration";
 
 export type SearchRequest = {
   q?: string;
@@ -135,7 +147,7 @@ export type SearchRequest = {
   models?: SearchModel[];
   ids?: SearchResultId[];
   filter_items_in_personal_collection?: "only" | "exclude";
-  context?: SearchContext;
+  context: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;
   last_edited_at?: string | null;

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -161,7 +161,7 @@ function ActionPickerWithModels(
     data: searchResponse,
     isLoading: isLoadingSearch,
     error: searchError,
-  } = useSearchQuery({ models: ["dataset"] });
+  } = useSearchQuery({ models: ["dataset"], context: "entity-picker" });
   const {
     data: actions = [],
     isLoading: isLoadingActions,

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
@@ -24,7 +24,7 @@ export function useDefaultPreviewResource(): {
   const shouldFallback = !isRecentsLoading && recentResource == null;
 
   const { data: dashboards, isLoading: isDashboardLoading } = useSearchQuery(
-    { models: ["dashboard"], limit: 1 },
+    { models: ["dashboard"], limit: 1, context: "embedding-setup" },
     { skip: !shouldFallback },
   );
 
@@ -32,7 +32,7 @@ export function useDefaultPreviewResource(): {
   const hasDashboard = dashboard != null && typeof dashboard.id === "number";
 
   const { data: questions, isLoading: isQuestionLoading } = useSearchQuery(
-    { models: ["card"], limit: 1 },
+    { models: ["card"], limit: 1, context: "embedding-setup" },
     { skip: !shouldFallback || isDashboardLoading || hasDashboard },
   );
 

--- a/frontend/src/metabase/api/analytics.ts
+++ b/frontend/src/metabase/api/analytics.ts
@@ -1,4 +1,5 @@
 import { trackSchemaEvent } from "metabase/analytics";
+import { isTrackedSearchContext } from "metabase/search/analytics";
 import { openSaveDialog } from "metabase/utils/dom";
 import { hashSearchTerm, shouldReportSearchTerm } from "metabase/utils/search";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
@@ -87,7 +88,9 @@ export const trackSearchRequest = (
       verified_items: !!searchRequest.verified,
       search_native_queries: !!searchRequest.search_native_query,
       search_archived: !!searchRequest.archived,
-      context: searchRequest.context ?? null,
+      context: isTrackedSearchContext(searchRequest.context)
+        ? searchRequest.context
+        : null,
       runtime_milliseconds: duration,
       total_results: searchResponse.total,
       page_results: searchResponse.limit,

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -1,3 +1,4 @@
+import { isTrackedSearchContext } from "metabase/search/analytics";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
 
 import { trackSearchRequest } from "./analytics";
@@ -16,7 +17,7 @@ export const searchApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),
       onQueryStarted: (args, { queryFulfilled, requestId }) => {
-        if (args.context) {
+        if (isTrackedSearchContext(args.context)) {
           const start = Date.now();
           return handleQueryFulfilled(queryFulfilled, (data) => {
             const duration = Date.now() - start;

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -485,6 +485,7 @@ function SearchItemList({ query: externalQuery }: { query: string }) {
       q: query,
       models: models as SearchModel[],
       limit: 50,
+      context: "data-picker",
     };
     const extraParams =
       typeof searchParams === "function" ? searchParams(params) : searchParams;

--- a/frontend/src/metabase/common/hooks/use-fetch-metrics.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-metrics.tsx
@@ -9,6 +9,7 @@ export const useFetchMetrics = (
       ? req
       : {
           models: ["metric"],
+          context: "browse",
           ...req,
         },
   );

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -11,6 +11,7 @@ export const useFetchModels = (
           models: ["dataset"], // 'model' in the sense of 'type of thing'
           filter_items_in_personal_collection: "exclude",
           model_ancestors: false,
+          context: "browse",
           ...req,
         },
   );

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -92,6 +92,7 @@ export function QuestionList({
             : ["card", "dataset", "metric"],
           offset: queryOffset,
           limit: DEFAULT_SEARCH_LIMIT,
+          context: "entity-picker",
         }
       : skipToken,
   );

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
@@ -166,6 +166,7 @@ function LinkVizInner({
                   forceEntitySelect
                   onEntitySelect={handleEntitySelect}
                   models={MODELS_TO_SEARCH}
+                  context="entity-picker"
                 />
               </SearchResultsContainer>
             )

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useSearch.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useSearch.ts
@@ -17,6 +17,7 @@ export function useSearch(query: string) {
       : {
           q: query,
           models: ["table"],
+          context: "data-picker",
         },
   );
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -67,6 +67,7 @@ export const SdkIframeEmbedSetupProvider = ({
   const { data: searchData } = useSearchQuery({
     limit: 0,
     models: ["dataset"],
+    context: "embedding-setup",
   });
 
   const modelCount = searchData?.total ?? 0;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
@@ -20,6 +20,7 @@ export const useRecentlyCreatedDashboards = () => {
       models: ["dashboard"],
       created_by: currentUserId ? [currentUserId] : undefined,
       limit: 5,
+      context: "embedding-setup",
 
       // If the dashboard is created more than 1 hour ago,
       // it is likely stale and latest activity should take priority.

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useSearch.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useSearch.ts
@@ -17,6 +17,7 @@ export function useSearch(query: string) {
       : {
           q: query,
           models: ["table"],
+          context: "data-picker",
         },
   );
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -230,7 +230,7 @@ function SearchBarView({
               searchText={searchText}
               onSearchItemSelect={onSearchItemSelect}
               goToSearchApp={goToSearchApp}
-              isSearchBar={true}
+              context="search-bar"
             />
           ) : (
             <RecentsList />

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -14,7 +14,6 @@ import {
 } from "metabase/nav/components/search/SearchResults/SearchResults.styled";
 import { useDispatch } from "metabase/redux";
 import { SearchResult } from "metabase/search/components/SearchResult/SearchResult";
-import { SearchContextTypes } from "metabase/search/constants";
 import type { SearchFilters } from "metabase/search/types";
 import { Loader } from "metabase/ui";
 import { modelToUrl } from "metabase/urls";
@@ -24,6 +23,7 @@ import {
 } from "metabase/utils/constants";
 import type {
   CollectionItem,
+  SearchContext,
   SearchModel,
   SearchResult as SearchResultType,
   SearchResponse as SearchResultsType,
@@ -47,7 +47,7 @@ export type SearchResultsProps = {
   models?: SearchModel[];
   footerComponent?: SearchResultsFooter;
   onFooterSelect?: () => void;
-  isSearchBar?: boolean;
+  context: SearchContext;
 };
 
 export const SearchLoadingSpinner = () => (
@@ -62,7 +62,7 @@ export const SearchResults = ({
   models,
   footerComponent,
   onFooterSelect,
-  isSearchBar = false,
+  context,
 }: SearchResultsProps) => {
   const dispatch = useDispatch();
 
@@ -82,17 +82,14 @@ export const SearchResults = ({
     q?: string;
     limit: number;
     models?: SearchModel[];
-    context?: "search-bar" | "search-app";
+    context: SearchContext;
   } & SearchFilters = {
     q: debouncedSearchText,
     limit: DEFAULT_SEARCH_LIMIT,
+    context,
     ...searchFilters,
     models: models ?? searchFilters.type,
   };
-
-  if (isSearchBar) {
-    query.context = SearchContextTypes.SEARCH_BAR;
-  }
 
   const { data: response, isLoading } = useSearchQuery(
     debouncedSearchText ? query : skipToken,
@@ -170,7 +167,7 @@ export const SearchResults = ({
                 isSelected={cursorIndex === index}
                 onClick={onClick}
                 index={index}
-                context="search-bar"
+                context={context}
                 searchTerm={searchText}
               />
             </li>

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
@@ -65,6 +65,7 @@ const setup = async ({
           forceEntitySelect={forceEntitySelect}
           searchText={searchText}
           footerComponent={footer}
+          context="search-bar"
         />
       )}
     />,

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.tsx
@@ -3,7 +3,7 @@ import { jt, t } from "ttag";
 import type { SearchResultsFooter } from "metabase/nav/components/search/SearchResults";
 import { SearchResults } from "metabase/nav/components/search/SearchResults";
 import { Icon, Text, rem } from "metabase/ui";
-import type { SearchResult } from "metabase-types/api";
+import type { SearchContext, SearchResult } from "metabase-types/api";
 
 import {
   SearchDropdownFooter,
@@ -15,14 +15,14 @@ export type SearchResultsDropdownProps = {
   searchText: string;
   onSearchItemSelect: (item: SearchResult) => void;
   goToSearchApp: () => void;
-  isSearchBar?: boolean;
+  context: SearchContext;
 };
 
 export const SearchResultsDropdown = ({
   searchText,
   onSearchItemSelect,
   goToSearchApp,
-  isSearchBar = false,
+  context,
 }: SearchResultsDropdownProps) => {
   const renderFooter: SearchResultsFooter = ({ metadata, isSelected }) => {
     const resultText =
@@ -58,7 +58,7 @@ export const SearchResultsDropdown = ({
         onEntitySelect={onSearchItemSelect}
         footerComponent={renderFooter}
         onFooterSelect={goToSearchApp}
-        isSearchBar={isSearchBar}
+        context={context}
       />
     </SearchResultsContainer>
   );

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
@@ -70,6 +70,7 @@ const setup = async ({
           searchText={searchText}
           onSearchItemSelect={onSearchItemSelect}
           goToSearchApp={goToSearchApp}
+          context="search-bar"
         />
       )}
     />,

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -65,7 +65,9 @@ export const useCommandPaletteBasicActions = ({
     enabled: isLoggedIn,
   });
   const { data: searchResults } = useSearchQuery(
-    isLoggedIn ? { models: ["dataset"], limit: 1 } : skipToken,
+    isLoggedIn
+      ? { models: ["dataset"], limit: 1, context: "command-palette" }
+      : skipToken,
   );
   const hasModels = (searchResults?.data?.length ?? 0) > 0;
 

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
@@ -1128,6 +1128,7 @@ function withAvailableModels(WrappedComponent) {
       calculate_available_models: true,
       limit: 0,
       models: ["dataset", "metric"],
+      context: "data-picker",
     });
     let metadata;
     if (response) {

--- a/frontend/src/metabase/querying/components/DataReference/DatabasePane.tsx
+++ b/frontend/src/metabase/querying/components/DataReference/DatabasePane.tsx
@@ -252,6 +252,7 @@ export const DatabasePane = ({
       ? {
           models: ["dataset", "table"],
           table_db_id: databaseId,
+          context: "data-picker",
         }
       : skipToken,
   );

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -39,6 +39,7 @@ export function EmbeddingDataPicker({
     useSearchQuery({
       models: ["dataset", "table"],
       limit: 0,
+      context: "data-picker",
     });
 
   const databaseId = Lib.databaseID(query);

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/useEntitySearch.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/useEntitySearch.ts
@@ -27,7 +27,10 @@ import {
 } from "./suggestionHooks";
 import { buildUserMenuItems, filterRecents } from "./suggestionUtils";
 
-export type EntitySearchOptions = Omit<SearchRequest, "q" | "models" | "limit">;
+export type EntitySearchOptions = Omit<
+  SearchRequest,
+  "q" | "models" | "limit" | "context"
+>;
 
 interface UseEntitySearchOptions {
   query: string;
@@ -81,6 +84,7 @@ export function useEntitySearch({
         (model): model is SearchModel => model !== "user",
       ),
       limit: LINK_SEARCH_LIMIT,
+      context: "document",
       ...searchOptions,
     },
     {

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -1,6 +1,26 @@
 import { trackSchemaEvent } from "metabase/analytics";
 import { hashSearchTerm, shouldReportSearchTerm } from "metabase/utils/search";
-import type { SearchRequest } from "metabase-types/api";
+import type { SearchContext, SearchRequest } from "metabase-types/api";
+
+// The search `context` values we publish Snowplow analytics events for.
+// The other contexts (data pickers, browse, etc.) also issue searches; we don't publish those because it
+// would require a Snowplow schema migration — this list must stay a subset of the `context` enum in the
+// iglu `search` schema (snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/*).
+const ANALYTICS_TRACKED_CONTEXTS = [
+  "search-app",
+  "search-bar",
+  "command-palette",
+  "entity-picker",
+] as const satisfies readonly SearchContext[];
+
+export type AnalyticsSearchContext =
+  (typeof ANALYTICS_TRACKED_CONTEXTS)[number];
+
+export const isTrackedSearchContext = (
+  context: SearchContext | null | undefined,
+): context is AnalyticsSearchContext =>
+  context != null &&
+  (ANALYTICS_TRACKED_CONTEXTS as readonly SearchContext[]).includes(context);
 
 type TrackSearchClickParams = {
   itemType: "item" | "view_more";
@@ -28,7 +48,7 @@ export const trackSearchClick = ({
       event: "search_click",
       position,
       target_type: itemType,
-      context: context ?? null,
+      context: isTrackedSearchContext(context) ? context : null,
       search_engine: searchEngine,
       request_id: requestId,
       entity_model: entityModel,

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
@@ -12,6 +12,7 @@ const EMPTY_SEARCH_QUERY = {
   models: ["dataset" as const],
   limit: 1,
   calculate_available_models: true as const,
+  context: "type-filter" as const,
 };
 
 export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"] =

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
@@ -136,6 +136,7 @@ export function DatasetsList({
         models: ["card", "dataset", "metric"],
         include_dashboard_questions: true,
         include_metadata: true,
+        context: "data-picker",
         ...(visualizationType &&
           isCartesianChart(visualizationType) &&
           search.length === 0 && {

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -209,7 +209,9 @@
     has-temporal-dim                    :has_temporal_dim}
    :- [:map
        [:q                                   {:optional true} [:maybe :string]]
-       [:context                             {:optional true, :default :api} search.config/Context]
+       ;; no `:optional true`: default-value-transformer skips defaults for absent optional keys, so it's
+       ;; what makes `:default :api` actually apply when the param is omitted
+       [:context                             {:default :api} search.config/Context]
        [:archived                            {:default false} [:maybe :boolean]]
        [:collection                          {:optional true} [:maybe ms/PositiveInt]]
        [:table_db_id                         {:optional true} [:maybe ms/PositiveInt]]

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -161,11 +161,14 @@
   "Search for items in Metabase.
   For the list of supported models, check [[metabase.search.config/all-models]].
 
+  `context` identifies the surface issuing the search; it selects the ranking weights and filter defaults.
+  It defaults to `api`, the value for programmatic callers.
+
   Filters:
   - `archived`: set to true to search archived items only, default is false
   - `table_db_id`: search for tables, cards, and models of a certain DB
   - `models`: only search for items of specific models. If not provided, search for all models
-  - `filters_items_in_personal_collection`: only search for items in personal collections
+  - `filter_items_in_personal_collection`: only search for items in personal collections
   - `created_at`: search for items created at a specific timestamp
   - `created_by`: search for items created by a specific user
   - `last_edited_at`: search for items last edited at a specific timestamp
@@ -206,7 +209,7 @@
     has-temporal-dim                    :has_temporal_dim}
    :- [:map
        [:q                                   {:optional true} [:maybe :string]]
-       [:context                             {:optional true} [:maybe :keyword]]
+       [:context                             {:optional true, :default :api} search.config/Context]
        [:archived                            {:default false} [:maybe :boolean]]
        [:collection                          {:optional true} [:maybe ms/PositiveInt]]
        [:table_db_id                         {:optional true} [:maybe ms/PositiveInt]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -282,17 +282,16 @@
   "Search `context` values for non-frontend callers.
   Excluded from the frontend `SearchContext` type so the frontend cannot use them."
   [:api       ; programmatic / third-party API access
-   :metabot]) ; built in-process by Metabot and the agent API, never sent over HTTP
+   :metabot]) ; Metabot / agent API searches; accepted over HTTP too, for debugging and reproduction
 
 (def ^:private contexts
   "All valid search request `context` values: [[ui-contexts]] plus [[non-ui-contexts]]."
   (into ui-contexts non-ui-contexts))
 
 (def Context
-  "Malli enum for the search request `context` query parameter: every value in [[contexts]] except
-  `:metabot`, which is constructed in-process and is never sent over HTTP.
+  "Malli enum for the search request `context` query parameter, over every value in [[contexts]].
   The `:decode/string keyword` hook coerces the query-string value (e.g. \"search-app\") to a keyword."
-  (into [:enum {:decode/string keyword}] (remove #{:metabot} contexts)))
+  (into [:enum {:decode/string keyword}] contexts))
 
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -260,6 +260,40 @@
   separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
   [:hnsw :brute-force])
 
+(def ^:private ui-contexts
+  "Search `context` values issued by the frontend, one per UI surface.
+  Selects the ranking weights ([[static-weights]]) and filter defaults ([[filter-defaults-by-context]]).
+  Keep in sync with the frontend `SearchContext` type (frontend/src/metabase-types/api/search.ts).
+  Give every value a comment naming the surface that issues it."
+  [:search-bar          ; the global navbar search typeahead
+   :search-app          ; the full-page search results app
+   :command-palette     ; the ⌘K command palette
+   :entity-picker       ; the entity-picker modal (cards, dashboards, collections, …)
+   :data-picker         ; picking a data source (table/model/metric) while building a query
+   :type-filter         ; the search type-filter dropdown's available-models lookup
+   :browse              ; the Browse models / Browse metrics pages
+   :embedding-setup     ; embedding/SDK setup and preview resource selection
+   :document            ; entity references embedded in documents
+   :library             ; the data-studio Library page (EE)
+   :dependencies        ; the dependency-graph entry search (EE)
+   :model-migration])   ; the migrate-models admin page (EE)
+
+(def ^:private non-ui-contexts
+  "Search `context` values for non-frontend callers.
+  Excluded from the frontend `SearchContext` type so the frontend cannot use them."
+  [:api       ; programmatic / third-party API access
+   :metabot]) ; built in-process by Metabot and the agent API, never sent over HTTP
+
+(def ^:private contexts
+  "All valid search request `context` values: [[ui-contexts]] plus [[non-ui-contexts]]."
+  (into ui-contexts non-ui-contexts))
+
+(def Context
+  "Malli enum for the search request `context` query parameter: every value in [[contexts]] except
+  `:metabot`, which is constructed in-process and is never sent over HTTP.
+  The `:decode/string keyword` hook coerces the query-string value (e.g. \"search-app\") to a keyword."
+  (into [:enum {:decode/string keyword}] (remove #{:metabot} contexts)))
+
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   [:map {:closed true}

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -310,6 +310,23 @@
   [& args]
   (map clean-result (apply search-request-data-with identity args)))
 
+(deftest context-param-test
+  (testing "context is an enum parameter that defaults to :api"
+    (testing "a missing context is accepted and resolves to :api"
+      (let [captured (atom nil)]
+        (mt/with-dynamic-fn-redefs [search/search (fn [search-ctx]
+                                                    (reset! captured search-ctx)
+                                                    {:data [] :total 0 :engine "test"})]
+          (is (=? {:engine string?}
+                  (mt/user-http-request :crowberto :get 200 "search" :q "x"))))
+        (is (= :api (:context @captured)))))
+    (testing "an unknown context value is rejected"
+      (is (=? {:errors {:context #"enum of.*"}}
+              (mt/user-http-request :crowberto :get 400 "search" :q "x" :context "bogus"))))
+    (testing "a known context value is accepted"
+      (is (=? {:engine string?}
+              (mt/user-http-request :crowberto :get 200 "search" :q "x" :context "search-app"))))))
+
 (deftest basic-test
   (testing "Basic search, should find 1 of each entity type, all items in the root collection"
     (with-search-items-in-root-collection "test"

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.search.config-test
   (:require
    [clojure.test :refer :all]
-   [metabase.search.config :as search.config]))
+   [metabase.search.config :as search.config]
+   [metabase.util.malli.registry :as mr]))
 
 ;; All that matters is that this is not legacy search.
 (def ^:private search-engine :search.engine/appdb)
@@ -22,3 +23,9 @@
            (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))
     (is (= "exclude-others"
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
+
+(deftest context-schema-test
+  (testing "the HTTP `context` enum allows the UI surfaces and :api, but not the in-process-only :metabot"
+    (is (mr/validate search.config/Context :search-app))
+    (is (mr/validate search.config/Context :api))
+    (is (not (mr/validate search.config/Context :metabot)))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -25,7 +25,9 @@
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
 
 (deftest context-schema-test
-  (testing "the HTTP `context` enum allows the UI surfaces and :api, but not the in-process-only :metabot"
+  (testing "the HTTP `context` enum allows the UI surfaces, :api, and :metabot (accepted for debugging)"
     (is (mr/validate search.config/Context :search-app))
     (is (mr/validate search.config/Context :api))
-    (is (not (mr/validate search.config/Context :metabot)))))
+    (is (mr/validate search.config/Context :metabot)))
+  (testing "values outside the enum are rejected"
+    (is (not (mr/validate search.config/Context :bogus)))))


### PR DESCRIPTION
## Summary

`GET /api/search` previously accepted an **optional, free-form** `:keyword` `context`. This PR turns it into a **validated Malli enum** naming the surface that issued the search (used to pick ranking weights and filter defaults), and **defaults it to `api`** when omitted.

Two design rules:
1. **Omitting `context` on the frontend is a type error** — `SearchRequest.context` is required.
2. **The frontend cannot use the `api`/`metabot` contexts** — those are backend-only and excluded from the FE `SearchContext` type.

Because the frontend always sends its own UI context, the `api` default only ever applies to **programmatic / third-party API callers** — for whom `api` is the correct value. That keeps real-world API usage ergonomic and avoids churning the backend test suite with boilerplate.

## Frontend
- `SearchContext` lists only the UI surfaces. New values added for previously context-less callers: 
  - `data-picker`
  - `type-filter`
  - `browse`
  - `embedding-setup`
  - `document`
  - `library`
  - `dependencies`
  - `model-migration`
- Every `useSearchQuery` caller now passes a sensible context.
- `SearchResults` takes a required `context` prop in place of the `isSearchBar` flag.
- **Snowplow:** since `context` is now always present, search analytics is gated to the four contexts that exist in the iglu `search` schema (`search-app`, `search-bar`, `command-palette`, `entity-picker`); picker/browse searches don't emit events - matching prior behavior.