### PR TITLE
feat(search): retune ranking — boost exact, make library opt-in

### DIFF
--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -161,11 +161,23 @@ describe("scenarios > search > snowplow", () => {
           context: "search-app",
         });
 
-        cy.findByRole("heading", { name: "Orders in a dashboard" }).click();
-        H.expectUnstructuredSnowplowEvent({
-          event: SEARCH_CLICK,
-          context: "search-app",
-          position: 0,
+        // The result's rank depends on ranking weights, so derive its position from the DOM order
+        // rather than pinning a specific index.
+        cy.findAllByTestId("search-result-item").then(($items) => {
+          const position = $items
+            .toArray()
+            .findIndex((el) =>
+              el.textContent?.includes("Orders in a dashboard"),
+            );
+          expect(position, "Orders in a dashboard is in the results").to.be.gte(
+            0,
+          );
+          cy.wrap($items.eq(position)).click();
+          H.expectUnstructuredSnowplowEvent({
+            event: SEARCH_CLICK,
+            context: "search-app",
+            position,
+          });
         });
       });
     });

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -88,15 +88,16 @@
    :view-count          2
    :text                5
    :mine                1
-   :exact               5
+   ;; An exact (case-insensitive) name match is the strongest single intent signal: :exact (100) overpowers
+   ;; any one curation tier (:official-collection / :verified, and the :data-picker :library boost, 80 each).
+   ;; Base text/recency scorers (0–5) only break ties within a tier.
+   :exact               100
    :prefix              0
-   ;; User-curated tiers, from strongest to weakest.
-   ;; :library at 200 exceeds :official-collection + :verified (80 each) combined,
-   ;; so a library item always outranks a non-library one.
-   ;; Base text/recency scorers (0–5 range) only break ties *within* a tier.
-   :library             200
    :official-collection 80
    :verified            80
+   ;; :library is a data-layer curation signal relevant only when picking a data source, so it is off by
+   ;; default; the :data-picker context opts in, at a curation-tier level that an exact match can overpower.
+   :library             0
    ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
    :rrf                 500
    ;; Maps the backend's cosine distance to a [0, 1] score: 1 = identical vector, 0 = maximally distant or keyword-only hit.
@@ -120,6 +121,10 @@
     :model/dataset  1
     :model/metric   1
     :model/question 0}
+   :data-picker
+   ;; Boost curated library items when picking a data source, but keep it a curation-tier signal (80, like
+   ;; :verified/:official) so an exact name match (:exact 100) can overpower it.
+   {:library 80}
    ;; TODO: lift :data-layer up to :default. It's a structural signal (every visible warehouse
    ;; table gets `data_layer "final"`), so the +33 boost flips orderings across every search
    ;; surface and breaks e2e specs that pin specific top results. To make progress:

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -69,3 +69,14 @@
     ;; :library lives in :default; :data-layer only in :metabot
     (is (contains? search.config/known-rankers :library))
     (is (contains? search.config/known-rankers :data-layer))))
+
+(deftest weight-tuning-test
+  (testing "an exact name match outranks a single curation tier"
+    (is (> (search.config/weight {:context :global} :exact)
+           (search.config/weight {:context :global} :verified))))
+  (testing "the library boost is opt-in: off by default, a curation-tier boost for the data picker"
+    (is (= 0 (search.config/weight {:context :global} :library)))
+    (is (= 80 (search.config/weight {:context :data-picker} :library))))
+  (testing "in the data picker, an exact name match can overpower the library boost"
+    (is (> (search.config/weight {:context :data-picker} :exact)
+           (search.config/weight {:context :data-picker} :library)))))


### PR DESCRIPTION
Config-only change on top of the weight-profile split.

- Bump `:exact` 5 -> 100 so an exact (case-insensitive) name match outranks a single curation tier (`:official-collection` / `:verified` at 80). Exact match is a 0/1 signal, so its weight is its contribution.
- Move the `:library` boost out of the base (now 0) and make it opt-in on `:data-picker` at a curation-tier level (80) — strong enough to surface curated data, but low enough that an exact name match (`:exact` 100) can overpower it.