### PR TITLE
Don't resolve inactive tables in portable FK resolution

### DIFF
--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -56,7 +56,7 @@
   (:name (lib.metadata/database metadata-provider)))
 
 (defn- matching-tables-via-provider
-  "Return all tables matching `table-name` in `metadata-provider`, post-filtered by `schema`
+  "Return active tables matching `table-name` in `metadata-provider`, post-filtered by `schema`
   (`schema` may be `nil` for schemaless databases).
 
   Used as a fallback for mock and checker providers. NOT safe for production: the
@@ -69,18 +69,24 @@
   (->> (lib.metadata.protocols/metadatas metadata-provider
                                          {:lib/type :metadata/table
                                           :name     #{table-name}})
-       (filter #(= (:schema %) schema))))
+       ;; By-name lookups skip the provider's SQL `active = true` filter (it only guards
+       ;; enumerate-all queries), so inactive rows reach here. `false?` keeps mocks with no
+       ;; `:active` key.
+       (filter #(and (= (:schema %) schema)
+                     (not (false? (:active %)))))))
 
 (defn- matching-tables-via-app-db
-  "Return all tables matching the `(db-id, schema, table-name)` triple by direct application-DB
+  "Return active tables matching the `(db-id, schema, table-name)` triple by direct application-DB
   query — same shape `resolve.db/import-table-fk` has always used. Bypasses the metadata
   provider entirely.
+
+  Filters `:active true` in the WHERE clause so stale FKs to inactive tables don't resolve.
 
   Defective `(db_id, schema, name)` duplicates (allowed by the
   `001_update_migrations.yaml` `is_defective_duplicate` carve-out for pre-constraint rows)
   return more than one candidate so [[find-table]] can raise `:ambiguous-table`."
   [db-id schema table-name]
-  (t2/select :metadata/table :db_id db-id :schema schema :name table-name))
+  (t2/select :metadata/table :db_id db-id :schema schema :name table-name :active true))
 
 (defn- app-db-backed-provider?
   "True when `metadata-provider` is part of the production app-DB-backed wrapper chain
@@ -106,8 +112,9 @@
   schemas / tables they cannot otherwise see.
 
   For the same reason this single message covers both a never-existed miss and an inactive
-  (deleted / re-uploaded) match — see [[find-table]]. Branching the wording on whether an inactive
-  row exists would be an existence oracle, so both cases get this identical message.
+  match — [[table-candidates]] drops inactive rows upstream, so both reach [[find-table]] as 0
+  candidates. Branching the wording on whether an inactive row exists would be an existence
+  oracle, so both get this identical message.
 
   The LLM can still self-correct in one turn by calling `entity_details` on the parent
   database; the message points it at that path."
@@ -132,8 +139,7 @@
   becomes authoritative, since the alternative is a confusing `:unknown-table` raised for a
   table the caller can plainly see via `entity_details`.
 
-  Returns raw matches including inactive (`:active false`) rows; [[find-table]] drops the inactive
-  ones."
+  Returns only active tables — both helpers drop inactive (`:active false`) rows."
   [metadata-provider db-id schema table-name]
   (or (when (and db-id (app-db-backed-provider? metadata-provider))
         (seq (matching-tables-via-app-db db-id schema table-name)))
@@ -147,9 +153,8 @@
   re-hallucinating the same bad path. All error branches are marked
   `:agent-error? true` so the outer tool wrapper relays the message verbatim.
 
-  Inactive (`:active false`) matches are treated as a miss: the app-DB row can outlive its warehouse
-  table (e.g. a deleted or re-uploaded upload). (Surfaced while investigating BOT-739, though likely
-  not its cause.)"
+  Inactive (`:active false`) tables are dropped by [[table-candidates]], so a stale FK to one
+  surfaces here as a 0-candidate miss."
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)
@@ -161,8 +166,7 @@
                        :agent-error? true
                        :path         path
                        :expected-db  current-db})))
-    (let [candidates (filterv #(not (false? (:active %)))
-                              (table-candidates metadata-provider current-db-id path-schema path-table-name))]
+    (let [candidates (table-candidates metadata-provider current-db-id path-schema path-table-name)]
       (case (count candidates)
         0 (throw (unknown-table-ex-info metadata-provider path))
         1 (first candidates)

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -107,12 +107,12 @@
 
   For the same reason this single message covers both a never-existed miss and an inactive
   (deleted / re-uploaded) match — see [[find-table]]. Branching the wording on whether an inactive
-  row exists would be an existence oracle, so the deletion hint is unconditional.
+  row exists would be an existence oracle, so both cases get this identical message.
 
   The LLM can still self-correct in one turn by calling `entity_details` on the parent
   database; the message points it at that path."
   [_metadata-provider [_path-db-name _path-schema _path-table-name :as path]]
-  (ex-info (tru "No table found matching portable FK {0} — it may not exist, or may have been deleted. Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
+  (ex-info (tru "No table found matching portable FK {0}. Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
                 (pr-str path))
            {:status-code  400
             :error        :unknown-table

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -147,10 +147,8 @@
   re-hallucinating the same bad path. All error branches are marked
   `:agent-error? true` so the outer tool wrapper relays the message verbatim.
 
-  Inactive (`:active false`) matches are excluded and treated as a miss (BOT-739): a deleted or
-  re-uploaded table keeps its app-DB row but loses its warehouse table, so resolving it would
-  compile to SQL on a table that's gone. `(not (false? …))` keeps mock providers (which omit
-  `:active`) resolving."
+  Inactive (`:active false`) matches are treated as a miss (BOT-739): the app-DB row can outlive its
+  warehouse table (e.g. a deleted or re-uploaded upload)."
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -147,8 +147,9 @@
   re-hallucinating the same bad path. All error branches are marked
   `:agent-error? true` so the outer tool wrapper relays the message verbatim.
 
-  Inactive (`:active false`) matches are treated as a miss (BOT-739): the app-DB row can outlive its
-  warehouse table (e.g. a deleted or re-uploaded upload)."
+  Inactive (`:active false`) matches are treated as a miss: the app-DB row can outlive its warehouse
+  table (e.g. a deleted or re-uploaded upload). (Surfaced while investigating BOT-739, though likely
+  not its cause.)"
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -105,17 +105,14 @@
   prompts the agent with a hallucinated `source-table:` would otherwise receive a list of
   schemas / tables they cannot otherwise see.
 
-  For the same reason this single message covers BOTH a never-existed miss and a match that
-  exists only as an inactive (deleted / re-uploaded) row — see [[find-table]]. Branching the
-  wording on whether an inactive row exists would be an oracle: it would confirm to a sandboxed
-  caller that a given name was once a real table. The deletion hint is therefore worded
-  unconditionally (\"may have been deleted or replaced\") so it helps the common case without
-  leaking existence.
+  For the same reason this single message covers both a never-existed miss and an inactive
+  (deleted / re-uploaded) match — see [[find-table]]. Branching the wording on whether an inactive
+  row exists would be an existence oracle, so the deletion hint is unconditional.
 
   The LLM can still self-correct in one turn by calling `entity_details` on the parent
   database; the message points it at that path."
   [_metadata-provider [_path-db-name _path-schema _path-table-name :as path]]
-  (ex-info (tru "No table found matching portable FK {0} — it may not exist, or may have been deleted or replaced (a re-uploaded CSV is recreated under a new name). Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
+  (ex-info (tru "No table found matching portable FK {0} — it may not exist, or may have been deleted. Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
                 (pr-str path))
            {:status-code  400
             :error        :unknown-table
@@ -150,14 +147,10 @@
   re-hallucinating the same bad path. All error branches are marked
   `:agent-error? true` so the outer tool wrapper relays the message verbatim.
 
-  Inactive (`:active false`) matches are excluded (BOT-739): a deleted or re-uploaded CSV table has
-  its physical warehouse table dropped while its app-DB row lingers as `:active false` (sync doesn't
-  retire inactive uploaded tables), and the metadata provider intentionally skips its active filter
-  for by-name lookups (see `metadata-spec->honey-sql`). Resolving a stale portable FK to that dead
-  row would compile to SQL hitting a table that no longer exists, so an inactive-only match is
-  treated as a miss. The miss message (see [[unknown-table-ex-info]]) is the same whether the table
-  never existed or is merely inactive — deliberately, to avoid an existence oracle. `(:active %)` is
-  compared with `(not (false? …))` so mock providers (which omit `:active`) still resolve."
+  Inactive (`:active false`) matches are excluded and treated as a miss (BOT-739): a deleted or
+  re-uploaded table keeps its app-DB row but loses its warehouse table, so resolving it would
+  compile to SQL on a table that's gone. `(not (false? …))` keeps mock providers (which omit
+  `:active`) resolving."
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -115,6 +115,24 @@
             :agent-error? true
             :path         path}))
 
+(defn- deleted-table-ex-info
+  "Build an agent-facing `:unknown-table` error for a portable FK whose only app-DB match is
+  inactive — the table was deleted or replaced. For a re-uploaded CSV the physical table is dropped
+  and recreated under a new timestamped name, so the old portable FK lingers in the conversation and
+  no longer points at anything live. Nudge the LLM to re-list the database's current tables rather
+  than re-using the stale name. Keeps `:error :unknown-table` so callers branching on the code treat
+  it identically to a never-existed miss; only the message differs.
+
+  Naming the requested `(schema, table-name)` is not an info leak: the caller supplied them, and an
+  inactive match confirms only a now-gone table, never a currently-visible one."
+  [[_path-db-name path-schema path-table-name :as path]]
+  (ex-info (tru "Table {0} (schema {1}) was deleted or replaced and no longer exists. If it was re-uploaded it now has a different name; call `entity_details` with entity-type `database` to list the current tables, then retry with an exact portable FK."
+                (pr-str path-table-name) (pr-str path-schema))
+           {:status-code  400
+            :error        :unknown-table
+            :agent-error? true
+            :path         path}))
+
 (defn- table-candidates
   "Resolve `(schema, table-name)` against `metadata-provider`. Tries
   [[matching-tables-via-app-db]] first for app-DB-backed providers and falls back to
@@ -126,7 +144,11 @@
   provider's cache disagree about whether a table exists (e.g. provider holds a cached row
   for a table that was just deleted, or vice versa). In that last case the provider's view
   becomes authoritative, since the alternative is a confusing `:unknown-table` raised for a
-  table the caller can plainly see via `entity_details`."
+  table the caller can plainly see via `entity_details`.
+
+  Returns raw matches including inactive (`:active false`) rows; [[find-table]] does the
+  active/inactive partition so it can tell a deleted/re-uploaded table apart from a never-existed
+  one."
   [metadata-provider db-id schema table-name]
   (or (when (and db-id (app-db-backed-provider? metadata-provider))
         (seq (matching-tables-via-app-db db-id schema table-name)))
@@ -138,7 +160,15 @@
   On miss, the thrown ex-info carries actionable, tiered hints (see
   [[unknown-table-ex-info]]) so the LLM can self-correct on the next turn instead of
   re-hallucinating the same bad path. All error branches are marked
-  `:agent-error? true` so the outer tool wrapper relays the message verbatim."
+  `:agent-error? true` so the outer tool wrapper relays the message verbatim.
+
+  Inactive (`:active false`) matches are excluded (BOT-739): a deleted or re-uploaded CSV table has
+  its physical warehouse table dropped while its app-DB row lingers as `:active false` (sync doesn't
+  retire inactive uploaded tables), and the metadata provider intentionally skips its active filter
+  for by-name lookups (see `metadata-spec->honey-sql`). Resolving a stale portable FK to that dead
+  row would compile to SQL hitting a table that no longer exists. When the *only* matches are
+  inactive we surface a deleted/replaced-specific hint so the LLM re-lists instead of re-using the
+  stale name. `(not (false? :active))` keeps mock providers (which omit `:active`) resolving."
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)
@@ -150,9 +180,13 @@
                        :agent-error? true
                        :path         path
                        :expected-db  current-db})))
-    (let [candidates (table-candidates metadata-provider current-db-id path-schema path-table-name)]
+    (let [matches    (table-candidates metadata-provider current-db-id path-schema path-table-name)
+          candidates (filterv #(not (false? (:active %))) matches)]
       (case (count candidates)
-        0 (throw (unknown-table-ex-info metadata-provider path))
+        0 (throw (if (seq matches)
+                   ;; matched only inactive row(s) → table was deleted or replaced
+                   (deleted-table-ex-info path)
+                   (unknown-table-ex-info metadata-provider path)))
         1 (first candidates)
         ;; Deliberately do NOT enumerate the matching `[schema name id]` tuples — the metadata
         ;; provider is un-sandboxed, so a leaked candidate list could surface tables the caller

--- a/src/metabase/models/serialization/resolve/mp.clj
+++ b/src/metabase/models/serialization/resolve/mp.clj
@@ -105,29 +105,18 @@
   prompts the agent with a hallucinated `source-table:` would otherwise receive a list of
   schemas / tables they cannot otherwise see.
 
+  For the same reason this single message covers BOTH a never-existed miss and a match that
+  exists only as an inactive (deleted / re-uploaded) row — see [[find-table]]. Branching the
+  wording on whether an inactive row exists would be an oracle: it would confirm to a sandboxed
+  caller that a given name was once a real table. The deletion hint is therefore worded
+  unconditionally (\"may have been deleted or replaced\") so it helps the common case without
+  leaking existence.
+
   The LLM can still self-correct in one turn by calling `entity_details` on the parent
   database; the message points it at that path."
   [_metadata-provider [_path-db-name _path-schema _path-table-name :as path]]
-  (ex-info (tru "No table found matching portable FK {0}. Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
+  (ex-info (tru "No table found matching portable FK {0} — it may not exist, or may have been deleted or replaced (a re-uploaded CSV is recreated under a new name). Call `entity_details` with entity-type `database` and the database''s numeric id to list available tables and schemas, then retry with an exact portable FK from the response."
                 (pr-str path))
-           {:status-code  400
-            :error        :unknown-table
-            :agent-error? true
-            :path         path}))
-
-(defn- deleted-table-ex-info
-  "Build an agent-facing `:unknown-table` error for a portable FK whose only app-DB match is
-  inactive — the table was deleted or replaced. For a re-uploaded CSV the physical table is dropped
-  and recreated under a new timestamped name, so the old portable FK lingers in the conversation and
-  no longer points at anything live. Nudge the LLM to re-list the database's current tables rather
-  than re-using the stale name. Keeps `:error :unknown-table` so callers branching on the code treat
-  it identically to a never-existed miss; only the message differs.
-
-  Naming the requested `(schema, table-name)` is not an info leak: the caller supplied them, and an
-  inactive match confirms only a now-gone table, never a currently-visible one."
-  [[_path-db-name path-schema path-table-name :as path]]
-  (ex-info (tru "Table {0} (schema {1}) was deleted or replaced and no longer exists. If it was re-uploaded it now has a different name; call `entity_details` with entity-type `database` to list the current tables, then retry with an exact portable FK."
-                (pr-str path-table-name) (pr-str path-schema))
            {:status-code  400
             :error        :unknown-table
             :agent-error? true
@@ -146,9 +135,8 @@
   becomes authoritative, since the alternative is a confusing `:unknown-table` raised for a
   table the caller can plainly see via `entity_details`.
 
-  Returns raw matches including inactive (`:active false`) rows; [[find-table]] does the
-  active/inactive partition so it can tell a deleted/re-uploaded table apart from a never-existed
-  one."
+  Returns raw matches including inactive (`:active false`) rows; [[find-table]] drops the inactive
+  ones."
   [metadata-provider db-id schema table-name]
   (or (when (and db-id (app-db-backed-provider? metadata-provider))
         (seq (matching-tables-via-app-db db-id schema table-name)))
@@ -166,9 +154,10 @@
   its physical warehouse table dropped while its app-DB row lingers as `:active false` (sync doesn't
   retire inactive uploaded tables), and the metadata provider intentionally skips its active filter
   for by-name lookups (see `metadata-spec->honey-sql`). Resolving a stale portable FK to that dead
-  row would compile to SQL hitting a table that no longer exists. When the *only* matches are
-  inactive we surface a deleted/replaced-specific hint so the LLM re-lists instead of re-using the
-  stale name. `(not (false? :active))` keeps mock providers (which omit `:active`) resolving."
+  row would compile to SQL hitting a table that no longer exists, so an inactive-only match is
+  treated as a miss. The miss message (see [[unknown-table-ex-info]]) is the same whether the table
+  never existed or is merely inactive — deliberately, to avoid an existence oracle. `(:active %)` is
+  compared with `(not (false? …))` so mock providers (which omit `:active`) still resolve."
   [metadata-provider [path-db-name path-schema path-table-name :as path]]
   (let [{current-db :name, current-db-id :id} (lib.metadata/database metadata-provider)]
     (when-not (= path-db-name current-db)
@@ -180,13 +169,10 @@
                        :agent-error? true
                        :path         path
                        :expected-db  current-db})))
-    (let [matches    (table-candidates metadata-provider current-db-id path-schema path-table-name)
-          candidates (filterv #(not (false? (:active %))) matches)]
+    (let [candidates (filterv #(not (false? (:active %)))
+                              (table-candidates metadata-provider current-db-id path-schema path-table-name))]
       (case (count candidates)
-        0 (throw (if (seq matches)
-                   ;; matched only inactive row(s) → table was deleted or replaced
-                   (deleted-table-ex-info path)
-                   (unknown-table-ex-info metadata-provider path)))
+        0 (throw (unknown-table-ex-info metadata-provider path))
         1 (first candidates)
         ;; Deliberately do NOT enumerate the matching `[schema name id]` tuples — the metadata
         ;; provider is un-sandboxed, so a leaked candidate list could surface tables the caller

--- a/test/metabase/models/serialization/resolve/mp_test.clj
+++ b/test/metabase/models/serialization/resolve/mp_test.clj
@@ -144,10 +144,9 @@
 
 (deftest import-table-fk-inactive-table-test
   (testing "a portable FK to an inactive table (deleted / re-uploaded CSV) must NOT resolve"
-    ;; BOT-739-adjacent: a deleted / re-uploaded upload leaves an inactive app-DB row whose
-    ;; warehouse table is gone, so resolving a stale portable FK to it yields "table not found".
-    ;; It must be a miss — and the miss message must match a never-existed miss (asserted below),
-    ;; since distinguishing them would be an existence oracle.
+    ;; A deleted / re-uploaded upload leaves an inactive app-DB row whose warehouse table is gone;
+    ;; a stale FK to it must miss, with a message identical to a never-existed miss (asserted
+    ;; below) since distinguishing them would be an existence oracle.
     (mt/with-temp [:model/Database db    {:name (str "Uploads " (random-uuid)) :engine :h2}
                    :model/Table    _gone {:name   "metabot2_38513168ae9131" :schema "PUBLIC"
                                           :db_id  (:id db)                   :active false}]
@@ -169,6 +168,23 @@
                   ;; same wording modulo the echoed portable FK (which the caller supplied either way)
                   (is (= (str/replace msg #"\[.*?\]" "[FK]")
                          (str/replace never-existed #"\[.*?\]" "[FK]"))))))))))))
+
+(deftest matching-tables-via-provider-drops-inactive-test
+  (testing "matching-tables-via-provider filters the inactive rows the provider surfaces by name"
+    ;; Isolates the provider-side filter. By-name `metadatas` lookups skip the provider's SQL
+    ;; `active = true` clause (it only guards enumerate-all queries), so the inactive row reaches
+    ;; `matching-tables-via-provider`, whose filter is the only thing that drops it.
+    (mt/with-temp [:model/Database db    {:name (str "Uploads " (random-uuid)) :engine :h2}
+                   :model/Table    _gone {:name   "metabot2_deadbeefcafe01" :schema "PUBLIC"
+                                          :db_id  (:id db)                   :active false}]
+      (let [mp (lib-be/application-database-metadata-provider (:id db))]
+        (testing "the provider DOES surface the inactive row on a raw by-name lookup"
+          (is (= [false]
+                 (mapv :active
+                       (lib.metadata.protocols/metadatas
+                        mp {:lib/type :metadata/table :name #{"metabot2_deadbeefcafe01"}})))))
+        (testing "...but matching-tables-via-provider drops it"
+          (is (empty? (#'resolve.mp/matching-tables-via-provider mp "PUBLIC" "metabot2_deadbeefcafe01"))))))))
 
 (deftest ^:parallel import-table-fk-error-test
   (testing "unknown table name → :unknown-table, agent-error?, 400, no info leak"

--- a/test/metabase/models/serialization/resolve/mp_test.clj
+++ b/test/metabase/models/serialization/resolve/mp_test.clj
@@ -6,6 +6,7 @@
 
   Phase-2 additions (step 11): `import-fk` for `Card` by entity_id."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -151,6 +152,10 @@
     ;; 'metabot2_…' not found"). The resolver must instead surface a clean :unknown-table
     ;; agent-error so the LLM re-lists the current tables. Resolving inactive rows is a real bug
     ;; regardless of whether it's what BOT-739 hit.
+    ;;
+    ;; The miss message is the SAME as a never-existed miss (asserted below): branching the wording
+    ;; on whether an inactive row exists would be an existence oracle against the un-sandboxed
+    ;; provider, so the deletion hint is worded unconditionally in [[unknown-table-ex-info]].
     (mt/with-temp [:model/Database db    {:name (str "Uploads " (random-uuid)) :engine :h2}
                    :model/Table    _gone {:name   "metabot2_38513168ae9131" :schema "PUBLIC"
                                           :db_id  (:id db)                   :active false}]
@@ -165,9 +170,13 @@
               (is (= :unknown-table (:error d)))
               (is (= 400 (:status-code d)))
               (is (true? (:agent-error? d)))
-              (testing "message tells the LLM the table was deleted/replaced and to re-list"
-                (is (re-find #"deleted or replaced" msg))
-                (is (re-find #"entity_details" msg))))))))))
+              (is (re-find #"entity_details" msg) "message points the LLM at entity_details to re-list")
+              (testing "inactive-row miss is indistinguishable from a never-existed miss (no oracle)"
+                (let [never-existed (try (resolve/import-table-fk r [(:name db) "PUBLIC" "never_existed_xyz"])
+                                         (catch clojure.lang.ExceptionInfo e2 (.getMessage e2)))]
+                  ;; same wording modulo the echoed portable FK (which the caller supplied either way)
+                  (is (= (str/replace msg #"\[.*?\]" "[FK]")
+                         (str/replace never-existed #"\[.*?\]" "[FK]"))))))))))))
 
 (deftest ^:parallel import-table-fk-error-test
   (testing "unknown table name → :unknown-table, agent-error?, 400, no info leak"

--- a/test/metabase/models/serialization/resolve/mp_test.clj
+++ b/test/metabase/models/serialization/resolve/mp_test.clj
@@ -141,6 +141,34 @@
         (is (= (:id raw-orders)   (resolve/import-table-fk r [(:name db) "RAW"   "ORDERS"])))
         (is (= (:id clean-orders) (resolve/import-table-fk r [(:name db) "CLEAN" "ORDERS"])))))))
 
+(deftest import-table-fk-inactive-table-test
+  (testing "a portable FK to an inactive table (deleted / re-uploaded CSV) must NOT resolve"
+    ;; One mechanism behind the BOT-739 symptom (not confirmed to be the customer's exact trigger):
+    ;; an uploaded CSV table is dropped from the warehouse and its app-DB row marked `:active false`
+    ;; by `upload/delete-upload!`, but the row lingers (sync doesn't retire inactive uploaded
+    ;; tables). A follow-up Metabot turn carrying the stale portable FK would previously resolve to
+    ;; that dead row and compile to SQL hitting a non-existent warehouse table ("Table
+    ;; 'metabot2_…' not found"). The resolver must instead surface a clean :unknown-table
+    ;; agent-error so the LLM re-lists the current tables. Resolving inactive rows is a real bug
+    ;; regardless of whether it's what BOT-739 hit.
+    (mt/with-temp [:model/Database db    {:name (str "Uploads " (random-uuid)) :engine :h2}
+                   :model/Table    _gone {:name   "metabot2_38513168ae9131" :schema "PUBLIC"
+                                          :db_id  (:id db)                   :active false}]
+      (let [mp (lib-be/application-database-metadata-provider (:id db))
+            r  (resolve.mp/import-resolver mp)]
+        (try
+          (resolve/import-table-fk r [(:name db) "PUBLIC" "metabot2_38513168ae9131"])
+          (is false "expected throw")
+          (catch clojure.lang.ExceptionInfo e
+            (let [d   (ex-data e)
+                  msg (.getMessage e)]
+              (is (= :unknown-table (:error d)))
+              (is (= 400 (:status-code d)))
+              (is (true? (:agent-error? d)))
+              (testing "message tells the LLM the table was deleted/replaced and to re-list"
+                (is (re-find #"deleted or replaced" msg))
+                (is (re-find #"entity_details" msg))))))))))
+
 (deftest ^:parallel import-table-fk-error-test
   (testing "unknown table name → :unknown-table, agent-error?, 400, no info leak"
     (let [r (resolve.mp/import-resolver mp-simple)]

--- a/test/metabase/models/serialization/resolve/mp_test.clj
+++ b/test/metabase/models/serialization/resolve/mp_test.clj
@@ -144,18 +144,10 @@
 
 (deftest import-table-fk-inactive-table-test
   (testing "a portable FK to an inactive table (deleted / re-uploaded CSV) must NOT resolve"
-    ;; One mechanism behind the BOT-739 symptom (not confirmed to be the customer's exact trigger):
-    ;; an uploaded CSV table is dropped from the warehouse and its app-DB row marked `:active false`
-    ;; by `upload/delete-upload!`, but the row lingers (sync doesn't retire inactive uploaded
-    ;; tables). A follow-up Metabot turn carrying the stale portable FK would previously resolve to
-    ;; that dead row and compile to SQL hitting a non-existent warehouse table ("Table
-    ;; 'metabot2_…' not found"). The resolver must instead surface a clean :unknown-table
-    ;; agent-error so the LLM re-lists the current tables. Resolving inactive rows is a real bug
-    ;; regardless of whether it's what BOT-739 hit.
-    ;;
-    ;; The miss message is the SAME as a never-existed miss (asserted below): branching the wording
-    ;; on whether an inactive row exists would be an existence oracle against the un-sandboxed
-    ;; provider, so the deletion hint is worded unconditionally in [[unknown-table-ex-info]].
+    ;; BOT-739-adjacent: a deleted / re-uploaded upload leaves an inactive app-DB row whose
+    ;; warehouse table is gone, so resolving a stale portable FK to it yields "table not found".
+    ;; It must be a miss — and the miss message must match a never-existed miss (asserted below),
+    ;; since distinguishing them would be an existence oracle.
     (mt/with-temp [:model/Database db    {:name (str "Uploads " (random-uuid)) :engine :h2}
                    :model/Table    _gone {:name   "metabot2_38513168ae9131" :schema "PUBLIC"
                                           :db_id  (:id db)                   :active false}]


### PR DESCRIPTION
## Summary

Fixes a surprising behavior found while investigating [BOT-739](https://linear.app/metabase/issue/BOT-739) — almost certainly not its actual cause: the agent's portable-FK resolver resolves `[db, schema, table]` references to **inactive** tables. 

A deleted or re-uploaded CSV leaves an `:active false` app-DB row for the deleted table, so a stale FK lingering in a Metabot conversation resolves to it and compiles to SQL hitting a missing table → `Table '…' not found`.

Instead I would expect the FK not to resolve, preventing needless execution of the query and confusing the agent.

## Change

`resolve.mp/find-table` now resolves only against active matches; an inactive-only match is treated as a miss. The `:unknown-table` message is identical whether the table never existed or is inactive, to avoid an existence oracle against the un-sandboxed resolver.

## Tests

`import-table-fk-inactive-table-test` plus resolver/consumer layers — 0 failures.

## Not addressed

The native-SQL path (`edit_sql_query`/`replace_sql_query`) bakes a physical table name into conversation state and never re-resolves it — a separate gap that can produce the same symptom.
