### PR TITLE
Send expandedIds when clicking on a table collection in table view of Data Studio

### DIFF
--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.tsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router";
+import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
+import { useCollectionPath } from "metabase/data-studio/common/hooks/use-collection-path/useCollectionPath";
 import { Box } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { Table } from "metabase-types/api";
@@ -14,6 +16,14 @@ type TableCollectionProps = {
 
 export function TableCollection({ table }: TableCollectionProps) {
   const { collection } = table;
+  const { path } = useCollectionPath({ collectionId: collection?.id ?? null });
+
+  // Expand the path down to the published collection (skipping the library
+  // root, which isn't a tree node) so it's revealed instead of the root.
+  const expandedIds = match({ path, collection })
+    .with({ path: P.nonNullable }, ({ path }) => path.slice(1).map((c) => c.id))
+    .with({ collection: P.nonNullable }, ({ collection }) => [collection.id])
+    .otherwise(() => []);
 
   return (
     <>
@@ -22,7 +32,7 @@ export function TableCollection({ table }: TableCollectionProps) {
           <Box
             className={S.link}
             component={Link}
-            to={Urls.dataStudioLibrary({ expandedIds: [collection.id] })}
+            to={Urls.dataStudioLibrary({ expandedIds })}
             fw="bold"
           >
             {collection.name}

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableCollection.unit.spec.tsx
@@ -1,0 +1,91 @@
+import { Route } from "react-router";
+
+import { setupCollectionByIdEndpoint } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Collection, Table } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockTable,
+} from "metabase-types/api/mocks";
+
+import { TableCollection } from "./TableCollection";
+
+const ROOT_ANCESTOR = createMockCollection({
+  id: "root",
+  name: "Our analytics",
+});
+const LIBRARY = createMockCollection({ id: 5, name: "Library" });
+const DATA = createMockCollection({ id: 6, name: "Data" });
+
+function setup({
+  collection,
+  ancestors,
+}: {
+  collection: Collection | null;
+  ancestors?: Collection[];
+}) {
+  const table: Table = createMockTable({
+    collection_id: collection?.id ?? null,
+    collection: collection ?? undefined,
+  });
+
+  setupCollectionByIdEndpoint({
+    collections: [
+      createMockCollection({ id: "root", name: "Our analytics" }),
+      ...(collection
+        ? [{ ...collection, effective_ancestors: ancestors ?? [] }]
+        : []),
+    ],
+  });
+
+  renderWithProviders(
+    <Route path="/" component={() => <TableCollection table={table} />} />,
+    { withRouter: true },
+  );
+}
+
+describe("TableCollection", () => {
+  it("links a nested published collection to the library expanded down to that collection (metabase#UXW-4171)", async () => {
+    const ordersCollection = createMockCollection({
+      id: 8,
+      name: "Orders collection",
+    });
+
+    setup({
+      collection: ordersCollection,
+      ancestors: [ROOT_ANCESTOR, LIBRARY, DATA],
+    });
+
+    const link = await screen.findByRole("link", {
+      name: "Orders collection",
+    });
+
+    // Must expand the Data root (6) AND the collection itself (8) so the
+    // referenced collection is actually revealed — not just the library root.
+    expect(link).toHaveAttribute(
+      "href",
+      "/data-studio/library?expandedId=6&expandedId=8",
+    );
+  });
+
+  it("links a top-level published collection to the library expanded to it", async () => {
+    const dataCollection = createMockCollection({ id: 6, name: "Data" });
+
+    setup({
+      collection: dataCollection,
+      ancestors: [ROOT_ANCESTOR, LIBRARY],
+    });
+
+    const link = await screen.findByRole("link", { name: "Data" });
+
+    expect(link).toHaveAttribute("href", "/data-studio/library?expandedId=6");
+  });
+
+  it("shows a no-access message when the collection is not available", () => {
+    setup({ collection: null });
+
+    expect(
+      screen.getByText("You don't have access to this collection"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Small change to the TableCollection component so that it can fetch a table collections's path and properly expand the library tree when clicked

### How to verify

1. Go to Data Studio -> Tables
2. Navigate to a publshed table
3. In the table section, scroll down to the pubished table. click the link
4. You should be brought to the library with the collections expanded to show the target collection

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
