### PR TITLE
Make defaulted defendpoint params Optional in OpenAPI

### DIFF
--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -52,7 +52,7 @@
 
 (mu/defn- merge-required :- :metabase.api.open-api/parameter.schema.object
   [schema]
-  (let [optional? (set (keep (fn [[k v]] (when (:optional v) k))
+  (let [optional? (set (keep (fn [[k v]] (when (or (:optional v) (contains? v :default)) k))
                              (:properties schema)))]
     (-> schema
         (m/update-existing :required #(into []
@@ -149,8 +149,9 @@
           :let             [k (get renames k k)]
           :when            (in-fn k)
           :let             [schema    (fix-json-schema param-schema)
-                            ;; if schema does not indicate it's optional, it's not :)
-                            optional? (:optional schema)]]
+                            ;; optional if flagged so, or if it carries a `:default` (a defaulted param is
+                            ;; safe to omit, so it shouldn't be advertised as required)
+                            optional? (or (:optional schema) (contains? schema :default))]]
       (cond-> {:in          (in-fn k)
                :name        (u/qualified-name k)
                :required    (and (contains? required k) (not optional?))

--- a/test/metabase/api/macros/defendpoint/open_api_test.clj
+++ b/test/metabase/api/macros/defendpoint/open_api_test.clj
@@ -40,6 +40,24 @@
             (#'defendpoint.open-api/fix-json-schema
              (mjs/transform (ms/maps-with-unique-key [:sequential [:map [:id :int]]] :id)))))))
 
+(deftest ^:parallel default-params-are-optional-test
+  (testing "a param carrying a :default is advertised as optional, since omitting it is safe"
+    (binding [defendpoint.open-api/*definitions* (atom (sorted-map))]
+      (let [by-name (into {}
+                          (map (juxt :name identity))
+                          (#'defendpoint.open-api/schema->params*
+                           [:map
+                            [:required-param :string]
+                            [:defaulted-param {:default :api} [:enum :api :x]]
+                            [:optional-param {:optional true} :string]]
+                           (constantly :query)
+                           {}))]
+        (is (true?  (get-in by-name ["required-param" :required])))
+        (is (false? (get-in by-name ["defaulted-param" :required])))
+        (is (false? (get-in by-name ["optional-param" :required])))
+        (testing "the default value is still rendered in the param schema"
+          (is (= :api (get-in by-name ["defaulted-param" :schema :default]))))))))
+
 (deftest ^:parallel collect-definitions-test
   (binding [defendpoint.open-api/*definitions* (atom [])]
     (is (=? {:properties {:value {:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}}}


### PR DESCRIPTION
A query/body param that carries a `:default` is safe to omit, so the generated OpenAPI should advertise it as optional rather than required. Both param paths (merge-required for bodies, schema->params* for query/path) now treat a `:default`-bearing property as optional; the default value is still rendered.

This also lets endpoints use the natural `{:default x}` idiom (which already injects the default at runtime via default-value-transformer) without the param showing up as required in the docs.