### PR TITLE
Make workspace db updates in a transaction

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -222,18 +222,15 @@
     (when (some #(= database-id (:database_id %)) (:databases ws))
       (throw (ex-info "Database already in workspace"
                       {:status-code 409 :workspace_id workspace-id :database_id database-id})))
-    (let [wsd-id (t2/insert-returning-pk! :model/WorkspaceDatabase
-                                          {:workspace_id     workspace-id
-                                           :database_id      database-id
-                                           :input_schemas    input-schemas
-                                           :database_details {}
-                                           :output_namespace ""})]
-      (try
-        (provisioning/provision-single! wsd-id)
-        (catch Throwable t
-          (t2/delete! :model/WorkspaceDatabase :id wsd-id)
-          (throw t)))
-      (workspace/get-workspace workspace-id))))
+    (t2/with-transaction [_conn]
+      (let [wsd-id (t2/insert-returning-pk! :model/WorkspaceDatabase
+                                            {:workspace_id     workspace-id
+                                             :database_id      database-id
+                                             :input_schemas    input-schemas
+                                             :database_details {}
+                                             :output_namespace ""})]
+        (provisioning/provision-single! wsd-id)))
+    (workspace/get-workspace workspace-id)))
 
 (defn update-database!
   "Update a database's config in a workspace: deprovision the existing one (if provisioned),
@@ -245,9 +242,10 @@
     (assert-input-schemas-when-supported! database-id input-schemas)
     (when (= :provisioned (:status wsd))
       (provisioning/deprovision-single! (:id wsd)))
-    (t2/update! :model/WorkspaceDatabase {:id (:id wsd)}
-                {:input_schemas input-schemas})
-    (provisioning/provision-single! (:id wsd))
+    (t2/with-transaction [_conn]
+      (t2/update! :model/WorkspaceDatabase {:id (:id wsd)}
+                  {:input_schemas input-schemas})
+      (provisioning/provision-single! (:id wsd)))
     (workspace/get-workspace workspace-id)))
 
 (defn remove-database!

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -237,15 +237,17 @@
    update `input-schemas`, then reprovision (blocking). `input-schemas` is a vector of
    driver-opaque schema name strings. Returns the updated workspace, hydrated."
   [workspace-id database-id input-schemas]
-  (let [ws  (assert-workspace-exists workspace-id)
-        wsd (find-wsd ws database-id)]
+  (let [ws     (assert-workspace-exists workspace-id)
+        wsd    (find-wsd ws database-id)
+        wsd-id (:id wsd)]
     (assert-input-schemas-when-supported! database-id input-schemas)
     (when (= :provisioned (:status wsd))
-      (provisioning/deprovision-single! (:id wsd)))
-    (t2/with-transaction [_conn]
-      (t2/update! :model/WorkspaceDatabase {:id (:id wsd)}
-                  {:input_schemas input-schemas})
-      (provisioning/provision-single! (:id wsd)))
+      (provisioning/deprovision-single! wsd-id))
+    (provisioning/with-workspace-database-lock wsd-id
+      (t2/with-transaction [_conn]
+        (t2/update! :model/WorkspaceDatabase {:id wsd-id}
+                    {:input_schemas input-schemas})
+        (provisioning/provision-single! wsd-id)))
     (workspace/get-workspace workspace-id)))
 
 (defn remove-database!

--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -83,8 +83,7 @@
   on success, or back to `:unprovisioned` on failure."
   [workspace-database-id provisioner]
   (try
-    (cluster-lock/with-cluster-lock {:lock            (wsd-lock-key workspace-database-id)
-                                     :timeout-seconds provisioning-lock-timeout-seconds}
+    (with-workspace-database-lock workspace-database-id
       (let [wsd (t2/select-one :model/WorkspaceDatabase :id workspace-database-id)]
         (when-not wsd
           (throw (ex-info "WorkspaceDatabase not found" {:id workspace-database-id})))
@@ -120,8 +119,7 @@
   or back to `:provisioned` on failure."
   [workspace-database-id provisioner]
   (try
-    (cluster-lock/with-cluster-lock {:lock            (wsd-lock-key workspace-database-id)
-                                     :timeout-seconds provisioning-lock-timeout-seconds}
+    (with-workspace-database-lock workspace-database-id
       (let [wsd (t2/select-one :model/WorkspaceDatabase :id workspace-database-id)]
         (when-not wsd
           (throw (ex-info "WorkspaceDatabase not found" {:id workspace-database-id})))
@@ -148,9 +146,9 @@
               ;; by iso namespace alone is correct.
               ;;
               ;; Rebind `*current-connectable*` to nil so the DELETE runs on a
-              ;; fresh autocommit connection outside the `with-cluster-lock` tx.
-              ;; Otherwise, when `destroy!` throws, the surrounding tx rolls back
-              ;; and undoes the DELETE.
+              ;; fresh autocommit connection outside the workspace-database lock's
+              ;; tx. Otherwise, when `destroy!` throws, the surrounding tx rolls
+              ;; back and undoes the DELETE.
               (binding [t2.connection/*current-connectable* nil]
                 (ws.remapping-cleanup/clear-mappings-for-iso! db
                                                               (:database_id wsd)

--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -59,6 +59,22 @@
   (keyword "metabase-enterprise.workspaces.provisioning"
            (str "wsd-" workspace-database-id)))
 
+(defn do-with-workspace-database-lock
+  "Run `thunk` while holding the per-row cluster lock for `workspace-database-id`.
+   [[provision-single!]]/[[deprovision-single!]] take this same lock internally, so
+   the acquisition here is reentrant — it lets a caller atomically combine an app-db
+   change with provisioning under a single lock, acquired *before* the row is
+   mutated (the lock-before-mutate order the rest of the system relies on)."
+  [workspace-database-id thunk]
+  (cluster-lock/with-cluster-lock {:lock            (wsd-lock-key workspace-database-id)
+                                   :timeout-seconds provisioning-lock-timeout-seconds}
+    (thunk)))
+
+(defmacro with-workspace-database-lock
+  "Sugar over [[do-with-workspace-database-lock]]."
+  [workspace-database-id & body]
+  `(do-with-workspace-database-lock ~workspace-database-id (fn [] ~@body)))
+
 ;;; ---------------------------------------- Single-database operations -----------------------------------------------
 
 (defn provision-workspace-database!

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -125,7 +125,24 @@
           (let [ws' (ws/update-database! (:id ws) (mt/id) ["PUBLIC" "ANALYTICS"])]
             (is (= ["PUBLIC" "ANALYTICS"]
                    (:input_schemas (first (:databases ws')))))
-            (is (= :provisioned (:status (first (:databases ws')))))))))))
+            (is (= :provisioned (:status (first (:databases ws'))))))))))
+  (testing "reprovision failure rolls the input-schemas change back"
+    (mt/with-model-cleanup [:model/Workspace]
+      (let [ws (ws/create-workspace! {:name "Update Roll Back" :creator_id (mt/user->id :crowberto)})]
+        (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+          (ws/add-database! (:id ws) (mt/id) ["PUBLIC"]))
+        (let [failing-provisioner (reify provisioning/Provisioner
+                                    (init!    [_ _ _ _]   (throw (ex-info "failure" {})))
+                                    (grant!   [_ _ _ _ _] nil)
+                                    (destroy! [_ _ _ _]   nil))]
+          (with-redefs [provisioning/dispatching-provisioner failing-provisioner]
+            (is (thrown-with-msg? ExceptionInfo #"boom"
+                                  (ws/update-database! (:id ws) (mt/id) ["PUBLIC" "ANALYTICS"]))))
+          (let [wsd (first (:databases (ws/get-workspace (:id ws))))]
+            (is (= ["PUBLIC"] (:input_schemas wsd))
+                "the new input_schemas must not commit when reprovisioning fails")
+            (is (= :unprovisioned (:status wsd))
+                "the row is left unprovisioned, consistent with the torn-down warehouse")))))))
 
 ;;; ----------------------------------------- Delete Workspace ------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -136,7 +136,7 @@
                                     (grant!   [_ _ _ _ _] nil)
                                     (destroy! [_ _ _ _]   nil))]
           (with-redefs [provisioning/dispatching-provisioner failing-provisioner]
-            (is (thrown-with-msg? ExceptionInfo #"boom"
+            (is (thrown-with-msg? ExceptionInfo #"failure"
                                   (ws/update-database! (:id ws) (mt/id) ["PUBLIC" "ANALYTICS"]))))
           (let [wsd (first (:databases (ws/get-workspace (:id ws))))]
             (is (= ["PUBLIC"] (:input_schemas wsd))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GHY-3711/avoid-creating-a-database-entry-on-provisioning-failure