### PR TITLE
Re-clone remote sync repo if its temp dir was deleted (GHY-3815)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -424,7 +424,7 @@
   (FileUtils/deleteDirectory repo-path))
 
 (defn- get-jgit [^File path {:keys [remote-url token] :as args}]
-  (if-let [obj (get @jgit (.getPath path))]
+  (if-let [obj (when (.exists path) (get @jgit (.getPath path)))]
     obj
     (get (swap! jgit assoc (.getPath path) (u/prog1 (open-jgit path {:remote-url remote-url
                                                                      :token      token})

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -451,6 +451,27 @@
                (map :message (git/log repaired-source)))
             "Should be able to fetch after origin repair")))))
 
+(deftest get-jgit-reclones-after-local-repo-deleted-test
+  (testing "GHY-3815: if the cached local clone dir is deleted out from under us, the next
+            operation re-clones instead of returning a stale cached Git instance (which fails
+            permanently with 'origin: not found' until an instance restart)"
+    (mt/with-temp-dir [remote-dir nil]
+      (let [[source remote] (init-source! "master" remote-dir :branches ["branch-1"])
+            remote-url (:remote-url source)
+            local-path (#'git/repo-path {:remote-url remote-url})
+            ^Git cached-git (:git source)]
+        (is (.exists local-path) "Precondition: local clone dir exists after the initial clone")
+        (is (= ["branch-1" "master"] (source.p/branches source))
+            "Precondition: branches works before the dir is deleted")
+        (FileUtils/deleteDirectory local-path)
+        (is (not (.exists local-path)) "Local clone dir is gone")
+        (let [fresh-source (->source! "master" remote)]
+          (is (.exists local-path) "Local clone dir was re-created (re-cloned)")
+          (is (not (identical? cached-git (:git fresh-source)))
+              "A fresh Git instance is returned, not the stale cached one")
+          (is (= ["branch-1" "master"] (source.p/branches fresh-source))
+              "branches works again after the dir was deleted, without an instance restart"))))))
+
 (deftest ^:parallel credentials-provider-test
   (testing "GitHub URL uses x-access-token"
     (let [provider (git/credentials-provider "https://github.com/org/repo.git" "my-token")]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/git_test.clj
@@ -458,7 +458,7 @@
     (mt/with-temp-dir [remote-dir nil]
       (let [[source remote] (init-source! "master" remote-dir :branches ["branch-1"])
             remote-url (:remote-url source)
-            local-path (#'git/repo-path {:remote-url remote-url})
+            ^File local-path (#'git/repo-path {:remote-url remote-url})
             ^Git cached-git (:git source)]
         (is (.exists local-path) "Precondition: local clone dir exists after the initial clone")
         (is (= ["branch-1" "master"] (source.p/branches source))


### PR DESCRIPTION
## Problem

If `\$TMPDIR/metabase-git` is deleted, all remote sync operations fail permanently with `origin: not found` — recoverable only by restarting the instance.

Fixes [GHY-3815](https://linear.app/metabase/issue/GHY-3815). Closes #71364.

## Root cause

`get-jgit` caches `Git` instances in an in-memory atom keyed by repo path, and returned a cached instance without checking whether the underlying directory still existed. Once the directory was deleted, the cached `Git` instance's `StoredConfig` could no longer read the config, so JGit dropped the `origin` remote and treated `"origin"` as a literal (nonexistent) path. Every operation (`branches`, `default-branch`, `snapshot`, push/pull) flows through `git-source` → `get-jgit`, so all of them broke until restart (which works because the atom starts empty and re-clones).

## Fix

Only return the cached instance when its directory still exists on disk:

```clojure
(if-let [obj (when (.exists path) (get @jgit (.getPath path)))]
```

If the directory is gone, `get-jgit` falls through to `open-jgit`, which re-clones (the path is missing) and the `swap! assoc` overwrites the stale cache entry. Since `git-source` is constructed fresh per request, the next operation recovers with no restart. This complements the existing `stale-cache-error?` recovery in `snapshot`, which handles a different case (force-push staleness, where the directory still exists).

## Test

Added `get-jgit-reclones-after-local-repo-deleted-test`: deletes the cached clone dir, then asserts the next source construction re-creates the dir, returns a fresh `Git` instance, and that `branches` works again. The `.exists`/`identical?` assertions are deterministic regression guards — verified failing without the fix (2 failures, 1 error) and passing with it.

Full namespace passes (25 tests, 92 assertions); kondo clean.