### PR TITLE
Improve API, add styles isolation, add router components

### DIFF
--- a/.claude/skills/add-data-app-routing/SKILL.md
+++ b/.claude/skills/add-data-app-routing/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: add-data-app-routing
+description: Add client-side routing (multiple pages) to an existing Metabase data-app project using the host-provided `DataAppRouter`, `DataAppLink`, and `useDataAppLocation` primitives. Use when the user has an existing data-app project and wants more than one page.
+---
+
+# Add routing to a data-app
+
+A Metabase data-app bundle doesn't bundle a router library — it uses three small primitives the host endows on `globalThis`:
+
+| API | Purpose |
+|---|---|
+| `<DataAppRouter>` | Wrap the app once. Tracks the current sub-path. Auto-detects the iframe's URL prefix; bundle author writes no basename. |
+| `<DataAppLink to="/customers/42">` | Internal navigation link. Renders a real `<a href>` so middle-click / cmd-click open in a new tab. |
+| `useDataAppLocation()` | Returns `{ pathname, navigate }`. Use `pathname` for match-by-equality / `startsWith` rendering; use `navigate(to)` for programmatic nav. |
+
+That's the entire surface. **No `react-router` of any version, no `<BrowserRouter>`, no `<HashRouter>`.** The API is deliberately decoupled from any router library so a future Metabase version can swap the underlying implementation without touching bundle code.
+
+## When to use this skill
+
+- The user has a working data-app project — `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview.
+- The user wants the bundle to render different content at different URLs (`/overview`, `/customers/:id`).
+- **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, stop and tell the user a project needs to exist first.
+
+## Step 1 — Add the endowment types to `src/globals.d.ts`
+
+Extend `globalThis` so TypeScript knows the routing primitives. The types use only plain React DOM types — no `react-router` types leak in.
+
+```ts
+declare global {
+  // ... existing MetabaseProvider / StaticQuestion / etc. types
+
+  var DataAppRouter: (props: { children?: React.ReactNode }) => JSX.Element;
+
+  var DataAppLink: (
+    props: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      to: string;
+      children?: React.ReactNode;
+    },
+  ) => JSX.Element;
+
+  var useDataAppLocation: () => {
+    pathname: string;
+    navigate: (to: string) => void;
+  };
+}
+
+export {};
+```
+
+## Step 2 — Wrap `App.tsx` with `<DataAppRouter>`
+
+Read the destructured globals at module load like the other endowments. The router does NOT take a `basename` prop — it auto-detects the iframe's URL prefix (`/embed/data-app/<name>`) in production and resolves to no prefix in the Vite dev preview.
+
+```tsx
+import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
+
+const {
+  MetabaseProvider,
+  StaticQuestion,
+  DataAppRouter,
+  DataAppLink,
+  useDataAppLocation,
+} = globalThis;
+
+const sdkTheme: MetabaseTheme = {
+  // (your existing theme)
+};
+
+function Nav() {
+  return (
+    <nav style={{ padding: 16, borderBottom: "1px solid #e5e7eb" }}>
+      <DataAppLink to="/" style={{ marginRight: 16 }}>Overview</DataAppLink>
+      <DataAppLink to="/customers/42">Customer 42</DataAppLink>
+    </nav>
+  );
+}
+
+function Page() {
+  const { pathname } = useDataAppLocation();
+
+  if (pathname === "/") {
+    return (
+      <div style={{ padding: 24 }}>
+        <h1>Overview</h1>
+        <StaticQuestion questionId={1} height={360} />
+      </div>
+    );
+  }
+
+  const customerMatch = pathname.match(/^\/customers\/(\d+)$/);
+  if (customerMatch) {
+    const id = Number(customerMatch[1]);
+    return (
+      <div style={{ padding: 24 }}>
+        <h1>Customer #{id}</h1>
+        <StaticQuestion questionId={id} height={360} />
+      </div>
+    );
+  }
+
+  return <div style={{ padding: 24 }}>Not found: {pathname}</div>;
+}
+
+export default function App() {
+  return (
+    <MetabaseProvider theme={sdkTheme}>
+      <DataAppRouter>
+        <Nav />
+        <Page />
+      </DataAppRouter>
+    </MetabaseProvider>
+  );
+}
+```
+
+Run `yarn dev`, click the links, watch the URL bar change. Reload at `http://localhost:5174/customers/42` and the dev preview lands on the customer route directly.
+
+## Step 3 — Mirror the endowments in `src/dev-globals.tsx`
+
+In production the host endows these on `globalThis`. In dev mode you have to mirror that yourself with a tiny local implementation. Add to `src/dev-globals.tsx` (alongside the existing `MetabaseProvider` shim):
+
+```tsx
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+
+const RouterContext = createContext<{
+  pathname: string;
+  navigate: (to: string) => void;
+} | null>(null);
+
+function DataAppRouterDev({ children }: { children?: ReactNode }) {
+  const [pathname, setPathname] = useState(
+    () => window.location.pathname || "/",
+  );
+
+  useEffect(() => {
+    const sync = () => setPathname(window.location.pathname || "/");
+    window.addEventListener("popstate", sync);
+    return () => window.removeEventListener("popstate", sync);
+  }, []);
+
+  const navigate = useCallback((to: string) => {
+    if (window.location.pathname !== to) {
+      window.history.pushState(null, "", to);
+    }
+    setPathname(to || "/");
+  }, []);
+
+  const value = useMemo(() => ({ pathname, navigate }), [pathname, navigate]);
+  return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
+}
+
+function DataAppLinkDev({
+  to,
+  children,
+  onClick,
+  ...rest
+}: AnchorHTMLAttributes<HTMLAnchorElement> & {
+  to: string;
+  children?: ReactNode;
+}) {
+  const ctx = useContext(RouterContext);
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+    if (
+      e.defaultPrevented ||
+      e.button !== 0 ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey
+    )
+      return;
+    e.preventDefault();
+    ctx?.navigate(to);
+  };
+  return <a {...rest} href={to} onClick={handleClick}>{children}</a>;
+}
+
+function useDataAppLocationDev() {
+  const ctx = useContext(RouterContext);
+  if (!ctx) {
+    throw new Error("useDataAppLocation must be inside <DataAppRouter>");
+  }
+  return ctx;
+}
+
+globalThis.DataAppRouter = DataAppRouterDev;
+globalThis.DataAppLink = DataAppLinkDev;
+globalThis.useDataAppLocation = useDataAppLocationDev;
+```
+
+## How navigation translates to the parent URL
+
+You don't need to do anything for this. For context:
+
+- Bundle calls `<DataAppLink to="/customers/42">` → host's `navigate` runs `pushState` with `/embed/data-app/<name>/customers/42`.
+- The parent's `AppView` observes the iframe URL change and mirrors it to the parent's URL bar as `/data-app/<name>/customers/42` — the `/embed` prefix is stripped because the parent's React Router route is `/data-app/:name/*`, not `/embed/...`.
+- Reload works because the BE serves the same `data-app.html` for every `/embed/data-app/:name/*` sub-path; the iframe boots, `<DataAppRouter>` reads `window.location.pathname`, auto-detects the prefix, and starts at the right sub-path.
+
+## What NOT to do
+
+- **Don't add `react-router-dom`** (or any router library) to the project. The bundle doesn't need it.
+- **Don't use `<BrowserRouter>` or `<HashRouter>`** inside the bundle. They run their own `setState` flow that hits the Near Membrane batching bug.
+- **Don't call `window.history.pushState` directly** from inside the bundle. Use `<DataAppLink>` or `navigate` from `useDataAppLocation`.
+- **Don't try to read or write the parent's URL.** The iframe's sandbox attribute blocks it by design.
+
+## Common patterns
+
+### Conditional render based on path
+
+```tsx
+const { pathname } = useDataAppLocation();
+if (pathname === "/") return <Home />;
+if (pathname.startsWith("/customers/")) return <Customer />;
+return <NotFound />;
+```
+
+### Programmatic navigation (e.g. from a `<button>`)
+
+```tsx
+function OpenCustomerButton({ id }: { id: number }) {
+  const { navigate } = useDataAppLocation();
+  return <button onClick={() => navigate(`/customers/${id}`)}>Open #{id}</button>;
+}
+```
+
+### Parsing path params manually
+
+There's no built-in `useParams`. Match yourself:
+
+```tsx
+const { pathname } = useDataAppLocation();
+const match = pathname.match(/^\/customers\/(\d+)$/);
+if (match) {
+  const id = Number(match[1]);
+  // ...
+}
+```
+
+If you find yourself doing this often, factor it into your own helper inside the bundle:
+
+```tsx
+function useCustomerIdFromPath(): number | null {
+  const { pathname } = useDataAppLocation();
+  const m = pathname.match(/^\/customers\/(\d+)$/);
+  return m ? Number(m[1]) : null;
+}
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `DataAppLink must be rendered inside a <DataAppRouter>` thrown at runtime. | Wrap the tree with `<DataAppRouter>`. If you're in the dev preview and the error persists, `dev-globals.tsx` is missing the dev mirror — check Step 3. |
+| URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
+| Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |
+| Middle-click on a `<DataAppLink>` does nothing. | The link uses `event.button !== 0` to skip non-left clicks; check you haven't wrapped it in another component that swallows the event. |

--- a/.claude/skills/add-data-app-routing/SKILL.md
+++ b/.claude/skills/add-data-app-routing/SKILL.md
@@ -5,7 +5,7 @@ description: Add client-side routing (multiple pages) to an existing Metabase da
 
 # Add routing to a data-app
 
-A Metabase data-app bundle doesn't bundle a router library — it uses three small primitives the host endows on `globalThis`:
+A Metabase data-app bundle doesn't bundle a router library — it imports three small primitives from `@metabase/embedding-sdk-react/data-app`:
 
 | API | Purpose |
 |---|---|
@@ -21,50 +21,27 @@ That's the entire surface. **No `react-router` of any version, no `<BrowserRoute
 - The user wants the bundle to render different content at different URLs (`/overview`, `/customers/:id`).
 - **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, stop and tell the user a project needs to exist first.
 
-## Step 1 — Add the endowment types to `src/globals.d.ts`
+## Prerequisite — `data-app` subpath externalized in `vite.config.ts`
 
-Extend `globalThis` so TypeScript knows the routing primitives. The types use only plain React DOM types — no `react-router` types leak in.
+Before continuing, confirm `vite.config.ts` has both `react` *and* `@metabase/embedding-sdk-react/data-app` in `rollupOptions.external` and a corresponding entry in `output.globals` (mapping to `__metabase_data_app__`). A correctly scaffolded data-app project ships with this already.
 
-```ts
-declare global {
-  // ... existing MetabaseProvider / StaticQuestion / etc. types
+If it's missing, the routing primitives below will work in dev preview and silently break in the production iframe: the bundler inlines the subpath's implementations into `dist/index.js`, those run inside the Near Membrane sandbox, and React's state batching swallows the navigation `setState`. URL changes, UI doesn't.
 
-  var DataAppRouter: (props: { children?: React.ReactNode }) => JSX.Element;
+If you see that symptom after following the steps below, missing externals is the cause.
 
-  var DataAppLink: (
-    props: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-      to: string;
-      children?: React.ReactNode;
-    },
-  ) => JSX.Element;
+## Step 1 — Wrap `App.tsx` with `<DataAppRouter>`
 
-  var useDataAppLocation: () => {
-    pathname: string;
-    navigate: (to: string) => void;
-  };
-}
+Import the routing primitives normally. `<DataAppRouter>` does NOT take a `basename` prop — it auto-detects the iframe's URL prefix (`/embed/data-app/<name>`) in production and resolves to no prefix in the Vite dev preview.
 
-export {};
-```
-
-## Step 2 — Wrap `App.tsx` with `<DataAppRouter>`
-
-Read the destructured globals at module load like the other endowments. The router does NOT take a `basename` prop — it auto-detects the iframe's URL prefix (`/embed/data-app/<name>`) in production and resolves to no prefix in the Vite dev preview.
+`App.tsx` is pure content — no `<MetabaseProvider>` here. The dev entry (`src/dev.tsx`) and the production host both wrap the tree.
 
 ```tsx
-import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
-
-const {
-  MetabaseProvider,
-  StaticQuestion,
+import { StaticQuestion } from "@metabase/embedding-sdk-react";
+import {
   DataAppRouter,
   DataAppLink,
   useDataAppLocation,
-} = globalThis;
-
-const sdkTheme: MetabaseTheme = {
-  // (your existing theme)
-};
+} from "@metabase/embedding-sdk-react/data-app";
 
 function Nav() {
   return (
@@ -103,101 +80,15 @@ function Page() {
 
 export default function App() {
   return (
-    <MetabaseProvider theme={sdkTheme}>
-      <DataAppRouter>
-        <Nav />
-        <Page />
-      </DataAppRouter>
-    </MetabaseProvider>
+    <DataAppRouter>
+      <Nav />
+      <Page />
+    </DataAppRouter>
   );
 }
 ```
 
 Run `yarn dev`, click the links, watch the URL bar change. Reload at `http://localhost:5174/customers/42` and the dev preview lands on the customer route directly.
-
-## Step 3 — Mirror the endowments in `src/dev-globals.tsx`
-
-In production the host endows these on `globalThis`. In dev mode you have to mirror that yourself with a tiny local implementation. Add to `src/dev-globals.tsx` (alongside the existing `MetabaseProvider` shim):
-
-```tsx
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type AnchorHTMLAttributes,
-  type MouseEvent,
-  type ReactNode,
-} from "react";
-
-const RouterContext = createContext<{
-  pathname: string;
-  navigate: (to: string) => void;
-} | null>(null);
-
-function DataAppRouterDev({ children }: { children?: ReactNode }) {
-  const [pathname, setPathname] = useState(
-    () => window.location.pathname || "/",
-  );
-
-  useEffect(() => {
-    const sync = () => setPathname(window.location.pathname || "/");
-    window.addEventListener("popstate", sync);
-    return () => window.removeEventListener("popstate", sync);
-  }, []);
-
-  const navigate = useCallback((to: string) => {
-    if (window.location.pathname !== to) {
-      window.history.pushState(null, "", to);
-    }
-    setPathname(to || "/");
-  }, []);
-
-  const value = useMemo(() => ({ pathname, navigate }), [pathname, navigate]);
-  return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
-}
-
-function DataAppLinkDev({
-  to,
-  children,
-  onClick,
-  ...rest
-}: AnchorHTMLAttributes<HTMLAnchorElement> & {
-  to: string;
-  children?: ReactNode;
-}) {
-  const ctx = useContext(RouterContext);
-  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    onClick?.(e);
-    if (
-      e.defaultPrevented ||
-      e.button !== 0 ||
-      e.metaKey ||
-      e.ctrlKey ||
-      e.shiftKey ||
-      e.altKey
-    )
-      return;
-    e.preventDefault();
-    ctx?.navigate(to);
-  };
-  return <a {...rest} href={to} onClick={handleClick}>{children}</a>;
-}
-
-function useDataAppLocationDev() {
-  const ctx = useContext(RouterContext);
-  if (!ctx) {
-    throw new Error("useDataAppLocation must be inside <DataAppRouter>");
-  }
-  return ctx;
-}
-
-globalThis.DataAppRouter = DataAppRouterDev;
-globalThis.DataAppLink = DataAppLinkDev;
-globalThis.useDataAppLocation = useDataAppLocationDev;
-```
 
 ## How navigation translates to the parent URL
 
@@ -261,7 +152,8 @@ function useCustomerIdFromPath(): number | null {
 
 | Symptom | Fix |
 |---|---|
-| `DataAppLink must be rendered inside a <DataAppRouter>` thrown at runtime. | Wrap the tree with `<DataAppRouter>`. If you're in the dev preview and the error persists, `dev-globals.tsx` is missing the dev mirror — check Step 3. |
+| `DataAppLink must be rendered inside a <DataAppRouter>` thrown at runtime. | Wrap the tree with `<DataAppRouter>`. |
+| URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` is missing `@metabase/embedding-sdk-react/data-app` in `external` / `output.globals` — see Step 1. Without it Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
 | URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
 | Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |
 | Middle-click on a `<DataAppLink>` does nothing. | The link uses `event.button !== 0` to skip non-left clicks; check you haven't wrapped it in another component that swallows the event. |

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -7,7 +7,7 @@ description: Scaffold a new Metabase data-app development project — a Vite + R
 
 A Metabase **data-app** is a single JS bundle that the host loads inside a Near Membrane sandbox and renders inside its own React tree. This skill scaffolds a proper Vite + TypeScript project: source code in `src/` (multiple `.tsx` files allowed and encouraged), a dev server with HMR that previews the app against a real Metabase via the Embedding SDK, and `yarn build` producing a single `dist/index.js` to upload via Admin → Data apps.
 
-**Always use TypeScript (`.tsx` / `.ts`).** The host endowments have public types you'll declare in `src/globals.d.ts` so usages of `globalThis.MetabaseProvider`, `globalThis.useQuestionQuery`, etc. are typed correctly.
+**Always use TypeScript (`.tsx` / `.ts`).** The bundle imports SDK values as normal package imports — `import { StaticQuestion } from "@metabase/embedding-sdk-react"` — and `vite.config.ts` externalizes those imports so the production iframe reads the host-realm copies at runtime. The Vite dev server resolves the same imports to the real npm package.
 
 ## When to invoke this skill
 
@@ -50,11 +50,10 @@ my-data-app/
 ├── tsconfig.json
 ├── index.html                  ← Vite dev entry
 ├── src/
-│   ├── globals.d.ts            ← types for globalThis endowments (MetabaseProvider, …)
-│   ├── index.tsx               ← PRODUCTION entry — exports the factory
-│   ├── dev.tsx                 ← DEV entry — sets up globals, mounts App
-│   ├── dev-globals.tsx         ← DEV-only: imports real SDK, populates globalThis
-│   ├── App.tsx                 ← top-level component (you edit this)
+│   ├── index.tsx               ← PRODUCTION entry — factory returns { component, theme }
+│   ├── dev.tsx                 ← DEV entry — wraps App with MetabaseProvider + authConfig
+│   ├── theme.ts                ← MetabaseTheme, shared between dev + prod entries
+│   ├── App.tsx                 ← top-level component (you edit this); pure content, no MetabaseProvider wrap
 │   └── components/             ← split components freely; multiple .tsx files OK
 │       └── …
 ├── public/                     ← static assets if needed
@@ -69,8 +68,8 @@ my-data-app/
 
 | | Source loaded | Output | Used for |
 |---|---|---|---|
-| **`yarn dev`** | `src/dev.tsx` (loads `dev-globals` then mounts `<App/>`) | http://localhost:5174 with HMR | Iterating visually against a real Metabase |
-| **`yarn build`** | `src/index.tsx` (exports factory) | `dist/index.js` (single IIFE) | Uploading to Metabase |
+| **`yarn dev`** | `src/dev.tsx` (wraps `<App/>` in the SDK's `<MetabaseProvider authConfig={…}>` and mounts it) | http://localhost:5174 with HMR | Iterating visually against a real Metabase |
+| **`yarn build`** | `src/index.tsx` (factory returns `{ component, theme }`; host wraps with `DataAppProvider`) | `dist/index.js` (single IIFE) | Uploading to Metabase |
 
 `App.tsx` and everything in `src/components/` is shared between both modes. The split is only at the entry layer.
 
@@ -113,9 +112,20 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-// See "Two modes, same source" above. `react` is externalized so the
-// bundle uses the host's `globalThis.React`; `jsxRuntime: "classic"`
-// keeps the externalization to a single package.
+// See "Two modes, same source" above.
+//
+// Externals:
+//   - `react` → `globalThis.React`. The bundle uses the host's React
+//     instance so there's only one React in the tree.
+//   - `@metabase/embedding-sdk-react` → `globalThis.__metabase_sdk__`.
+//     The SDK components and hooks (`MetabaseProvider`, `StaticQuestion`,
+//     etc.) are host-realm so React state from them survives the Near
+//     Membrane boundary correctly.
+//   - `@metabase/embedding-sdk-react/data-app` → `globalThis.__metabase_data_app__`.
+//     Host-owned primitives (routing, etc.) — same rationale.
+//
+// `jsxRuntime: "classic"` keeps `react` externalization to a single
+// package (no separate `react/jsx-runtime` global needed).
 export default defineConfig({
   plugins: [react({ jsxRuntime: "classic" })],
   build: {
@@ -128,8 +138,18 @@ export default defineConfig({
       name: "__dataAppFactory__",
     },
     rollupOptions: {
-      external: ["react"],
-      output: { globals: { react: "React" } },
+      external: [
+        "react",
+        "@metabase/embedding-sdk-react",
+        "@metabase/embedding-sdk-react/data-app",
+      ],
+      output: {
+        globals: {
+          react: "React",
+          "@metabase/embedding-sdk-react": "__metabase_sdk__",
+          "@metabase/embedding-sdk-react/data-app": "__metabase_data_app__",
+        },
+      },
     },
   },
   server: { port: 5174, host: "localhost" },
@@ -202,133 +222,9 @@ If you want bundle-specific styles, put them in a CSS module or `<style>`/`<link
 </html>
 ```
 
-### `src/globals.d.ts` — types for host endowments
+### `src/vite-env.d.ts` — env var types
 
-```ts
-import type {
-  CollectionBrowser,
-  CreateDashboardModal,
-  CreateQuestion,
-  EditableDashboard,
-  InteractiveDashboard,
-  InteractiveQuestion,
-  MetabaseTheme,
-  MetabotQuestion,
-  StaticDashboard,
-  StaticQuestion,
-  useQuestionQuery,
-} from "@metabase/embedding-sdk-react";
-import type * as ReactNS from "react";
-
-// The SDK endowments below need `var` (not `const`) to attach to the
-// `globalThis` shape; suppress the standard lint complaints once for the
-// whole block instead of per-line.
-/* eslint-disable vars-on-top, no-var */
-declare global {
-  // Host's React. Plain JSX (`<div/>`) and `globalThis.React.useState`
-  // both go through this.
-  const React: typeof ReactNS;
-
-  var MetabaseProvider: (props: {
-    theme?: MetabaseTheme;
-    children?: ReactNS.ReactNode;
-  }) => ReactNS.ReactElement;
-  var InteractiveQuestion: typeof InteractiveQuestion;
-  var StaticQuestion: typeof StaticQuestion;
-  var CreateQuestion: typeof CreateQuestion;
-  var MetabotQuestion: typeof MetabotQuestion;
-  var EditableDashboard: typeof EditableDashboard;
-  var InteractiveDashboard: typeof InteractiveDashboard;
-  var StaticDashboard: typeof StaticDashboard;
-  var CreateDashboardModal: typeof CreateDashboardModal;
-  var CollectionBrowser: typeof CollectionBrowser;
-  var useQuestionQuery: typeof useQuestionQuery;
-}
-/* eslint-enable vars-on-top, no-var */
-
-export {};
-```
-
-This file makes `globalThis.StaticQuestion`, `<MetabaseProvider/>`, etc. type-check everywhere. It re-exports the SDK package's types (which the agent's source code never actually `import`s at runtime — they're erased after compilation).
-
-### `src/index.tsx` — production entry
-
-```tsx
-import App from "./App";
-
-type Factory = (hostApi: Record<string, unknown>) => {
-  component: React.ComponentType;
-};
-
-/**
- * Production entry. Vite lib mode emits an IIFE whose return value is
- * assigned to globalThis.__dataAppFactory__ (the `name` field in
- * vite.config.ts). The Metabase host evaluates the bundle text, reads
- * `__dataAppFactory__` back out, calls it with hostApi, and renders the
- * returned `component` inside its own React tree.
- */
-const factory: Factory = (_hostApi) => ({ component: App });
-
-export default factory;
-```
-
-### `src/dev-globals.tsx` — dev-only endowment setup
-
-```tsx
-import {
-  CollectionBrowser,
-  CreateDashboardModal,
-  CreateQuestion,
-  EditableDashboard,
-  InteractiveDashboard,
-  InteractiveQuestion,
-  type MetabaseAuthConfig,
-  MetabaseProvider as SdkMetabaseProvider,
-  type MetabaseTheme,
-  MetabotQuestion,
-  StaticDashboard,
-  StaticQuestion,
-  useQuestionQuery,
-} from "@metabase/embedding-sdk-react";
-import * as React from "react";
-
-// Dev-only mirror of the host's endowments. `MetabaseProvider` is wrapped
-// so the bundle's <MetabaseProvider theme={…}>…</MetabaseProvider> call
-// stays auth-agnostic; the authConfig is injected from .env.local here.
-const authConfig: MetabaseAuthConfig = {
-  metabaseInstanceUrl: import.meta.env.VITE_MB_URL,
-  apiKey: import.meta.env.VITE_MB_API_KEY,
-};
-
-function MetabaseProvider({
-  theme,
-  children,
-}: {
-  theme?: MetabaseTheme;
-  children?: React.ReactNode;
-}) {
-  return (
-    <SdkMetabaseProvider authConfig={authConfig} theme={theme}>
-      {children}
-    </SdkMetabaseProvider>
-  );
-}
-
-globalThis.React = React;
-globalThis.MetabaseProvider = MetabaseProvider;
-globalThis.InteractiveQuestion = InteractiveQuestion;
-globalThis.StaticQuestion = StaticQuestion;
-globalThis.CreateQuestion = CreateQuestion;
-globalThis.MetabotQuestion = MetabotQuestion;
-globalThis.EditableDashboard = EditableDashboard;
-globalThis.InteractiveDashboard = InteractiveDashboard;
-globalThis.StaticDashboard = StaticDashboard;
-globalThis.CreateDashboardModal = CreateDashboardModal;
-globalThis.CollectionBrowser = CollectionBrowser;
-globalThis.useQuestionQuery = useQuestionQuery;
-```
-
-You'll also need a `vite-env.d.ts` (or the same `globals.d.ts`) entry for the env vars:
+The bundle no longer needs a `globals.d.ts` for SDK types — they come from `@metabase/embedding-sdk-react` as normal package types. The only ambient declarations needed are for the Vite env vars used in `dev.tsx`:
 
 ```ts
 interface ImportMetaEnv {
@@ -340,34 +236,14 @@ interface ImportMeta {
 }
 ```
 
-### `src/dev.tsx` — dev entry
+### `src/theme.ts` — shared theme
 
-```tsx
-import "./dev-globals";
+Used by both the production `index.tsx` (passed through the factory) and the dev `dev.tsx` (passed to the dev preview's `<MetabaseProvider>`).
 
-import { createRoot } from "react-dom/client";
-
-import App from "./App";
-
-const root = document.getElementById("root");
-if (!root) throw new Error("#root not found");
-createRoot(root).render(<App />);
-```
-
-The `import "./dev-globals"` line is intentionally the first statement so all `globalThis.*` assignments run before `App.tsx` evaluates and reads them.
-
-### `src/App.tsx` — starter
-
-```tsx
+```ts
 import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
 
-// SDK components are endowed on globalThis by the host in production and
-// by src/dev-globals.tsx in dev. Read them at module load time — when this
-// module evaluates, the endowments are already in place. Types come from
-// src/globals.d.ts.
-const { MetabaseProvider, StaticQuestion } = globalThis;
-
-const sdkTheme: MetabaseTheme = {
+export const sdkTheme: MetabaseTheme = {
   colors: {
     brand: "#4D96FF",
     "brand-hover": "#4D96FF",
@@ -383,27 +259,99 @@ const sdkTheme: MetabaseTheme = {
   },
   fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
 };
+```
+
+### `src/index.tsx` — production entry
+
+```tsx
+import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
+
+import App from "./App";
+import { sdkTheme } from "./theme";
+
+type Factory = () => {
+  component: React.ComponentType;
+  theme?: MetabaseTheme;
+};
+
+/**
+ * Production entry. Vite lib mode emits an IIFE whose return value is
+ * assigned to globalThis.__dataAppFactory__ (the `name` field in
+ * vite.config.ts). The Metabase host evaluates the bundle text, reads
+ * `__dataAppFactory__` back out, calls it with NO arguments, and wraps
+ * the returned `component` in its own `DataAppProvider` (which sets up
+ * the SDK Redux store, theme, and portal container in host realm).
+ *
+ * The bundle deliberately does NOT render `<MetabaseProvider>` inside
+ * `App.tsx`. That's the host's job in prod, and the dev entry's job in
+ * dev. Bundle-side wrapping would force the SDK's `setState`-via-listener
+ * paths through the Near Membrane sandbox and break drill popups,
+ * plugin init, and similar.
+ *
+ * The factory takes no arguments. Everything the host exposes to the
+ * bundle comes through normal package imports from
+ * `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app`.
+ */
+const factory: Factory = () => ({ component: App, theme: sdkTheme });
+
+export default factory;
+```
+
+### `src/dev.tsx` — dev entry
+
+In production the host wraps the bundle in `DataAppProvider`. In dev there's no host, so the dev entry uses the SDK's real `<MetabaseProvider>` (which needs an `authConfig`) to set up the same providers locally.
+
+```tsx
+import {
+  type MetabaseAuthConfig,
+  MetabaseProvider,
+} from "@metabase/embedding-sdk-react";
+import { createRoot } from "react-dom/client";
+
+import App from "./App";
+import { sdkTheme } from "./theme";
+
+const authConfig: MetabaseAuthConfig = {
+  metabaseInstanceUrl: import.meta.env.VITE_MB_URL,
+  apiKey: import.meta.env.VITE_MB_API_KEY,
+};
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("#root not found");
+}
+createRoot(root).render(
+  <MetabaseProvider authConfig={authConfig} theme={sdkTheme}>
+    <App />
+  </MetabaseProvider>,
+);
+```
+
+### `src/App.tsx` — starter
+
+`App.tsx` is **pure content** — no `<MetabaseProvider>` wrap (that's `dev.tsx` in dev and the host in prod). Imports come from the SDK package as normal; the bundle's `vite.config.ts` externalizes them so production references the host's copies at runtime, and Vite's dev server uses the real package directly.
+
+```tsx
+import { StaticQuestion } from "@metabase/embedding-sdk-react";
 
 export default function App() {
   return (
-    <MetabaseProvider theme={sdkTheme}>
-      <div style={{ minHeight: "100vh", background: "#f5f5f7" }}>
-        <header style={{ padding: 24 }}>
-          <h1 style={{ margin: 0 }}>Hello, data app</h1>
-          <p style={{ color: "#555" }}>Edit src/App.tsx to begin.</p>
-        </header>
-        <div style={{ margin: 24, padding: 16, background: "white", borderRadius: 12 }}>
-          <div style={{ height: 360, overflow: "hidden" }}>
-            <StaticQuestion
-              questionId={1}
-              withChartTypeSelector={false}
-              height="100%"
-              width="100%"
-            />
-          </div>
+    <div style={{ minHeight: "100vh", background: "#f5f5f7" }}>
+      <header style={{ padding: 24 }}>
+        <h1 style={{ margin: 0 }}>Hello, data app</h1>
+        <p style={{ color: "#555" }}>Edit src/App.tsx to begin.</p>
+      </header>
+      <div style={{ margin: 24, padding: 16, background: "white", borderRadius: 12 }}>
+        <div style={{ height: 360, overflow: "hidden" }}>
+          <StaticQuestion
+            questionId={1}
+            withChartTypeSelector={false}
+            height="100%"
+            width="100%"
+          />
         </div>
       </div>
-    </MetabaseProvider>
+    </div>
   );
 }
 ```
@@ -489,29 +437,27 @@ src/
 └── theme.ts
 ```
 
-### 3. Read SDK components from `globalThis`, NOT from `@metabase/embedding-sdk-react`
+### 3. Import SDK values from `@metabase/embedding-sdk-react` directly
 
-In source code, **never `import` runtime values from `@metabase/embedding-sdk-react`**. The SDK is loaded into the host page and exposed on `globalThis`. Importing the npm package would inline a second copy into your bundle — bigger output, broken contexts, separate Redux store.
+Just use normal package imports. `vite.config.ts` externalizes both `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app` so the build maps them to host-realm globals (`__metabase_sdk__` / `__metabase_data_app__`); the Vite dev server resolves them to the real npm package.
 
 ```tsx
-// ✅ correct — runtime values from globalThis, types via `import type`
-import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
-const { MetabaseProvider, StaticQuestion } = globalThis;
+// ✅ correct
+import { StaticQuestion, useQuestionQuery } from "@metabase/embedding-sdk-react";
+import { DataAppRouter, DataAppLink } from "@metabase/embedding-sdk-react/data-app";
 
-// ❌ wrong — bundles a second SDK copy
-import { MetabaseProvider, StaticQuestion } from "@metabase/embedding-sdk-react";
+// ❌ wrong — globalThis pattern is gone; you'd be reading nothing
+const { MetabaseProvider, StaticQuestion } = globalThis;
 ```
 
-`import type { … } from "@metabase/embedding-sdk-react"` is fine — type-only imports are erased by the TypeScript compiler and don't end up in the bundle.
+**Do NOT render `<MetabaseProvider>` in `App.tsx`.** The dev entry (`src/dev.tsx`) and the production host both wrap your tree in a provider that lives in their own realm — wrapping inside the bundle would route the SDK's `setState`-via-listener paths through the Near Membrane sandbox and silently break drill popups, plugin init, and similar.
 
-The only file that does a *runtime* import from the SDK package is `src/dev-globals.tsx`, and only for the dev preview — `dev-globals.tsx` is never reached from `src/index.tsx`, so it's tree-shaken out of the production build.
+### 4. Import `react` normally too
 
-### 4. `React` is in scope automatically; pull hooks off it
+The bundle's `vite.config.ts` externalizes `react` (mapped to `globalThis.React`), so a plain `import` resolves to the host's React in production and the npm package in dev. Same syntax in both modes:
 
-`src/globals.d.ts` declares `React` as a global. Don't `import React from "react"` in source files, and don't `import { useState } from "react"` — destructure hooks off the global so Rollup's import graph stays clean:
-
-```ts
-const { useState, useEffect, useMemo } = React;
+```tsx
+import { useState, useEffect, useMemo } from "react";
 ```
 
 ## Theme rules
@@ -531,21 +477,22 @@ const { useState, useEffect, useMemo } = React;
 
 **Don't expect per-subtree theming.** Multiple `<MetabaseProvider>`s on the page fight for the single CSS-variable slot. If the look needs to change with state, recompute `sdkTheme` at the App level and re-render — the whole tree re-themes.
 
-## Available endowments
+## Available SDK surface
 
-Set on `globalThis` by the host in production and by `src/dev-globals.tsx` in dev.
+The bundle imports normally from `@metabase/embedding-sdk-react`. Vite externalizes the package at build time, so production references the host's copies at runtime (`globalThis.__metabase_sdk__`); the Vite dev server resolves to the real npm package directly.
 
-| Endowment | Purpose |
+`<MetabaseProvider>` is **not** rendered by the bundle's `App.tsx` — `dev.tsx` and the host wrap it for their respective modes. Bundle author only renders the **content** below.
+
+| Import | Purpose |
 |---|---|
-| `React` | Host React. Use `globalThis.React.useState` etc. for hooks. |
-| `MetabaseProvider` | Wraps the root; takes `{ theme, children }`. |
+| `React` (from `"react"`) | Hooks (`useState`, `useEffect`, etc.), JSX runtime. Externalized to the host's React via `react: "React"`. |
 | `StaticQuestion` | Non-drillable question. Props include `questionId`, `withChartTypeSelector`, `height`, `width`. |
 | `InteractiveQuestion` | Drillable question. Same props as StaticQuestion plus drill behaviors. |
 | `CreateQuestion`, `MetabotQuestion` | More question variants. |
 | `StaticDashboard`, `InteractiveDashboard`, `EditableDashboard` | Dashboard variants. |
 | `CreateDashboardModal` | Modal for new-dashboard flow. |
 | `CollectionBrowser` | Collection picker. |
-| `useQuestionQuery` | Hook that runs a saved question and returns its dataset (`{ data, isLoading, error, refetch }`). Use when you want to read raw query results (rows, columns, metadata) and render your own UI from them instead of dropping in a `StaticQuestion` / `InteractiveQuestion`. **Signature:** `useQuestionQuery(questionId, options?)` — the first arg is the bare numeric id, NOT an object. The optional second arg is `{ initialSqlParameters?, enabled? }`. Must be called from inside a component rendered under `MetabaseProvider`. |
+| `useQuestionQuery` | Hook that runs a saved question and returns its dataset (`{ data, isLoading, error, refetch }`). Use when you want to read raw query results (rows, columns, metadata) and render your own UI from them instead of dropping in a `StaticQuestion` / `InteractiveQuestion`. **Signature:** `useQuestionQuery(questionId, options?)` — the first arg is the bare numeric id, NOT an object. The optional second arg is `{ initialSqlParameters?, enabled? }`. Must be called from inside a component rendered under `<MetabaseProvider>` (which `dev.tsx` and the host provide). |
 
 ### Blocked APIs
 
@@ -590,8 +537,9 @@ Lift the call to the highest component that needs the data, then **pass the resu
 
 ```tsx
 // ✅ One call, derived values + multiple presentations
+import { useQuestionQuery } from "@metabase/embedding-sdk-react";
+
 function Dashboard() {
-  const { useQuestionQuery } = globalThis;
   const { data, isLoading, error } = useQuestionQuery(1);
   if (isLoading) return <Spinner />;
   if (error) return <ErrorBox error={error} />;
@@ -662,7 +610,9 @@ To replace: delete the data app, upload again. Per-app replace endpoint isn't wi
 | Bundle is multi-MB. | Runtime-importing `@metabase/embedding-sdk-react` from non-dev source (see *Source conventions §3*). |
 | `dist/index.js` doesn't assign to `__dataAppFactory__`. | `lib.name: "__dataAppFactory__"` missing in `vite.config.ts`. |
 | Dev preview blank, console says `MetabaseProvider is undefined`. | `src/dev.tsx` must `import "./dev-globals"` BEFORE `import App from "./App"`. |
-| `globalThis.MetabaseProvider` shows as `any` in the editor. | `src/globals.d.ts` missing or not in `tsconfig.json#include`. |
+| `Cannot find module '@metabase/embedding-sdk-react'`. | Run `yarn install` to install the SDK package. Types come from the package directly. |
+| Drill popups don't open / SDK components show empty / "MetabaseProvider not found" at runtime in dev. | `src/dev.tsx` is missing the `<MetabaseProvider authConfig={…}>` wrap. The bundle's `App.tsx` does NOT include `MetabaseProvider` — `dev.tsx` provides it. |
+| URL changes but UI doesn't update in production (works in dev). | `vite.config.ts` is missing `@metabase/embedding-sdk-react/data-app` in `external` / `output.globals`. Without it, the data-app routing primitives get inlined into the bundle and the React-state-batching-through-Near-Membrane bug breaks navigation re-renders. |
 
 ## Confirm scope before generating code
 

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -20,7 +20,7 @@ Before writing any files, check whether the working directory already looks
 like a data-app project. Telltale signs:
 
 - `src/index.tsx` exists, **or**
-- `vite.config.ts` with a `name: "__customVizPlugin__"` entry, **or**
+- `vite.config.ts` with a `name: "__dataAppFactory__"` entry, **or**
 - `package.json` whose `scripts` include `vite build` and depends on
   `@metabase/embedding-sdk-react`.
 
@@ -125,7 +125,7 @@ export default defineConfig({
       entry: resolve(__dirname, "src/index.tsx"),
       formats: ["iife"],
       fileName: () => "index.js",
-      name: "__customVizPlugin__",
+      name: "__dataAppFactory__",
     },
     rollupOptions: {
       external: ["react"],
@@ -262,9 +262,9 @@ type Factory = (hostApi: Record<string, unknown>) => {
 
 /**
  * Production entry. Vite lib mode emits an IIFE whose return value is
- * assigned to globalThis.__customVizPlugin__ (the `name` field in
+ * assigned to globalThis.__dataAppFactory__ (the `name` field in
  * vite.config.ts). The Metabase host evaluates the bundle text, reads
- * `__customVizPlugin__` back out, calls it with hostApi, and renders the
+ * `__dataAppFactory__` back out, calls it with hostApi, and renders the
  * returned `component` inside its own React tree.
  */
 const factory: Factory = (_hostApi) => ({ component: App });
@@ -660,7 +660,7 @@ To replace: delete the data app, upload again. Per-app replace endpoint isn't wi
 | Chart overflows its container. | Pass `height` / `width` to the SDK component (see *SDK component sizing*). |
 | "Invalid hook call" at runtime. | `react` not externalized — check `vite.config.ts`. |
 | Bundle is multi-MB. | Runtime-importing `@metabase/embedding-sdk-react` from non-dev source (see *Source conventions §3*). |
-| `dist/index.js` doesn't assign to `__customVizPlugin__`. | `lib.name: "__customVizPlugin__"` missing in `vite.config.ts`. |
+| `dist/index.js` doesn't assign to `__dataAppFactory__`. | `lib.name: "__dataAppFactory__"` missing in `vite.config.ts`. |
 | Dev preview blank, console says `MetabaseProvider is undefined`. | `src/dev.tsx` must `import "./dev-globals"` BEFORE `import App from "./App"`. |
 | `globalThis.MetabaseProvider` shows as `any` in the editor. | `src/globals.d.ts` missing or not in `tsconfig.json#include`. |
 

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -170,6 +170,19 @@ export default defineConfig({
 
 ### `index.html`
 
+**Write this verbatim. Do not edit it.** Production data-apps render inside an isolated iframe whose document is hard-coded to the exact head/CSS-reset/`#root` shell below (charset, viewport, `lang`, the CSS reset, the font-family). Diverging here means the bundle looks one way in the Vite dev preview and a different way in production — the iframe doesn't read this file. The host serves a byte-for-byte equivalent template at runtime, so any baseline tweak (different font, different reset) has to land in the host side first, not here.
+
+Things you may NOT change in this file:
+- The `lang` attribute, `<meta charset>`, or `<meta name="viewport">`.
+- The CSS reset rules (`html, body, #root { height: 100%; margin: 0; }`).
+- The `body` font-family declaration.
+
+Things you may change:
+- The `<title>` (cosmetic — only shown in the dev preview's browser tab).
+- Adding more script tags is fine if you genuinely need them in dev (none should be needed for a normal data app).
+
+If you want bundle-specific styles, put them in a CSS module or `<style>`/`<link>` inside a component — not here.
+
 ```html
 <!doctype html>
 <html lang="en">

--- a/enterprise/frontend/src/embedding-sdk-package/bin/generate-package-support-files.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/bin/generate-package-support-files.ts
@@ -34,6 +34,34 @@ export * from "./main.bundle.js";
 writeToFile("nextjs.cjs", nextjs_cjs);
 writeToFile("nextjs.js", nextjs_js);
 
+// Data-app specific imports
+const dataApp_cjs = `
+const { DataAppRouter, DataAppLink, useDataAppLocation } = require("./main.bundle");
+
+module.exports = { DataAppRouter, DataAppLink, useDataAppLocation };
+`.trim();
+
+const dataApp_js = `
+export { DataAppRouter, DataAppLink, useDataAppLocation } from "./main.bundle.js";
+`.trim();
+
+writeToFile("data-app.cjs", dataApp_cjs);
+writeToFile("data-app.js", dataApp_js);
+
+const dataApp_dts = `
+import {
+  DataAppRouter as _DataAppRouter,
+  DataAppLink as _DataAppLink,
+  useDataAppLocation as _useDataAppLocation,
+} from './index.d.ts';
+
+export declare const DataAppRouter: typeof _DataAppRouter;
+export declare const DataAppLink: typeof _DataAppLink;
+export declare const useDataAppLocation: typeof _useDataAppLocation;
+`.trim();
+
+writeToFile("data-app.d.ts", dataApp_dts);
+
 // Development mode entry point.
 // When the host app bundler resolves the "development" exports condition,
 // this file sets a window global so the SDK bundle can detect dev mode.

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -41,6 +41,12 @@ export { defineMetabaseAuthConfig } from "./lib/public/define-metabase-auth-conf
 export { defineMetabaseTheme } from "./lib/public/define-metabase-theme";
 
 export {
+  DataAppRouter,
+  DataAppLink,
+  useDataAppLocation,
+} from "metabase/data_apps/router";
+
+export {
   type CollectionBrowserProps,
   type CollectionBrowserListColumns,
 } from "embedding-sdk-bundle/components/public/CollectionBrowser";

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -19,6 +19,11 @@
       "require": "./dist/nextjs.cjs",
       "import": "./dist/nextjs.js"
     },
+    "./data-app": {
+      "types": "./dist/data-app.d.ts",
+      "require": "./dist/data-app.cjs",
+      "import": "./dist/data-app.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {

--- a/frontend/src/metabase/app-data-app.tsx
+++ b/frontend/src/metabase/app-data-app.tsx
@@ -1,0 +1,42 @@
+import { createRoot } from "react-dom/client";
+
+import "metabase/utils/csp";
+import "metabase/utils/dayjs";
+
+import { DataAppIframeApp } from "metabase/data_apps/DataAppIframeApp";
+import registerVisualizations from "metabase/visualizations/register";
+
+/**
+ * Entry point loaded by `data-app.html` and served from `/embed/data-app/:name`.
+ *
+ * This script boots inside the iframe — separate from the host Metabase
+ * app's React tree. It reads the data-app `:name` from the URL, fetches the
+ * bundle, instantiates it inside a Near Membrane sandbox bound to *this*
+ * window, and renders the resulting component.
+ *
+ * No `MetabaseProvider`/Redux/Router scaffolding is bundled at the iframe
+ * top level — the data-app bundle is expected to wrap itself in the
+ * `MetabaseProvider` endowment, which sets up the SDK Redux store and
+ * theme on demand.
+ */
+function _init() {
+  document.body.style.margin = "0";
+
+  registerVisualizations();
+
+  const rootElement = document.getElementById("root");
+
+  if (!rootElement) {
+    // eslint-disable-next-line no-console
+    console.error("no #root element on data-app iframe entry");
+    return;
+  }
+
+  createRoot(rootElement).render(<DataAppIframeApp />);
+}
+
+if (document.readyState !== "loading") {
+  _init();
+} else {
+  document.addEventListener("DOMContentLoaded", _init);
+}

--- a/frontend/src/metabase/app-data-app.tsx
+++ b/frontend/src/metabase/app-data-app.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import "metabase/utils/csp";
 import "metabase/utils/dayjs";
 
+import api from "metabase/api/legacy-client";
 import { DataAppIframeApp } from "metabase/data_apps/DataAppIframeApp";
 import registerVisualizations from "metabase/visualizations/register";
 
@@ -19,6 +20,9 @@ import registerVisualizations from "metabase/visualizations/register";
  * `MetabaseProvider` endowment, which sets up the SDK Redux store and
  * theme on demand.
  */
+
+api.basename = (window.MetabaseRoot ?? "").replace(/\/+$/, "");
+
 function _init() {
   document.body.style.margin = "0";
 

--- a/frontend/src/metabase/app-data-app.tsx
+++ b/frontend/src/metabase/app-data-app.tsx
@@ -1,8 +1,5 @@
 import { createRoot } from "react-dom/client";
 
-import "metabase/utils/csp";
-import "metabase/utils/dayjs";
-
 import api from "metabase/api/legacy-client";
 import { DataAppIframeApp } from "metabase/data_apps/DataAppIframeApp";
 import registerVisualizations from "metabase/visualizations/register";

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useGetDataAppQuery } from "metabase/api";
@@ -10,30 +11,140 @@ interface AppViewProps {
 }
 
 /**
- * /app/:name — renders the requested data-app inside an isolated iframe.
+ * Maps the parent's `/data-app/:name(/sub/route)` path to the iframe's
+ * `/embed/data-app/:name(/sub/route)` path.
  *
- * The iframe loads a real BE-served route (`/embed/data-app/:name`) that
- * returns `data-app.html` — a stand-alone HTML shell that boots its own
- * React app (`app-data-app.tsx`). That iframe-side app fetches the bundle,
- * sandboxes it via Near Membrane bound to the iframe window, and renders
- * the resulting component.
+ * The sub-path is read from `window.location.pathname` at component init
+ * (it is later changed *from inside the iframe*, never from the parent's
+ * own URL — we intentionally don't re-sync the parent → iframe direction
+ * after initial mount). Trailing characters after the name segment are
+ * preserved verbatim.
+ */
+function deriveIframeSrc(name: string): string {
+  const prefix = `/data-app/${encodeURIComponent(name)}`;
+  const path = window.location.pathname;
+  const i = path.indexOf(prefix);
+  const tail = i >= 0 ? path.slice(i + prefix.length) : "";
+  return getSubpathSafeUrl(`/embed/data-app/${encodeURIComponent(name)}${tail}`);
+}
+
+/**
+ * Mirrors the iframe's URL into the parent's URL bar (no page reload).
  *
- * Isolation: `data-app.html` links only the narrow `data-app-vendors.css`
- * (Mantine + SDK essentials), NOT Metabase's `index.module.css`. Same-origin
- * frame, so cookie-based session auth still works.
+ * Same-origin frame, so we monkey-patch the iframe's `History` methods
+ * directly — no `postMessage` bridge. Wrapping `pushState`/`replaceState`
+ * catches programmatic nav; `popstate` catches browser back/forward
+ * inside the iframe. Each change is mirrored via the parent's
+ * `replaceState` (not `pushState`) so iframe-internal navigations don't
+ * clutter the parent's back-history with one entry each.
  *
- * Parent's only responsibilities here are: validate the name, fetch the
- * metadata for the title, and render the `<iframe>`.
+ * Returns a cleanup that restores the originals.
+ */
+function attachIframeUrlMirror(
+  iframeWindow: Window,
+  parentName: string,
+): () => void {
+  const iframePrefix = `/embed/data-app/${encodeURIComponent(parentName)}`;
+  const parentPrefix = `/data-app/${encodeURIComponent(parentName)}`;
+
+  const mirror = () => {
+    const iframePath = iframeWindow.location.pathname;
+    const tail = iframePath.startsWith(iframePrefix)
+      ? iframePath.slice(iframePrefix.length)
+      : "";
+    const parentTarget =
+      parentPrefix + tail + window.location.search + window.location.hash;
+    const parentCurrent =
+      window.location.pathname + window.location.search + window.location.hash;
+    if (parentCurrent !== parentTarget) {
+      window.history.replaceState(window.history.state, "", parentTarget);
+    }
+  };
+
+  const history = iframeWindow.history;
+  const origPush = history.pushState;
+  const origReplace = history.replaceState;
+  history.pushState = function (...args) {
+    origPush.apply(this, args);
+    mirror();
+  };
+  history.replaceState = function (...args) {
+    origReplace.apply(this, args);
+    mirror();
+  };
+  iframeWindow.addEventListener("popstate", mirror);
+
+  return () => {
+    history.pushState = origPush;
+    history.replaceState = origReplace;
+    iframeWindow.removeEventListener("popstate", mirror);
+  };
+}
+
+/**
+ * /data-app/:name(/*) — renders the requested data-app inside an isolated
+ * iframe, mirroring the iframe's internal route into the parent's URL.
+ *
+ * Sync semantics:
+ *   - Parent → iframe: only on initial mount. The parent's current
+ *     sub-path is read once and appended to the iframe's `src`. Later
+ *     parent navigations are ignored (re-mounting the iframe is what
+ *     would happen, and that's both expensive and against the design).
+ *   - Iframe → parent: continuous. Every `pushState` / `replaceState` /
+ *     `popstate` inside the iframe updates the parent's URL via
+ *     `replaceState` (no parent reload, no extra history entry).
+ *
+ * The data-app bundle itself knows nothing about either direction —
+ * it just uses React Router as if it were the top-level app.
  */
 export function AppView({ params }: AppViewProps) {
   const name = params.name;
   const validName = typeof name === "string" && name.length > 0;
+  // Callback ref (vs `useRef`) — fires when the iframe element actually
+  // mounts. The iframe is conditionally rendered (only after `meta`
+  // resolves), so a `useEffect` keyed on `[name, validName]` alone would
+  // run before the iframe exists and silently skip.
+  const [iframeEl, setIframeEl] = useState<HTMLIFrameElement | null>(null);
+
+  // Read parent path → iframe src ONCE; never re-derive on later renders.
+  const src = useMemo(
+    () => (validName ? deriveIframeSrc(name) : ""),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   const {
     data: meta,
     isLoading: metaLoading,
     error: metaError,
   } = useGetDataAppQuery(name, { skip: !validName });
+
+  useEffect(() => {
+    if (!iframeEl || !validName) {
+      return undefined;
+    }
+    let detach: (() => void) | null = null;
+
+    const onLoad = () => {
+      const win = iframeEl.contentWindow;
+      if (!win) {
+        return;
+      }
+      detach?.();
+      detach = attachIframeUrlMirror(win, name);
+    };
+
+    iframeEl.addEventListener("load", onLoad);
+    // If the iframe already loaded before the effect ran, attach now.
+    if (iframeEl.contentWindow?.document.readyState === "complete") {
+      onLoad();
+    }
+
+    return () => {
+      iframeEl.removeEventListener("load", onLoad);
+      detach?.();
+    };
+  }, [iframeEl, name, validName]);
 
   if (!validName) {
     return (
@@ -55,11 +166,10 @@ export function AppView({ params }: AppViewProps) {
     );
   }
 
-  const src = getSubpathSafeUrl(`/embed/data-app/${encodeURIComponent(name)}`);
-
   return (
     <Box style={{ height: "100%", minHeight: "100vh" }}>
       <iframe
+        ref={setIframeEl}
         title={meta.display_name}
         src={src}
         sandbox="allow-scripts allow-same-origin allow-downloads allow-forms allow-modals allow-popups"

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -1,20 +1,75 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { t } from "ttag";
 
+import { useGetDataAppQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { Box, Text } from "metabase/ui";
-import { useGetDataAppQuery } from "metabase/api";
+import { getCspNonce } from "metabase/utils/csp";
 
-import { type LoadedDataApp, loadDataAppBundle } from "./loader";
+import { fetchDataAppBundleCode, instantiateDataAppBundle } from "./loader";
 
 interface AppViewProps {
   params: { name: string };
 }
 
 /**
- * /app/:name — fetch the data-app's metadata and JS bundle by name, evaluate
- * the bundle in a Near Membrane sandbox, and render the returned component
- * inside the host React tree.
+ * Minimal iframe document. The `<head>`/CSS-reset/`#root` shell here MUST
+ * stay byte-for-byte equivalent to the dev-preview `index.html` that the
+ * `create-data-app` skill writes (charset / viewport / `lang` / CSS reset
+ * / font-family) so a bundle author iterating against the Vite dev
+ * preview sees the same baseline they'll get in this production iframe.
+ *
+ * Differences from the dev-preview template:
+ *   - `<title>` is set per-bundle on the parent's `<iframe title>` instead.
+ *   - No `<script src="/src/dev.tsx">` — the dev preview boots itself, but
+ *     the production iframe is mounted from the parent: `AppView` evaluates
+ *     the bundle via Near Membrane bound to this window and `createRoot`s
+ *     into `#root` from outside the frame.
+ *
+ * No Metabase main-app stylesheets, no Mantine theme. SDK components
+ * rendered into the iframe inject their own `<style>` tags via Emotion /
+ * Mantine `ownerDocument` detection — they land in this document's
+ * `<head>`, not the host page's.
+ */
+/**
+ * `srcdoc` iframes inherit the embedder's Content-Security-Policy. Metabase
+ * runs with `style-src 'self' 'nonce-…'` (no `unsafe-inline`), so any inline
+ * `<style>` we drop into the srcdoc gets dropped on the floor unless the
+ * nonce attribute matches. We build the srcdoc lazily per-mount so we can
+ * stamp the current page's nonce on the baseline style tag.
+ */
+function buildIframeSrcdoc(nonce: string) {
+  // Nonce is generated server-side and is a base64-ish string; it has no
+  // characters that need HTML-escaping. Guarded anyway.
+  const safeNonce = nonce.replace(/[^A-Za-z0-9+/=_-]/g, "");
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style nonce="${safeNonce}">
+      html, body, #root { height: 100%; margin: 0; }
+      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
+    </style>
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+}
+
+/**
+ * /app/:name — render the requested data-app inside an isolated iframe.
+ *
+ * The iframe is same-origin and `srcdoc`-driven, so it has no Metabase
+ * main-app CSS or JS in scope; auth still works because cookies cross the
+ * same-origin frame boundary. The Near Membrane sandbox is created against
+ * the iframe's `contentWindow`, so the bundle's DOM mutations and any
+ * style-tag injection happen in the iframe's document — leaving the host
+ * page entirely undisturbed.
+ *
+ * Routing (parent ↔ iframe sub-route sync) is deliberately not handled
+ * here yet; the iframe is a single-page mount and any in-app navigation
+ * the bundle does today still happens inside it.
  */
 export function AppView({ params }: AppViewProps) {
   const name = params.name;
@@ -26,32 +81,81 @@ export function AppView({ params }: AppViewProps) {
     error: metaError,
   } = useGetDataAppQuery(name, { skip: !validName });
 
-  const [app, setApp] = useState<LoadedDataApp | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const reactRootRef = useRef<Root | null>(null);
   const [bundleError, setBundleError] = useState<string | null>(null);
+  const srcDoc = useMemo(() => buildIframeSrcdoc(getCspNonce() ?? ""), []);
 
+  // Fetch the bundle source and mount it inside the iframe whenever the
+  // metadata changes (new upload → new `bundle_hash` → re-mount). The
+  // effect awaits both the network response and the iframe being ready
+  // before instantiating the sandbox.
   useEffect(() => {
     if (!validName || !meta) {
-      return;
+      return undefined;
     }
     let cancelled = false;
-    setApp(null);
     setBundleError(null);
-    loadDataAppBundle(name, meta.id)
-      .then((loaded) => {
-        if (!cancelled) {
-          setApp(loaded);
+
+    const waitForIframe = (iframe: HTMLIFrameElement) =>
+      new Promise<void>((resolve) => {
+        const doc = iframe.contentDocument;
+        if (doc && doc.readyState === "complete") {
+          resolve();
+          return;
         }
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setBundleError(e instanceof Error ? e.message : String(e));
-        }
+        iframe.addEventListener("load", () => resolve(), { once: true });
       });
+
+    const mount = async () => {
+      const iframe = iframeRef.current;
+      if (!iframe) {
+        return;
+      }
+      const [code] = await Promise.all([
+        fetchDataAppBundleCode(name),
+        waitForIframe(iframe),
+      ]);
+      if (cancelled) {
+        return;
+      }
+
+      const win = iframe.contentWindow;
+      const doc = iframe.contentDocument;
+      const rootEl = doc?.getElementById("root");
+      if (!win || !doc || !rootEl) {
+        throw new Error("Iframe document is not ready");
+      }
+
+      const { component: AppComponent } = instantiateDataAppBundle(
+        code,
+        meta.id,
+        win,
+      );
+      reactRootRef.current?.unmount();
+      const root = createRoot(rootEl);
+      reactRootRef.current = root;
+      root.render(<AppComponent />);
+    };
+
+    mount().catch((e: unknown) => {
+      if (!cancelled) {
+        setBundleError(e instanceof Error ? e.message : String(e));
+      }
+    });
+
     return () => {
       cancelled = true;
     };
-    // meta.bundle_hash changes on re-upload → re-fetch.
   }, [name, validName, meta?.bundle_hash, meta]);
+
+  // Unmount the React tree we mounted inside the iframe on AppView teardown.
+  useEffect(() => {
+    return () => {
+      reactRootRef.current?.unmount();
+      reactRootRef.current = null;
+    };
+  }, []);
 
   if (!validName) {
     return (
@@ -74,14 +178,31 @@ export function AppView({ params }: AppViewProps) {
   }
 
   return (
-    <Box>
+    <Box style={{ height: "100%", minHeight: "100vh" }}>
       {bundleError && (
         <Text c="error" p="md">
           {t`Failed to load data app:`} {bundleError}
         </Text>
       )}
-      {!app && !bundleError && <Text p="md">{t`Loading bundle…`}</Text>}
-      {app && <app.component />}
+
+      <iframe
+        ref={iframeRef}
+        title={meta.display_name}
+        srcDoc={srcDoc}
+        // `allow-same-origin` so cookies cross the boundary and the SDK's
+        // session-cookie auth works without any token relay. No
+        // `allow-scripts` is harmless because we evaluate the bundle from
+        // the parent via Near Membrane bound to the iframe window — we
+        // don't load scripts via `<script>` tags inside the iframe.
+        sandbox="allow-same-origin allow-scripts"
+        style={{
+          display: "block",
+          width: "100%",
+          height: "100%",
+          minHeight: "100vh",
+          border: 0,
+        }}
+      />
     </Box>
   );
 }

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -55,15 +55,14 @@ export function AppView({ params }: AppViewProps) {
     );
   }
 
-  const src = getSubpathSafeUrl(
-    `/embed/data-app/${encodeURIComponent(name)}`,
-  );
+  const src = getSubpathSafeUrl(`/embed/data-app/${encodeURIComponent(name)}`);
 
   return (
     <Box style={{ height: "100%", minHeight: "100vh" }}>
       <iframe
         title={meta.display_name}
         src={src}
+        sandbox="allow-scripts allow-same-origin allow-downloads allow-forms allow-modals allow-popups"
         style={{
           display: "block",
           width: "100%",

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -1,78 +1,29 @@
-import createCache from "@emotion/cache";
-// eslint-disable-next-line no-restricted-imports
-import { CacheProvider } from "@emotion/react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { t } from "ttag";
 
 import { useGetDataAppQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { Box, Text } from "metabase/ui";
-import { getCspNonce } from "metabase/utils/csp";
-
-import { fetchDataAppBundleCode, instantiateDataAppBundle } from "./loader";
+import { getSubpathSafeUrl } from "metabase/urls";
 
 interface AppViewProps {
   params: { name: string };
 }
 
 /**
- * Minimal iframe document. The `<head>`/CSS-reset/`#root` shell here MUST
- * stay byte-for-byte equivalent to the dev-preview `index.html` that the
- * `create-data-app` skill writes (charset / viewport / `lang` / CSS reset
- * / font-family) so a bundle author iterating against the Vite dev
- * preview sees the same baseline they'll get in this production iframe.
+ * /app/:name — renders the requested data-app inside an isolated iframe.
  *
- * Differences from the dev-preview template:
- *   - `<title>` is set per-bundle on the parent's `<iframe title>` instead.
- *   - No `<script src="/src/dev.tsx">` — the dev preview boots itself, but
- *     the production iframe is mounted from the parent: `AppView` evaluates
- *     the bundle via Near Membrane bound to this window and `createRoot`s
- *     into `#root` from outside the frame.
+ * The iframe loads a real BE-served route (`/embed/data-app/:name`) that
+ * returns `data-app.html` — a stand-alone HTML shell that boots its own
+ * React app (`app-data-app.tsx`). That iframe-side app fetches the bundle,
+ * sandboxes it via Near Membrane bound to the iframe window, and renders
+ * the resulting component.
  *
- * No Metabase main-app stylesheets, no Mantine theme. SDK components
- * rendered into the iframe inject their own `<style>` tags via Emotion /
- * Mantine `ownerDocument` detection — they land in this document's
- * `<head>`, not the host page's.
- */
-/**
- * `srcdoc` iframes inherit the embedder's Content-Security-Policy. Metabase
- * runs with `style-src 'self' 'nonce-…'` (no `unsafe-inline`), so any inline
- * `<style>` we drop into the srcdoc gets dropped on the floor unless the
- * nonce attribute matches. We build the srcdoc lazily per-mount so we can
- * stamp the current page's nonce on the baseline style tag.
- */
-function buildIframeSrcdoc(nonce: string) {
-  // Nonce is generated server-side and is a base64-ish string; it has no
-  // characters that need HTML-escaping. Guarded anyway.
-  const safeNonce = nonce.replace(/[^A-Za-z0-9+/=_-]/g, "");
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <style nonce="${safeNonce}">
-      html, body, #root { height: 100%; margin: 0; }
-      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
-    </style>
-  </head>
-  <body><div id="root"></div></body>
-</html>`;
-}
-
-/**
- * /app/:name — render the requested data-app inside an isolated iframe.
+ * Isolation: `data-app.html` links only the narrow `data-app-vendors.css`
+ * (Mantine + SDK essentials), NOT Metabase's `index.module.css`. Same-origin
+ * frame, so cookie-based session auth still works.
  *
- * The iframe is same-origin and `srcdoc`-driven, so it has no Metabase
- * main-app CSS or JS in scope; auth still works because cookies cross the
- * same-origin frame boundary. The Near Membrane sandbox is created against
- * the iframe's `contentWindow`, so the bundle's DOM mutations and any
- * style-tag injection happen in the iframe's document — leaving the host
- * page entirely undisturbed.
- *
- * Routing (parent ↔ iframe sub-route sync) is deliberately not handled
- * here yet; the iframe is a single-page mount and any in-app navigation
- * the bundle does today still happens inside it.
+ * Parent's only responsibilities here are: validate the name, fetch the
+ * metadata for the title, and render the `<iframe>`.
  */
 export function AppView({ params }: AppViewProps) {
   const name = params.name;
@@ -83,96 +34,6 @@ export function AppView({ params }: AppViewProps) {
     isLoading: metaLoading,
     error: metaError,
   } = useGetDataAppQuery(name, { skip: !validName });
-
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const reactRootRef = useRef<Root | null>(null);
-  const [bundleError, setBundleError] = useState<string | null>(null);
-  const srcDoc = useMemo(() => buildIframeSrcdoc(getCspNonce() ?? ""), []);
-
-  // Fetch the bundle source and mount it inside the iframe whenever the
-  // metadata changes (new upload → new `bundle_hash` → re-mount). The
-  // effect awaits both the network response and the iframe being ready
-  // before instantiating the sandbox.
-  useEffect(() => {
-    if (!validName || !meta) {
-      return undefined;
-    }
-    let cancelled = false;
-    setBundleError(null);
-
-    const waitForIframe = (iframe: HTMLIFrameElement) =>
-      new Promise<void>((resolve) => {
-        const doc = iframe.contentDocument;
-        if (doc && doc.readyState === "complete") {
-          resolve();
-          return;
-        }
-        iframe.addEventListener("load", () => resolve(), { once: true });
-      });
-
-    const mount = async () => {
-      const iframe = iframeRef.current;
-      if (!iframe) {
-        return;
-      }
-      const [code] = await Promise.all([
-        fetchDataAppBundleCode(name),
-        waitForIframe(iframe),
-      ]);
-      if (cancelled) {
-        return;
-      }
-
-      const win = iframe.contentWindow;
-      const doc = iframe.contentDocument;
-      const rootEl = doc?.getElementById("root");
-      if (!win || !doc || !rootEl) {
-        throw new Error("Iframe document is not ready");
-      }
-
-      const { component: AppComponent } = instantiateDataAppBundle(
-        code,
-        meta.id,
-        win,
-      );
-      // Emotion's default cache injects nonce-less `<style>` tags into the
-      // host document, which our same-origin iframe inherits a strict
-      // `style-src 'self' 'nonce-…'` CSP from. Give it a cache that (a)
-      // targets the iframe's `<head>` and (b) stamps the parent's nonce on
-      // every generated style tag so they survive CSP.
-      const iframeEmotionCache = createCache({
-        key: "data-app",
-        container: doc.head,
-        nonce: getCspNonce() ?? undefined,
-      });
-      reactRootRef.current?.unmount();
-      const root = createRoot(rootEl);
-      reactRootRef.current = root;
-      root.render(
-        <CacheProvider value={iframeEmotionCache}>
-          <AppComponent />
-        </CacheProvider>,
-      );
-    };
-
-    mount().catch((e: unknown) => {
-      if (!cancelled) {
-        setBundleError(e instanceof Error ? e.message : String(e));
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [name, validName, meta?.bundle_hash, meta]);
-
-  // Unmount the React tree we mounted inside the iframe on AppView teardown.
-  useEffect(() => {
-    return () => {
-      reactRootRef.current?.unmount();
-      reactRootRef.current = null;
-    };
-  }, []);
 
   if (!validName) {
     return (
@@ -194,24 +55,15 @@ export function AppView({ params }: AppViewProps) {
     );
   }
 
+  const src = getSubpathSafeUrl(
+    `/embed/data-app/${encodeURIComponent(name)}`,
+  );
+
   return (
     <Box style={{ height: "100%", minHeight: "100vh" }}>
-      {bundleError && (
-        <Text c="error" p="md">
-          {t`Failed to load data app:`} {bundleError}
-        </Text>
-      )}
-
       <iframe
-        ref={iframeRef}
         title={meta.display_name}
-        srcDoc={srcDoc}
-        // `allow-same-origin` so cookies cross the boundary and the SDK's
-        // session-cookie auth works without any token relay. No
-        // `allow-scripts` is harmless because we evaluate the bundle from
-        // the parent via Near Membrane bound to the iframe window — we
-        // don't load scripts via `<script>` tags inside the iframe.
-        sandbox="allow-same-origin allow-scripts"
+        src={src}
         style={{
           display: "block",
           width: "100%",

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { useGetDataAppQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
 import { Box, Text } from "metabase/ui";
 import { getSubpathSafeUrl } from "metabase/urls";
 
@@ -25,7 +26,9 @@ function deriveIframeSrc(name: string): string {
   const path = window.location.pathname;
   const i = path.indexOf(prefix);
   const tail = i >= 0 ? path.slice(i + prefix.length) : "";
-  return getSubpathSafeUrl(`/embed/data-app/${encodeURIComponent(name)}${tail}`);
+  return getSubpathSafeUrl(
+    `${DATA_APP_EMBED_PREFIX}/${encodeURIComponent(name)}${tail}`,
+  );
 }
 
 /**
@@ -44,7 +47,7 @@ function attachIframeUrlMirror(
   iframeWindow: Window,
   parentName: string,
 ): () => void {
-  const iframePrefix = `/embed/data-app/${encodeURIComponent(parentName)}`;
+  const iframePrefix = `${DATA_APP_EMBED_PREFIX}/${encodeURIComponent(parentName)}`;
   const parentPrefix = `/data-app/${encodeURIComponent(parentName)}`;
 
   const mirror = () => {

--- a/frontend/src/metabase/data_apps/AppView.tsx
+++ b/frontend/src/metabase/data_apps/AppView.tsx
@@ -1,3 +1,6 @@
+import createCache from "@emotion/cache";
+// eslint-disable-next-line no-restricted-imports
+import { CacheProvider } from "@emotion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { t } from "ttag";
@@ -132,10 +135,24 @@ export function AppView({ params }: AppViewProps) {
         meta.id,
         win,
       );
+      // Emotion's default cache injects nonce-less `<style>` tags into the
+      // host document, which our same-origin iframe inherits a strict
+      // `style-src 'self' 'nonce-…'` CSP from. Give it a cache that (a)
+      // targets the iframe's `<head>` and (b) stamps the parent's nonce on
+      // every generated style tag so they survive CSP.
+      const iframeEmotionCache = createCache({
+        key: "data-app",
+        container: doc.head,
+        nonce: getCspNonce() ?? undefined,
+      });
       reactRootRef.current?.unmount();
       const root = createRoot(rootEl);
       reactRootRef.current = root;
-      root.render(<AppComponent />);
+      root.render(
+        <CacheProvider value={iframeEmotionCache}>
+          <AppComponent />
+        </CacheProvider>,
+      );
     };
 
     mount().catch((e: unknown) => {

--- a/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
+++ b/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
@@ -3,9 +3,16 @@ import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import { type ComponentType, useEffect, useMemo, useState } from "react";
 
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { getCspNonce } from "metabase/utils/csp";
 
+import { DataAppProvider } from "./components/DataAppProvider";
 import { fetchDataAppBundleCode, instantiateDataAppBundle } from "./loader";
+
+interface LoadedApp {
+  component: ComponentType<Record<string, unknown>>;
+  theme: MetabaseTheme | undefined;
+}
 
 /**
  * Reads the requested data-app name from the iframe URL.
@@ -29,13 +36,18 @@ interface BundleHostProps {
 }
 
 /**
- * Fetches + sandboxes the bundle, then renders the resulting component
- * under the iframe-side Emotion cache.
+ * Fetches + sandboxes the bundle, then wraps the resulting component
+ * with `DataAppProvider` (host-realm Redux store, SDK theme, portal
+ * container) and renders it under the iframe-side Emotion cache.
+ *
+ * `DataAppProvider` lives here in host code (not inside the bundle), so
+ * the SDK's `setState`-via-listener paths (drill popups, plugin init,
+ * etc.) run in host realm and don't hit the React-18-batching-through-
+ * Near-Membrane bug. The bundle's `App.tsx` returns pure content; the
+ * factory passes the theme through as `{ component, theme }`.
  */
 function BundleHost({ name, cache }: BundleHostProps) {
-  const [AppComponent, setAppComponent] = useState<ComponentType<
-    Record<string, unknown>
-  > | null>(null);
+  const [loaded, setLoaded] = useState<LoadedApp | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -43,11 +55,14 @@ function BundleHost({ name, cache }: BundleHostProps) {
 
     const load = async () => {
       const code = await fetchDataAppBundleCode(name);
+
       if (cancelled) {
         return;
       }
-      const { component } = instantiateDataAppBundle(code, name, window);
-      setAppComponent(() => component);
+
+      const { component, theme } = instantiateDataAppBundle(code, name, window);
+
+      setLoaded({ component, theme });
     };
 
     load().catch((e: unknown) => {
@@ -64,12 +79,18 @@ function BundleHost({ name, cache }: BundleHostProps) {
   if (error) {
     return <div style={{ padding: 16, color: "#b00" }}>Error: {error}</div>;
   }
-  if (!AppComponent) {
+
+  if (!loaded) {
     return <div style={{ padding: 16 }}>Loading…</div>;
   }
+
+  const { component: AppComponent, theme } = loaded;
+
   return (
     <CacheProvider value={cache}>
-      <AppComponent />
+      <DataAppProvider theme={theme}>
+        <AppComponent />
+      </DataAppProvider>
     </CacheProvider>
   );
 }

--- a/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
+++ b/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
@@ -1,0 +1,87 @@
+import createCache from "@emotion/cache";
+// eslint-disable-next-line no-restricted-imports
+import { CacheProvider } from "@emotion/react";
+import { type ComponentType, useEffect, useMemo, useState } from "react";
+
+import { getCspNonce } from "metabase/utils/csp";
+
+import { fetchDataAppBundleCode, instantiateDataAppBundle } from "./loader";
+
+/**
+ * Reads the requested data-app name from the iframe URL.
+ *
+ * The BE serves this iframe at `/embed/data-app/:name`. Anything that comes
+ * after that segment (e.g. the future sub-route `/embed/data-app/foo/q1`)
+ * is ignored for now — the bundle's own router will own internal navigation
+ * when we add it.
+ */
+function readNameFromUrl(): string | null {
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  const i = segments.indexOf("data-app");
+
+  if (i < 0 || i === segments.length - 1) {
+    return null;
+  }
+
+  return decodeURIComponent(segments[i + 1] ?? "");
+}
+
+export const DataAppIframeApp = () => {
+  const [AppComponent, setAppComponent] = useState<ComponentType<
+    Record<string, unknown>
+  > | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const emotionCache = useMemo(
+    () =>
+      createCache({
+        key: "data-app",
+        nonce: getCspNonce() ?? undefined,
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const name = readNameFromUrl();
+
+    if (!name) {
+      setError("Missing data-app name in URL");
+      return;
+    }
+
+    const load = async () => {
+      const code = await fetchDataAppBundleCode(name);
+
+      if (cancelled) {
+        return;
+      }
+
+      const { component } = instantiateDataAppBundle(code, name, window);
+
+      setAppComponent(() => component);
+    };
+
+    load().catch((e: unknown) => {
+      if (!cancelled) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return <div style={{ padding: 16, color: "#b00" }}>Error: {error}</div>;
+  }
+  if (!AppComponent) {
+    return <div style={{ padding: 16 }}>Loading…</div>;
+  }
+  return (
+    <CacheProvider value={emotionCache}>
+      <AppComponent />
+    </CacheProvider>
+  );
+};

--- a/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
+++ b/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
@@ -10,55 +10,43 @@ import { fetchDataAppBundleCode, instantiateDataAppBundle } from "./loader";
 /**
  * Reads the requested data-app name from the iframe URL.
  *
- * The BE serves this iframe at `/embed/data-app/:name`. Anything that comes
- * after that segment (e.g. the future sub-route `/embed/data-app/foo/q1`)
- * is ignored for now — the bundle's own router will own internal navigation
- * when we add it.
+ * The BE serves this iframe at `/embed/data-app/:name(/sub/route)`. Anything
+ * after the `:name` segment is owned by the bundle's own router and mirrored
+ * back to the parent by `attachIframeUrlMirror` in `AppView`.
  */
 function readNameFromUrl(): string | null {
   const segments = window.location.pathname.split("/").filter(Boolean);
   const i = segments.indexOf("data-app");
-
   if (i < 0 || i === segments.length - 1) {
     return null;
   }
-
   return decodeURIComponent(segments[i + 1] ?? "");
 }
 
-export const DataAppIframeApp = () => {
+interface BundleHostProps {
+  name: string;
+  cache: ReturnType<typeof createCache>;
+}
+
+/**
+ * Fetches + sandboxes the bundle, then renders the resulting component
+ * under the iframe-side Emotion cache.
+ */
+function BundleHost({ name, cache }: BundleHostProps) {
   const [AppComponent, setAppComponent] = useState<ComponentType<
     Record<string, unknown>
   > | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const emotionCache = useMemo(
-    () =>
-      createCache({
-        key: "data-app",
-        nonce: getCspNonce() ?? undefined,
-      }),
-    [],
-  );
-
   useEffect(() => {
     let cancelled = false;
-    const name = readNameFromUrl();
-
-    if (!name) {
-      setError("Missing data-app name in URL");
-      return;
-    }
 
     const load = async () => {
       const code = await fetchDataAppBundleCode(name);
-
       if (cancelled) {
         return;
       }
-
       const { component } = instantiateDataAppBundle(code, name, window);
-
       setAppComponent(() => component);
     };
 
@@ -71,7 +59,7 @@ export const DataAppIframeApp = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [name]);
 
   if (error) {
     return <div style={{ padding: 16, color: "#b00" }}>Error: {error}</div>;
@@ -80,8 +68,32 @@ export const DataAppIframeApp = () => {
     return <div style={{ padding: 16 }}>Loading…</div>;
   }
   return (
-    <CacheProvider value={emotionCache}>
+    <CacheProvider value={cache}>
       <AppComponent />
     </CacheProvider>
   );
+}
+
+/**
+ * Iframe-top React app. Reads the data-app name from the URL, mounts the
+ * bundle, and gets out of the way. Any sub-routes the bundle navigates to
+ * (via `history.pushState`, `react-router`, etc.) are mirrored back to the
+ * parent URL by `attachIframeUrlMirror` — the bundle doesn't need to know.
+ */
+export const DataAppIframeApp = () => {
+  const name = useMemo(() => readNameFromUrl(), []);
+  const emotionCache = useMemo(
+    () => createCache({ key: "data-app", nonce: getCspNonce() ?? undefined }),
+    [],
+  );
+
+  if (!name) {
+    return (
+      <div style={{ padding: 16, color: "#b00" }}>
+        Missing data-app name in URL
+      </div>
+    );
+  }
+
+  return <BundleHost name={name} cache={emotionCache} />;
 };

--- a/frontend/src/metabase/data_apps/ManageDataAppsPage.tsx
+++ b/frontend/src/metabase/data_apps/ManageDataAppsPage.tsx
@@ -14,10 +14,7 @@ import {
   Text,
   Title,
 } from "metabase/ui";
-import {
-  useDeleteDataAppMutation,
-  useListDataAppsQuery,
-} from "metabase/api";
+import { useDeleteDataAppMutation, useListDataAppsQuery } from "metabase/api";
 
 import { DataAppListItem } from "./DataAppListItem";
 import S from "./ManageDataAppsPage.module.css";

--- a/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
+++ b/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
@@ -1,3 +1,4 @@
+import { PortalContainer } from "embedding-sdk-bundle/components/private/SdkPortalContainer";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
 import { getHostBackedSdkStore } from "metabase/data_apps/host-sdk-init";
@@ -10,15 +11,21 @@ import { MetabaseReduxProvider } from "metabase/redux";
 
 /**
  * In-host equivalent of the SDK's `MetabaseProvider` / `ComponentProvider`:
- * provides the SDK Redux store (pre-initialized, no auth handshake) and the
- * SDK theme provider in one go.
+ * provides the SDK Redux store (pre-initialized, no auth handshake), the
+ * SDK theme provider, and the portal container the SDK's Mantine
+ * components (drill popups, dropdowns, modals) target via
+ * `#metabase-sdk-portal-root`. Without `PortalContainer` rendered, those
+ * overlays mount to `document.body` or silently fail.
  */
 export const DataAppProvider = ({ theme, children }: MetabaseProviderProps) => {
   const sdkStore = getHostBackedSdkStore();
 
   return (
     <MetabaseReduxProvider store={sdkStore}>
-      <SdkThemeProvider theme={theme}>{children}</SdkThemeProvider>
+      <SdkThemeProvider theme={theme}>
+        {children}
+        <PortalContainer />
+      </SdkThemeProvider>
     </MetabaseReduxProvider>
   );
 };

--- a/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
+++ b/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
+
 import { PortalContainer } from "embedding-sdk-bundle/components/private/SdkPortalContainer";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
-import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { getHostBackedSdkStore } from "metabase/data_apps/host-sdk-init";
 import { MetabaseReduxProvider } from "metabase/redux";
 
@@ -9,6 +11,11 @@ import { MetabaseReduxProvider } from "metabase/redux";
 // effect-import CSS here — those imports run at parent-bundle eval and land
 // in the host document, not the iframe.
 
+interface DataAppProviderProps {
+  theme?: MetabaseTheme;
+  children?: ReactNode;
+}
+
 /**
  * In-host equivalent of the SDK's `MetabaseProvider` / `ComponentProvider`:
  * provides the SDK Redux store (pre-initialized, no auth handshake), the
@@ -16,8 +23,11 @@ import { MetabaseReduxProvider } from "metabase/redux";
  * components (drill popups, dropdowns, modals) target via
  * `#metabase-sdk-portal-root`. Without `PortalContainer` rendered, those
  * overlays mount to `document.body` or silently fail.
+ *
+ * Takes only `{ theme, children }` — no `authConfig`. The data-app surface
+ * inherits the host's session cookie; auth is already established.
  */
-export const DataAppProvider = ({ theme, children }: MetabaseProviderProps) => {
+export const DataAppProvider = ({ theme, children }: DataAppProviderProps) => {
   const sdkStore = getHostBackedSdkStore();
 
   return (

--- a/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
+++ b/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
@@ -1,0 +1,24 @@
+import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
+import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
+import { getHostBackedSdkStore } from "metabase/data_apps/host-sdk-init";
+import { MetabaseReduxProvider } from "metabase/redux";
+
+// Note: Mantine + SDK CSS is loaded into the iframe via the `data-app-vendors`
+// Rspack entry (`<link rel="stylesheet">` in the iframe srcdoc). Don't side-
+// effect-import CSS here — those imports run at parent-bundle eval and land
+// in the host document, not the iframe.
+
+/**
+ * In-host equivalent of the SDK's `MetabaseProvider` / `ComponentProvider`:
+ * provides the SDK Redux store (pre-initialized, no auth handshake) and the
+ * SDK theme provider in one go.
+ */
+export const DataAppProvider = ({ theme, children }: MetabaseProviderProps) => {
+  const sdkStore = getHostBackedSdkStore();
+
+  return (
+    <MetabaseReduxProvider store={sdkStore}>
+      <SdkThemeProvider theme={theme}>{children}</SdkThemeProvider>
+    </MetabaseReduxProvider>
+  );
+};

--- a/frontend/src/metabase/data_apps/constants.ts
+++ b/frontend/src/metabase/data_apps/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * URL prefix the BE uses to serve the data-app iframe. Kept as a single
+ * constant so the regex in `DataAppRouter`, the `src` builder in
+ * `AppView`, and the URL-mirror logic don't drift apart.
+ *
+ * Must match the route definitions in `src/metabase/server/routes.clj`:
+ *   `(GET ["/data-app/:name" …] [] index/data-app)`
+ *   `(GET ["/data-app/:name/*" …] [] index/data-app)`
+ * under the `/embed` context.
+ */
+export const DATA_APP_EMBED_PREFIX = "/embed/data-app";

--- a/frontend/src/metabase/data_apps/iframe-baseline.css
+++ b/frontend/src/metabase/data_apps/iframe-baseline.css
@@ -1,0 +1,14 @@
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
+}

--- a/frontend/src/metabase/data_apps/iframe-vendors.ts
+++ b/frontend/src/metabase/data_apps/iframe-vendors.ts
@@ -1,0 +1,4 @@
+import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+
+import "./iframe-baseline.css";

--- a/frontend/src/metabase/data_apps/iframe-vendors.ts
+++ b/frontend/src/metabase/data_apps/iframe-vendors.ts
@@ -2,3 +2,6 @@ import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 
 import "./iframe-baseline.css";
+
+import "metabase/utils/csp";
+import "metabase/utils/dayjs";

--- a/frontend/src/metabase/data_apps/loader.ts
+++ b/frontend/src/metabase/data_apps/loader.ts
@@ -1,7 +1,6 @@
 import type * as React from "react";
 
 import { getSubpathSafeUrl } from "metabase/urls";
-import type { DataAppId } from "metabase-types/api";
 
 import { type DataAppHostApi, createDataAppSandbox } from "./sandbox";
 
@@ -10,10 +9,8 @@ export interface LoadedDataApp {
 }
 
 /**
- * Fetch a data-app bundle's raw JS source. Pulled out from
- * [[loadDataAppBundle]] so the parent React tree can fetch the bundle in
- * parallel with iframe bootstrap, then instantiate the sandbox once the
- * iframe is ready and its `contentWindow` exists.
+ * Fetch a data-app bundle's raw JS source. Called from the iframe-top
+ * `DataAppIframeApp` after it reads the `:name` from the URL.
  */
 export async function fetchDataAppBundleCode(name: string): Promise<string> {
   const url = getSubpathSafeUrl(
@@ -30,43 +27,27 @@ export async function fetchDataAppBundleCode(name: string): Promise<string> {
 }
 
 /**
- * Build a Near Membrane sandbox bound to `targetWindow` (the iframe's
- * `contentWindow`), evaluate the bundle inside it, and return the React
- * component the factory produces. DOM mutations from the sandbox land in
- * `targetWindow.document`.
- *
- * Endowments (React, SDK components, hooks) come from the parent's module
- * graph — they're passed across by reference. `MetabaseProvider` and the
- * Redux store stay singletons in the parent so auth, theming, and store
- * state don't fragment per app instance.
+ * Build a Near Membrane sandbox bound to `targetWindow` and evaluate the
+ * bundle inside it. With the iframe-top app architecture, `targetWindow` is
+ * the iframe's own `window` — same realm as the React tree rendering the
+ * factory's component, so no cross-document mounting.
  */
 export function instantiateDataAppBundle(
   code: string,
-  id: DataAppId,
+  label: string,
   targetWindow: Window,
 ): LoadedDataApp {
-  const sandbox = createDataAppSandbox(id, targetWindow);
+  const sandbox = createDataAppSandbox(label, targetWindow);
   const factory = sandbox.evaluate(code);
 
   const hostApi: DataAppHostApi = {};
   const def = factory(hostApi);
+
   if (!def || typeof def.component !== "function") {
     throw new Error(
       "Factory return value is missing a `component` function (expected { component })",
     );
   }
-  return { component: def.component };
-}
 
-/**
- * Convenience wrapper for in-host (non-iframe) mounts: fetch the bundle and
- * instantiate it in the current window. Used by anything that wants the
- * old, pre-iframe rendering shape.
- */
-export async function loadDataAppBundle(
-  name: string,
-  id: DataAppId,
-): Promise<LoadedDataApp> {
-  const code = await fetchDataAppBundleCode(name);
-  return instantiateDataAppBundle(code, id, window);
+  return { component: def.component };
 }

--- a/frontend/src/metabase/data_apps/loader.ts
+++ b/frontend/src/metabase/data_apps/loader.ts
@@ -1,11 +1,13 @@
 import type * as React from "react";
 
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { getSubpathSafeUrl } from "metabase/urls";
 
-import { type DataAppHostApi, createDataAppSandbox } from "./sandbox";
+import { createDataAppSandbox } from "./sandbox";
 
 export interface LoadedDataApp {
   component: React.ComponentType<Record<string, unknown>>;
+  theme?: MetabaseTheme;
 }
 
 /**
@@ -40,14 +42,13 @@ export function instantiateDataAppBundle(
   const sandbox = createDataAppSandbox(label, targetWindow);
   const factory = sandbox.evaluate(code);
 
-  const hostApi: DataAppHostApi = {};
-  const def = factory(hostApi);
+  const def = factory();
 
   if (!def || typeof def.component !== "function") {
     throw new Error(
-      "Factory return value is missing a `component` function (expected { component })",
+      "Factory return value is missing a `component` function (expected { component, theme? })",
     );
   }
 
-  return { component: def.component };
+  return { component: def.component, theme: def.theme };
 }

--- a/frontend/src/metabase/data_apps/loader.ts
+++ b/frontend/src/metabase/data_apps/loader.ts
@@ -10,28 +10,42 @@ export interface LoadedDataApp {
 }
 
 /**
- * Fetch a data-app bundle by name, evaluate it in a Near Membrane sandbox
- * with React + the SDK component set endowed, and return the host-renderable
- * React component the factory produces.
- *
- * `id` is used to scope the sandbox's DOM access — it's compared against the
- * `data-data-app=<id>` attribute on the container element AppView renders
- * around the returned component.
+ * Fetch a data-app bundle's raw JS source. Pulled out from
+ * [[loadDataAppBundle]] so the parent React tree can fetch the bundle in
+ * parallel with iframe bootstrap, then instantiate the sandbox once the
+ * iframe is ready and its `contentWindow` exists.
  */
-export async function loadDataAppBundle(
-  name: string,
-  id: DataAppId,
-): Promise<LoadedDataApp> {
+export async function fetchDataAppBundleCode(name: string): Promise<string> {
   const url = getSubpathSafeUrl(
     `/api/data-app/${encodeURIComponent(name)}/bundle?t=${Date.now()}`,
   );
+
   const res = await fetch(url, { cache: "no-store" });
+
   if (!res.ok) {
     throw new Error(`Failed to fetch data-app bundle: HTTP ${res.status}`);
   }
-  const code = await res.text();
 
-  const sandbox = createDataAppSandbox(id);
+  return res.text();
+}
+
+/**
+ * Build a Near Membrane sandbox bound to `targetWindow` (the iframe's
+ * `contentWindow`), evaluate the bundle inside it, and return the React
+ * component the factory produces. DOM mutations from the sandbox land in
+ * `targetWindow.document`.
+ *
+ * Endowments (React, SDK components, hooks) come from the parent's module
+ * graph — they're passed across by reference. `MetabaseProvider` and the
+ * Redux store stay singletons in the parent so auth, theming, and store
+ * state don't fragment per app instance.
+ */
+export function instantiateDataAppBundle(
+  code: string,
+  id: DataAppId,
+  targetWindow: Window,
+): LoadedDataApp {
+  const sandbox = createDataAppSandbox(id, targetWindow);
   const factory = sandbox.evaluate(code);
 
   const hostApi: DataAppHostApi = {};
@@ -42,4 +56,17 @@ export async function loadDataAppBundle(
     );
   }
   return { component: def.component };
+}
+
+/**
+ * Convenience wrapper for in-host (non-iframe) mounts: fetch the bundle and
+ * instantiate it in the current window. Used by anything that wants the
+ * old, pre-iframe rendering shape.
+ */
+export async function loadDataAppBundle(
+  name: string,
+  id: DataAppId,
+): Promise<LoadedDataApp> {
+  const code = await fetchDataAppBundleCode(name);
+  return instantiateDataAppBundle(code, id, window);
 }

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -1,11 +1,7 @@
-import {
-  type AnchorHTMLAttributes,
-  type MouseEvent,
-  type ReactNode,
-  useContext,
-} from "react";
+import { type AnchorHTMLAttributes, type ReactNode, useContext } from "react";
+import { Link } from "react-router";
 
-import { DataAppRouterContext } from "./DataAppRouter";
+import { DataAppRouterContext, getBasename } from "./DataAppRouter";
 
 interface DataAppLinkProps
   extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
@@ -16,54 +12,29 @@ interface DataAppLinkProps
 /**
  * Internal-only navigation link inside a data app.
  *
- * Renders a real `<a href>` so middle-click / cmd-click open in a new tab
- * the way users expect. On a plain left-click, intercepts the navigation
- * and routes via `DataAppRouter`'s `navigate` — no full page reload.
+ * Renders react-router 3's `<Link>` under the hood — middle-click /
+ * cmd-click / modifier-key handling and `<a href>` rendering all come
+ * from v3's implementation. When MB upgrades to a newer router, this
+ * file's `import { Link } from "react-router"` changes; the bundle's
+ * `<DataAppLink to="…">` usage doesn't.
  *
- * The `to` prop is bundle-relative (e.g. `to="/customers/42"`); the
- * provider's auto-detected basename is added when building the `href`.
+ * The `to` prop is bundle-relative (e.g. `to="/customers/42"`); we add
+ * the auto-detected basename before handing the URL to v3's `Link`.
  */
-export function DataAppLink({
-  to,
-  children,
-  onClick,
-  ...rest
-}: DataAppLinkProps) {
+export function DataAppLink({ to, children, ...rest }: DataAppLinkProps) {
+  // Defensive — surface a clear error if the bundle puts `<DataAppLink>`
+  // outside a `<DataAppRouter>`. v3's `<Link>` would fail more cryptically
+  // (no router context) without this.
   const ctx = useContext(DataAppRouterContext);
   if (!ctx) {
     throw new Error("DataAppLink must be rendered inside a <DataAppRouter>");
   }
 
-  // For the rendered `href`, use the parent's clean path so the link reads
-  // correctly when hovered / right-clicked / shared. The provider's own
-  // `navigate` knows how to translate it back when clicked.
-  const parentBasename = window.location.pathname.match(
-    /^\/embed\/data-app\/[^/]+/,
-  )?.[0];
-  const parentSurfaceBasename = parentBasename
-    ? parentBasename.replace(/^\/embed/, "")
-    : "";
-  const href = parentSurfaceBasename + to;
-
-  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    onClick?.(event);
-    if (
-      event.defaultPrevented ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return;
-    }
-    event.preventDefault();
-    ctx.navigate(to);
-  };
+  const target = getBasename() + to;
 
   return (
-    <a {...rest} href={href} onClick={handleClick}>
+    <Link to={target} {...rest}>
       {children}
-    </a>
+    </Link>
   );
 }

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -1,0 +1,69 @@
+import {
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  useContext,
+} from "react";
+
+import { DataAppRouterContext } from "./DataAppRouter";
+
+interface DataAppLinkProps
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+  to: string;
+  children?: ReactNode;
+}
+
+/**
+ * Internal-only navigation link inside a data app.
+ *
+ * Renders a real `<a href>` so middle-click / cmd-click open in a new tab
+ * the way users expect. On a plain left-click, intercepts the navigation
+ * and routes via `DataAppRouter`'s `navigate` — no full page reload.
+ *
+ * The `to` prop is bundle-relative (e.g. `to="/customers/42"`); the
+ * provider's auto-detected basename is added when building the `href`.
+ */
+export function DataAppLink({
+  to,
+  children,
+  onClick,
+  ...rest
+}: DataAppLinkProps) {
+  const ctx = useContext(DataAppRouterContext);
+  if (!ctx) {
+    throw new Error("DataAppLink must be rendered inside a <DataAppRouter>");
+  }
+
+  // For the rendered `href`, use the parent's clean path so the link reads
+  // correctly when hovered / right-clicked / shared. The provider's own
+  // `navigate` knows how to translate it back when clicked.
+  const parentBasename = window.location.pathname.match(
+    /^\/embed\/data-app\/[^/]+/,
+  )?.[0];
+  const parentSurfaceBasename = parentBasename
+    ? parentBasename.replace(/^\/embed/, "")
+    : "";
+  const href = parentSurfaceBasename + to;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    ctx.navigate(to);
+  };
+
+  return (
+    <a {...rest} href={href} onClick={handleClick}>
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -1,12 +1,10 @@
-import { type AnchorHTMLAttributes, type ReactNode, useContext } from "react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { Link } from "react-router";
 
-import { DataAppRouterContext, getBasename } from "./DataAppRouter";
+import { getBasename } from "./DataAppRouter";
 
-interface DataAppLinkProps extends Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  "href"
-> {
+interface DataAppLinkProps
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
   to: string;
   children?: ReactNode;
 }
@@ -22,21 +20,13 @@ interface DataAppLinkProps extends Omit<
  *
  * The `to` prop is bundle-relative (e.g. `to="/customers/42"`); we add
  * the auto-detected basename before handing the URL to v3's `Link`.
+ *
+ * Must be rendered inside a `<DataAppRouter>` — v3's `<Link>` reads its
+ * router from the surrounding `<Router>` (which `<DataAppRouter>` mounts)
+ * and will throw without it.
  */
-export function DataAppLink({ to, children, ...rest }: DataAppLinkProps) {
-  // Defensive — surface a clear error if the bundle puts `<DataAppLink>`
-  // outside a `<DataAppRouter>`. v3's `<Link>` would fail more cryptically
-  // (no router context) without this.
-  const ctx = useContext(DataAppRouterContext);
-  if (!ctx) {
-    throw new Error("DataAppLink must be rendered inside a <DataAppRouter>");
-  }
-
-  const target = getBasename() + to;
-
-  return (
-    <Link to={target} {...rest}>
-      {children}
-    </Link>
-  );
-}
+export const DataAppLink = ({ to, children, ...rest }: DataAppLinkProps) => (
+  <Link to={getBasename() + to} {...rest}>
+    {children}
+  </Link>
+);

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -3,8 +3,10 @@ import { Link } from "react-router";
 
 import { DataAppRouterContext, getBasename } from "./DataAppRouter";
 
-interface DataAppLinkProps
-  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+interface DataAppLinkProps extends Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> {
   to: string;
   children?: ReactNode;
 }

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Route, Router, browserHistory } from "react-router";
+import { Router, browserHistory } from "react-router";
 
 import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
 
@@ -91,6 +91,13 @@ function RouteContent() {
   return useContext(RouteContentBridge);
 }
 
+// react-router 3 ignores route changes after the first mount and warns
+// "You cannot change <Router routes>; it will be ignored" if you re-pass
+// JSX children each render. Hoist the route definition to a single
+// module-level reference so the `routes` prop is identity-stable across
+// every `<DataAppRouter>` re-render.
+const STABLE_ROUTES = { path: "*", component: RouteContent };
+
 interface DataAppRouterProps {
   children?: ReactNode;
 }
@@ -147,9 +154,7 @@ export function DataAppRouter({ children }: DataAppRouterProps) {
 
   return (
     <RouteContentBridge.Provider value={bridgeValue}>
-      <Router history={browserHistory}>
-        <Route path="*" component={RouteContent} />
-      </Router>
+      <Router history={browserHistory} routes={STABLE_ROUTES} />
     </RouteContentBridge.Provider>
   );
 }

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -2,28 +2,25 @@ import {
   type ReactNode,
   createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useState,
 } from "react";
+import { Route, Router, browserHistory } from "react-router";
 
 /**
  * Data-app routing primitives.
  *
- * Why custom — and not `react-router-dom` in the bundle:
+ * Implementation uses Metabase's bundled `react-router@3` — same library
+ * MB uses everywhere else. The bundle never sees the router library: it
+ * only depends on the `{ pathname, navigate }` context shape we expose
+ * and on the `<DataAppLink>` component. When MB jumps v3 → v6/v7, this
+ * file's internals change; bundles stay untouched.
  *
- * The bundle runs inside a Near Membrane sandbox. When `react-router-dom`'s
- * `setState` (inside `BrowserRouter`'s `history.listen` handler) crosses
- * from the bundle realm into host React, React 18's automatic batching
- * silently drops the update — same structural bug class as
- * https://github.com/facebook/react/issues/24458, but triggered by Near
- * Membrane's detached-iframe realm rather than the Safari microtask quirk.
- * Result: URL changes, UI doesn't.
- *
- * The fix is to keep every `setState` on the host side of the membrane.
- * This provider lives in host code; the bundle just renders
- * `<DataAppRouter>`, `<DataAppLink>`, `useDataAppLocation()` and never
- * touches `window.history` or React state related to routing itself.
+ * Lives in host code, endowed to the bundle via
+ * `@metabase/embedding-sdk-react/data-app`. Every `setState` here runs in
+ * host realm; no Near Membrane crossing.
  */
 interface DataAppRouterContextValue {
   pathname: string;
@@ -44,10 +41,29 @@ function detectBasename(): string {
   return window.location.pathname.match(DATA_APP_BASENAME_RE)?.[0] ?? "";
 }
 
+export function getBasename(): string {
+  return detectBasename();
+}
+
 function computeSubPath(basename: string): string {
   const full = window.location.pathname;
-  const sub = basename && full.startsWith(basename) ? full.slice(basename.length) : full;
+  const sub =
+    basename && full.startsWith(basename) ? full.slice(basename.length) : full;
   return sub || "/";
+}
+
+/**
+ * Internal: react-router 3 expects `<Route>` children inside `<Router>`,
+ * and `<Route>`'s `component` prop must be a stable reference (otherwise
+ * v3 remounts on every render and the child tree loses state). We pass
+ * the user's content through React Context so the Route's component can
+ * stay a stable function reference while still rendering whatever the
+ * `<DataAppRouter>` is currently wrapping.
+ */
+const RouteContentBridge = createContext<ReactNode>(null);
+
+function RouteContent() {
+  return useContext(RouteContentBridge);
 }
 
 interface DataAppRouterProps {
@@ -71,22 +87,21 @@ export function DataAppRouter({ children }: DataAppRouterProps) {
   const [pathname, setPathname] = useState(() => computeSubPath(basename));
 
   useEffect(() => {
-    // Browser back/forward and our own `pushState`-driven updates: both
-    // observed by re-reading `window.location.pathname`.
-    const sync = () => setPathname(computeSubPath(basename));
-    window.addEventListener("popstate", sync);
-    return () => window.removeEventListener("popstate", sync);
+    // `browserHistory.listen` fires for every navigation — `Link` clicks,
+    // imperative `push` calls, and browser back/forward. One subscription
+    // covers all of them.
+    const unsubscribe = browserHistory.listen(() => {
+      setPathname(computeSubPath(basename));
+    });
+
+    return unsubscribe;
   }, [basename]);
 
   const navigate = useCallback(
     (to: string) => {
       // `to` is bundle-relative (e.g. "/customers/42"). The real URL is
       // `basename + to`.
-      const target = basename + to;
-      if (window.location.pathname !== target) {
-        window.history.pushState(null, "", target);
-      }
-      setPathname(to || "/");
+      browserHistory.push(basename + to);
     },
     [basename],
   );
@@ -96,9 +111,20 @@ export function DataAppRouter({ children }: DataAppRouterProps) {
     [pathname, navigate],
   );
 
+  const bridgeValue = useMemo(
+    () => (
+      <DataAppRouterContext.Provider value={value}>
+        {children}
+      </DataAppRouterContext.Provider>
+    ),
+    [value, children],
+  );
+
   return (
-    <DataAppRouterContext.Provider value={value}>
-      {children}
-    </DataAppRouterContext.Provider>
+    <RouteContentBridge.Provider value={bridgeValue}>
+      <Router history={browserHistory}>
+        <Route path="*" component={RouteContent} />
+      </Router>
+    </RouteContentBridge.Provider>
   );
 }

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -1,12 +1,4 @@
-import {
-  type ReactNode,
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { type ReactNode, createContext, useContext } from "react";
 import { Router, browserHistory } from "react-router";
 
 import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
@@ -16,21 +8,15 @@ import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
  *
  * Implementation uses Metabase's bundled `react-router@3` — same library
  * MB uses everywhere else. The bundle never sees the router library: it
- * only depends on the `{ pathname, navigate }` context shape we expose
- * and on the `<DataAppLink>` component. When MB jumps v3 → v6/v7, this
- * file's internals change; bundles stay untouched.
+ * only depends on the `{ pathname, navigate }` shape exposed by
+ * `useDataAppLocation` and on the `<DataAppLink>` component. When MB
+ * jumps v3 → v6/v7, this file's internals change; bundles stay untouched.
  *
  * Lives in host code, endowed to the bundle via
- * `@metabase/embedding-sdk-react/data-app`. Every `setState` here runs in
- * host realm; no Near Membrane crossing.
+ * `@metabase/embedding-sdk-react/data-app`. All routing state lives on
+ * `browserHistory` (a `react-router` singleton) — no custom React Context
+ * is needed across the public API.
  */
-interface DataAppRouterContextValue {
-  pathname: string;
-  navigate: (to: string) => void;
-}
-
-export const DataAppRouterContext =
-  createContext<DataAppRouterContextValue | null>(null);
 
 /**
  * Escape a string for safe use as a literal inside a `RegExp`. The
@@ -38,9 +24,8 @@ export const DataAppRouterContext =
  * but escaping makes the regex robust against future changes to the
  * constant.
  */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+const escapeRegExp = (str: string): string =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 // Captures everything from the start of `pathname` up to and including the
 // data-app `:name` segment. Tolerates a Metabase subpath install
@@ -53,49 +38,22 @@ const DATA_APP_BASENAME_RE = new RegExp(
 
 /**
  * Returns the iframe URL's data-app prefix — including any Metabase
- * subpath install root — so the provider can strip it before exposing
- * the sub-path to the bundle. Returns `""` for non-iframe contexts (the
- * dev preview).
+ * subpath install root — so consumers can strip it before exposing the
+ * sub-path to the bundle. Returns `""` for non-iframe contexts (the dev
+ * preview).
  *
  * Examples:
  *   `/embed/data-app/sales/customers/42`       → `/embed/data-app/sales`
  *   `/mb/embed/data-app/sales/customers/42`    → `/mb/embed/data-app/sales`
  *   `/customers/42`                            → `""`
  */
-function detectBasename(): string {
-  return window.location.pathname.match(DATA_APP_BASENAME_RE)?.[1] ?? "";
-}
+export const getBasename = (): string =>
+  window.location.pathname.match(DATA_APP_BASENAME_RE)?.[1] ?? "";
 
-export function getBasename(): string {
-  return detectBasename();
-}
-
-function computeSubPath(basename: string): string {
-  const full = window.location.pathname;
-  const sub =
-    basename && full.startsWith(basename) ? full.slice(basename.length) : full;
-  return sub || "/";
-}
-
-/**
- * Internal: react-router 3 expects `<Route>` children inside `<Router>`,
- * and `<Route>`'s `component` prop must be a stable reference (otherwise
- * v3 remounts on every render and the child tree loses state). We pass
- * the user's content through React Context so the Route's component can
- * stay a stable function reference while still rendering whatever the
- * `<DataAppRouter>` is currently wrapping.
- */
 const RouteContentBridge = createContext<ReactNode>(null);
 
-function RouteContent() {
-  return useContext(RouteContentBridge);
-}
+const RouteContent = () => useContext(RouteContentBridge);
 
-// react-router 3 ignores route changes after the first mount and warns
-// "You cannot change <Router routes>; it will be ignored" if you re-pass
-// JSX children each render. Hoist the route definition to a single
-// module-level reference so the `routes` prop is identity-stable across
-// every `<DataAppRouter>` re-render.
 const STABLE_ROUTES = { path: "*", component: RouteContent };
 
 interface DataAppRouterProps {
@@ -106,55 +64,13 @@ interface DataAppRouterProps {
  * Wrap your data-app tree once. Inside, use `<DataAppLink to="…">` for
  * navigation and `useDataAppLocation()` to read the current path.
  *
- * No `basename` prop: the provider auto-detects the iframe's URL prefix
+ * No `basename` prop: the basename is auto-detected from the iframe URL
  * (`/embed/data-app/<name>`). In the dev preview where there's no prefix,
  * the same code works — `basename` resolves to `""` and the sub-path is
  * just the raw pathname.
  */
-export function DataAppRouter({ children }: DataAppRouterProps) {
-  // Basename never changes after mount — the iframe doesn't navigate to a
-  // different `<name>`; that'd be a parent-level route change which
-  // re-mounts the iframe entirely.
-  const basename = useMemo(() => detectBasename(), []);
-  const [pathname, setPathname] = useState(() => computeSubPath(basename));
-
-  useEffect(() => {
-    // `browserHistory.listen` fires for every navigation — `Link` clicks,
-    // imperative `push` calls, and browser back/forward. One subscription
-    // covers all of them.
-    const unsubscribe = browserHistory.listen(() => {
-      setPathname(computeSubPath(basename));
-    });
-
-    return unsubscribe;
-  }, [basename]);
-
-  const navigate = useCallback(
-    (to: string) => {
-      // `to` is bundle-relative (e.g. "/customers/42"). The real URL is
-      // `basename + to`.
-      browserHistory.push(basename + to);
-    },
-    [basename],
-  );
-
-  const value = useMemo<DataAppRouterContextValue>(
-    () => ({ pathname, navigate }),
-    [pathname, navigate],
-  );
-
-  const bridgeValue = useMemo(
-    () => (
-      <DataAppRouterContext.Provider value={value}>
-        {children}
-      </DataAppRouterContext.Provider>
-    ),
-    [value, children],
-  );
-
-  return (
-    <RouteContentBridge.Provider value={bridgeValue}>
-      <Router history={browserHistory} routes={STABLE_ROUTES} />
-    </RouteContentBridge.Provider>
-  );
-}
+export const DataAppRouter = ({ children }: DataAppRouterProps) => (
+  <RouteContentBridge.Provider value={children}>
+    <Router history={browserHistory} routes={STABLE_ROUTES} />
+  </RouteContentBridge.Provider>
+);

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import { Route, Router, browserHistory } from "react-router";
 
+import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
+
 /**
  * Data-app routing primitives.
  *
@@ -30,15 +32,38 @@ interface DataAppRouterContextValue {
 export const DataAppRouterContext =
   createContext<DataAppRouterContextValue | null>(null);
 
-const DATA_APP_BASENAME_RE = /^\/embed\/data-app\/[^/]+/;
+/**
+ * Escape a string for safe use as a literal inside a `RegExp`. The
+ * embed-prefix constant doesn't currently contain regex metacharacters,
+ * but escaping makes the regex robust against future changes to the
+ * constant.
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Captures everything from the start of `pathname` up to and including the
+// data-app `:name` segment. Tolerates a Metabase subpath install
+// (`/mb/embed/data-app/sales/…`) by allowing arbitrary characters before
+// the `DATA_APP_EMBED_PREFIX` literal. In root installs (no subpath) the
+// pre-segment is empty and the match becomes `${DATA_APP_EMBED_PREFIX}/<name>`.
+const DATA_APP_BASENAME_RE = new RegExp(
+  `^(.*?${escapeRegExp(DATA_APP_EMBED_PREFIX)}/[^/]+)`,
+);
 
 /**
- * Returns the iframe URL's data-app prefix (e.g. `/embed/data-app/sales`)
- * so the provider can strip it before exposing the sub-path to the bundle.
- * Returns `""` for non-iframe contexts (the dev preview).
+ * Returns the iframe URL's data-app prefix — including any Metabase
+ * subpath install root — so the provider can strip it before exposing
+ * the sub-path to the bundle. Returns `""` for non-iframe contexts (the
+ * dev preview).
+ *
+ * Examples:
+ *   `/embed/data-app/sales/customers/42`       → `/embed/data-app/sales`
+ *   `/mb/embed/data-app/sales/customers/42`    → `/mb/embed/data-app/sales`
+ *   `/customers/42`                            → `""`
  */
 function detectBasename(): string {
-  return window.location.pathname.match(DATA_APP_BASENAME_RE)?.[0] ?? "";
+  return window.location.pathname.match(DATA_APP_BASENAME_RE)?.[1] ?? "";
 }
 
 export function getBasename(): string {

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -1,0 +1,104 @@
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+/**
+ * Data-app routing primitives.
+ *
+ * Why custom — and not `react-router-dom` in the bundle:
+ *
+ * The bundle runs inside a Near Membrane sandbox. When `react-router-dom`'s
+ * `setState` (inside `BrowserRouter`'s `history.listen` handler) crosses
+ * from the bundle realm into host React, React 18's automatic batching
+ * silently drops the update — same structural bug class as
+ * https://github.com/facebook/react/issues/24458, but triggered by Near
+ * Membrane's detached-iframe realm rather than the Safari microtask quirk.
+ * Result: URL changes, UI doesn't.
+ *
+ * The fix is to keep every `setState` on the host side of the membrane.
+ * This provider lives in host code; the bundle just renders
+ * `<DataAppRouter>`, `<DataAppLink>`, `useDataAppLocation()` and never
+ * touches `window.history` or React state related to routing itself.
+ */
+interface DataAppRouterContextValue {
+  pathname: string;
+  navigate: (to: string) => void;
+}
+
+export const DataAppRouterContext =
+  createContext<DataAppRouterContextValue | null>(null);
+
+const DATA_APP_BASENAME_RE = /^\/embed\/data-app\/[^/]+/;
+
+/**
+ * Returns the iframe URL's data-app prefix (e.g. `/embed/data-app/sales`)
+ * so the provider can strip it before exposing the sub-path to the bundle.
+ * Returns `""` for non-iframe contexts (the dev preview).
+ */
+function detectBasename(): string {
+  return window.location.pathname.match(DATA_APP_BASENAME_RE)?.[0] ?? "";
+}
+
+function computeSubPath(basename: string): string {
+  const full = window.location.pathname;
+  const sub = basename && full.startsWith(basename) ? full.slice(basename.length) : full;
+  return sub || "/";
+}
+
+interface DataAppRouterProps {
+  children?: ReactNode;
+}
+
+/**
+ * Wrap your data-app tree once. Inside, use `<DataAppLink to="…">` for
+ * navigation and `useDataAppLocation()` to read the current path.
+ *
+ * No `basename` prop: the provider auto-detects the iframe's URL prefix
+ * (`/embed/data-app/<name>`). In the dev preview where there's no prefix,
+ * the same code works — `basename` resolves to `""` and the sub-path is
+ * just the raw pathname.
+ */
+export function DataAppRouter({ children }: DataAppRouterProps) {
+  // Basename never changes after mount — the iframe doesn't navigate to a
+  // different `<name>`; that'd be a parent-level route change which
+  // re-mounts the iframe entirely.
+  const basename = useMemo(() => detectBasename(), []);
+  const [pathname, setPathname] = useState(() => computeSubPath(basename));
+
+  useEffect(() => {
+    // Browser back/forward and our own `pushState`-driven updates: both
+    // observed by re-reading `window.location.pathname`.
+    const sync = () => setPathname(computeSubPath(basename));
+    window.addEventListener("popstate", sync);
+    return () => window.removeEventListener("popstate", sync);
+  }, [basename]);
+
+  const navigate = useCallback(
+    (to: string) => {
+      // `to` is bundle-relative (e.g. "/customers/42"). The real URL is
+      // `basename + to`.
+      const target = basename + to;
+      if (window.location.pathname !== target) {
+        window.history.pushState(null, "", target);
+      }
+      setPathname(to || "/");
+    },
+    [basename],
+  );
+
+  const value = useMemo<DataAppRouterContextValue>(
+    () => ({ pathname, navigate }),
+    [pathname, navigate],
+  );
+
+  return (
+    <DataAppRouterContext.Provider value={value}>
+      {children}
+    </DataAppRouterContext.Provider>
+  );
+}

--- a/frontend/src/metabase/data_apps/router/index.ts
+++ b/frontend/src/metabase/data_apps/router/index.ts
@@ -1,0 +1,3 @@
+export { DataAppRouter } from "./DataAppRouter";
+export { DataAppLink } from "./DataAppLink";
+export { useDataAppLocation } from "./useDataAppLocation";

--- a/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
+++ b/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
@@ -15,10 +15,12 @@ export function useDataAppLocation(): {
   navigate: (to: string) => void;
 } {
   const ctx = useContext(DataAppRouterContext);
+
   if (!ctx) {
     throw new Error(
       "useDataAppLocation must be called inside a <DataAppRouter>",
     );
   }
+
   return { pathname: ctx.pathname, navigate: ctx.navigate };
 }

--- a/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
+++ b/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
@@ -1,0 +1,24 @@
+import { useContext } from "react";
+
+import { DataAppRouterContext } from "./DataAppRouter";
+
+/**
+ * Returns the current data-app sub-path and a `navigate` function.
+ *
+ * Path is relative to the data-app root: `/`, `/customers/42`, etc.
+ * `navigate(to)` switches to a new sub-path without a full reload.
+ *
+ * Must be called inside a `<DataAppRouter>` subtree.
+ */
+export function useDataAppLocation(): {
+  pathname: string;
+  navigate: (to: string) => void;
+} {
+  const ctx = useContext(DataAppRouterContext);
+  if (!ctx) {
+    throw new Error(
+      "useDataAppLocation must be called inside a <DataAppRouter>",
+    );
+  }
+  return { pathname: ctx.pathname, navigate: ctx.navigate };
+}

--- a/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
+++ b/frontend/src/metabase/data_apps/router/useDataAppLocation.ts
@@ -1,26 +1,51 @@
-import { useContext } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { browserHistory } from "react-router";
 
-import { DataAppRouterContext } from "./DataAppRouter";
+import { getBasename } from "./DataAppRouter";
+
+const computeSubPath = (basename: string): string => {
+  const pathname = window.location.pathname;
+  const subPath =
+    basename && pathname.startsWith(basename)
+      ? pathname.slice(basename.length)
+      : pathname;
+
+  return subPath || "/";
+};
 
 /**
  * Returns the current data-app sub-path and a `navigate` function.
  *
  * Path is relative to the data-app root: `/`, `/customers/42`, etc.
  * `navigate(to)` switches to a new sub-path without a full reload.
- *
- * Must be called inside a `<DataAppRouter>` subtree.
  */
-export function useDataAppLocation(): {
+export const useDataAppLocation = (): {
   pathname: string;
   navigate: (to: string) => void;
-} {
-  const ctx = useContext(DataAppRouterContext);
+} => {
+  // Basename never changes after mount: the iframe doesn't navigate to a
+  // different `<name>`; that'd be a parent-level route change which
+  // re-mounts the iframe entirely.
+  const basename = useMemo(() => getBasename(), []);
+  const [pathname, setPathname] = useState(() => computeSubPath(basename));
 
-  if (!ctx) {
-    throw new Error(
-      "useDataAppLocation must be called inside a <DataAppRouter>",
-    );
-  }
+  useEffect(() => {
+    // `browserHistory.listen` fires for every navigation — `<Link>` clicks,
+    // imperative `push` calls, and browser back/forward. One subscription
+    // covers all of them.
+    return browserHistory.listen(() => {
+      setPathname(computeSubPath(basename));
+    });
+  }, [basename]);
 
-  return { pathname: ctx.pathname, navigate: ctx.navigate };
-}
+  const navigate = useCallback(
+    (to: string) => {
+      // `to` is bundle-relative (e.g. "/customers/42"). The real URL is
+      // `basename + to`.
+      browserHistory.push(basename + to);
+    },
+    [basename],
+  );
+
+  return { pathname, navigate };
+};

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -33,9 +33,10 @@ import { makeDistortionCallback } from "./sandbox/distortions";
  *     info). Each one assumes it's rendered inside a `MetabaseProvider` —
  *     no internal wrapping — matching the published SDK API.
  *
- * Plugin contract: write a factory function to globalThis.__customVizPlugin__.
- * The host calls factory(hostApi) and renders the returned `component` inside
- * its own React tree.
+ * Bundle contract: the bundle's Vite IIFE assigns its factory function to
+ * `globalThis.__dataAppFactory__`. The host captures it via the endowment
+ * below, calls `factory(hostApi)`, and renders the returned `component`
+ * inside its own React tree.
  */
 
 // Future: { runQuery, fetchCard, … }. Empty for the PoC.
@@ -84,10 +85,10 @@ export function createDataAppSandbox(
         CreateDashboardModal,
         // Collection
         CollectionBrowser,
-        get __customVizPlugin__() {
+        get __dataAppFactory__() {
           return captured;
         },
-        set __customVizPlugin__(value: unknown) {
+        set __dataAppFactory__(value: unknown) {
           captured = value;
         },
       }),
@@ -109,7 +110,7 @@ export function createDataAppSandbox(
       }
       if (typeof captured !== "function") {
         throw new Error(
-          "Bundle did not assign a function to __customVizPlugin__",
+          "Bundle did not assign a function to __dataAppFactory__",
         );
       }
       return captured as DataAppFactory;

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -1,7 +1,6 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 import * as React from "react";
 
-import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
 import { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
 import { CreateQuestion } from "embedding-sdk-bundle/components/public/CreateQuestion";
@@ -16,10 +15,8 @@ import {
 } from "embedding-sdk-bundle/components/public/dashboard";
 import { useMetabaseQuery } from "embedding-sdk-package/hooks/public/use-metabase-query";
 import { useQuestionQuery } from "embedding-sdk-package/hooks/public/use-question-query";
-import type { MetabaseEmbeddingTheme } from "metabase/embedding-sdk/theme";
-import { MetabaseReduxProvider } from "metabase/redux";
+import { DataAppProvider } from "metabase/data_apps/components/DataAppProvider";
 
-import { getHostBackedSdkStore } from "./host-sdk-init";
 import { makeDistortionCallback } from "./sandbox/distortions";
 
 /**
@@ -52,35 +49,8 @@ function isLiveTarget(target: object): boolean {
   return target instanceof CSSStyleDeclaration;
 }
 
-interface MetabaseProviderProps {
-  theme?: MetabaseEmbeddingTheme;
-  children?: React.ReactNode;
-}
-
-/**
- * In-host equivalent of the SDK's `MetabaseProvider` / `ComponentProvider`:
- * provides the SDK Redux store (pre-initialized, no auth handshake) and the
- * SDK theme provider in one go. Plugins wrap their tree with this once.
- */
-function MetabaseProvider(props: MetabaseProviderProps) {
-  const sdkStore = getHostBackedSdkStore();
-  // Children come from the third arg of createElement, but SdkThemeProvider's
-  // TS props mark children as required — cast props to satisfy the type
-  // without duplicating the value.
-  type ThemeProps = React.ComponentProps<typeof SdkThemeProvider>;
-  return React.createElement(
-    MetabaseReduxProvider,
-    { store: sdkStore },
-    React.createElement(
-      SdkThemeProvider,
-      { theme: props.theme } as ThemeProps,
-      props.children,
-    ),
-  );
-}
-
 export function createDataAppSandbox(
-  appId: number = 0,
+  label: string = "",
   targetWindow: Window = window,
 ) {
   let captured: unknown;
@@ -92,7 +62,7 @@ export function createDataAppSandbox(
   const env = createVirtualEnvironment(
     targetWindow as Window & typeof globalThis,
     {
-      distortionCallback: makeDistortionCallback(appId),
+      distortionCallback: makeDistortionCallback(label),
       liveTargetCallback: isLiveTarget,
       endowments: Object.getOwnPropertyDescriptors({
         React,
@@ -100,7 +70,7 @@ export function createDataAppSandbox(
         useQuestionQuery,
         useMetabaseQuery,
         // Provider
-        MetabaseProvider,
+        MetabaseProvider: DataAppProvider,
         // Question components
         InteractiveQuestion,
         StaticQuestion,

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -16,6 +16,11 @@ import {
 import { useMetabaseQuery } from "embedding-sdk-package/hooks/public/use-metabase-query";
 import { useQuestionQuery } from "embedding-sdk-package/hooks/public/use-question-query";
 import { DataAppProvider } from "metabase/data_apps/components/DataAppProvider";
+import {
+  DataAppLink,
+  DataAppRouter,
+  useDataAppLocation,
+} from "metabase/data_apps/router";
 
 import { makeDistortionCallback } from "./sandbox/distortions";
 
@@ -85,6 +90,11 @@ export function createDataAppSandbox(
         CreateDashboardModal,
         // Collection
         CollectionBrowser,
+        // Routing — host-owned (see `metabase/data_apps/router/DataAppRouter`
+        // for why the bundle can't use `react-router-dom` directly)
+        DataAppRouter,
+        DataAppLink,
+        useDataAppLocation,
         get __dataAppFactory__() {
           return captured;
         },

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -79,40 +79,50 @@ function MetabaseProvider(props: MetabaseProviderProps) {
   );
 }
 
-export function createDataAppSandbox(appId: number = 0) {
+export function createDataAppSandbox(
+  appId: number = 0,
+  targetWindow: Window = window,
+) {
   let captured: unknown;
 
-  const env = createVirtualEnvironment(window, {
-    distortionCallback: makeDistortionCallback(appId),
-    liveTargetCallback: isLiveTarget,
-    endowments: Object.getOwnPropertyDescriptors({
-      React,
-      // Data fetching
-      useQuestionQuery,
-      useMetabaseQuery,
-      // Provider
-      MetabaseProvider,
-      // Question components
-      InteractiveQuestion,
-      StaticQuestion,
-      SdkQuestion,
-      CreateQuestion,
-      MetabotQuestion,
-      // Dashboard components
-      EditableDashboard,
-      InteractiveDashboard,
-      StaticDashboard,
-      CreateDashboardModal,
-      // Collection
-      CollectionBrowser,
-      get __customVizPlugin__() {
-        return captured;
-      },
-      set __customVizPlugin__(value: unknown) {
-        captured = value;
-      },
-    }),
-  });
+  // near-membrane-dom narrows the first arg to `Window & typeof globalThis`
+  // (i.e., the global window). Foreign-realm windows from same-origin
+  // iframes match the shape at runtime — Near Membrane only reads
+  // standard DOM properties — but TS can't prove the assignability.
+  const env = createVirtualEnvironment(
+    targetWindow as Window & typeof globalThis,
+    {
+      distortionCallback: makeDistortionCallback(appId),
+      liveTargetCallback: isLiveTarget,
+      endowments: Object.getOwnPropertyDescriptors({
+        React,
+        // Data fetching
+        useQuestionQuery,
+        useMetabaseQuery,
+        // Provider
+        MetabaseProvider,
+        // Question components
+        InteractiveQuestion,
+        StaticQuestion,
+        SdkQuestion,
+        CreateQuestion,
+        MetabotQuestion,
+        // Dashboard components
+        EditableDashboard,
+        InteractiveDashboard,
+        StaticDashboard,
+        CreateDashboardModal,
+        // Collection
+        CollectionBrowser,
+        get __customVizPlugin__() {
+          return captured;
+        },
+        set __customVizPlugin__(value: unknown) {
+          captured = value;
+        },
+      }),
+    },
+  );
 
   return {
     evaluate(code: string): DataAppFactory {

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -15,40 +15,27 @@ import {
 } from "embedding-sdk-bundle/components/public/dashboard";
 import { useMetabaseQuery } from "embedding-sdk-package/hooks/public/use-metabase-query";
 import { useQuestionQuery } from "embedding-sdk-package/hooks/public/use-question-query";
-import { DataAppProvider } from "metabase/data_apps/components/DataAppProvider";
 import {
   DataAppLink,
   DataAppRouter,
   useDataAppLocation,
 } from "metabase/data_apps/router";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { makeDistortionCallback } from "./sandbox/distortions";
 
 /**
- * Sandbox for data-app plugin bundles.
- *
- * Endowments:
- *   - React: the host's React instance so plugins don't bundle their own.
- *   - MetabaseProvider: wraps a subtree with the SDK Redux store and an
- *     `SdkThemeProvider`. The plugin uses this exactly as it would the
- *     public SDK's `MetabaseProvider`: wrap your tree once, pass `theme`,
- *     and use the other SDK components inside.
- *   - All public SDK components (questions, dashboards, collection browser,
- *     create-question / create-dashboard modals, Metabot question, debug
- *     info). Each one assumes it's rendered inside a `MetabaseProvider` —
- *     no internal wrapping — matching the published SDK API.
- *
- * Bundle contract: the bundle's Vite IIFE assigns its factory function to
- * `globalThis.__dataAppFactory__`. The host captures it via the endowment
- * below, calls `factory(hostApi)`, and renders the returned `component`
- * inside its own React tree.
+ * The bundle's factory returns:
+ *   - `component` — the React tree the host will mount inside its
+ *     `DataAppProvider`. Should be pure content; no `<MetabaseProvider>`
+ *     inside — the host owns the provider wrap so the SDK store/theme/
+ *     portal context live in host realm.
+ *   - `theme` — the theme passed to `<DataAppProvider theme={…}>`. Same
+ *     shape as the SDK's public `MetabaseTheme`.
  */
-
-// Future: { runQuery, fetchCard, … }. Empty for the PoC.
-export type DataAppHostApi = Record<string, never>;
-
-export type DataAppFactory = (hostApi: DataAppHostApi) => {
+export type DataAppFactory = () => {
   component: React.ComponentType<Record<string, unknown>>;
+  theme?: MetabaseTheme;
 };
 
 function isLiveTarget(target: object): boolean {
@@ -61,10 +48,6 @@ export function createDataAppSandbox(
 ) {
   let captured: unknown;
 
-  // near-membrane-dom narrows the first arg to `Window & typeof globalThis`
-  // (i.e., the global window). Foreign-realm windows from same-origin
-  // iframes match the shape at runtime — Near Membrane only reads
-  // standard DOM properties — but TS can't prove the assignability.
   const env = createVirtualEnvironment(
     targetWindow as Window & typeof globalThis,
     {
@@ -72,29 +55,30 @@ export function createDataAppSandbox(
       liveTargetCallback: isLiveTarget,
       endowments: Object.getOwnPropertyDescriptors({
         React,
-        // Data fetching
-        useQuestionQuery,
-        useMetabaseQuery,
-        // Provider
-        MetabaseProvider: DataAppProvider,
-        // Question components
-        InteractiveQuestion,
-        StaticQuestion,
-        SdkQuestion,
-        CreateQuestion,
-        MetabotQuestion,
-        // Dashboard components
-        EditableDashboard,
-        InteractiveDashboard,
-        StaticDashboard,
-        CreateDashboardModal,
-        // Collection
-        CollectionBrowser,
-        // Routing — host-owned (see `metabase/data_apps/router/DataAppRouter`
-        // for why the bundle can't use `react-router-dom` directly)
-        DataAppRouter,
-        DataAppLink,
-        useDataAppLocation,
+        __metabase_sdk__: {
+          // Data fetching
+          useQuestionQuery,
+          useMetabaseQuery,
+          // Question components
+          InteractiveQuestion,
+          StaticQuestion,
+          SdkQuestion,
+          CreateQuestion,
+          MetabotQuestion,
+          // Dashboard components
+          EditableDashboard,
+          InteractiveDashboard,
+          StaticDashboard,
+          CreateDashboardModal,
+          // Collection
+          CollectionBrowser,
+        },
+        __metabase_data_app__: {
+          // Routing
+          DataAppRouter,
+          DataAppLink,
+          useDataAppLocation,
+        },
         get __dataAppFactory__() {
           return captured;
         },

--- a/frontend/src/metabase/data_apps/sandbox/distortions.ts
+++ b/frontend/src/metabase/data_apps/sandbox/distortions.ts
@@ -1,5 +1,4 @@
 import { makeSandboxDistortionCallback } from "metabase/utils/scripts-sandbox";
-import type { DataAppId } from "metabase-types/api";
 
 /**
  * Data-app Near Membrane distortion callback.
@@ -14,6 +13,6 @@ import type { DataAppId } from "metabase-types/api";
  * no sibling DOM to protect from. If we ever want defense-in-depth there,
  * add scoping in this file — the shared module is unchanged.
  */
-export function makeDistortionCallback(appId: DataAppId) {
-  return makeSandboxDistortionCallback(`data-app ${appId}`);
+export function makeDistortionCallback(label: string) {
+  return makeSandboxDistortionCallback(`data-app ${label}`);
 }

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -148,6 +148,11 @@ export const getRoutes = (store) => {
               reserves `/app/*` for static asset serving. */}
           <Route path="data-app/:name" component={IsAdmin}>
             <IndexRoute component={DataAppView} />
+            {/* Sub-paths under /data-app/:name are owned by the iframe's
+                router. Same component — `DataAppView` just keeps the
+                iframe mounted; the URL change is mirrored back from
+                inside the iframe via `history.replaceState`. */}
+            <Route path="*" component={DataAppView} />
           </Route>
 
           {/* The global all hands routes, things in here are for all the folks */}

--- a/resources/frontend_client/data-app.html
+++ b/resources/frontend_client/data-app.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{{language}}}" translate="no">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta name="base-href" content="{{{baseHref}}}" />
+    <meta name="uri" content="{{{uri}}}" />
+
+    {{{embedCode}}}
+
+    <title>{{{applicationName}}}</title>
+
+    <base href="{{{baseHref}}}" />
+
+    <script type="application/json" id="_metabaseBootstrap">
+      {{{bootstrapJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseUserLocalization">
+      {{{userLocalizationJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseSiteLocalization">
+      {{{siteLocalizationJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseUserColorScheme">
+      {{{userColorScheme}}}
+    </script>
+
+    <script type="application/json" id="_metabaseNonce">
+      {{{nonceJSON}}}
+    </script>
+
+    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.server.middleware.security -->
+    <script type="text/javascript">{{{bootstrapJS}}}</script>
+    <script type="text/javascript">{{{assetOnErrorJS}}}</script>
+  <script defer src="http://localhost:8080/app/dist/runtime.hot.bundle.js" onerror="Metabase.AssetErrorLoad(this)"></script><script defer src="http://localhost:8080/app/dist/data-app-vendors.hot.bundle.js" onerror="Metabase.AssetErrorLoad(this)"></script><script defer src="http://localhost:8080/app/dist/app-data-app.hot.bundle.js" onerror="Metabase.AssetErrorLoad(this)"></script><link href="http://localhost:8080/app/dist/data-app-vendors.css" rel="stylesheet"><link href="http://localhost:8080/app/dist/app-data-app.css" rel="stylesheet"></head>
+
+  <!--
+    No `mb-wrapper` class on body: SDK components add it to their own
+    wrappers via `PublicComponentStylesWrapper`. Setting it on the body
+    would put the entire iframe (including the bundle's own chrome) under
+    Metabase's `.mb-wrapper`-scoped resets, which is what we're trying to
+    avoid.
+  -->
+  <body dir="ltr">
+    <div id="root"></div>
+  </body>
+</html>

--- a/resources/frontend_client/data_app_template.html
+++ b/resources/frontend_client/data_app_template.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{{language}}}" translate="no">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta name="base-href" content="{{{baseHref}}}" />
+    <meta name="uri" content="{{{uri}}}" />
+
+    {{{embedCode}}}
+
+    <title>{{{applicationName}}}</title>
+
+    <base href="{{{baseHref}}}" />
+
+    <script type="application/json" id="_metabaseBootstrap">
+      {{{bootstrapJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseUserLocalization">
+      {{{userLocalizationJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseSiteLocalization">
+      {{{siteLocalizationJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseUserColorScheme">
+      {{{userColorScheme}}}
+    </script>
+
+    <script type="application/json" id="_metabaseNonce">
+      {{{nonceJSON}}}
+    </script>
+
+    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.server.middleware.security -->
+    <script type="text/javascript">{{{bootstrapJS}}}</script>
+    <script type="text/javascript">{{{assetOnErrorJS}}}</script>
+  </head>
+
+  <!--
+    No `mb-wrapper` class on body: SDK components add it to their own
+    wrappers via `PublicComponentStylesWrapper`. Setting it on the body
+    would put the entire iframe (including the bundle's own chrome) under
+    Metabase's `.mb-wrapper`-scoped resets, which is what we're trying to
+    avoid.
+  -->
+  <body dir="ltr">
+    <div id="root"></div>
+  </body>
+</html>

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -115,6 +115,8 @@ const config = {
     "app-embed-mcp": "./app-embed-mcp.tsx",
     "vendor-styles": "./css/vendor.css",
     styles: "./css/index.module.css",
+    "app-data-app": "./app-data-app.tsx",
+    "data-app-vendors": "./data_apps/iframe-vendors.ts",
   },
 
   // we override it for dev mode below
@@ -233,7 +235,13 @@ const config = {
       cacheGroups: {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
-          chunks: "initial",
+          // The data-app iframe is self-contained — keep its node_modules
+          // (incl. React, Emotion, Mantine CSS) inside its own chunks so
+          // `data-app.html` doesn't need to load the main app's vendor
+          // bundle. Otherwise the iframe would have to link `vendor.[hash]`
+          // and inherit whatever else lives in that shared chunk.
+          chunks: (chunk) =>
+            chunk.name !== "data-app-vendors" && chunk.name !== "app-data-app",
           name: "vendor",
           priority: -10,
         },
@@ -295,6 +303,12 @@ const config = {
       chunksSortMode: "manual",
       chunks: ["vendor", "vendor-styles", "styles", "app-embed-sdk"],
       template: __dirname + "/resources/frontend_client/index_template.html",
+    }),
+    new HtmlWebpackPlugin({
+      filename: "../../data-app.html",
+      chunksSortMode: "manual",
+      chunks: ["data-app-vendors", "app-data-app"],
+      template: __dirname + "/resources/frontend_client/data_app_template.html",
     }),
     new HtmlWebpackPlugin({
       filename: "../../embed-mcp.html",

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -235,11 +235,9 @@ const config = {
       cacheGroups: {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
-          // The data-app iframe is self-contained — keep its node_modules
-          // (incl. React, Emotion, Mantine CSS) inside its own chunks so
-          // `data-app.html` doesn't need to load the main app's vendor
-          // bundle. Otherwise the iframe would have to link `vendor.[hash]`
-          // and inherit whatever else lives in that shared chunk.
+          // The data-app iframe is isolated from main-app CSS/JS by design;
+          // sharing the vendor chunk would re-link them. Keep its
+          // node_modules in its own chunks.
           chunks: (chunk) =>
             chunk.name !== "data-app-vendors" && chunk.name !== "app-data-app",
           name: "vendor",

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -41,6 +41,7 @@
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defroutes ^:private ^{:arglists '([request respond raise])} embed-routes
   (GET "/sdk/v1" [] index/embed-sdk)
+  (GET ["/data-app/:name", :name #"[^/]+"] [] index/data-app)
   (GET ["/question/:token.:export-format", :export-format qp.schema/export-formats-regex]
     [token export-format]
     (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (system/site-url) token export-format)))

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -41,7 +41,11 @@
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defroutes ^:private ^{:arglists '([request respond raise])} embed-routes
   (GET "/sdk/v1" [] index/embed-sdk)
+  ;; Same `data-app.html` for the bare path and any deeper sub-route — the
+  ;; iframe's React Router owns the sub-path; reloads at an inner URL still
+  ;; have to serve the SPA shell.
   (GET ["/data-app/:name", :name #"[^/]+"] [] index/data-app)
+  (GET ["/data-app/:name/*", :name #"[^/]+"] [] index/data-app)
   (GET ["/question/:token.:export-format", :export-format qp.schema/export-formats-regex]
     [token export-format]
     (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (system/site-url) token export-format)))

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -127,3 +127,4 @@
 (def public "/public index.html entrypoint." (partial entrypoint "public" :embeddable))
 (def embed  "/embed index.html entrypoint."  (partial entrypoint "embed"  :embeddable))
 (def embed-sdk  "/embed/sdk/v1 index.html entrypoint."  (partial entrypoint "embed-sdk"  :embeddable))
+(def data-app   "/embed/data-app/:name iframe entrypoint." (partial entrypoint "data-app"   :embeddable))


### PR DESCRIPTION
This PR renders a Data App in an iframe to isolate styles. As everything inside iframe needs proper styles (emotion/mantine) + some libs (dayjs) it's done similar to other iframe rendered pages like EAJS - via a separate entry point.

<img width="3288" height="1548" alt="image" src="https://github.com/user-attachments/assets/9feddf52-9f2c-4dfd-930b-9350fa07f4e5" />

Also it adds routing components, see demo https://metaboat.slack.com/archives/C0B622E447M/p1780947742955899

