### PR TITLE
Fix flaky homepage x-ray save test

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -78,10 +78,6 @@ describe("scenarios > home > homepage", () => {
         triggered_from: "suggestion_sidebar",
       });
 
-      // Remember the current URL so we can wait for the *final* navigation to actually
-      // settle before saving (see the save step below).
-      cy.url().as("urlBeforeFinalXray");
-
       cy.findByRole("complementary").within(() => {
         cy.findByRole("heading", { name: "More X-rays" }).should("be.visible");
         cy.findByRole("heading", { name: "Related" })
@@ -97,19 +93,17 @@ describe("scenarios > home > homepage", () => {
         triggered_from: "suggestion_sidebar",
       });
 
-      // `cy.wait("@getXrayDashboard")` only confirms the automagic *metadata* request; the
-      // SPA route change + dashboard remount for the final ("Related → Orders") x-ray lag it.
-      // Clicking "Save this" before that remount settles discards the save dispatch — no
-      // POST /api/dashboard/save is ever sent. Wait for the URL to actually land on the new
-      // x-ray dashboard first; the disabled-until-loaded "Save this" button then handles the
-      // data-load gap.
-      cy.get("@urlBeforeFinalXray").then((urlBeforeFinalXray) => {
-        cy.url().should("not.eq", urlBeforeFinalXray);
-      });
-
-      cy.intercept("POST", "/api/dashboard/save").as("saveDashboard");
       cy.findByTestId("automatic-dashboard-header").button("Save this").click();
-      cy.wait("@saveDashboard");
+
+      // Assert the save succeeded via the resulting UI — the header switches to a "Saved"
+      // button + "See it" link — rather than waiting on the POST /api/dashboard/save
+      // request. The request-alias wait was timing-sensitive and flaked with "No request
+      // ever occurred"; the saved-state UI is the real user-observable outcome and Cypress
+      // retries it until the save completes.
+      cy.findByTestId("automatic-dashboard-header").within(() => {
+        cy.findByText("See it").should("be.visible");
+        cy.findByText("Saved").should("be.visible");
+      });
 
       H.expectUnstructuredSnowplowEvent({
         event: "x-ray_saved",

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -95,7 +95,10 @@ describe("scenarios > home > homepage", () => {
 
       cy.intercept("POST", "/api/dashboard/save").as("saveDashboard");
       cy.findByTestId("automatic-dashboard-header").button("Save this").click();
-      cy.wait("@saveDashboard");
+      // Diagnostic: CI is slower than local, so give the save request more time to
+      // appear before failing. If it still times out at 30s, the request genuinely
+      // never fires (a save-path/navigation race), not just slowness.
+      cy.wait("@saveDashboard", { requestTimeout: 30000 });
 
       H.expectUnstructuredSnowplowEvent({
         event: "x-ray_saved",

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -78,6 +78,10 @@ describe("scenarios > home > homepage", () => {
         triggered_from: "suggestion_sidebar",
       });
 
+      // Remember the current URL so we can wait for the *final* navigation to actually
+      // settle before saving (see the save step below).
+      cy.url().as("urlBeforeFinalXray");
+
       cy.findByRole("complementary").within(() => {
         cy.findByRole("heading", { name: "More X-rays" }).should("be.visible");
         cy.findByRole("heading", { name: "Related" })
@@ -93,12 +97,19 @@ describe("scenarios > home > homepage", () => {
         triggered_from: "suggestion_sidebar",
       });
 
+      // `cy.wait("@getXrayDashboard")` only confirms the automagic *metadata* request; the
+      // SPA route change + dashboard remount for the final ("Related → Orders") x-ray lag it.
+      // Clicking "Save this" before that remount settles discards the save dispatch — no
+      // POST /api/dashboard/save is ever sent. Wait for the URL to actually land on the new
+      // x-ray dashboard first; the disabled-until-loaded "Save this" button then handles the
+      // data-load gap.
+      cy.get("@urlBeforeFinalXray").then((urlBeforeFinalXray) => {
+        cy.url().should("not.eq", urlBeforeFinalXray);
+      });
+
       cy.intercept("POST", "/api/dashboard/save").as("saveDashboard");
       cy.findByTestId("automatic-dashboard-header").button("Save this").click();
-      // Diagnostic: CI is slower than local, so give the save request more time to
-      // appear before failing. If it still times out at 30s, the request genuinely
-      // never fires (a save-path/navigation race), not just slowness.
-      cy.wait("@saveDashboard", { requestTimeout: 30000 });
+      cy.wait("@saveDashboard");
 
       H.expectUnstructuredSnowplowEvent({
         event: "x-ray_saved",

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -93,6 +93,15 @@ describe("scenarios > home > homepage", () => {
         triggered_from: "suggestion_sidebar",
       });
 
+      // Wait for the final x-ray dashboard to actually be ready before saving.
+      // `@getXrayDashboard` only confirms the automagic metadata GET; the dashboard isn't in
+      // the store yet. Once it is, `useDashboardUrlQuery`
+      // (frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.ts) syncs the
+      // dashboard's parameters into the URL (dispatch(replace(...))), so the query string
+      // becomes populated. That is a reliable "dashboard is ready" signal; clicking
+      // "Save this" before it means the dashboard isn't ready and the save is lost.
+      cy.location("search").should("not.be.empty");
+
       cy.findByTestId("automatic-dashboard-header").button("Save this").click();
 
       // Assert the save succeeded via the resulting UI — the header switches to a "Saved"

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -146,6 +146,11 @@ const AutomaticDashboardAppInner = () => {
                         className={cx(CS.mlAuto, CS.textNoWrap)}
                         success
                         borderless
+                        // The dashboard isn't always loaded when the header first
+                        // renders. Without this guard, "Save this" is clickable while
+                        // `dashboard` is undefined, which fires a false `x-ray_saved`
+                        // event and no-ops `save()` (no save request is sent).
+                        disabled={!dashboard}
                         actionFn={() => {
                           trackXRaySaved();
                           return save();


### PR DESCRIPTION
Resolves [GDGT-2537](https://linear.app/metabase/issue/GDGT-2537/flaky-test-e2e-tests-after-setup-scenarios-home-homepage-after-setup)

## Root cause

The `homepage` x-ray test clicked **"Save this"** in the gap *after* `cy.wait("@getXrayDashboard")` (which only confirms the automagic *metadata* GET) but *before* the final x-ray dashboard was actually in the store with its parameters populated. A save dispatched in that window is lost, so no `POST /api/dashboard/save` is ever sent — which surfaced as `cy.wait("@saveDashboard")` timing out with *"No request ever occurred"* (Trunk's most common failure reason for this test). It's a race: worse on faster/unthrottled runs.

The original `cy.wait` on the request alias masked this as a network/timing issue rather than a readiness one.

## Fix (2 files)

- **`AutomaticDashboardApp.tsx`** — `disabled={!dashboard}` on the "Save this" `ActionButton`. It rendered fully clickable before `dashboard` loaded; a click in that window fired a **false `x-ray_saved` analytics event** and no-opped `save()`. Minimal blast radius (one prop), and a real correctness fix.
- **`homepage.cy.spec.js`** — two test-side changes:
  - Wait for the dashboard's **readiness signal** before saving: once the dashboard is in the store with populated parameters, `useDashboardUrlQuery` syncs them into the URL query string, so `cy.location("search").should("not.be.empty")` is a reliable "ready" gate that `@getXrayDashboard` doesn't provide.
  - Assert the **saved-state UI** ("Saved" button + "See it" link) instead of `cy.wait("@saveDashboard")` — the user-observable outcome, retried by Cypress, immune to request-alias timing.

## Stress test (burn_in=50, fail_fast, single test via grep)

Both green, 50/50 passing in each mode:
- ✅ network throttling ON:  https://github.com/metabase/metabase/actions/runs/27161360241
- ✅ network throttling OFF: https://github.com/metabase/metabase/actions/runs/27161361650

> Branch history includes a few superseded diagnostic commits; the net diff is the 2 files above. Squash on merge.


