### PR TITLE
Fix schema breadcrumb after table route refresh

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -15,7 +15,11 @@ import {
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { setErrorPage } from "metabase/redux/app";
 import type { DispatchFn } from "metabase/redux/hooks";
-import { fetchTableMetadata, updateMetadata } from "metabase/redux/metadata";
+import {
+  fetchDatabaseMetadata,
+  fetchTableMetadata,
+  updateMetadata,
+} from "metabase/redux/metadata";
 import { INITIALIZE_QB, resetQB } from "metabase/redux/query-builder";
 import type {
   Dispatch,
@@ -303,6 +307,10 @@ async function handleQBInit(
     const table = getMetadata(getState()).table(slugEntityId);
     if (!table) {
       dispatch(setErrorPage(NOT_FOUND_ERROR));
+      return;
+    }
+    await dispatch(fetchDatabaseMetadata(table.db_id));
+    if (isStale()) {
       return;
     }
     // The /table URL only carries the table id; resolve its db so the QB can

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -6,6 +6,7 @@ import { snippetApi } from "metabase/api";
 import * as CardLib from "metabase/common/utils/card";
 import * as questionActions from "metabase/questions/actions";
 import { setErrorPage } from "metabase/redux/app";
+import * as metadataActions from "metabase/redux/metadata";
 import * as sharedQB from "metabase/redux/query-builder";
 import { createMockState } from "metabase/redux/store/mocks";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -955,6 +956,17 @@ describe("QB Actions > initializeQB", () => {
       const { result } = await setupTableRoute(ORDERS_ID);
       expect(result.card.id).toBeUndefined();
       expect(result.card.displayIsLocked).toBeFalsy();
+    });
+
+    it("fetches database metadata for schema breadcrumbs (metabase#75393)", async () => {
+      const fetchDatabaseMetadataSpy = jest.spyOn(
+        metadataActions,
+        "fetchDatabaseMetadata",
+      );
+
+      await setupTableRoute(ORDERS_ID);
+
+      expect(fetchDatabaseMetadataSpy).toHaveBeenCalledWith(SAMPLE_DB_ID);
     });
 
     it("shows a not-found error for an unknown table", async () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75393
Closes https://linear.app/metabase/issue/UXW-4416/schema-breadcrumb-missing-after-refreshing-table-opened-in-the-query

### Description

Loads the parent database metadata when initializing Query Builder from `/table/:slug`, so refreshed table pages have the full schema context needed for breadcrumbs.

Adds a regression test that the table route requests database metadata after resolving the table slug.

### How to verify

1. Have a multi-schema database.
2. Browse to Databases, open the database, open a schema, and open a table.
3. Confirm the URL is `/table/:id-name` and the breadcrumb includes the schema.
4. Refresh the page.
5. Confirm the schema remains visible in the breadcrumb.

### Demo
https://www.loom.com/share/4d57aa1396cc480fbd07346742e9cb8e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
