### PR TITLE
Fix stale dashboard breadcrumb after rename

### DIFF
--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -1,6 +1,7 @@
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
 
+import { skipToken, useGetDashboardQuery } from "metabase/api";
 import { useInitialCollectionId } from "metabase/collections/hooks";
 import {
   getCommentSidebarOpen,
@@ -87,8 +88,11 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
   const originalQuestion = useSelector(getOriginalQuestion);
 
   const { pathname } = props.location;
-  const dashboard =
-    pathname && isQuestionPath(pathname) ? question?.dashboard() : undefined;
+  const dashboardId =
+    pathname && isQuestionPath(pathname) ? question?.dashboardId() : undefined;
+  const { data: dashboard } = useGetDashboardQuery(
+    dashboardId != null ? { id: dashboardId } : skipToken,
+  );
 
   const locationState = props.location.state as { cardId?: number } | undefined;
 

--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -88,8 +88,8 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
   const originalQuestion = useSelector(getOriginalQuestion);
 
   const { pathname } = props.location;
-  const dashboardId =
-    pathname && isQuestionPath(pathname) ? question?.dashboardId() : undefined;
+  const isOnQuestionPage = pathname && isQuestionPath(pathname);
+  const dashboardId = isOnQuestionPage ? question?.dashboard()?.id : undefined;
   const { data: dashboard } = useGetDashboardQuery(
     dashboardId != null ? { id: dashboardId } : skipToken,
   );
@@ -109,7 +109,11 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
     <AppBarView
       {...props}
       collectionId={collectionId}
-      collectionBreadcrumbs={<CollectionBreadcrumbs dashboard={dashboard} />}
+      collectionBreadcrumbs={
+        <CollectionBreadcrumbs
+          dashboard={dashboardId != null ? dashboard : undefined}
+        />
+      }
       questionLineage={
         <QuestionLineage
           question={question}

--- a/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
@@ -52,6 +52,16 @@ const CARD_IN_DASHBOARD = createMockCard({
   dashboard_id: 4,
   dashboard: BAR_DASHBOARD,
 });
+const CARD_IN_RENAMED_DASHBOARD = createMockCard({
+  id: 4,
+  collection_id: 3,
+  dashboard_id: 4,
+  dashboard: createMockDashboard({
+    id: 4,
+    name: "Stale Dashboard Name",
+    collection_id: 3,
+  }),
+});
 
 describe("AppBar", () => {
   const matchMediaSpy = jest.spyOn(window, "matchMedia");
@@ -239,6 +249,20 @@ describe("AppBar", () => {
 
         expect(await screen.findByText("Foo Collection")).toBeInTheDocument();
         expect(await screen.findByText("Bar Dashboard")).toBeInTheDocument();
+      });
+
+      it("should use the latest dashboard name for question breadcrumbs (#75184)", async () => {
+        setup({
+          embedOptions: {
+            breadcrumbs: true,
+          },
+          card: CARD_IN_RENAMED_DASHBOARD,
+        });
+
+        expect(await screen.findByText("Bar Dashboard")).toBeInTheDocument();
+        expect(
+          screen.queryByText("Stale Dashboard Name"),
+        ).not.toBeInTheDocument();
       });
 
       it("should work for dashboards", async () => {

--- a/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.unit.spec.tsx
@@ -62,6 +62,12 @@ const CARD_IN_RENAMED_DASHBOARD = createMockCard({
     collection_id: 3,
   }),
 });
+const CARD_WITH_DASHBOARD_ID = createMockCard({
+  id: 5,
+  collection_id: 3,
+  dashboard_id: 4,
+  dashboard: undefined,
+});
 
 describe("AppBar", () => {
   const matchMediaSpy = jest.spyOn(window, "matchMedia");
@@ -263,6 +269,18 @@ describe("AppBar", () => {
         expect(
           screen.queryByText("Stale Dashboard Name"),
         ).not.toBeInTheDocument();
+      });
+
+      it("should not show dashboard breadcrumbs without dashboard context", async () => {
+        setup({
+          embedOptions: {
+            breadcrumbs: true,
+          },
+          card: CARD_WITH_DASHBOARD_ID,
+        });
+
+        expect(await screen.findByText("Foo Collection")).toBeInTheDocument();
+        expect(screen.queryByText("Bar Dashboard")).not.toBeInTheDocument();
       });
 
       it("should work for dashboards", async () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75184
Closes https://linear.app/metabase/issue/UXW-4370/stale-dashboard-name-shown-after-renaming

### Description

Question-page breadcrumbs now load the dashboard by `dashboard_id` instead of reading the stale embedded dashboard snapshot from the cached card payload. This keeps the navbar dashboard badge in sync after dashboard renames.

### How to verify

1. Create a question and save it in a dashboard.
2. Open the question.
3. Go back to the dashboard and rename it.
4. Open the question again.
5. Confirm the navbar breadcrumb shows the renamed dashboard.

### Demo
https://www.loom.com/share/1b8784e135b04600b5f205c7f58aee3d
(Video includes before and after)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)