### PR TITLE
Fix pdf download violations

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -104,6 +104,7 @@ const elements = [
   createElement({ type: "shared", name: "pulse" }),
   createElement({ type: "shared", name: "querying", enforceOutgoing: false }),
   createElement({ type: "shared", name: "questions" }),
+  createElement({ type: "shared", name: "redux" }),
   createElement({ type: "shared", name: "router" }),
   createElement({
     type: "shared",

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -21,27 +21,6 @@ export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   });
 };
 
-export type DashboardAccessedVia =
-  | "internal"
-  | "public-link"
-  | "static-embed"
-  | "interactive-iframe-embed"
-  | "sdk-embed";
-
-export const trackExportDashboardToPDF = ({
-  dashboardId,
-  dashboardAccessedVia,
-}: {
-  dashboardId?: DashboardId;
-  dashboardAccessedVia: DashboardAccessedVia;
-}) => {
-  trackSchemaEvent("dashboard", {
-    event: "dashboard_pdf_exported",
-    dashboard_id: getDashboardId(dashboardId),
-    dashboard_accessed_via: dashboardAccessedVia,
-  });
-};
-
 export const trackDashboardWidthChange = (
   dashboardId: DashboardId,
   width: DashboardWidth,

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -12,9 +12,9 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useSelector } from "metabase/redux";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import { Box, Flex, Loader } from "metabase/ui";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { DashboardCard } from "metabase-types/api";
 
-import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "../../constants";
 import { DashboardArchivedEntityBanner } from "../DashboardArchivedEntityBanner";
 import {
   DashboardInfoButton,

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.unit.spec.tsx
@@ -8,10 +8,12 @@ import { createMockDashboard } from "metabase-types/api/mocks";
 import { ExportAsPdfButton } from "./ExportAsPdfButton";
 
 jest.mock("metabase/visualizations/lib/save-dashboard-pdf", () => ({
+  ...jest.requireActual("metabase/visualizations/lib/save-dashboard-pdf"),
   saveDashboardPdf: jest.fn(() => new Promise(() => {})),
 }));
 
-jest.mock("metabase/dashboard/analytics", () => ({
+jest.mock("metabase/redux/analytics", () => ({
+  ...jest.requireActual("metabase/redux/analytics"),
   trackExportDashboardToPDF: jest.fn(),
 }));
 

--- a/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
@@ -1,7 +1,6 @@
 import cx from "classnames";
 import { useRef } from "react";
 
-import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useIsParameterPanelSticky } from "metabase/dashboard/hooks/use-is-parameter-panel-sticky";
 import { getDashboardHeaderValuePopulatedParameters } from "metabase/dashboard/selectors";
@@ -10,6 +9,7 @@ import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { useSelector } from "metabase/redux";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import { isSmallScreen } from "metabase/utils/dom";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/visualizations/lib/save-dashboard-pdf";
 
 import DashboardS from "../Dashboard/Dashboard.module.css";
 import { FixedWidthContainer } from "../Dashboard/DashboardComponents";

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -49,11 +49,6 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
 
 export const DASHBOARD_SLOW_TIMEOUT = 15 * 1000;
 
-export const DASHBOARD_PDF_EXPORT_ROOT_ID =
-  "Dashboard-Parameters-And-Cards-Container";
-export const DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID =
-  "Dashboard-Parameters-Content";
-
 export const DEFAULT_DASHBOARD_DISPLAY_OPTIONS: EmbedDisplayParams = {
   background: true,
   bordered: false,

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -11,7 +11,6 @@ import { Link } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { navigateToNewCardFromDashboard } from "metabase/dashboard/actions";
 import { Dashboard } from "metabase/dashboard/components/Dashboard";
-import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import {
   DashboardContextProvider,
   useDashboardContext,
@@ -22,6 +21,7 @@ import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
 import { Box, Button, Flex, Group, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { Dashboard as IDashboard } from "metabase-types/api";
 
 import { FixedWidthContainer } from "../../components/Dashboard/DashboardComponents";

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -10,10 +10,6 @@ import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module
 import { FixedWidthContainer } from "metabase/dashboard/components/Dashboard/DashboardComponents";
 import { ExportAsPdfButton } from "metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton";
 import { FilterApplyToast } from "metabase/dashboard/components/FilterApplyToast";
-import {
-  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
-  DASHBOARD_PDF_EXPORT_ROOT_ID,
-} from "metabase/dashboard/constants";
 import { useIsParameterPanelSticky } from "metabase/dashboard/hooks/use-is-parameter-panel-sticky";
 import {
   ActionButtonsContainer,
@@ -33,6 +29,10 @@ import { Box } from "metabase/ui";
 import { getDashboardType } from "metabase/utils/dashboard";
 import { initializeIframeResizer, isSmallScreen } from "metabase/utils/dom";
 import { SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS } from "metabase/visualizations/lib/image-exports";
+import {
+  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
+  DASHBOARD_PDF_EXPORT_ROOT_ID,
+} from "metabase/visualizations/lib/save-dashboard-pdf";
 import type Question from "metabase-lib/v1/Question";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/PublicOrEmbeddedDashboardPage.enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/PublicOrEmbeddedDashboardPage.enterprise.unit.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { setupLastDownloadFormatEndpoints } from "__support__/server-mocks";
 import { screen, waitFor } from "__support__/ui";
-import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/visualizations/lib/save-dashboard-pdf";
 
 import { type SetupOpts, setup } from "./setup";
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/PublicOrEmbeddedDashboardPage.premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/tests/PublicOrEmbeddedDashboardPage.premium.unit.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { setupLastDownloadFormatEndpoints } from "__support__/server-mocks";
 import { screen, waitFor } from "__support__/ui";
-import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/visualizations/lib/save-dashboard-pdf";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import { type SetupOpts, setup } from "./setup";

--- a/frontend/src/metabase/redux/analytics.ts
+++ b/frontend/src/metabase/redux/analytics.ts
@@ -1,8 +1,28 @@
 import { trackSchemaEvent } from "metabase/analytics";
+import type { DashboardId } from "metabase-types/api";
 
 import type { ResourceAccessedVia, ResourceType } from "./downloads";
 
 const SCHEMA = "downloads";
+
+// dashboard_id is required in the snowplow schema, but we don't send UUIDs or
+// JWTs in public/static-embed scenarios, so fall back to 0 there.
+const getTrackedDashboardId = (dashboardId: DashboardId | undefined) =>
+  typeof dashboardId === "number" ? dashboardId : 0;
+
+export const trackExportDashboardToPDF = ({
+  dashboardId,
+  dashboardAccessedVia,
+}: {
+  dashboardId?: DashboardId;
+  dashboardAccessedVia: ResourceAccessedVia;
+}) => {
+  trackSchemaEvent("dashboard", {
+    event: "dashboard_pdf_exported",
+    dashboard_id: getTrackedDashboardId(dashboardId),
+    dashboard_accessed_via: dashboardAccessedVia,
+  });
+};
 
 export const trackDownloadResults = ({
   resourceType,

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -12,11 +12,6 @@ import { datasetApi } from "metabase/api/dataset";
 import api from "metabase/api/legacy-client";
 import { exportFormatPng } from "metabase/common/types/export";
 import { waitUntilNextFramePainted } from "metabase/common/utils/wait-until-next-frame-paints";
-import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
-import {
-  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
-  DASHBOARD_PDF_EXPORT_ROOT_ID,
-} from "metabase/dashboard/constants";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { DownloadsState, State } from "metabase/redux/store";
 import { createAsyncThunk } from "metabase/redux/utils";
@@ -28,7 +23,11 @@ import { isJWT } from "metabase/utils/jwt";
 import { checkNotNull } from "metabase/utils/types";
 import { isUuid } from "metabase/utils/uuid";
 import { saveChartImage } from "metabase/visualizations/lib/save-chart-image";
-import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
+import {
+  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
+  DASHBOARD_PDF_EXPORT_ROOT_ID,
+  saveDashboardPdf,
+} from "metabase/visualizations/lib/save-dashboard-pdf";
 import { getCardKey } from "metabase/visualizations/lib/utils";
 import type Question from "metabase-lib/v1/Question";
 import type {
@@ -40,7 +39,7 @@ import type {
 } from "metabase-types/api";
 import type { EntityToken, EntityUuid } from "metabase-types/api/entity";
 
-import { trackDownloadResults } from "./analytics";
+import { trackDownloadResults, trackExportDashboardToPDF } from "./analytics";
 
 export interface DownloadQueryResultsOpts {
   type: string;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -14,6 +14,12 @@ import {
 import { fixParameterLegendOffsetForExport } from "./image-exports";
 import { SAVING_DOM_IMAGE_CLASS } from "./save-chart-image";
 
+// DOM ids on exportable nodes so the PDF exporter and downloads thunk can find them
+export const DASHBOARD_PDF_EXPORT_ROOT_ID =
+  "Dashboard-Parameters-And-Cards-Container";
+export const DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID =
+  "Dashboard-Parameters-Content";
+
 const TARGET_ASPECT_RATIO = 21 / 17;
 
 interface DashCardBounds {


### PR DESCRIPTION
Fixes two violations where redux was depending on dashboards for download logic. 

The fix is moving the node IDs into shared, because the download logic needs to reference them. 

The embedding change is just updating import paths