### PR TITLE
Public link passwords: Add `public_link_password` column to Card and Dashboard

### DIFF
--- a/resources/migrations/063/20260608_public_link_password.yaml
+++ b/resources/migrations/063/20260608_public_link_password.yaml
@@ -1,0 +1,50 @@
+databaseChangeLog:
+  - changeSet:
+      id: v63.2026-06-08T00:00:00
+      author: sebastien
+      comment: Add public_link_password column to report_card for password-gated public links
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: report_card
+                columnName: public_link_password
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: public_link_password
+                  type: ${text.type}
+                  remarks: Encrypted password for gating public link access. NULL means no password required.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_card
+            columnName: public_link_password
+
+  - changeSet:
+      id: v63.2026-06-08T00:00:01
+      author: sebastien
+      comment: Add public_link_password column to report_dashboard for password-gated public links
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: report_dashboard
+                columnName: public_link_password
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: public_link_password
+                  type: ${text.type}
+                  remarks: Encrypted password for gating public link access. NULL means no password required.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: report_dashboard
+            columnName: public_link_password

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -68,8 +68,13 @@
   #{:last_viewed_at})
 
 (t2/deftransforms :model/Dashboard
-  {:parameters       parameters/transform-parameters
-   :embedding_params mi/transform-json})
+  {:parameters            parameters/transform-parameters
+   :embedding_params      mi/transform-json
+   :public_link_password  mi/transform-encrypted-text})
+
+(methodical/defmethod mi/to-json :model/Dashboard
+  [dashboard json-generator]
+  (next-method (dissoc dashboard :public_link_password) json-generator))
 
 (t2/define-before-delete :model/Dashboard
   [dashboard]
@@ -423,7 +428,9 @@
    :skip      [;; those stats are inherently local state
                :view_count :last_viewed_at
                ;; this is deprecated
-               :cache_ttl]
+               :cache_ttl
+               ;; instance-specific, encrypted password for public link gating
+               :public_link_password]
    :transform {:created_at             (serdes/date)
                :initially_published_at (serdes/date)
                :collection_id          (serdes/fk :model/Collection)

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1181,8 +1181,9 @@
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-exists? :model/Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
   (t2/update! :model/Dashboard dashboard-id
-              {:public_uuid       nil
-               :made_public_by_id nil})
+              {:public_uuid          nil
+               :made_public_by_id    nil
+               :public_link_password nil})
   (events/publish-event! :event/dashboard-public-link-deleted
                          {:object-id dashboard-id
                           :user-id api/*current-user-id*})

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -327,6 +327,11 @@
   {:in  encrypted-json-in
    :out cached-encrypted-json-out})
 
+(def transform-encrypted-text
+  "Transform for an encrypted plain-text string. Encrypts on write, decrypts on read."
+  {:in  encryption/maybe-encrypt
+   :out encryption/maybe-decrypt})
+
 ;;; TODO (Cam 10/27/25) -- this stuff should be moved into a different module instead of the general models interface,
 ;;; either `queries` or a new module along with [[metabase.models.visualization-settings]].
 (mr/def ::viz-settings-ref

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -120,7 +120,8 @@
    :parameter_mappings     parameters/transform-parameter-mappings
    :type                   mi/transform-keyword
    :dimensions             metrics/transform-dimensions
-   :dimension_mappings     metrics/transform-dimension-mappings})
+   :dimension_mappings     metrics/transform-dimension-mappings
+   :public_link_password   mi/transform-encrypted-text})
 
 (doto :model/Card
   (derive :metabase/model)
@@ -1294,7 +1295,7 @@
   ;; `:dataset_query` key entirely if it is empty, as it is in a lot of tests.
   (let [card (cond-> card
                (map? (:dataset_query card)) (update :dataset_query dissoc :lib/metadata))]
-    (next-method card json-generator)))
+    (next-method (dissoc card :public_link_password) json-generator)))
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
@@ -1387,7 +1388,9 @@
           ;; always derivable from dataset_query by populate-query-fields; nil when not derivable
           :query_type
           ;; always re-derived from dataset_query by populate-query-fields on import
-          :table_id :source_card_id]
+          :table_id :source_card_id
+          ;; instance-specific, encrypted password for public link gating
+          :public_link_password]
    :transform
    {:created_at             (serdes/date)
     ;; database_id is usually derivable from dataset_query, but must be kept when the query

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -1008,8 +1008,9 @@
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-exists? :model/Card :id card-id, :public_uuid [:not= nil])
   (t2/update! :model/Card card-id
-              {:public_uuid       nil
-               :made_public_by_id nil})
+              {:public_uuid          nil
+               :made_public_by_id    nil
+               :public_link_password nil})
   (events/publish-event! :event/card-public-link-deleted
                          {:object-id card-id
                           :user-id api/*current-user-id*})

--- a/src/metabase/revisions/impl/card.clj
+++ b/src/metabase/revisions/impl/card.clj
@@ -17,6 +17,7 @@
     :legacy_query
     :made_public_by_id
     :metabase_version
+    :public_link_password
     :public_uuid
     :updated_at
     :view_count})

--- a/src/metabase/revisions/impl/dashboard.clj
+++ b/src/metabase/revisions/impl/dashboard.clj
@@ -18,7 +18,7 @@
     ;; > The position this Dashboard should appear in the Dashboards list,
     ;;   lower-numbered positions appearing before higher numbered ones.
     ;; TODO: querying on stats we don't have any dashboard that has a position, maybe we could just drop it?
-    :public_uuid :made_public_by_id
+    :public_link_password :public_uuid :made_public_by_id
     :position :initially_published_at :view_count
     :last_viewed_at})
 

--- a/test/metabase/activity_feed/api_test.clj
+++ b/test/metabase/activity_feed/api_test.clj
@@ -45,7 +45,8 @@
                                          {:topic :event/table-read :event {:object table-1}}]]
             (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
           (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed non-archived dashboard."
-            (is (= (assoc dash-2 :collection nil :view_count 1)
+            ;; public_link_password is stripped from API responses by Dashboard's to-json
+            (is (= (-> dash-2 (assoc :collection nil :view_count 1) (dissoc :public_link_password))
                    (mt/user-http-request :crowberto :get 200 "activity/most_recently_viewed_dashboard")))))
         (mt/with-test-user :rasta
           (testing "If nothing has been viewed, return a 204"
@@ -53,7 +54,8 @@
                                             "activity/most_recently_viewed_dashboard"))))
           (events/publish-event! :event/dashboard-read {:object-id (:id dash-1) :user-id (mt/user->id :rasta)})
           (testing "Only the user's own views are returned."
-            (is (= (assoc dash-1 :collection nil :view_count 2)
+            ;; public_link_password is stripped from API responses by Dashboard's to-json
+            (is (= (-> dash-1 (assoc :collection nil :view_count 2) (dissoc :public_link_password))
                    (mt/user-http-request :rasta :get 200
                                          "activity/most_recently_viewed_dashboard"))))
           (events/publish-event! :event/dashboard-read {:object-id (:id dash-1) :user-id (mt/user->id :rasta)})
@@ -73,12 +75,14 @@
             (testing "view a dashboard in a personal collection"
               (events/publish-event! :event/dashboard-read {:object-id (:id dash-1) :user-id (mt/user->id :crowberto)})
               (let [crowberto-personal-coll (t2/select-one :model/Collection :personal_owner_id (mt/user->id :crowberto))]
-                (is (= (assoc dash-1 :collection (assoc crowberto-personal-coll :is_personal true) :view_count 1)
+                ;; public_link_password is stripped from API responses by Dashboard's to-json
+                (is (= (-> dash-1 (assoc :collection (assoc crowberto-personal-coll :is_personal true) :view_count 1) (dissoc :public_link_password))
                        (mt/user-http-request :crowberto :get 200
                                              "activity/most_recently_viewed_dashboard")))))
             (testing "view a dashboard in a public collection"
               (events/publish-event! :event/dashboard-read {:object-id (:id dash-2) :user-id (mt/user->id :crowberto)})
-              (is (= (assoc dash-2 :collection (assoc coll :is_personal false) :view_count 1)
+              ;; public_link_password is stripped from API responses by Dashboard's to-json
+              (is (= (-> dash-2 (assoc :collection (assoc coll :is_personal false) :view_count 1) (dissoc :public_link_password))
                      (mt/user-http-request :crowberto :get 200
                                            "activity/most_recently_viewed_dashboard"))))))))))
 

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -272,17 +272,19 @@
         :user-id      (mt/user->id :crowberto)
         :is-creation? true
         :object       crowberto-dash})
-      (is (=? (merge crowberto-dash
-                     {:creator {:id          (mt/user->id :crowberto)
-                                :email       "crowberto@metabase.com"
-                                :first_name  "Crowberto"
-                                :last_name   "Corv"
-                                :common_name "Crowberto Corv"}}
-                     {:last-edit-info {:id         (mt/user->id :crowberto)
-                                       :first_name "Crowberto"
-                                       :last_name  "Corv"
-                                       :email      "crowberto@metabase.com"
-                                       :timestamp  true}})
+      ;; public_link_password is stripped from API responses by Dashboard's to-json
+      (is (=? (-> (merge crowberto-dash
+                         {:creator {:id          (mt/user->id :crowberto)
+                                    :email       "crowberto@metabase.com"
+                                    :first_name  "Crowberto"
+                                    :last_name   "Corv"
+                                    :common_name "Crowberto Corv"}}
+                         {:last-edit-info {:id         (mt/user->id :crowberto)
+                                           :first_name "Crowberto"
+                                           :last_name  "Corv"
+                                           :email      "crowberto@metabase.com"
+                                           :timestamp  true}})
+                  (dissoc :public_link_password))
               (-> (m/find-first #(= (:id %) crowberto-dash-id)
                                 (mt/user-http-request :crowberto :get 200 "dashboard" :f "mine"))
                   (update-in [:last-edit-info :timestamp] boolean)))))

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -725,7 +725,8 @@
                                        :archived true
                                        :database_id (mt/id)
                                        :table_id (mt/id :categories)}]
-      (is (=? {:metrics [(assoc metric :type "metric" :display "table")]}
+      ;; public_link_password is stripped from API responses by Card's to-json
+      (is (=? {:metrics [(-> metric (assoc :type "metric" :display "table") (dissoc :public_link_password))]}
               (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :categories))))))))
 
 (deftest ^:parallel table-segment-query-metadata-test


### PR DESCRIPTION
Closes [EMB-1810: Add `public_link_password` column to Card and Dashboard](https://linear.app/metabase/issue/EMB-1810/add-public-link-password-column-to-card-and-dashboard)

**Review order:** PR 1/9 in the password-protected public links stack.

### Description

Liquibase migration adding a nullable encrypted text column `public_link_password` to `report_card` and `report_dashboard`. Adds a `transform-encrypted-text` Toucan transform, strips the column from API JSON output via `to-json`, and excludes it from revision tracking.

### How to verify

1. Start Metabase, confirm the migration runs without error
2. Check the DB schema — both tables should have the new column

### Checklist

- [x] Tests have been added/updated to cover changes in this PR