### PR TITLE
Public link passwords: Add metabase.public-sharing.unlock namespace

### DIFF
--- a/src/metabase/public_sharing/unlock.clj
+++ b/src/metabase/public_sharing/unlock.clj
@@ -1,0 +1,160 @@
+(ns metabase.public-sharing.unlock
+  "Shared unlock primitives for password-gated public links.
+
+  Provides:
+  - Constant-time password verification against the encrypted column
+  - HMAC-signed cookie helpers for storing unlock receipts
+  - Throttle for brute-force protection keyed on [entity-type uuid]"
+  (:require
+   [buddy.core.bytes :as bytes]
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [buddy.core.mac :as mac]
+   [environ.core :as env]
+   [metabase.util.json :as json]
+   [ring.util.response :as response]
+   [throttle.core :as throttle])
+  (:import
+   (java.time Instant)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------- Password verify --------------------------------------------------
+
+(defn verify-password
+  "Constant-time comparison of `candidate` against the stored (already-decrypted) `stored-password`.
+  Returns true when they match. Both must be non-nil strings."
+  [candidate stored-password]
+  (when (and (some? candidate) (some? stored-password))
+    (bytes/equals? (.getBytes ^String candidate "UTF-8")
+                   (.getBytes ^String stored-password "UTF-8"))))
+
+(defn password-hash
+  "Return a short (8 hex char) hash of `password`, used inside cookie entries so that a password change
+  by an admin automatically invalidates existing unlock cookies."
+  ^String [^String password]
+  (subs (codecs/bytes->hex (buddy-hash/sha256 password)) 0 8))
+
+;;; ---------------------------------------------------- Throttle -----------------------------------------------------
+
+(def unlock-throttle
+  "Rate limiter for unlock attempts, keyed on `\"<entity-type>/<uuid>\"`."
+  (throttle/make-throttler :unlock-key
+                           :attempts-threshold 10
+                           :initial-delay-ms   500
+                           :attempt-ttl-ms     60000
+                           :delay-exponent     2))
+
+(defn throttle-key
+  "Build the throttle key string from an entity type keyword and uuid string."
+  [entity-type uuid]
+  (str (name entity-type) "/" uuid))
+
+;;; ------------------------------------------------- Signed cookie ----------------------------------------------------
+
+(def ^:private cookie-name "metabase.PUBLIC_UNLOCK")
+(def ^:private max-entries 50)
+(def ^:private entry-ttl-seconds (* 7 24 60 60)) ;; 7 days
+
+(defn- hmac-key
+  "Derive the HMAC signing key. Uses MB_ENCRYPTION_SECRET_KEY when available, falls back to a static key
+  (acceptable because the cookie only gates public content, not authenticated data)."
+  ^String []
+  (or (env/env :mb-encryption-secret-key)
+      "metabase-public-unlock-default-key"))
+
+(defn- hmac-sign
+  "HMAC-SHA256 sign `message`, returning a hex string."
+  ^String [^String message]
+  (let [key-bytes (.getBytes ^String (str (hmac-key)) "UTF-8")]
+    (-> (mac/hash message {:key key-bytes :alg :hmac+sha256})
+        (codecs/bytes->hex))))
+
+(defn- hmac-verify
+  "Constant-time verify that `signature` matches `message`."
+  [^String message ^String signature]
+  (let [expected (hmac-sign message)]
+    (bytes/equals? (.getBytes ^String expected "UTF-8")
+                   (.getBytes ^String signature "UTF-8"))))
+
+(defn- now-epoch-seconds []
+  (.getEpochSecond (Instant/now)))
+
+(defn- encode-cookie-value
+  "Encode `entries` as a signed cookie value: `<base64-payload>.<hex-signature>`."
+  [entries]
+  (let [payload (json/encode entries)
+        sig     (hmac-sign payload)]
+    (str payload "." sig)))
+
+(defn- decode-cookie-value
+  "Parse and verify a cookie value. Returns the entries vector on success, nil on failure."
+  [^String cookie-value]
+  (when (string? cookie-value)
+    (let [dot-idx (.lastIndexOf cookie-value ".")]
+      (when (pos? dot-idx)
+        (let [payload   (subs cookie-value 0 dot-idx)
+              signature (subs cookie-value (inc dot-idx))]
+          (when (hmac-verify payload signature)
+            (try
+              (json/decode+kw payload)
+              (catch Exception _
+                nil))))))))
+
+(defn- prune-expired
+  "Remove entries whose `exp` is in the past."
+  [entries]
+  (let [now (now-epoch-seconds)]
+    (filterv #(> (:exp %) now) entries)))
+
+(defn- cap-entries
+  "Keep at most `max-entries`, evicting oldest (first) entries."
+  [entries]
+  (if (> (count entries) max-entries)
+    (vec (take-last max-entries entries))
+    entries))
+
+(defn- read-cookie-entries
+  "Read and decode the unlock cookie entries from the request. Returns [] if absent or invalid."
+  [request]
+  (let [raw (get-in request [:cookies cookie-name :value])]
+    (or (some-> raw decode-cookie-value prune-expired) [])))
+
+(defn unlocked?
+  "Returns true if the request's unlock cookie contains a valid, non-expired entry for `entity-type` and `uuid`
+  whose `pwd_hash` matches the current password."
+  [request entity-type uuid current-password]
+  (let [entries     (read-cookie-entries request)
+        et-name     (name entity-type)
+        current-hash (password-hash current-password)]
+    (some (fn [{:keys [entity pwd_hash] e-uuid :uuid}]
+            (and (= entity et-name)
+                 (= e-uuid uuid)
+                 (= pwd_hash current-hash)))
+          entries)))
+
+(defn- cookie-options
+  "Cookie attributes for the unlock receipt."
+  []
+  {:http-only true
+   :same-site :none
+   :secure    true
+   :path      "/api/public"})
+
+(defn add-unlock-entry
+  "Add an unlock entry for `entity-type`/`uuid` to the response cookie, reading existing entries from the request.
+  Includes a short hash of `password` so the cookie is invalidated if the password changes.
+  Caps at ~50 entries with FIFO eviction."
+  [request response entity-type uuid password]
+  (let [existing (read-cookie-entries request)
+        ;; Remove any existing entry for same entity+uuid to avoid duplicates
+        filtered (filterv (fn [{:keys [entity] e-uuid :uuid}]
+                            (not (and (= entity (name entity-type))
+                                      (= e-uuid uuid))))
+                          existing)
+        new-entry {:entity   (name entity-type)
+                   :uuid     uuid
+                   :exp      (+ (now-epoch-seconds) entry-ttl-seconds)
+                   :pwd_hash (password-hash password)}
+        entries  (-> (conj filtered new-entry) cap-entries)]
+    (response/set-cookie response cookie-name (encode-cookie-value entries) (cookie-options))))

--- a/test/metabase/public_sharing/unlock_test.clj
+++ b/test/metabase/public_sharing/unlock_test.clj
@@ -1,0 +1,85 @@
+(ns metabase.public-sharing.unlock-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.public-sharing.unlock :as unlock]))
+
+(deftest verify-password-test
+  (testing "matching passwords return true"
+    (is (true? (unlock/verify-password "secret123" "secret123"))))
+  (testing "mismatched passwords return falsy"
+    (is (not (unlock/verify-password "secret123" "wrong"))))
+  (testing "nil inputs return falsy"
+    (is (not (unlock/verify-password nil "secret123")))
+    (is (not (unlock/verify-password "secret123" nil)))
+    (is (not (unlock/verify-password nil nil)))))
+
+(deftest password-hash-test
+  (testing "returns an 8-char hex string"
+    (let [h (unlock/password-hash "mypassword")]
+      (is (= 8 (count h)))
+      (is (re-matches #"[0-9a-f]{8}" h))))
+  (testing "same input produces same hash"
+    (is (= (unlock/password-hash "abc") (unlock/password-hash "abc"))))
+  (testing "different input produces different hash"
+    (is (not= (unlock/password-hash "abc") (unlock/password-hash "xyz")))))
+
+(deftest throttle-key-test
+  (is (= "card/abc-123" (unlock/throttle-key :card "abc-123")))
+  (is (= "dashboard/xyz" (unlock/throttle-key :dashboard "xyz"))))
+
+(deftest cookie-round-trip-test
+  (testing "add-unlock-entry sets a cookie that unlocked? can read back"
+    (let [request  {:cookies {}}
+          response (unlock/add-unlock-entry request {} :card "uuid-1" "secret")]
+      (is (get-in response [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          "cookie is set on response")
+      (let [cookie-val (get-in response [:cookies "metabase.PUBLIC_UNLOCK" :value])
+            request2   {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie-val}}}]
+        (is (unlock/unlocked? request2 :card "uuid-1" "secret"))
+        (testing "wrong uuid is not unlocked"
+          (is (not (unlock/unlocked? request2 :card "uuid-other" "secret"))))
+        (testing "wrong entity type is not unlocked"
+          (is (not (unlock/unlocked? request2 :dashboard "uuid-1" "secret"))))))))
+
+(deftest cookie-multiple-entries-test
+  (testing "multiple unlock entries accumulate in the cookie"
+    (let [request  {:cookies {}}
+          resp1    (unlock/add-unlock-entry request {} :card "uuid-1" "pw1")
+          cookie1  (get-in resp1 [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          request2 {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie1}}}
+          resp2    (unlock/add-unlock-entry request2 {} :dashboard "uuid-2" "pw2")
+          cookie2  (get-in resp2 [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          request3 {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie2}}}]
+      (is (unlock/unlocked? request3 :card "uuid-1" "pw1"))
+      (is (unlock/unlocked? request3 :dashboard "uuid-2" "pw2")))))
+
+(deftest cookie-tamper-detection-test
+  (testing "tampered cookie value is rejected"
+    (let [request  {:cookies {}}
+          response (unlock/add-unlock-entry request {} :card "uuid-1" "secret")
+          cookie-val (get-in response [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          tampered (str "TAMPERED" cookie-val)
+          request2 {:cookies {"metabase.PUBLIC_UNLOCK" {:value tampered}}}]
+      (is (not (unlock/unlocked? request2 :card "uuid-1" "secret"))))))
+
+(deftest cookie-dedup-test
+  (testing "re-unlocking the same entity+uuid replaces the old entry rather than duplicating"
+    (let [request  {:cookies {}}
+          resp1    (unlock/add-unlock-entry request {} :card "uuid-1" "pw")
+          cookie1  (get-in resp1 [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          request2 {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie1}}}
+          resp2    (unlock/add-unlock-entry request2 {} :card "uuid-1" "pw")
+          cookie2  (get-in resp2 [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          request3 {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie2}}}]
+      (is (unlock/unlocked? request3 :card "uuid-1" "pw")))))
+
+(deftest cookie-password-change-invalidation-test
+  (testing "changing the password invalidates existing cookie entries"
+    (let [request  {:cookies {}}
+          response (unlock/add-unlock-entry request {} :card "uuid-1" "old-password")
+          cookie-val (get-in response [:cookies "metabase.PUBLIC_UNLOCK" :value])
+          request2 {:cookies {"metabase.PUBLIC_UNLOCK" {:value cookie-val}}}]
+      (testing "cookie is valid with old password"
+        (is (unlock/unlocked? request2 :card "uuid-1" "old-password")))
+      (testing "cookie is invalid after password change"
+        (is (not (unlock/unlocked? request2 :card "uuid-1" "new-password")))))))


### PR DESCRIPTION
Closes [EMB-1811: Add `metabase.public-sharing.unlock` namespace](https://linear.app/metabase/issue/EMB-1811/add-metabasepublic-sharingunlock-namespace)

**Review order:** PR 2/9 in the password-protected public links stack.

### Description

New namespace with shared unlock primitives: constant-time password verification, HMAC-SHA256 signed cookie helpers (HttpOnly, SameSite=None, Secure, 50-entry FIFO cap), and a throttle keyed on [entity-type uuid]. Cookie entries include a short hash of the current password so admin password changes invalidate existing cookies.

### How to verify

1. Run `./bin/test-agent :only '[metabase.public-sharing.unlock-test]'` — 8 tests, 21 assertions

### Checklist

- [x] Tests have been added/updated to cover changes in this PR