### PR TITLE
Public link passwords: Wire +unlock-check middleware and POST unlock endpoints

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1591,11 +1591,13 @@
 
   public-sharing
   {:team "UX West"
-   :api  #{metabase.public-sharing.core
+   :api  #{metabase.public-sharing.api
+           metabase.public-sharing.core
            metabase.public-sharing.init
            metabase.public-sharing.unlock
            metabase.public-sharing.validation}
    :uses #{api
+           premium-features
            settings
            util}
    :model-imports #{:model/Card :model/Dashboard}}
@@ -3226,6 +3228,15 @@
    :api  #{}
    :uses #{premium-features
            util}}
+
+  enterprise/public-link-passwords
+  {:team "Embedding"
+   :api  #{metabase-enterprise.public-link-passwords.init}
+   :uses #{api
+           events
+           premium-features
+           util}
+   :model-imports #{:model/Card :model/Dashboard}}
 
   enterprise/remote-sync
   {:team "UX West"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1593,10 +1593,12 @@
   {:team "UX West"
    :api  #{metabase.public-sharing.core
            metabase.public-sharing.init
+           metabase.public-sharing.unlock
            metabase.public-sharing.validation}
    :uses #{api
            settings
-           util}}
+           util}
+   :model-imports #{:model/Card :model/Dashboard}}
 
   public-sharing-rest
   {:team "UX West"

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -16,6 +16,7 @@
    [metabase-enterprise.dependencies.init]
    [metabase-enterprise.gsheets.init]
    [metabase-enterprise.metabot.init]
+   [metabase-enterprise.public-link-passwords.init]
    [metabase-enterprise.remote-sync.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.security-center.init]

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.public-link-passwords.core
+  "EE implementation of public-link password management, gated on the `:public-link-passwords` premium token."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.events.core :as events]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]
+   [toucan2.core :as t2]))
+
+(def ^:private min-password-length 6)
+
+(defn- validate-password [password]
+  (api/check (>= (count password) min-password-length)
+             [400 (tru "Password must be at least {0} characters." min-password-length)]))
+
+(defn- model->event-prefix [model]
+  (case model
+    :model/Card      "card"
+    :model/Dashboard "dashboard"))
+
+(defenterprise set-public-link-password!
+  "Validate and store a password on a public link. Encryption is handled by the model's
+  `:public_link_password` transform, so the plaintext is passed through as-is here."
+  :feature :public-link-passwords
+  [model id password]
+  (validate-password password)
+  (t2/update! model id {:public_link_password password}))
+
+(defenterprise get-public-link-password
+  "Return the decrypted plaintext password for a public link. Audit-logged."
+  :feature :public-link-passwords
+  [model id]
+  (let [password (t2/select-one-fn :public_link_password model :id id)]
+    (api/check-404 password)
+    (events/publish-event! (keyword "event" (str (model->event-prefix model) "-public-pwd-revealed"))
+                           {:object-id id
+                            :user-id   api/*current-user-id*})
+    {:password password}))
+
+(defenterprise delete-public-link-password!
+  "Remove the password from a public link without revoking it."
+  :feature :public-link-passwords
+  [model id]
+  (t2/update! model id {:public_link_password nil}))

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.public-link-passwords.init
+  (:require
+   [metabase-enterprise.public-link-passwords.core]))

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -121,6 +121,7 @@
             :etl_connections                false
             :etl_connections_pg             false
             :dependencies                   false
+            :public_link_passwords          false
             :schema-viewer                  false
             :workspaces                     false
             :writable_connection            true}

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -56,6 +56,8 @@
 (derive :event/card-public-link-deleted ::publicize-card)
 (derive :event/dashboard-public-link-created ::publicize-dashboard)
 (derive :event/dashboard-public-link-deleted ::publicize-dashboard)
+(derive :event/card-public-pwd-revealed ::publicize-card)
+(derive :event/dashboard-public-pwd-revealed ::publicize-dashboard)
 
 (methodical/defmethod events/publish-event! ::publicize
   [topic {:keys [user-id object-id] :as _event}]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -31,6 +31,7 @@
    [metabase.parameters.params :as params]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.permissions.core :as perms]
+   [metabase.public-sharing.api :as public-sharing.api]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.pulse.core :as pulse]
    [metabase.queries.core :as queries]
@@ -1149,9 +1150,12 @@
 (api.macros/defendpoint :post "/:dashboard-id/public_link"
   "Generate publicly-accessible links for this Dashboard. Returns UUID to be used in public links. (If this
   Dashboard has already been shared, it will return the existing public link rather than creating a new one.) Public
-  sharing must be enabled."
+  sharing must be enabled. Optionally accepts a `password` in the request body (requires premium token)."
   [{:keys [dashboard-id]} :- [:map
-                              [:dashboard-id ms/PositiveInt]]]
+                              [:dashboard-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password {:optional true} [:maybe ms/NonBlankString]]]]
   (api/check-superuser)
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Dashboard dashboard-id))
@@ -1164,6 +1168,8 @@
                    (t2/update! :model/Dashboard dashboard-id
                                {:public_uuid       <>
                                 :made_public_by_id api/*current-user-id*})))]
+    (when password
+      (public-sharing.api/set-public-link-password! :model/Dashboard dashboard-id password))
     {:uuid uuid}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -1187,6 +1193,40 @@
   (events/publish-event! :event/dashboard-public-link-deleted
                          {:object-id dashboard-id
                           :user-id api/*current-user-id*})
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/:dashboard-id/public_password"
+  "Reveal the plaintext password for a Dashboard's public link. Visible to any user who can see the Dashboard.
+  Requires premium token. Audit-logged."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]]
+  (api/read-check :model/Dashboard dashboard-id)
+  (public-sharing.api/get-public-link-password :model/Dashboard dashboard-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :put "/:dashboard-id/public_password"
+  "Set or update the password on a Dashboard's public link. Requires premium token."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]]
+  (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
+  (public-sharing.api/set-public-link-password! :model/Dashboard dashboard-id password)
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :delete "/:dashboard-id/public_password"
+  "Remove the password from a Dashboard's public link without revoking the link. Requires premium token."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]]
+  (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
+  (public-sharing.api/delete-public-link-password! :model/Dashboard dashboard-id)
   {:status 204, :body nil})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -86,6 +86,8 @@
 (mr/def :event/dashboard-public-link-deleted ::publicize)
 (mr/def :event/card-public-link-created ::publicize)
 (mr/def :event/card-public-link-deleted ::publicize)
+(mr/def :event/card-public-pwd-revealed ::publicize)
+(mr/def :event/dashboard-public-pwd-revealed ::publicize)
 
 ;; user events
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -174,6 +174,10 @@
   "Should we enable user/group provisioning via SCIM?"
   :scim)
 
+(define-premium-feature enable-public-link-passwords?
+  "Should we enable password protection on public links?"
+  :public-link-passwords)
+
 (defn enable-any-sso?
   "Should we enable any SSO-based authentication?"
   []
@@ -428,7 +432,8 @@
    :workspaces                     (enable-workspaces?)
    :whitelabel                     (enable-whitelabeling?)
    :writable_connection            (enable-writable-connection?)
-   :ai_controls                    (enable-ai-controls?)})
+   :ai_controls                    (enable-ai-controls?)
+   :public_link_passwords          (enable-public-link-passwords?)})
 
 (defsetting token-features
   "Features registered for this instance's token"

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -1,0 +1,24 @@
+(ns metabase.public-sharing.api
+  "OSS stubs for public-link password management. EE implementations live in
+  `metabase-enterprise.public-link-passwords.core`."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]))
+
+(defenterprise set-public-link-password!
+  "Validate, encrypt, and store a password on a public link. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id _password]
+  (throw (ex-info (tru "Setting passwords on public links is a paid feature.") {:status-code 402})))
+
+(defenterprise get-public-link-password
+  "Return the decrypted plaintext password for a public link. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id]
+  (throw (ex-info (tru "Public link passwords is a paid feature.") {:status-code 402})))
+
+(defenterprise delete-public-link-password!
+  "Remove the password from a public link without revoking it. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id]
+  (throw (ex-info (tru "Public link passwords is a paid feature.") {:status-code 402})))

--- a/src/metabase/public_sharing/validation.clj
+++ b/src/metabase/public_sharing/validation.clj
@@ -3,7 +3,9 @@
    [metabase.api.common :as api]
    [metabase.api.routes.common :as routes.common]
    [metabase.public-sharing.settings :as public-sharing.settings]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.public-sharing.unlock :as unlock]
+   [metabase.util.i18n :refer [tru]]
+   [toucan2.core :as t2]))
 
 (defn check-public-sharing-enabled
   "Check that the `public-sharing-enabled` Setting is `true`, or throw a `400`."
@@ -22,3 +24,60 @@
 (def ^{:arglists '([handler])} +public-sharing-enabled
   "Wrap `routes` so they may only be accessed when public sharing is enabled."
   (routes.common/wrap-middleware-for-open-api-spec-generation enforce-public-sharing-enabled))
+
+;;; -------------------------------------------- Unlock check middleware -----------------------------------------------
+
+(def ^:private uuid-regex "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+(defn- unlock-path?
+  "Returns true if `path` is an unlock endpoint that should be exempt from the unlock check."
+  [path]
+  (boolean (re-matches (re-pattern (str "/(?:card|dashboard)/" uuid-regex "/unlock")) path)))
+
+(defn- parse-public-entity
+  "Parse the request path (relative to `/api/public/`) to extract `[entity-type uuid]`.
+  Returns nil for paths that don't resolve a card/dashboard UUID (oembed, action, document, unlock)."
+  [path]
+  (when-not (unlock-path? path)
+    (some (fn [[pattern entity-type]]
+            (when-let [[_ uuid] (re-matches pattern path)]
+              [entity-type uuid]))
+          [[#_card      (re-pattern (str "/card/(" uuid-regex ")(?:/.*)?"))      :card]
+           [#_dashboard (re-pattern (str "/dashboard/(" uuid-regex ")(?:/.*)?")) :dashboard]
+           [#_pivot     (re-pattern (str "/pivot/card/(" uuid-regex ")(?:/.*)?"))      :card]
+           [#_pivot     (re-pattern (str "/pivot/dashboard/(" uuid-regex ")(?:/.*)?")) :dashboard]
+           [#_tiles     (re-pattern (str "/tiles/card/(" uuid-regex ")(?:/.*)?"))      :card]
+           [#_tiles     (re-pattern (str "/tiles/dashboard/(" uuid-regex ")(?:/.*)?")) :dashboard]])))
+
+(defn- entity-password
+  "Look up the `public_link_password` for a card or dashboard by public UUID. Returns the decrypted password or nil."
+  [entity-type uuid]
+  (case entity-type
+    :card      (t2/select-one-fn :public_link_password :model/Card      :public_uuid uuid :archived false)
+    :dashboard (t2/select-one-fn :public_link_password :model/Dashboard :public_uuid uuid :archived false)))
+
+(def ^:private locked-response
+  {:status  403
+   :headers {"Content-Type" "application/json; charset=utf-8"}
+   :body    "{\"error_code\":\"public-link-password-required\"}"})
+
+(defn enforce-unlock-check
+  "Ring middleware that gates password-protected public links. If the entity has a password and the request
+  lacks a valid unlock cookie, responds with 403 `{error_code: \"public-link-password-required\"}`."
+  [handler]
+  (fn [request respond raise]
+    (let [path (or (:compojure/path request) (:path-info request) (:uri request))]
+      (if-let [[entity-type uuid] (parse-public-entity path)]
+        (if-let [password (entity-password entity-type uuid)]
+          ;; Entity is locked — check for a valid unlock cookie
+          (if (unlock/unlocked? request entity-type uuid password)
+            (handler request respond raise)
+            (respond locked-response))
+          ;; No password set — pass through
+          (handler request respond raise))
+        ;; Not a card/dashboard UUID path (oembed, action, document, unlock) — pass through
+        (handler request respond raise)))))
+
+(def ^{:arglists '([handler])} +unlock-check
+  "Wrap `routes` so password-protected public links require a valid unlock cookie."
+  (routes.common/wrap-middleware-for-open-api-spec-generation enforce-unlock-check))

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -15,6 +15,7 @@
    [metabase.models.interface :as mi]
    [metabase.parameters.dashboard :as parameters.dashboard]
    [metabase.parameters.params :as params]
+   [metabase.public-sharing.unlock :as unlock]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
@@ -827,12 +828,46 @@
                 :format-rows?          format_rows
                 :pivot?                pivot_results}))
 
+;;; --------------------------------------------------- Unlock ------------------------------------------------------
+
+(defn- do-unlock
+  "Verify the password for a public entity and set the unlock cookie on success."
+  [request entity-type uuid password]
+  (public-sharing.validation/check-public-sharing-enabled)
+  (let [throttle-key (unlock/throttle-key entity-type uuid)]
+    (throttle/check unlock/unlock-throttle throttle-key)
+    (let [model    (case entity-type :card :model/Card :dashboard :model/Dashboard)
+          stored   (api/check-404 (t2/select-one-fn :public_link_password model
+                                                    :public_uuid uuid :archived false))]
+      (if (and stored (unlock/verify-password password stored))
+        (unlock/add-unlock-entry request {:status 200 :body {:success true}} entity-type uuid stored)
+        {:status 403 :body {:error (tru "Incorrect password.")}}))))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/card/:uuid/unlock"
+  "Verify the password for a public card and set the unlock cookie."
+  [{:keys [uuid]} :- [:map [:uuid ms/UUIDString]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]
+   request]
+  (do-unlock request :card uuid password))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/dashboard/:uuid/unlock"
+  "Verify the password for a public dashboard and set the unlock cookie."
+  [{:keys [uuid]} :- [:map [:uuid ms/UUIDString]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]
+   request]
+  (do-unlock request :dashboard uuid password))
+
 ;;; ----------------------------------------- Route Definitions & Complaints -----------------------------------------
 
 ;; TODO - a smart person would probably just parse the UUIDs automatically in middleware as appropriate for
 ;;`/dashboard` vs `/card`
 
 (def ^{:arglists '([request respond raise])} routes
-  "`/api/public` routes. Enforces public-sharing-enabled check via middleware, in addition to
-  per-endpoint checks."
-  (api.macros/ns-handler *ns* public-sharing.validation/+public-sharing-enabled))
+  "`/api/public` routes. Enforces public-sharing-enabled and unlock check via middleware."
+  (api.macros/ns-handler *ns*
+                         public-sharing.validation/+public-sharing-enabled
+                         public-sharing.validation/+unlock-check))

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -18,6 +18,7 @@
    [metabase.models.interface :as mi]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.permissions.core :as perms]
+   [metabase.public-sharing.api :as public-sharing.api]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as queries]
    [metabase.queries.schema :as queries.schema]
@@ -976,9 +977,12 @@
 (api.macros/defendpoint :post "/:card-id/public_link"
   "Generate publicly-accessible links for this Card. Returns UUID to be used in public links. (If this Card has
   already been shared, it will return the existing public link rather than creating a new one.)  Public sharing must
-  be enabled."
+  be enabled. Optionally accepts a `password` in the request body (requires premium token)."
   [{:keys [card-id]} :- [:map
-                         [:card-id ms/PositiveInt]]]
+                         [:card-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password {:optional true} [:maybe ms/NonBlankString]]]]
   (perms/check-has-application-permission :setting)
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Card card-id))
@@ -991,6 +995,8 @@
                    (t2/update! :model/Card card-id
                                {:public_uuid       <>
                                 :made_public_by_id api/*current-user-id*})))]
+    (when password
+      (public-sharing.api/set-public-link-password! :model/Card card-id password))
     {:uuid uuid}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -1014,6 +1020,40 @@
   (events/publish-event! :event/card-public-link-deleted
                          {:object-id card-id
                           :user-id api/*current-user-id*})
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/:card-id/public_password"
+  "Reveal the plaintext password for a Card's public link. Visible to any user who can see the Card.
+  Requires premium token. Audit-logged."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]]
+  (api/read-check :model/Card card-id)
+  (public-sharing.api/get-public-link-password :model/Card card-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :put "/:card-id/public_password"
+  "Set or update the password on a Card's public link. Requires premium token."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]]
+  (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Card :id card-id, :public_uuid [:not= nil])
+  (public-sharing.api/set-public-link-password! :model/Card card-id password)
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :delete "/:card-id/public_password"
+  "Remove the password from a Card's public link without revoking the link. Requires premium token."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]]
+  (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Card :id card-id, :public_uuid [:not= nil])
+  (public-sharing.api/delete-public-link-password! :model/Card card-id)
   {:status 204, :body nil})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -563,7 +563,8 @@
     :cloud-custom-smtp
     :session-timeout-config
     :sso-oidc
-    :admin-security-center})
+    :admin-security-center
+    :public-link-passwords})
 
 (deftest every-feature-is-accounted-for-test
   (testing "Is every premium feature either tracked under the :features key, or intentionally excluded?"

--- a/test/metabase/public_sharing/validation_test.clj
+++ b/test/metabase/public_sharing/validation_test.clj
@@ -1,0 +1,153 @@
+(ns metabase.public-sharing.validation-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.public-sharing.validation :as validation]
+   [metabase.test :as mt]
+   [metabase.test.http-client :as client]
+   [metabase.util.encryption :as encryption]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------- parse-public-entity tests -------------------------------------------
+
+(deftest parse-public-entity-test
+  (let [parse #'validation/parse-public-entity]
+    (testing "card paths"
+      (is (= [:card "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/card/550e8400-e29b-41d4-a716-446655440000")))
+      (is (= [:card "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/card/550e8400-e29b-41d4-a716-446655440000/query")))
+      (is (= [:card "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/card/550e8400-e29b-41d4-a716-446655440000/params/foo/values"))))
+    (testing "dashboard paths"
+      (is (= [:dashboard "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/dashboard/550e8400-e29b-41d4-a716-446655440000")))
+      (is (= [:dashboard "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/dashboard/550e8400-e29b-41d4-a716-446655440000/dashcard/1/card/2"))))
+    (testing "pivot paths"
+      (is (= [:card "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/pivot/card/550e8400-e29b-41d4-a716-446655440000/query")))
+      (is (= [:dashboard "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/pivot/dashboard/550e8400-e29b-41d4-a716-446655440000/dashcard/1/card/2"))))
+    (testing "tiles paths"
+      (is (= [:card "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/tiles/card/550e8400-e29b-41d4-a716-446655440000/1/2/3")))
+      (is (= [:dashboard "550e8400-e29b-41d4-a716-446655440000"]
+             (parse "/tiles/dashboard/550e8400-e29b-41d4-a716-446655440000/dashcard/1/card/2/3/4/5"))))
+    (testing "exempt paths return nil"
+      (is (nil? (parse "/oembed")))
+      (is (nil? (parse "/action/550e8400-e29b-41d4-a716-446655440000")))
+      (is (nil? (parse "/document/550e8400-e29b-41d4-a716-446655440000")))
+      (is (nil? (parse "/card/550e8400-e29b-41d4-a716-446655440000/unlock")))
+      (is (nil? (parse "/dashboard/550e8400-e29b-41d4-a716-446655440000/unlock"))))))
+
+;;; ---------------------------------------------- Middleware tests ---------------------------------------------------
+
+(defn- shared-card-attrs []
+  {:public_uuid       (str (random-uuid))
+   :made_public_by_id (mt/user->id :crowberto)
+   :dataset_query     {:database (mt/id)
+                       :type     :query
+                       :query    {:source-table (mt/id :venues)
+                                  :aggregation  [[:count]]}}})
+
+(defn- shared-dashboard-attrs []
+  {:public_uuid       (str (random-uuid))
+   :made_public_by_id (mt/user->id :crowberto)})
+
+(deftest unlock-check-middleware-card-no-password-test
+  (testing "Card without a password is not blocked"
+    (mt/with-temp [:model/Card card (shared-card-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (is (= 200
+               (:status (client/client-full-response :get 200
+                                                     (str "public/card/" (:public_uuid card))))))))))
+
+(deftest unlock-check-middleware-card-locked-test
+  (testing "Card with a password returns 403 without unlock cookie"
+    (mt/with-temp [:model/Card card (shared-card-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (t2/update! :model/Card (:id card) {:public_link_password (encryption/maybe-encrypt "secret99")})
+        (let [response (client/client-full-response :get 403
+                                                    (str "public/card/" (:public_uuid card)))]
+          (is (= "public-link-password-required"
+                 (:error_code (:body response)))))))))
+
+(deftest unlock-check-middleware-dashboard-locked-test
+  (testing "Dashboard with a password returns 403 without unlock cookie"
+    (mt/with-temp [:model/Dashboard dashboard (shared-dashboard-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (t2/update! :model/Dashboard (:id dashboard) {:public_link_password (encryption/maybe-encrypt "secret99")})
+        (let [response (client/client-full-response :get 403
+                                                    (str "public/dashboard/" (:public_uuid dashboard)))]
+          (is (= "public-link-password-required"
+                 (:error_code (:body response)))))))))
+
+;;; ---------------------------------------------- Unlock endpoint tests -----------------------------------------------
+
+(deftest unlock-card-endpoint-test
+  (testing "POST /api/public/card/:uuid/unlock"
+    (mt/with-temp [:model/Card card (shared-card-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (t2/update! :model/Card (:id card) {:public_link_password (encryption/maybe-encrypt "correct-pw")})
+        (let [uuid (:public_uuid card)]
+          (testing "correct password returns 200 with Set-Cookie"
+            (let [response (client/client-full-response :post 200
+                                                        (str "public/card/" uuid "/unlock")
+                                                        {:password "correct-pw"})]
+              (is (get-in response [:headers "Set-Cookie"]))
+              (is (true? (get-in response [:body :success])))))
+          (testing "incorrect password returns 403"
+            (client/client :post 403
+                           (str "public/card/" uuid "/unlock")
+                           {:password "wrong-pw"})))))))
+
+(deftest unlock-dashboard-endpoint-test
+  (testing "POST /api/public/dashboard/:uuid/unlock"
+    (mt/with-temp [:model/Dashboard dashboard (shared-dashboard-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (t2/update! :model/Dashboard (:id dashboard) {:public_link_password (encryption/maybe-encrypt "dash-pw")})
+        (let [uuid (:public_uuid dashboard)]
+          (testing "correct password returns 200 with Set-Cookie"
+            (let [response (client/client-full-response :post 200
+                                                        (str "public/dashboard/" uuid "/unlock")
+                                                        {:password "dash-pw"})]
+              (is (get-in response [:headers "Set-Cookie"]))
+              (is (true? (get-in response [:body :success])))))
+          (testing "incorrect password returns 403"
+            (client/client :post 403
+                           (str "public/dashboard/" uuid "/unlock")
+                           {:password "wrong-pw"})))))))
+
+(deftest unlock-nonexistent-entity-test
+  (testing "unlock endpoint returns 404 for nonexistent entity"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (client/client :post 404
+                     (str "public/card/" (random-uuid) "/unlock")
+                     {:password "any"}))))
+
+(deftest unlock-flow-card-test
+  (testing "Full flow: locked card → unlock → access with cookie"
+    (mt/with-temp [:model/Card card (shared-card-attrs)]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (t2/update! :model/Card (:id card) {:public_link_password (encryption/maybe-encrypt "pw123")})
+        (let [uuid (:public_uuid card)]
+          ;; Step 1: blocked without cookie
+          (client/client :get 403 (str "public/card/" uuid))
+          ;; Step 2: unlock
+          (let [unlock-resp (client/client-full-response :post 200
+                                                         (str "public/card/" uuid "/unlock")
+                                                         {:password "pw123"})
+                set-cookie  (get-in unlock-resp [:headers "Set-Cookie"])
+                ;; Set-Cookie may be a string or a seq of strings
+                set-cookie  (if (string? set-cookie) set-cookie (first set-cookie))
+                ;; Extract cookie value from Set-Cookie header
+                cookie-val  (second (re-find #"metabase\.PUBLIC_UNLOCK=([^;]+)" set-cookie))]
+            ;; Step 3: access with cookie
+            (is (some? cookie-val))
+            (let [response (client/client-full-response :get 200
+                                                        (str "public/card/" uuid)
+                                                        {:request-options
+                                                         {:headers {"cookie" (str "metabase.PUBLIC_UNLOCK=" cookie-val)}}})]
+              (is (= 200 (:status response))))))))))


### PR DESCRIPTION
Closes [EMB-1812: Wire `+unlock-check` middleware and `POST .../unlock` endpoints](https://linear.app/metabase/issue/EMB-1812/wire-unlock-check-middleware-and-post-unlock-endpoints)

**Review order:** PR 3/9 in the password-protected public links stack.

### Description

Adds `enforce-unlock-check` middleware that gates password-protected public links with 403 `{error_code: "public-link-password-required"}`. Exempt paths: `/oembed`, `/action/*`, `/document/*`, `/unlock`. Adds `POST /api/public/card/:uuid/unlock` and `POST /api/public/dashboard/:uuid/unlock` endpoints with throttling and cookie-setting.

### How to verify

1. Run `./bin/test-agent :only '[metabase.public-sharing.validation-test]'` — 8 tests, 34 assertions
2. Run `./bin/test-agent :only '[metabase.public-sharing-rest.api-test]'` — all 56 existing tests still pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR