### PR TITLE
Public link passwords: EE module: management API + public-link-passwords premium token

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1578,11 +1578,13 @@
 
   public-sharing
   {:team "UX West"
-   :api  #{metabase.public-sharing.core
+   :api  #{metabase.public-sharing.api
+           metabase.public-sharing.core
            metabase.public-sharing.init
            metabase.public-sharing.unlock
            metabase.public-sharing.validation}
    :uses #{api
+           premium-features
            settings
            util}
    :model-imports #{:model/Card :model/Dashboard}}
@@ -3194,6 +3196,15 @@
    :api  #{}
    :uses #{premium-features
            util}}
+
+  enterprise/public-link-passwords
+  {:team "Embedding"
+   :api  #{metabase-enterprise.public-link-passwords.init}
+   :uses #{api
+           events
+           premium-features
+           util}
+   :model-imports #{:model/Card :model/Dashboard}}
 
   enterprise/remote-sync
   {:team "UX West"

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -16,6 +16,7 @@
    [metabase-enterprise.dependencies.init]
    [metabase-enterprise.gsheets.init]
    [metabase-enterprise.metabot.init]
+   [metabase-enterprise.public-link-passwords.init]
    [metabase-enterprise.remote-sync.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.security-center.init]

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
@@ -4,7 +4,6 @@
    [metabase.api.common :as api]
    [metabase.events.core :as events]
    [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
 
@@ -20,11 +19,12 @@
     :model/Dashboard "dashboard"))
 
 (defenterprise set-public-link-password!
-  "Validate, encrypt, and store a password on a public link."
+  "Validate and store a password on a public link. Encryption is handled by the model's
+  `:public_link_password` transform, so the plaintext is passed through as-is here."
   :feature :public-link-passwords
   [model id password]
   (validate-password password)
-  (t2/update! model id {:public_link_password (encryption/maybe-encrypt password)}))
+  (t2/update! model id {:public_link_password password}))
 
 (defenterprise get-public-link-password
   "Return the decrypted plaintext password for a public link. Audit-logged."

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.public-link-passwords.core
+  "EE implementation of public-link password management, gated on the `:public-link-passwords` premium token."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.events.core :as events]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.encryption :as encryption]
+   [metabase.util.i18n :refer [tru]]
+   [toucan2.core :as t2]))
+
+(def ^:private min-password-length 6)
+
+(defn- validate-password [password]
+  (api/check (>= (count password) min-password-length)
+             [400 (tru "Password must be at least {0} characters." min-password-length)]))
+
+(defn- model->event-prefix [model]
+  (case model
+    :model/Card      "card"
+    :model/Dashboard "dashboard"))
+
+(defenterprise set-public-link-password!
+  "Validate, encrypt, and store a password on a public link."
+  :feature :public-link-passwords
+  [model id password]
+  (validate-password password)
+  (t2/update! model id {:public_link_password (encryption/maybe-encrypt password)}))
+
+(defenterprise get-public-link-password
+  "Return the decrypted plaintext password for a public link. Audit-logged."
+  :feature :public-link-passwords
+  [model id]
+  (let [password (t2/select-one-fn :public_link_password model :id id)]
+    (api/check-404 password)
+    (events/publish-event! (keyword "event" (str (model->event-prefix model) "-public-pwd-revealed"))
+                           {:object-id id
+                            :user-id   api/*current-user-id*})
+    {:password password}))
+
+(defenterprise delete-public-link-password!
+  "Remove the password from a public link without revoking it."
+  :feature :public-link-passwords
+  [model id]
+  (t2/update! model id {:public_link_password nil}))

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.public-link-passwords.init
+  (:require
+   [metabase-enterprise.public-link-passwords.core]))

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -121,6 +121,7 @@
             :etl_connections                false
             :etl_connections_pg             false
             :dependencies                   false
+            :public_link_passwords          false
             :schema-viewer                  false
             :workspaces                     false
             :writable_connection            true}

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -56,6 +56,8 @@
 (derive :event/card-public-link-deleted ::publicize-card)
 (derive :event/dashboard-public-link-created ::publicize-dashboard)
 (derive :event/dashboard-public-link-deleted ::publicize-dashboard)
+(derive :event/card-public-pwd-revealed ::publicize-card)
+(derive :event/dashboard-public-pwd-revealed ::publicize-dashboard)
 
 (methodical/defmethod events/publish-event! ::publicize
   [topic {:keys [user-id object-id] :as _event}]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1214,6 +1214,7 @@
    _query-params
    {:keys [password]} :- [:map [:password ms/NonBlankString]]]
   (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
   (public-sharing.api/set-public-link-password! :model/Dashboard dashboard-id password)
   {:status 204, :body nil})
 
@@ -1224,6 +1225,7 @@
   [{:keys [dashboard-id]} :- [:map
                               [:dashboard-id ms/PositiveInt]]]
   (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
   (public-sharing.api/delete-public-link-password! :model/Dashboard dashboard-id)
   {:status 204, :body nil})
 

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -31,6 +31,7 @@
    [metabase.parameters.params :as params]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.permissions.core :as perms]
+   [metabase.public-sharing.api :as public-sharing.api]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.pulse.core :as pulse]
    [metabase.queries.core :as queries]
@@ -1149,9 +1150,12 @@
 (api.macros/defendpoint :post "/:dashboard-id/public_link"
   "Generate publicly-accessible links for this Dashboard. Returns UUID to be used in public links. (If this
   Dashboard has already been shared, it will return the existing public link rather than creating a new one.) Public
-  sharing must be enabled."
+  sharing must be enabled. Optionally accepts a `password` in the request body (requires premium token)."
   [{:keys [dashboard-id]} :- [:map
-                              [:dashboard-id ms/PositiveInt]]]
+                              [:dashboard-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password {:optional true} [:maybe ms/NonBlankString]]]]
   (api/check-superuser)
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Dashboard dashboard-id))
@@ -1164,6 +1168,8 @@
                    (t2/update! :model/Dashboard dashboard-id
                                {:public_uuid       <>
                                 :made_public_by_id api/*current-user-id*})))]
+    (when password
+      (public-sharing.api/set-public-link-password! :model/Dashboard dashboard-id password))
     {:uuid uuid}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -1187,6 +1193,38 @@
   (events/publish-event! :event/dashboard-public-link-deleted
                          {:object-id dashboard-id
                           :user-id api/*current-user-id*})
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/:dashboard-id/public_password"
+  "Reveal the plaintext password for a Dashboard's public link. Visible to any user who can see the Dashboard.
+  Requires premium token. Audit-logged."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]]
+  (api/read-check :model/Dashboard dashboard-id)
+  (public-sharing.api/get-public-link-password :model/Dashboard dashboard-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :put "/:dashboard-id/public_password"
+  "Set or update the password on a Dashboard's public link. Requires premium token."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]]
+  (perms/check-has-application-permission :setting)
+  (public-sharing.api/set-public-link-password! :model/Dashboard dashboard-id password)
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :delete "/:dashboard-id/public_password"
+  "Remove the password from a Dashboard's public link without revoking the link. Requires premium token."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]]
+  (perms/check-has-application-permission :setting)
+  (public-sharing.api/delete-public-link-password! :model/Dashboard dashboard-id)
   {:status 204, :body nil})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -86,6 +86,8 @@
 (mr/def :event/dashboard-public-link-deleted ::publicize)
 (mr/def :event/card-public-link-created ::publicize)
 (mr/def :event/card-public-link-deleted ::publicize)
+(mr/def :event/card-public-pwd-revealed ::publicize)
+(mr/def :event/dashboard-public-pwd-revealed ::publicize)
 
 ;; user events
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -174,6 +174,10 @@
   "Should we enable user/group provisioning via SCIM?"
   :scim)
 
+(define-premium-feature enable-public-link-passwords?
+  "Should we enable password protection on public links?"
+  :public-link-passwords)
+
 (defn enable-any-sso?
   "Should we enable any SSO-based authentication?"
   []
@@ -428,7 +432,8 @@
    :workspaces                     (enable-workspaces?)
    :whitelabel                     (enable-whitelabeling?)
    :writable_connection            (enable-writable-connection?)
-   :ai_controls                    (enable-ai-controls?)})
+   :ai_controls                    (enable-ai-controls?)
+   :public_link_passwords          (enable-public-link-passwords?)})
 
 (defsetting token-features
   "Features registered for this instance's token"

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -1,0 +1,24 @@
+(ns metabase.public-sharing.api
+  "OSS stubs for public-link password management. EE implementations live in
+  `metabase-enterprise.public-link-passwords.core`."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]))
+
+(defenterprise set-public-link-password!
+  "Validate, encrypt, and store a password on a public link. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id _password]
+  (throw (ex-info (tru "Setting passwords on public links is a paid feature.") {:status-code 402})))
+
+(defenterprise get-public-link-password
+  "Return the decrypted plaintext password for a public link. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id]
+  (throw (ex-info (tru "Public link passwords is a paid feature.") {:status-code 402})))
+
+(defenterprise delete-public-link-password!
+  "Remove the password from a public link without revoking it. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id]
+  (throw (ex-info (tru "Public link passwords is a paid feature.") {:status-code 402})))

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -1039,6 +1039,7 @@
    _query-params
    {:keys [password]} :- [:map [:password ms/NonBlankString]]]
   (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Card :id card-id, :public_uuid [:not= nil])
   (public-sharing.api/set-public-link-password! :model/Card card-id password)
   {:status 204, :body nil})
 
@@ -1049,6 +1050,7 @@
   [{:keys [card-id]} :- [:map
                          [:card-id ms/PositiveInt]]]
   (perms/check-has-application-permission :setting)
+  (api/check-exists? :model/Card :id card-id, :public_uuid [:not= nil])
   (public-sharing.api/delete-public-link-password! :model/Card card-id)
   {:status 204, :body nil})
 

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -18,6 +18,7 @@
    [metabase.models.interface :as mi]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.permissions.core :as perms]
+   [metabase.public-sharing.api :as public-sharing.api]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as queries]
    [metabase.queries.schema :as queries.schema]
@@ -974,9 +975,12 @@
 (api.macros/defendpoint :post "/:card-id/public_link"
   "Generate publicly-accessible links for this Card. Returns UUID to be used in public links. (If this Card has
   already been shared, it will return the existing public link rather than creating a new one.)  Public sharing must
-  be enabled."
+  be enabled. Optionally accepts a `password` in the request body (requires premium token)."
   [{:keys [card-id]} :- [:map
-                         [:card-id ms/PositiveInt]]]
+                         [:card-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password {:optional true} [:maybe ms/NonBlankString]]]]
   (perms/check-has-application-permission :setting)
   (public-sharing.validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Card card-id))
@@ -989,6 +993,8 @@
                    (t2/update! :model/Card card-id
                                {:public_uuid       <>
                                 :made_public_by_id api/*current-user-id*})))]
+    (when password
+      (public-sharing.api/set-public-link-password! :model/Card card-id password))
     {:uuid uuid}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -1012,6 +1018,38 @@
   (events/publish-event! :event/card-public-link-deleted
                          {:object-id card-id
                           :user-id api/*current-user-id*})
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/:card-id/public_password"
+  "Reveal the plaintext password for a Card's public link. Visible to any user who can see the Card.
+  Requires premium token. Audit-logged."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]]
+  (api/read-check :model/Card card-id)
+  (public-sharing.api/get-public-link-password :model/Card card-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :put "/:card-id/public_password"
+  "Set or update the password on a Card's public link. Requires premium token."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]
+   _query-params
+   {:keys [password]} :- [:map [:password ms/NonBlankString]]]
+  (perms/check-has-application-permission :setting)
+  (public-sharing.api/set-public-link-password! :model/Card card-id password)
+  {:status 204, :body nil})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :delete "/:card-id/public_password"
+  "Remove the password from a Card's public link without revoking the link. Requires premium token."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]]
+  (perms/check-has-application-permission :setting)
+  (public-sharing.api/delete-public-link-password! :model/Card card-id)
   {:status 204, :body nil})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -563,7 +563,8 @@
     :cloud-custom-smtp
     :session-timeout-config
     :sso-oidc
-    :admin-security-center})
+    :admin-security-center
+    :public-link-passwords})
 
 (deftest every-feature-is-accounted-for-test
   (testing "Is every premium feature either tracked under the :features key, or intentionally excluded?"


### PR DESCRIPTION
Closes [EMB-1813: EE module: management API + `:public-link-passwords` premium token](https://linear.app/metabase/issue/EMB-1813/ee-module-management-api-public-link-passwords-premium-token)

**Review order:** PR 4/9 in the password-protected public links stack.

### Description

Registers `:public-link-passwords` premium feature. OSS `defenterprise` stubs throw 402. EE implementations: `set-public-link-password!` (min 6 chars, encrypt, store), `get-public-link-password` (decrypt, audit-log), `delete-public-link-password!`. Extends `POST /:id/public_link` with optional password. Adds `GET/PUT/DELETE /:id/public_password` endpoints. Audit-log events for password reveal.

### How to verify

To test with a stubbed feature token:

1. Start Metabase: `clj -M:dev:ee:drivers`
2. At the `user=>` prompt: `(dev/start!)`
3. Stub the token:
   ```clojure
   (alter-var-root
     #'metabase.premium-features.token-check/*token-features*
     (constantly (constantly #{"public-link-passwords"})))
   ```
4. `PUT /api/card/:id/public_password` with `{"password": "secret"}` sets a password
5. `GET /api/card/:id/public_password` reveals it
6. `DELETE /api/card/:id/public_password` clears it
7. Without the stubbed token, these return 402

### Checklist

- [x] Tests have been added/updated to cover changes in this PR