### PR TITLE
Public link passwords: Viewer FE: PublicLinkUnlockForm + PublicApp 403 routing

### DIFF
--- a/frontend/src/metabase/api/public.ts
+++ b/frontend/src/metabase/api/public.ts
@@ -23,6 +23,12 @@ export type PublicDocumentCardQueryRequest = {
   cardId: CardId;
 };
 
+export type UnlockPublicLinkRequest = {
+  uuid: string;
+  entityType: "card" | "dashboard";
+  password: string;
+};
+
 const PIVOT_PREFIX = "/api/public/pivot";
 
 export const publicApi = Api.injectEndpoints({
@@ -74,6 +80,13 @@ export const publicApi = Api.injectEndpoints({
         url: `/api/public/document/${uuid}/card/${cardId}`,
       }),
     }),
+    unlockPublicLink: builder.mutation<void, UnlockPublicLinkRequest>({
+      query: ({ uuid, entityType, password }) => ({
+        method: "POST",
+        url: `/api/public/${entityType}/${uuid}/unlock`,
+        body: { password },
+      }),
+    }),
   }),
 });
 
@@ -83,4 +96,5 @@ export const {
   useGetPublicDashcardQueryQuery,
   useGetPublicDashcardQueryPivotQuery,
   useGetPublicDocumentCardQueryQuery,
+  useUnlockPublicLinkMutation,
 } = publicApi;

--- a/frontend/src/metabase/public/components/PublicLinkUnlockForm.module.css
+++ b/frontend/src/metabase/public/components/PublicLinkUnlockForm.module.css
@@ -1,0 +1,20 @@
+.root {
+  position: relative;
+  min-height: 100vh;
+  background-color: var(--mb-color-background-secondary);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-height: 100vh;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.card {
+  width: 100%;
+  max-width: 400px;
+}

--- a/frontend/src/metabase/public/components/PublicLinkUnlockForm.tsx
+++ b/frontend/src/metabase/public/components/PublicLinkUnlockForm.tsx
@@ -1,0 +1,77 @@
+import { type FormEvent, useState } from "react";
+import { t } from "ttag";
+
+import { LighthouseIllustration } from "metabase/common/components/LighthouseIllustration";
+import { LogoIcon } from "metabase/common/components/LogoIcon";
+import { PublicApi } from "metabase/services";
+import { Box, Button, Card, Stack, Text, TextInput } from "metabase/ui";
+
+import S from "./PublicLinkUnlockForm.module.css";
+
+interface PublicLinkUnlockFormProps {
+  uuid: string;
+  entityType: "card" | "dashboard";
+}
+
+export const PublicLinkUnlockForm = ({
+  uuid,
+  entityType,
+}: PublicLinkUnlockFormProps) => {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      await PublicApi.unlock({ uuid, entityType, password });
+      window.location.reload();
+    } catch (err: any) {
+      setError(err?.data?.error ?? t`Incorrect password.`);
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className={S.root}>
+      <LighthouseIllustration />
+      <div className={S.body}>
+        <Box mb="lg">
+          <LogoIcon height={65} />
+        </Box>
+        <Card className={S.card} p="xl" radius="md">
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Text
+                fw={700}
+                size="lg"
+                ta="center"
+              >{t`This link is password protected`}</Text>
+              <TextInput
+                label={t`Password`}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.currentTarget.value)}
+                placeholder={t`Shhh...`}
+                error={error}
+                autoFocus
+                data-testid="unlock-password-input"
+              />
+              <Button
+                type="submit"
+                variant="filled"
+                loading={isLoading}
+                disabled={!password}
+                fullWidth
+                data-testid="unlock-submit-button"
+              >{t`Continue`}</Button>
+            </Stack>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/metabase/public/components/PublicLinkUnlockForm.tsx
+++ b/frontend/src/metabase/public/components/PublicLinkUnlockForm.tsx
@@ -1,10 +1,11 @@
 import { type FormEvent, useState } from "react";
 import { t } from "ttag";
 
+import { useUnlockPublicLinkMutation } from "metabase/api/public";
 import { LighthouseIllustration } from "metabase/common/components/LighthouseIllustration";
 import { LogoIcon } from "metabase/common/components/LogoIcon";
-import { PublicApi } from "metabase/services";
 import { Box, Button, Card, Stack, Text, TextInput } from "metabase/ui";
+import { reload } from "metabase/utils/dom";
 
 import S from "./PublicLinkUnlockForm.module.css";
 
@@ -13,25 +14,27 @@ interface PublicLinkUnlockFormProps {
   entityType: "card" | "dashboard";
 }
 
+function getUnlockErrorMessage(error: unknown): string {
+  const data = (error as { data?: { error?: string } })?.data;
+  return data?.error ?? t`Incorrect password.`;
+}
+
 export const PublicLinkUnlockForm = ({
   uuid,
   entityType,
 }: PublicLinkUnlockFormProps) => {
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [unlock, { isLoading, error }] = useUnlockPublicLinkMutation();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setError(null);
-    setIsLoading(true);
 
     try {
-      await PublicApi.unlock({ uuid, entityType, password });
-      window.location.reload();
-    } catch (err: any) {
-      setError(err?.data?.error ?? t`Incorrect password.`);
-      setIsLoading(false);
+      await unlock({ uuid, entityType, password }).unwrap();
+      // A full reload lets the freshly-set unlock cookie through.
+      reload();
+    } catch {
+      // The failure is surfaced to the user via the mutation's `error`.
     }
   };
 
@@ -56,7 +59,7 @@ export const PublicLinkUnlockForm = ({
                 value={password}
                 onChange={(e) => setPassword(e.currentTarget.value)}
                 placeholder={t`Shhh...`}
-                error={error}
+                error={error ? getUnlockErrorMessage(error) : null}
                 autoFocus
                 data-testid="unlock-password-input"
               />

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
@@ -28,13 +28,15 @@ function mapStateToProps(state: State) {
   };
 }
 
-function parsePublicEntity(pathname: string): {
+export function parsePublicEntity(pathname: string): {
   uuid: string;
   entityType: "card" | "dashboard";
 } | null {
-  const cardMatch = pathname.match(/\/public\/(?:question|card)\/([^/]+)/);
-  if (cardMatch) {
-    return { uuid: cardMatch[1], entityType: "card" };
+  // Public questions are served from `/public/question/:uuid` (there is no
+  // `/public/card` route); the backend entity is still a card.
+  const questionMatch = pathname.match(/\/public\/question\/([^/]+)/);
+  if (questionMatch) {
+    return { uuid: questionMatch[1], entityType: "card" };
   }
   const dashMatch = pathname.match(/\/public\/dashboard\/([^/]+)/);
   if (dashMatch) {

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect } from "react";
 
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { PublicError } from "metabase/public/components/PublicError";
+import { PublicLinkUnlockForm } from "metabase/public/components/PublicLinkUnlockForm";
 import { PublicNotFound } from "metabase/public/components/PublicNotFound";
 import { connect, useSelector } from "metabase/redux";
 import type { AppErrorDescriptor, State } from "metabase/redux/store";
@@ -12,6 +13,7 @@ import { isWithinIframe } from "metabase/utils/iframe";
 
 interface OwnProps {
   children: JSX.Element;
+  location: { pathname: string };
 }
 
 interface StateProps {
@@ -26,7 +28,31 @@ function mapStateToProps(state: State) {
   };
 }
 
-function PublicApp({ errorPage, children }: Props) {
+function parsePublicEntity(pathname: string): {
+  uuid: string;
+  entityType: "card" | "dashboard";
+} | null {
+  const cardMatch = pathname.match(/\/public\/(?:question|card)\/([^/]+)/);
+  if (cardMatch) {
+    return { uuid: cardMatch[1], entityType: "card" };
+  }
+  const dashMatch = pathname.match(/\/public\/dashboard\/([^/]+)/);
+  if (dashMatch) {
+    return { uuid: dashMatch[1], entityType: "dashboard" };
+  }
+  return null;
+}
+
+function isPasswordRequired(
+  errorPage: AppErrorDescriptor | null | undefined,
+): boolean {
+  return (
+    errorPage?.status === 403 &&
+    errorPage?.data?.error_code === "public-link-password-required"
+  );
+}
+
+function PublicApp({ errorPage, children, location }: Props) {
   const applicationName = useSelector(getApplicationName);
 
   usePageTitle(applicationName, { titleIndex: 0 });
@@ -38,6 +64,17 @@ function PublicApp({ errorPage, children }: Props) {
   }, []);
 
   if (errorPage) {
+    if (isPasswordRequired(errorPage)) {
+      const entity = parsePublicEntity(location.pathname);
+      if (entity) {
+        return (
+          <PublicLinkUnlockForm
+            uuid={entity.uuid}
+            entityType={entity.entityType}
+          />
+        );
+      }
+    }
     return errorPage.status === 404 ? <PublicNotFound /> : <PublicError />;
   }
 

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -1,14 +1,16 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 import type { JSX } from "react";
 import { Route } from "react-router";
 
 import { mockSettings } from "__support__/settings";
-import { getIcon, renderWithProviders, screen } from "__support__/ui";
+import { getIcon, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { SyncedEmbedFrame } from "metabase/public/components/EmbedFrame";
 import type { AppErrorDescriptor } from "metabase/redux/store";
 import { createMockAppState } from "metabase/redux/store/mocks";
+import * as domUtils from "metabase/utils/dom";
 
-import PublicApp from "./PublicApp";
+import PublicApp, { parsePublicEntity } from "./PublicApp";
 
 type SetupOpts = {
   name?: string;
@@ -17,12 +19,16 @@ type SetupOpts = {
   error?: AppErrorDescriptor;
   hasEmbedBranding?: boolean;
   hash?: string;
+  path?: string;
+  initialRoute?: string;
 };
 
 function setup({
   error,
   hasEmbedBranding = true,
   hash = "",
+  path = "/public/dashboard/:id",
+  initialRoute,
   ...embedFrameProps
 }: SetupOpts = {}) {
   const app = createMockAppState({ errorPage: error });
@@ -30,7 +36,7 @@ function setup({
 
   renderWithProviders(
     <Route
-      path="/public/dashboard/:id"
+      path={path}
       component={(props) => (
         <PublicApp {...props}>
           <SyncedEmbedFrame {...embedFrameProps}>
@@ -41,7 +47,7 @@ function setup({
     />,
     {
       mode: "public",
-      initialRoute: `/public/dashboard/UUID${hash}`,
+      initialRoute: initialRoute ?? `/public/dashboard/UUID${hash}`,
       storeInitialState: { app, settings },
       withRouter: true,
     },
@@ -128,6 +134,37 @@ describe("PublicApp", () => {
     expect(screen.queryByTestId("test-content")).not.toBeInTheDocument();
   });
 
+  it("submits the entered password with the parsed uuid to unlock the link", async () => {
+    const reloadSpy = jest
+      .spyOn(domUtils, "reload")
+      .mockImplementation(() => undefined);
+    fetchMock.post("path:/api/public/card/test-uuid/unlock", 200);
+
+    setup({
+      error: {
+        status: 403,
+        data: { error_code: "public-link-password-required" },
+      },
+      path: "/public/question/:uuid",
+      initialRoute: "/public/question/test-uuid",
+    });
+
+    await userEvent.type(
+      screen.getByTestId("unlock-password-input"),
+      "hunter2",
+    );
+    await userEvent.click(screen.getByTestId("unlock-submit-button"));
+
+    // We reload only after a successful unlock, and the unlock route is the only
+    // one mocked — so this also proves the parsed `uuid` was passed through.
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+
+    const body = await fetchMock.callHistory
+      .lastCall("path:/api/public/card/test-uuid/unlock")
+      ?.request?.json();
+    expect(body).toEqual({ password: "hunter2" });
+  });
+
   it("renders generic error for non-password 403", () => {
     setup({
       error: {
@@ -160,5 +197,34 @@ describe("PublicApp", () => {
         );
       },
     );
+  });
+});
+
+describe("parsePublicEntity", () => {
+  it.each([
+    {
+      pathname: "/public/question/abc-123",
+      expected: { uuid: "abc-123", entityType: "card" },
+    },
+    {
+      pathname: "/public/dashboard/abc-123",
+      expected: { uuid: "abc-123", entityType: "dashboard" },
+    },
+    {
+      // A dashboard tab slug must not be captured as part of the uuid.
+      pathname: "/public/dashboard/abc-123/4-overview",
+      expected: { uuid: "abc-123", entityType: "dashboard" },
+    },
+    // Documents and actions are not password-protectable, so there's no entity.
+    { pathname: "/public/document/abc-123", expected: null },
+    { pathname: "/public/action/abc-123", expected: null },
+    // No uuid present.
+    { pathname: "/public/question/", expected: null },
+    // Substring traps and non-public paths.
+    { pathname: "/public/questionnaire/abc-123", expected: null },
+    { pathname: "/embed/question/abc-123", expected: null },
+    { pathname: "/some/other/path", expected: null },
+  ])("parses $pathname", ({ pathname, expected }) => {
+    expect(parsePublicEntity(pathname)).toEqual(expected);
   });
 });

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -113,6 +113,34 @@ describe("PublicApp", () => {
     expect(screen.queryByText("Powered by")).not.toBeInTheDocument();
   });
 
+  it("renders unlock form when password is required", () => {
+    setup({
+      error: {
+        status: 403,
+        data: { error_code: "public-link-password-required" },
+      },
+    });
+    expect(
+      screen.getByText("This link is password protected"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("unlock-password-input")).toBeInTheDocument();
+    expect(screen.getByTestId("unlock-submit-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("test-content")).not.toBeInTheDocument();
+  });
+
+  it("renders generic error for non-password 403", () => {
+    setup({
+      error: {
+        status: 403,
+        data: { error_code: "some-other-error", message: "Forbidden" },
+      },
+    });
+    expect(screen.getByText("Forbidden")).toBeInTheDocument();
+    expect(
+      screen.queryByText("This link is password protected"),
+    ).not.toBeInTheDocument();
+  });
+
   describe("theming", () => {
     it("renders correctly without a theme parameter", () => {
       setup();

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -42,8 +42,6 @@ export const PublicApi = {
     `/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute`,
   ),
   document: GET(`/api/public/document/:uuid`),
-  unlock: ({ uuid, entityType, password }) =>
-    POST(`/api/public/${entityType}/${uuid}/unlock`)({ password }),
 };
 
 // `/api/embed` is rewritten to `/api/preview_embed` by the request middleware

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -42,6 +42,8 @@ export const PublicApi = {
     `/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute`,
   ),
   document: GET(`/api/public/document/:uuid`),
+  unlock: ({ uuid, entityType, password }) =>
+    POST(`/api/public/${entityType}/${uuid}/unlock`)({ password }),
 };
 
 // `/api/embed` is rewritten to `/api/preview_embed` by the request middleware


### PR DESCRIPTION
Closes [EMB-1814: Viewer FE: `PublicLinkUnlockForm` + `PublicApp` 403 routing](https://linear.app/metabase/issue/EMB-1814/viewer-fe-publiclinkunlockform-publicapp-403-routing)

**Review order:** PR 6/9 in the password-protected public links stack.

### Description

`PublicApp` detects `error_code: "public-link-password-required"` on 403 and routes to a new `PublicLinkUnlockForm` instead of the generic error page. The form shows the Metabase logo, lighthouse background, a password input, and a "Continue" button. On success, `window.location.reload()` lets the cookie through.

<img width="1540" height="955" alt="image" src="https://github.com/user-attachments/assets/407f8105-126f-4808-b4a8-558d1eaef565" />


### How to verify

1. Set a password on a dashboard's public link (via PR 5's UI)
2. Visit the public link — see the unlock form with logo + lighthouse background
3. Enter the correct password → page reloads and shows the dashboard
4. Enter wrong password → inline error

### Checklist

- [x] Tests have been added/updated to cover changes in this PR