### PR TITLE
Setting to remove recent views from Metabot context

### DIFF
--- a/src/metabase/metabot/context.clj
+++ b/src/metabase/metabot/context.clj
@@ -300,9 +300,11 @@
   /dashboards before taking the top 5. Tables are not moderatable and always pass through."
   [context {:keys [metabot-id] :as _opts}]
   (try
-    (cond-> context
-      (metabot.settings/metabot-recent-views-enabled?)
-      (assoc :user_recently_viewed
+    ;; When disabled, strip any preexisting :user_recently_viewed so the setting guarantees recent
+    ;; views never reach the prompt, even for a caller-supplied context that already carries the key.
+    (if-not (metabot.settings/metabot-recent-views-enabled?)
+      (dissoc context :user_recently_viewed)
+      (assoc context :user_recently_viewed
              (let [recents (:recents (activity-feed/get-recents api/*current-user-id*
                                                                 [:views :selections]
                                                                 {:models [:card :dataset :metric :dashboard :table]}))

--- a/src/metabase/metabot/context.clj
+++ b/src/metabase/metabot/context.clj
@@ -11,6 +11,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.metabot.config :as metabot.config]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.table-utils :as table-utils]
    [metabase.premium-features.core :as premium-features]
    [metabase.transforms-base.util :as transforms-base.u]
@@ -299,23 +300,25 @@
   /dashboards before taking the top 5. Tables are not moderatable and always pass through."
   [context {:keys [metabot-id] :as _opts}]
   (try
-    (let [recents (:recents (activity-feed/get-recents api/*current-user-id*
-                                                       [:views :selections]
-                                                       {:models [:card :dataset :metric :dashboard :table]}))
-          recents (cond->> recents
-                    (verified-only? (get-metabot metabot-id))
-                    filter-recents-to-verified)
-          processed-recents (mapv (fn [item]
-                                    (let [item-type
-                                          (case (:model item)
-                                            :card "question"
-                                            :dataset "model"
-                                            (name (:model item)))]
-                                      (-> item
-                                          (select-keys [:id :name :description])
-                                          (assoc :type item-type))))
-                                  (take 5 recents))]
-      (assoc context :user_recently_viewed processed-recents))
+    (cond-> context
+      (metabot.settings/metabot-recent-views-enabled?)
+      (assoc :user_recently_viewed
+             (let [recents (:recents (activity-feed/get-recents api/*current-user-id*
+                                                                [:views :selections]
+                                                                {:models [:card :dataset :metric :dashboard :table]}))
+                   recents (cond->> recents
+                             (verified-only? (get-metabot metabot-id))
+                             filter-recents-to-verified)]
+               (mapv (fn [item]
+                       (let [item-type
+                             (case (:model item)
+                               :card "question"
+                               :dataset "model"
+                               (name (:model item)))]
+                         (-> item
+                             (select-keys [:id :name :description])
+                             (assoc :type item-type))))
+                     (take 5 recents)))))
     (catch Exception e
       (log/error e "Error adding recent views to metabot context")
       context)))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -93,6 +93,13 @@
                     (setting/get-value-of-type :boolean :embedded-metabot-enabled?))
   :export?    true)
 
+(defsetting metabot-recent-views-enabled?
+  (deferred-tru "Whether the user''s recently viewed items are included in the Metabot system prompt.")
+  :type       :boolean
+  :visibility :internal
+  :default    true
+  :export?    false)
+
 ;;; ------------------------------------------------- LLM Provider ------------------------------------------------
 
 (def ^:private direct-providers

--- a/test/metabase/metabot/context_test.clj
+++ b/test/metabase/metabot/context_test.clj
@@ -9,7 +9,8 @@
    [metabase.metabot.agent.user-context :as user-context]
    [metabase.metabot.context :as context]
    [metabase.metabot.table-utils :as table-utils]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (def ^:private users-native-query (lib/native-query meta/metadata-provider "SELECT * FROM users"))
 (def ^:private users-mbql-query (lib/query meta/metadata-provider (meta/table-metadata :users)))
@@ -240,6 +241,18 @@
           ;; Assert that collection is excluded even though it was viewed most recently
           (is (= #{"question" "model" "dashboard" "table"}
                  (set (map :type recently-viewed)))))))))
+
+(deftest recent-views-disabled-by-setting-test
+  (testing "Omits recent views from context when metabot-recent-views-enabled? is false"
+    (mt/with-test-user :rasta
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (mt/with-temp [:model/Card  {card-id :id}  {:type "question" :name "my question"}
+                       :model/Table {table-id :id} {}]
+          (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
+          (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table table-id :selection)
+          (mt/with-temporary-setting-values [metabot-recent-views-enabled? false]
+            (let [context (context/create-context {})]
+              (is (not (contains? context :user_recently_viewed))))))))))
 
 (deftest recent-views-verified-content-filter-test
   (testing "Recent views filtering by verified content"

--- a/test/metabase/metabot/context_test.clj
+++ b/test/metabase/metabot/context_test.clj
@@ -254,6 +254,12 @@
             (let [context (context/create-context {})]
               (is (not (contains? context :user_recently_viewed))))))))))
 
+(deftest recent-views-disabled-strips-preexisting-test
+  (testing "Disabling the setting strips a caller-supplied :user_recently_viewed already in the context"
+    (mt/with-temporary-setting-values [metabot-recent-views-enabled? false]
+      (is (not (contains? (#'context/add-recent-views {:user_recently_viewed [{:id 1 :name "stale"}]} {})
+                          :user_recently_viewed))))))
+
 (deftest recent-views-verified-content-filter-test
   (testing "Recent views filtering by verified content"
     (mt/with-test-user :rasta

--- a/test/metabase/metabot/context_test.clj
+++ b/test/metabase/metabot/context_test.clj
@@ -251,8 +251,8 @@
           (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
           (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table table-id :selection)
           (mt/with-temporary-setting-values [metabot-recent-views-enabled? false]
-            (let [context (context/create-context {})]
-              (is (not (contains? context :user_recently_viewed))))))))))
+            (let [ctx (context/create-context {})]
+              (is (not (contains? ctx :user_recently_viewed))))))))))
 
 (deftest recent-views-disabled-strips-preexisting-test
   (testing "Disabling the setting strips a caller-supplied :user_recently_viewed already in the context"


### PR DESCRIPTION
## Summary

Adds an internal `metabot-recent-views-enabled?` setting (default `true`) and uses it to gate whether the user's recently viewed items are injected into the Metabot system prompt. When disabled, `add-recent-views` skips the `activity-feed` lookup and omits `:user_recently_viewed` from the context entirely.

This supports running benchmarks with/without recently viewed items in context.

## Details

- New `defsetting metabot-recent-views-enabled?` (`:type :boolean`, `:visibility :internal`, `:default true`, `:export? false`) in `metabase.metabot.settings`.
- `metabase.metabot.context/add-recent-views` now wraps the recents computation in a `cond->` keyed on the setting, so the work (and the `:user_recently_viewed` key) is only added when enabled.

## How it was made

Cherry-picked from the `metabot-offsite-2026` branch (commits by Mike Appleby) onto a fresh branch off `master`.

## Testing

`metabase.metabot.context-test` — 26 tests, 58 assertions, 0 failures.