### PR TITLE
Public link passwords: Hide password by default with reveal toggle

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3232,7 +3232,8 @@
   enterprise/public-link-passwords
   {:team "Embedding"
    :api  #{metabase-enterprise.public-link-passwords.init}
-   :uses #{api
+   :uses #{analytics
+           api
            events
            premium-features
            util}

--- a/docs/embedding/public-links.md
+++ b/docs/embedding/public-links.md
@@ -45,6 +45,25 @@ To share a document via a public link, admins can click on the **Sharing** butto
 
 Public documents are read-only: viewers cannot edit the content or add comments. For charts embedded in the document, viewers can download the results in CSV, XLSX, or JSON format using the **Download results** option in the chart menu.
 
+## Set a password on a public link
+
+{% include plans-blockquote.html feature="Password-protected public links" is_plural=true %}
+
+You can add a password to a public link so that people need to enter it before they can view the question or dashboard.
+
+Only admins can set, change, or remove a password from a public link.
+
+1. Click on **Sharing** for a question or dashboard.
+2. If you haven't already, create a public link.
+3. Toggle **Require password**.
+4. Enter a password (minimum 6 characters) and click **Save**.
+
+Anyone who can see the resource will be able to see the password.
+
+When people enter the password to view the link, the browser will issue an unlock cookie good for seven days. Changing or deleting the password will immediately invalidate these cookies.
+
+In some cases, viewers may need to input the password on each visit (for example, if you've embedded the public link in an iframe in another domain, and the person's browser blocks third-party cookies).
+
 ## Exporting raw, unformatted question results
 
 To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL Metabase generates. For example, if you create a public link for a CSV download, the URL would look like:

--- a/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
@@ -1,0 +1,214 @@
+const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails: StructuredQuestionDetails = {
+  name: "Orders count",
+  query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
+  display: "scalar",
+};
+
+const PASSWORD = "secret123";
+const UPDATED_PASSWORD = "updated456";
+
+describe(
+  "scenarios > sharing > public link password protection",
+  { tags: ["@enterprise"] },
+  () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+      H.updateSetting("enable-public-sharing", true);
+    });
+
+    it("viewer: unlock form blocks access then allows it after correct password (dashboard)", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          cy.log("Create public link and set a password via API");
+          cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`).then(
+            ({ body: { uuid } }) => {
+              cy.request(
+                "PUT",
+                `/api/dashboard/${dashboard_id}/public_password`,
+                { password: PASSWORD },
+              );
+
+              cy.log("Visit public dashboard as anonymous user");
+              cy.signOut();
+              cy.visit(`/public/dashboard/${uuid}`);
+
+              cy.log("Unlock form should be displayed");
+              cy.findByTestId("unlock-password-input").should("be.visible");
+              cy.findByTestId("unlock-submit-button").should("be.visible");
+
+              cy.log("Wrong password shows error");
+              cy.findByTestId("unlock-password-input").type("wrongpass");
+              cy.findByTestId("unlock-submit-button").click();
+              cy.findByText("Incorrect password.").should("be.visible");
+
+              cy.log("Correct password unlocks the dashboard");
+              cy.findByTestId("unlock-password-input").clear().type(PASSWORD);
+
+              cy.intercept("POST", `/api/public/dashboard/${uuid}/unlock`).as(
+                "unlock",
+              );
+              cy.findByTestId("unlock-submit-button").click();
+              cy.wait("@unlock");
+
+              cy.log("Dashboard content should be visible after reload");
+              cy.findByTestId("scalar-value").should("be.visible");
+            },
+          );
+        },
+      );
+    });
+
+    it("creator can set, update, and remove a password on a dashboard public link", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          H.visitDashboard(dashboard_id);
+
+          cy.log("Create a public link");
+          H.openSharingMenu("Create a public link");
+
+          cy.log("Toggle password on and set it");
+          cy.findByTestId("public-link-password-toggle").click({ force: true });
+          cy.findByTestId("public-link-password-input")
+            .should("be.visible")
+            .type(PASSWORD);
+
+          cy.intercept("PUT", "/api/dashboard/*/public_password").as(
+            "setPassword",
+          );
+          cy.intercept("GET", "/api/dashboard/*/public_password").as(
+            "getPassword",
+          );
+          cy.findByTestId("public-link-password-save").click();
+          cy.wait("@setPassword");
+          cy.wait("@getPassword");
+
+          cy.log("Password should be saved and displayed");
+          cy.findByTestId("public-link-password-display").should("be.visible");
+
+          cy.log("Edit the password");
+          cy.findByTestId("public-link-password-edit").click();
+          cy.findByTestId("public-link-password-input")
+            .clear()
+            .type(UPDATED_PASSWORD);
+
+          cy.intercept("PUT", "/api/dashboard/*/public_password").as(
+            "updatePassword",
+          );
+          cy.intercept("GET", "/api/dashboard/*/public_password").as(
+            "getUpdatedPassword",
+          );
+          cy.findByTestId("public-link-password-confirm").click();
+          cy.wait("@updatePassword");
+          cy.wait("@getUpdatedPassword");
+
+          cy.log("Password should still be displayed");
+          cy.findByTestId("public-link-password-display").should("be.visible");
+
+          cy.log("Remove the password by toggling off");
+          cy.intercept("DELETE", "/api/dashboard/*/public_password").as(
+            "deletePassword",
+          );
+          cy.findByTestId("public-link-password-toggle").click({ force: true });
+          cy.wait("@deletePassword");
+
+          cy.log("Password section should be gone");
+          cy.findByTestId("public-link-password-toggle").should("exist");
+          cy.findByTestId("public-link-password-display").should("not.exist");
+        },
+      );
+    });
+
+    it("creator can set, update, and remove a password on a question public link", () => {
+      H.createQuestion(questionDetails).then(({ body: { id } }) => {
+        H.visitQuestion(id);
+
+        cy.log("Create a public link");
+        H.openSharingMenu("Create a public link");
+
+        cy.log("Toggle password on and set it");
+        cy.findByTestId("public-link-password-toggle").click({ force: true });
+        cy.findByTestId("public-link-password-input")
+          .should("be.visible")
+          .type(PASSWORD);
+
+        cy.intercept("PUT", "/api/card/*/public_password").as("setPassword");
+        cy.intercept("GET", "/api/card/*/public_password").as("getPassword");
+        cy.findByTestId("public-link-password-save").click();
+        cy.wait("@setPassword");
+        cy.wait("@getPassword");
+
+        cy.log("Password should be saved and displayed");
+        cy.findByTestId("public-link-password-display").should("be.visible");
+
+        cy.log("Edit the password");
+        cy.findByTestId("public-link-password-edit").click();
+        cy.findByTestId("public-link-password-input")
+          .clear()
+          .type(UPDATED_PASSWORD);
+
+        cy.intercept("PUT", "/api/card/*/public_password").as("updatePassword");
+        cy.intercept("GET", "/api/card/*/public_password").as(
+          "getUpdatedPassword",
+        );
+        cy.findByTestId("public-link-password-confirm").click();
+        cy.wait("@updatePassword");
+        cy.wait("@getUpdatedPassword");
+
+        cy.log("Password should still be displayed");
+        cy.findByTestId("public-link-password-display").should("be.visible");
+
+        cy.log("Remove the password by toggling off");
+        cy.intercept("DELETE", "/api/card/*/public_password").as(
+          "deletePassword",
+        );
+        cy.findByTestId("public-link-password-toggle").click({ force: true });
+        cy.wait("@deletePassword");
+
+        cy.log("Password section should be gone");
+        cy.findByTestId("public-link-password-toggle").should("exist");
+        cy.findByTestId("public-link-password-display").should("not.exist");
+      });
+    });
+
+    it("creator: the password is masked and only fetched on an explicit reveal", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          cy.log("Create a public link and set a password via API");
+          cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`);
+          cy.request("PUT", `/api/dashboard/${dashboard_id}/public_password`, {
+            password: PASSWORD,
+          });
+
+          cy.intercept("POST", "/api/dashboard/*/public_password/reveal").as(
+            "revealPassword",
+          );
+
+          H.visitDashboard(dashboard_id);
+          H.openSharingMenu("Public link");
+
+          cy.log("Password is masked and the secret is not fetched on open");
+          cy.findByTestId("public-link-password-display")
+            .should("be.visible")
+            .and("not.have.value", PASSWORD);
+          cy.get("@revealPassword.all").should("have.length", 0);
+
+          cy.log("Clicking reveal fetches and shows the password");
+          cy.findByTestId("public-link-password-reveal").click();
+          cy.wait("@revealPassword");
+          cy.findByTestId("public-link-password-display").should(
+            "have.value",
+            PASSWORD,
+          );
+        },
+      );
+    });
+  },
+);

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.public-link-passwords.core
   "EE implementation of public-link password management, gated on the `:public-link-passwords` premium token."
   (:require
+   [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.events.core :as events]
    [metabase.premium-features.core :refer [defenterprise]]
@@ -18,35 +19,47 @@
     :model/Card      "card"
     :model/Dashboard "dashboard"))
 
+(defn- track-password-action!
+  "Record a password action on both the audit log and Snowplow. Tracking lives on the backend so it captures
+  direct API calls, and so every action (set/reveal/delete) is tracked consistently."
+  [model id audit-suffix snowplow-event]
+  (let [prefix (model->event-prefix model)]
+    (events/publish-event! (keyword "event" (str prefix "-public-pwd-" audit-suffix))
+                           {:object-id id
+                            :user-id   api/*current-user-id*})
+    (analytics/track-event! :snowplow/simple_event
+                            {:event        snowplow-event
+                             :event_detail prefix})))
+
 (defenterprise set-public-link-password!
   "Validate and store a password on a public link. Encryption is handled by the model's
-  `:public_link_password` transform, so the plaintext is passed through as-is here."
+  `:public_link_password` transform, so the plaintext is passed through as-is here. Tracked."
   :feature :public-link-passwords
   [model id password]
   (validate-password password)
-  (t2/update! model id {:public_link_password password}))
+  (t2/update! model id {:public_link_password password})
+  (track-password-action! model id "set" "public_link_password_set"))
 
 (defenterprise get-public-link-password-existence
-  "Return whether a public link has a password set, without exposing the secret. Not audit-logged, so it
+  "Return whether a public link has a password set, without exposing the secret. Not tracked, so it
   is safe to call when rendering the sharing UI."
   :feature :public-link-passwords
   [model id]
   {:has_password (some? (t2/select-one-fn :public_link_password model :id id))})
 
 (defenterprise get-public-link-password-value
-  "Return the decrypted plaintext password for a public link. Audit-logged, since reading the secret is the
+  "Return the decrypted plaintext password for a public link. Tracked, since reading the secret is the
   \"reveal\" action."
   :feature :public-link-passwords
   [model id]
   (let [password (t2/select-one-fn :public_link_password model :id id)]
     (api/check-404 password)
-    (events/publish-event! (keyword "event" (str (model->event-prefix model) "-public-pwd-revealed"))
-                           {:object-id id
-                            :user-id   api/*current-user-id*})
+    (track-password-action! model id "revealed" "public_link_password_revealed")
     {:password password}))
 
 (defenterprise delete-public-link-password!
-  "Remove the password from a public link without revoking it."
+  "Remove the password from a public link without revoking it. Tracked."
   :feature :public-link-passwords
   [model id]
-  (t2/update! model id {:public_link_password nil}))
+  (t2/update! model id {:public_link_password nil})
+  (track-password-action! model id "deleted" "public_link_password_removed"))

--- a/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/public_link_passwords/core.clj
@@ -26,8 +26,16 @@
   (validate-password password)
   (t2/update! model id {:public_link_password password}))
 
-(defenterprise get-public-link-password
-  "Return the decrypted plaintext password for a public link. Audit-logged."
+(defenterprise get-public-link-password-existence
+  "Return whether a public link has a password set, without exposing the secret. Not audit-logged, so it
+  is safe to call when rendering the sharing UI."
+  :feature :public-link-passwords
+  [model id]
+  {:has_password (some? (t2/select-one-fn :public_link_password model :id id))})
+
+(defenterprise get-public-link-password-value
+  "Return the decrypted plaintext password for a public link. Audit-logged, since reading the secret is the
+  \"reveal\" action."
   :feature :public-link-passwords
   [model id]
   (let [password (t2/select-one-fn :public_link_password model :id id)]

--- a/enterprise/backend/test/metabase_enterprise/public_link_passwords/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_link_passwords/core_test.clj
@@ -1,0 +1,49 @@
+(ns metabase-enterprise.public-link-passwords.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.public-link-passwords.core :as public-link-passwords]
+   [metabase.analytics.snowplow-test :as snowplow-test]
+   [metabase.api.common :as api]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- latest-audit-topic [model-id]
+  (t2/select-one-fn :topic :model/AuditLog :model_id model-id {:order-by [[:id :desc]]}))
+
+(defn- snowplow-event-data! []
+  (map :data (snowplow-test/pop-event-data-and-user-id!)))
+
+(defn- assert-tracked!
+  "Run `thunk` (a password action) and assert it recorded both the expected audit-log event and Snowplow event."
+  [model-id entity-type audit-suffix snowplow-event thunk]
+  (binding [api/*current-user-id* (mt/user->id :crowberto)]
+    (snowplow-test/with-fake-snowplow-collector
+      (thunk)
+      (testing "records an audit-log event"
+        (is (= (keyword (str entity-type "-public-pwd-" audit-suffix))
+               (latest-audit-topic model-id))))
+      (testing "records a Snowplow event"
+        (is (contains? (set (snowplow-event-data!))
+                       {"event" snowplow-event "event_detail" entity-type}))))))
+
+(deftest public-link-password-actions-are-tracked-test
+  (testing "set/reveal/delete each record an audit-log event and a Snowplow event, on the backend"
+    (mt/with-premium-features #{:public-link-passwords :audit-app}
+      (testing "card"
+        (mt/with-temp [:model/Card {card-id :id} {:public_uuid          (str (random-uuid))
+                                                  :public_link_password "secret123"}]
+          (assert-tracked! card-id "card" "set" "public_link_password_set"
+                           #(public-link-passwords/set-public-link-password! :model/Card card-id "newsecret"))
+          (assert-tracked! card-id "card" "revealed" "public_link_password_revealed"
+                           #(public-link-passwords/get-public-link-password-value :model/Card card-id))
+          (assert-tracked! card-id "card" "deleted" "public_link_password_removed"
+                           #(public-link-passwords/delete-public-link-password! :model/Card card-id))))
+      (testing "dashboard"
+        (mt/with-temp [:model/Dashboard {dashboard-id :id} {:public_uuid          (str (random-uuid))
+                                                            :public_link_password "secret123"}]
+          (assert-tracked! dashboard-id "dashboard" "set" "public_link_password_set"
+                           #(public-link-passwords/set-public-link-password! :model/Dashboard dashboard-id "newsecret"))
+          (assert-tracked! dashboard-id "dashboard" "revealed" "public_link_password_revealed"
+                           #(public-link-passwords/get-public-link-password-value :model/Dashboard dashboard-id))
+          (assert-tracked! dashboard-id "dashboard" "deleted" "public_link_password_removed"
+                           #(public-link-passwords/delete-public-link-password! :model/Dashboard dashboard-id)))))))

--- a/enterprise/frontend/src/metabase-enterprise/public_link_passwords/PublicLinkPasswordSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/public_link_passwords/PublicLinkPasswordSection.tsx
@@ -19,6 +19,7 @@ import S from "./PublicLinkPasswordSection.module.css";
 import {
   useDeletePublicLinkPasswordMutation,
   useGetPublicLinkPasswordQuery,
+  useRevealPublicLinkPasswordMutation,
   useSetPublicLinkPasswordMutation,
 } from "./api";
 
@@ -54,14 +55,15 @@ export const PublicLinkPasswordSection = ({
 
   const [setPassword] = useSetPublicLinkPasswordMutation();
   const [deletePassword] = useDeletePublicLinkPasswordMutation();
+  const [revealPassword] = useRevealPublicLinkPasswordMutation();
 
-  const is404 = (fetchError as any)?.status === 404;
-  const hasPassword = !!passwordData?.password && !fetchError;
-  const currentPassword = passwordData?.password ?? "";
+  const hasPassword = !!passwordData?.has_password && !fetchError;
 
   const [mode, setMode] = useState<PasswordMode>(null);
   const [inputValue, setInputValue] = useState("");
-  const [revealed, setRevealed] = useState(false);
+  // The plaintext secret, once revealed. `null` means hidden — the value is
+  // never fetched on mount, only on an explicit (audited) reveal/edit.
+  const [revealedPassword, setRevealedPassword] = useState<string | null>(null);
 
   const isEditing = mode === "setting" || mode === "editing";
   const isViewing = hasPassword && mode === null;
@@ -70,18 +72,40 @@ export const PublicLinkPasswordSection = ({
     : undefined;
   const canSave =
     inputValue.length >= MIN_PASSWORD_LENGTH &&
-    (mode !== "editing" || inputValue !== currentPassword);
+    (mode !== "editing" || inputValue !== revealedPassword);
 
   const resetDraft = useCallback(() => {
     setMode(null);
     setInputValue("");
   }, []);
 
+  // Fetch the plaintext secret — the audited "reveal" action. Reuses the value
+  // if it is already revealed in memory, so copying/editing an already-revealed
+  // password does not re-trigger the audit event.
+  const fetchPassword = useCallback(async () => {
+    if (revealedPassword != null) {
+      return revealedPassword;
+    }
+    const { password } = await revealPassword({
+      entityType,
+      entityId,
+    }).unwrap();
+    return password;
+  }, [revealedPassword, revealPassword, entityType, entityId]);
+
+  const handleReveal = useCallback(async () => {
+    try {
+      setRevealedPassword(await fetchPassword());
+    } catch {
+      // Stay masked if the reveal fails.
+    }
+  }, [fetchPassword]);
+
   const handleToggle = useCallback(async () => {
     if (hasPassword) {
       await deletePassword({ entityType, entityId });
       resetDraft();
-      setRevealed(false);
+      setRevealedPassword(null);
     } else {
       setMode(mode === "setting" ? null : "setting");
       setInputValue("");
@@ -101,23 +125,34 @@ export const PublicLinkPasswordSection = ({
         entityId,
         password: inputValue,
       }).unwrap();
-      setRevealed(true);
+      // The admin just typed this value, so show it revealed without a separate
+      // audited reveal.
+      setRevealedPassword(inputValue);
       resetDraft();
     } catch {
       // Keep the user in the input so they can retry.
     }
   }, [canSave, inputValue, setPassword, entityType, entityId, resetDraft]);
 
-  const handleEdit = useCallback(() => {
-    setMode("editing");
-    setInputValue(currentPassword);
-  }, [currentPassword]);
+  const handleEdit = useCallback(async () => {
+    try {
+      // Editing needs the current secret to pre-fill and to detect changes —
+      // this counts as a reveal.
+      const password = await fetchPassword();
+      setRevealedPassword(password);
+      setInputValue(password);
+      setMode("editing");
+    } catch {
+      // Leave the user in the viewing state if the reveal fails.
+    }
+  }, [fetchPassword]);
 
-  if (isLoading || (fetchError && !is404)) {
+  if (isLoading || fetchError) {
     return null;
   }
 
   const toggleOn = hasPassword || mode === "setting";
+  const isRevealed = revealedPassword != null;
 
   return (
     <Box mt="md">
@@ -173,16 +208,20 @@ export const PublicLinkPasswordSection = ({
 
           {isViewing && (
             <TextInput
-              value={revealed ? currentPassword : "••••••••"}
+              value={isRevealed ? revealedPassword : "••••••••"}
               readOnly
               data-testid="public-link-password-display"
               rightSection={
                 <Group gap={12} wrap="nowrap">
                   <IconButton
-                    icon={revealed ? "eye_crossed_out" : "eye"}
-                    onClick={() => setRevealed((r) => !r)}
+                    icon={isRevealed ? "eye_crossed_out" : "eye"}
+                    onClick={
+                      isRevealed
+                        ? () => setRevealedPassword(null)
+                        : handleReveal
+                    }
                     aria-label={
-                      revealed ? t`Hide password` : t`Reveal password`
+                      isRevealed ? t`Hide password` : t`Reveal password`
                     }
                     data-testid="public-link-password-reveal"
                   />
@@ -194,7 +233,13 @@ export const PublicLinkPasswordSection = ({
                       data-testid="public-link-password-edit"
                     />
                   )}
-                  <CopyButton value={currentPassword} />
+                  <CopyButton
+                    value={fetchPassword}
+                    className={cx(S.iconButton, S.iconButtonBrandHover)}
+                    target={<Icon name="copy" size={16} />}
+                    aria-label={t`Copy password`}
+                    data-testid="public-link-password-copy"
+                  />
                 </Group>
               }
             />

--- a/enterprise/frontend/src/metabase-enterprise/public_link_passwords/PublicLinkPasswordSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/public_link_passwords/PublicLinkPasswordSection.tsx
@@ -61,6 +61,7 @@ export const PublicLinkPasswordSection = ({
 
   const [mode, setMode] = useState<PasswordMode>(null);
   const [inputValue, setInputValue] = useState("");
+  const [revealed, setRevealed] = useState(false);
 
   const isEditing = mode === "setting" || mode === "editing";
   const isViewing = hasPassword && mode === null;
@@ -80,6 +81,7 @@ export const PublicLinkPasswordSection = ({
     if (hasPassword) {
       await deletePassword({ entityType, entityId });
       resetDraft();
+      setRevealed(false);
     } else {
       setMode(mode === "setting" ? null : "setting");
       setInputValue("");
@@ -99,6 +101,7 @@ export const PublicLinkPasswordSection = ({
         entityId,
         password: inputValue,
       }).unwrap();
+      setRevealed(true);
       resetDraft();
     } catch {
       // Keep the user in the input so they can retry.
@@ -170,12 +173,19 @@ export const PublicLinkPasswordSection = ({
 
           {isViewing && (
             <TextInput
-              value={currentPassword}
+              value={revealed ? currentPassword : "••••••••"}
               readOnly
               data-testid="public-link-password-display"
-              iconBoxWidth={isAdmin ? 70 : 36}
               rightSection={
                 <Group gap={12} wrap="nowrap">
+                  <IconButton
+                    icon={revealed ? "eye_crossed_out" : "eye"}
+                    onClick={() => setRevealed((r) => !r)}
+                    aria-label={
+                      revealed ? t`Hide password` : t`Reveal password`
+                    }
+                    data-testid="public-link-password-reveal"
+                  />
                   {isAdmin && (
                     <IconButton
                       icon="pencil"
@@ -231,7 +241,7 @@ const IconButton = ({
   onClick,
   ...props
 }: {
-  icon: "pencil" | "close" | "check";
+  icon: "pencil" | "close" | "check" | "eye" | "eye_crossed_out";
   variant?: "brand" | "error" | "success";
   disabled?: boolean;
   onClick?: () => void;

--- a/enterprise/frontend/src/metabase-enterprise/public_link_passwords/api.ts
+++ b/enterprise/frontend/src/metabase-enterprise/public_link_passwords/api.ts
@@ -5,7 +5,11 @@ type EntityParams = {
   entityId: number;
 };
 
-type PasswordResponse = {
+type PasswordStatusResponse = {
+  has_password: boolean;
+};
+
+type RevealPasswordResponse = {
   password: string;
 };
 
@@ -17,7 +21,9 @@ function entityUrl({ entityType, entityId }: EntityParams) {
 
 export const publicLinkPasswordsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    getPublicLinkPassword: builder.query<PasswordResponse, EntityParams>({
+    // Returns whether a password is set, without exposing the secret. Safe to
+    // call when the sharing popover opens (not audit-logged).
+    getPublicLinkPassword: builder.query<PasswordStatusResponse, EntityParams>({
       query: (params) => ({
         method: "GET",
         url: entityUrl(params),
@@ -28,6 +34,19 @@ export const publicLinkPasswordsApi = Api.injectEndpoints({
           id: `${params.entityType}-${params.entityId}`,
         },
       ],
+    }),
+
+    // Fetches the plaintext secret. This is the audited "reveal" action, so it
+    // is only triggered by an explicit user action (reveal/copy/edit), never on
+    // mount.
+    revealPublicLinkPassword: builder.mutation<
+      RevealPasswordResponse,
+      EntityParams
+    >({
+      query: (params) => ({
+        method: "POST",
+        url: `${entityUrl(params)}/reveal`,
+      }),
     }),
 
     setPublicLinkPassword: builder.mutation<
@@ -64,6 +83,7 @@ export const publicLinkPasswordsApi = Api.injectEndpoints({
 
 export const {
   useGetPublicLinkPasswordQuery,
+  useRevealPublicLinkPasswordMutation,
   useSetPublicLinkPasswordMutation,
   useDeletePublicLinkPasswordMutation,
 } = publicLinkPasswordsApi;

--- a/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
+++ b/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
@@ -1,6 +1,6 @@
-import { useClipboard } from "@mantine/hooks";
+import { useClipboard, useTimeout } from "@mantine/hooks";
 import cx from "classnames";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import { isPlainKey } from "metabase/common/utils/keyboard";
@@ -13,12 +13,21 @@ export const COPY_BUTTON_ICON = (
   <Icon className={CopyButtonStyles.CopyButton} tabIndex={0} name="copy" />
 );
 
+// A ready-to-copy string, or a getter that may resolve the value asynchronously
+// (e.g. a secret that must be fetched on demand). Async getters are copied via
+// the ClipboardItem promise API so the write keeps the user activation — plain
+// `writeText` after an `await` is blocked by Safari.
+type CopyValue = string | (() => string | Promise<string>);
+
+const COPY_FEEDBACK_TIMEOUT = 2000;
+
 type CopyButtonProps = {
-  value: string;
+  value: CopyValue;
   onCopy?: () => void;
   className?: string;
   style?: object;
   "aria-label"?: string;
+  "data-testid"?: string;
   target?: React.ReactNode;
 };
 
@@ -27,14 +36,48 @@ export const CopyButton = ({
   onCopy,
   className = cx(Styles.textBrandHover, Styles.cursorPointer),
   style,
+  "aria-label": ariaLabel,
+  "data-testid": dataTestId = "copy-button",
   target = COPY_BUTTON_ICON,
 }: CopyButtonProps) => {
-  const clipboard = useClipboard({ timeout: 2000 });
+  const clipboard = useClipboard({ timeout: COPY_FEEDBACK_TIMEOUT });
+
+  // The Mantine clipboard hook only tracks `copied` for its own synchronous
+  // `copy()`. The async path writes via ClipboardItem, so it manages its own
+  // feedback flag.
+  const [asyncCopied, setAsyncCopied] = useState(false);
+  const { start: resetAsyncCopied } = useTimeout(
+    () => setAsyncCopied(false),
+    COPY_FEEDBACK_TIMEOUT,
+  );
 
   const onCopyValue = useCallback(() => {
-    clipboard.copy(value);
+    const resolved = typeof value === "function" ? value() : value;
+
+    if (typeof resolved === "string") {
+      clipboard.copy(resolved);
+    } else {
+      // Hand the still-pending text to the clipboard synchronously so the write
+      // stays within the user gesture while it resolves (Safari requirement).
+      void navigator.clipboard
+        .write([
+          new ClipboardItem({
+            "text/plain": resolved.then(
+              (text) => new Blob([text], { type: "text/plain" }),
+            ),
+          }),
+        ])
+        .then(() => {
+          setAsyncCopied(true);
+          resetAsyncCopied();
+        })
+        .catch(() => {
+          // Leave the feedback untouched if the copy is rejected.
+        });
+    }
+
     onCopy?.();
-  }, [clipboard, value, onCopy]);
+  }, [clipboard, value, onCopy, resetAsyncCopied]);
 
   const copyOnEnter = useCallback(
     (e: React.KeyboardEvent<HTMLElement>) => {
@@ -48,14 +91,15 @@ export const CopyButton = ({
   return (
     <div
       className={className}
-      data-testid="copy-button"
+      data-testid={dataTestId}
+      aria-label={ariaLabel}
       onClick={onCopyValue}
       onKeyDown={copyOnEnter}
       style={style}
     >
       <Tooltip
         label={<Text fw={700} c="inherit">{t`Copied!`}</Text>}
-        opened={clipboard.copied}
+        opened={clipboard.copied || asyncCopied}
       >
         <span>{target}</span>
       </Tooltip>

--- a/frontend/src/metabase/common/components/CopyButton/CopyButton.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CopyButton/CopyButton.unit.spec.tsx
@@ -1,0 +1,48 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import { CopyButton } from "./CopyButton";
+
+describe("CopyButton", () => {
+  beforeEach(() => {
+    jest.mocked(navigator.clipboard.writeText).mockClear();
+    jest.mocked(navigator.clipboard.write).mockClear();
+  });
+
+  it("copies a string value synchronously via writeText", async () => {
+    renderWithProviders(<CopyButton value="hello" />);
+
+    await userEvent.click(screen.getByTestId("copy-button"));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+    expect(navigator.clipboard.write).not.toHaveBeenCalled();
+  });
+
+  it("resolves and copies an async getter via the ClipboardItem path", async () => {
+    const getValue = jest.fn(() => Promise.resolve("secret"));
+
+    renderWithProviders(<CopyButton value={getValue} />);
+
+    await userEvent.click(screen.getByTestId("copy-button"));
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(navigator.clipboard.write).toHaveBeenCalled());
+    // The async path must not fall back to writeText (blocked by Safari after an await).
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("only resolves the value when clicked, never on render", () => {
+    const getValue = jest.fn(() => Promise.resolve("secret"));
+
+    renderWithProviders(<CopyButton value={getValue} />);
+
+    expect(getValue).not.toHaveBeenCalled();
+  });
+
+  it("supports a custom data-testid", () => {
+    renderWithProviders(<CopyButton value="hello" data-testid="my-copy" />);
+
+    expect(screen.getByTestId("my-copy")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/components/CopyButton/CopyButton.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CopyButton/CopyButton.unit.spec.tsx
@@ -5,6 +5,18 @@ import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { CopyButton } from "./CopyButton";
 
 describe("CopyButton", () => {
+  // The async copy path uses `navigator.clipboard.write` + `ClipboardItem`, which
+  // jsdom doesn't implement. Stub them here (not in the global jest setup) so we
+  // don't shadow the clipboard that @testing-library/user-event installs for
+  // other tests.
+  beforeAll(() => {
+    globalThis.ClipboardItem =
+      class {} as unknown as typeof globalThis.ClipboardItem;
+    Object.assign(navigator.clipboard, {
+      write: jest.fn(() => Promise.resolve()),
+    });
+  });
+
   beforeEach(() => {
     jest.mocked(navigator.clipboard.writeText).mockClear();
     jest.mocked(navigator.clipboard.write).mockClear();

--- a/frontend/test/jest-setup-env.js
+++ b/frontend/test/jest-setup-env.js
@@ -6,8 +6,18 @@ import fetchMock from "fetch-mock";
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(() => Promise.resolve()),
+    write: jest.fn(() => Promise.resolve()),
   },
 });
+
+// jsdom does not implement ClipboardItem, used by the async CopyButton path.
+if (typeof global.ClipboardItem === "undefined") {
+  global.ClipboardItem = class ClipboardItem {
+    constructor(items) {
+      this.items = items;
+    }
+  };
+}
 
 beforeEach(() => {
   fetchMock.mockGlobal();

--- a/frontend/test/jest-setup-env.js
+++ b/frontend/test/jest-setup-env.js
@@ -6,18 +6,8 @@ import fetchMock from "fetch-mock";
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(() => Promise.resolve()),
-    write: jest.fn(() => Promise.resolve()),
   },
 });
-
-// jsdom does not implement ClipboardItem, used by the async CopyButton path.
-if (typeof global.ClipboardItem === "undefined") {
-  global.ClipboardItem = class ClipboardItem {
-    constructor(items) {
-      this.items = items;
-    }
-  };
-}
 
 beforeEach(() => {
   fetchMock.mockGlobal();

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -56,8 +56,12 @@
 (derive :event/card-public-link-deleted ::publicize-card)
 (derive :event/dashboard-public-link-created ::publicize-dashboard)
 (derive :event/dashboard-public-link-deleted ::publicize-dashboard)
+(derive :event/card-public-pwd-set ::publicize-card)
+(derive :event/dashboard-public-pwd-set ::publicize-dashboard)
 (derive :event/card-public-pwd-revealed ::publicize-card)
 (derive :event/dashboard-public-pwd-revealed ::publicize-dashboard)
+(derive :event/card-public-pwd-deleted ::publicize-card)
+(derive :event/dashboard-public-pwd-deleted ::publicize-dashboard)
 
 (methodical/defmethod events/publish-event! ::publicize
   [topic {:keys [user-id object-id] :as _event}]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1198,12 +1198,22 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:dashboard-id/public_password"
+  "Return whether a Dashboard's public link has a password set, without exposing the secret. Visible to any
+  user who can see the Dashboard. Requires premium token."
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]]
+  (api/read-check :model/Dashboard dashboard-id)
+  (public-sharing.api/get-public-link-password-existence :model/Dashboard dashboard-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/:dashboard-id/public_password/reveal"
   "Reveal the plaintext password for a Dashboard's public link. Visible to any user who can see the Dashboard.
   Requires premium token. Audit-logged."
   [{:keys [dashboard-id]} :- [:map
                               [:dashboard-id ms/PositiveInt]]]
   (api/read-check :model/Dashboard dashboard-id)
-  (public-sharing.api/get-public-link-password :model/Dashboard dashboard-id))
+  (public-sharing.api/get-public-link-password-value :model/Dashboard dashboard-id))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -86,8 +86,12 @@
 (mr/def :event/dashboard-public-link-deleted ::publicize)
 (mr/def :event/card-public-link-created ::publicize)
 (mr/def :event/card-public-link-deleted ::publicize)
+(mr/def :event/card-public-pwd-set ::publicize)
+(mr/def :event/dashboard-public-pwd-set ::publicize)
 (mr/def :event/card-public-pwd-revealed ::publicize)
 (mr/def :event/dashboard-public-pwd-revealed ::publicize)
+(mr/def :event/card-public-pwd-deleted ::publicize)
+(mr/def :event/dashboard-public-pwd-deleted ::publicize)
 
 ;; user events
 

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -11,7 +11,13 @@
   [_model _id _password]
   (throw (ex-info (tru "Setting passwords on public links is a paid feature.") {:status-code 402})))
 
-(defenterprise get-public-link-password
+(defenterprise get-public-link-password-existence
+  "Return whether a public link has a password set, without exposing the secret. OSS: throws 402."
+  metabase-enterprise.public-link-passwords.core
+  [_model _id]
+  (throw (ex-info (tru "Public link passwords is a paid feature.") {:status-code 402})))
+
+(defenterprise get-public-link-password-value
   "Return the decrypted plaintext password for a public link. OSS: throws 402."
   metabase-enterprise.public-link-passwords.core
   [_model _id]

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -1025,12 +1025,22 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:card-id/public_password"
+  "Return whether a Card's public link has a password set, without exposing the secret. Visible to any user
+  who can see the Card. Requires premium token."
+  [{:keys [card-id]} :- [:map
+                         [:card-id ms/PositiveInt]]]
+  (api/read-check :model/Card card-id)
+  (public-sharing.api/get-public-link-password-existence :model/Card card-id))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
+                      :metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/:card-id/public_password/reveal"
   "Reveal the plaintext password for a Card's public link. Visible to any user who can see the Card.
   Requires premium token. Audit-logged."
   [{:keys [card-id]} :- [:map
                          [:card-id ms/PositiveInt]]]
   (api/read-check :model/Card card-id)
-  (public-sharing.api/get-public-link-password :model/Card card-id))
+  (public-sharing.api/get-public-link-password-value :model/Card card-id))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}


### PR DESCRIPTION
Closes [EMB-1855: The password should be hidden by default](https://linear.app/metabase/issue/EMB-1855/the-password-should-be-hidden-by-default)

**Review order:** PR 7/9 in the password-protected public links stack.

### Description

Password is masked (••••••••) by default in the viewing state. An eye icon toggles reveal/hide. Right after first save, the password auto-reveals so the creator can confirm what they set. Copy button always copies the real password regardless of mask state.

### How to verify

1. Set a password on a dashboard's public link
2. Password appears masked with an eye icon
3. Click the eye → password revealed, icon changes to crossed-out eye
4. Click again → masked
5. First time setting a password → auto-revealed after save

### Checklist

- [x] Tests have been added/updated to cover changes in this PR