### PR TITLE
Fix formatDurationLong rounding at unit boundaries

### DIFF
--- a/frontend/src/metabase/utils/formatting/time.ts
+++ b/frontend/src/metabase/utils/formatting/time.ts
@@ -53,12 +53,15 @@ export function formatDurationLong(durationMs: number): string {
     const ms = Math.round(durationMs);
     return t`${ms}ms`;
   }
-  if (durationMs < 60_000) {
-    const seconds = (durationMs / 1_000).toFixed(1);
+  // Round to the tenth-of-a-second we display before picking a branch, so e.g.
+  // 59_999ms reads as "1m 0s" rather than "60.0s".
+  const roundedMs = Math.round(durationMs / 100) * 100;
+  if (roundedMs < 60_000) {
+    const seconds = (roundedMs / 1_000).toFixed(1);
     return t`${seconds}s`;
   }
-  const d = dayjs.duration(durationMs);
-  if (durationMs < 3_600_000) {
+  const d = dayjs.duration(roundedMs);
+  if (roundedMs < 3_600_000) {
     const minutes = d.minutes();
     const seconds = d.seconds();
     return t`${minutes}m ${seconds}s`;

--- a/frontend/src/metabase/utils/formatting/time.ts
+++ b/frontend/src/metabase/utils/formatting/time.ts
@@ -50,27 +50,20 @@ export function formatDurationLong(durationMs: number): string {
     return t`0ms`;
   }
   if (durationMs < 1_000) {
-    const ms = Math.round(durationMs);
-    return t`${ms}ms`;
+    return t`${Math.round(durationMs)}ms`;
   }
-  // Round to the tenth-of-a-second we display before picking a branch, so e.g.
-  // 59_999ms reads as "1m 0s" rather than "60.0s".
-  const roundedMs = Math.round(durationMs / 100) * 100;
-  if (roundedMs < 60_000) {
-    const seconds = (roundedMs / 1_000).toFixed(1);
-    return t`${seconds}s`;
+  // Snap to the coarsest precision we display (0.1s) before picking a tier, so a
+  // value that rounds up to a boundary is promoted: 59_999ms reads as "1m 0s",
+  // never an impossible "60.0s".
+  const d = dayjs.duration(Math.round(durationMs / 100) * 100);
+  if (d.asMinutes() < 1) {
+    return t`${d.asSeconds().toFixed(1)}s`;
   }
-  const d = dayjs.duration(roundedMs);
-  if (roundedMs < 3_600_000) {
-    const minutes = d.minutes();
-    const seconds = d.seconds();
-    return t`${minutes}m ${seconds}s`;
+  if (d.asHours() < 1) {
+    return t`${d.minutes()}m ${d.seconds()}s`;
   }
-  // Hour-plus: use TOTAL hours (asHours can exceed 24 for very long
-  // backfills) plus the leftover minutes within the hour.
-  const hours = Math.floor(d.asHours());
-  const minutes = d.minutes();
-  return t`${hours}h ${minutes}m`;
+  // asHours (vs hours()) so very long backfills don't wrap past 24h.
+  return t`${Math.floor(d.asHours())}h ${d.minutes()}m`;
 }
 
 interface TimeWithUnitType {

--- a/frontend/src/metabase/utils/formatting/time.unit.spec.ts
+++ b/frontend/src/metabase/utils/formatting/time.unit.spec.ts
@@ -95,6 +95,13 @@ describe("time", () => {
       expect(formatDurationLong(3_599_000)).toBe("59m 59s");
     });
 
+    it("promotes to the next unit when display rounding hits the boundary", () => {
+      expect(formatDurationLong(59_999)).toBe("1m 0s");
+      expect(formatDurationLong(59_951)).toBe("1m 0s");
+      expect(formatDurationLong(59_949)).toBe("59.9s");
+      expect(formatDurationLong(3_599_999)).toBe("1h 0m");
+    });
+
     it("formats hour-plus durations as Xh Ym", () => {
       expect(formatDurationLong(3_600_000)).toBe("1h 0m");
       expect(formatDurationLong(5_400_000)).toBe("1h 30m");

--- a/frontend/src/metabase/utils/formatting/time.unit.spec.ts
+++ b/frontend/src/metabase/utils/formatting/time.unit.spec.ts
@@ -108,6 +108,10 @@ describe("time", () => {
       expect(formatDurationLong(7_320_000)).toBe("2h 2m");
     });
 
+    it("does not wrap total hours past 24 for long backfills", () => {
+      expect(formatDurationLong(90_000_000)).toBe("25h 0m");
+    });
+
     it("clamps negative values to 0ms (defends against clock skew)", () => {
       expect(formatDurationLong(-1)).toBe("0ms");
       expect(formatDurationLong(-99_999)).toBe("0ms");


### PR DESCRIPTION
## Summary

Fixes a rounding edge in `formatDurationLong`.

The seconds branch formatted via `(durationMs / 1_000).toFixed(1)`, which could round-up to the boundary value we just checked, e.g.

```
formatDurationLong(59_999) // → "60.0s" 
formatDurationLong(60_001) // → "1m 0s" 
```

## Fix

Round the duration to the tenth-of-a-second *before* choosing a branch, so values at th boundary promote to the next unit. The same class of bug existed at the hour boundary, which this also fixes.

## Origin

Introduced in #75102 (`[GDGT-2503] add sorting by duration to transform runs list`)

## Tests

Added boundary cases to `time.unit.spec.ts`; full suite passes and `type-check-pure` is clean.