### PR TITLE
Fix broken parameters api snippets

### DIFF
--- a/.typedoc/typedoc-plugin-frontmatter.js
+++ b/.typedoc/typedoc-plugin-frontmatter.js
@@ -28,6 +28,17 @@ export function load(app) {
       .map(([key, value]) => `${key}: ${value}`)
       .join("\n");
 
-    page.contents = `---\n${yamlItems}\n---\n\n${page.contents}`;
+    // Generate a redirect_from for the parallel `embedding/api/<Name>` path.
+    // Snippets in `sdk/api/snippets/*.md` link with relative `./api/X.md`; when
+    // included into a doc outside `sdk/` (e.g. `embedding/parameters.md`),
+    // that resolves to `embedding/api/X` instead of `embedding/sdk/api/X`.
+    // The redirect makes those URLs resolve via 301 instead of 404'ing.
+    const pageName = page.url.replace(/\.html$/, "");
+    const redirectBlock =
+      pageName && pageName !== "index"
+        ? `\nredirect_from:\n  - /docs/latest/embedding/api/${pageName}`
+        : "";
+
+    page.contents = `---\n${yamlItems}${redirectBlock}\n---\n\n${page.contents}`;
   });
 }

--- a/docs/embedding/parameters.md
+++ b/docs/embedding/parameters.md
@@ -162,7 +162,9 @@ Delivered to `onParametersChange` (SDK) and as `event.detail` for the `parameter
 
 `source` indicates why the callback fired:
 
-{% include_file "{{ dirname }}/sdk/api/snippets/ParameterChangeSource.md" %}
+- `initial-state` - first applied snapshot, fired once per dashboard load.
+- `manual-change` - user edited parameters in UI.
+- `auto-change` - in the case of auto-updates, e.g. to pass normalized values back to parent.
 
 ## SQL question parameter change payload
 
@@ -172,4 +174,6 @@ Delivered to `onSqlParametersChange` (SDK) and as `event.detail` for the `sql-pa
 
 `source` indicates why the callback fired:
 
-{% include_file "{{ dirname }}/sdk/api/snippets/SqlParameterChangeSource.md" %}
+- `initial-state` - first applied state, fired once per question load.
+- `manual-change` - user edited parameters in UI.
+- `auto-change` - in the case of auto-updates, e.g. to pass normalized values back to parent.


### PR DESCRIPTION
- inlines source values
- adds redirects from paths like `https://www.metabase.com/docs/v0.62/embedding/api/ParameterValues` to `https://www.metabase.com/docs/v0.62/embedding/sdkapi/ParameterValues`