### PR TITLE
Fix flaky test: warn about unsaved changes when navigating away while save modal is open

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/reproductions.cy.spec.ts
@@ -243,6 +243,14 @@ describe("issue GDGT-2429", () => {
     H.leaveConfirmationModal().should("be.visible");
 
     cy.log("pressing Esc should close the warning, not the saving modal");
+    // Wait for Mantine's focus trap to move focus inside the leave-confirm modal
+    // before pressing Escape. `be.visible` passes during the open transition,
+    // before the trap engages, so an early Escape lands outside the modal's
+    // focus-trapped content (where its closeOnEscape handler lives) and is lost,
+    // leaving the modal open.
+    H.leaveConfirmationModal().within(() => {
+      cy.get(":focus").should("exist");
+    });
     cy.realPress("Escape");
     H.leaveConfirmationModal().should("not.exist");
     H.modal().findByText("Save your transform").should("be.visible");


### PR DESCRIPTION
Resolves [GDGT-2599](https://linear.app/metabase/issue/GDGT-2599/flaky-test-e2e-tests-issue-gdgt-2429-issue-gdgt-2429-should-warn-about)

## Root cause
The leave-confirmation modal is a Mantine `Modal` (`LeaveConfirmModal` → `ConfirmModal`), and Mantine wires `closeOnEscape` through an `onKeyDown` on the modal's focus-trapped content — so an Escape keypress only closes the modal once Mantine's FocusTrap has moved focus inside it. The test pressed `cy.realPress("Escape")` immediately after `H.leaveConfirmationModal().should("be.visible")`, but `be.visible` becomes true *during* the modal's open transition, before the focus trap engages (focus is still in the underlying "Save your transform" modal). The keydown was therefore dispatched outside the leave-confirm modal and lost, so the modal stayed in the DOM and the subsequent `should("not.exist")` assertion timed out. Two stacked Mantine modals (save + leave-confirm, not a `Modal.Stack`) make the focus hand-off racy, which is exactly when this surfaced.

## Fix
Test-scoped, no source change. Before pressing Escape, wait for Mantine's focus trap to move focus inside the leave-confirm modal so the keydown deterministically lands on the focus-trapped content where the `closeOnEscape` handler lives:

```js
H.leaveConfirmationModal().should("be.visible");
H.leaveConfirmationModal().within(() => {
  cy.get(":focus").should("exist");
});
cy.realPress("Escape");
H.leaveConfirmationModal().should("not.exist");
```

## Stress test (burn_in=50, single test via grep)
- ✅ network throttling ON:  https://github.com/metabase/metabase/actions/runs/27209983757
- ✅ network throttling OFF: https://github.com/metabase/metabase/actions/runs/27209985646