### PR TITLE
chore: after gold SDK release checklist on master

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -400,10 +400,10 @@ jobs:
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
 
+  # When a newer release branch goes gold, remove this entire job from this branch.
   tag-latest:
     name: Tag npm release as latest
-    # ⚠️ This should only run on the most recent release branch (e.g. `release-x.61.x`),
-    # and only once it becomes stable (gold). Delete this line when gold — do not delete during the pre-gold window.
+    # Pre-gold: remove `if: false` once this branch becomes gold.
     if: false
     needs: [publish-npm, determine-sdk-version]
     uses: ./.github/workflows/embedding-sdk-tag-latest.yml

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.62.0-alpha",
+  "version": "0.63.0-alpha",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Fixes EMB-1848

Part of the [embedding release checklist](https://app.notion.com/p/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d).

Bump `package.template.json` on master to `0.63.0-alpha` now that v62 has gone gold.