### PR TITLE
chore: after gold SDK release checklist on release-x.62.x

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -387,13 +387,10 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          npm publish --tag 62-beta
+          npm publish --tag 62-stable
 
   tag-latest:
     name: Tag npm release as latest
-    # ⚠️ This should only run on the most recent release branch (e.g. `release-x.61.x`),
-    # and only once it becomes stable (gold). Delete this line when gold — do not delete during the pre-gold window.
-    if: false
     needs: [publish-npm, determine-sdk-version]
     uses: ./.github/workflows/embedding-sdk-tag-latest.yml
     with:

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -389,6 +389,7 @@ jobs:
         run: |
           npm publish --tag 62-stable
 
+  # When a newer release branch goes gold, remove this entire job from this branch.
   tag-latest:
     name: Tag npm release as latest
     needs: [publish-npm, determine-sdk-version]

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.62.0-beta.0",
+  "version": "0.62.x",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Fixes EMB-1848

Part of the [embedding release checklist](https://app.notion.com/p/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d).

Post-gold checklist changes for v62 SDK release:
- Change npm publish tag from `62-beta` to `62-stable`
- Enable `tag-latest` job (was guarded by `if: false` pre-gold)
- Bump `package.template.json` version to `0.62.x`