### PR TITLE
chore: after gold SDK release checklist on release-x.61.x

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -388,13 +388,6 @@ jobs:
         run: |
           npm publish --tag 61-stable
 
-      # ⚠️ This step should only be executed on the latest stable (gold) release branch.
-      # Only uncomment this when the new release branch becomes stable (gold).
-      - name: Add `latest` tag to the latest release branch (`release-x.61.x`) deployment
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
-
   git-tag:
     needs: [publish-npm, determine-sdk-version]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}


### PR DESCRIPTION
Fixes EMB-1848

Part of the [embedding release checklist](https://app.notion.com/p/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d).

Remove the `npm dist-tag add ... latest` step from release-x.61.x. Now that v62 is gold, releasing from 61.x should no longer tag as `latest` on npm.