### PR TITLE
Prepare skills for data app template + adjust router components

### DIFF
--- a/.claude/skills/add-data-app-routing/SKILL.md
+++ b/.claude/skills/add-data-app-routing/SKILL.md
@@ -17,7 +17,7 @@ That's the entire surface. **No `react-router` of any version, no `<BrowserRoute
 
 ## When to use this skill
 
-- The user has a working data-app project — scaffolded from the `metabase-data-app-template` repo, so `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview already exist.
+- The user has a working data-app project — scaffolded from the `data-app-template` repo, so `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview already exist.
 - The user wants the bundle to render different content at different URLs (`/overview`, `/customers/:id`).
 - **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, invoke the `create-data-app` skill first.
 
@@ -147,7 +147,7 @@ function useCustomerIdFromPath(): number | null {
 | Symptom | Fix |
 |---|---|
 | `<DataAppLink>` throws "You should not use <Link> outside a <Router>". | Wrap the tree with `<DataAppRouter>` — `<DataAppLink>` needs the router context it mounts. |
-| URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` got edited and lost `@metabase/embedding-sdk-react/data-app` from `external` / `output.globals`. Restore from the [template](https://github.com/metabase/metabase-data-app-template) — without it, Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
+| URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` got edited and lost `@metabase/embedding-sdk-react/data-app` from `external` / `output.globals`. Restore from the [template](https://github.com/metabase/data-app-template) — without it, Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
 | URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
 | Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |
 | Middle-click on a `<DataAppLink>` does nothing. | The link uses `event.button !== 0` to skip non-left clicks; check you haven't wrapped it in another component that swallows the event. |

--- a/.claude/skills/add-data-app-routing/SKILL.md
+++ b/.claude/skills/add-data-app-routing/SKILL.md
@@ -146,7 +146,7 @@ function useCustomerIdFromPath(): number | null {
 
 | Symptom | Fix |
 |---|---|
-| `<DataAppLink>` throws "You should not use <Link> outside a <Router>". | Wrap the tree with `<DataAppRouter>` — `<DataAppLink>` needs the router context it mounts. |
+| `<DataAppLink>` renders as plain text (no clickable link) on initial load. | The bundle hasn't finished loading and the fallback path is showing. Confirm the tree is wrapped in `<MetabaseProvider authConfig=…>` (dev) or `<DataAppProvider>` (host) so the bundle gets triggered. The fallback resolves to a real link once the bundle is up. |
 | URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` got edited and lost `@metabase/embedding-sdk-react/data-app` from `external` / `output.globals`. Restore from the [template](https://github.com/metabase/data-app-template) — without it, Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
 | URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
 | Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |

--- a/.claude/skills/add-data-app-routing/SKILL.md
+++ b/.claude/skills/add-data-app-routing/SKILL.md
@@ -17,17 +17,11 @@ That's the entire surface. **No `react-router` of any version, no `<BrowserRoute
 
 ## When to use this skill
 
-- The user has a working data-app project — `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview.
+- The user has a working data-app project — scaffolded from the `metabase-data-app-template` repo, so `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview already exist.
 - The user wants the bundle to render different content at different URLs (`/overview`, `/customers/:id`).
-- **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, stop and tell the user a project needs to exist first.
+- **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, invoke the `create-data-app` skill first.
 
-## Prerequisite — `data-app` subpath externalized in `vite.config.ts`
-
-Before continuing, confirm `vite.config.ts` has both `react` *and* `@metabase/embedding-sdk-react/data-app` in `rollupOptions.external` and a corresponding entry in `output.globals` (mapping to `__metabase_data_app__`). A correctly scaffolded data-app project ships with this already.
-
-If it's missing, the routing primitives below will work in dev preview and silently break in the production iframe: the bundler inlines the subpath's implementations into `dist/index.js`, those run inside the Near Membrane sandbox, and React's state batching swallows the navigation `setState`. URL changes, UI doesn't.
-
-If you see that symptom after following the steps below, missing externals is the cause.
+The template already externalizes `@metabase/embedding-sdk-react/data-app` in `vite.config.ts`. You do NOT need to edit `vite.config.ts` to add routing — just edit `src/App.tsx` (and add more component files as needed) per the step below.
 
 ## Step 1 — Wrap `App.tsx` with `<DataAppRouter>`
 
@@ -152,8 +146,8 @@ function useCustomerIdFromPath(): number | null {
 
 | Symptom | Fix |
 |---|---|
-| `DataAppLink must be rendered inside a <DataAppRouter>` thrown at runtime. | Wrap the tree with `<DataAppRouter>`. |
-| URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` is missing `@metabase/embedding-sdk-react/data-app` in `external` / `output.globals` — see Step 1. Without it Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
+| `<DataAppLink>` throws "You should not use <Link> outside a <Router>". | Wrap the tree with `<DataAppRouter>` — `<DataAppLink>` needs the router context it mounts. |
+| URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` got edited and lost `@metabase/embedding-sdk-react/data-app` from `external` / `output.globals`. Restore from the [template](https://github.com/metabase/metabase-data-app-template) — without it, Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
 | URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
 | Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |
 | Middle-click on a `<DataAppLink>` does nothing. | The link uses `event.button !== 0` to skip non-left clicks; check you haven't wrapped it in another component that swallows the event. |

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-data-app
-description: Scaffold a new Metabase data-app development project — a Vite + React + TypeScript project with hot-reload preview against a live Metabase, plus a production build that emits a single uploadable bundle. Use when the user asks to start, create, scaffold, or set up a data-app from scratch.
+description: Scaffold a new Metabase data-app development project by cloning the `metabase-data-app-template` GitHub repo. Use when the user asks to start, create, scaffold, or set up a data-app from scratch.
 ---
 
 # Create a Metabase Data App
 
-A Metabase **data-app** is a single JS bundle that the host loads inside a Near Membrane sandbox and renders inside its own React tree. This skill scaffolds a proper Vite + TypeScript project: source code in `src/` (multiple `.tsx` files allowed and encouraged), a dev server with HMR that previews the app against a real Metabase via the Embedding SDK, and `yarn build` producing a single `dist/index.js` to upload via Admin → Data apps.
+A Metabase **data-app** is a single JS bundle that the host loads inside a Near Membrane sandbox and renders inside its own React tree. The scaffold is a Vite + React + TypeScript project: source under `src/`, a dev server with HMR that previews the app against a real Metabase via the Embedding SDK, and `npm run build` producing a single `dist/index.js` to upload via Admin → Data apps.
 
-**Always use TypeScript (`.tsx` / `.ts`).** The bundle imports SDK values as normal package imports — `import { StaticQuestion } from "@metabase/embedding-sdk-react"` — and `vite.config.ts` externalizes those imports so the production iframe reads the host-realm copies at runtime. The Vite dev server resolves the same imports to the real npm package.
+**The scaffold itself lives in a separate GitHub repo: [`metabase/metabase-data-app-template`](https://github.com/metabase/metabase-data-app-template).** This skill clones that template and then guides the agent through the customization + first-app-content steps — it never generates project files from scratch. If you find yourself writing `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`, `src/index.tsx`, or `src/dev.tsx` by hand, stop — clone the template instead.
 
 ## When to invoke this skill
 
@@ -16,437 +16,130 @@ A Metabase **data-app** is a single JS bundle that the host loads inside a Near 
 
 ### Detecting an existing project
 
-Before writing any files, check whether the working directory already looks
-like a data-app project. Telltale signs:
+Before cloning, look for an existing data-app project. Surface signs (one of):
+`src/index.tsx`, `vite.config.ts` with `name: "__dataAppFactory__"`, or
+`package.json` depending on `@metabase/embedding-sdk-react` with a `vite build`
+script.
 
-- `src/index.tsx` exists, **or**
-- `vite.config.ts` with a `name: "__dataAppFactory__"` entry, **or**
-- `package.json` whose `scripts` include `vite build` and depends on
-  `@metabase/embedding-sdk-react`.
+If any surface sign is present, verify the project matches the current
+`metabase-data-app-template`. Check **all** of:
 
-If any of these signals are present, **do not silently re-scaffold** — pause
-and ask the user:
+1. `vite.config.ts` externals include `"react"`, `"react/jsx-runtime"`,
+   `"@metabase/embedding-sdk-react"`, `"@metabase/embedding-sdk-react/data-app"`
+   with corresponding `output.globals` (`React`, `__react_jsx_runtime__`,
+   `__metabase_sdk__`, `__metabase_data_app__`).
+2. `src/index.tsx`'s factory returns `{ component, theme }` (no args).
+3. `src/dev.tsx` wraps in the SDK's `<MetabaseProvider authConfig={…}>`.
 
-> "I see this looks like an existing data-app project. Should I keep
-> working in it (extend the current `src/`), or do you want me to
-> scaffold a fresh project somewhere else?"
+**All checks pass** → template-shaped. Ask: "Extend this one, or scaffold fresh
+elsewhere?" If extend → skip the clone step, edit `src/`. If fresh → ask for a
+target path, clone there.
 
-Only continue once the user has answered:
+**Any check fails** → not template-shaped (older scaffold or drift). **Stop.**
+Tell the user the structure differs from the current template, extending it
+risks breaking the bundle contract, and ask whether to (1) migrate it, (2)
+scaffold fresh and port the code over, or (3) proceed anyway at their risk.
+Wait for the answer.
 
-- **"Keep working in this one"** → skip the file-writing steps below and
-  edit the existing `src/` files (typically `src/App.tsx` and
-  `src/components/`).
-- **"Scaffold fresh"** → ask for the target path, then write the files
-  there.
+Never overwrite existing files without explicit confirmation.
 
-Do not overwrite existing files without explicit confirmation.
+## Step 1 — Clone the template
 
-## What gets created
+Source: `metabase/metabase-data-app-template`. Any GitHub remote created should
+be **private**.
 
-```
-my-data-app/
-├── package.json
-├── vite.config.ts
-├── tsconfig.json
-├── index.html                  ← Vite dev entry
-├── src/
-│   ├── index.tsx               ← PRODUCTION entry — factory returns { component, theme }
-│   ├── dev.tsx                 ← DEV entry — wraps App with MetabaseProvider + authConfig
-│   ├── theme.ts                ← MetabaseTheme, shared between dev + prod entries
-│   ├── App.tsx                 ← top-level component (you edit this); pure content, no MetabaseProvider wrap
-│   └── components/             ← split components freely; multiple .tsx files OK
-│       └── …
-├── public/                     ← static assets if needed
-├── dist/                       ← produced by `yarn build` (gitignored)
-│   └── index.js                ← THE file to upload to Metabase
-├── .env.local.example
-├── .gitignore
-└── README.md
-```
+- **Empty CWD** → clone in-place via `degit` (no name to ask for, no remote
+  created — user can add one later). Make an initial git commit afterwards.
+- **Non-empty CWD** → ask the user for a target directory name (e.g.
+  `sales-app`). Prefer `gh repo create --template … --private --clone` so a
+  private GitHub remote is wired up at the same time. Fall back to `degit` (no
+  remote) if `gh` isn't available.
 
-## Two modes, same source
+## Step 2 — Customize
 
-| | Source loaded | Output | Used for |
-|---|---|---|---|
-| **`yarn dev`** | `src/dev.tsx` (wraps `<App/>` in the SDK's `<MetabaseProvider authConfig={…}>` and mounts it) | http://localhost:5174 with HMR | Iterating visually against a real Metabase |
-| **`yarn build`** | `src/index.tsx` (factory returns `{ component, theme }`; host wraps with `DataAppProvider`) | `dist/index.js` (single IIFE) | Uploading to Metabase |
+Once the template is on disk:
 
-`App.tsx` and everything in `src/components/` is shared between both modes. The split is only at the entry layer.
+1. Edit `package.json` `name` to match the project folder.
+2. Pin `@metabase/embedding-sdk-react` to the target Metabase version (e.g. `"^63.0.0"`) — the template ships with `*`. v63 is the floor; earlier versions don't ship the data-app contract surface.
+3. Copy `.env.local.example` → `.env.local` and fill in `VITE_MB_URL` (the running Metabase instance) and `VITE_MB_API_KEY` (Admin → Authentication → API keys).
+4. `npm install` (or whichever package manager the user prefers — the template ships with no lockfile, so `npm` / `yarn` / `pnpm` / `bun` all work; use the project's existing lockfile if one appears post-clone). After install succeeds, **strip the lockfile-ignoring block from `.gitignore`** — the template ignores `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock*` to stay PM-agnostic, but the downstream project wants its lockfile committed for reproducible installs.
+5. `npm run dev` and confirm the preview at http://localhost:5174 renders the starter "Hello, data app" message.
+6. If the preview hits CORS, add `http://localhost:5174` under Admin → Embedding → Embedded analytics SDK → CORS.
 
-## Step 1 — Project files (write these verbatim)
+## Step 3 — Confirm what the app should do
 
-### `package.json`
+Before writing a single component, confirm the app's scope with the user. If they haven't described the screens, data, or flow, **ask first**:
 
-```json
-{
-  "name": "data-app",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite --port 5174",
-    "build": "vite build"
-  },
-  "dependencies": {
-    "@metabase/embedding-sdk-react": "*",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "^5.6.3",
-    "vite": "^5.4.10"
-  }
-}
-```
+- What are the screen(s) and the rough layout? (single screen, multi-page, etc.)
+- Which Metabase questions, dashboards, or data sources drive each screen?
+- Any specific interactions (filters, drill-downs, write-back via actions)?
+- Branding / theme constraints?
 
-`@metabase/embedding-sdk-react` **must be at least v62** — earlier versions don't ship the component surface (`MetabaseProvider`, the question/dashboard components) the data-app contract depends on. Pin to the exact version matching your target Metabase when you commit (e.g. `"@metabase/embedding-sdk-react": "^62.0.0"`).
+## Step 4 — Write the actual app
 
-### `vite.config.ts`
+Replace `src/App.tsx`'s starter content with the screens the user described. **Structure the project properly from the start** — don't stuff everything into `App.tsx`. Each screen/page becomes its own file under `src/pages/` (or wherever fits the app's shape), shared UI lives in `src/components/`, data-fetching hooks in `src/hooks/`, derived/computed helpers in `src/lib/`, types in `src/types/`. `App.tsx` should end up small: routing + composition of the page components, not implementation. Vite bundles everything reachable from `src/index.tsx` into the one IIFE.
 
-```ts
-import { resolve } from "node:path";
+**Do not modify `src/index.tsx`, `src/dev.tsx`, `vite.config.ts`, `tsconfig.json`, or `index.html` unless the change is genuinely required.** They encode the bundle contract with the host (factory shape, externals, document shell). Tweaks here drift the dev preview from production — the iframe doesn't read your `index.html`, the host serves a byte-for-byte template — and silently break things like drill popups and routing.
 
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
-
-// See "Two modes, same source" above.
-//
-// Externals:
-//   - `react` → `globalThis.React`. The bundle uses the host's React
-//     instance so there's only one React in the tree.
-//   - `@metabase/embedding-sdk-react` → `globalThis.__metabase_sdk__`.
-//     The SDK components and hooks (`MetabaseProvider`, `StaticQuestion`,
-//     etc.) are host-realm so React state from them survives the Near
-//     Membrane boundary correctly.
-//   - `@metabase/embedding-sdk-react/data-app` → `globalThis.__metabase_data_app__`.
-//     Host-owned primitives (routing, etc.) — same rationale.
-//
-// `jsxRuntime: "classic"` keeps `react` externalization to a single
-// package (no separate `react/jsx-runtime` global needed).
-export default defineConfig({
-  plugins: [react({ jsxRuntime: "classic" })],
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-    lib: {
-      entry: resolve(__dirname, "src/index.tsx"),
-      formats: ["iife"],
-      fileName: () => "index.js",
-      name: "__dataAppFactory__",
-    },
-    rollupOptions: {
-      external: [
-        "react",
-        "@metabase/embedding-sdk-react",
-        "@metabase/embedding-sdk-react/data-app",
-      ],
-      output: {
-        globals: {
-          react: "React",
-          "@metabase/embedding-sdk-react": "__metabase_sdk__",
-          "@metabase/embedding-sdk-react/data-app": "__metabase_data_app__",
-        },
-      },
-    },
-  },
-  server: { port: 5174, host: "localhost" },
-});
-```
-
-### `tsconfig.json`
-
-```json
-{
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react",
-    "jsxFactory": "React.createElement",
-    "jsxFragmentFactory": "React.Fragment",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "strict": true,
-    "allowJs": false,
-    "checkJs": false,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
-    "types": ["vite/client"]
-  },
-  "include": ["src", "vite.config.ts"]
-}
-```
-
-### `index.html`
-
-**Write this verbatim. Do not edit it.** Production data-apps render inside an isolated iframe whose document is hard-coded to the exact head/CSS-reset/`#root` shell below (charset, viewport, `lang`, the CSS reset, the font-family). Diverging here means the bundle looks one way in the Vite dev preview and a different way in production — the iframe doesn't read this file. The host serves a byte-for-byte equivalent template at runtime, so any baseline tweak (different font, different reset) has to land in the host side first, not here.
-
-Things you may NOT change in this file:
-- The `lang` attribute, `<meta charset>`, or `<meta name="viewport">`.
-- The CSS reset rules (`html, body, #root { height: 100%; margin: 0; }`).
-- The `body` font-family declaration.
-
-Things you may change:
-- The `<title>` (cosmetic — only shown in the dev preview's browser tab).
-- Adding more script tags is fine if you genuinely need them in dev (none should be needed for a normal data app).
-
-If you want bundle-specific styles, put them in a CSS module or `<style>`/`<link>` inside a component — not here.
-
-```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Data App Dev Preview</title>
-    <style>
-      html, body, #root { height: 100%; margin: 0; }
-      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/dev.tsx"></script>
-  </body>
-</html>
-```
-
-### `src/vite-env.d.ts` — env var types
-
-The bundle no longer needs a `globals.d.ts` for SDK types — they come from `@metabase/embedding-sdk-react` as normal package types. The only ambient declarations needed are for the Vite env vars used in `dev.tsx`:
-
-```ts
-interface ImportMetaEnv {
-  readonly VITE_MB_URL: string;
-  readonly VITE_MB_API_KEY: string;
-}
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-```
-
-### `src/theme.ts` — shared theme
-
-Used by both the production `index.tsx` (passed through the factory) and the dev `dev.tsx` (passed to the dev preview's `<MetabaseProvider>`).
-
-```ts
-import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
-
-export const sdkTheme: MetabaseTheme = {
-  colors: {
-    brand: "#4D96FF",
-    "brand-hover": "#4D96FF",
-    positive: "#4D96FF",
-    charts: ["#4D96FF"],
-    // The SDK widget's surface — match the IMMEDIATE PARENT of the chart.
-    background: "white",
-    "background-secondary": "white",
-    // Text on the SDK surface — must contrast with `background`.
-    "text-primary": "#1f2937",
-    "text-secondary": "#4b5563",
-    "text-tertiary": "#6b7280",
-  },
-  fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
-};
-```
-
-### `src/index.tsx` — production entry
-
-```tsx
-import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
-
-import App from "./App";
-import { sdkTheme } from "./theme";
-
-type Factory = () => {
-  component: React.ComponentType;
-  theme?: MetabaseTheme;
-};
-
-/**
- * Production entry. Vite lib mode emits an IIFE whose return value is
- * assigned to globalThis.__dataAppFactory__ (the `name` field in
- * vite.config.ts). The Metabase host evaluates the bundle text, reads
- * `__dataAppFactory__` back out, calls it with NO arguments, and wraps
- * the returned `component` in its own `DataAppProvider` (which sets up
- * the SDK Redux store, theme, and portal container in host realm).
- *
- * The bundle deliberately does NOT render `<MetabaseProvider>` inside
- * `App.tsx`. That's the host's job in prod, and the dev entry's job in
- * dev. Bundle-side wrapping would force the SDK's `setState`-via-listener
- * paths through the Near Membrane sandbox and break drill popups,
- * plugin init, and similar.
- *
- * The factory takes no arguments. Everything the host exposes to the
- * bundle comes through normal package imports from
- * `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app`.
- */
-const factory: Factory = () => ({ component: App, theme: sdkTheme });
-
-export default factory;
-```
-
-### `src/dev.tsx` — dev entry
-
-In production the host wraps the bundle in `DataAppProvider`. In dev there's no host, so the dev entry uses the SDK's real `<MetabaseProvider>` (which needs an `authConfig`) to set up the same providers locally.
-
-```tsx
-import {
-  type MetabaseAuthConfig,
-  MetabaseProvider,
-} from "@metabase/embedding-sdk-react";
-import { createRoot } from "react-dom/client";
-
-import App from "./App";
-import { sdkTheme } from "./theme";
-
-const authConfig: MetabaseAuthConfig = {
-  metabaseInstanceUrl: import.meta.env.VITE_MB_URL,
-  apiKey: import.meta.env.VITE_MB_API_KEY,
-};
-
-const root = document.getElementById("root");
-if (!root) {
-  throw new Error("#root not found");
-}
-createRoot(root).render(
-  <MetabaseProvider authConfig={authConfig} theme={sdkTheme}>
-    <App />
-  </MetabaseProvider>,
-);
-```
-
-### `src/App.tsx` — starter
-
-`App.tsx` is **pure content** — no `<MetabaseProvider>` wrap (that's `dev.tsx` in dev and the host in prod). Imports come from the SDK package as normal; the bundle's `vite.config.ts` externalizes them so production references the host's copies at runtime, and Vite's dev server uses the real package directly.
-
-```tsx
-import { StaticQuestion } from "@metabase/embedding-sdk-react";
-
-export default function App() {
-  return (
-    <div style={{ minHeight: "100vh", background: "#f5f5f7" }}>
-      <header style={{ padding: 24 }}>
-        <h1 style={{ margin: 0 }}>Hello, data app</h1>
-        <p style={{ color: "#555" }}>Edit src/App.tsx to begin.</p>
-      </header>
-      <div style={{ margin: 24, padding: 16, background: "white", borderRadius: 12 }}>
-        <div style={{ height: 360, overflow: "hidden" }}>
-          <StaticQuestion
-            questionId={1}
-            withChartTypeSelector={false}
-            height="100%"
-            width="100%"
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-```
-
-### `.env.local.example`
-
-```
-VITE_MB_URL=http://localhost:3000
-VITE_MB_API_KEY=mb_replace_me
-```
-
-### `.gitignore`
-
-```
-node_modules
-.env.local
-.vite
-dist
-```
-
-### `README.md`
-
-```md
-# data-app
-
-A Metabase data-app authored as a Vite + React + TypeScript (TSX) project.
-See the project's SKILL.md for full guidance; the short version is `yarn`
-then `yarn dev` (preview at http://localhost:5174 — first set
-`VITE_MB_URL` + `VITE_MB_API_KEY` in `.env.local`), and `yarn build` to
-produce `dist/index.js` for upload via Admin → Data apps → Add.
-
-If the dev preview hits CORS, add `http://localhost:5174` under
-Admin → Embedding → Embedded analytics SDK → CORS.
-```
-
-## Step 2 — Install + run
-
-```bash
-yarn
-cp .env.local.example .env.local
-# fill in VITE_MB_URL + VITE_MB_API_KEY (Admin → Authentication → API keys)
-yarn dev      # preview at http://localhost:5174 with HMR
-yarn build    # produces dist/index.js
-```
+**After every meaningful round of edits, run `npm run typecheck`.** It runs `tsc --noEmit` over `src/` and `vite.config.ts` — catches wrong prop shapes against the SDK types, broken refactors, missing imports, etc. The Vite dev server does NOT typecheck (it only transpiles), so errors that would fail a production CI run can sit invisibly in a passing `npm run dev` session. Run it before declaring a task complete.
 
 ## Source conventions
 
-### 1. Write TSX.
+### 1. Write TSX
 
-The source is plain ESM + TSX:
+Plain ESM + TSX, normal package imports:
 
 ```tsx
-// src/components/PokemonCard.tsx
-type Pokemon = { name: string; questionId: number };
+// src/components/CustomerCard.tsx
+import { StaticQuestion } from "@metabase/embedding-sdk-react";
 
-const { StaticQuestion } = globalThis;
+type Customer = { name: string; questionId: number };
 
-export default function PokemonCard({ pokemon }: { pokemon: Pokemon }) {
+export default function CustomerCard({ customer }: { customer: Customer }) {
   return (
-    <article style={{ /* … */ }}>
-      <h3>{pokemon.name}</h3>
-      <StaticQuestion questionId={pokemon.questionId} height={300} width="100%" />
+    <article>
+      <h3>{customer.name}</h3>
+      <StaticQuestion questionId={customer.questionId} height={300} width="100%" />
     </article>
   );
 }
 ```
 
-### 2. Multiple files are encouraged
+### 2. Structure from the start
 
-Split components, helpers, data into separate files in `src/`. Vite bundles everything in `src/` reachable from `src/index.tsx` into a single `dist/index.js` IIFE.
+Default project layout (see Step 4 for the principle — don't dump everything into `App.tsx`):
 
 ```
 src/
-├── globals.d.ts
-├── index.tsx
-├── App.tsx
-├── components/
-│   ├── Hero.tsx
-│   ├── PokemonCard.tsx
-│   └── TypePill.tsx
-├── data/
-│   └── pokemon.ts
-└── theme.ts
+├── index.tsx          (template — don't edit)
+├── dev.tsx            (template — don't edit)
+├── App.tsx            (routing + composition only)
+├── theme.ts
+├── pages/             (one file per screen)
+│   ├── Overview.tsx
+│   └── CustomerDetail.tsx
+├── components/        (shared UI)
+│   └── Card.tsx
+├── hooks/             (data-fetching wrappers, custom hooks)
+│   └── useCustomers.ts
+├── lib/               (pure helpers / derivations)
+│   └── format.ts
+└── types/             (shared TS types)
+    └── customer.ts
 ```
+
+Vite bundles everything reachable from `src/index.tsx` into a single `dist/index.js` IIFE — the folder layout is purely for your own readability.
 
 ### 3. Import SDK values from `@metabase/embedding-sdk-react` directly
 
-Just use normal package imports. `vite.config.ts` externalizes both `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app` so the build maps them to host-realm globals (`__metabase_sdk__` / `__metabase_data_app__`); the Vite dev server resolves them to the real npm package.
+`vite.config.ts` externalizes `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app`, so production maps them to host-realm globals (`__metabase_sdk__` / `__metabase_data_app__`); the Vite dev server resolves them to the real npm package.
 
 ```tsx
 // ✅ correct
 import { StaticQuestion, useQuestionQuery } from "@metabase/embedding-sdk-react";
 import { DataAppRouter, DataAppLink } from "@metabase/embedding-sdk-react/data-app";
 
-// ❌ wrong — globalThis pattern is gone; you'd be reading nothing
+// ❌ wrong — no globalThis pattern; you'd be reading nothing
 const { MetabaseProvider, StaticQuestion } = globalThis;
 ```
 
@@ -454,15 +147,23 @@ const { MetabaseProvider, StaticQuestion } = globalThis;
 
 ### 4. Import `react` normally too
 
-The bundle's `vite.config.ts` externalizes `react` (mapped to `globalThis.React`), so a plain `import` resolves to the host's React in production and the npm package in dev. Same syntax in both modes:
+`vite.config.ts` externalizes `react` (mapped to `globalThis.React`), so a plain `import` resolves to the host's React in production and the npm package in dev:
 
 ```tsx
 import { useState, useEffect, useMemo } from "react";
 ```
 
+**No `import React from "react"` needed in TSX files** — the template uses the automatic JSX runtime (`jsx: "react-jsx"` in `tsconfig.json`, `react()` plugin default in `vite.config.ts`). The compiler injects the `react/jsx-runtime` imports it needs. Just write JSX and named imports — that's it.
+
+For React *types* (e.g. `ComponentType`, `ReactNode`, `RefObject`), use named type imports rather than the `React.` namespace:
+
+```ts
+import type { ComponentType, ReactNode } from "react";
+```
+
 ## Theme rules
 
-`MetabaseProvider`'s `theme` is the only way SDK component appearance changes. It is NOT a stylesheet for the bundle's own chrome.
+`MetabaseProvider`'s `theme` (defined in `src/theme.ts`) is the only way SDK component appearance changes. It is NOT a stylesheet for the bundle's own chrome.
 
 | Field | Purpose | Notes |
 |---|---|---|
@@ -473,7 +174,7 @@ import { useState, useEffect, useMemo } from "react";
 | `colors.text-primary`, `text-secondary`, `text-tertiary` | Text on SDK surfaces | **MUST contrast with `background`.** For white bg: use `#1f2937` or similar dark color. The SDK's default `text-primary` resolves to ~white, so leaving it unset on a white surface produces invisible white text. **Always pair `background` and `text-primary` when overriding.** |
 | `fontFamily` | SDK widget typography | |
 
-**Never put page-chrome colors in the theme.** Style page chrome with inline `style={{ background: "#f5f5f7" }}` on your own `div`s.
+**The theme only styles SDK widgets — never your own UI.** For your page background, headers, card wrappers, etc., use inline `style={{ background: "#f5f5f7" }}` or CSS modules on your own elements.
 
 **Don't expect per-subtree theming.** Multiple `<MetabaseProvider>`s on the page fight for the single CSS-variable slot. If the look needs to change with state, recompute `sdkTheme` at the App level and re-render — the whole tree re-themes.
 
@@ -501,7 +202,7 @@ The Near Membrane sandbox throws at runtime on these globals. Use the endowed al
 - **Network** (`fetch`, `XMLHttpRequest`, `WebSocket`) → the data hooks for reads, `useAction` for writes. No raw network from the bundle, ever.
 - **UI dialogs** (`alert`, `confirm`, `prompt`) → render a React modal in your own tree.
 - **Storage** (`localStorage`, `sessionStorage`, `indexedDB`, `document.cookie`) → treat the Data App as stateless across reloads; persist via a Metabase action.
-- **Window / history navigation** (`window.open`, `history.pushState`, `history.replaceState`) → `useDataAppNavigate()` for in-app, `<a target="_blank" rel="noopener">` for external.
+- **Window / history navigation** (`window.open`, `history.pushState`, `history.replaceState`) → `useDataAppLocation().navigate` for in-app, `<a target="_blank" rel="noopener">` for external.
 - **`navigator.*` device APIs** (`clipboard`, `geolocation`, etc.) → not available.
 - **Global event listeners on `document` / `window`** for typing or clipboard events (`keydown`, `keyup`, `keypress`, `beforeinput`, `input`, `paste`, `copy`, `cut`, `before*paste/copy/cut`, `compositionstart/update/end`, `storage`) → attach the listener to your own element instead, or use the React event handler (`onKeyDown`, `onPaste`, …) on the specific input/container that needs it. Same listener on a script-owned element still works.
 
@@ -591,7 +292,7 @@ Without `height`/`width`, the SDK component renders at its intrinsic size and ov
 
 ## Upload to Metabase
 
-1. `yarn build` → produces `dist/index.js`.
+1. `npm run build` → produces `dist/index.js`.
 2. Open Metabase → Admin → Data apps → **Add**.
 3. Pick a short `name` (used in `/data-app/<name>` URL) and a display name.
 4. Upload `dist/index.js`.
@@ -606,14 +307,10 @@ To replace: delete the data app, upload again. Per-app replace endpoint isn't wi
 | "Failed to fetch the user, the session might be invalid." | Bad API key or CORS — check `curl -H "X-API-Key: $KEY" $URL/api/user/current`, add `http://localhost:5174` to SDK CORS origins. |
 | Invisible chart labels. | Set `text-primary` in the theme (see *Theme rules*). |
 | Chart overflows its container. | Pass `height` / `width` to the SDK component (see *SDK component sizing*). |
-| "Invalid hook call" at runtime. | `react` not externalized — check `vite.config.ts`. |
-| Bundle is multi-MB. | Runtime-importing `@metabase/embedding-sdk-react` from non-dev source (see *Source conventions §3*). |
-| `dist/index.js` doesn't assign to `__dataAppFactory__`. | `lib.name: "__dataAppFactory__"` missing in `vite.config.ts`. |
-| Dev preview blank, console says `MetabaseProvider is undefined`. | `src/dev.tsx` must `import "./dev-globals"` BEFORE `import App from "./App"`. |
-| `Cannot find module '@metabase/embedding-sdk-react'`. | Run `yarn install` to install the SDK package. Types come from the package directly. |
+| "Invalid hook call" at runtime. | `react` not externalized — the template ships with this configured; check you didn't edit `vite.config.ts`. |
+| Bundle is multi-MB. | One of `react`, `@metabase/embedding-sdk-react`, or `@metabase/embedding-sdk-react/data-app` was removed from `vite.config.ts`'s `external` — restore from the template. |
+| `dist/index.js` doesn't assign to `__dataAppFactory__`. | `lib.name: "__dataAppFactory__"` got removed from `vite.config.ts` — restore from the template. |
+| Dev preview blank, console says `MetabaseProvider is undefined`. | `src/dev.tsx` got edited and lost the `<MetabaseProvider authConfig={…}>` wrap. |
+| `Cannot find module '@metabase/embedding-sdk-react'`. | Run `npm install` (or the equivalent for your package manager). Types come from the package directly. |
 | Drill popups don't open / SDK components show empty / "MetabaseProvider not found" at runtime in dev. | `src/dev.tsx` is missing the `<MetabaseProvider authConfig={…}>` wrap. The bundle's `App.tsx` does NOT include `MetabaseProvider` — `dev.tsx` provides it. |
-| URL changes but UI doesn't update in production (works in dev). | `vite.config.ts` is missing `@metabase/embedding-sdk-react/data-app` in `external` / `output.globals`. Without it, the data-app routing primitives get inlined into the bundle and the React-state-batching-through-Near-Membrane bug breaks navigation re-renders. |
-
-## Confirm scope before generating code
-
-Once the project files are in place (whether freshly scaffolded or detected as existing), confirm what the data app should *do* before writing components. If the user hasn't already described the screen / charts / flow, ask first — code generated against an assumed brief is the most common rework cause.
+| URL changes but UI doesn't update in production (works in dev). | `vite.config.ts` is missing `@metabase/embedding-sdk-react/data-app` in `external` / `output.globals`. Without it, the data-app routing primitives get inlined into the bundle and the React-state-batching-through-Near-Membrane bug breaks navigation re-renders. Restore from the template. |

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -62,9 +62,10 @@ Once the template is on disk:
 1. Edit `package.json` `name` to match the project folder.
 2. Pin `@metabase/embedding-sdk-react` to the target Metabase version (e.g. `"^63.0.0"`) — the template ships with `*`. v63 is the floor; earlier versions don't ship the data-app contract surface.
 3. Copy `.env.local.example` → `.env.local` and fill in `VITE_MB_URL` (the running Metabase instance) and `VITE_MB_API_KEY` (Admin → Authentication → API keys).
-4. `npm install` (or whichever package manager the user prefers — the template ships with no lockfile, so `npm` / `yarn` / `pnpm` / `bun` all work; use the project's existing lockfile if one appears post-clone). After install succeeds, **strip the lockfile-ignoring block from `.gitignore`** — the template ignores `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock*` to stay PM-agnostic, but the downstream project wants its lockfile committed for reproducible installs.
-5. `npm run dev` and confirm the preview at http://localhost:5174 renders the starter "Hello, data app" message.
-6. If the preview hits CORS, add `http://localhost:5174` under Admin → Embedding → Embedded analytics SDK → CORS.
+4. `npm install` (or whichever package manager the user prefers — the template ships with no lockfile, so `npm` / `yarn` / `pnpm` / `bun` all work; use the project's existing lockfile if one appears post-clone).
+5. **Strip the lockfile-ignoring block from `.gitignore`.** The template ignores `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock` / `bun.lockb` plus the leading comment block (the chunk between `# Lockfiles —` and `bun.lockb`). The block has to go so the downstream project commits its lockfile for reproducible installs. **Verify with `git status`** — the lockfile your package manager just generated must now appear as a new untracked file. If it doesn't, the block is still in `.gitignore`; remove it and re-check. Do **not** skip this step or defer it to "later"; agents have repeatedly forgotten and shipped projects with no committed lockfile.
+6. `npm run dev` and confirm the preview at http://localhost:5174 renders the starter "Hello, data app" message.
+7. If the preview hits CORS, add `http://localhost:5174` under Admin → Embedding → Embedded analytics SDK → CORS.
 
 ## Step 3 — Pull the typed schema
 

--- a/.claude/skills/create-data-app/SKILL.md
+++ b/.claude/skills/create-data-app/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-data-app
-description: Scaffold a new Metabase data-app development project by cloning the `metabase-data-app-template` GitHub repo. Use when the user asks to start, create, scaffold, or set up a data-app from scratch.
+description: Scaffold a new Metabase data-app development project by cloning the `data-app-template` GitHub repo. Use when the user asks to start, create, scaffold, or set up a data-app from scratch.
 ---
 
 # Create a Metabase Data App
 
 A Metabase **data-app** is a single JS bundle that the host loads inside a Near Membrane sandbox and renders inside its own React tree. The scaffold is a Vite + React + TypeScript project: source under `src/`, a dev server with HMR that previews the app against a real Metabase via the Embedding SDK, and `npm run build` producing a single `dist/index.js` to upload via Admin → Data apps.
 
-**The scaffold itself lives in a separate GitHub repo: [`metabase/metabase-data-app-template`](https://github.com/metabase/metabase-data-app-template).** This skill clones that template and then guides the agent through the customization + first-app-content steps — it never generates project files from scratch. If you find yourself writing `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`, `src/index.tsx`, or `src/dev.tsx` by hand, stop — clone the template instead.
+**The scaffold itself lives in a separate GitHub repo: [`metabase/data-app-template`](https://github.com/metabase/data-app-template).** This skill clones that template and then guides the agent through the customization + first-app-content steps — it never generates project files from scratch. If you find yourself writing `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`, `src/index.tsx`, or `src/dev.tsx` by hand, stop — clone the template instead.
 
 ## When to invoke this skill
 
@@ -22,7 +22,7 @@ Before cloning, look for an existing data-app project. Surface signs (one of):
 script.
 
 If any surface sign is present, verify the project matches the current
-`metabase-data-app-template`. Check **all** of:
+`data-app-template`. Check **all** of:
 
 1. `vite.config.ts` externals include `"react"`, `"react/jsx-runtime"`,
    `"@metabase/embedding-sdk-react"`, `"@metabase/embedding-sdk-react/data-app"`
@@ -45,7 +45,7 @@ Never overwrite existing files without explicit confirmation.
 
 ## Step 1 — Clone the template
 
-Source: `metabase/metabase-data-app-template`. Any GitHub remote created should
+Source: `metabase/data-app-template`. Any GitHub remote created should
 be **private**.
 
 - **Empty CWD** → clone in-place via `degit` (no name to ask for, no remote
@@ -66,18 +66,36 @@ Once the template is on disk:
 5. `npm run dev` and confirm the preview at http://localhost:5174 renders the starter "Hello, data app" message.
 6. If the preview hits CORS, add `http://localhost:5174` under Admin → Embedding → Embedded analytics SDK → CORS.
 
-## Step 3 — Confirm what the app should do
+## Step 3 — Pull the typed schema
 
-Before writing a single component, confirm the app's scope with the user. If they haven't described the screens, data, or flow, **ask first**:
+Generate `src/metabase.data.ts` by invoking the
+[`metabase-semantic-schema-data-apps`](../metabase-semantic-schema-data-apps/SKILL.md)
+skill. It prompts the user for an API key, hits
+`/api/typed-schemas/v1/typescript` on the target Metabase, and writes the file.
+
+The schema is the **single source of truth** for what data the app can render. Every saved question, table, metric, segment, measure, and field the app references must come from it (`schema.questions.<name>`, `schema.tables.<t>.fields.<f>`, `schema.metrics.<m>.dimensions.<d>`, etc.). Never copy numeric IDs into constants; never invent fields the schema doesn't have. Re-run the schema skill whenever the upstream semantic layer changes (new question, renamed metric, added column).
+
+This step is mandatory before Step 4 — the schema is the catalog you'll check the user's brief against, and the agent needs it loaded into context before discussing what the app should do.
+
+## Step 4 — Confirm what the app should do
+
+Before writing a single component, confirm the app's scope with the user **and check it against the schema you just pulled**. If they haven't described the screens, data, or flow, ask first:
 
 - What are the screen(s) and the rough layout? (single screen, multi-page, etc.)
 - Which Metabase questions, dashboards, or data sources drive each screen?
 - Any specific interactions (filters, drill-downs, write-back via actions)?
 - Branding / theme constraints?
 
-## Step 4 — Write the actual app
+**Schema-matching rule.** Every entity the user references should map to something in `src/metabase.data.ts`:
+
+- **Match exists** → confirm what you found by name. Example: "Your schema has `schema.questions.overview_revenue` and `schema.tables.customers` with the `lifetime_value` measure — is that what you want me to use?"
+- **Topic doesn't match** → don't fabricate. Push back: explain the schema doesn't expose anything for that topic, and ask whether to (1) add it upstream in the Metabase semantic layer first and re-run Step 3, (2) pick a different topic that's already curated, or (3) ship the app without that part. **Don't invent mock data. Don't create new questions from inside the app.** The schema is curated upstream; the app is presentation only.
+
+## Step 5 — Write the actual app
 
 Replace `src/App.tsx`'s starter content with the screens the user described. **Structure the project properly from the start** — don't stuff everything into `App.tsx`. Each screen/page becomes its own file under `src/pages/` (or wherever fits the app's shape), shared UI lives in `src/components/`, data-fetching hooks in `src/hooks/`, derived/computed helpers in `src/lib/`, types in `src/types/`. `App.tsx` should end up small: routing + composition of the page components, not implementation. Vite bundles everything reachable from `src/index.tsx` into the one IIFE.
+
+**Reference Metabase data through the schema, never with raw IDs.** Import `schema` from `src/metabase.data.ts` and pass `schema.questions.<name>.id`, `schema.tables.<t>.id`, `schema.metrics.<m>.id` to the data hooks. For query patterns (typed row shapes, `useMetabaseQuery` generics, segments / measures / breakouts, debugging), follow the `metabase-semantic-schema-data-apps` skill — it owns the data-side conventions; this skill owns the project-side conventions.
 
 **Do not modify `src/index.tsx`, `src/dev.tsx`, `vite.config.ts`, `tsconfig.json`, or `index.html` unless the change is genuinely required.** They encode the bundle contract with the host (factory shape, externals, document shell). Tweaks here drift the dev preview from production — the iframe doesn't read your `index.html`, the host serves a byte-for-byte template — and silently break things like drill popups and routing.
 
@@ -136,7 +154,7 @@ Vite bundles everything reachable from `src/index.tsx` into a single `dist/index
 
 ```tsx
 // ✅ correct
-import { StaticQuestion, useQuestionQuery } from "@metabase/embedding-sdk-react";
+import { StaticQuestion, useMetabaseQuery } from "@metabase/embedding-sdk-react";
 import { DataAppRouter, DataAppLink } from "@metabase/embedding-sdk-react/data-app";
 
 // ❌ wrong — no globalThis pattern; you'd be reading nothing
@@ -193,7 +211,8 @@ The bundle imports normally from `@metabase/embedding-sdk-react`. Vite externali
 | `StaticDashboard`, `InteractiveDashboard`, `EditableDashboard` | Dashboard variants. |
 | `CreateDashboardModal` | Modal for new-dashboard flow. |
 | `CollectionBrowser` | Collection picker. |
-| `useQuestionQuery` | Hook that runs a saved question and returns its dataset (`{ data, isLoading, error, refetch }`). Use when you want to read raw query results (rows, columns, metadata) and render your own UI from them instead of dropping in a `StaticQuestion` / `InteractiveQuestion`. **Signature:** `useQuestionQuery(questionId, options?)` — the first arg is the bare numeric id, NOT an object. The optional second arg is `{ initialSqlParameters?, enabled? }`. Must be called from inside a component rendered under `<MetabaseProvider>` (which `dev.tsx` and the host provide). |
+| `useMetabaseQuery` | Schema-backed data-fetching hook for questions / tables / metrics. **The `metabase-semantic-schema-data-apps` skill owns the full hook contract** — signature, generics, table-vs-metric variants, segments / measures / breakouts, debugging. Don't reinvent its rules here. |
+| `useQuestionQuery` | Question-only data-fetching hook (`useQuestionQuery(questionId, options?)` returning `{ data, isLoading, error, refetch }`). The bare numeric id is the first arg; optional `{ initialSqlParameters?, enabled? }` is the second. Must be called under `<MetabaseProvider>`. Use when you need a quick question fetch without going through the schema layer (e.g. ad-hoc tooling, pre-schema apps); prefer `useMetabaseQuery` for new schema-backed work. |
 
 ### Blocked APIs
 
@@ -208,70 +227,20 @@ The Near Membrane sandbox throws at runtime on these globals. Use the endowed al
 
 **Rule of thumb:** if you're about to touch `window.X`, `document.X`, `navigator.X`, `history.X`, or any storage global, stop and pick the endowed replacement above. The endowed surface (React + SDK components + data hooks + `useAction` + DataAppRouter) covers every routine need; anything outside it is intentionally unreachable.
 
-### When to use `useQuestionQuery` vs a `StaticQuestion` / `InteractiveQuestion`
+### When to use `useMetabaseQuery` vs a `StaticQuestion` / `InteractiveQuestion`
 
-This is a decision the agent makes per-rendering, not once for the whole app:
+This is a per-rendering decision, not a project-wide one:
 
-- **`StaticQuestion` / `InteractiveQuestion`** — use ONLY when a stock Metabase chart, displayed as-is, is exactly what the data app needs. No surrounding custom layout that the chart has to integrate with, no custom interactions, no derived/aggregated values pulled out of the dataset, no per-row UI, no list/grid/card pattern built from the rows. The SDK widget renders its own chrome, sizing, and interaction model — you take it or leave it.
-- **`useQuestionQuery`** — use **whenever ANY of the following applies**, even slightly:
-    - You want to render the data as something other than the saved question's visualization type (a stat tile, a list of cards, a custom table, a Pokémon-style grid, a sparkline, anything bespoke).
-    - You need to read a single value out of the result (e.g. "the count from the first row", "the sum of column X") and display it.
-    - You want to drive your own state or other components from the rows (filters, selections, derived dashboards-of-tiles, etc.).
-    - You need to format, transform, group, or join the rows before display.
-    - You want custom empty/loading/error states.
-    - You want the data layout to integrate with the surrounding bundle UI (consistent fonts, spacings, branded headers, etc.) that the SDK widget can't be styled into.
+- **`StaticQuestion` / `InteractiveQuestion`** — only when a stock Metabase chart, displayed as-is, IS the deliverable. No custom layout the chart has to integrate with, no derived/aggregated values pulled out, no per-row UI, no bespoke list/grid/card pattern. The SDK widget renders its own chrome and sizing — take it or leave it.
+- **`useMetabaseQuery`** — whenever **any** of the following applies, even slightly: rendering as something other than the saved question's viz type (stat tile, custom table, grid, sparkline, anything bespoke); reading a single value out of the result; driving your own state or other components from the rows; formatting / transforming / grouping rows before display; custom empty/loading/error states; or making the data layout match the bundle's chrome.
 
-**Default to `useQuestionQuery`.** Reach for `StaticQuestion`/`InteractiveQuestion` only when the saved-question chart, with its own framing, IS the deliverable. The moment the user asks for "something custom" — even subtle, even just "show the count nicely" — switch to `useQuestionQuery` and render the UI yourself.
+**Default to `useMetabaseQuery`.** Reach for `StaticQuestion` / `InteractiveQuestion` only when the saved-question chart with its own framing is exactly what the user asked for. The moment they want "something custom" — even subtle, even just "show the count nicely" — switch to the hook.
 
-The hook returns `{ data, isLoading, error, ... }` from the SDK. Read `data` once it's loaded to get rows/columns/metadata; render with normal React. Hooks must be called from inside a component rendered under `MetabaseProvider`.
+**Always render a spinner (or skeleton) while `isLoading` is `true`** — never an empty slot or stale value, which causes layout shift when the data arrives. Same rule for lifted / derived queries (pass `isLoading` down) and for `useAction`'s `isExecuting` (spinner in the button + `disabled={isExecuting}`).
 
-**Always render a spinner (or skeleton) while `isLoading` is `true`** — never an empty slot or stale value, which causes layout shift when the data arrives. Same rule for lifted/derived queries (pass `isLoading` down to each consumer) and for action triggers (`useAction`'s `isExecuting` → spinner in the button, plus `disabled={isExecuting}`).
+**Call each schema entry at most once per render tree.** Multiple `useMetabaseQuery` calls on the same `questionId` (or same `tableId` + identical filters/measures/breakouts) mount independent subscriptions, fire duplicate queries, and let consumers disagree mid-load. Lift the call to the highest component that needs the data; pass `data` / `isLoading` / `error` down as props. Different ids — or the same id with different filters / breakouts — are different data sources; call them separately.
 
-#### Call each question at most once per render tree
-
-**Call `useQuestionQuery(N)` exactly once per unique question id** in the rendered tree. Calling it from multiple components with the same id is almost never what you want:
-
-- Each call mounts an independent subscription and fires its own query — same rows fetched multiple times, more bytes, slower first paint, and the components can briefly disagree if one finishes before the other.
-- The query state (`isLoading`, `error`, `data`) is duplicated, so each consuming component has to handle the loading dance separately even though they're all waiting on the same query.
-
-Lift the call to the highest component that needs the data, then **pass the result down as props** (or a context if the consumers are deep). Each consumer becomes a pure render of one shared `data`/`isLoading`/`error` triple. Think of `useQuestionQuery(N)` as defining a single "data source" per question — derived values (count, sum, top-K, filtered subset) come from JS on top of that one `data`, not from extra calls.
-
-```tsx
-// ✅ One call, derived values + multiple presentations
-import { useQuestionQuery } from "@metabase/embedding-sdk-react";
-
-function Dashboard() {
-  const { data, isLoading, error } = useQuestionQuery(1);
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorBox error={error} />;
-  if (!data) return null;
-
-  const rows = data.rows;
-  const total = rows.length;
-  const topByValue = [...rows].sort((a, b) => Number(b[2]) - Number(a[2])).slice(0, 5);
-
-  return (
-    <>
-      <StatTile label="Total customers" value={total} />
-      <TopList rows={topByValue} />
-      <CustomTable rows={rows} cols={data.cols} />
-    </>
-  );
-}
-
-// ❌ Same question fetched three times
-function Dashboard() {
-  return (
-    <>
-      <StatTile /> {/* calls useQuestionQuery(1) */}
-      <TopList />  {/* calls useQuestionQuery(1) */}
-      <CustomTable /> {/* calls useQuestionQuery(1) */}
-    </>
-  );
-}
-```
-
-Different ids, or the same id with different `initialSqlParameters`, are different data sources — call them separately. Same id + same parameters → fetch once.
+(For the hook contract itself — generics, table-vs-metric variants, segments / measures / breakouts, debugging — see the `metabase-semantic-schema-data-apps` skill.)
 
 ## SDK component sizing
 

--- a/.typedoc/typedoc-plugin-not-exported.js
+++ b/.typedoc/typedoc-plugin-not-exported.js
@@ -1,0 +1,27 @@
+import { Comment, Converter } from "typedoc";
+
+const TAG = "@notExported";
+
+export function load(app) {
+  app.options.getDeclaration("blockTags").defaultValue?.push?.(TAG);
+
+  app.converter.on(Converter.EVENT_RESOLVE_END, (context) => {
+    const project = context.project;
+    const intentional = new Set(app.options.getValue("intentionallyNotExported"));
+
+    for (const id in project.reflections) {
+      const ref = project.reflections[id];
+      const tags = ref.comment?.blockTags ?? [];
+      for (const tag of tags) {
+        if (tag.tag === TAG) {
+          const name = Comment.combineDisplayParts(tag.content).trim();
+          if (name) {
+            intentional.add(name);
+          }
+        }
+      }
+    }
+
+    app.options.setValue("intentionallyNotExported", [...intentional]);
+  });
+}

--- a/.typedoc/typedoc.common.config.js
+++ b/.typedoc/typedoc.common.config.js
@@ -10,6 +10,7 @@ const config = {
     "typedoc-plugin-dt-links",
     "typedoc-plugin-redirect",
     "./typedoc-plugin-replace-text.js",
+    "./typedoc-plugin-not-exported.js",
   ],
   entryPoints: ["../resources/embedding-sdk/dist/index.d.ts"],
   router: "structure",

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
@@ -2,22 +2,21 @@ import type { DataAppLinkProps } from "metabase/data_apps/router";
 
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
-/**
- * Internal navigation link inside a data app.
- *
- * @function
- * @category DataAppRouter
- */
 export const DataAppLink = ({ to, children, ...rest }: DataAppLinkProps) => {
-  const DataAppLink = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.DataAppLink;
+  const BundleDataAppLink =
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.DataAppLink;
 
-  if (!DataAppLink) {
-    return children;
+  if (!BundleDataAppLink) {
+    return (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    );
   }
 
   return (
-    <DataAppLink to={to} {...rest}>
+    <BundleDataAppLink to={to} {...rest}>
       {children}
-    </DataAppLink>
+    </BundleDataAppLink>
   );
 };

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
@@ -1,0 +1,23 @@
+import type { DataAppLinkProps } from "metabase/data_apps/router";
+
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * Internal navigation link inside a data app.
+ *
+ * @function
+ * @category DataAppRouter
+ */
+export const DataAppLink = ({ to, children, ...rest }: DataAppLinkProps) => {
+  const DataAppLink = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.DataAppLink;
+
+  if (!DataAppLink) {
+    return children;
+  }
+
+  return (
+    <DataAppLink to={to} {...rest}>
+      {children}
+    </DataAppLink>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/DataAppLink.tsx
@@ -1,6 +1,5 @@
-import type { DataAppLinkProps } from "metabase/data_apps/router";
-
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
+import type { DataAppLinkProps } from "metabase/data_apps/router";
 
 export const DataAppLink = ({ to, children, ...rest }: DataAppLinkProps) => {
   const BundleDataAppLink =

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppLink/index.ts
@@ -1,0 +1,1 @@
+export { DataAppLink } from "./DataAppLink";

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/DataAppRouter.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/DataAppRouter.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * Wraps the data-app tree. The implementation lives in the SDK bundle
+ * — this is a thin forwarder that renders the bundle's component when
+ * the bundle has loaded, falling back to a passthrough otherwise so
+ * `<DataAppLink>` / `useDataAppLocation()` callers don't crash during
+ * the bundle-loading window.
+ *
+ * @function
+ * @category DataAppRouter
+ */
+export const DataAppRouter = ({ children }: { children?: ReactNode }) => {
+  const DataAppRouter =
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.DataAppRouter;
+
+  if (!DataAppRouter) {
+    return <>{children}</>;
+  }
+
+  return <DataAppRouter>{children}</DataAppRouter>;
+};

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/DataAppRouter.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/DataAppRouter.tsx
@@ -2,23 +2,13 @@ import type { ReactNode } from "react";
 
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
-/**
- * Wraps the data-app tree. The implementation lives in the SDK bundle
- * — this is a thin forwarder that renders the bundle's component when
- * the bundle has loaded, falling back to a passthrough otherwise so
- * `<DataAppLink>` / `useDataAppLocation()` callers don't crash during
- * the bundle-loading window.
- *
- * @function
- * @category DataAppRouter
- */
 export const DataAppRouter = ({ children }: { children?: ReactNode }) => {
-  const DataAppRouter =
+  const BundleDataAppRouter =
     getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.DataAppRouter;
 
-  if (!DataAppRouter) {
+  if (!BundleDataAppRouter) {
     return <>{children}</>;
   }
 
-  return <DataAppRouter>{children}</DataAppRouter>;
+  return <BundleDataAppRouter>{children}</BundleDataAppRouter>;
 };

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/DataAppRouter/index.ts
@@ -1,0 +1,1 @@
+export { DataAppRouter } from "./DataAppRouter";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -77,10 +77,15 @@ export type SchemaValue<TColumn extends SchemaColumn> =
           ? string | Date | null
           : RowValue | null;
 
+/** @notExported SchemaValue */
 export type SchemaRow<TSchema extends { columns: readonly SchemaColumn[] }> = {
   [TColumn in TSchema["columns"][number] as TColumn["name"]]: SchemaValue<TColumn>;
 };
 
+/**
+ * @notExported DatasetColumn
+ * @notExported RowValues
+ */
 export type QueryData<TRow> = {
   id?: QueryQuestionResult["id"] | null;
   name?: QueryQuestionResult["name"] | null;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/index.ts
@@ -1,0 +1,4 @@
+export {
+  useDataAppLocation,
+  type UseDataAppLocationResult,
+} from "./use-data-app-location";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/use-data-app-location.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/use-data-app-location.ts
@@ -8,35 +8,6 @@ import {
 
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 
-/**
- * Returns the bundle's `dataAppRouting` object, re-evaluating whenever
- * the bundle finishes loading.
- *
- * The bundle is attached to `window.METABASE_EMBEDDING_SDK_BUNDLE`
- * asynchronously after `<MetabaseProvider>` triggers it. Because
- * `<MetabaseProvider>` is memo'd and passes its children through as a
- * prop, bundle-load state changes inside the provider don't cause
- * sibling consumers to re-render. Subscribing to the
- * `metabase-sdk-bundle-loaded` event with `useSyncExternalStore` gives
- * the hook its own re-render signal so it can subscribe to routing
- * events once the bundle is up.
- */
-const useDataAppRouting = () =>
-  useSyncExternalStore(
-    (notify) => {
-      const handler = () => notify();
-      const target = typeof document !== "undefined" ? document : null;
-
-      target?.addEventListener("metabase-sdk-bundle-loaded", handler);
-
-      return () => {
-        target?.removeEventListener("metabase-sdk-bundle-loaded", handler);
-      };
-    },
-    () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.dataAppRouting,
-    () => undefined,
-  );
-
 export type UseDataAppLocationResult = {
   pathname: string;
   navigate: (to: string) => void;
@@ -56,18 +27,23 @@ const computeSubPath = (basename: string): string => {
   return subPath || "/";
 };
 
-/**
- * Returns the current data-app sub-path and a `navigate` function.
- *
- * @function
- * @category DataAppRouter
- */
+const useDataAppRouting = () =>
+  useSyncExternalStore(
+    (notify) => {
+      const target = typeof document !== "undefined" ? document : null;
+      const handler = () => notify();
+      target?.addEventListener("metabase-sdk-bundle-loaded", handler);
+      return () => {
+        target?.removeEventListener("metabase-sdk-bundle-loaded", handler);
+      };
+    },
+    () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.dataAppRouting,
+    () => undefined,
+  );
+
 export const useDataAppLocation = (): UseDataAppLocationResult => {
   const dataAppRouting = useDataAppRouting();
 
-  // Basename never changes after mount: the iframe doesn't navigate to a
-  // different `<name>`; that'd be a parent-level route change that
-  // re-mounts the iframe entirely.
   const basename = useMemo(
     () => dataAppRouting?.getBasename() ?? "",
     [dataAppRouting],
@@ -80,8 +56,6 @@ export const useDataAppLocation = (): UseDataAppLocationResult => {
       return;
     }
 
-    // Re-sync immediately when the bundle becomes available — the
-    // initial useState may have run before the basename was known.
     setPathname(computeSubPath(dataAppRouting.getBasename()));
 
     return dataAppRouting.subscribe(() => {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/use-data-app-location.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-data-app-location/use-data-app-location.ts
@@ -1,0 +1,100 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * Returns the bundle's `dataAppRouting` object, re-evaluating whenever
+ * the bundle finishes loading.
+ *
+ * The bundle is attached to `window.METABASE_EMBEDDING_SDK_BUNDLE`
+ * asynchronously after `<MetabaseProvider>` triggers it. Because
+ * `<MetabaseProvider>` is memo'd and passes its children through as a
+ * prop, bundle-load state changes inside the provider don't cause
+ * sibling consumers to re-render. Subscribing to the
+ * `metabase-sdk-bundle-loaded` event with `useSyncExternalStore` gives
+ * the hook its own re-render signal so it can subscribe to routing
+ * events once the bundle is up.
+ */
+const useDataAppRouting = () =>
+  useSyncExternalStore(
+    (notify) => {
+      const handler = () => notify();
+      const target = typeof document !== "undefined" ? document : null;
+
+      target?.addEventListener("metabase-sdk-bundle-loaded", handler);
+
+      return () => {
+        target?.removeEventListener("metabase-sdk-bundle-loaded", handler);
+      };
+    },
+    () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.dataAppRouting,
+    () => undefined,
+  );
+
+export type UseDataAppLocationResult = {
+  pathname: string;
+  navigate: (to: string) => void;
+};
+
+const computeSubPath = (basename: string): string => {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+
+  const pathname = window.location.pathname;
+  const subPath =
+    basename && pathname.startsWith(basename)
+      ? pathname.slice(basename.length)
+      : pathname;
+
+  return subPath || "/";
+};
+
+/**
+ * Returns the current data-app sub-path and a `navigate` function.
+ *
+ * @function
+ * @category DataAppRouter
+ */
+export const useDataAppLocation = (): UseDataAppLocationResult => {
+  const dataAppRouting = useDataAppRouting();
+
+  // Basename never changes after mount: the iframe doesn't navigate to a
+  // different `<name>`; that'd be a parent-level route change that
+  // re-mounts the iframe entirely.
+  const basename = useMemo(
+    () => dataAppRouting?.getBasename() ?? "",
+    [dataAppRouting],
+  );
+
+  const [pathname, setPathname] = useState(() => computeSubPath(basename));
+
+  useEffect(() => {
+    if (!dataAppRouting) {
+      return;
+    }
+
+    // Re-sync immediately when the bundle becomes available — the
+    // initial useState may have run before the basename was known.
+    setPathname(computeSubPath(dataAppRouting.getBasename()));
+
+    return dataAppRouting.subscribe(() => {
+      setPathname(computeSubPath(dataAppRouting.getBasename()));
+    });
+  }, [dataAppRouting]);
+
+  const navigate = useCallback(
+    (to: string) => {
+      dataAppRouting?.navigate(to);
+    },
+    [dataAppRouting],
+  );
+
+  return { pathname, navigate };
+};

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -210,6 +210,11 @@ type MetricQuery<TMetric, TSchema> = {
   enabled?: boolean;
 };
 
+/**
+ * @notExported QuestionQuery
+ * @notExported TableQuery
+ * @notExported MetricQuery
+ */
 export type MetabaseQueryOptions<TEntity, TSchema = unknown> =
   | QuestionQuery<TEntity>
   | TableQuery<TEntity>
@@ -259,6 +264,7 @@ type InferQuerySchema<TEntity, TQuery> = InferSchema<
 > &
   RowsFromColumns<QueryBreakoutColumns<TQuery> | QueryMeasureColumns<TQuery>>;
 
+/** @notExported InferQuerySchema */
 export type UseMetabaseQueryResult<TEntity = unknown, TQuery = unknown> = {
   data: QueryData<InferQuerySchema<TEntity, TQuery>> | null;
   isLoading: boolean;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metric-query/use-metric-query.ts
@@ -49,6 +49,11 @@ type MetricDimensionName<TMetric> = TMetric extends {
       : string
   : string;
 
+/**
+ * @notExported MetricDimensionName
+ * @notExported MetricDimensionSchema
+ * @notExported MetricFilterOperator
+ */
 export type MetricFilter<TMetric = unknown> = {
   dimension: MetricDimensionName<TMetric> | MetricDimensionSchema;
   operator: MetricFilterOperator;
@@ -56,6 +61,10 @@ export type MetricFilter<TMetric = unknown> = {
   values?: readonly unknown[];
 };
 
+/**
+ * @notExported MetricDimensionName
+ * @notExported MetricDimensionSchema
+ */
 export type MetricBreakout<TMetric = unknown> =
   | MetricDimensionName<TMetric>
   | MetricDimensionSchema
@@ -69,6 +78,7 @@ export type MetricBreakout<TMetric = unknown> =
       };
     };
 
+/** @notExported JsMetricDefinition */
 export type UseMetricQueryOptions<TMetric = unknown> = {
   enabled?: boolean;
   definition?: JsMetricDefinition;
@@ -76,6 +86,7 @@ export type UseMetricQueryOptions<TMetric = unknown> = {
   breakouts?: readonly MetricBreakout<TMetric>[];
 };
 
+/** @notExported InferSchema */
 export type UseMetricQueryResult<TMetric = unknown> = {
   data: QueryData<InferSchema<TMetric, Record<string, unknown>>> | null;
   isLoading: boolean;

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -40,11 +40,9 @@ export type {
 export { defineMetabaseAuthConfig } from "./lib/public/define-metabase-auth-config";
 export { defineMetabaseTheme } from "./lib/public/define-metabase-theme";
 
-export {
-  DataAppRouter,
-  DataAppLink,
-  useDataAppLocation,
-} from "metabase/data_apps/router";
+export { DataAppRouter } from "./components/public/DataAppRouter";
+export { DataAppLink } from "./components/public/DataAppLink";
+export { useDataAppLocation } from "./hooks/public/use-data-app-location";
 
 export {
   type CollectionBrowserProps,

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -48,6 +48,11 @@ import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { defineBuildInfo } from "metabase/embedding-sdk/lib/define-build-info";
 import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
+import {
+  DataAppLink,
+  DataAppRouter,
+} from "metabase/data_apps/router";
+import { dataAppRouting } from "embedding-sdk-bundle/lib/data-app/router";
 
 defineBuildInfo("METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO");
 
@@ -60,6 +65,8 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   CollectionBrowser,
   CreateDashboardModal,
   CreateQuestion,
+  DataAppLink,
+  DataAppRouter,
   EditableDashboard,
   InteractiveDashboard,
   InteractiveQuestion,
@@ -81,6 +88,7 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   queryDataset,
   queryMetric,
   queryQuestion,
+  dataAppRouting,
 };
 
 // Define a global export METABASE_EMBEDDING_SDK_BUNDLE for SDK package

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -48,10 +48,7 @@ import { queryMetric } from "embedding-sdk-bundle/lib/query-metric";
 import { queryQuestion } from "embedding-sdk-bundle/lib/query-question";
 import { defineBuildInfo } from "metabase/embedding-sdk/lib/define-build-info";
 import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
-import {
-  DataAppLink,
-  DataAppRouter,
-} from "metabase/data_apps/router";
+import { DataAppLink, DataAppRouter } from "metabase/data_apps/router";
 import { dataAppRouting } from "embedding-sdk-bundle/lib/data-app/router";
 
 defineBuildInfo("METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO");

--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router.ts
@@ -2,17 +2,6 @@ import { browserHistory } from "react-router";
 
 import { getBasename } from "metabase/data_apps/router";
 
-/**
- * Imperative routing primitives exposed on
- * `window.METABASE_EMBEDDING_SDK_BUNDLE.dataAppRouting` for the SDK
- * package's `useDataAppLocation` hook to consume. The hook owns React
- * state and lifecycle; these primitives are plain functions that talk
- * to the iframe's URL and the underlying history singleton.
- *
- * Keeping the implementation in the bundle means the SDK npm package
- * never bundles a router library — it just forwards to whatever the
- * host's data-app routing uses.
- */
 export const dataAppRouting = {
   getBasename,
   navigate: (to: string) => browserHistory.push(getBasename() + to),

--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router.ts
@@ -1,0 +1,20 @@
+import { browserHistory } from "react-router";
+
+import { getBasename } from "metabase/data_apps/router";
+
+/**
+ * Imperative routing primitives exposed on
+ * `window.METABASE_EMBEDDING_SDK_BUNDLE.dataAppRouting` for the SDK
+ * package's `useDataAppLocation` hook to consume. The hook owns React
+ * state and lifecycle; these primitives are plain functions that talk
+ * to the iframe's URL and the underlying history singleton.
+ *
+ * Keeping the implementation in the bundle means the SDK npm package
+ * never bundles a router library — it just forwards to whatever the
+ * host's data-app routing uses.
+ */
+export const dataAppRouting = {
+  getBasename,
+  navigate: (to: string) => browserHistory.push(getBasename() + to),
+  subscribe: (callback: () => void) => browserHistory.listen(callback),
+};

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -12,6 +12,7 @@ import type { StaticQuestion } from "embedding-sdk-bundle/components/public/Stat
 import type { EditableDashboard } from "embedding-sdk-bundle/components/public/dashboard/EditableDashboard";
 import type { InteractiveDashboard } from "embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard";
 import type { StaticDashboard } from "embedding-sdk-bundle/components/public/dashboard/StaticDashboard";
+import type { DataAppLink, DataAppRouter } from "metabase/data_apps/router";
 import type {
   QueryDatasetParams,
   QueryDatasetResult,
@@ -53,12 +54,15 @@ export type MetabaseEmbeddingSdkBundleExports = PublicExports &
   ReduxStoreSelectorsExports &
   InternalHooksExports &
   SchemaValidationUtils &
-  InternalComponentExports;
+  InternalComponentExports &
+  DataAppRoutingExports;
 
 type PublicExports = {
   CollectionBrowser: InternalComponent<typeof CollectionBrowser>;
   CreateDashboardModal: InternalComponent<typeof CreateDashboardModal>;
   CreateQuestion: InternalComponent<typeof CreateQuestion>;
+  DataAppLink: typeof DataAppLink;
+  DataAppRouter: typeof DataAppRouter;
   EditableDashboard: InternalComponent<typeof EditableDashboard>;
   InteractiveDashboard: InternalComponent<typeof InteractiveDashboard>;
   InteractiveQuestion: InternalComponent<typeof InteractiveQuestion>;
@@ -67,6 +71,14 @@ type PublicExports = {
   SdkDebugInfo: InternalComponent<typeof SdkDebugInfo>;
   StaticDashboard: InternalComponent<typeof StaticDashboard>;
   StaticQuestion: InternalComponent<typeof StaticQuestion>;
+};
+
+type DataAppRoutingExports = {
+  dataAppRouting: {
+    getBasename: () => string;
+    navigate: (to: string) => void;
+    subscribe: (callback: () => void) => () => void;
+  };
 };
 
 type ReduxStoreExports = {

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -12,7 +12,6 @@ import type { StaticQuestion } from "embedding-sdk-bundle/components/public/Stat
 import type { EditableDashboard } from "embedding-sdk-bundle/components/public/dashboard/EditableDashboard";
 import type { InteractiveDashboard } from "embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard";
 import type { StaticDashboard } from "embedding-sdk-bundle/components/public/dashboard/StaticDashboard";
-import type { DataAppLink, DataAppRouter } from "metabase/data_apps/router";
 import type {
   QueryDatasetParams,
   QueryDatasetResult,
@@ -32,6 +31,7 @@ import type {
 } from "embedding-sdk-bundle/types";
 import type { LoginStatus } from "embedding-sdk-bundle/types/user";
 import type { FunctionSchemaValidationResult } from "embedding-sdk-shared/types/validation";
+import type { DataAppLink, DataAppRouter } from "metabase/data_apps/router";
 import type { User } from "metabase-types/api";
 
 export type InternalComponent<TComponent extends JSXElementConstructor<any>> =

--- a/frontend/src/metabase/app-data-app.tsx
+++ b/frontend/src/metabase/app-data-app.tsx
@@ -28,7 +28,6 @@ function _init() {
   const rootElement = document.getElementById("root");
 
   if (!rootElement) {
-    // eslint-disable-next-line no-console
     console.error("no #root element on data-app iframe entry");
     return;
   }

--- a/frontend/src/metabase/data_apps/DataAppFormPage.tsx
+++ b/frontend/src/metabase/data_apps/DataAppFormPage.tsx
@@ -7,6 +7,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
+import { useCreateDataAppMutation } from "metabase/api";
 import {
   Form,
   FormErrorMessage,
@@ -17,7 +18,6 @@ import {
 import { useDispatch } from "metabase/redux";
 import { Box, Button, Flex, Group, Stack, Text, Title } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
-import { useCreateDataAppMutation } from "metabase/api";
 
 import {
   JsBundleDropzone,

--- a/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
+++ b/frontend/src/metabase/data_apps/DataAppIframeApp.tsx
@@ -2,8 +2,10 @@ import createCache from "@emotion/cache";
 // eslint-disable-next-line no-restricted-imports
 import { CacheProvider } from "@emotion/react";
 import { type ComponentType, useEffect, useMemo, useState } from "react";
+import { t } from "ttag";
 
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
+import { color } from "metabase/ui/colors";
 import { getCspNonce } from "metabase/utils/csp";
 
 import { DataAppProvider } from "./components/DataAppProvider";
@@ -77,11 +79,15 @@ function BundleHost({ name, cache }: BundleHostProps) {
   }, [name]);
 
   if (error) {
-    return <div style={{ padding: 16, color: "#b00" }}>Error: {error}</div>;
+    return (
+      <div style={{ padding: 16, color: color("error") }}>
+        {t`Error:`} {error}
+      </div>
+    );
   }
 
   if (!loaded) {
-    return <div style={{ padding: 16 }}>Loading…</div>;
+    return <div style={{ padding: 16 }}>{t`Loading…`}</div>;
   }
 
   const { component: AppComponent, theme } = loaded;
@@ -110,8 +116,8 @@ export const DataAppIframeApp = () => {
 
   if (!name) {
     return (
-      <div style={{ padding: 16, color: "#b00" }}>
-        Missing data-app name in URL
+      <div style={{ padding: 16, color: color("error") }}>
+        {t`Missing data-app name in URL`}
       </div>
     );
   }

--- a/frontend/src/metabase/data_apps/ManageDataAppsPage.tsx
+++ b/frontend/src/metabase/data_apps/ManageDataAppsPage.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import { useDeleteDataAppMutation, useListDataAppsQuery } from "metabase/api";
 import { Link } from "metabase/common/components/Link";
 import {
   Box,
@@ -14,7 +15,6 @@ import {
   Text,
   Title,
 } from "metabase/ui";
-import { useDeleteDataAppMutation, useListDataAppsQuery } from "metabase/api";
 
 import { DataAppListItem } from "./DataAppListItem";
 import S from "./ManageDataAppsPage.module.css";

--- a/frontend/src/metabase/data_apps/ReplaceDataAppBundleModal.tsx
+++ b/frontend/src/metabase/data_apps/ReplaceDataAppBundleModal.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 
+import { useUpdateDataAppMutation } from "metabase/api";
 import {
   Form,
   FormErrorMessage,
@@ -10,7 +11,6 @@ import {
 } from "metabase/forms";
 import { Button, Group, Modal, Stack, Text } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
-import { useUpdateDataAppMutation } from "metabase/api";
 import type { DataApp } from "metabase-types/api";
 
 import {

--- a/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
+++ b/frontend/src/metabase/data_apps/components/DataAppProvider.tsx
@@ -1,9 +1,12 @@
+// eslint-disable-next-line no-restricted-imports -- emotion <Global> is the only way to inject SCOPED_CSS_RESET
+import { Global } from "@emotion/react";
 import type { ReactNode } from "react";
 
+import { SCOPED_CSS_RESET } from "embedding-sdk-bundle/components/private/PublicComponentStylesWrapper";
 import { PortalContainer } from "embedding-sdk-bundle/components/private/SdkPortalContainer";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { getHostBackedSdkStore } from "metabase/data_apps/host-sdk-init";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { MetabaseReduxProvider } from "metabase/redux";
 
 // Note: Mantine + SDK CSS is loaded into the iframe via the `data-app-vendors`
@@ -33,7 +36,10 @@ export const DataAppProvider = ({ theme, children }: DataAppProviderProps) => {
   return (
     <MetabaseReduxProvider store={sdkStore}>
       <SdkThemeProvider theme={theme}>
+        <Global styles={SCOPED_CSS_RESET} />
+
         {children}
+
         <PortalContainer />
       </SdkThemeProvider>
     </MetabaseReduxProvider>

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -12,21 +12,10 @@ export interface DataAppLinkProps
 /**
  * Internal-only navigation link inside a data app.
  *
- * Renders a plain `<a href>` with our own click handler. Middle-click /
- * cmd-click / shift-click / alt-click / any non-primary button defer to
- * the browser's native handling (new tab, new window, download). Primary
- * left-clicks call `browserHistory.push()` to SPA-navigate.
- *
- * `to` is bundle-relative (e.g. `to="/customers/42"`); the auto-detected
- * basename is prepended before navigation so the real URL becomes
- * `/embed/data-app/<name>/customers/42`.
- *
  * Deliberately does NOT delegate to react-router 3's `<Link>` —
  * v3 components use deprecated React APIs (`getDefaultProps`,
  * `childContextTypes`) that emit dev-mode warnings and will be removed
- * in React 19. Keeping the implementation as a plain `<a>` means the
- * component has no class component, no legacy API surface, and no
- * coupling to the v3 router context.
+ * in React 19.
  */
 export const DataAppLink = ({
   to,

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -1,5 +1,5 @@
-import type { AnchorHTMLAttributes, ReactNode } from "react";
-import { Link } from "react-router";
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { browserHistory } from "react-router";
 
 import { getBasename } from "./DataAppRouter";
 
@@ -12,21 +12,62 @@ interface DataAppLinkProps
 /**
  * Internal-only navigation link inside a data app.
  *
- * Renders react-router 3's `<Link>` under the hood — middle-click /
- * cmd-click / modifier-key handling and `<a href>` rendering all come
- * from v3's implementation. When MB upgrades to a newer router, this
- * file's `import { Link } from "react-router"` changes; the bundle's
- * `<DataAppLink to="…">` usage doesn't.
+ * Renders a plain `<a href>` with our own click handler. Middle-click /
+ * cmd-click / shift-click / alt-click / any non-primary button defer to
+ * the browser's native handling (new tab, new window, download). Primary
+ * left-clicks call `browserHistory.push()` to SPA-navigate.
  *
- * The `to` prop is bundle-relative (e.g. `to="/customers/42"`); we add
- * the auto-detected basename before handing the URL to v3's `Link`.
+ * `to` is bundle-relative (e.g. `to="/customers/42"`); the auto-detected
+ * basename is prepended before navigation so the real URL becomes
+ * `/embed/data-app/<name>/customers/42`.
  *
- * Must be rendered inside a `<DataAppRouter>` — v3's `<Link>` reads its
- * router from the surrounding `<Router>` (which `<DataAppRouter>` mounts)
- * and will throw without it.
+ * Deliberately does NOT delegate to react-router 3's `<Link>` —
+ * v3 components use deprecated React APIs (`getDefaultProps`,
+ * `childContextTypes`) that emit dev-mode warnings and will be removed
+ * in React 19. Keeping the implementation as a plain `<a>` means the
+ * component has no class component, no legacy API surface, and no
+ * coupling to the v3 router context.
  */
-export const DataAppLink = ({ to, children, ...rest }: DataAppLinkProps) => (
-  <Link to={getBasename() + to} {...rest}>
-    {children}
-  </Link>
-);
+export const DataAppLink = ({
+  to,
+  children,
+  onClick,
+  target,
+  ...rest
+}: DataAppLinkProps) => {
+  const href = getBasename() + to;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (target && target !== "_self") {
+      // Explicit `target="_blank"` etc. — let the browser handle it.
+      return;
+    }
+
+    if (
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      // Modifier keys / middle / right click → browser handles it (new tab,
+      // download, etc.). Don't preventDefault — we want the native action.
+      return;
+    }
+
+    event.preventDefault();
+    browserHistory.push(href);
+  };
+
+  return (
+    <a href={href} target={target} onClick={handleClick} {...rest}>
+      {children}
+    </a>
+  );
+};

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -3,7 +3,7 @@ import { browserHistory } from "react-router";
 
 import { getBasename } from "./DataAppRouter";
 
-interface DataAppLinkProps
+export interface DataAppLinkProps
   extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
   to: string;
   children?: ReactNode;

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -3,8 +3,10 @@ import { browserHistory } from "react-router";
 
 import { getBasename } from "./DataAppRouter";
 
-export interface DataAppLinkProps
-  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+export interface DataAppLinkProps extends Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> {
   to: string;
   children?: ReactNode;
 }

--- a/frontend/src/metabase/data_apps/router/DataAppLink.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppLink.tsx
@@ -3,10 +3,8 @@ import { browserHistory } from "react-router";
 
 import { getBasename } from "./DataAppRouter";
 
-export interface DataAppLinkProps extends Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  "href"
-> {
+export interface DataAppLinkProps
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
   to: string;
   children?: ReactNode;
 }
@@ -24,9 +22,13 @@ export const DataAppLink = ({
   children,
   onClick,
   target,
+  rel,
   ...rest
 }: DataAppLinkProps) => {
   const href = getBasename() + to;
+
+  const isExternalTarget = target != null && target !== "_self";
+  const resolvedRel = rel ?? (isExternalTarget ? "noopener noreferrer" : rel);
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event);
@@ -35,7 +37,7 @@ export const DataAppLink = ({
       return;
     }
 
-    if (target && target !== "_self") {
+    if (isExternalTarget) {
       // Explicit `target="_blank"` etc. — let the browser handle it.
       return;
     }
@@ -57,7 +59,13 @@ export const DataAppLink = ({
   };
 
   return (
-    <a href={href} target={target} onClick={handleClick} {...rest}>
+    <a
+      href={href}
+      target={target}
+      rel={resolvedRel}
+      onClick={handleClick}
+      {...rest}
+    >
       {children}
     </a>
   );

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -63,4 +63,6 @@ interface DataAppRouterProps {
  * the same code works — `basename` resolves to `""` and the sub-path is
  * just the raw pathname.
  */
-export const DataAppRouter = ({ children }: DataAppRouterProps) => <>{children}</>;
+export const DataAppRouter = ({ children }: DataAppRouterProps) => (
+  <>{children}</>
+);

--- a/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
+++ b/frontend/src/metabase/data_apps/router/DataAppRouter.tsx
@@ -1,21 +1,21 @@
-import { type ReactNode, createContext, useContext } from "react";
-import { Router, browserHistory } from "react-router";
+import type { ReactNode } from "react";
 
 import { DATA_APP_EMBED_PREFIX } from "metabase/data_apps/constants";
 
 /**
  * Data-app routing primitives.
  *
- * Implementation uses Metabase's bundled `react-router@3` — same library
- * MB uses everywhere else. The bundle never sees the router library: it
- * only depends on the `{ pathname, navigate }` shape exposed by
- * `useDataAppLocation` and on the `<DataAppLink>` component. When MB
- * jumps v3 → v6/v7, this file's internals change; bundles stay untouched.
+ * The bundle never sees a router library directly — it only depends on
+ * the `{ pathname, navigate }` shape exposed by `useDataAppLocation` and
+ * on the `<DataAppLink>` component. All routing state lives on the
+ * `browserHistory` singleton (from `react-router`, but used only for its
+ * function-based `push` / `listen` API — no React components, no legacy
+ * context).
  *
- * Lives in host code, endowed to the bundle via
- * `@metabase/embedding-sdk-react/data-app`. All routing state lives on
- * `browserHistory` (a `react-router` singleton) — no custom React Context
- * is needed across the public API.
+ * `<DataAppRouter>` itself is a pass-through today. It stays as a
+ * dedicated component so future additions (error boundaries, suspense,
+ * routing-scoped providers) can land here without a breaking change to
+ * the bundle's `<DataAppRouter>` usage.
  */
 
 /**
@@ -50,12 +50,6 @@ const DATA_APP_BASENAME_RE = new RegExp(
 export const getBasename = (): string =>
   window.location.pathname.match(DATA_APP_BASENAME_RE)?.[1] ?? "";
 
-const RouteContentBridge = createContext<ReactNode>(null);
-
-const RouteContent = () => useContext(RouteContentBridge);
-
-const STABLE_ROUTES = { path: "*", component: RouteContent };
-
 interface DataAppRouterProps {
   children?: ReactNode;
 }
@@ -69,8 +63,4 @@ interface DataAppRouterProps {
  * the same code works — `basename` resolves to `""` and the sub-path is
  * just the raw pathname.
  */
-export const DataAppRouter = ({ children }: DataAppRouterProps) => (
-  <RouteContentBridge.Provider value={children}>
-    <Router history={browserHistory} routes={STABLE_ROUTES} />
-  </RouteContentBridge.Provider>
-);
+export const DataAppRouter = ({ children }: DataAppRouterProps) => <>{children}</>;

--- a/frontend/src/metabase/data_apps/router/index.ts
+++ b/frontend/src/metabase/data_apps/router/index.ts
@@ -1,3 +1,3 @@
-export { DataAppRouter } from "./DataAppRouter";
-export { DataAppLink } from "./DataAppLink";
+export { DataAppRouter, getBasename } from "./DataAppRouter";
+export { DataAppLink, type DataAppLinkProps } from "./DataAppLink";
 export { useDataAppLocation } from "./useDataAppLocation";

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -14,7 +14,9 @@ import {
   InteractiveDashboard,
   StaticDashboard,
 } from "embedding-sdk-bundle/components/public/dashboard";
+// eslint-disable-next-line no-restricted-imports
 import { useMetabaseQuery } from "embedding-sdk-package/hooks/public/use-metabase-query";
+// eslint-disable-next-line no-restricted-imports
 import { useQuestionQuery } from "embedding-sdk-package/hooks/public/use-question-query";
 import {
   DataAppLink,

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -56,15 +56,6 @@ export function createDataAppSandbox(
       liveTargetCallback: isLiveTarget,
       endowments: Object.getOwnPropertyDescriptors({
         React,
-        // Exposes the host's `react/jsx-runtime` (the production
-        // automatic-runtime entry) to the bundle. The data-app
-        // template's `vite.config.ts` externalizes
-        // `react/jsx-runtime` to this global, so JSX-emitted
-        // `import { jsx } from "react/jsx-runtime"` resolves to the
-        // host's React — keeping a single React instance + matching
-        // element symbol shape across host and bundle. Without this,
-        // the bundle inlines its own copy of the CJS jsx-runtime shim
-        // which calls `require("react")` and explodes at runtime.
         __react_jsx_runtime__: ReactJsxRuntime,
         __metabase_sdk__: {
           // Data fetching

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -1,5 +1,6 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 import * as React from "react";
+import * as ReactJsxRuntime from "react/jsx-runtime";
 
 import { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
@@ -55,6 +56,16 @@ export function createDataAppSandbox(
       liveTargetCallback: isLiveTarget,
       endowments: Object.getOwnPropertyDescriptors({
         React,
+        // Exposes the host's `react/jsx-runtime` (the production
+        // automatic-runtime entry) to the bundle. The data-app
+        // template's `vite.config.ts` externalizes
+        // `react/jsx-runtime` to this global, so JSX-emitted
+        // `import { jsx } from "react/jsx-runtime"` resolves to the
+        // host's React — keeping a single React instance + matching
+        // element symbol shape across host and bundle. Without this,
+        // the bundle inlines its own copy of the CJS jsx-runtime shim
+        // which calls `require("react")` and explodes at runtime.
+        __react_jsx_runtime__: ReactJsxRuntime,
         __metabase_sdk__: {
           // Data fetching
           useQuestionQuery,

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -30,6 +30,7 @@ import { ArchiveDashboardModalConnected } from "metabase/dashboard/containers/Ar
 import { AutomaticDashboardApp } from "metabase/dashboard/containers/AutomaticDashboardApp";
 import { DashboardApp } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
 import { getDataStudioRoutes } from "metabase/data-studio/routes";
+import { AppView as DataAppView } from "metabase/data_apps/AppView";
 import { TableDetailPage } from "metabase/detail-view/pages/TableDetailPage";
 import { CommentsSidesheet } from "metabase/documents/components/CommentsSidesheet";
 import { DocumentPageOuter } from "metabase/documents/routes";
@@ -42,7 +43,6 @@ import { getMetricRoutes } from "metabase/metrics/routes";
 import { MetricsViewerPage } from "metabase/metrics-viewer";
 import NewModelOptions from "metabase/models/containers/NewModelOptions";
 import { getRoutes as getModelRoutes } from "metabase/models/routes";
-import { AppView as DataAppView } from "metabase/data_apps/AppView";
 import {
   PLUGIN_COLLECTIONS,
   PLUGIN_LANDING_PAGE,


### PR DESCRIPTION
PR prepares skills for data app template:
- simplifies skills
- passes jsx-runtime to the data app sandboxing

Also it adjusts router components:
- uses a custom DataAppLink implementation as the one from react-router-3 throws warnings
- splits logic between HostedBundle and SDK package