### PR TITLE
🤖 Backport MCP canonical-URL aliases to v62 (#75025)

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -41,16 +41,16 @@ The field accepts wildcards (`*`) for subdomains. Changes take effect in about a
 
 ## Connect an MCP client
 
-If your admin has turned on [your Metabase's MCP server](#enable-mcp-server), all you need to do is point your MCP client at Metabase's MCP endpoint, `/api/mcp`. For example:
+If your admin has turned on [your Metabase's MCP server](#enable-mcp-server), all you need to do is point your MCP client at Metabase's MCP endpoint, `/api/metabase-mcp`. For example:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
 
 In the terminal, for example, you can run the following command.
 
 ```
-claude mcp add --transport http metabase https://{your-metabase-url}/api/mcp
+claude mcp add --transport http metabase https://{your-metabase-url}/api/metabase-mcp
 ```
 
 Replacing {your-metabase-url} with your Metabase address. Once added, Claude Code will handle the OAuth flow for you:

--- a/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
@@ -40,7 +40,9 @@ describe("admin > MCP apps settings > Cursor install link", () => {
 
           const decoded = JSON.parse(atob(config as string));
 
-          expect(decoded.url).to.eq(`${Cypress.config("baseUrl")}/api/mcp`);
+          expect(decoded.url).to.eq(
+            `${Cypress.config("baseUrl")}/api/metabase-mcp`,
+          );
         });
 
       cy.log(

--- a/frontend/src/metabase/admin/ai/MCPServerUrlSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MCPServerUrlSection.unit.spec.tsx
@@ -14,7 +14,7 @@ import { createMockSettings } from "metabase-types/api/mocks";
 import { McpServerUrlSection } from "./MCPServerUrlSection";
 
 const SITE_URL = "https://metabase.example.com";
-const MCP_URL = `${SITE_URL}/api/mcp`;
+const MCP_URL = `${SITE_URL}/api/metabase-mcp`;
 
 function setup({ siteUrl = SITE_URL }: { siteUrl?: string | undefined } = {}) {
   const settings = createMockSettings({ "site-url": siteUrl });

--- a/frontend/src/metabase/admin/ai/utils.ts
+++ b/frontend/src/metabase/admin/ai/utils.ts
@@ -161,5 +161,5 @@ export function useMCPServerURL() {
     return null;
   }
 
-  return `${siteUrl}/api/mcp`;
+  return `${siteUrl}/api/metabase-mcp`;
 }

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -192,8 +192,11 @@
    "/llm"                  (+auth metabase.llm.api/routes)
    "/logger"               (+auth 'metabase.logger.api)
    "/login-history"        (+auth 'metabase.login-history.api)
+   ;; `/mcp` is a legacy alias of the canonical `/metabase-mcp` below, kept for back-compat with
+   ;; existing clients. See [[metabase.mcp.api/endpoint-paths]].
    "/mcp"                  (metabase.mcp.api/+mcp-enabled metabase.mcp.api/handler)
    "/measure"              (+auth 'metabase.measures.api)
+   "/metabase-mcp"         (metabase.mcp.api/+mcp-enabled metabase.mcp.api/handler)
    "/metabot"              metabase.metabot.api/routes
    "/metric"               (+auth 'metabase.metrics.api)
    "/model-index"          (+auth 'metabase.indexed-entities.api)

--- a/src/metabase/mcp/README.md
+++ b/src/metabase/mcp/README.md
@@ -11,15 +11,18 @@ creating/updating content - all scoped to the connecting user's permissions.
 The MCP server is available at:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
+
+The legacy `/api/mcp` path still works as an alias for existing clients, but `/api/metabase-mcp` is the
+canonical URL to advertise.
 
 ## Connecting a client
 
-Point any MCP-compatible client at the `/api/mcp` endpoint. For example, with Claude Code:
+Point any MCP-compatible client at the `/api/metabase-mcp` endpoint. For example, with Claude Code:
 
 ```sh
-claude mcp add metabase https://{your-metabase.example.com}/api/mcp --transport streamable-http
+claude mcp add metabase https://{your-metabase.example.com}/api/metabase-mcp --transport streamable-http
 ```
 
 For Claude Desktop, create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
@@ -28,7 +31,7 @@ using the same URL.
 For Cursor, open **Settings > MCP** and add a new server with the type set to `streamable-http` and the URL:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
 
 ## Authentication
@@ -68,7 +71,7 @@ Wildcard patterns (e.g. `agent:*`) match any scope with that prefix.
 OAuth protected resource metadata is available at:
 
 ```
-/.well-known/oauth-protected-resource/api/mcp
+/.well-known/oauth-protected-resource/api/metabase-mcp
 ```
 
 By default our consent screen grants access to all scopes without the opportunity to customize.
@@ -160,7 +163,7 @@ The implementation lives in these files:
 
 ```
 MCP client
-  -> POST /api/mcp (JSON-RPC)
+  -> POST /api/metabase-mcp (JSON-RPC)
   -> Origin + session validation
   -> Auth: OAuth bearer token or browser session
   -> Scope check against requested tool

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -1,6 +1,6 @@
 (ns metabase.mcp.api
   "MCP (Model Context Protocol) Streamable HTTP transport handler.
-   Exposes Metabase's agent tools via JSON-RPC 2.0 over a single `/api/mcp` endpoint."
+   Exposes Metabase's agent tools via JSON-RPC 2.0 over each of the MCP endpoints."
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
@@ -347,8 +347,23 @@
 
 ;;; ---------------------------------------------------- Handler ---------------------------------------------------
 
-(defn- www-authenticate-discovery []
-  (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource/api/mcp\""))
+;; Source of truth for the route aliases — keep in sync with the route-map in
+;; [[metabase.api-routes.routes]] and resource-metadata endpoints in [[metabase.oauth-server.api.metadata]].
+(def ^:private endpoint-paths
+  "URL paths that serve the MCP endpoint, relative to site-url.
+   `/api/metabase-mcp` is canonical (the advertised URL); `/api/mcp` is a legacy alias kept for
+   back-compat with existing clients."
+  #{"/api/metabase-mcp" "/api/mcp"})
+
+(defn- www-authenticate-discovery
+  "Build the `WWW-Authenticate` header advertising OAuth discovery for the path the client hit.
+   A client connecting via an alias is pointed at that same alias as the protected resource."
+  [request]
+  ;; Routing matches on the first path segment, so a trailing slash (e.g. `/api/metabase-mcp/`) still
+  ;; reaches the handler — strip it so the alias is recognized rather than falling back to canonical.
+  (let [uri  (str/replace (:uri request) #"/+$" "")
+        path (if (contains? endpoint-paths uri) uri "/api/metabase-mcp")]
+    (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource" path "\"")))
 
 (def +mcp-enabled
   "Wrap routes so they may only be accessed when the MCP server is enabled."
@@ -400,5 +415,5 @@
            ;; No auth at all — return 401 with discovery
            :else
            (respond (json-response 401 (jsonrpc-error nil -32603 "Authentication required")
-                                   {"WWW-Authenticate" (www-authenticate-discovery)}))))))
+                                   {"WWW-Authenticate" (www-authenticate-discovery request)}))))))
    (constantly nil)))

--- a/src/metabase/mcp/callback_api.clj
+++ b/src/metabase/mcp/callback_api.clj
@@ -2,7 +2,7 @@
   "Iframe-callback endpoints for the embedded MCP UI. The MCP iframe POSTs here to
    stash query payloads server-side so the agent never has to carry them in the
    model context — it just receives a handle UUID it can pass to the corresponding
-   MCP tool. Mounted as a sibling of `/api/mcp` so the JSON-RPC handler doesn't
+   MCP tool. Mounted as a sibling of `/api/metabase-mcp` so the JSON-RPC handler doesn't
    have to special-case non-protocol routes."
   (:require
    [clojure.string :as str]

--- a/src/metabase/mcp/llms-install.md
+++ b/src/metabase/mcp/llms-install.md
@@ -2,7 +2,7 @@
 
 This guide is written for AI coding agents (Claude Code, Cursor, Windsurf, etc.) helping a user connect their MCP
 client to the **Metabase MCP server**. The server is built into every Metabase instance and is served at
-`/api/mcp` on the instance itself — there is nothing to download, install locally, or run as a separate process.
+`/api/metabase-mcp` on the instance itself — there is nothing to download, install locally, or run as a separate process.
 
 ## Step 1 — Ask the user for their Metabase instance URL
 
@@ -16,10 +16,10 @@ Examples of what to ask for:
 - For local development, e.g. `http://localhost:3000`
 
 Do **not** guess or assume the URL. If the user has not told you what their Metabase instance URL is, ask them
-explicitly before continuing. The MCP server endpoint is always the instance URL followed by `/api/mcp`:
+explicitly before continuing. The MCP server endpoint is always the instance URL followed by `/api/metabase-mcp`:
 
 ```
-{METABASE_URL}/api/mcp
+{METABASE_URL}/api/metabase-mcp
 ```
 
 For the rest of this guide, replace `{METABASE_URL}` with whatever the user provides (with no trailing slash).
@@ -30,7 +30,7 @@ The MCP server ships with Metabase but requires a reasonably recent version. If 
 ask them to confirm:
 
 1. They are on a Metabase version that includes the MCP server (recent stable release).
-2. They can reach `{METABASE_URL}/api/mcp` from the machine running the MCP client (no VPN/firewall blocking it).
+2. They can reach `{METABASE_URL}/api/metabase-mcp` from the machine running the MCP client (no VPN/firewall blocking it).
 3. They have a Metabase account on that instance that they can log in with.
 
 Authentication happens via **OAuth 2.0** against Metabase itself — there is no API key, no token to paste, and no
@@ -46,7 +46,7 @@ Most MCP clients accept a JSON configuration block. Use the following, substitut
   "mcpServers": {
     "metabase": {
       "type": "http",
-      "url": "{METABASE_URL}/api/mcp"
+      "url": "{METABASE_URL}/api/metabase-mcp"
     }
   }
 }
@@ -61,14 +61,14 @@ documents.
 **Claude Code** (CLI):
 
 ```sh
-claude mcp add metabase {METABASE_URL}/api/mcp --transport streamable-http
+claude mcp add metabase {METABASE_URL}/api/metabase-mcp --transport streamable-http
 ```
 
 **Claude Desktop**: create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
-pointing at `{METABASE_URL}/api/mcp`.
+pointing at `{METABASE_URL}/api/metabase-mcp`.
 
 **Cursor**: open **Settings → MCP**, add a new server, set the type to `streamable-http`, and use
-`{METABASE_URL}/api/mcp` as the URL.
+`{METABASE_URL}/api/metabase-mcp` as the URL.
 
 **VS Code** (GitHub Copilot Chat / agent mode): add the server to `.vscode/mcp.json` in the workspace, or to the
 user-level `mcp.json`. VS Code uses a `servers` top-level key (not `mcpServers`):
@@ -78,14 +78,14 @@ user-level `mcp.json`. VS Code uses a `servers` top-level key (not `mcpServers`)
   "servers": {
     "metabase": {
       "type": "http",
-      "url": "{METABASE_URL}/api/mcp"
+      "url": "{METABASE_URL}/api/metabase-mcp"
     }
   }
 }
 ```
 
 You can also run **MCP: Add Server** from the command palette and pick **HTTP**, then paste
-`{METABASE_URL}/api/mcp` as the URL.
+`{METABASE_URL}/api/metabase-mcp` as the URL.
 
 **Cline** (VS Code extension): Cline uses its own camelCase value for the transport type. Edit Cline's MCP settings
 file and add:
@@ -95,7 +95,7 @@ file and add:
   "mcpServers": {
     "metabase": {
       "type": "streamableHttp",
-      "url": "{METABASE_URL}/api/mcp"
+      "url": "{METABASE_URL}/api/metabase-mcp"
     }
   }
 }
@@ -105,13 +105,13 @@ Note: the value is `streamableHttp` (camelCase) — `http` or `streamable-http` 
 
 **Other clients**: if your client is not listed above, consult its MCP documentation and translate the JSON block
 above into the format it expects (`json`, `yaml`, TOML, etc.). The two things that always need to be set are the
-transport (`streamable-http` / `http`) and the URL (`{METABASE_URL}/api/mcp`).
+transport (`streamable-http` / `http`) and the URL (`{METABASE_URL}/api/metabase-mcp`).
 
 ## Step 4 — Complete the OAuth login
 
 The first time the client connects, it will:
 
-1. Discover Metabase's OAuth endpoints at `{METABASE_URL}/.well-known/oauth-protected-resource/api/mcp`.
+1. Discover Metabase's OAuth endpoints at `{METABASE_URL}/.well-known/oauth-protected-resource/api/metabase-mcp`.
 2. Register itself with Metabase as an OAuth client.
 3. Open a browser tab where the user logs in to Metabase and approves the connection.
 4. Receive an access token scoped to the user's Metabase permissions.
@@ -128,6 +128,6 @@ list, the connection is working.
 
 If the tool list is empty or the client reports an authentication error, re-check that:
 
-- The URL is exactly `{METABASE_URL}/api/mcp` with no trailing slash and no extra path segments.
+- The URL is exactly `{METABASE_URL}/api/metabase-mcp` with no trailing slash and no extra path segments.
 - The user successfully completed the OAuth login in the browser.
 - The Metabase instance is reachable from the machine running the client.

--- a/src/metabase/mcp/server.json
+++ b/src/metabase/mcp/server.json
@@ -20,7 +20,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://{metabase_host}/api/mcp",
+      "url": "https://{metabase_host}/api/metabase-mcp",
       "variables": {
         "metabase_host": {
           "description": "Your Metabase hostname, e.g. 'metabase.example.com'.",

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -267,7 +267,7 @@
 (defn store-handle!
   "Insert a new handle row binding `encoded-query` to the calling user, and return the handle UUID.
 
-   `mcp-session-id` is recorded so DELETE /api/mcp can sweep the session's handles, and so reads can log
+   `mcp-session-id` is recorded so DELETE /api/metabase-mcp can sweep the session's handles, and so reads can log
    when a handle is resolved across sessions (see [[find-handle-row]]) — the read path itself is purely
    user-scoped, since handle UUIDs are globally unique.
 

--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -38,18 +38,10 @@
   (or (discovery-response)
       {:status 404 :body {:error "not_found"}}))
 
-(defn- protected-resource-response
-  "Build the OAuth Protected Resource Metadata (RFC 9728) response for the MCP endpoint."
-  []
-  (let [site-url (system/site-url)]
-    {:status  200
-     :headers {"Content-Type" "application/json"}
-     :body    {:resource                  (str site-url "/api/mcp")
-               :authorization_servers     [site-url]
-               :scopes_supported          (vec (oauth-server/all-agent-scopes))
-               :bearer_methods_supported  ["header"]}}))
-
-(def ^:private protected-resource-schema
+;; One endpoint per MCP path (canonical and legacy), kept in sync with [[metabase.mcp.api/endpoint-paths]].
+;; Each advertises its own path as `:resource`, so a strict RFC 9728 client connecting via the legacy
+;; alias still sees a resource value matching the URL it hit.
+(def ^:private resource-metadata-response-schema
   [:map
    [:status [:= 200]]
    [:body [:map
@@ -58,16 +50,33 @@
            [:scopes_supported [:sequential :string]]
            [:bearer_methods_supported [:sequential :string]]]]])
 
-(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
-  :- protected-resource-schema
+(defn- protected-resource-metadata
+  "OAuth Protected Resource Metadata (RFC 9728) advertising `resource-path` as the protected resource."
+  [resource-path]
+  (let [site-url (system/site-url)]
+    {:status  200
+     :headers {"Content-Type" "application/json"}
+     :body    {:resource                  (str site-url resource-path)
+               :authorization_servers     [site-url]
+               :scopes_supported          (vec (oauth-server/all-agent-scopes))
+               :bearer_methods_supported  ["header"]}}))
+
+(api.macros/defendpoint :get "/oauth-protected-resource/api/metabase-mcp"
+  :- resource-metadata-response-schema
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
   []
-  (protected-resource-response))
+  (protected-resource-metadata "/api/metabase-mcp"))
+
+(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
+  :- resource-metadata-response-schema
+  "Returns OAuth Protected Resource Metadata (RFC 9728) for the legacy `/api/mcp` MCP alias."
+  []
+  (protected-resource-metadata "/api/mcp"))
 
 ;; Some clients probe the bare resource path instead of the resource-specific one; serve the same metadata here so
 ;; the request doesn't fall through to the SPA's HTML catch-all and trip a `JSON.parse` error (BOT-1617).
 (api.macros/defendpoint :get "/oauth-protected-resource"
-  :- protected-resource-schema
+  :- resource-metadata-response-schema
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
   []
-  (protected-resource-response))
+  (protected-resource-metadata "/api/mcp"))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -78,6 +78,24 @@
                                :delete "mcp"
                                {:request-options {:headers extra-headers}}))
 
+(def ^:private mcp-endpoint-paths
+  "Client paths that serve the MCP endpoint, appended to the test client's `/api`: the canonical
+   `metabase-mcp` and the legacy `mcp` alias."
+  ["metabase-mcp" "mcp"])
+
+(defn- mcp-request-to
+  "Like `mcp-request` but to an explicit endpoint path (e.g. \"metabase-mcp\"), authenticated as :crowberto."
+  [path body]
+  (client/client-full-response (test.users/username->token :crowberto)
+                               :post path
+                               {:request-options {:headers {}}}
+                               body))
+
+(defn- mcp-request-unauthenticated-to
+  "Make an unauthenticated POST to an explicit endpoint path, expecting a 401."
+  [path body]
+  (client/client-full-response :post 401 path {:request-options {:headers {}}} body))
+
 (defn- jsonrpc-request
   "Build a JSON-RPC 2.0 request map."
   ([method]
@@ -1109,6 +1127,55 @@
         (is (=? {:status  401
                  :headers {"WWW-Authenticate" #(str/includes? % "oauth-protected-resource")}}
                 response))))))
+
+;;; ----------------------------------------- Canonical and legacy endpoints ---------------------------------------
+
+(deftest endpoint-alias-routing-test
+  (testing "initialize succeeds (session auth) on both the canonical and legacy MCP paths"
+    (doseq [path mcp-endpoint-paths]
+      (testing (str "/api/" path)
+        (is (=? {:status  200
+                 :headers {"Mcp-Session-Id" some?}
+                 :body    {:result {:serverInfo {:name "metabase"}}}}
+                (mcp-request-to path (jsonrpc-request "initialize"))))))))
+
+(deftest endpoint-alias-discovery-401-test
+  (testing "unauthenticated request on each path advertises that same path as the protected resource"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (doseq [path mcp-endpoint-paths]
+        (testing (str "/api/" path)
+          ;; The trailing quote pins the match to the exact path (so /api/mcp can't match /api/metabase-mcp).
+          (let [expected (str "/.well-known/oauth-protected-resource/api/" path "\"")]
+            (is (=? {:status  401
+                     :headers {"WWW-Authenticate" #(str/includes? % expected)}}
+                    (mcp-request-unauthenticated-to path (jsonrpc-request "initialize"))))))))))
+
+(deftest endpoint-alias-trailing-slash-discovery-test
+  (testing "a trailing-slash request still advertises the matching path (not canonical fallback)"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (let [expected "/.well-known/oauth-protected-resource/api/mcp\""]
+        (is (=? {:status  401
+                 :headers {"WWW-Authenticate" #(str/includes? % expected)}}
+                (mcp-request-unauthenticated-to "mcp/" (jsonrpc-request "initialize"))))))))
+
+(deftest endpoint-alias-bearer-token-test
+  (testing "bearer-token handling is identical on the legacy path — same invalid_token 401 as canonical"
+    ;; Bearer validation (validate-bearer-token) has no path logic, so reaching it via the legacy
+    ;; alias must behave exactly like the canonical path. We assert the invalid-token branch since
+    ;; it's deterministic and doesn't depend on minting a live token.
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (oauth-server/reset-provider!)
+      (try
+        (doseq [path mcp-endpoint-paths]
+          (testing (str "/api/" path)
+            (is (=? {:status  401
+                     :headers {"WWW-Authenticate" #(str/includes? % "invalid_token")}}
+                    (client/client-full-response
+                     :post 401 path
+                     {:request-options {:headers {"authorization" "Bearer totally-bogus-token"}}}
+                     (jsonrpc-request "initialize"))))))
+        (finally
+          (oauth-server/reset-provider!))))))
 
 (deftest invalid-bearer-token-returns-401-test
   (testing "POST with invalid bearer token returns 401 with invalid_token error"

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -37,14 +37,17 @@
         (is (nil? (:id_token_signing_alg_values_supported response)))))))
 
 (deftest protected-resource-metadata-test
-  (testing "GET /.well-known/oauth-protected-resource/api/mcp returns correct metadata"
+  (testing "the canonical and legacy MCP paths each advertise themselves as the OAuth protected resource (RFC 9728)"
     (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
-      (let [response (mt/user-http-request :crowberto :get 200
-                                           ".well-known/oauth-protected-resource/api/mcp")]
-        (is (=? {:resource                "http://localhost:3000/api/mcp"
-                 :authorization_servers   ["http://localhost:3000"]
-                 :bearer_methods_supported ["header"]}
-                response))))))
+      (doseq [path ["/api/metabase-mcp" "/api/mcp"]]
+        (testing path
+          (let [response (mt/user-http-request :crowberto :get 200
+                                               (str ".well-known/oauth-protected-resource" path))]
+            (is (=? {:resource                 (str "http://localhost:3000" path)
+                     :authorization_servers    ["http://localhost:3000"]
+                     :bearer_methods_supported ["header"]
+                     :scopes_supported         sequential?}
+                    response))))))))
 
 (deftest protected-resource-metadata-bare-path-test
   (testing "GET /.well-known/oauth-protected-resource (no resource suffix) serves the same metadata as JSON (BOT-1617)"


### PR DESCRIPTION
Manual backport of #75025 to `release-x.62.x`.

`/api/metabase-mcp` is now the canonical MCP server URL; `/api/mcp` stays as an unadvertised legacy alias so existing clients keep working. OAuth discovery is path-aware, so each path advertises itself as the protected resource (RFC 9728).

Clean cherry-pick — identical to the original PR. The sibling fix #75110 is already on this branch via #75164.