### PR TITLE
🤖 Backport MCP canonical URL + OAuth proxy discovery to v61 (#75025, #75110)

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -41,16 +41,16 @@ The field accepts wildcards (`*`) for subdomains. Changes take effect in about a
 
 ## Connect an MCP client
 
-If your admin has turned on [your Metabase's MCP server](#enable-mcp-server), all you need to do is point your MCP client at Metabase's MCP endpoint, `/api/mcp`. For example:
+If your admin has turned on [your Metabase's MCP server](#enable-mcp-server), all you need to do is point your MCP client at Metabase's MCP endpoint, `/api/metabase-mcp`. For example:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
 
 In the terminal, for example, you can run the following command.
 
 ```
-claude mcp add --transport http metabase https://{your-metabase-url}/api/mcp
+claude mcp add --transport http metabase https://{your-metabase-url}/api/metabase-mcp
 ```
 
 Replacing {your-metabase-url} with your Metabase address. Once added, Claude Code will handle the OAuth flow for you:

--- a/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
@@ -40,7 +40,9 @@ describe("admin > MCP apps settings > Cursor install link", () => {
 
           const decoded = JSON.parse(atob(config as string));
 
-          expect(decoded.url).to.eq(`${Cypress.config("baseUrl")}/api/mcp`);
+          expect(decoded.url).to.eq(
+            `${Cypress.config("baseUrl")}/api/metabase-mcp`,
+          );
         });
 
       cy.log(

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
@@ -14,7 +14,7 @@ import { createMockSettings } from "metabase-types/api/mocks";
 import { McpServerUrlSection } from "./MCPServerUrlSection";
 
 const SITE_URL = "https://metabase.example.com";
-const MCP_URL = `${SITE_URL}/api/mcp`;
+const MCP_URL = `${SITE_URL}/api/metabase-mcp`;
 
 function setup({ siteUrl = SITE_URL }: { siteUrl?: string | undefined } = {}) {
   const settings = createMockSettings({ "site-url": siteUrl });

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/utils.ts
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/utils.ts
@@ -161,5 +161,5 @@ export function useMCPServerURL() {
     return null;
   }
 
-  return `${siteUrl}/api/mcp`;
+  return `${siteUrl}/api/metabase-mcp`;
 }

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -189,8 +189,11 @@
    "/llm"                  (+auth metabase.llm.api/routes)
    "/logger"               (+auth 'metabase.logger.api)
    "/login-history"        (+auth 'metabase.login-history.api)
+   ;; `/mcp` is a legacy alias of the canonical `/metabase-mcp` below, kept for back-compat with
+   ;; existing clients. See [[metabase.mcp.api/endpoint-paths]].
    "/mcp"                  (metabase.mcp.api/+mcp-enabled metabase.mcp.api/handler)
    "/measure"              (+auth 'metabase.measures.api)
+   "/metabase-mcp"         (metabase.mcp.api/+mcp-enabled metabase.mcp.api/handler)
    "/metabot"              metabase.metabot.api/routes
    "/metric"               (+auth 'metabase.metrics.api)
    "/model-index"          (+auth 'metabase.indexed-entities.api)

--- a/src/metabase/mcp/README.md
+++ b/src/metabase/mcp/README.md
@@ -11,15 +11,18 @@ scoped to the connecting user's permissions.
 The MCP server is available at:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
+
+The legacy `/api/mcp` path still works as an alias for existing clients, but `/api/metabase-mcp` is the
+canonical URL to advertise.
 
 ## Connecting a client
 
-Point any MCP-compatible client at the `/api/mcp` endpoint. For example, with Claude Code:
+Point any MCP-compatible client at the `/api/metabase-mcp` endpoint. For example, with Claude Code:
 
 ```sh
-claude mcp add metabase https://{your-metabase.example.com}/api/mcp --transport streamable-http
+claude mcp add metabase https://{your-metabase.example.com}/api/metabase-mcp --transport streamable-http
 ```
 
 For Claude Desktop, create a [custom connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
@@ -28,7 +31,7 @@ using the same URL.
 For Cursor, open **Settings > MCP** and add a new server with the type set to `streamable-http` and the URL:
 
 ```
-https://{your-metabase.example.com}/api/mcp
+https://{your-metabase.example.com}/api/metabase-mcp
 ```
 
 ## Authentication
@@ -65,7 +68,7 @@ Wildcard patterns (e.g. `agent:*`) match any scope with that prefix.
 OAuth protected resource metadata is available at:
 
 ```
-/.well-known/oauth-protected-resource/api/mcp
+/.well-known/oauth-protected-resource/api/metabase-mcp
 ```
 
 By default our consent screen grants access to all scopes without the opportunity to customize.
@@ -136,7 +139,7 @@ The implementation lives in these files:
 
 ```
 MCP client
-  → POST /api/mcp (JSON-RPC)
+  → POST /api/metabase-mcp (JSON-RPC)
   → Origin + session validation
   → Auth: OAuth bearer token or browser session
   → Scope check against requested tool

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -1,6 +1,6 @@
 (ns metabase.mcp.api
   "MCP (Model Context Protocol) Streamable HTTP transport handler.
-   Exposes Metabase's agent tools via JSON-RPC 2.0 over a single `/api/mcp` endpoint."
+   Exposes Metabase's agent tools via JSON-RPC 2.0 over each of the MCP endpoints."
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
@@ -327,8 +327,23 @@
 
 ;;; ---------------------------------------------------- Handler ---------------------------------------------------
 
-(defn- www-authenticate-discovery []
-  (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource/api/mcp\""))
+;; Source of truth for the route aliases — keep in sync with the route-map in
+;; [[metabase.api-routes.routes]] and resource-metadata endpoints in [[metabase.oauth-server.api.metadata]].
+(def ^:private endpoint-paths
+  "URL paths that serve the MCP endpoint, relative to site-url.
+   `/api/metabase-mcp` is canonical (the advertised URL); `/api/mcp` is a legacy alias kept for
+   back-compat with existing clients."
+  #{"/api/metabase-mcp" "/api/mcp"})
+
+(defn- www-authenticate-discovery
+  "Build the `WWW-Authenticate` header advertising OAuth discovery for the path the client hit.
+   A client connecting via an alias is pointed at that same alias as the protected resource."
+  [request]
+  ;; Routing matches on the first path segment, so a trailing slash (e.g. `/api/metabase-mcp/`) still
+  ;; reaches the handler — strip it so the alias is recognized rather than falling back to canonical.
+  (let [uri  (str/replace (:uri request) #"/+$" "")
+        path (if (contains? endpoint-paths uri) uri "/api/metabase-mcp")]
+    (str "Bearer realm=\"mcp\" resource_metadata=\"" (system/site-url) "/.well-known/oauth-protected-resource" path "\"")))
 
 (def +mcp-enabled
   "Wrap routes so they may only be accessed when the MCP server is enabled."
@@ -373,5 +388,5 @@
            ;; No auth at all — return 401 with discovery
            :else
            (respond (json-response 401 (jsonrpc-error nil -32603 "Authentication required")
-                                   {"WWW-Authenticate" (www-authenticate-discovery)}))))))
+                                   {"WWW-Authenticate" (www-authenticate-discovery request)}))))))
    (constantly nil)))

--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -38,18 +38,10 @@
   (or (discovery-response)
       {:status 404 :body {:error "not_found"}}))
 
-(defn- protected-resource-response
-  "Build the OAuth Protected Resource Metadata (RFC 9728) response for the MCP endpoint."
-  []
-  (let [site-url (system/site-url)]
-    {:status  200
-     :headers {"Content-Type" "application/json"}
-     :body    {:resource                  (str site-url "/api/mcp")
-               :authorization_servers     [site-url]
-               :scopes_supported          (oauth-server/all-agent-scopes)
-               :bearer_methods_supported  ["header"]}}))
-
-(def ^:private protected-resource-schema
+;; One endpoint per MCP path (canonical and legacy), kept in sync with [[metabase.mcp.api/endpoint-paths]].
+;; Each advertises its own path as `:resource`, so a strict RFC 9728 client connecting via the legacy
+;; alias still sees a resource value matching the URL it hit.
+(def ^:private resource-metadata-response-schema
   [:map
    [:status [:= 200]]
    [:body [:map
@@ -58,16 +50,33 @@
            [:scopes_supported [:sequential :string]]
            [:bearer_methods_supported [:sequential :string]]]]])
 
-(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
-  :- protected-resource-schema
+(defn- protected-resource-metadata
+  "OAuth Protected Resource Metadata (RFC 9728) advertising `resource-path` as the protected resource."
+  [resource-path]
+  (let [site-url (system/site-url)]
+    {:status  200
+     :headers {"Content-Type" "application/json"}
+     :body    {:resource                  (str site-url resource-path)
+               :authorization_servers     [site-url]
+               :scopes_supported          (vec (oauth-server/all-agent-scopes))
+               :bearer_methods_supported  ["header"]}}))
+
+(api.macros/defendpoint :get "/oauth-protected-resource/api/metabase-mcp"
+  :- resource-metadata-response-schema
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
   []
-  (protected-resource-response))
+  (protected-resource-metadata "/api/metabase-mcp"))
+
+(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
+  :- resource-metadata-response-schema
+  "Returns OAuth Protected Resource Metadata (RFC 9728) for the legacy `/api/mcp` MCP alias."
+  []
+  (protected-resource-metadata "/api/mcp"))
 
 ;; Some clients probe the bare resource path instead of the resource-specific one; serve the same metadata here so
 ;; the request doesn't fall through to the SPA's HTML catch-all and trip a `JSON.parse` error (BOT-1617).
 (api.macros/defendpoint :get "/oauth-protected-resource"
-  :- protected-resource-schema
+  :- resource-metadata-response-schema
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
   []
-  (protected-resource-response))
+  (protected-resource-metadata "/api/mcp"))

--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -38,15 +38,8 @@
   (or (discovery-response)
       {:status 404 :body {:error "not_found"}}))
 
-(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
-  :- [:map
-      [:status [:= 200]]
-      [:body [:map
-              [:resource :string]
-              [:authorization_servers [:sequential :string]]
-              [:scopes_supported [:sequential :string]]
-              [:bearer_methods_supported [:sequential :string]]]]]
-  "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
+(defn- protected-resource-response
+  "Build the OAuth Protected Resource Metadata (RFC 9728) response for the MCP endpoint."
   []
   (let [site-url (system/site-url)]
     {:status  200
@@ -55,3 +48,26 @@
                :authorization_servers     [site-url]
                :scopes_supported          (oauth-server/all-agent-scopes)
                :bearer_methods_supported  ["header"]}}))
+
+(def ^:private protected-resource-schema
+  [:map
+   [:status [:= 200]]
+   [:body [:map
+           [:resource :string]
+           [:authorization_servers [:sequential :string]]
+           [:scopes_supported [:sequential :string]]
+           [:bearer_methods_supported [:sequential :string]]]]])
+
+(api.macros/defendpoint :get "/oauth-protected-resource/api/mcp"
+  :- protected-resource-schema
+  "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
+  []
+  (protected-resource-response))
+
+;; Some clients probe the bare resource path instead of the resource-specific one; serve the same metadata here so
+;; the request doesn't fall through to the SPA's HTML catch-all and trip a `JSON.parse` error (BOT-1617).
+(api.macros/defendpoint :get "/oauth-protected-resource"
+  :- protected-resource-schema
+  "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
+  []
+  (protected-resource-response))

--- a/src/metabase/oauth_server/core.clj
+++ b/src/metabase/oauth_server/core.clj
@@ -10,6 +10,10 @@
 
 (set! *warn-on-reflection* true)
 
+;; Cache holds `{:site-url <string>, :provider <Provider>}`. Every endpoint baked into the provider config is
+;; derived from the Site URL (see [[build-provider-config]]), so a changed Site URL must rebuild the provider --
+;; otherwise discovery keeps advertising the stale issuer/endpoints (e.g. http:// behind a TLS-terminating proxy
+;; after the operator corrects Site URL to https://).
 (defonce ^:private provider (atom nil))
 
 (defn all-agent-scopes
@@ -45,13 +49,18 @@
   (oidc/create-provider (build-provider-config)))
 
 (defn get-provider
-  "Returns the current provider instance, creating it lazily if needed."
+  "Returns the current provider instance, (re)creating it when absent or when the Site URL has changed."
   []
-  (or @provider
-      (swap! provider (fn [p] (or p (create-provider))))))
+  (let [site-url (system/site-url)]
+    (:provider
+     (swap! provider
+            (fn [cached]
+              (if (and cached (= (:site-url cached) site-url))
+                cached
+                {:site-url site-url, :provider (create-provider)}))))))
 
 (defn reset-provider!
-  "Reset the provider atom to nil. Useful for testing."
+  "Reset the provider cache to nil. Useful for testing."
   []
   (reset! provider nil))
 

--- a/src/metabase/server/middleware/misc.clj
+++ b/src/metabase/server/middleware/misc.clj
@@ -7,6 +7,7 @@
    [metabase.request.core :as request]
    [metabase.server.streaming-response]
    [metabase.system.core :as system]
+   [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
@@ -58,12 +59,28 @@
 ;;
 ;; Effectively the very first API request that gets sent to us (usually some sort of setup request) ends up setting
 ;; the (initial) value of `site-url`
-(defn- maybe-set-site-url* [{{:strs [origin x-forwarded-host host user-agent]} :headers, uri :uri}]
+(defn- forwarded-scheme
+  "The scheme a TLS-terminating proxy used to reach us, from `X-Forwarded-Proto`."
+  [x-forwarded-proto]
+  ;; first hop of a comma-separated chain (`https, http`), lower-cased: URL schemes are case-insensitive
+  ;; (RFC 3986) but normalize-site-url's "http" prefix check is not, so `HTTPS` would be mangled as scheme-less.
+  (some-> x-forwarded-proto (str/split #",") first str/trim not-empty u/lower-case-en))
+
+(defn- maybe-set-site-url* [{{:strs [origin x-forwarded-host x-forwarded-proto host user-agent]} :headers, uri :uri}]
   (when (and (mdb/db-is-set-up?)
              (not (system/site-url))
              (not (#{"/api/health" "/livez" "/readyz"} uri))
              (or (nil? user-agent) ((complement str/includes?) user-agent "HealthChecker")))
-    (when-let [site-url (or origin x-forwarded-host host)]
+    ;; `origin` already carries a scheme; the `*-host` headers normally don't, so prepend the scheme the proxy
+    ;; terminated TLS with -- otherwise `normalize-site-url` defaults to `http://` and a TLS-terminating proxy ends
+    ;; up advertising `http://` auth/discovery URLs over an `https` origin, breaking MCP OAuth (BOT-1617). Only
+    ;; prepend when the host is scheme-less; a scheme-bearing host passes through untouched.
+    (when-let [site-url (or origin
+                            (when-let [host (or x-forwarded-host host)]
+                              (if-let [scheme (and (not (str/includes? host "://"))
+                                                   (forwarded-scheme x-forwarded-proto))]
+                                (str scheme "://" host)
+                                host)))]
       (log/infof "Setting Metabase site URL to %s" site-url)
       (try
         (system/site-url! site-url)

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -63,6 +63,24 @@
                                :delete "mcp"
                                {:request-options {:headers extra-headers}}))
 
+(def ^:private mcp-endpoint-paths
+  "Client paths that serve the MCP endpoint, appended to the test client's `/api`: the canonical
+   `metabase-mcp` and the legacy `mcp` alias."
+  ["metabase-mcp" "mcp"])
+
+(defn- mcp-request-to
+  "Like `mcp-request` but to an explicit endpoint path (e.g. \"metabase-mcp\"), authenticated as :crowberto."
+  [path body]
+  (client/client-full-response (test.users/username->token :crowberto)
+                               :post path
+                               {:request-options {:headers {}}}
+                               body))
+
+(defn- mcp-request-unauthenticated-to
+  "Make an unauthenticated POST to an explicit endpoint path, expecting a 401."
+  [path body]
+  (client/client-full-response :post 401 path {:request-options {:headers {}}} body))
+
 (defn- jsonrpc-request
   "Build a JSON-RPC 2.0 request map."
   ([method]
@@ -674,6 +692,55 @@
         (is (=? {:status  401
                  :headers {"WWW-Authenticate" #(str/includes? % "oauth-protected-resource")}}
                 response))))))
+
+;;; ----------------------------------------- Canonical and legacy endpoints ---------------------------------------
+
+(deftest endpoint-alias-routing-test
+  (testing "initialize succeeds (session auth) on both the canonical and legacy MCP paths"
+    (doseq [path mcp-endpoint-paths]
+      (testing (str "/api/" path)
+        (is (=? {:status  200
+                 :headers {"Mcp-Session-Id" some?}
+                 :body    {:result {:serverInfo {:name "metabase"}}}}
+                (mcp-request-to path (jsonrpc-request "initialize"))))))))
+
+(deftest endpoint-alias-discovery-401-test
+  (testing "unauthenticated request on each path advertises that same path as the protected resource"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (doseq [path mcp-endpoint-paths]
+        (testing (str "/api/" path)
+          ;; The trailing quote pins the match to the exact path (so /api/mcp can't match /api/metabase-mcp).
+          (let [expected (str "/.well-known/oauth-protected-resource/api/" path "\"")]
+            (is (=? {:status  401
+                     :headers {"WWW-Authenticate" #(str/includes? % expected)}}
+                    (mcp-request-unauthenticated-to path (jsonrpc-request "initialize"))))))))))
+
+(deftest endpoint-alias-trailing-slash-discovery-test
+  (testing "a trailing-slash request still advertises the matching path (not canonical fallback)"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (let [expected "/.well-known/oauth-protected-resource/api/mcp\""]
+        (is (=? {:status  401
+                 :headers {"WWW-Authenticate" #(str/includes? % expected)}}
+                (mcp-request-unauthenticated-to "mcp/" (jsonrpc-request "initialize"))))))))
+
+(deftest endpoint-alias-bearer-token-test
+  (testing "bearer-token handling is identical on the legacy path — same invalid_token 401 as canonical"
+    ;; Bearer validation (validate-bearer-token) has no path logic, so reaching it via the legacy
+    ;; alias must behave exactly like the canonical path. We assert the invalid-token branch since
+    ;; it's deterministic and doesn't depend on minting a live token.
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (oauth-server/reset-provider!)
+      (try
+        (doseq [path mcp-endpoint-paths]
+          (testing (str "/api/" path)
+            (is (=? {:status  401
+                     :headers {"WWW-Authenticate" #(str/includes? % "invalid_token")}}
+                    (client/client-full-response
+                     :post 401 path
+                     {:request-options {:headers {"authorization" "Bearer totally-bogus-token"}}}
+                     (jsonrpc-request "initialize"))))))
+        (finally
+          (oauth-server/reset-provider!))))))
 
 (deftest invalid-bearer-token-returns-401-test
   (testing "POST with invalid bearer token returns 401 with invalid_token error"

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -46,6 +46,27 @@
                  :bearer_methods_supported ["header"]}
                 response))))))
 
+(deftest protected-resource-metadata-bare-path-test
+  (testing "GET /.well-known/oauth-protected-resource (no resource suffix) serves the same metadata as JSON (BOT-1617)"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (let [response (mt/user-http-request :crowberto :get 200
+                                           ".well-known/oauth-protected-resource")]
+        (is (=? {:resource                "http://localhost:3000/api/mcp"
+                 :authorization_servers   ["http://localhost:3000"]
+                 :bearer_methods_supported ["header"]}
+                response))))))
+
+(deftest discovery-endpoint-rebuilds-on-site-url-change-test
+  (testing "Discovery advertises endpoints for the *current* site-url, even after it changes (BOT-1617)"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (is (=? {:issuer "http://localhost:3000"}
+              (mt/user-http-request :crowberto :get 200 ".well-known/oauth-authorization-server"))))
+    (mt/with-temporary-setting-values [site-url "https://mb.example.com"]
+      (is (=? {:issuer                "https://mb.example.com"
+               :authorization_endpoint "https://mb.example.com/oauth/authorize"
+               :token_endpoint         "https://mb.example.com/oauth/token"}
+              (mt/user-http-request :crowberto :get 200 ".well-known/oauth-authorization-server"))))))
+
 ;;; ----------------------------------------- Dynamic Client Registration ----------------------------------------------
 
 (defn- register-client!

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -37,14 +37,17 @@
         (is (nil? (:id_token_signing_alg_values_supported response)))))))
 
 (deftest protected-resource-metadata-test
-  (testing "GET /.well-known/oauth-protected-resource/api/mcp returns correct metadata"
+  (testing "the canonical and legacy MCP paths each advertise themselves as the OAuth protected resource (RFC 9728)"
     (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
-      (let [response (mt/user-http-request :crowberto :get 200
-                                           ".well-known/oauth-protected-resource/api/mcp")]
-        (is (=? {:resource                "http://localhost:3000/api/mcp"
-                 :authorization_servers   ["http://localhost:3000"]
-                 :bearer_methods_supported ["header"]}
-                response))))))
+      (doseq [path ["/api/metabase-mcp" "/api/mcp"]]
+        (testing path
+          (let [response (mt/user-http-request :crowberto :get 200
+                                               (str ".well-known/oauth-protected-resource" path))]
+            (is (=? {:resource                 (str "http://localhost:3000" path)
+                     :authorization_servers    ["http://localhost:3000"]
+                     :bearer_methods_supported ["header"]
+                     :scopes_supported         sequential?}
+                    response))))))))
 
 (deftest protected-resource-metadata-bare-path-test
   (testing "GET /.well-known/oauth-protected-resource (no resource suffix) serves the same metadata as JSON (BOT-1617)"

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -51,6 +51,35 @@
           (maybe-set-site-url request)
           (is (= "https://mb1.example.com" (system/site-url))))))))
 
+(deftest maybe-set-site-url-forwarded-proto-test
+  (testing "scheme-less `*-host` headers get the scheme from `X-Forwarded-Proto` (BOT-1617)"
+    (doseq [host-header ["X-Forwarded-Host" "Host"]]
+      (testing host-header
+        (mt/with-temporary-setting-values [site-url nil]
+          (maybe-set-site-url (-> (m/dissoc-in (ring.mock/request :get "/") [:headers "host"])
+                                  (ring.mock/header host-header "mb.example.com")
+                                  (ring.mock/header "X-Forwarded-Proto" "https")))
+          (is (= "https://mb.example.com" (system/site-url)))))))
+  (testing "`X-Forwarded-Proto` is matched case-insensitively (RFC 3986)"
+    (mt/with-temporary-setting-values [site-url nil]
+      (maybe-set-site-url (-> (mock-request "/" nil "mb.example.com" nil)
+                              (ring.mock/header "X-Forwarded-Proto" "HTTPS")))
+      (is (= "https://mb.example.com" (system/site-url)))))
+  (testing "the first hop wins when `X-Forwarded-Proto` is a comma-separated chain"
+    (mt/with-temporary-setting-values [site-url nil]
+      (maybe-set-site-url (-> (mock-request "/" nil "mb.example.com" nil)
+                              (ring.mock/header "X-Forwarded-Proto" "https, http")))
+      (is (= "https://mb.example.com" (system/site-url)))))
+  (testing "without `X-Forwarded-Proto`, a scheme-less host falls back to http:// (unchanged behavior)"
+    (mt/with-temporary-setting-values [site-url nil]
+      (maybe-set-site-url (mock-request "/" nil "mb.example.com" nil))
+      (is (= "http://mb.example.com" (system/site-url)))))
+  (testing "a scheme-bearing host header is left untouched, even alongside `X-Forwarded-Proto` (no double scheme)"
+    (mt/with-temporary-setting-values [site-url nil]
+      (maybe-set-site-url (-> (mock-request "/" nil "https://mb.example.com" nil)
+                              (ring.mock/header "X-Forwarded-Proto" "https")))
+      (is (= "https://mb.example.com" (system/site-url))))))
+
 (deftest add-version-header-test
   (testing "x-metabase-version is only added on API calls"
     (with-redefs [config/mb-version-info {:tag "v42"}]

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -593,14 +593,19 @@
                           on-enter        (fn [] (await-barrier barrier-enter))
                           on-exit         (fn [] (await-barrier barrier-exit) (.set tl-tripped true))
                           original-insert transforms.u/try-start-unless-already-running]
-                      (mt/with-dynamic-fn-redefs [transforms.u/try-start-unless-already-running
-                                                  (fn [transform-id run-method user-id]
-                                                    (on-enter)
-                                                    (let [[ret ex] (try
-                                                                     [(original-insert transform-id run-method user-id)]
-                                                                     (catch Throwable t [nil t]))]
-                                                      (on-exit)
-                                                      (if ex (throw ex) ret)))]
+                      ;; with-redefs, not with-dynamic-fn-redefs: run-transforms! dispatches each transform on an
+                      ;; ExecutorService worker (transforms-sql-worker), which doesn't convey dynamic bindings, so a
+                      ;; proxy-based redef is invisible there and the barrier choreography silently no-ops. A global
+                      ;; root swap is seen by every thread.
+                      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+                      (with-redefs [transforms.u/try-start-unless-already-running
+                                    (fn [transform-id run-method user-id]
+                                      (on-enter)
+                                      (let [[ret ex] (try
+                                                       [(original-insert transform-id run-method user-id)]
+                                                       (catch Throwable t [nil t]))]
+                                        (on-exit)
+                                        (if ex (throw ex) ret)))]
                         (let [run1 (transforms.job-run/start-run! (:id job) :manual)
                               run2 (transforms.job-run/start-run! (:id job) :manual)
                               fut1 (future


### PR DESCRIPTION
Manual backport of #75025 and #75110 to `release-x.61.x`.

- **#75025** — `/api/metabase-mcp` is now the canonical MCP route (legacy `/api/mcp` kept as an unadvertised alias); path-aware OAuth discovery so each path advertises itself as the protected resource.
- **#75110** — rebuild the OAuth provider when Site URL changes, honor `X-Forwarded-Proto` when auto-seeding Site URL, and serve JSON at the bare `/.well-known/oauth-protected-resource` path (fixes MCP OAuth sign-in behind a TLS-terminating proxy).

**Backport notes ("only what applies"):**
- Dropped files that don't exist on this branch: `mcp/server.json`, `mcp/session.clj`, `mcp/callback_api.clj`, `mcp/llms-install.md`.
- The "MCP Server URL" admin section lives at the older `metabot/components/MetabotAdmin/` path here; #75025's frontend changes applied there via rename detection (deeplink + tests emit `/api/metabase-mcp`).
- #75110's squash bundled an unrelated flaky-test fix to `transforms/jobs_test.clj`; carried along verbatim.

The third sibling, #74923, is already on this branch.