### PR TITLE
add admin transforms redirect routes

### DIFF
--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -429,6 +429,10 @@ export const getRoutes = (store: AppStore) => {
         to="/admin/permissions/collections"
       />
 
+      {/* Transforms moved from /admin to /data-studio */}
+      <Redirect from="/admin/transforms" to="/data-studio/transforms" />
+      <Redirect from="/admin/transforms/*" to="/data-studio/transforms/*" />
+
       {/* MISC */}
       <Route path="/unsubscribe" component={UnsubscribePage} />
       <Route path="/unauthorized" component={Unauthorized} />


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C099RKNLP6U/p1780948109789709)

LLMs may generate wrong transfoms URLs as the initial release placed them into the admin panel. This PR adds just a two redirect routes
