### PR TITLE
Use dashboard filters in Visualizer data

### DIFF
--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -7,6 +7,8 @@ import type {
   QuestionDashboardCard,
   VirtualCard,
   VirtualDashboardCard,
+  VisualizerDashboardCard,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
 
 import { createMockCard } from "./card";
@@ -103,6 +105,34 @@ export const createMockVirtualCard = (
   archived: false,
   ...opts,
 });
+
+type VisualizerDashboardCardOpts = Partial<
+  Omit<VisualizerDashboardCard, "visualization_settings">
+> & {
+  visualization_settings?: Partial<
+    VisualizerDashboardCard["visualization_settings"]
+  >;
+};
+
+export const createMockVisualizerDashboardCard = (
+  opts?: VisualizerDashboardCardOpts,
+): VisualizerDashboardCard => {
+  const visualization: VisualizerVizDefinition = opts?.visualization_settings
+    ?.visualization ?? {
+    display: "table",
+    columnValuesMapping: {},
+    settings: {},
+  };
+
+  return {
+    ...createMockDashboardCard(opts),
+    ...opts,
+    visualization_settings: {
+      ...opts?.visualization_settings,
+      visualization,
+    },
+  };
+};
 
 export const createMockActionDashboardCard = (
   opts?: Partial<ActionDashboardCard>,

--- a/frontend/src/metabase/redux/store/visualizer.ts
+++ b/frontend/src/metabase/redux/store/visualizer.ts
@@ -32,8 +32,8 @@ export interface VisualizerVizDefinitionWithColumns extends VisualizerVizDefinit
   columns: DatasetColumn[];
 }
 
-export interface VisualizerVizDefinitionWithColumnsAndFallbacks extends VisualizerVizDefinitionWithColumns {
-  datasetFallbacks?: Record<number, Dataset | null | undefined>;
+export interface VisualizerVizDefinitionWithColumnsAndPreloadedDatasets extends VisualizerVizDefinitionWithColumns {
+  preloadedDatasets?: Record<number, Dataset | null | undefined>;
 }
 
 export interface VisualizerState extends VisualizerVizDefinitionWithColumns {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -1,4 +1,4 @@
-import type { VisualizerVizDefinitionWithColumnsAndFallbacks } from "metabase/redux/store/visualizer";
+import type { VisualizerVizDefinitionWithColumnsAndPreloadedDatasets } from "metabase/redux/store/visualizer";
 import { isNotNull } from "metabase/utils/types";
 import { isCartesianChart } from "metabase/visualizations";
 import { isPivotGroupColumn } from "metabase/visualizations/lib/data_grid";
@@ -106,19 +106,19 @@ function pickColumns(
 export function getInitialStateForCardDataSource(
   card: Card,
   dataset: Dataset,
-): VisualizerVizDefinitionWithColumnsAndFallbacks {
+): VisualizerVizDefinitionWithColumnsAndPreloadedDatasets {
   const {
     data: { cols: originalColumns },
   } = dataset;
 
-  const state: VisualizerVizDefinitionWithColumnsAndFallbacks = {
+  const state: VisualizerVizDefinitionWithColumnsAndPreloadedDatasets = {
     display: isVisualizerSupportedVisualization(card.display)
       ? card.display
       : DEFAULT_VISUALIZER_DISPLAY,
     columns: [],
     columnValuesMapping: {},
     settings: {},
-    datasetFallbacks: { [card.id]: dataset },
+    preloadedDatasets: { [card.id]: dataset },
   };
 
   const dataSource = createDataSource("card", card.id, card.name);

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -407,7 +407,7 @@ describe("getInitialStateForCardDataSource", () => {
           "funnel.metric": "METRIC",
           "funnel.dimension": "DIMENSION",
         },
-        datasetFallbacks: { [card.id]: dataset },
+        preloadedDatasets: { [card.id]: dataset },
       });
     },
   );

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -1,4 +1,4 @@
-import type { VisualizerVizDefinitionWithColumnsAndFallbacks } from "metabase/redux/store/visualizer";
+import type { VisualizerVizDefinitionWithColumnsAndPreloadedDatasets } from "metabase/redux/store/visualizer";
 import { isNotNull } from "metabase/utils/types";
 import type {
   Card,
@@ -63,7 +63,7 @@ function mapColumnVizSettings(
 function processColumnsForDataSource(
   dataSource: VisualizerDataSource,
   columns: DatasetColumn[],
-  state: VisualizerVizDefinitionWithColumnsAndFallbacks,
+  state: VisualizerVizDefinitionWithColumnsAndPreloadedDatasets,
 ): ColumnInfo[] {
   const columnInfos: ColumnInfo[] = [];
 
@@ -111,12 +111,12 @@ function processColumnsForDataSource(
 export function getInitialStateForMultipleSeries(rawSeries: RawSeries) {
   const mainCard = rawSeries[0].card;
 
-  const state: VisualizerVizDefinitionWithColumnsAndFallbacks = {
+  const state: VisualizerVizDefinitionWithColumnsAndPreloadedDatasets = {
     display: mainCard.display,
     columns: [],
     columnValuesMapping: {},
     settings: {},
-    datasetFallbacks: rawSeries.reduce(
+    preloadedDatasets: rawSeries.reduce(
       (acc, s) => {
         acc[s.card.id] = s as unknown as Dataset;
         return acc;

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
@@ -95,5 +95,10 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
       "graph.metrics": ["COLUMN_2", "COLUMN_4"],
       "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
     });
+
+    expect(initialState.preloadedDatasets).toEqual({
+      [firstCard.id]: rawSeries[0],
+      [secondCard.id]: rawSeries[1],
+    });
   });
 });

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-visualizer-card.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-visualizer-card.ts
@@ -9,7 +9,7 @@ import { getVisualizationColumns } from "./get-visualization-columns";
 
 export function getInitialStateForVisualizerCard(
   dashcard: VisualizerDashboardCard,
-  datasets: Record<number, Dataset | null | undefined>,
+  preloadedDatasets: Record<number, Dataset | null | undefined>,
 ) {
   const visualizationEntity = dashcard.visualization_settings?.visualization;
 
@@ -26,7 +26,7 @@ export function getInitialStateForVisualizerCard(
     VisualizerDataSourceId,
     Dataset | null | undefined
   > = Object.fromEntries(
-    Object.entries(datasets ?? {}).map(([cardId, dataset]) => [
+    Object.entries(preloadedDatasets ?? {}).map(([cardId, dataset]) => [
       `card:${cardId}`,
       dataset,
     ]),
@@ -38,5 +38,5 @@ export function getInitialStateForVisualizerCard(
     dataSources,
   );
 
-  return { ...visualizationEntity, columns, datasetFallbacks: datasets };
+  return { ...visualizationEntity, columns, preloadedDatasets };
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-visualizer-card.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-visualizer-card.unit.spec.ts
@@ -1,0 +1,118 @@
+import registerVisualizations from "metabase/visualizations/register";
+import type { VisualizerVizDefinition } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+  createMockVisualizerDashboardCard,
+} from "metabase-types/api/mocks";
+
+import { getInitialStateForVisualizerCard } from "./get-initial-state-for-visualizer-card";
+
+registerVisualizations();
+
+describe("getInitialStateForVisualizerCard", () => {
+  const mainCard = createMockCard({
+    id: 1,
+    name: "Main card",
+    display: "line",
+  });
+
+  const seriesCard = createMockCard({
+    id: 2,
+    name: "Series card",
+    display: "line",
+  });
+
+  const mainDataset = createMockDataset({
+    data: createMockDatasetData({
+      rows: [["Gadget", 10]],
+      cols: [
+        createMockColumn({ name: "Category" }),
+        createMockColumn({ name: "Count" }),
+      ],
+    }),
+  });
+
+  const seriesDataset = createMockDataset({
+    data: createMockDatasetData({
+      rows: [["2024-01-01", 5]],
+      cols: [
+        createMockColumn({ name: "Date" }),
+        createMockColumn({ name: "Revenue" }),
+      ],
+    }),
+  });
+
+  const visualizationEntity: VisualizerVizDefinition = {
+    display: "line",
+    columnValuesMapping: {
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "Category",
+          sourceId: `card:${mainCard.id}`,
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "Count",
+          sourceId: `card:${mainCard.id}`,
+        },
+      ],
+    },
+    settings: {
+      "graph.dimensions": ["COLUMN_1"],
+      "graph.metrics": ["COLUMN_2"],
+    },
+  };
+
+  it("should include preloadedDatasets from dashcard data", () => {
+    const dashcard = createMockVisualizerDashboardCard({
+      card: mainCard,
+      visualization_settings: {
+        visualization: visualizationEntity,
+      },
+    });
+
+    const preloadedDatasets = {
+      [mainCard.id]: mainDataset,
+    };
+
+    const initialState = getInitialStateForVisualizerCard(
+      dashcard,
+      preloadedDatasets,
+    );
+
+    expect(initialState.preloadedDatasets).toEqual(preloadedDatasets);
+    expect(initialState.display).toBe("line");
+    expect(initialState.columnValuesMapping).toEqual(
+      visualizationEntity.columnValuesMapping,
+    );
+    expect(initialState.columns).toHaveLength(2);
+  });
+
+  it("should include preloadedDatasets for main card and series cards", () => {
+    const dashcard = createMockVisualizerDashboardCard({
+      card: mainCard,
+      series: [seriesCard],
+      visualization_settings: {
+        visualization: visualizationEntity,
+      },
+    });
+
+    const preloadedDatasets = {
+      [mainCard.id]: mainDataset,
+      [seriesCard.id]: seriesDataset,
+    };
+
+    const initialState = getInitialStateForVisualizerCard(
+      dashcard,
+      preloadedDatasets,
+    );
+
+    expect(initialState.preloadedDatasets).toEqual(preloadedDatasets);
+  });
+});

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -15,7 +15,7 @@ import type {
   DraggedItem,
   VisualizerState,
   VisualizerVizDefinitionWithColumns,
-  VisualizerVizDefinitionWithColumnsAndFallbacks,
+  VisualizerVizDefinitionWithColumnsAndPreloadedDatasets,
 } from "metabase/redux/store/visualizer";
 import { createAsyncThunk, createThunkAction } from "metabase/redux/utils";
 import { clone } from "metabase/utils/clone";
@@ -97,7 +97,7 @@ function getInitialState(): VisualizerState {
 
 type InitVisualizerPayload =
   | {
-      state?: Partial<VisualizerVizDefinitionWithColumns>;
+      state?: Partial<VisualizerVizDefinitionWithColumnsAndPreloadedDatasets>;
     }
   | { cardId: CardId };
 
@@ -121,7 +121,7 @@ const initializeFromState = async (
   {
     state: initialState = {},
   }: {
-    state?: Partial<VisualizerVizDefinitionWithColumnsAndFallbacks>;
+    state?: Partial<VisualizerVizDefinitionWithColumnsAndPreloadedDatasets>;
   },
   dispatch: Dispatch,
 ) => {
@@ -140,7 +140,7 @@ const initializeFromState = async (
           dispatch(
             fetchCardQuery({
               cardId: Number(cardId),
-              fallbacks: initialState.datasetFallbacks,
+              preloadedDatasets: initialState.preloadedDatasets,
             }),
           ),
         ];
@@ -279,26 +279,26 @@ const fetchCard = createAsyncThunk<Card, CardId>(
 
 const fetchCardQuery = createAsyncThunk<
   Dataset,
-  { cardId: CardId; fallbacks?: Record<CardId, Dataset | null | undefined> }
->("visualizer/fetchCardQuery", async ({ cardId, fallbacks }, { dispatch }) => {
-  const result = await dispatch(
-    cardApi.endpoints.getCardQuery.initiate({ cardId, parameters: [] }),
-  );
-  if (result.data != null) {
-    const shouldAttemptFallback =
-      result.data.error_type &&
-      !result.data.data?.rows?.length &&
-      !result.data.data?.cols?.length;
-    if (shouldAttemptFallback) {
-      const fallback = fallbacks?.[cardId];
-      if (fallback) {
-        return fallback;
-      }
-    }
-    return result.data;
+  {
+    cardId: CardId;
+    preloadedDatasets?: Record<CardId, Dataset | null | undefined>;
   }
-  throw new Error("Failed to fetch card query");
-});
+>(
+  "visualizer/fetchCardQuery",
+  async ({ cardId, preloadedDatasets }, { dispatch }) => {
+    const dataset = preloadedDatasets?.[cardId];
+    if (dataset) {
+      return dataset;
+    }
+    const result = await dispatch(
+      cardApi.endpoints.getCardQuery.initiate({ cardId, parameters: [] }),
+    );
+    if (result.data != null) {
+      return result.data;
+    }
+    throw new Error("Failed to fetch card query");
+  },
+);
 
 export const undo = createAction("visualizer/undo");
 export const redo = createAction("visualizer/redo");

--- a/frontend/src/metabase/visualizer/visualizer.slice.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.unit.spec.ts
@@ -1,0 +1,100 @@
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import {
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+} from "__support__/server-mocks";
+import { Api } from "metabase/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import {
+  initializeVisualizer,
+  reducer as visualizerReducer,
+} from "./visualizer.slice";
+
+function setup() {
+  return getStore(
+    {
+      [Api.reducerPath]: Api.reducer,
+      visualizer: visualizerReducer,
+    },
+    {},
+    [Api.middleware],
+  );
+}
+
+describe("visualizer slice", () => {
+  describe("initializeVisualizer", () => {
+    it("should use preloaded dashboard datasets instead of refetching unfiltered card queries", async () => {
+      const card = createMockCard({
+        id: 1,
+        name: "Filtered card",
+        display: "table",
+      });
+
+      const filteredDataset = createMockDataset({
+        data: createMockDatasetData({
+          rows: [["Gadget", 10]],
+          cols: [
+            createMockColumn({ name: "Category" }),
+            createMockColumn({ name: "Count" }),
+          ],
+        }),
+      });
+
+      const unfilteredDataset = createMockDataset({
+        data: createMockDatasetData({
+          rows: [
+            ["Doohickey", 5],
+            ["Gadget", 10],
+          ],
+          cols: [
+            createMockColumn({ name: "Category" }),
+            createMockColumn({ name: "Count" }),
+          ],
+        }),
+      });
+
+      setupCardEndpoints(card);
+      setupCardQueryEndpoints(card, unfilteredDataset);
+
+      const store = setup();
+
+      await store.dispatch(
+        initializeVisualizer({
+          state: {
+            display: "table",
+            columns: [],
+            columnValuesMapping: {
+              COLUMN_1: [
+                {
+                  name: "COLUMN_1",
+                  originalName: "Category",
+                  sourceId: "card:1",
+                },
+              ],
+            },
+            settings: {},
+            preloadedDatasets: {
+              [card.id]: filteredDataset,
+            },
+          },
+        }),
+      );
+
+      expect(
+        store.getState().visualizer.present.datasets["card:1"].data.rows,
+      ).toEqual(filteredDataset.data.rows);
+
+      expect(
+        fetchMock.callHistory.called(`path:/api/card/${card.id}/query`),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #64468: this issue has the best description of the bug's root cause and repro steps
Closes #73152: same root cause as #64468, less detailed repro steps
Closes #70839: same root cause as #64468, presented as a feature request - even if it doesn't prevent them from saving viz settings, users expect that the data in the Visualizer matches the data shown in the dashboard

### Description

The Visualizer does not always display the same dataset that's displayed in the dashboard. #61230 partially fixed this by having DashCards pass their datasets into the Visualizer's initial state. However, #61230 used those datasets as a fallback - it was intended only to solve the case where a missing dashboard filter parameter led to invalid SQL.

This PR instead uses those datasets as the primary source for Visualizer when available. That fixes the bug where a dataset with zero rows prevents users from saving updated viz settings, and matches user expectations that what they see in Visualizer should match what they see in the dashboard.

There are still cases (e.g. `addDataSource`) where `fetchCardQuery` is not called with `preloadedDatasets` and will fall back to using the `getCardQuery` endpoint. This is correct behavior - a card that has just been added to the dashboard has no filter parameters attached to it, so `getCardQuery` provides the correct results.

### How to verify

1. Follow the steps in #64468 or the below demo
2. Verify that the chart shown in the visualizer matches the chart in the dashboard, and that you can update and save viz settings

### Demo

[Loom](https://www.loom.com/share/6034c4e11f7d41ff82259121a722440e)

[Stats repro](https://stats.metabase.com/dashboard/9300-73152-64468-dash)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
