### PR TITLE
Render transform job details before the transform plan loads

### DIFF
--- a/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
@@ -27,6 +27,7 @@ type JobEditorProps = {
   menu?: ReactNode;
   actions?: ReactNode;
   readOnly?: boolean;
+  isCheckingPermissions?: boolean;
   onNameChange: (name: string) => void;
   onScheduleChange: (
     schedule: string,
@@ -40,6 +41,7 @@ export function JobEditor({
   menu,
   actions,
   readOnly,
+  isCheckingPermissions,
   onNameChange,
   onScheduleChange,
   onTagListChange,
@@ -86,6 +88,7 @@ export function JobEditor({
         <ScheduleSection
           job={job}
           readOnly={readOnly}
+          isCheckingPermissions={isCheckingPermissions}
           onScheduleChange={onScheduleChange}
         />
         <TagSection

--- a/frontend/src/metabase/transforms/components/JobEditor/ScheduleSection/ScheduleSection.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/ScheduleSection/ScheduleSection.tsx
@@ -21,6 +21,7 @@ import type { TransformJobInfo } from "../types";
 type ScheduleSectionProps = {
   job: TransformJobInfo;
   readOnly?: boolean;
+  isCheckingPermissions?: boolean;
   onScheduleChange: (
     schedule: string,
     uiDisplayType: ScheduleDisplayType,
@@ -30,6 +31,7 @@ type ScheduleSectionProps = {
 export function ScheduleSection({
   job,
   readOnly,
+  isCheckingPermissions,
   onScheduleChange,
 }: ScheduleSectionProps) {
   return (
@@ -48,7 +50,11 @@ export function ScheduleSection({
           run={job?.last_run ?? null}
           neverRunMessage={t`This job hasn’t been run before.`}
         />
-        <RunButtonSection job={job} readOnly={readOnly} />
+        <RunButtonSection
+          job={job}
+          readOnly={readOnly}
+          isCheckingPermissions={isCheckingPermissions}
+        />
       </Group>
     </TitleSection>
   );
@@ -115,15 +121,23 @@ function ScheduleWidget({ job, onChangeSchedule }: ScheduleWidgetProps) {
 type RunButtonSectionProps = {
   job: TransformJobInfo;
   readOnly?: boolean;
+  isCheckingPermissions?: boolean;
 };
 
-function RunButtonSection({ job, readOnly }: RunButtonSectionProps) {
+function RunButtonSection({
+  job,
+  readOnly,
+  isCheckingPermissions,
+}: RunButtonSectionProps) {
   const [runJob] = useRunTransformJobMutation();
   const { sendErrorToast } = useMetadataToasts();
   const isSaved = job.id != null;
   const hasTags = job.tag_ids?.length !== 0;
 
   const tooltipLabel = (() => {
+    if (isCheckingPermissions) {
+      return t`Checking permissions…`;
+    }
     if (!hasTags) {
       return t`This job doesn't have tags to run.`;
     }
@@ -152,6 +166,7 @@ function RunButtonSection({ job, readOnly }: RunButtonSectionProps) {
         id={job.id}
         run={job.last_run}
         isDisabled={!isSaved || !hasTags || readOnly}
+        isLoading={isCheckingPermissions}
         onRun={handleRun}
       />
     </Tooltip>

--- a/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
+++ b/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
@@ -115,14 +115,6 @@ function getRunButtonInfo({
   isLoading,
   isDisabled,
 }: RunButtonOpts): RunButtonInfo {
-  if (isLoading && run?.status !== "started" && run?.status !== "canceling") {
-    return {
-      label: t`Run now`,
-      leftSection: <Loader size="sm" />,
-      isDisabled: true,
-    };
-  }
-
   if (run?.status === "started") {
     return {
       label: t`Running now…`,
@@ -136,6 +128,14 @@ function getRunButtonInfo({
       label: t`Canceling…`,
       leftSection: <Loader size="sm" />,
       color: "text-secondary",
+      isDisabled: true,
+    };
+  }
+
+  if (isLoading) {
+    return {
+      label: t`Run now`,
+      leftSection: <Loader size="sm" />,
       isDisabled: true,
     };
   }

--- a/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
+++ b/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
@@ -24,6 +24,7 @@ type RunButtonProps = {
   id: TransformId | TransformJobId | undefined;
   run: TransformRun | null | undefined;
   isDisabled?: boolean;
+  isLoading?: boolean;
   allowCancellation?: boolean;
   size?: ButtonProps["size"];
   onRun: () => void;
@@ -35,6 +36,7 @@ export const RunButton = forwardRef(function RunButton(
     id,
     run,
     isDisabled: isExternallyDisabled = false,
+    isLoading = false,
     allowCancellation = false,
     size = "md",
     onRun,
@@ -47,6 +49,7 @@ export const RunButton = forwardRef(function RunButton(
   const { label, color, leftSection, isDisabled } = getRunButtonInfo({
     run,
     isRecent,
+    isLoading,
     isDisabled: isExternallyDisabled || !!isMeterLocked,
   });
 
@@ -95,6 +98,7 @@ export const RunButton = forwardRef(function RunButton(
 type RunButtonOpts = {
   run: TransformRun | null | undefined;
   isRecent: boolean;
+  isLoading: boolean;
   isDisabled: boolean;
 };
 
@@ -108,8 +112,17 @@ type RunButtonInfo = {
 function getRunButtonInfo({
   run,
   isRecent,
+  isLoading,
   isDisabled,
 }: RunButtonOpts): RunButtonInfo {
+  if (isLoading && run?.status !== "started" && run?.status !== "canceling") {
+    return {
+      label: t`Run now`,
+      leftSection: <Loader size="sm" />,
+      isDisabled: true,
+    };
+  }
+
   if (run?.status === "started") {
     return {
       label: t`Running now…`,

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
@@ -51,14 +51,12 @@ export function JobPage({ params }: JobPageProps) {
 
   const { transformsDatabases, isLoadingDatabases, databasesError } =
     useTransformPermissions();
-  const {
-    data: transforms,
-    isLoading: isLoadingTransforms,
-    error: transformsError,
-  } = useListTransformJobTransformsQuery(jobId || skipToken);
+  const { data: transforms, isLoading: isLoadingTransforms } =
+    useListTransformJobTransformsQuery(jobId || skipToken);
+  const isCheckingPermissions = isLoadingTransforms;
   const readOnly = useMemo(() => {
     if (!transformsDatabases || !transforms) {
-      return;
+      return true;
     }
     return !transforms.every((t) => canEditTransform(t, transformsDatabases));
   }, [transforms, transformsDatabases]);
@@ -67,9 +65,8 @@ export function JobPage({ params }: JobPageProps) {
     setIsPolling(isPollingNeeded(job));
   }
 
-  const isLoading = isLoadingJob || isLoadingDatabases || isLoadingTransforms;
-  const error = jobError || databasesError || transformsError;
-
+  const isLoading = isLoadingJob || isLoadingDatabases;
+  const error = jobError || databasesError;
   if (isLoading || error != null || job == null) {
     return (
       <Center h="100%">
@@ -78,15 +75,26 @@ export function JobPage({ params }: JobPageProps) {
     );
   }
 
-  return <JobPageBody job={job} readOnly={readOnly} />;
+  return (
+    <JobPageBody
+      job={job}
+      readOnly={readOnly}
+      isCheckingPermissions={isCheckingPermissions}
+    />
+  );
 }
 
 type JobPageBodyProps = {
   job: TransformJob;
   readOnly?: boolean;
+  isCheckingPermissions?: boolean;
 };
 
-function JobPageBody({ job, readOnly }: JobPageBodyProps) {
+function JobPageBody({
+  job,
+  readOnly,
+  isCheckingPermissions,
+}: JobPageBodyProps) {
   const [updateJob] = useUpdateTransformJobMutation();
   const { sendErrorToast, sendSuccessToast, sendUndoToast } =
     useMetadataToasts();
@@ -151,6 +159,7 @@ function JobPageBody({ job, readOnly }: JobPageBodyProps) {
       job={job}
       menu={!readOnly && <JobMoreMenu job={job} />}
       readOnly={readOnly}
+      isCheckingPermissions={isCheckingPermissions}
       onNameChange={handleNameChange}
       onScheduleChange={handleScheduleChange}
       onTagListChange={handleTagListChange}

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
@@ -53,7 +53,6 @@ export function JobPage({ params }: JobPageProps) {
     useTransformPermissions();
   const { data: transforms, isLoading: isLoadingTransforms } =
     useListTransformJobTransformsQuery(jobId || skipToken);
-  const isCheckingPermissions = isLoadingTransforms;
   const readOnly = useMemo(() => {
     if (!transformsDatabases || !transforms) {
       return true;
@@ -79,7 +78,7 @@ export function JobPage({ params }: JobPageProps) {
     <JobPageBody
       job={job}
       readOnly={readOnly}
-      isCheckingPermissions={isCheckingPermissions}
+      isCheckingPermissions={isLoadingTransforms}
     />
   );
 }

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
@@ -4,12 +4,11 @@ import { Route } from "react-router";
 import { setupDatabaseListEndpoint } from "__support__/server-mocks";
 import {
   setupGetTransformJobEndpoint,
-  setupListTransformJobTransformsEndpoint,
   setupListTransformTagsEndpoint,
 } from "__support__/server-mocks/transform";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import { act, renderWithProviders, screen, within } from "__support__/ui";
 import * as Urls from "metabase/urls";
-import type { Transform, TransformJob } from "metabase-types/api";
+import type { TransformJob } from "metabase-types/api";
 import {
   createMockDatabase,
   createMockTransformJob,
@@ -17,69 +16,58 @@ import {
 
 import { JobPage } from "./JobPage";
 
-type Deferred = {
-  promise: Promise<Transform[]>;
-  resolve: (transforms: Transform[]) => void;
-};
-
-function deferred(): Deferred {
-  let resolve!: (transforms: Transform[]) => void;
-  const promise = new Promise<Transform[]>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
-}
+const TRANSFORMS_DELAY = 1000;
 
 type SetupOpts = {
   job?: TransformJob;
-  // When provided, the transform plan endpoint stays pending until the deferred
-  // is resolved, simulating the slow (10+ seconds) response
-  pendingTransforms?: Deferred;
+  transformsDelay?: number;
 };
 
-function setup({
+const setup = ({
   job = createMockTransformJob({ id: 1, name: "My Job" }),
-  pendingTransforms,
-}: SetupOpts = {}) {
+  transformsDelay = 0,
+}: SetupOpts = {}) => {
   setupGetTransformJobEndpoint(job);
   setupDatabaseListEndpoint([createMockDatabase()]);
   setupListTransformTagsEndpoint([]);
-
-  if (pendingTransforms) {
-    fetchMock.get(
-      `path:/api/transform-job/${job.id}/transforms`,
-      pendingTransforms.promise,
-    );
-  } else {
-    setupListTransformJobTransformsEndpoint(job.id, []);
-  }
+  fetchMock.get(`path:/api/transform-job/${job.id}/transforms`, [], {
+    delay: transformsDelay,
+  });
 
   const path = Urls.transformJob(job.id);
   renderWithProviders(
     <Route path="/data-studio/transforms/jobs/:jobId" component={JobPage} />,
     { withRouter: true, initialRoute: path },
   );
-}
+};
 
 describe("JobPage", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("renders the job details before the transform plan resolves", async () => {
-    const pendingTransforms = deferred();
-    setup({ pendingTransforms });
+    jest.useFakeTimers({ advanceTimers: true });
+    setup({ transformsDelay: TRANSFORMS_DELAY });
 
     // The job header and its details render without waiting for the slow
-    // transforms endpoint, which is still pending here.
+    // transforms endpoint.
     const header = await screen.findByTestId("jobs-header");
     expect(within(header).getByDisplayValue("My Job")).toBeInTheDocument();
     expect(screen.getByText("Transforms")).toBeInTheDocument();
 
-    // The transforms list itself has not loaded yet, and editing stays locked
-    // while permissions are still being checked.
+    // The transforms list hasn't loaded yet, and editing stays locked while
+    // permissions are still being checked.
     expect(
       screen.queryByText("There are no transforms for this job."),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("run-button")).toBeDisabled();
 
-    pendingTransforms.resolve([]);
+    act(() => {
+      jest.advanceTimersByTime(TRANSFORMS_DELAY);
+    });
+
+    // Once the plan resolves, the transforms list renders and editing unlocks.
     expect(
       await screen.findByText("There are no transforms for this job."),
     ).toBeInTheDocument();

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
@@ -1,0 +1,88 @@
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import { setupDatabaseListEndpoint } from "__support__/server-mocks";
+import {
+  setupGetTransformJobEndpoint,
+  setupListTransformJobTransformsEndpoint,
+  setupListTransformTagsEndpoint,
+} from "__support__/server-mocks/transform";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import * as Urls from "metabase/urls";
+import type { Transform, TransformJob } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockTransformJob,
+} from "metabase-types/api/mocks";
+
+import { JobPage } from "./JobPage";
+
+type Deferred = {
+  promise: Promise<Transform[]>;
+  resolve: (transforms: Transform[]) => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: (transforms: Transform[]) => void;
+  const promise = new Promise<Transform[]>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+type SetupOpts = {
+  job?: TransformJob;
+  // When provided, the transform plan endpoint stays pending until the deferred
+  // is resolved, simulating the slow (10+ seconds) response
+  pendingTransforms?: Deferred;
+};
+
+function setup({
+  job = createMockTransformJob({ id: 1, name: "My Job" }),
+  pendingTransforms,
+}: SetupOpts = {}) {
+  setupGetTransformJobEndpoint(job);
+  setupDatabaseListEndpoint([createMockDatabase()]);
+  setupListTransformTagsEndpoint([]);
+
+  if (pendingTransforms) {
+    fetchMock.get(
+      `path:/api/transform-job/${job.id}/transforms`,
+      pendingTransforms.promise,
+    );
+  } else {
+    setupListTransformJobTransformsEndpoint(job.id, []);
+  }
+
+  const path = Urls.transformJob(job.id);
+  renderWithProviders(
+    <Route path="/data-studio/transforms/jobs/:jobId" component={JobPage} />,
+    { withRouter: true, initialRoute: path },
+  );
+}
+
+describe("JobPage", () => {
+  it("renders the job details before the transform plan resolves", async () => {
+    const pendingTransforms = deferred();
+    setup({ pendingTransforms });
+
+    // The job header and its details render without waiting for the slow
+    // transforms endpoint, which is still pending here.
+    const header = await screen.findByTestId("jobs-header");
+    expect(within(header).getByDisplayValue("My Job")).toBeInTheDocument();
+    expect(screen.getByText("Transforms")).toBeInTheDocument();
+
+    // The transforms list itself has not loaded yet, and editing stays locked
+    // while permissions are still being checked.
+    expect(
+      screen.queryByText("There are no transforms for this job."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("run-button")).toBeDisabled();
+
+    pendingTransforms.resolve([]);
+    expect(
+      await screen.findByText("There are no transforms for this job."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("run-button")).toBeEnabled();
+  });
+});


### PR DESCRIPTION
Closes [GDGT-2595](https://linear.app/metabase/issue/GDGT-2595)

### Description

Previously, opening a transform job's details page (`data-studio/transforms/jobs/:id`) showed a full-screen spinner until *every* query resolved — including the transform plan endpoint (`/api/transform-job/:id/transforms`), which computes the job's execution plan and can take 10+ seconds. So the whole page sat blank waiting on the slowest call, even though the job's name, schedule, and tags are already available almost immediately.

`JobPage` now only blocks on the fast `job` and `databases` queries; the job header, schedule, and tag sections render right away. The transform plan loads independently inside `TransformsSection`, which already owns its own loading and error states — so a slow (or failing) plan no longer holds the rest of the page hostage, and a plan error surfaces in that section instead of blowing up the whole page.

One wrinkle: the run button and the editing controls are gated by `readOnly`, which is derived from the transform plan (it checks that every transform's source DB is writable). To avoid a window where a read-only user sees enabled controls, editing stays **locked** while the plan loads.

### How to verify

1. Open a transform job. To simulate the slow plan, throttle the `/api/transform-job/:id/transforms` request in your browser dev tools.
2. The job name, schedule, and tags should render immediately — no full-page spinner.
3. The Transforms section should show its own loading state while the plan loads.
4. During that window, the run button is disabled and its tooltip reads "Checking permissions…" (not "you don't have permission…").
5. Once the plan loads, the run button unlocks to its real permission state.

### Demo

Before:

https://github.com/user-attachments/assets/3f48a1a5-cf10-4ffd-b18c-200cb960c764

After:

https://github.com/user-attachments/assets/eac5a6d5-5fbd-473d-b12d-74269a471b44


### Checklist

- [x] Tests have been added/updated to cover changes in this PR