### PR TITLE
Missed spots with deprecating /mcp route

### DIFF
--- a/src/metabase/oauth_server/api/metadata.clj
+++ b/src/metabase/oauth_server/api/metadata.clj
@@ -73,10 +73,11 @@
   []
   (protected-resource-metadata "/api/mcp"))
 
-;; Some clients probe the bare resource path instead of the resource-specific one; serve the same metadata here so
-;; the request doesn't fall through to the SPA's HTML catch-all and trip a `JSON.parse` error (BOT-1617).
+;; Some clients probe the bare resource path instead of the resource-specific one; serve metadata here so the
+;; request doesn't fall through to the SPA's HTML catch-all and trip a `JSON.parse` error (BOT-1617). Advertise the
+;; canonical `/api/metabase-mcp` resource, matching the URL clients are now told to use.
 (api.macros/defendpoint :get "/oauth-protected-resource"
   :- resource-metadata-response-schema
   "Returns OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint."
   []
-  (protected-resource-metadata "/api/mcp"))
+  (protected-resource-metadata "/api/metabase-mcp"))

--- a/src/metabase/server/middleware/misc.clj
+++ b/src/metabase/server/middleware/misc.clj
@@ -62,17 +62,15 @@
 (defn- forwarded-scheme
   "The scheme a TLS-terminating proxy used to reach us, inferred from the same forwarded headers as [[u/https?]]."
   [{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https]}]
-  (cond
-    ;; Proto-style headers carry the scheme directly. Take the first hop of a comma-separated chain (`https, http`)
-    ;; and lower-case it: URL schemes are case-insensitive (RFC 3986) but normalize-site-url's "http" prefix check
-    ;; is not, so `HTTPS` would be mangled as scheme-less.
-    (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
-    (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
-            (str/split #",") first str/trim not-empty u/lower-case-en)
-
-    ;; Boolean-style headers are `on` when the original request was HTTPS.
-    (or x-forwarded-ssl front-end-https)
-    (when (= "on" (u/lower-case-en (or x-forwarded-ssl front-end-https))) "https")))
+  ;; Proto-style headers carry the scheme directly. Take the first hop of a comma-separated chain (`https, http`)
+  ;; and lower-case it: URL schemes are case-insensitive (RFC 3986) but normalize-site-url's "http" prefix check
+  ;; is not, so `HTTPS` would be mangled as scheme-less. Normalize first and branch on the result so a blank
+  ;; proto header (e.g. `X-Forwarded-Proto: ""`) falls through to the boolean-style HTTPS indicators below.
+  (or (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+              (str/split #",") first str/trim not-empty u/lower-case-en)
+      ;; Boolean-style headers are `on` when the original request was HTTPS.
+      (when-let [ssl (or x-forwarded-ssl front-end-https)]
+        (when (= "on" (u/lower-case-en ssl)) "https"))))
 
 (defn- maybe-set-site-url* [{headers :headers, uri :uri}]
   (let [{:strs [origin x-forwarded-host host user-agent]} headers]

--- a/src/metabase/server/middleware/misc.clj
+++ b/src/metabase/server/middleware/misc.clj
@@ -60,32 +60,41 @@
 ;; Effectively the very first API request that gets sent to us (usually some sort of setup request) ends up setting
 ;; the (initial) value of `site-url`
 (defn- forwarded-scheme
-  "The scheme a TLS-terminating proxy used to reach us, from `X-Forwarded-Proto`."
-  [x-forwarded-proto]
-  ;; first hop of a comma-separated chain (`https, http`), lower-cased: URL schemes are case-insensitive
-  ;; (RFC 3986) but normalize-site-url's "http" prefix check is not, so `HTTPS` would be mangled as scheme-less.
-  (some-> x-forwarded-proto (str/split #",") first str/trim not-empty u/lower-case-en))
+  "The scheme a TLS-terminating proxy used to reach us, inferred from the same forwarded headers as [[u/https?]]."
+  [{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https]}]
+  (cond
+    ;; Proto-style headers carry the scheme directly. Take the first hop of a comma-separated chain (`https, http`)
+    ;; and lower-case it: URL schemes are case-insensitive (RFC 3986) but normalize-site-url's "http" prefix check
+    ;; is not, so `HTTPS` would be mangled as scheme-less.
+    (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+    (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+            (str/split #",") first str/trim not-empty u/lower-case-en)
 
-(defn- maybe-set-site-url* [{{:strs [origin x-forwarded-host x-forwarded-proto host user-agent]} :headers, uri :uri}]
-  (when (and (mdb/db-is-set-up?)
-             (not (system/site-url))
-             (not (#{"/api/health" "/livez" "/readyz"} uri))
-             (or (nil? user-agent) ((complement str/includes?) user-agent "HealthChecker")))
-    ;; `origin` already carries a scheme; the `*-host` headers normally don't, so prepend the scheme the proxy
-    ;; terminated TLS with -- otherwise `normalize-site-url` defaults to `http://` and a TLS-terminating proxy ends
-    ;; up advertising `http://` auth/discovery URLs over an `https` origin, breaking MCP OAuth (BOT-1617). Only
-    ;; prepend when the host is scheme-less; a scheme-bearing host passes through untouched.
-    (when-let [site-url (or origin
-                            (when-let [host (or x-forwarded-host host)]
-                              (if-let [scheme (and (not (str/includes? host "://"))
-                                                   (forwarded-scheme x-forwarded-proto))]
-                                (str scheme "://" host)
-                                host)))]
-      (log/infof "Setting Metabase site URL to %s" site-url)
-      (try
-        (system/site-url! site-url)
-        (catch Throwable e
-          (log/warn e "Failed to set site-url"))))))
+    ;; Boolean-style headers are `on` when the original request was HTTPS.
+    (or x-forwarded-ssl front-end-https)
+    (when (= "on" (u/lower-case-en (or x-forwarded-ssl front-end-https))) "https")))
+
+(defn- maybe-set-site-url* [{headers :headers, uri :uri}]
+  (let [{:strs [origin x-forwarded-host host user-agent]} headers]
+    (when (and (mdb/db-is-set-up?)
+               (not (system/site-url))
+               (not (#{"/api/health" "/livez" "/readyz"} uri))
+               (or (nil? user-agent) ((complement str/includes?) user-agent "HealthChecker")))
+      ;; `origin` already carries a scheme; the `*-host` headers normally don't, so prepend the scheme the proxy
+      ;; terminated TLS with -- otherwise `normalize-site-url` defaults to `http://` and a TLS-terminating proxy ends
+      ;; up advertising `http://` auth/discovery URLs over an `https` origin, breaking MCP OAuth (BOT-1617). Only
+      ;; prepend when the host is scheme-less; a scheme-bearing host passes through untouched.
+      (when-let [site-url (or origin
+                              (when-let [host (or x-forwarded-host host)]
+                                (if-let [scheme (and (not (str/includes? host "://"))
+                                                     (forwarded-scheme headers))]
+                                  (str scheme "://" host)
+                                  host)))]
+        (log/infof "Setting Metabase site URL to %s" site-url)
+        (try
+          (system/site-url! site-url)
+          (catch Throwable e
+            (log/warn e "Failed to set site-url")))))))
 
 (defn maybe-set-site-url
   "Middleware to set the `site-url` setting on the initial setup request"

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -50,12 +50,12 @@
                     response))))))))
 
 (deftest protected-resource-metadata-bare-path-test
-  (testing "GET /.well-known/oauth-protected-resource (no resource suffix) serves the same metadata as JSON (BOT-1617)"
+  (testing "GET /.well-known/oauth-protected-resource (no resource suffix) serves JSON advertising the canonical resource (BOT-1617)"
     (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
       (let [response (mt/user-http-request :crowberto :get 200
                                            ".well-known/oauth-protected-resource")]
-        (is (=? {:resource                "http://localhost:3000/api/mcp"
-                 :authorization_servers   ["http://localhost:3000"]
+        (is (=? {:resource                 "http://localhost:3000/api/metabase-mcp"
+                 :authorization_servers    ["http://localhost:3000"]
                  :bearer_methods_supported ["header"]}
                 response))))))
 

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -70,6 +70,16 @@
       (maybe-set-site-url (-> (mock-request "/" nil "mb.example.com" nil)
                               (ring.mock/header "X-Forwarded-Proto" "https, http")))
       (is (= "https://mb.example.com" (system/site-url)))))
+  (testing "the alternate HTTPS-indicator headers `u/https?` recognizes also seed the scheme"
+    (doseq [[header value] [["X-Forwarded-Protocol" "https"]
+                            ["X-URL-Scheme"         "https"]
+                            ["X-Forwarded-Ssl"      "on"]
+                            ["Front-End-Https"      "on"]]]
+      (testing header
+        (mt/with-temporary-setting-values [site-url nil]
+          (maybe-set-site-url (-> (mock-request "/" nil "mb.example.com" nil)
+                                  (ring.mock/header header value)))
+          (is (= "https://mb.example.com" (system/site-url)))))))
   (testing "without `X-Forwarded-Proto`, a scheme-less host falls back to http:// (unchanged behavior)"
     (mt/with-temporary-setting-values [site-url nil]
       (maybe-set-site-url (mock-request "/" nil "mb.example.com" nil))


### PR DESCRIPTION
## Summary

Follow-up to #75025 (canonical `/api/metabase-mcp` route) and #75110 (proxy OAuth discovery).

## Changes

- **`oauth_server/api/metadata.clj`** — the bare `/.well-known/oauth-protected-resource` fallback advertised the legacy `/api/mcp` as `:resource`. A client probing the bare path for the now-canonical URL would get a `resource` that doesn't match the server it's connecting to. Advertise the canonical `/api/metabase-mcp` instead.

- **`server/middleware/misc.clj`** — `forwarded-scheme` only honored `X-Forwarded-Proto`. Deployments fronted by a proxy that sets one of the other HTTPS-indicator headers `util/https?` already recognizes (`X-Forwarded-Protocol`, `X-URL-Scheme`, `X-Forwarded-Ssl`, `Front-End-Https`) with a scheme-less host would still auto-seed `site-url` as `http://`, leaving OAuth discovery broken. Honor the same header set, keeping the comma-chain / case-insensitive handling.

## Testing

`metabase.server.middleware.misc-test` and `metabase.oauth-server.api-test` — 56 tests, 193 assertions, all green. New cases cover the bare-path canonical resource and each alternate HTTPS-indicator header.

## Backport

Should backport to 60/61/62, but **only after** #75493 / #75494 / #75495 land (this builds on the canonical endpoint they add). I'll line that up once they merge rather than triggering it prematurely.