### PR TITLE
Support `single-backport` escape hatch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
+> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
 
 > **Warning**
 >

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -76,19 +76,23 @@ jobs:
           github-token-2: ${{ secrets.GITHUB_TOKEN }}
 
   # --- Legacy escape hatch: explicit depth backports -----------------------
-  # `double-backport`/`triple-backport` keep their original behavior — backport to
-  # CURRENT_VERSION and the 1–2 lines below it — independent of `major_version_support`.
-  # Kept for the short term for one-off manual depth control. If a branch from the
-  # primary path above already exists, create-backport simply errors on the duplicate.
+  # `single-backport`/`double-backport`/`triple-backport` keep their original behavior —
+  # backport to CURRENT_VERSION and the 0–2 lines below it — independent of
+  # `major_version_support`. `single-backport` is a fallback for when the primary path
+  # can't be used and only CURRENT_VERSION is wanted. Kept for the short term for one-off
+  # manual depth control. If a branch from the primary path above already exists,
+  # create-backport simply errors on the duplicate.
   legacy-backport:
     if:
       | # triggered only by the legacy depth labels, at merge or when added afterwards
       github.event.pull_request.merged == true && (
         github.event.action == 'closed' && (
+          contains(github.event.pull_request.labels.*.name, 'single-backport') ||
           contains(github.event.pull_request.labels.*.name, 'double-backport') ||
           contains(github.event.pull_request.labels.*.name, 'triple-backport')
         ) ||
         github.event.action == 'labeled' && (
+          github.event.label.name == 'single-backport' ||
           github.event.label.name == 'double-backport' ||
           github.event.label.name == 'triple-backport'
         )


### PR DESCRIPTION
Resolves DEV-2150

Going forward, you can use a `single-backport` label if you only need to backport to the currently active release-x.NN.x branch.