### PR TITLE
Update Backport Reminder

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -195,6 +195,10 @@ documentation:
   - "docs/**"
   - "**/*.md"
 
+# Used only in .github/workflows/backport-reminder.yml
+docs:
+  - "docs/**"
+
 embedding_documentation:
   - ".typedoc/**"
   - "docs/embedding/**"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -195,7 +195,6 @@ documentation:
   - "docs/**"
   - "**/*.md"
 
-# Used only in .github/workflows/backport-reminder.yml
 docs:
   - "docs/**"
 

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -50,7 +50,7 @@ jobs:
           needs.files-changed.outputs.docs == 'true' &&
           needs.flags.outputs.has_backport_label == 'false'
         run: |
-          echo "::error::PR is missing a backport decision label. Add one of: no-backport, backport, double-backport, triple-backport"
+          echo "::error::PR has docs changes and is missing a backport decision label. Add one of: no-backport, backport, single-backport, double-backport, or triple-backport"
           exit 1
 
   priority-backport-reminder:

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -5,11 +5,27 @@ on:
     types: [auto_merge_enabled, review_requested, labeled, unlabeled, synchronize]
     branches:
       - "master"
-  merge_group:
 
 jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 3
+    outputs:
+      docs: ${{ steps.changes.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test which files changed
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
+
   backport-reminder:
-    name: Decide whether to backport or not
+    needs: [ files-changed ]
+    if: ${{ !cancelled() }}
+    name: Decide whether to backport docs or not
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     permissions: {}
@@ -17,6 +33,7 @@ jobs:
       - name: Fail if backport decision label is missing
         if: >
           github.event_name == 'pull_request' &&
+          needs.files-changed.outputs.docs == 'true' &&
           !contains(github.event.pull_request.labels.*.name, 'no-backport') &&
           !contains(github.event.pull_request.labels.*.name, 'backport') &&
           !contains(github.event.pull_request.labels.*.name, 'double-backport') &&

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -2,11 +2,25 @@ name: Backport Reminder
 
 on:
   pull_request:
-    types: [auto_merge_enabled, review_requested, labeled, unlabeled, synchronize]
+    types: [opened, edited, auto_merge_enabled, review_requested, labeled, unlabeled, synchronize]
     branches:
       - "master"
 
 jobs:
+  flags:
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    outputs:
+      has_backport_label: ${{ steps.c.outputs.value }}
+    steps:
+      - id: c
+        run: |
+          echo "value=${{
+            contains(github.event.pull_request.labels.*.name, 'no-backport') ||
+            contains(github.event.pull_request.labels.*.name, 'backport') ||
+            contains(github.event.pull_request.labels.*.name, 'single-backport') ||
+            contains(github.event.pull_request.labels.*.name, 'double-backport') ||
+            contains(github.event.pull_request.labels.*.name, 'triple-backport') }}" >> "$GITHUB_OUTPUT"
+
   files-changed:
     name: Check which files changed
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -23,7 +37,7 @@ jobs:
           filters: .github/file-paths.yaml
 
   backport-reminder:
-    needs: [ files-changed ]
+    needs: [ files-changed, flags ]
     if: ${{ !cancelled() }}
     name: Decide whether to backport docs or not
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -34,10 +48,123 @@ jobs:
         if: >
           github.event_name == 'pull_request' &&
           needs.files-changed.outputs.docs == 'true' &&
-          !contains(github.event.pull_request.labels.*.name, 'no-backport') &&
-          !contains(github.event.pull_request.labels.*.name, 'backport') &&
-          !contains(github.event.pull_request.labels.*.name, 'double-backport') &&
-          !contains(github.event.pull_request.labels.*.name, 'triple-backport')
+          needs.flags.outputs.has_backport_label == 'false'
         run: |
           echo "::error::PR is missing a backport decision label. Add one of: no-backport, backport, double-backport, triple-backport"
           exit 1
+
+  priority-backport-reminder:
+    name: Remind about backporting P0 + P1 fixes
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    needs: [flags]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add, update, or remove the high-priority backport reminder
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v9
+        env:
+          HAS_BACKPORT_LABEL: ${{ needs.flags.outputs.has_backport_label }}
+        with:
+          script: | # js
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // A backport decision has already been made if a decision label is present.
+            const alreadyDecided = process.env.HAS_BACKPORT_LABEL === "true";
+
+            // Issues linked to this PR via closing keywords (fixes/closes/resolves #N),
+            // together with their labels.
+            const query = `
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                        title
+                        url
+                        labels(first: 50) { nodes { name } }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const data = await github.graphql(query, { owner, repo, pr: prNumber });
+            const linkedIssues =
+              data.repository.pullRequest.closingIssuesReferences.nodes ?? [];
+
+            const PRIORITY_LABELS = ["Priority:P0", "Priority:P1"];
+            const priorityIssues = linkedIssues.filter((issue) =>
+              issue.labels.nodes.some((l) => PRIORITY_LABELS.includes(l.name)),
+            );
+
+            // Hidden marker so we can find/update/remove our own comment idempotently.
+            const MARKER = "<!-- backport-priority-reminder -->";
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find(
+              (c) => c.body && c.body.includes(MARKER),
+            );
+
+            // Remind only while a high-priority issue is closed AND no decision
+            // has been made yet. Once either stops being true the comment is no
+            // longer needed, so we remove any stale one below.
+            const shouldComment = priorityIssues.length > 0 && !alreadyDecided;
+
+            if (!shouldComment) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                });
+                console.log("Removed stale backport-priority reminder.");
+              } else {
+                console.log(
+                  "Reminder not needed (no high-priority linked issues, or a backport decision label is already applied).",
+                );
+              }
+              return;
+            }
+
+            const list = priorityIssues
+              .map((i) => {
+                const tags = i.labels.nodes
+                  .map((l) => l.name)
+                  .filter((n) => PRIORITY_LABELS.includes(n))
+                  .join(", ");
+                return `- #${i.number} ${i.title} (${tags})`;
+              })
+              .join("\n");
+
+            const body = [
+              MARKER,
+              "⚠️ This PR closes one or more high-priority issues:",
+              "",
+              list,
+              "",
+              "Please apply the `backport` label unless you have a very good reason not to.",
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -39,7 +39,7 @@ jobs:
   backport-reminder:
     needs: [ files-changed, flags ]
     if: ${{ !cancelled() }}
-    name: Decide whether to backport docs or not
+    name: Decide whether to backport or not
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - "master"
 
+concurrency:
+  group: "backport-reminder-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
 jobs:
   flags:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}

--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -9,7 +9,7 @@ redirect_from:
 
 _Admin > AI_
 
-FIXME. This page covers admin settings for AI features in Metabase, including [Metabot](./metabot.md). To limit _who_ can use Metabot, see [AI controls](./usage-controls.md).
+This page covers admin settings for AI features in Metabase, including [Metabot](./metabot.md). To limit _who_ can use Metabot, see [AI controls](./usage-controls.md).
 
 ## Enable AI features
 

--- a/docs/ai/settings.md
+++ b/docs/ai/settings.md
@@ -9,7 +9,7 @@ redirect_from:
 
 _Admin > AI_
 
-This page covers admin settings for AI features in Metabase, including [Metabot](./metabot.md). To limit _who_ can use Metabot, see [AI controls](./usage-controls.md).
+FIXME. This page covers admin settings for AI features in Metabase, including [Metabot](./metabot.md). To limit _who_ can use Metabot, see [AI controls](./usage-controls.md).
 
 ## Enable AI features
 


### PR DESCRIPTION
Updates the Backport Reminder check so that it
- Auto-passes by default
- Does not auto-pass for PRs with docs changes (at @alexyarosh 's reques)
- Posts a reminder comment if it finds a PR that closes a P0 or P1 issue


Example comment:

<img width="946" height="316" alt="CleanShot 2026-06-09 at 10 25 52" src="https://github.com/user-attachments/assets/33fd1e7c-2c0e-4f12-b6cb-5d3546fd2084" />

