### PR TITLE
Surface curation signals to Metabot in search results

### DIFF
--- a/resources/metabot/prompts/llm_shape.selmer
+++ b/resources/metabot/prompts/llm_shape.selmer
@@ -273,7 +273,7 @@ or jargon that may be relevant to the user's questions.
 </user>
 {% endif %}
 {% if is_search_result %}
-<{{search_tag_name}} id="{{search_id}}" name="{{search_name}}"{% if search_has_verified %} is_verified="{{search_verified}}"{% endif %}{% if search_database_id %} database_id="{{search_database_id}}"{% endif %}{% if search_database_name %} database_name="{{search_database_name}}"{% endif %}{% if search_database_engine %} database_engine="{{search_database_engine}}"{% endif %}{% if search_fqn %} fully_qualified_name="{{search_fqn}}"{% endif %}{% if search_base_table_fqn %} base_table_fully_qualified_name="{{search_base_table_fqn}}"{% endif %}{% if search_portable_entity_id %} portable_entity_id="{{search_portable_entity_id}}"{% endif %}>
+<{{search_tag_name}} id="{{search_id}}" name="{{search_name}}"{% if search_has_curated %} is_curated="{{search_curated}}"{% endif %}{% if search_has_verified %} is_verified="{{search_verified}}"{% endif %}{% if search_has_official %} is_official="{{search_official}}"{% endif %}{% if search_data_layer %} data_layer="{{search_data_layer}}"{% endif %}{% if search_data_authority %} data_authority="{{search_data_authority}}"{% endif %}{% if search_database_id %} database_id="{{search_database_id}}"{% endif %}{% if search_database_name %} database_name="{{search_database_name}}"{% endif %}{% if search_database_engine %} database_engine="{{search_database_engine}}"{% endif %}{% if search_fqn %} fully_qualified_name="{{search_fqn}}"{% endif %}{% if search_base_table_fqn %} base_table_fully_qualified_name="{{search_base_table_fqn}}"{% endif %}{% if search_portable_entity_id %} portable_entity_id="{{search_portable_entity_id}}"{% endif %}>
 {% if search_description %}
 {{search_description}}
 {% endif %}

--- a/src/metabase/metabot/tools/search.clj
+++ b/src/metabase/metabot/tools/search.clj
@@ -28,10 +28,14 @@
 
 (defn- postprocess-search-result
   "Transform a single search result to match the appropriate entity-specific schema."
-  [{:keys [verified moderated_status collection] :as result}]
+  [{:keys [verified moderated_status collection data_authority curated data_layer] :as result}]
   (let [model (:model result)
         verified? (or (boolean verified) (= moderated_status "verified"))
         collection-info (select-keys collection [:id :name :authority_level])
+        ;; Curation signals beyond verified, so the LLM can see *why* content is curated. `:curated` is
+        ;; the precomputed rollup (present on the appdb/semantic engines); `:data_layer` is table-only.
+        ;; assoc-some keeps them off results that don't carry them (e.g. the in-place fallback).
+        official? (= "official" (:authority_level collection-info))
         common-fields {:id          (:id result)
                        :type        (metabot.search-models/search-model->entity-type model)
                        :name        (:name result)
@@ -43,26 +47,33 @@
       common-fields
 
       "table"
-      (merge common-fields
-             {:name            (:table_name result)
-              :display_name    (:name result)
-              :database_id     (:database_id result)
-              :database_schema (:table_schema result)})
+      (-> common-fields
+          (merge {:name            (:table_name result)
+                  :display_name    (:name result)
+                  :database_id     (:database_id result)
+                  :database_schema (:table_schema result)
+                  :official        official?
+                  :data_authority  data_authority})
+          (m/assoc-some :curated curated :data_layer data_layer))
 
       "dashboard"
-      (merge common-fields
-             {:verified    verified?
-              :collection  collection-info})
+      (-> common-fields
+          (merge {:verified   verified?
+                  :official   official?
+                  :collection collection-info})
+          (m/assoc-some :curated curated))
 
       "transform"
       (merge common-fields
              {:database_id (:database_id result)})
 
       ;; Questions, metrics, and datasets
-      (merge common-fields
-             {:database_id (:database_id result)
-              :verified    verified?
-              :collection  collection-info}))))
+      (-> common-fields
+          (merge {:database_id (:database_id result)
+                  :verified    verified?
+                  :official    official?
+                  :collection  collection-info})
+          (m/assoc-some :curated curated)))))
 
 (defn- enrich-with-collection-descriptions
   "Fetch and merge collection descriptions for all search results that have collection IDs."

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -652,10 +652,6 @@
                   (if (keyword? database_engine)
                     (clojure.core/name database_engine)
                     database_engine)))]
-    ;; TODO (Chris 2026-06-09) -- surface the other curation signals to the LLM (is_curated / official /
-    ;; in_library / data_layer), not just is_verified, so it can reason about why content is curated.
-    ;; The signals are on the search-index row; thread them through postprocess-search-result and add
-    ;; attributes here + in llm_shape.selmer. Run ai-benchmarks before landing — it changes model input.
     (render-llm-template
      :search_result
      {:search_tag_name (search-result-tag-name type)

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -636,7 +636,7 @@
    gives the LLM the full portable FK `[database_name, schema, table]` it must put in
    `source-table:` when using `[metric, {}, <portable_entity_id>]` as an aggregation —
    without a separate `entity_details` round-trip."
-  [{:keys [id type name description verified collection
+  [{:keys [id type name description verified official curated data_authority data_layer collection
            database_id database_name database_engine database_schema portable_entity_id
            base_table_portable_fk]}]
   (let [fqn (cond
@@ -663,6 +663,13 @@
       :search_name name
       :search_has_verified (some? verified)
       :search_verified verified
+      :search_has_official (some? official)
+      :search_official official
+      :search_has_curated (some? curated)
+      :search_curated curated
+      :search_data_layer (some-> data_layer clojure.core/name)
+      :search_data_authority (when (and data_authority (not= "unconfigured" (clojure.core/name data_authority)))
+                               (clojure.core/name data_authority))
       :search_description description
       :search_collection_name (:name collection)
       :search_database_id (when database_id (str database_id))

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -117,7 +117,9 @@
    ;; returned for Card and Action
    :dataset_query       :text
    ;; returned for Table
-   :is_published        :boolean))
+   :is_published        :boolean
+   :data_authority      :text
+   :data_layer          :text))
 
 (mu/defn- canonical-columns :- [:sequential HoneySQLColumn]
   "Returns a seq of lists of canonical columns for the search query with the given `model` Will return column names
@@ -264,9 +266,11 @@
         columns-to-search (->> all-search-columns
                                (filter (fn [[_k v]] (= v :text)))
                                (map first)
+                               ;; data_authority/data_layer are curation signals, not name/text fields —
+                               ;; exclude them from exact-match ranking (and to keep in-place ordering stable).
                                (remove #{:collection_authority_level :moderated_status
                                          :initial_sync_status :pk_ref :location
-                                         :collection_location}))
+                                         :collection_location :data_authority :data_layer}))
         case-clauses      (as-> columns-to-search <>
                             (map (fn [col] [:like [:lower col] match]) <>)
                             (interleave <> (repeat [:inline 0]))
@@ -481,6 +485,8 @@
      :collection.name] :collection_name]
    [:collection.authority_level :collection_authority_level]
    [:collection.type :collection_type]
+   [:table.data_authority :data_authority]
+   [:table.data_layer :data_layer]
    [:metabase_database.name :database_name]])
 
 (defmethod columns-for-model "transform"

--- a/test/metabase/metabot/tools/search_test.clj
+++ b/test/metabase/metabot/tools/search_test.clj
@@ -136,9 +136,30 @@
                     :description "Order table"
                     :database_id 42
                     :database_schema "public"
+                    :official false
+                    :data_authority nil
                     :updated_at "2024-01-01"
                     :created_at "2024-01-01"}]
       (is (= expected (#'search/postprocess-search-result result))))))
+
+(deftest ^:parallel postprocess-search-result-curation-signals-test
+  (testing "non-null curation signals (curated, official collection, table data_authority + data_layer) carried through"
+    (is (=? {:type           "table"
+             :curated        true
+             :official       true
+             :data_authority "authoritative"
+             :data_layer     "final"}
+            (#'search/postprocess-search-result
+             {:model          "table"
+              :id             9
+              :table_name     "Gold"
+              :name           "Gold"
+              :database_id    1
+              :table_schema   "public"
+              :curated        true
+              :data_authority "authoritative"
+              :data_layer     "final"
+              :collection     {:id 3 :name "Official" :authority_level "official"}})))))
 
 (deftest ^:parallel postprocess-search-result-test-2
   (testing "model (dataset) result postprocessing"
@@ -157,6 +178,7 @@
                     :description "Model for sales"
                     :database_id 43
                     :verified true
+                    :official false
                     :collection {}
                     :updated_at "2024-01-02"
                     :created_at "2024-01-02"}]
@@ -195,6 +217,7 @@
                     :name "Main Dashboard"
                     :description "Dashboard desc"
                     :verified false
+                    :official true
                     :collection {:id 10 :name "Finance" :authority_level "official"}
                     :updated_at "2024-01-03"
                     :created_at "2024-01-03"}]
@@ -216,6 +239,7 @@
                     :description "Question desc"
                     :database_id nil
                     :verified true
+                    :official false
                     :collection {:id 11 :name "Analytics" :authority_level nil}
                     :updated_at "2024-01-04"
                     :created_at "2024-01-04"}]
@@ -236,6 +260,7 @@
                     :description "Metric desc"
                     :database_id nil
                     :verified false
+                    :official false
                     :collection {}
                     :updated_at "2024-01-05"
                     :created_at "2024-01-05"}]

--- a/test/metabase/metabot/tools/search_test.clj
+++ b/test/metabase/metabot/tools/search_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib-be.metadata.jvm :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.metabot.tools.search :as search]
+   [metabase.metabot.tools.shared.llm-shape :as llm-shape]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.search.core :as search-core]
@@ -160,6 +161,26 @@
               :data_authority "authoritative"
               :data_layer     "final"
               :collection     {:id 3 :name "Official" :authority_level "official"}})))))
+
+(deftest ^:parallel search-result-xml-renders-curation-signals-test
+  (testing "the XML the LLM actually sees carries curated/data_layer/data_authority for a table result —
+            the render path that was a no-op until these reached search results (BOT-1570)"
+    (let [result (#'search/postprocess-search-result
+                  {:model          "table"
+                   :id             9
+                   :table_name     "Gold"
+                   :name           "Gold"
+                   :database_id    1
+                   :table_schema   "public"
+                   :curated        true
+                   :data_authority "authoritative"
+                   :data_layer     "final"
+                   :collection     {:id 3 :name "Official" :authority_level "official"}})
+          xml    (llm-shape/search-result->xml result)]
+      (is (str/includes? xml "is_curated=\"true\""))
+      (is (str/includes? xml "is_official=\"true\""))
+      (is (str/includes? xml "data_layer=\"final\""))
+      (is (str/includes? xml "data_authority=\"authoritative\"")))))
 
 (deftest ^:parallel postprocess-search-result-test-2
   (testing "model (dataset) result postprocessing"

--- a/test/metabase/search/in_place/legacy_test.clj
+++ b/test/metabase/search/in_place/legacy_test.clj
@@ -1,0 +1,10 @@
+(ns metabase.search.in-place.legacy-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.search.in-place.legacy :as legacy]))
+
+(deftest table-projection-includes-data-authority-test
+  (testing "the in-place table projection selects the real data_authority column (not a NULL pad) so it
+            reaches search results on the no-index fallback path (BOT-1570)"
+    (is (some #{[:table.data_authority :data_authority]}
+              (#'legacy/select-clause-for-model "table")))))


### PR DESCRIPTION
See BOT-1570

Beyond `is_verified`, search results now tell the LLM why content is curated: `is_curated` (the precomputed rollup), `is_official` (collection authority level) for cards and dashboards, and `data_layer` plus `data_authority` for tables. These are threaded through `postprocess-search-result` and rendered in `llm_shape.selmer`.

The signals ride in each result's `legacy_input` (plumbed in #75510), so both the appdb and semantic engines return them rather than dropping them at the projection. A test renders a table result end to end through `search-result->xml` to lock in the LLM-facing output.

NOTE: this changes what the model sees, so run `ai-benchmarks` before merging.
