### PR TITLE
Further MCP improvements for HTTPS detection

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -253,8 +253,8 @@
          proto
          (= "https" proto)
 
-         ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Frontend-End-Https`, which
-         ;; will be set to `on` if the original request was over HTTPS.
+          ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
+          ;; will be set to `on` if the original request was over HTTPS.
          ssl
          (= "on" (lower-case-en ssl))
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -241,27 +241,33 @@
      request handled by Jetty will be over HTTP."
      [{{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https origin]} :headers
        :keys                                                                                                [scheme]}]
-     (cond
-       ;; If `X-Forwarded-Proto` is present use that. There are several alternate headers that mean the same thing. See
-       ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-       (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
-       (= "https" (lower-case-en (or x-forwarded-proto x-forwarded-protocol x-url-scheme)))
+     (let [;; Take the first hop of a comma-separated chain (`https, http`), trim, and drop blanks, mirroring
+           ;; `misc/forwarded-scheme`. Branching on the normalized value (not raw presence) lets a blank proto header
+           ;; (e.g. `X-Forwarded-Proto: ""`) fall through to the boolean-style HTTPS indicators below.
+           proto (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+                         (str/split #",") first str/trim not-empty lower-case-en)
+           ssl   (or x-forwarded-ssl front-end-https)]
+       (cond
+         ;; If `X-Forwarded-Proto` is present use that. There are several alternate headers that mean the same thing. See
+         ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+         proto
+         (= "https" proto)
 
-       ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Frontend-End-Https`, which
-       ;; will be set to `on` if the original request was over HTTPS.
-       (or x-forwarded-ssl front-end-https)
-       (= "on" (lower-case-en (or x-forwarded-ssl front-end-https)))
+         ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Frontend-End-Https`, which
+         ;; will be set to `on` if the original request was over HTTPS.
+         ssl
+         (= "on" (lower-case-en ssl))
 
-       ;; If none of the above are present, we are most not likely being accessed over a reverse proxy. Still, there's a
-       ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
-       ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
-       origin
-       (str/starts-with? (lower-case-en origin) "https")
+         ;; If none of the above are present, we are most not likely being accessed over a reverse proxy. Still, there's a
+         ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
+         ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+         origin
+         (str/starts-with? (lower-case-en origin) "https")
 
-       ;; Last but not least, if none of the above are set (meaning there are no proxy servers such as ELBs or nginx in
-       ;; front of us), we can look directly at the scheme of the request sent to Jetty.
-       scheme
-       (= scheme :https))))
+         ;; Last but not least, if none of the above are set (meaning there are no proxy servers such as ELBs or nginx in
+         ;; front of us), we can look directly at the scheme of the request sent to Jetty.
+         scheme
+         (= scheme :https)))))
 
 (defn regex->str
   "Returns the contents of a regex as a string.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -258,7 +258,7 @@
          ssl
          (= "on" (lower-case-en ssl))
 
-         ;; If none of the above are present, we are most not likely being accessed over a reverse proxy. Still, there's a
+          ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
          ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
          ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
          origin

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -253,12 +253,12 @@
          proto
          (= "https" proto)
 
-          ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
-          ;; will be set to `on` if the original request was over HTTPS.
+         ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
+         ;; will be set to `on` if the original request was over HTTPS.
          ssl
          (= "on" (lower-case-en ssl))
 
-          ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
+         ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
          ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
          ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
          origin

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -42,7 +42,14 @@
                               {"front-end-https" "on"}         true
                               {"front-end-https" "off"}        false
                               {"origin" "https://mysite.com"}  true
-                              {"origin" "http://mysite.com"}   false}]
+                              {"origin" "http://mysite.com"}   false
+                              ;; a blank proto header must fall through to the boolean HTTPS indicators (BOT-1617)
+                              {"x-forwarded-proto" "" "x-forwarded-ssl" "on"} true
+                              {"x-forwarded-proto" "" "front-end-https" "on"} true
+                              {"x-forwarded-proto" "  " "origin" "https://mysite.com"} true
+                              ;; the first hop of a comma-separated chain wins
+                              {"x-forwarded-proto" "https, http"} true
+                              {"x-forwarded-proto" "HTTPS"}        true}]
     (testing (pr-str (list 'https? {:headers headers}))
       (is (= expected
              (req.util/https? {:headers headers}))))))

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -44,12 +44,12 @@
                               {"origin" "https://mysite.com"}  true
                               {"origin" "http://mysite.com"}   false
                               ;; a blank proto header must fall through to the boolean HTTPS indicators (BOT-1617)
-                              {"x-forwarded-proto" "" "x-forwarded-ssl" "on"} true
-                              {"x-forwarded-proto" "" "front-end-https" "on"} true
+                              {"x-forwarded-proto" "" "x-forwarded-ssl" "on"}          true
+                              {"x-forwarded-proto" "" "front-end-https" "on"}          true
                               {"x-forwarded-proto" "  " "origin" "https://mysite.com"} true
                               ;; the first hop of a comma-separated chain wins
                               {"x-forwarded-proto" "https, http"} true
-                              {"x-forwarded-proto" "HTTPS"}        true}]
+                              {"x-forwarded-proto" "HTTPS"}       true}]
     (testing (pr-str (list 'https? {:headers headers}))
       (is (= expected
              (req.util/https? {:headers headers}))))))


### PR DESCRIPTION
## Summary

Follow-up to #75500 (deprecating the `/mcp` route) around inferring the original request scheme behind a TLS-terminating proxy (BOT-1617).

It turns out the headers can be even more delightful to interpret.

## How to verify

```
./bin/test-agent :only '[metabase.request.util-test/https?-test]'
```
