### PR TITLE
UXW-4443: Re-encrypt additional columns during key rotation

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -338,8 +338,7 @@
            connection-pool
            task
            util}
-   :model-imports #{:model/Database
-                    :model/Field
+   :model-imports #{:model/Field
                     :model/QueryCache
                     :model/Secret
                     :model/Setting}}

--- a/src/metabase/app_db/encryption.clj
+++ b/src/metabase/app_db/encryption.clj
@@ -3,10 +3,33 @@
    [metabase.util.encryption :as encryption]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+;; All columns encrypted via `mi/transform-encrypted-json`. The on-disk format of such a column is
+;; `encrypt(json-string)`, so rotating the key only requires decrypting the raw value with the current key and
+;; re-encrypting the resulting string. We list raw table names (not models) so this also works for enterprise models
+;; (e.g. WorkspaceDatabase) that aren't loaded in every edition.
+(def ^:private encrypted-json-columns
+  [[:metabase_database :details]
+   [:metabase_database :settings]
+   [:metabase_database :write_data_details]
+   [:metabase_database :admin_details]
+   [:core_user :settings]
+   [:channel :details]
+   [:workspace_database :database_details]])
+
+(defn- reencrypt-encrypted-json-column!
+  "Re-encrypt `column` for every row in `table` using `encrypt-str-fn`. See `encrypted-json-columns`."
+  [conn table column encrypt-str-fn]
+  (doseq [{:keys [id value]} (t2/select [table :id [column :value]])]
+    (when (some? value)
+      (let [decrypted (encryption/maybe-decrypt value)]
+        (when (encryption/possibly-encrypted-string? decrypted)
+          (throw (ex-info (trs "Can''t decrypt app db with MB_ENCRYPTION_SECRET_KEY")
+                          {:table table, :id id, :column column})))
+        (t2/update! :conn conn table {:id id} {column (encrypt-str-fn decrypted)})))))
 
 (defn- do-encryption
   "Encrypt or decrypts the db using the current `MB_ENCRYPTION_SECRET_KEY` to read data.
@@ -16,12 +39,8 @@
   (let [encrypt-str-fn (make-encrypt-fn encryption/maybe-encrypt)
         encrypt-bytes-fn (make-encrypt-fn encryption/maybe-encrypt-bytes)]
     (t2/with-transaction [conn {:datasource data-source}]
-      (doseq [[id details] (t2/select-pk->fn :details :model/Database)]
-        (when (encryption/possibly-encrypted-string? details)
-          (throw (ex-info (trs "Can''t decrypt app db with MB_ENCRYPTION_SECRET_KEY") {:database-id id})))
-        (t2/update! :conn conn :metabase_database
-                    {:id id}
-                    {:details (encrypt-str-fn (json/encode details))}))
+      (doseq [[table column] encrypted-json-columns]
+        (reencrypt-encrypted-json-column! conn table column encrypt-str-fn))
       (doseq [[key value] (t2/select-fn->fn :key :value :model/Setting)]
         (case key
           "settings-last-updated" (let [current-timestamp-as-string-honeysql (h2x/cast (if (= db-type :mysql) :char :text)

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -98,6 +98,9 @@
               (encryption-test/with-secret-key k1
                 (t2/insert! :model/Setting {:key "k1crypted", :value "encrypted with k1"})
                 (t2/update! :model/Database 1 {:details {:db "/tmp/test.db"}})
+                ;; other encrypted-json columns that must also be re-encrypted on rotation
+                (t2/update! :model/Database 1 {:settings {:database-enable-actions true}})
+                (t2/update! :model/User @user-id {:settings {:locale "en"}})
                 (let [secret (first (t2/insert-returning-instances! :model/Secret {:name       "My Secret (encrypted)"
                                                                                    :kind       "password"
                                                                                    :value      (.getBytes secret-val StandardCharsets/UTF_8)
@@ -125,11 +128,15 @@
                   (encryption-test/with-secret-key k2
                     (is (= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (= {:db "/tmp/test.db"} (t2/select-one-fn :details :model/Database :id 1)))
+                    (is (= {:database-enable-actions true} (t2/select-one-fn :settings :model/Database :id 1)))
+                    (is (= {:locale "en"} (t2/select-one-fn :settings :model/User :id @user-id)))
                     (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))
                 (testing "but not with old key"
                   (encryption-test/with-secret-key k1
                     (is (not= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (not= "{\"db\":\"/tmp/test.db\"}" (t2/select-one-fn :details :model/Database :id 1)))
+                    (is (not= {:database-enable-actions true} (t2/select-one-fn :settings :model/Database :id 1)))
+                    (is (not= {:locale "en"} (t2/select-one-fn :settings :model/User :id @user-id)))
                     (is (not (mt/secret-value-equals? secret-val
                                                       (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))))
               (testing "full rollback when a database details looks encrypted with a different key than the current one"


### PR DESCRIPTION
There were 6 columns that we weren't correctly rotating during key rotation. This is a mechanical change to add them to the list of things we rotate. The "Right Way" to fix this would probably be closer to UXW-4444 (a refactor that mechanically prevents this from happening again) but this triage makes sense for now.

[UXW-4443: Re-encrypt additional encrypted columns during key rotation](https://linear.app/metabase/issue/UXW-4443/re-encrypt-additional-encrypted-columns-during-key-rotation)
