### PR TITLE
Don't log user names or emails on authentication

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
@@ -84,8 +84,8 @@
       (let [final-redirect (or (:redirect-url login-result) "/")
             base-response  (-> (response/redirect final-redirect)
                                (sso/clear-oidc-state-cookie))]
-        (log/infof "OIDC authentication successful for provider %s, user %s"
-                   provider-key (get-in login-result [:user :email]))
+        (log/infof "OIDC authentication successful for provider %s, user ID: %s"
+                   provider-key (get-in login-result [:user :id]))
         (if-let [session (:session login-result)]
           (request/set-session-cookies request
                                        base-response

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -108,7 +108,8 @@
           (throw (ex-info (tru "JWT token missing email claim")
                           {:status-code 400
                            :error :missing-email})))
-        (log/infof "Successfully authenticated JWT token for: %s %s" first-name last-name)
+        (log/infof "Successfully authenticated JWT token for user ID: %s"
+                   (t2/select-one-fn :id :model/User :%lower.email (u/lower-case-en email)))
         {:success? true
          :tenant-slug (some-> tenant-slug str)
          :tenant-attributes tenant-attributes

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -108,8 +108,7 @@
           (throw (ex-info (tru "JWT token missing email claim")
                           {:status-code 400
                            :error :missing-email})))
-        (log/infof "Successfully authenticated JWT token for user ID: %s"
-                   (t2/select-one-fn :id :model/User :%lower.email (u/lower-case-en email)))
+        (log/debug "Successfully authenticated JWT token")
         {:success? true
          :tenant-slug (some-> tenant-slug str)
          :tenant-attributes tenant-attributes

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
@@ -12,8 +12,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
-   [saml20-clj.core :as saml]
-   [toucan2.core :as t2]))
+   [saml20-clj.core :as saml]))
 
 (set! *warn-on-reflection* true)
 
@@ -127,8 +126,7 @@
                                     (sso-settings/saml-attribute-email)))
                           {:status-code 400
                            :user-attributes (keys user-attributes)})))
-        (log/infof "Successfully authenticated SAML assertion for user ID: %s"
-                   (t2/select-one-fn :id :model/User :%lower.email (u/lower-case-en email)))
+        (log/debug "Successfully authenticated SAML assertion")
         {:success? true
          :user-data {:email email
                      :first_name first-name

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
@@ -12,7 +12,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
-   [saml20-clj.core :as saml]))
+   [saml20-clj.core :as saml]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -126,7 +127,8 @@
                                     (sso-settings/saml-attribute-email)))
                           {:status-code 400
                            :user-attributes (keys user-attributes)})))
-        (log/infof "Successfully authenticated SAML assertion for: %s %s" first-name last-name)
+        (log/infof "Successfully authenticated SAML assertion for user ID: %s"
+                   (t2/select-one-fn :id :model/User :%lower.email (u/lower-case-en email)))
         {:success? true
          :user-data {:email email
                      :first_name first-name

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -1314,3 +1314,21 @@
                     (is (some? tenant))
                     (testing "tenant created but with no attributes since the value wasn't a map"
                       (is (nil? (:attributes tenant))))))))))))))
+
+(deftest successful-jwt-login-does-not-log-pii-test
+  (testing "Successful JWT authentication should not log user's first or last name"
+    (with-jwt-default-setup!
+      (mt/with-log-messages-for-level [log-messages [metabase-enterprise.sso.providers.jwt :info]]
+        ;; client-full-response uses mock client (in-process, future) so dynamic bindings are conveyed
+        (let [response (client/client-full-response :get 302 "/auth/sso"
+                                                    {:request-options {:redirect-strategy :none}}
+                                                    :return_to default-redirect-uri
+                                                    :jwt
+                                                    (jwt/sign
+                                                     {:email      "rasta@metabase.com"
+                                                      :first_name "Rasta"
+                                                      :last_name  "Toucan"}
+                                                     default-jwt-secret))]
+          (is (sso.test-setup/successful-login? response))
+          (is (not-any? #(re-find #"Rasta|Toucan" (:message %)) (log-messages))
+              "Log messages should not contain user's first or last name"))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -389,3 +389,17 @@
                (is (contains?
                     (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id (:id user))
                     group-id))))))))))
+
+(deftest successful-oidc-callback-does-not-log-pii-test
+  (testing "Successful OIDC callback should not log user's email address"
+    (mt/with-additional-premium-features #{:sso-oidc}
+      (mt/with-log-messages-for-level [log-messages [metabase-enterprise.sso.integrations.oidc :info]]
+        ;; Mock login! to return a successful result with user email, in-thread so log capture works
+        (with-redefs [auth-identity/login! (constantly {:success? true
+                                                        :redirect-url "/"
+                                                        :user {:email "jane@example.com"}})]
+          (metabase-enterprise.sso.integrations.oidc/sso-callback
+           "test-idp"
+           {:params {:code "test-code" :state "test-state"}})
+          (is (not-any? #(re-find #"jane@example.com" (:message %)) (log-messages))
+              "Log messages should not contain user's email address"))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.sso.integrations.oidc :as oidc-integration]
    [metabase-enterprise.sso.test-setup :as sso.test-setup]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.server.instance :as server.instance]
@@ -398,7 +399,7 @@
         (with-redefs [auth-identity/login! (constantly {:success? true
                                                         :redirect-url "/"
                                                         :user {:email "jane@example.com"}})]
-          (metabase-enterprise.sso.integrations.oidc/sso-callback
+          (oidc-integration/sso-callback
            "test-idp"
            {:params {:code "test-code" :state "test-state"}})
           (is (not-any? #(re-find #"jane@example.com" (:message %)) (log-messages))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.sso.test-setup :as sso.test-setup]
    [metabase-enterprise.tenants.auth-provider] ;; make sure the auth provider is actually registered
    [metabase.appearance.settings :as appearance.settings]
+   [metabase.auth-identity.core :as auth-identity]
    [metabase.premium-features.token-check :as token-check]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
@@ -1149,6 +1150,21 @@
                (is (seq body-nonce)))
              (testing "Header nonce matches body script nonce"
                (is (= header-nonce body-nonce))))))))))
+
+(deftest successful-saml-login-does-not-log-pii-test
+  (testing "Successful SAML authentication should not log user's first or last name"
+    (with-saml-default-setup!
+      (mt/with-model-cleanup [:model/User]
+        (mt/with-log-messages-for-level [log-messages [metabase-enterprise.sso.providers.saml :info]]
+          ;; Mock SAML validation to run in-thread so log capture works (real HTTP calls don't convey dynamic bindings)
+          (with-redefs [saml/validate-response (constantly ::mock-response)
+                        saml/assertions (constantly [{:attrs {"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ["john@example.com"]
+                                                              "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" ["John"]
+                                                              "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" ["Doe"]}}])]
+            (let [result (auth-identity/authenticate :provider/saml {:request-method :post})]
+              (is (:success? result) "Authentication should succeed")
+              (is (not-any? #(re-find #"John|Doe" (:message %)) (log-messages))
+                  "Log messages should not contain user's first or last name"))))))))
 
 (deftest popup-csp-nonce-per-request-unique-test
   (testing "Each `/auth/sso` popup response carries a freshly generated nonce (no static reuse)."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75322
### Description

Do not include user names or emails in the logs during login logs. Because we don't have user ids coming from saml/jwt there is nothing identifiable left to log. I left the generic "authenticated" log message, but moved it to debug since it's not that helpful anymore. Pulling in the user ID would require a query against the user table which seems not worth it for a log.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
