### PR TITLE
Stop regenerating belize dataset

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1302,31 +1302,26 @@
 ;;;; (In Belize they know no DST anymore.)
 ;;;;
 
-(def ^:private belize-offset (t/zone-offset "-06:00"))
-
-(defn- rows-for-good-datetimes-in-belize
-  []
+(defn- rows-for-good-datetimes-in-belize []
   (let [number-of-points (* 4 3)
-        today-dt (t/truncate-to (t/offset-date-time belize-offset) :days)
-        first-dt-point (t/- today-dt (t/days 2))
+        first-dt-point (t/- #t "2026-06-09T00:00-06:00" (t/days 2))
         dt-points (for [i (range number-of-points)]
                     (t/+ first-dt-point (t/hours (* 6 i))))
         various-offset-strs ["-10:00" "-04:00" "+02:00" "+09:00"]]
-    (mapv (fn [today-dt offset-str]
-            (vector (t/with-offset-same-instant today-dt (t/zone-offset "Z"))
-                    (t/with-offset-same-instant today-dt (t/zone-offset offset-str))
-                    (t/local-date-time today-dt)
+    (mapv (fn [start-dt offset-str]
+            (vector (t/with-offset-same-instant start-dt (t/zone-offset "Z"))
+                    (t/with-offset-same-instant start-dt (t/zone-offset offset-str))
+                    (t/local-date-time start-dt)
                     ;;;; Shift local date time for belize offset so timestamp_ltz has same instant as rest!
                     ;;   Even though later in the test the user with America/Belize timezone does the data loading,
                     ;;   the timestamps have to be adjusted.
                     ;;   I believe that it is because of either (1) us hardcoding the :timestamp connection property
                     ;;   to UTC (see the `connection-details->spec :snowflake`) or (2) the fact that the JVM timezone
                     ;;   is set to UTC.
-                    (t/+ (t/local-date-time today-dt) (t/hours 6))))
+                    (t/+ (t/local-date-time start-dt) (t/hours 6))))
           dt-points
           (cycle various-offset-strs))))
 
-;; BEWARE: No cleanup is done atm. It is expected that every CI run creates its own instance of this database.
 (mt/defdataset good-datetimes-in-belize
   [["GOOD_DATETIMES" [{:field-name "IN_Z_OFFSET"
                        :base-type {:native "timestamptz"}}
@@ -1353,8 +1348,6 @@
                             (map (juxt :name :database-type :base-type :database-position))
                             (fetch-metadata/fields-metadata (mt/db)))))))))
 
-;; The test needs user with no report timezone set and database timezone other than UTC. That's the reason for redefs
-;; prior to dataset generation.
 (deftest ^:synchronized correct-timestamp-type-querying-test
   (mt/test-driver
     :snowflake
@@ -1372,55 +1365,54 @@
                       (-> (original-dbdef->connection-details driver connection-type database-definition)
                           (assoc :user "BELIZE_PERSON")))]
         (mt/with-temporary-setting-values [report-timezone "America/Belize"]
-          (mt/dataset
-            good-datetimes-in-belize
+          (mt/dataset (assoc good-datetimes-in-belize :timezone "America/Belize")
             (testing "Expected data is returned using yesterday filter"
-              (let [yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
-                    yesterday-last      (t/+ yesterday-first (t/hours 18))
-                    yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
-                    yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
-                (doseq [[tested-field-kw base-type database-type]
-                        [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
-                         [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
-                         [:JUST_NTZ           :type/DateTime            "timestampntz"]
-                         [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
-                        :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
-                  (testing (str "on column type " database-type)
-                    (let [rows (mt/rows (qp/process-query
-                                         {:database (mt/id)
-                                          :type     :query
-                                          :query {:source-table (mt/id :GOOD_DATETIMES)
-                                                  :fields [tested-field]
-                                                  :filter [:time-interval tested-field -1 :day]
-                                                  :order-by [[tested-field :asc]]}}))]
-                      (testing "Correct rows count returned"
-                        (is (= 4 (count rows))))
-                      (testing "First row has expected values"
-                        (is (= yesterday-first-str
-                               (ffirst rows))))
-                      (testing "Last row has expected values"
-                        (is (= yesterday-last-str
-                               (ffirst (reverse rows)))))))
-                  (testing "Rows should be properly allocated to days"
-                    (let [tested-day (assoc-in tested-field [2 :temporal-unit] :day)
-                          tested-minute (assoc-in tested-field [2 :temporal-unit] :minute)]
-                      (is (=? [[string? 4] [string? 4] [string? 4]]
-                              (mt/rows
-                               (qp/process-query
-                                (mt/mbql-query nil
-                                  {:source-table (mt/id :GOOD_DATETIMES)
-                                   :aggregation [[:count]]
-                                   :breakout [tested-day]})))))
-                      (is (= [[yesterday-first-str 4 yesterday-first-str yesterday-last-str]]
-                             (mt/rows
-                              (qp/process-query
-                               (mt/mbql-query nil
-                                 {:source-table (mt/id :GOOD_DATETIMES)
-                                  :aggregation [[:count]
-                                                [:min tested-minute]
-                                                [:max tested-minute]]
-                                  :breakout [tested-day]
-                                  :filter [:= tested-field (t/format :iso-local-date yesterday-last)]}))))))))))))))))
+          (let [base-first     #t "2026-06-08T00:00-06:00"
+                base-last      (t/+ base-first (t/hours 18))
+                base-first-str (t/format :iso-offset-date-time base-first)
+                base-last-str  (t/format :iso-offset-date-time base-last)]
+            (doseq [[tested-field-kw base-type database-type]
+                    [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
+                     [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
+                     [:JUST_NTZ           :type/DateTime            "timestampntz"]
+                     [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
+                    :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
+              (testing (str "on column type " database-type)
+                (let [rows (mt/rows (qp/process-query
+                                     {:database (mt/id)
+                                      :type     :query
+                                      :query {:source-table (mt/id :GOOD_DATETIMES)
+                                              :fields [tested-field]
+                                              :filter [:time-interval tested-field -1 :day]
+                                              :order-by [[tested-field :asc]]}}))]
+                  (testing "Correct rows count returned"
+                    (is (= 4 (count rows))))
+                  (testing "First row has expected values"
+                    (is (= base-first-str
+                           (ffirst rows))))
+                  (testing "Last row has expected values"
+                    (is (= base-last-str
+                           (ffirst (reverse rows)))))))
+              (testing "Rows should be properly allocated to days"
+                (let [tested-day (assoc-in tested-field [2 :temporal-unit] :day)
+                      tested-minute (assoc-in tested-field [2 :temporal-unit] :minute)]
+                  (is (=? [[string? 4] [string? 4] [string? 4]]
+                          (mt/rows
+                           (qp/process-query
+                            (mt/mbql-query nil
+                              {:source-table (mt/id :GOOD_DATETIMES)
+                               :aggregation [[:count]]
+                               :breakout [tested-day]})))))
+                  (is (= [[base-first-str 4 base-first-str base-last-str]]
+                         (mt/rows
+                          (qp/process-query
+                           (mt/mbql-query nil
+                             {:source-table (mt/id :GOOD_DATETIMES)
+                              :aggregation [[:count]
+                                            [:min tested-minute]
+                                            [:max tested-minute]]
+                              :breakout [tested-day]
+                              :filter [:= tested-field (t/format :iso-local-date base-last)]}))))))))))))))))
 
 (deftest snowflake-all-auth-combos-test
   (mt/test-driver

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -68,7 +68,7 @@
     ;;
     ;; SESSION parameters
     ;;
-    :timezone            "UTC"
+    :timezone            (:timezone dbdef "UTC")
     ;; return times with millisecond precision, if we don't set this then Snowflake will only return them with second
     ;; precision. Important mostly because other DBs use millisecond precision by default and this makes Snowflake test
     ;; results match up with others
@@ -100,21 +100,12 @@
   (sql-jdbc.conn/connection-details->spec :snowflake (tx/dbdef->connection-details :snowflake :server nil)))
 
 (defn- old-dataset-names
-  "Return a collection of all dataset names that are old
-   -- tracked that haven't been touched in a while or are not tracked and too old"
+  "All dataset names that haven't been accessed in a while"
   []
   (let [days-ago -5
-        ;; tracked UNION ALL untracked
-        ;; NB. currently appears that the second half never shows anything; all
-        ;; datasets currently appear to be tracked.
-        query "(select name from metabase_test_tracking.PUBLIC.datasets
-                where accessed_at < dateadd(day, ?, current_timestamp()))
-               UNION All
-               (select database_name from metabase_test_tracking.information_schema.databases d
-                where d.database_name not in (select name from metabase_test_tracking.PUBLIC.datasets)
-                and d.database_name like 'sha_%'
-                and created < dateadd(day, ?, current_timestamp()))"]
-    (into [] (map :name) (jdbc/reducible-query (no-db-connection-spec) [query days-ago days-ago]))))
+        query "select name from metabase_test_tracking.PUBLIC.datasets
+               where accessed_at < dateadd(day, ?, current_timestamp())"]
+    (into [] (map :name) (jdbc/reducible-query (no-db-connection-spec) [query days-ago]))))
 
 (defn- orphan-isolation-schemas
   "Return a collection of schema names with mb__isolation_ prefix that are more than 3 hours old,


### PR DESCRIPTION
This also takes the `good-datetimes-in-belize` dataset and makes it hard-coded instead of the current strategy of regenerating it afresh for every test run. It also allows the dataset to control the timezone of the database.