### PR TITLE
Add test demonstrating that #33698 has been fixed

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -468,6 +468,21 @@
                    :breakout    [$tips.source.username]
                    :limit       4}))))))))
 
+(deftest ^:parallel breakoutable-columns-disambiguates-same-named-nested-fields-test
+  (testing "Nested fields with the same leaf name at different paths get path-qualified display names (#33698)"
+    (mt/test-driver :mongo
+      (mt/dataset geographical-tips
+        (let [mp       (mt/metadata-provider)
+              query    (lib/query mp (lib.metadata/table mp (mt/id :tips)))
+              displays (into #{} (map #(lib/display-name query %))
+                             (lib/breakoutable-columns query))]
+          (testing "root-level vs nested same-name collision"
+            (is (contains? displays "URL"))
+            (is (contains? displays "Source: URL")))
+          (testing "sibling subdocument same-name collision"
+            (is (contains? displays "Source: Categories"))
+            (is (contains? displays "Venue: Categories"))))))))
+
 ;; Make sure that all-NULL columns work and are synced correctly (#6875)
 (tx/defdataset all-null-columns
   [["bird_species"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #33698
Closes QUE2-189

### Description

This has been fixed already, just a test is added that demonstrates that `breakoutable-columns` generates `:display-name`s with the full nesting path.

### How to verify

See the test.

### Demo

<img width="1023" height="720" alt="image" src="https://github.com/user-attachments/assets/f6114e88-3f66-4053-b15b-c4a7a12eb612" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
