### PR TITLE
GRO-388 mimic Snowplow.setUserId with metaplow

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -46,6 +46,7 @@ import { GlobalStyles } from "metabase/styled-components/containers/GlobalStyles
 import { PortalContainer } from "metabase/ui";
 import { EmotionCacheProvider } from "metabase/ui/components/theme/EmotionCacheProvider";
 import { captureConsoleErrors } from "metabase/utils/errors";
+import { initMetaplow } from "metabase/utils/metaplow";
 import { initTracing, rotateTraceId } from "metabase/utils/otel";
 import MetabaseSettings from "metabase/utils/settings";
 import registerVisualizations from "metabase/visualizations/register";
@@ -72,6 +73,12 @@ function _init(reducers, getRoutes, callback) {
   const syncedHistory = syncHistoryWithStore(browserHistory, store);
 
   createSnowplowTracker(() => getUserId(store.getState()));
+  initMetaplow({
+    beforeSend: (_type, payload) => ({
+      ...payload,
+      data: { ...payload.data, user_id: getUserId(store.getState()) },
+    }),
+  });
 
   // Initialize distributed tracing if enabled via MB_TRACING_ENABLED.
   // Uses bootstrap data so it's available before the first API call.

--- a/frontend/src/metabase/utils/metaplow.ts
+++ b/frontend/src/metabase/utils/metaplow.ts
@@ -58,20 +58,41 @@ async function send(payload: MetaplowPayload): Promise<unknown> {
   });
 }
 
+interface MetaplowConfig {
+  beforeSend: (
+    type: string,
+    payload: MetaplowPayload,
+  ) => MetaplowPayload | void;
+}
+
+let _config: MetaplowConfig = {
+  beforeSend: (_type, payload) => payload,
+};
+
+export function initMetaplow(config: Partial<MetaplowConfig>): void {
+  _config = { ..._config, ...config };
+}
+
 export function trackMetaplowEvent(
   name: MetaplowPayload["name"],
   data: MetaplowPayload["data"] = {},
 ): void {
-  send({
+  const payload = _config.beforeSend("event", {
     ...getBasePayload(window.location.href),
     name,
     data,
-  }).catch(() => undefined);
+  });
+  if (payload) {
+    send(payload).catch(() => undefined);
+  }
 }
 
-export function trackMetaplowPageView(url: string): Promise<unknown> {
-  return send({
+export function trackMetaplowPageView(url: string) {
+  const payload = _config.beforeSend("event", {
     ...getBasePayload(url),
     name: "pageview",
-  }).catch(() => undefined);
+  });
+  if (payload) {
+    send(payload).catch(() => undefined);
+  }
 }

--- a/frontend/src/metabase/utils/metaplow.unit.spec.ts
+++ b/frontend/src/metabase/utils/metaplow.unit.spec.ts
@@ -1,6 +1,10 @@
 import Settings from "metabase/utils/settings";
 
-import { trackMetaplowEvent, trackMetaplowPageView } from "./metaplow";
+import {
+  initMetaplow,
+  trackMetaplowEvent,
+  trackMetaplowPageView,
+} from "./metaplow";
 
 const METAPLOW_URL = "https://metaplow.example.com/api/send";
 const METAPLOW_WEBSITE_ID = "23eefa30-4c4f-490e-aa4f-084cd23b1561";
@@ -31,6 +35,36 @@ describe("metaplow", () => {
     );
     return JSON.parse(init?.body as string);
   };
+
+  describe("initMetaplow", () => {
+    describe("beforeSend", () => {
+      afterEach(() => {
+        initMetaplow({ beforeSend: (_type, payload) => payload });
+      });
+
+      it("can modify the payload before it's sent", () => {
+        initMetaplow({
+          beforeSend: (_type, payload) => ({
+            ...payload,
+            data: { ...payload.data, user_id: 123 },
+          }),
+        });
+
+        trackMetaplowEvent("button_clicked");
+
+        const { payload } = getSentPayload();
+        expect(payload.data.user_id).toBe(123);
+      });
+
+      it("suppresses the fetch call when a falsy value is returned", () => {
+        initMetaplow({ beforeSend: () => undefined });
+
+        trackMetaplowEvent("button_clicked");
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
 
   describe("trackMetaplowEvent", () => {
     it("does not call fetch when metaplow-url is not set", () => {


### PR DESCRIPTION
Related [GRO-388](https://linear.app/metabase/issue/GRO-388/update-the-analytics-tracker-script-to-be-able-to-capture-anonymous)

### Description

This is just one small piece of GRO-388, but it's independent. Specifically it's this piece:
> Send Metabase User id into "data": { user_id: 65 … } additionally for every event when the customer is logged in

This was happening with snowplow via `Snowplow.setUserId` (in frontend/src/metabase/analytics/snowplow.ts). This PR mimics that but with an umami flavor (pardon the pun, couldn't resist).

### How to verify

Similar to https://github.com/metabase/metabase/pull/72380, start up your instance with
```
MB_METAPLOW_URL="https://product-analytics-ingestion.staging.metabase.com/api/send"
```

https://stats.metabase.com/question/38068-metabase-instance-events


### Demo

<img width="1308" height="251" alt="Screenshot 2026-06-09 at 5 29 32 PM" src="https://github.com/user-attachments/assets/d27785d4-f39d-43ae-a5aa-5daa00e98eb3" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
