### PR TITLE
[Metabot] Don't send query in user is viewing context for questions without a data source

### DIFF
--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -1,6 +1,7 @@
 import { type UnknownAction, isRejected, nanoid } from "@reduxjs/toolkit";
 import { push } from "react-router-redux";
 import { P, isMatching, match } from "ts-pattern";
+import { t } from "ttag";
 import _ from "underscore";
 
 import {
@@ -83,6 +84,13 @@ const handleResponseError = (
   // HTTP failures arrive as the legacy client's `{ status, data }` shape, with
   // the parsed response body under `data`.
   return match(error)
+    .with({ status: 400 }, () => ({
+      error: { type: "http_error", message: t`Invalid request format` },
+      display: {
+        type: "message" as const,
+        message: METABOT_ERR_MSG.format(t`Invalid request format`),
+      },
+    }))
     .with({ status: 401 }, () => ({
       error: { type: "unauthenticated" },
       display: {

--- a/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
@@ -21,7 +21,7 @@ import {
 describe("metabot > errors", () => {
   it("should handle non-successful responses", async () => {
     setup();
-    fetchMock.post(`path:/api/metabot/agent-streaming`, 400);
+    fetchMock.post(`path:/api/metabot/agent-streaming`, 500);
 
     await enterChatMessage("Who is your favorite?");
 
@@ -29,6 +29,19 @@ describe("metabot > errors", () => {
       ["user", "Who is your favorite?"],
       // When no body is provided, a generic error message is shown
       ["agent", METABOT_ERR_MSG.default],
+    ]);
+    expect(await input()).toHaveTextContent("Who is your favorite?");
+  });
+
+  it("should show a validation error message for bad requests", async () => {
+    setup();
+    fetchMock.post(`path:/api/metabot/agent-streaming`, 400);
+
+    await enterChatMessage("Who is your favorite?");
+
+    await assertConversation([
+      ["user", "Who is your favorite?"],
+      ["agent", METABOT_ERR_MSG.format("Invalid request format")],
     ]);
     expect(await input()).toHaveTextContent("Who is your favorite?");
   });

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -231,6 +231,13 @@ export const registerQueryBuilderMetabotContextFn = async ({
 
   const query = question.query();
   const { isNative } = Lib.queryDisplayInfo(query);
+  const hasDataSource = isNative
+    ? Lib.databaseID(query) != null
+    : Lib.sourceTableOrCardId(query) != null;
+  if (!hasDataSource) {
+    return {};
+  }
+
   const queryCtx = {
     query: question.datasetQuery(),
     sql_engine: isNative ? Lib.engine(query) : undefined,

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
@@ -125,6 +125,19 @@ describe("registerQueryBuilderMetabotContextFn", () => {
     expect(viewing.type).toEqual("adhoc");
   });
 
+  it("should register no context for adhoc questions without a data source", async () => {
+    const question = new Question(
+      createAdHocCard({
+        dataset_query: { type: "query", database: null, query: {} },
+      }),
+    );
+
+    const data = createMockData({ question });
+    const result = await registerQueryBuilderMetabotContextFn(data);
+
+    expect(result).toEqual({});
+  });
+
   it("should generate an image for the current question", async () => {
     const card = createMockCard({ display: "line" });
     const data = createMockData({ question: new Question(card) });


### PR DESCRIPTION
### Description
Chatting with metabot from an empty notebook 400s because we put the blank query template `{ database: null, source-table: null }` into `user_is_viewing which fails the `agent-streaming` body schema. This PR prevents us sending this empty-ish context util we have a data source

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)