### PR TITLE
UXW-4402: Make explorations respect sandboxing/impersonation/db routing

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1006,6 +1006,7 @@
            metabot
            metrics
            models
+           permissions
            queries
            query-permissions
            query-processor

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -289,6 +289,7 @@
                     :model/Database
                     :model/Dimension
                     :model/Document
+                    :model/Exploration
                     :model/Measure
                     :model/ModelIndexValue
                     :model/NativeQuerySnippet
@@ -921,6 +922,7 @@
                     :model/DashboardTab
                     :model/Dimension
                     :model/Document
+                    :model/Exploration
                     :model/Measure
                     :model/NativeQuerySnippet
                     :model/PermissionsGroup

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -65,6 +65,16 @@
    api/*is-superuser?*
    db-or-id))
 
+(defenterprise routing-token-for-db
+  "Database-routing fingerprint for the current user on router `db-id` (the resolved destination
+  database id), or nil when the user resolves to the router db itself (admins, or non-admins
+  routed via the __METABASE_ROUTER__ sentinel) or when `db-id` is not a router database. May
+  throw when a routed non-admin is missing the required routing attribute."
+  :feature :database-routing
+  [db-id]
+  (when-let [dest (router-db-or-id->destination-db-id db-id)]
+    {:destination-db-id dest}))
+
 ;; We want, at all times, a guarantee that we are not hitting a router *or* destination database without being
 ;; intentional about it. It would be bad to EITHER:
 ;;

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -70,7 +70,7 @@
   database id), or nil when the user resolves to the router db itself (admins, or non-admins
   routed via the __METABASE_ROUTER__ sentinel) or when `db-id` is not a router database. May
   throw when a routed non-admin is missing the required routing attribute."
-  :feature :database-routing
+  :feature :none
   [db-id]
   (when-let [dest (router-db-or-id->destination-db-id db-id)]
     {:destination-db-id dest}))

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -113,6 +113,14 @@
     (when-let [role (and api/*current-user-id* (connection-impersonation-role db-id))]
       {:impersonation-role role})))
 
+(defenterprise impersonation-token-for-db
+  "Connection-impersonation fingerprint for the current user on `db-id` (the resolved database
+  role), or nil when not impersonated (including admins)."
+  :feature :advanced-permissions
+  [db-id]
+  (when-let [role (and api/*current-user-id* (connection-impersonation-role db-id))]
+    {:role role}))
+
 (def ^:dynamic *impersonation-role*
   "Set by Impersonation middleware, via the query processor, to define the role that should be used by
   `set-role-if-supported!`. If not set (for example, when we're not in the context of a query) we'll compute it

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -116,7 +116,7 @@
 (defenterprise impersonation-token-for-db
   "Connection-impersonation fingerprint for the current user on `db-id` (the resolved database
   role), or nil when not impersonated (including admins)."
-  :feature :advanced-permissions
+  :feature :none
   [db-id]
   (when-let [role (and api/*current-user-id* (connection-impersonation-role db-id))]
     {:role role}))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -83,3 +83,18 @@
   [field]
   (when (field-is-sandboxed? field)
     {:sandbox-attributes (field->sandbox-attributes-for-current-user field)}))
+
+(defenterprise sandbox-token-for-table
+  "Sandbox fingerprint for the current user on `table-id` (GTAP card, its version, and resolved
+  user-attribute values), or nil when the user is not *enforced*-sandboxed on that table. Reuses
+  the same enforcement guard (`field-is-sandboxed?`) and attribute-extraction as the FieldValues
+  cache, so superusers and users with full access via another group correctly get no token (and
+  thus see any creator's snapshot), and two genuinely-sandboxed users \"share a sandbox\" iff
+  they'd see the same rows. The card's `:updated_at` (element 1) is stringified so the token is
+  EDN-safe for storage on `stored_result.data_access_token`."
+  :feature :sandboxes
+  [table-id]
+  (let [field {:table_id table-id}]
+    (when (field-is-sandboxed? field)
+      (some-> (field->sandbox-attributes-for-current-user field)
+              (update 1 str)))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -90,11 +90,11 @@
   the same enforcement guard (`field-is-sandboxed?`) and attribute-extraction as the FieldValues
   cache, so superusers and users with full access via another group correctly get no token (and
   thus see any creator's snapshot), and two genuinely-sandboxed users \"share a sandbox\" iff
-  they'd see the same rows. The card's `:updated_at` (element 1) is stringified so the token is
-  EDN-safe for storage on `stored_result.data_access_token`."
+  they'd see the same rows. The card's `:updated_at` is stringified so the token is EDN-safe for
+  storage on `stored_result.data_access_token`."
   :feature :none
   [table-id]
   (let [field {:table_id table-id}]
     (when (field-is-sandboxed? field)
-      (some-> (field->sandbox-attributes-for-current-user field)
-              (update 1 str)))))
+      (when-let [[card-id updated-at attributes] (field->sandbox-attributes-for-current-user field)]
+        [card-id (str updated-at) attributes]))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -92,7 +92,7 @@
   thus see any creator's snapshot), and two genuinely-sandboxed users \"share a sandbox\" iff
   they'd see the same rows. The card's `:updated_at` (element 1) is stringified so the token is
   EDN-safe for storage on `stored_result.data_access_token`."
-  :feature :sandboxes
+  :feature :none
   [table-id]
   (let [field {:table_id table-id}]
     (when (field-is-sandboxed? field)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -1,97 +1,161 @@
 (ns metabase-enterprise.sandbox.explorations-test
-  "Tests that the result-access gate on `GET /api/exploration/query/:id` correctly blocks
-  cached-blob streaming for sandboxed, impersonated, and data-perm-deficient viewers of an
-  exploration in a shared collection. Metadata access (via collection perms) stays open in
-  the same scenarios."
+  "Tests the per-lens data-access gate on `GET /api/exploration/query/:id`. A cached exploration
+  result blob is computed once under its creator's lens; a non-creator viewer may stream it only
+  when their own sandbox/impersonation/routing lens is *compatible* with the creator's (see
+  `metabase.permissions.data-access-token`). Metadata access (collection perms) stays open
+  regardless."
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.sandbox.test-util :as sandbox.tu]
    [metabase-enterprise.test :as met]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.query-processor.middleware.cache.impl :as cache.impl]
+   [metabase.request.core :as request]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
-(defn- venues-count-query
-  "A `:metric` card's `:dataset_query`: count over the venues table, built with Lib."
-  []
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(defn- venues-count-query []
   (let [mp (mt/metadata-provider)]
     (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
         (lib/aggregate (lib/count)))))
 
-(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+(defn- price-sandbox
+  "A GTAP def filtering venues to rows whose `price` equals the user's `price` login attribute, so
+  two users 'share a sandbox' only when their `price` attribute matches."
+  []
+  {:gtaps      {:venues {:remappings {"price" [:dimension [:field (mt/id :venues :price) nil]]}}}
+   :attributes {"price" "1"}})
 
-(defn- with-shared-exploration!
-  "Create an exploration in a shared collection with one pending ExplorationQuery against the
-  venues table, and call `f` with `{:exploration ... :query ... :collection ...}`. The query
-  is left in `status=\"pending\"` and has no cached `result_data` row, so the API returns:
-    - 403 when the result-access gate denies (sandbox, impersonation, or missing data perms)
-    - 409 (pending status payload) when the gate allows
-  This makes the per-scenario assertions straightforward."
-  [f]
-  (mt/with-temp [:model/User       owner {:email (mt/random-email)}
-                 :model/Collection coll  {}
-                 :model/Card       metric {:name          "metric"
-                                           :type          :metric
-                                           :creator_id    (:id owner)
-                                           :database_id   (mt/id)
-                                           :dataset_query (venues-count-query)}
-                 :model/Exploration e   {:name          "shared"
-                                         :creator_id    (:id owner)
-                                         :collection_id (:id coll)}
+(defn- fake-result-bytes []
+  (cache.impl/do-with-serialization
+   (fn [in result-fn]
+     (in {:data {:cols [{:name "count"}] :rows [[1]]} :row_count 1 :status :completed})
+     (result-fn))))
+
+(defn- with-done-exploration!
+  "Create a shared-collection exploration whose single venues-count query is `done`, backed by a
+  StoredResult carrying `creator-id` and `data-access-token`. Calls `f` with the created rows."
+  [{:keys [creator-id data-access-token]} f]
+  (mt/with-temp [:model/Collection coll {}
+                 :model/Card        metric {:name          "metric"
+                                            :type          :metric
+                                            :creator_id    creator-id
+                                            :database_id   (mt/id)
+                                            :dataset_query (venues-count-query)}
+                 :model/Exploration e {:name "shared" :creator_id creator-id :collection_id (:id coll)}
                  :model/ExplorationThread th {:exploration_id (:id e)}
                  :model/ExplorationThreadGroup g {:exploration_thread_id (:id th)}
-                 :model/ExplorationQuery  q  {:exploration_thread_id (:id th)
-                                              :group_id     (:id g)
-                                              :card_id      (:id metric)
-                                              :dimension_id "d1"
-                                              :status       "pending"
-                                              :dataset_query (venues-count-query)}]
-    (f {:exploration e :query q :collection coll :owner owner})))
+                 :model/ExplorationQuery q {:exploration_thread_id (:id th)
+                                            :group_id              (:id g)
+                                            :card_id               (:id metric)
+                                            :dimension_id          "d1"
+                                            :status                "done"
+                                            :dataset_query         (venues-count-query)}
+                 :model/StoredResult sr {:result_data       (fake-result-bytes)
+                                         :creator_id        creator-id
+                                         :database_id       (mt/id)
+                                         :dataset_query     (venues-count-query)
+                                         :data_access_token data-access-token}
+                 :model/ExplorationQueryResult _ {:exploration_query_id (:id q)
+                                                  :stored_result_id     (:id sr)}]
+    (perms/grant-collection-read-permissions! (perms-group/all-users) coll)
+    (f {:exploration e :query q :collection coll})))
 
-(deftest sandboxed-viewer-blocked-from-cached-result-test
-  (with-shared-exploration!
-    (fn [{:keys [exploration query collection]}]
-      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-      (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
-        (testing "sandboxed viewer can still read the exploration metadata"
-          (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
-        (testing "but is blocked (403) from the cached query result"
-          (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))))))
+(deftest same-sandbox-viewer-sees-cached-result-test
+  (testing "a viewer whose sandbox lens matches the creator's may stream the cached result"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      ;; rasta is bound as current-user with price=1; capture the lens the snapshot is stored under
+      (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
+        (with-done-exploration!
+          {:creator-id (mt/user->id :lucky) :data-access-token token}
+          (fn [{:keys [exploration query]}]
+            (testing "metadata is readable via collection perms"
+              (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
+            (testing "and the cached result streams (same lens)"
+              (mt/user-http-request :rasta :get 202 (format "exploration/query/%d" (:id query))))))))))
 
-(deftest impersonated-viewer-blocked-from-cached-result-test
-  (with-shared-exploration!
-    (fn [{:keys [exploration query collection]}]
-      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-      ;; Impersonation is only "enforced" for a user when they don't ALSO have non-impersonated
-      ;; access through some other group. Strip default all-users data perms first.
-      (mt/with-no-data-perms-for-all-users!
-        (mt/with-temp [:model/PermissionsGroup           {gid :id} {}
-                       :model/PermissionsGroupMembership _         {:user_id  (mt/user->id :rasta)
-                                                                    :group_id gid}
-                       :model/ConnectionImpersonation    _         {:db_id     (mt/id)
-                                                                    :group_id  gid
-                                                                    :attribute "role"}]
-          (testing "impersonated viewer can still read the exploration metadata"
-            (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
-          (testing "but is blocked (403) from the cached query result"
-            (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))))))
+(deftest different-sandbox-viewer-blocked-from-cached-result-test
+  (testing "a viewer with the same sandbox policy but a different attribute value is blocked (403)"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      ;; snapshot stored under price=1 ...
+      (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
+        (with-done-exploration!
+          {:creator-id (mt/user->id :lucky) :data-access-token token}
+          (fn [{:keys [exploration query]}]
+            ;; ... but rasta now resolves to price=2 -> a different lens
+            (sandbox.tu/with-user-attributes! :rasta {"price" "2"}
+              (testing "metadata still readable"
+                (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
+              (testing "but the cached result is blocked"
+                (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query)))))))))))
+
+(deftest unsandboxed-viewer-with-perms-sees-cached-result-test
+  (testing "an unsandboxed viewer with data perms may stream a sandboxed creator's result (superset)"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      (let [token (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})]
+        ;; crowberto is a superuser -> unsandboxed, full data access -> sees the snapshot
+        (with-done-exploration!
+          {:creator-id (mt/user->id :lucky) :data-access-token token}
+          (fn [{:keys [query]}]
+            (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query)))))))))
+
+(deftest admin-sees-sandboxed-result-when-sandbox-is-on-all-users-test
+  (testing "an admin (superuser) is a member of All Users, but must NOT pick up a phantom sandbox
+            token from an All-Users sandbox — they see any creator's snapshot (regression: the
+            sandbox token must apply the enforcement guard, not just check group membership)"
+    (met/with-gtaps-for-all-users!
+      {:gtaps {:venues {:remappings {"price" [:dimension [:field (mt/id :venues :price) nil]]}}}}
+      (testing "the superuser's data-access token has no sandbox dimension"
+        (is (= {} (request/with-current-user (mt/user->id :crowberto)
+                    (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})))))
+      ;; capture a genuinely-sandboxed creator's lens
+      (let [token (sandbox.tu/with-user-attributes! :rasta {"price" "1"}
+                    (request/with-current-user (mt/user->id :rasta)
+                      (perms/data-access-token {:database-id (mt/id) :table-ids #{(mt/id :venues)}})))]
+        (testing "the captured creator lens really is a sandbox token"
+          (is (seq (:sandbox token))))
+        (with-done-exploration!
+          {:creator-id (mt/user->id :rasta) :data-access-token token}
+          (fn [{:keys [query]}]
+            (testing "and the admin streams the cached result"
+              (mt/user-http-request :crowberto :get 202 (format "exploration/query/%d" (:id query))))))))))
 
 (deftest viewer-without-data-perms-blocked-from-cached-result-test
-  (with-shared-exploration!
-    (fn [{:keys [exploration query collection]}]
-      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-      (mt/with-no-data-perms-for-all-users!
-        (testing "viewer with collection-read but no data perms reads metadata"
-          (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration))))
-        (testing "but cannot view the cached result"
+  (testing "a viewer with collection-read but no data perms cannot stream the result (403), but reads metadata"
+    (mt/with-no-data-perms-for-all-users!
+      (with-done-exploration!
+        {:creator-id (mt/user->id :lucky) :data-access-token {}}
+        (fn [{:keys [exploration query]}]
+          (mt/user-http-request :rasta :get 200 (format "exploration/%d" (:id exploration)))
           (mt/user-http-request :rasta :get 403 (format "exploration/query/%d" (:id query))))))))
 
-(deftest viewer-with-perms-and-no-sandbox-passes-gate-test
-  (with-shared-exploration!
-    (fn [{:keys [query collection]}]
-      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-      (testing "no sandbox + has data perms → gate passes; pending query returns 409 status"
-        (let [body (mt/user-http-request :rasta :get 409 (format "exploration/query/%d" (:id query)))]
+(deftest creator-bypasses-gate-test
+  (testing "the snapshot's creator always streams it, even against an incompatible stored token"
+    (with-done-exploration!
+      {:creator-id       (mt/user->id :rasta)
+       ;; a token rasta could never match, to prove the creator bypass overrides the gate
+       :data-access-token {:sandbox {(mt/id :venues) [1 "x" {"price" "999"}]}}}
+      (fn [{:keys [query]}]
+        (mt/user-http-request :rasta :get 202 (format "exploration/query/%d" (:id query)))))))
+
+(deftest pending-query-status-is-not-gated-test
+  (testing "the pending/error path returns status only (409) and is not data-gated — even for a sandboxed viewer"
+    (met/with-gtaps-for-user! :rasta (price-sandbox)
+      (mt/with-temp [:model/Collection coll {}
+                     :model/Card metric {:name "m" :type :metric :creator_id (mt/user->id :lucky)
+                                         :database_id (mt/id) :dataset_query (venues-count-query)}
+                     :model/Exploration e {:name "shared" :creator_id (mt/user->id :lucky) :collection_id (:id coll)}
+                     :model/ExplorationThread th {:exploration_id (:id e)}
+                     :model/ExplorationQuery q {:exploration_thread_id (:id th)
+                                                :card_id (:id metric)
+                                                :dimension_id "d1"
+                                                :status "pending"
+                                                :dataset_query (venues-count-query)}]
+        (perms/grant-collection-read-permissions! (perms-group/all-users) coll)
+        (let [body (mt/user-http-request :rasta :get 409 (format "exploration/query/%d" (:id q)))]
           (is (= "pending" (:status body))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/explorations_test.clj
@@ -151,7 +151,9 @@
                                          :database_id (mt/id) :dataset_query (venues-count-query)}
                      :model/Exploration e {:name "shared" :creator_id (mt/user->id :lucky) :collection_id (:id coll)}
                      :model/ExplorationThread th {:exploration_id (:id e)}
+                     :model/ExplorationThreadGroup g {:exploration_thread_id (:id th)}
                      :model/ExplorationQuery q {:exploration_thread_id (:id th)
+                                                :group_id (:id g)
                                                 :card_id (:id metric)
                                                 :dimension_id "d1"
                                                 :status "pending"

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationChartError.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationChartError.tsx
@@ -1,0 +1,56 @@
+import { t } from "ttag";
+
+import { Center, Icon, Stack, Text } from "metabase/ui";
+import type { ExplorationQuery } from "metabase-types/api";
+
+import { ExplorationVisualizationHeader } from "./ExplorationVisualizationHeader";
+
+function isPermissionError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error != null &&
+    "status" in error &&
+    (error as { status?: unknown }).status === 403
+  );
+}
+
+/**
+ * Shown in place of {@link ExplorationChartSkeleton} when an exploration query's
+ * result fetch fails. The common case is a 403: the snapshot was computed under
+ * its creator's data-access lens (sandboxing/impersonation/routing) and the
+ * current viewer's lens differs, so they cannot see these results — surface a
+ * permission message instead of looping on the loading skeleton forever.
+ */
+export function ExplorationChartError({
+  name,
+  explorationQuery,
+  error,
+}: {
+  name: string | null;
+  explorationQuery?: ExplorationQuery;
+  error: unknown;
+}) {
+  const permission = isPermissionError(error);
+  return (
+    <>
+      <ExplorationVisualizationHeader
+        name={name ?? ""}
+        explorationQuery={explorationQuery}
+      />
+      <Center h="100%" p="md">
+        <Stack align="center" gap="sm" maw="20rem">
+          <Icon
+            name={permission ? "lock" : "warning"}
+            size={24}
+            c={permission ? "text-secondary" : "error"}
+          />
+          <Text c="text-secondary" ta="center">
+            {permission
+              ? t`You don't have permission to view these results.`
+              : t`This chart couldn't be loaded.`}
+          </Text>
+        </Stack>
+      </Center>
+    </>
+  );
+}

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
@@ -20,6 +20,7 @@ import type {
 } from "metabase-types/api";
 import { isSettledExplorationQueryStatus } from "metabase-types/api";
 
+import { ExplorationChartError } from "./ExplorationChartError";
 import { ExplorationChartSkeleton } from "./ExplorationChartSkeleton";
 import S from "./ExplorationVisualization.module.css";
 import { ExplorationVisualizationHeader } from "./ExplorationVisualizationHeader";
@@ -191,6 +192,11 @@ function ExplorationGroupVisualizationChart({
   // Extract the identity-stable dataset references so they can be
   // individually tracked in the useMemo dependency array below.
   const datasets = datasetQueries.map((q) => q.currentData);
+  // A result fetch can fail (most commonly a 403 when the viewer's data-access
+  // lens differs from the snapshot creator's). `currentData` stays undefined in
+  // that case, same as while loading, so track errors separately to avoid
+  // showing the loading skeleton forever.
+  const datasetError = datasetQueries.find((q) => q.error)?.error;
 
   const { seriesGroups, layoutStrategy, chartsForDocumentEmbed } =
     useMemo(() => {
@@ -218,6 +224,15 @@ function ExplorationGroupVisualizationChart({
   }, [seriesGroups]);
 
   if (!seriesGroups) {
+    if (datasetError) {
+      return (
+        <ExplorationChartError
+          name={groupName}
+          explorationQuery={queries[0]}
+          error={datasetError}
+        />
+      );
+    }
     return (
       <ExplorationChartSkeleton
         name={groupName}

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
@@ -36,13 +36,15 @@ jest.mock("metabase/visualizations/components/Visualization", () => {
   return { __esModule: true, default: Visualization };
 });
 
-// Stub the per-query result hook so we can drive datasets from each test.
+// Stub the per-query result hook so we can drive datasets (and errors) from each test.
 const mockDatasetsByQueryId = new Map<number, Dataset | undefined>();
+const mockErrorsByQueryId = new Map<number, unknown>();
 jest.mock("metabase/api/exploration", () => ({
   __esModule: true,
   useGetExplorationQueryResultQuery: (id: number) => ({
     currentData: mockDatasetsByQueryId.get(id),
-    isLoading: !mockDatasetsByQueryId.has(id),
+    error: mockErrorsByQueryId.get(id),
+    isLoading: !mockDatasetsByQueryId.has(id) && !mockErrorsByQueryId.has(id),
   }),
   useAppendChartToDocumentMutation: () => [jest.fn()],
   useCreateExplorationDocumentMutation: () => [jest.fn()],
@@ -109,6 +111,7 @@ const group = createGroup({
 interface SetupOpts {
   queries: ExplorationQuery[];
   datasets?: Map<number, Dataset>;
+  errors?: Map<number, unknown>;
   availableTimelines?: Timeline[];
   interestingTimelineIds?: ReadonlySet<number>;
 }
@@ -116,13 +119,20 @@ interface SetupOpts {
 function setup({
   queries,
   datasets,
+  errors,
   availableTimelines = [],
   interestingTimelineIds,
 }: SetupOpts) {
   mockDatasetsByQueryId.clear();
+  mockErrorsByQueryId.clear();
   if (datasets) {
     for (const [id, ds] of datasets) {
       mockDatasetsByQueryId.set(id, ds);
+    }
+  }
+  if (errors) {
+    for (const [id, err] of errors) {
+      mockErrorsByQueryId.set(id, err);
     }
   }
 
@@ -144,6 +154,24 @@ function setup({
 describe("ExplorationGroupVisualization", () => {
   afterEach(() => {
     mockDatasetsByQueryId.clear();
+    mockErrorsByQueryId.clear();
+  });
+
+  it("shows a permission message (not the loading skeleton) when a settled query's result fetch is forbidden", () => {
+    setup({
+      queries: [
+        createQuery({ id: 101, name: "Q1", status: "done" }),
+        createQuery({ id: 102, name: "Q2", status: "done" }),
+      ],
+      // 101 streams fine, 102's cached result is gated by the viewer's data-access lens
+      datasets: new Map([[101, makeTimeseriesDataset()]]),
+      errors: new Map([[102, { status: 403 }]]),
+    });
+
+    expect(
+      screen.getByText("You don't have permission to view these results."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("visualization-stub")).not.toBeInTheDocument();
   });
 
   it("renders the aggregated error pane when any query has errored", () => {

--- a/resources/migrations/063/20260428_explorations.yaml
+++ b/resources/migrations/063/20260428_explorations.yaml
@@ -1497,3 +1497,17 @@ databaseChangeLog:
                   remarks: JSON-encoded effective-data-access token (sandbox/impersonation/routing fingerprint) for the creator's lens this snapshot was computed under. Compared against a viewer's token to gate cached reads. NULL means creator+admin only.
                   constraints:
                     nullable: true
+
+  - changeSet:
+      id: v63.storedresultdataaccesstokenbf
+      author: nvoxland
+      comment: Backfill data_access_token to the empty-map EDN sentinel '{}' for pre-token stored_result rows so legacy snapshots stay viewable by anyone with sufficient data perms (the nil-token read gate is creator+admin-only).
+      changes:
+        - update:
+            tableName: stored_result
+            columns:
+              - column:
+                  name: data_access_token
+                  value: "{}"
+            where: data_access_token IS NULL
+      rollback:

--- a/resources/migrations/063/20260428_explorations.yaml
+++ b/resources/migrations/063/20260428_explorations.yaml
@@ -1482,3 +1482,18 @@ databaseChangeLog:
                   remarks: Block anchor — "metric" or "dimension"
                   constraints:
                     nullable: true
+
+  - changeSet:
+      id: v63.storedresultdataaccesstoken
+      author: nvoxland
+      comment: Add stored_result.data_access_token for per-lens cached-read gating
+      changes:
+        - addColumn:
+            tableName: stored_result
+            columns:
+              - column:
+                  name: data_access_token
+                  type: ${text.type}
+                  remarks: JSON-encoded effective-data-access token (sandbox/impersonation/routing fingerprint) for the creator's lens this snapshot was computed under. Compared against a viewer's token to gate cached reads. NULL means creator+admin only.
+                  constraints:
+                    nullable: true

--- a/resources/migrations/063/20260428_explorations.yaml
+++ b/resources/migrations/063/20260428_explorations.yaml
@@ -1485,7 +1485,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v63.storedresultdataaccesstoken
-      author: nvoxland
+      author: johnswanson
       comment: Add stored_result.data_access_token for per-lens cached-read gating
       changes:
         - addColumn:
@@ -1500,7 +1500,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v63.storedresultdataaccesstokenbf
-      author: nvoxland
+      author: johnswanson
       comment: Backfill data_access_token to the empty-map EDN sentinel '{}' for pre-token stored_result rows so legacy snapshots stay viewable by anyone with sufficient data perms (the nil-token read gate is creator+admin-only).
       changes:
         - update:

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -10,6 +10,7 @@
    [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.documents.schema :as documents.schema]
    [metabase.events.core :as events]
+   [metabase.models.interface :as mi]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as card]
    [metabase.query-permissions.core :as query-perms]
@@ -148,10 +149,11 @@
   "Gets existing `Documents`."
   [_route-params
    _query-params]
-  {:items (t2/hydrate (t2/select :model/Document {:where [:and
-                                                          (collection/visible-collection-filter-clause)
-                                                          [:= :archived false]]})
-                      :creator :can_write :is_remote_synced)})
+  {:items (-> (t2/select :model/Document {:where [:and
+                                                  (collection/visible-collection-filter-clause)
+                                                  [:= :archived false]]})
+              (->> (filter mi/can-read?))
+              (t2/hydrate :creator :can_write :is_remote_synced))})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -149,11 +149,11 @@
   "Gets existing `Documents`."
   [_route-params
    _query-params]
-  {:items (-> (t2/select :model/Document {:where [:and
-                                                  (collection/visible-collection-filter-clause)
-                                                  [:= :archived false]]})
-              (->> (filter mi/can-read?))
-              (t2/hydrate :creator :can_write :is_remote_synced))})
+  {:items (as-> (t2/select :model/Document {:where [:and
+                                                    (collection/visible-collection-filter-clause)
+                                                    [:= :archived false]]}) docs
+            (filter mi/can-read? docs)
+            (t2/hydrate docs :creator :can_write :is_remote_synced))})
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/documents/core.clj
+++ b/src/metabase/documents/core.clj
@@ -16,7 +16,7 @@
  [metabase.documents.api.document
   get-document]
  [metabase.documents.models.document
-  register-exploration-doc-visibility-fn!]
+  register-doc-content-visibility-fn!]
  [metabase.documents.prose-mirror
   prose-mirror-content-type]
  [metabase.documents.validate

--- a/src/metabase/documents/core.clj
+++ b/src/metabase/documents/core.clj
@@ -1,6 +1,7 @@
 (ns metabase.documents.core
   (:require
    [metabase.documents.api.document]
+   [metabase.documents.models.document]
    [metabase.documents.prose-mirror]
    [metabase.documents.recent-views]
    [metabase.documents.validate]
@@ -8,11 +9,14 @@
 
 (comment
   metabase.documents.api.document/keep-me
+  metabase.documents.models.document/keep-me
   metabase.documents.recent-views/keep-me)
 
 (p/import-vars
  [metabase.documents.api.document
   get-document]
+ [metabase.documents.models.document
+  register-exploration-doc-visibility-fn!]
  [metabase.documents.prose-mirror
   prose-mirror-content-type]
  [metabase.documents.validate

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -33,43 +33,41 @@
   (derive :hook/entity-id))
 
 (defonce ^{:private true
-           :doc "Optional predicate, installed by the explorations module via
-                 [[register-exploration-doc-visibility-fn!]], gating the *content* of an
-                 exploration-attached document (e.g. the AI Summary) by the viewer's data-access
-                 lens. Defaults to always-visible so documents not produced by explorations — and
-                 installs where the explorations module isn't loaded — behave normally."}
-  exploration-doc-visibility-fn
+           :doc "Predicate gating a document's *content* (not merely its existence) below
+                 collection-read, for documents whose rendered body embeds data the viewer may not
+                 be entitled to see. Installed at init.
+
+                 The only user today is `explorations`: an AI-Summary document belongs to an
+                 exploration thread (the `:exploration_thread_id` FK on this table) and embeds
+                 verbatim — possibly sandboxed/impersonated/routed — result values, so a
+                 collaborator whose data-access lens differs from the creator's must not read it.
+
+                 `documents` can't call the consumer directly — the module graph runs one way
+                 (`explorations -> documents`) — so the consumer registers a callback here."}
+  doc-content-visibility-fn
   (atom (fn [_doc] true)))
 
-(defn register-exploration-doc-visibility-fn!
-  "Install the data-access gate the explorations module uses for its derived documents. Called once
-  at explorations init. `f` takes a document and returns whether the current user may see its
-  content."
+(defn register-doc-content-visibility-fn!
+  "Install the content-visibility gate (see [[doc-content-visibility-fn]]). Called once at the
+  consuming module's init. `f` takes a document and returns whether the current user may see its
+  rendered content."
   [f]
-  (reset! exploration-doc-visibility-fn f))
+  (reset! doc-content-visibility-fn f))
 
-(defn- exploration-doc-content-visible?
-  "An exploration-attached document's content is visible only when the registered exploration gate
-  passes. Non-exploration documents (no `:exploration_thread_id`) are unaffected."
-  [doc]
-  (or (nil? (:exploration_thread_id doc))
-      (boolean (@exploration-doc-visibility-fn doc))))
-
-;; Document read/write compose the parent-collection permission policy with the exploration
-;; data-access gate: an exploration's AI Summary embeds verbatim values from the creator's (possibly
-;; sandboxed/impersonated/routed) results, so a collaborator whose lens differs must not read it.
-;; This is the universal chokepoint — every read path funnels through `mi/can-read?`.
+;; can-read?/can-write? compose the collection-permission policy with the content-visibility gate:
+;; a document's rendered body can embed data the viewer isn't entitled to, so content access can be
+;; narrower than collection access.
 (defmethod mi/can-read? :model/Document
   ([instance]
    (and (mi/current-user-has-full-permissions? :read instance)
-        (exploration-doc-content-visible? instance)))
+        (boolean (@doc-content-visibility-fn instance))))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
 (defmethod mi/can-write? :model/Document
   ([instance]
    (and (mi/current-user-has-full-permissions? :write instance)
-        (exploration-doc-content-visible? instance)))
+        (boolean (@doc-content-visibility-fn instance))))
   ([model pk]
    (mi/can-write? (t2/select-one model pk))))
 

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -32,6 +32,47 @@
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 
+(defonce ^{:private true
+           :doc "Optional predicate, installed by the explorations module via
+                 [[register-exploration-doc-visibility-fn!]], gating the *content* of an
+                 exploration-attached document (e.g. the AI Summary) by the viewer's data-access
+                 lens. Defaults to always-visible so documents not produced by explorations — and
+                 installs where the explorations module isn't loaded — behave normally."}
+  exploration-doc-visibility-fn
+  (atom (fn [_doc] true)))
+
+(defn register-exploration-doc-visibility-fn!
+  "Install the data-access gate the explorations module uses for its derived documents. Called once
+  at explorations init. `f` takes a document and returns whether the current user may see its
+  content."
+  [f]
+  (reset! exploration-doc-visibility-fn f))
+
+(defn- exploration-doc-content-visible?
+  "An exploration-attached document's content is visible only when the registered exploration gate
+  passes. Non-exploration documents (no `:exploration_thread_id`) are unaffected."
+  [doc]
+  (or (nil? (:exploration_thread_id doc))
+      (boolean (@exploration-doc-visibility-fn doc))))
+
+;; Document read/write compose the parent-collection permission policy with the exploration
+;; data-access gate: an exploration's AI Summary embeds verbatim values from the creator's (possibly
+;; sandboxed/impersonated/routed) results, so a collaborator whose lens differs must not read it.
+;; This is the universal chokepoint — every read path funnels through `mi/can-read?`.
+(defmethod mi/can-read? :model/Document
+  ([instance]
+   (and (mi/current-user-has-full-permissions? :read instance)
+        (exploration-doc-content-visible? instance)))
+  ([model pk]
+   (mi/can-read? (t2/select-one model pk))))
+
+(defmethod mi/can-write? :model/Document
+  ([instance]
+   (and (mi/current-user-has-full-permissions? :write instance)
+        (exploration-doc-content-visible? instance)))
+  ([model pk]
+   (mi/can-write? (t2/select-one model pk))))
+
 (def DocumentName
   "Validations for the name of a document"
   (mu/with-api-error-message

--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -930,19 +930,19 @@
     (case (:status q)
       "done"
       (let [sr (api/check-404 (eqr/stored-results id))]
-        ;; The cached `result_data` was produced by the creator, so non-creator viewers might
-        ;; otherwise see data the QP would have filtered out for them. Block when the viewer
-        ;; is sandboxed/impersonated for the snapshot's DB or lacks data perms on it.
+        ;; The cached `result_data` was produced under the creator's lens, so a non-creator viewer
+        ;; might otherwise see rows the QP would have filtered out for them. Gate against the
+        ;; creator's stored data-access token (sandbox/impersonation/routing) + basic data perms.
         (when-not (= api/*current-user-id* (:creator_id sr))
           (queries/assert-can-view-cached-result! sr))
         (stream-stored-result format (:result_data sr)))
 
-      (do
-        (queries/assert-can-view-cached-result! {:id            (:id q)
-                                                 :database_id   (:database_id q)
-                                                 :dataset_query (:dataset_query q)})
-        {:status 409
-         :body   (select-keys q [:id :status :error_message :started_at :finished_at])}))))
+      ;; Pending / errored: no blob exists yet and the response is status-only (no rows, no
+      ;; derived text), so it carries no data to leak — it rides the exploration's collection
+      ;; perms (already enforced by `get-exploration-query-or-404`'s read-check), like seeing a
+      ;; dashboard card that's still loading.
+      {:status 409
+       :body   (select-keys q [:id :status :error_message :started_at :finished_at])})))
 
 (api.macros/defendpoint :put "/query/:id/interesting" :- ::ExplorationQuerySummary
   "Set the owner's interestingness rating on an exploration query.

--- a/src/metabase/explorations/core.clj
+++ b/src/metabase/explorations/core.clj
@@ -6,5 +6,4 @@
 (p/import-vars
  [impl
   exploration-data
-  min-interestingness
-  routed-database-ids])
+  min-interestingness])

--- a/src/metabase/explorations/document_perms.clj
+++ b/src/metabase/explorations/document_perms.clj
@@ -24,13 +24,15 @@
       (t2/select :model/StoredResult :id [:in sr-ids]))))
 
 (defn doc-content-visible-to-current-user?
-  "True when the current user may see the derived content of exploration-attached `doc`: their
-  data-access lens must be compatible with EVERY query result the doc's thread synthesizes (the AI
+  "True when the current user may see the derived content of `doc`. Documents not attached to an
+  exploration thread are always visible; for exploration-attached documents, the viewer's
+  data-access lens must be compatible with EVERY query result the thread synthesizes (the AI
   summary mixes values across all of them). The exploration's creator always sees their own
   summary. Takes the whole `doc` so the policy can later be narrowed to specific document kinds."
   [doc]
-  (let [stored-results (thread-stored-results (:exploration_thread_id doc))]
-    (every? (fn [sr]
-              (or (= api/*current-user-id* (:creator_id sr))
-                  (queries/viewer-can-view-cached-result? sr)))
-            stored-results)))
+  (or (nil? (:exploration_thread_id doc))
+      (let [stored-results (thread-stored-results (:exploration_thread_id doc))]
+        (every? (fn [sr]
+                  (or (= api/*current-user-id* (:creator_id sr))
+                      (queries/viewer-can-view-cached-result? sr)))
+                stored-results))))

--- a/src/metabase/explorations/document_perms.clj
+++ b/src/metabase/explorations/document_perms.clj
@@ -1,0 +1,36 @@
+(ns metabase.explorations.document-perms
+  "Gate the *content* of exploration-attached documents (the AI Summary) by the viewer's
+  data-access lens. The summary embeds verbatim values from the creator's (possibly
+  sandboxed/impersonated/routed) query results, so a collaborator whose lens differs must not read
+  it — even though they can see the exploration shell via collection perms.
+
+  Installed into the documents module's `can-read?`/`can-write?` chokepoint at init. The module
+  dependency only runs one way (explorations -> documents), so documents calls back in through a
+  registered hook rather than requiring explorations directly."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.queries.core :as queries]
+   [toucan2.core :as t2]))
+
+(defn- thread-stored-results
+  "All `stored_result`s feeding exploration thread `thread-id` (one per completed query).
+  Pending/errored queries have no stored_result and contribute nothing to the AI summary."
+  [thread-id]
+  (let [eq-ids (t2/select-pks-set :model/ExplorationQuery :exploration_thread_id thread-id)
+        sr-ids (when (seq eq-ids)
+                 (t2/select-fn-set :stored_result_id :model/ExplorationQueryResult
+                                   :exploration_query_id [:in eq-ids]))]
+    (when (seq sr-ids)
+      (t2/select :model/StoredResult :id [:in sr-ids]))))
+
+(defn doc-content-visible-to-current-user?
+  "True when the current user may see the derived content of exploration-attached `doc`: their
+  data-access lens must be compatible with EVERY query result the doc's thread synthesizes (the AI
+  summary mixes values across all of them). The exploration's creator always sees their own
+  summary. Takes the whole `doc` so the policy can later be narrowed to specific document kinds."
+  [doc]
+  (let [stored-results (thread-stored-results (:exploration_thread_id doc))]
+    (every? (fn [sr]
+              (or (= api/*current-user-id* (:creator_id sr))
+                  (queries/viewer-can-view-cached-result? sr)))
+            stored-results)))

--- a/src/metabase/explorations/impl.clj
+++ b/src/metabase/explorations/impl.clj
@@ -18,20 +18,6 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
-(defn routed-database-ids
-  "Subset of `db-ids` whose databases are routers (i.e., have a row in the `db_router` table).
-   Cards/metrics only ever target the router DB directly — destinations are swapped in at QP
-   time — so checking the router side is sufficient. We filter routed metrics out of
-   explorations entirely: a worker-cached result blob would be unsafe to share, since
-   different viewers would normally route to different destination DBs."
-  [db-ids]
-  (if (empty? db-ids)
-    #{}
-    (into #{} (map :database_id)
-          (t2/query {:select [:database_id]
-                     :from   [:db_router]
-                     :where  [:in :database_id (vec (set db-ids))]}))))
-
 (set! *warn-on-reflection* true)
 
 (def min-interestingness
@@ -237,18 +223,13 @@
      ids the user can read. When nil, returns all visible metric Cards.
    - `:q` (optional) — case-insensitive search across metric name and dimension display-name.
 
-   Metrics whose underlying database has database routing configured are filtered out
-   entirely — see [[routed-database-ids]] for the rationale.
-
    The returned shape is `{:metrics [...] :dimension_groups [...]}` exactly matching the
    `::DimensionsResponse` schema in `metabase.explorations.api`."
   [{:keys [metric-ids q]}]
   (lib-be/with-metadata-provider-cache
     (let [library-ids (or (library-metrics-collection-ids) #{})
           card-ids   (accessible-metric-ids metric-ids)
-          all-cards  (load-metric-cards card-ids)
-          routed-dbs (routed-database-ids (into #{} (keep :database_id) all-cards))
-          cards      (remove (comp routed-dbs :database_id) all-cards)
+          cards      (load-metric-cards card-ids)
           ;; Filter dimensions by user permissions for all metrics at once (one set of queries
           ;; for the whole batch, rather than per metric).
           permitted  (metrics/filter-dimensions-for-user-batch cards)

--- a/src/metabase/explorations/init.clj
+++ b/src/metabase/explorations/init.clj
@@ -12,7 +12,7 @@
    [metabase.explorations.settings]
    [metabase.explorations.task.runner]))
 
-;; Install the exploration data-access gate into the documents module's read/write chokepoint, so
-;; the AI Summary doc's content is hidden from collaborators whose lens differs from the creator's.
-(documents/register-exploration-doc-visibility-fn!
+;; Install the content-visibility gate into the documents module's read/write path, so the AI
+;; Summary doc's content is hidden from collaborators whose lens differs from the creator's.
+(documents/register-doc-content-visibility-fn!
  document-perms/doc-content-visible-to-current-user?)

--- a/src/metabase/explorations/init.clj
+++ b/src/metabase/explorations/init.clj
@@ -1,6 +1,8 @@
 (ns metabase.explorations.init
   (:require
+   [metabase.documents.core :as documents]
    [metabase.explorations.ai-summary]
+   [metabase.explorations.document-perms :as document-perms]
    [metabase.explorations.models.exploration]
    [metabase.explorations.models.exploration-query]
    [metabase.explorations.models.exploration-query-result]
@@ -9,3 +11,8 @@
    [metabase.explorations.models.exploration-thread-timeline]
    [metabase.explorations.settings]
    [metabase.explorations.task.runner]))
+
+;; Install the exploration data-access gate into the documents module's read/write chokepoint, so
+;; the AI Summary doc's content is hidden from collaborators whose lens differs from the creator's.
+(documents/register-exploration-doc-visibility-fn!
+ document-perms/doc-content-visible-to-current-user?)

--- a/src/metabase/explorations/query_plan.clj
+++ b/src/metabase/explorations/query_plan.clj
@@ -19,7 +19,6 @@
    [metabase.explorations.ai-summary :as ai-summary]
    [metabase.explorations.query-plan.context :as qp.context]
    [metabase.explorations.query-plan.llm :as qp.llm]
-   [metabase.explorations.query-plan.mbql :as qp.mbql]
    [metabase.explorations.query-plan.mechanical :as qp.mechanical]
    [metabase.explorations.query-plan.planner :as planner]
    [metabase.explorations.query-plan.variants :as qp.variants]
@@ -227,13 +226,7 @@
 (defn- run-planner!
   "Invoke the picked planner, persist rows / mark terminal as appropriate, and
   return the outcome keyword (`:ok`, `:skip-empty`, or `:failed`)."
-  [{:keys [thread-id metric-dim-ctx metric-by-key creator-id] :as ctx} picked planner-id pre]
-  ;; Enforce the no-routed-databases constraint up front; both planners would
-  ;; produce items but the variant builders would later fail when running queries.
-  (qp.mbql/check-no-routed-databases!
-   (into {} (for [g (:groups metric-dim-ctx)
-                  m (:metrics g)]
-              [(:metric-id m) (:card m)])))
+  [{:keys [thread-id metric-by-key creator-id] :as ctx} picked planner-id pre]
   (let [{:keys [outcome plan rationale transcript final-errors]} (planner/plan! picked ctx)
         transcript-body {:outcome      outcome
                          :rationale    rationale

--- a/src/metabase/explorations/query_plan/mbql.clj
+++ b/src/metabase/explorations/query_plan/mbql.clj
@@ -7,8 +7,7 @@
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib.core :as lib]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.metrics.core :as metrics]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.metrics.core :as metrics]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/explorations/query_plan/mbql.clj
+++ b/src/metabase/explorations/query_plan/mbql.clj
@@ -4,8 +4,6 @@
   LLM or persists state — everything is a thin wrapper over `metabase.lib`
   that the variant builders compose."
   (:require
-   [clojure.string :as str]
-   [metabase.explorations.core :as explorations]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib.core :as lib]
    [metabase.lib.types.isa :as lib.types.isa]
@@ -144,20 +142,3 @@
   (let [base-query (-> (lib/query mp card-dataset-query) lib/remove-all-breakouts)
         ref-clause (normalize-target-ref target)]
     (lib/breakout base-query (apply-default-bucket base-query ref-clause dim))))
-
-(defn check-no-routed-databases!
-  "Throw a 400 if any metric Card lives in a router database. The worker-cached
-  result blob reflects whichever destination the creator routed to, so different
-  viewers can't safely share it."
-  [cards]
-  (when-let [routed (seq (explorations/routed-database-ids
-                          (into #{} (keep :database_id) (vals cards))))]
-    (let [routed-set (set routed)
-          offenders  (->> (vals cards)
-                          (filter (comp routed-set :database_id))
-                          (map :name))]
-      (throw (ex-info (tru "Cannot create an exploration for metrics on a routed database: {0}"
-                           (str/join ", " offenders))
-                      {:status-code      400
-                       :metric-names     offenders
-                       :routed-databases routed})))))

--- a/src/metabase/explorations/task/runner.clj
+++ b/src/metabase/explorations/task/runner.clj
@@ -32,6 +32,8 @@
    [metabase.explorations.timeline-interestingness :as explorations.timeline-interestingness]
    [metabase.interestingness.core :as interestingness]
    [metabase.lib.core :as lib]
+   [metabase.permissions.core :as perms]
+   [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.middleware.cache.impl :as cache.impl]
    [metabase.request.core :as request]
@@ -356,31 +358,58 @@
                  (:id exploration-query))
       nil)))
 
+(defn- compute-data-access-token
+  "The creator's effective-data-access token for `dataset-query` — the sandbox/impersonation/routing
+  fingerprint the snapshot is computed under, stored on the `StoredResult` and compared against a
+  viewer's token to gate cached reads. Must be called inside the creator's `with-current-user` (+
+  routing-on) binding. Best-effort: any failure yields nil, which the read gate treats as
+  creator+admin-only."
+  [dataset-query db-id]
+  (try
+    (perms/data-access-token {:database-id db-id
+                              :table-ids   (query-perms/query->source-table-ids dataset-query)})
+    (catch Throwable e
+      (log/warn e "Failed to compute data-access token for exploration query result")
+      nil)))
+
 (defn- execute-and-persist-query-result!
   "Run the QP on `row`'s `:dataset_query`, compute the chart-config / stats / scores via the
   `safe-*` helpers, persist a `StoredResult` + `ExplorationQueryResult` + `StoredResultUse`, and
   flip the `ExplorationQuery` to `done`. `started` is the `OffsetDateTime` to stamp as the row's
-  `:started_at`."
+  `:started_at`.
+
+  The query runs as the exploration's creator, so the snapshot reflects the creator's own lens —
+  sandboxing, connection impersonation, and database routing (all applied by the QP's own
+  middleware under the bound user). The same lens is captured as a `:data_access_token` so
+  non-creator readers can be gated against it."
   [row ^OffsetDateTime started]
-  (let [qp-result    (qp.variants/pin-other-last
-                      (:query_type row)
-                      (qp/process-query
-                       (qp/userland-query-with-default-constraints
-                        (:dataset_query row)
-                        {:context :exploration})))
+  (let [creator-id (exploration-creator-id row)
+        db-id      (:database_id row)
+        run        (fn []
+                     {:qp-result (qp.variants/pin-other-last
+                                  (:query_type row)
+                                  (qp/process-query
+                                   (qp/userland-query-with-default-constraints
+                                    (:dataset_query row)
+                                    {:context :exploration})))
+                      :token     (compute-data-access-token (:dataset_query row) db-id)})
+        {:keys [qp-result token]} (if creator-id
+                                    (request/with-current-user creator-id
+                                      (run))
+                                    (run))
         bytes        (serialize-result qp-result)
         chart-config (safe-chart-config row qp-result)
         stats        (safe-deep-stats row chart-config)
         score        (safe-score row chart-config stats)
-        creator-id   (exploration-creator-id row)
         ctx          (safe-score+describe row chart-config creator-id)
         sr-id        (first
                       (t2/insert-returning-pks!
                        :model/StoredResult
-                       {:result_data   bytes
-                        :creator_id    creator-id
-                        :database_id   (:database_id row)
-                        :dataset_query (:dataset_query row)}))]
+                       {:result_data       bytes
+                        :creator_id        creator-id
+                        :database_id       db-id
+                        :dataset_query     (:dataset_query row)
+                        :data_access_token token}))]
     (t2/insert! :model/ExplorationQueryResult
                 {:exploration_query_id             (:id row)
                  :stored_result_id                 sr-id

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -2,6 +2,7 @@
   "`permissions` module API namespace."
   {:clj-kondo/config '{:linters {:missing-docstring {:level :off}}}}
   (:require
+   [metabase.permissions.data-access-token]
    [metabase.permissions.models.application-permissions-revision]
    [metabase.permissions.models.collection-permission-graph-revision]
    [metabase.permissions.models.collection.graph]
@@ -29,6 +30,7 @@
   metabase.permissions.models.permissions-group/keep-me
   metabase.permissions.models.permissions-group-membership/keep-me
   metabase.permissions.models.permissions-revision/keep-me
+  metabase.permissions.data-access-token/keep-me
   metabase.permissions.path/keep-me
   metabase.permissions.published-tables/keep-me
   metabase.permissions.user/keep-me
@@ -152,6 +154,11 @@
   published-table-visible-clause])
 
 (p/import-vars [metabase.permissions.settings use-tenants])
+
+(p/import-vars
+ [metabase.permissions.data-access-token
+  data-access-token
+  data-access-compatible?])
 
 ;;; import these vars with different names to make their purpose more obvious.
 (p/import-def metabase.permissions.models.permissions-group/all-users                    all-users-group)

--- a/src/metabase/permissions/data_access_token.clj
+++ b/src/metabase/permissions/data_access_token.clj
@@ -34,7 +34,8 @@
 
 (defenterprise impersonation-token-for-db
   "Connection-impersonation fingerprint for the current user on `db-id`, or nil when not
-  impersonated (including admins). The token is the resolved database role."
+  impersonated (including admins). The token is a map {:role <role-string>} representing the
+  resolved database role, or nil when not impersonated."
   metabase-enterprise.impersonation.driver
   [_db-id]
   nil)
@@ -42,7 +43,8 @@
 (defenterprise routing-token-for-db
   "Database-routing fingerprint for the current user on router `db-id`, or nil when the user
   resolves to the router db itself (admins, or non-admins routed via the __METABASE_ROUTER__
-  sentinel). The token is the resolved destination database id. May throw when a routed
+  sentinel). The token is a map {:destination-db-id <db-id>} representing the resolved
+  destination database, or nil when the user resolves to the router database itself. May throw when a routed
   non-admin is missing the required routing attribute."
   metabase-enterprise.database-routing.common
   [_db-id]

--- a/src/metabase/permissions/data_access_token.clj
+++ b/src/metabase/permissions/data_access_token.clj
@@ -1,0 +1,88 @@
+(ns metabase.permissions.data-access-token
+  "Effective-data-access fingerprint for the *current user* over a set of tables in one database,
+  plus the comparison used to decide whether a result blob computed under one user's lens may be
+  served to another.
+
+  A cached result (a `stored_result` blob, a cached FieldValues set, etc.) is computed once under
+  its creator's effective permissions — sandboxing, connection impersonation, and database
+  routing all silently change *which rows* the creator sees. Replaying that blob for another
+  viewer is only safe when the viewer's lens is *compatible* with the creator's.
+
+  The token is a per-dimension, per-target map. The convention is **absent = unrestricted**:
+
+      {:sandbox       {table-id <token>}   ; per touched table; absent key => not sandboxed there
+       :impersonation {db-id    <token>}   ; absent => not impersonated on that db
+       :routing       {db-id    <token>}}  ; absent => sees the router db (admins / __METABASE_ROUTER__)
+
+  Each per-dimension contributor is a `defenterprise` owned by its EE module (OSS => nil, so OSS
+  tokens are empty and everyone is compatible). They use `:feature :none` so a sandboxed /
+  impersonated / routed user is recognized even if the gating feature flag is momentarily
+  unavailable — fail closed, never leak.
+
+  Computing a token may THROW when the user lacks an attribute a routing / impersonation policy
+  requires; callers gating a read should treat a throw as \"deny\"."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise sandbox-token-for-table
+  "Sandbox fingerprint for the current user on `table-id`, or nil when the user is not sandboxed
+  on that table. Captures the GTAP card, its version, and the resolved user-attribute values, so
+  two users \"share a sandbox\" only when they'd see the same rows."
+  metabase-enterprise.sandbox.models.params.field-values
+  [_table-id]
+  nil)
+
+(defenterprise impersonation-token-for-db
+  "Connection-impersonation fingerprint for the current user on `db-id`, or nil when not
+  impersonated (including admins). The token is the resolved database role."
+  metabase-enterprise.impersonation.driver
+  [_db-id]
+  nil)
+
+(defenterprise routing-token-for-db
+  "Database-routing fingerprint for the current user on router `db-id`, or nil when the user
+  resolves to the router db itself (admins, or non-admins routed via the __METABASE_ROUTER__
+  sentinel). The token is the resolved destination database id. May throw when a routed
+  non-admin is missing the required routing attribute."
+  metabase-enterprise.database-routing.common
+  [_db-id]
+  nil)
+
+(defn data-access-token
+  "Compute the current user's effective-data-access token over `table-ids` in `database-id`.
+  See the namespace docstring for the shape. Empty dimensions are omitted; an entirely empty map
+  means the user is unrestricted across all three dimensions for this target (the OSS case)."
+  [{:keys [database-id table-ids]}]
+  (let [sandbox (into {}
+                      (keep (fn [table-id]
+                              (when-let [t (sandbox-token-for-table table-id)]
+                                [table-id t])))
+                      table-ids)
+        imp     (when database-id (impersonation-token-for-db database-id))
+        routing (when database-id (routing-token-for-db database-id))]
+    (cond-> {}
+      (seq sandbox) (assoc :sandbox sandbox)
+      imp           (assoc :impersonation {database-id imp})
+      routing       (assoc :routing {database-id routing}))))
+
+(defn data-access-compatible?
+  "True when a viewer holding `viewer-token` may be served a blob computed under `creator-token`.
+
+  Per dimension and per target key: the viewer must be **absent** (unrestricted there) OR hold
+  the **same** token as the creator. AND'd across every key in either token and across all three
+  dimensions. This yields exactly the intended semantics:
+
+    - same sandbox / role / destination     => compatible
+    - viewer unsandboxed / unimpersonated / admin (absent) => compatible (sees creator's lens)
+    - viewer restricted where creator is not (creator absent, viewer present) => NOT compatible"
+  [creator-token viewer-token]
+  (every?
+   (fn [dimension]
+     (let [cm (get creator-token dimension {})
+           vm (get viewer-token dimension {})]
+       (every? (fn [k]
+                 (let [vv (get vm k ::absent)]
+                   (or (= vv ::absent)
+                       (= vv (get cm k ::absent)))))
+               (into #{} (concat (keys cm) (keys vm))))))
+   [:sandbox :impersonation :routing]))

--- a/src/metabase/queries/cached_result.clj
+++ b/src/metabase/queries/cached_result.clj
@@ -11,6 +11,7 @@
   the card-query endpoint reuses this namespace for the cached path so callers go through
   one rendering pipeline whether the data is live or cached."
   (:require
+   [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.middleware.cache.impl :as cache.impl]
@@ -28,31 +29,57 @@
   validator, and the renderer agree."
   #{"value_asc" "value_desc" "label_asc" "label_desc"})
 
+(defn- viewer-lens-compatible?
+  "True when the current user's effective data-access lens (sandbox / impersonation / routing) is
+  compatible with the lens the `stored-result` blob was computed under — i.e. the viewer may be
+  served the creator's snapshot. See [[metabase.permissions.data-access-token]].
+
+  A `nil` `:data_access_token` (a pre-token snapshot, or a write that failed to capture one) is
+  treated as creator+admin-only; since this is only consulted for non-creators, that collapses to
+  admins-only. Token computation throwing — the viewer is missing a routing/impersonation
+  attribute the snapshot's database requires — means deny."
+  [stored-result]
+  (if-let [creator-token (:data_access_token stored-result)]
+    (try
+      (perms/data-access-compatible?
+       creator-token
+       (perms/data-access-token {:database-id (:database_id stored-result)
+                                 :table-ids   (query-perms/query->source-table-ids
+                                               (:dataset_query stored-result))}))
+      (catch Throwable _ false))
+    (boolean api/*is-superuser?*)))
+
 (defn- cached-result-blocked-reason
   "If the current user must NOT be served the cached blob for `stored-result`, return a keyword
   describing why. Returns nil when the cached blob is safe to stream.
 
   Reasons (in priority order):
-    `:sandboxed`     — current user has an enforced sandbox on the snapshot's database.
-    `:impersonated`  — current user has connection impersonation on the snapshot's database.
-    `:no-data-perms` — current user lacks the data perms required to run the underlying query."
+    `:no-data-perms`        — current user lacks the data perms required to run the underlying query.
+    `:incompatible-context` — current user's sandbox/impersonation/routing lens differs from the
+                              lens the snapshot was computed under."
   [stored-result]
-  (let [db-id (:database_id stored-result)]
-    (cond
-      (and db-id (perms/sandboxed-user-for-db? db-id))         :sandboxed
-      (and db-id (perms/impersonation-enforced-for-db? db-id)) :impersonated
-      (and (:dataset_query stored-result)
-           (not (query-perms/can-run-query? (:dataset_query stored-result))))
-      :no-data-perms)))
+  (cond
+    (and (:dataset_query stored-result)
+         (not (query-perms/can-run-query? (:dataset_query stored-result))))
+    :no-data-perms
+
+    (not (viewer-lens-compatible? stored-result))
+    :incompatible-context))
+
+(defn viewer-can-view-cached-result?
+  "Boolean form of [[assert-can-view-cached-result!]]: true when the current user may be served the
+  blob for `stored-result`. Does not bypass for the creator — callers wanting a creator bypass must
+  check that themselves."
+  [stored-result]
+  (nil? (cached-result-blocked-reason stored-result)))
 
 (defn assert-can-view-cached-result!
   "Throw a 403 if the current user must not see the cached blob for `stored-result`."
   [stored-result]
   (when-let [reason (cached-result-blocked-reason stored-result)]
     (throw (ex-info (case reason
-                      :sandboxed     (tru "Cannot show cached results: your account is sandboxed for the underlying data.")
-                      :impersonated  (tru "Cannot show cached results: connection impersonation is enforced for the underlying data.")
-                      :no-data-perms (tru "You do not have permissions to view the data underlying this cached result."))
+                      :no-data-perms        (tru "You do not have permissions to view the data underlying this cached result.")
+                      :incompatible-context (tru "Cannot show cached results: your data access differs from the user who generated them."))
                     {:status-code      403
                      :reason           reason
                      :stored-result-id (:id stored-result)}))))

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -54,6 +54,7 @@
  [metabase.queries.cached-result
   allowed-chart-sorts
   assert-can-view-cached-result!
+  viewer-can-view-cached-result?
   cached-dataset])
 
 #_{:clj-kondo/ignore [:missing-docstring]}

--- a/src/metabase/queries/models/stored_result.clj
+++ b/src/metabase/queries/models/stored_result.clj
@@ -7,15 +7,37 @@
   table. Lives in the queries module because the snapshot is tied to a query/card, not to
   any one feature that produced it."
   (:require
+   [clojure.edn :as edn]
    [metabase.models.interface :as mi]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 (methodical/defmethod t2/table-name :model/StoredResult [_model] :stored_result)
 
+(defn- data-access-token-in
+  "Serialize the effective-data-access token as EDN. JSON can't be used: the token is keyed by
+  integer table-id / database-id, and JSON mangles non-string map keys. `nil` (creator+admin-only)
+  is stored as SQL NULL rather than the string \"nil\"."
+  [v]
+  (when (some? v)
+    (pr-str v)))
+
+(defn- data-access-token-out
+  "Read the EDN token back. An unreadable blob decodes to `nil`, which the read gate treats as
+  creator+admin-only — fail closed, never widen access on a parse error."
+  [s]
+  (when (string? s)
+    (try
+      (edn/read-string {:readers {} :default (fn [_tag v] v)} s)
+      (catch Throwable e
+        (log/warn e "Failed to parse stored_result.data_access_token; treating as creator+admin-only")
+        nil))))
+
 (t2/deftransforms :model/StoredResult
-  {:result_data   mi/transform-secret-value
-   :dataset_query mi/transform-json})
+  {:result_data       mi/transform-secret-value
+   :dataset_query     mi/transform-json
+   :data_access_token {:in data-access-token-in :out data-access-token-out}})
 
 (doto :model/StoredResult
   (derive :metabase/model)

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -1166,15 +1166,24 @@
 
 (defn- store-fake-result!
   "Insert a StoredResult holding the worker-serialized bytes plus an ExplorationQueryResult
-  that points at it, mirroring what the runner produces so the read endpoints can replay it."
+  that points at it, mirroring what the runner produces so the read endpoints can replay it.
+  Stamps `creator_id` from the owning Exploration (as the real runner does) so the cached-read
+  gate's creator bypass behaves like production."
   [query-id qp-result]
-  (let [bytes (cache.impl/do-with-serialization
-               (fn [in result-fn]
-                 (in qp-result)
-                 (result-fn)))
-        sr-id (first (t2/insert-returning-pks!
-                      :model/StoredResult
-                      {:result_data bytes}))]
+  (let [bytes      (cache.impl/do-with-serialization
+                    (fn [in result-fn]
+                      (in qp-result)
+                      (result-fn)))
+        creator-id (t2/select-one-fn :creator_id :model/Exploration
+                                     {:select [:e.creator_id]
+                                      :from   [[:exploration :e]]
+                                      :join   [[:exploration_thread :t] [:= :t.exploration_id :e.id]
+                                               [:exploration_query :q]  [:= :q.exploration_thread_id :t.id]]
+                                      :where  [:= :q.id query-id]})
+        sr-id      (first (t2/insert-returning-pks!
+                           :model/StoredResult
+                           {:result_data bytes
+                            :creator_id  creator-id}))]
     (t2/insert! :model/ExplorationQueryResult
                 {:exploration_query_id query-id
                  :stored_result_id     sr-id})))
@@ -2067,48 +2076,24 @@
           (is (true? (:archived_directly d))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                       Routed-database creation block                                          |
+;;; |                                         Routed-database metrics                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest exploration-create-rejects-routed-database-metric-test
+(deftest dimensions-includes-routed-database-metrics-test
   (when config/ee-available?
-    (testing "Exploration planner refuses when any selected metric lives in a router database"
-      (mt/with-temp [:model/User u {:email "routed@example.com"}
-                     :model/Card metric (assoc (valid-metric-card (:id u)) :name "Routed Metric")
-                     :model/DatabaseRouter _ {:database_id    (mt/id)
-                                              :user_attribute "team"}]
-        ;; POST creates the exploration (now returns 200; routed-db check is async).
-        (let [resp (mt/user-http-request u :post 200 "exploration"
-                                         {:name   "routed"
-                                          :groups [{:name       "Group"
-                                                    :metrics    [{:card_id (:id metric)
-                                                                  :dimension_mappings [{:dimension_id "d1"
-                                                                                        :table_id (mt/id :venues)
-                                                                                        :target ["field" {} (mt/id :venues :price)]}]}]
-                                                    :dimensions [{:dimension_id "d1"}]}]})
-              tid    (-> resp :threads first :id)
-              result (query-plan/generate-query-plan! tid)]
-          ;; The planner detects the routed database and returns nil (caught throwable).
-          (is (nil? result) "planning should fail for routed-database metrics")
-          (let [thread (t2/select-one :model/ExplorationThread :id tid)]
-            ;; mark-thread-terminally-failed! sets completed_at (not query_plan_started_at,
-            ;; which is stamped by the task runner before calling generate-query-plan!).
-            (is (some? (:completed_at thread))
-                "thread is stamped as terminally processed")))))))
-
-(deftest dimensions-excludes-routed-database-metrics-test
-  (when config/ee-available?
-    (testing "GET /api/exploration/dimensions hides metrics whose database is a router"
+    (testing "GET /api/exploration/dimensions includes metrics whose database is a router — routed
+              results are gated per-lens on read (see stored_result.data_access_token) rather than
+              hidden from the picker"
       (with-sample-metrics-archived
-        (mt/with-temp [:model/Card        _ {:name          "Routed Hidden"
+        (mt/with-temp [:model/Card        _ {:name          "Routed Metric"
                                              :type          :metric
                                              :dataset_query (lib/->legacy-MBQL (let [mp (mt/metadata-provider)] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/aggregate (lib/count)))))}
                        :model/DatabaseRouter _ {:database_id    (mt/id)
                                                 :user_attribute "team"}]
           (let [resp  (mt/user-http-request :rasta :get 200 "exploration/dimensions")
                 names (set (map :name (:metrics resp)))]
-            (is (not (contains? names "Routed Hidden"))
-                "metric on a router database is filtered out of /dimensions")))))))
+            (is (contains? names "Routed Metric")
+                "metric on a router database is selectable in /dimensions")))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                              POST /api/exploration/thread/:thread-id/cancel                                    |

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -1306,8 +1306,8 @@
             (is (thrown? Throwable
                          (eqr/create-ephemeral-card-for-exploration-queries!
                           [qid] doc-id (:collection_id doc) u {}))))
-          (is (zero? (t2/count :model/StoredResult :creator_id (:id u)))
-              "the composite StoredResult is rolled back when a later write fails")
+          (is (= 1 (t2/count :model/StoredResult :creator_id (:id u)))
+              "only the source snapshot remains — no composite StoredResult leaks from the rolled-back append")
           (is (zero? (t2/count :model/Card :document_id doc-id))
               "no ephemeral Card leaks from the rolled-back append")
           (is (zero? (t2/count :model/StoredResultUse :stored_result_id
@@ -1348,8 +1348,8 @@
               use-rows  (t2/select :model/StoredResultUse :card_id (:card-id result))]
           (is (= src-sr-id (:stored-result-id result))
               "the embed points back at the source stored_result rather than a fresh copy")
-          (is (zero? (t2/count :model/StoredResult :creator_id (:id u)))
-              "no duplicate composite StoredResult is created for a single-query embed")
+          (is (= 1 (t2/count :model/StoredResult :creator_id (:id u)))
+              "only the reused source snapshot exists — no duplicate composite StoredResult is created for a single-query embed")
           (is (= [src-sr-id] (mapv :stored_result_id use-rows))
               "exactly one stored_result_use row, pointing at the source snapshot"))))))
 

--- a/test/metabase/permissions/data_access_token_test.clj
+++ b/test/metabase/permissions/data_access_token_test.clj
@@ -1,0 +1,71 @@
+(ns metabase.permissions.data-access-token-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.data-access-token :as data-access-token]))
+
+(def ^:private sandbox-ca {:sandbox {10 [:card 1 {"State" "CA"}]}})
+(def ^:private sandbox-ny {:sandbox {10 [:card 1 {"State" "NY"}]}})
+(def ^:private role-ro    {:impersonation {5 {:role "ro"}}})
+(def ^:private role-rw    {:impersonation {5 {:role "rw"}}})
+(def ^:private dest-a     {:routing {7 {:destination-db-id 100}}})
+(def ^:private dest-b     {:routing {7 {:destination-db-id 200}}})
+(def ^:private unrestricted {})
+
+(deftest data-access-compatible?-sandbox-test
+  (let [compatible? data-access-token/data-access-compatible?]
+    (testing "viewer with the same sandbox can see the creator's blob"
+      (is (true? (compatible? sandbox-ca sandbox-ca))))
+    (testing "viewer with a different sandbox cannot"
+      (is (false? (compatible? sandbox-ca sandbox-ny))))
+    (testing "an unsandboxed viewer can see a sandboxed creator's blob (viewer is the superset)"
+      (is (true? (compatible? sandbox-ca unrestricted))))
+    (testing "a sandboxed viewer cannot see an unsandboxed creator's (full-data) blob"
+      (is (false? (compatible? unrestricted sandbox-ca))))))
+
+(deftest data-access-compatible?-impersonation-test
+  (let [compatible? data-access-token/data-access-compatible?]
+    (testing "same role sees, different role does not"
+      (is (true? (compatible? role-ro role-ro)))
+      (is (false? (compatible? role-ro role-rw))))
+    (testing "an unimpersonated viewer sees an impersonated creator's blob; the reverse is blocked"
+      (is (true? (compatible? role-ro unrestricted)))
+      (is (false? (compatible? unrestricted role-ro))))))
+
+(deftest data-access-compatible?-routing-test
+  (let [compatible? data-access-token/data-access-compatible?]
+    (testing "same destination sees, different destination does not"
+      (is (true? (compatible? dest-a dest-a)))
+      (is (false? (compatible? dest-a dest-b))))
+    (testing "the router cohort (admins / __METABASE_ROUTER__, absent token) sees a routed creator's blob"
+      (is (true? (compatible? dest-a unrestricted))))
+    (testing "a routed viewer cannot see a router-cohort creator's blob"
+      (is (false? (compatible? unrestricted dest-a))))))
+
+(deftest data-access-compatible?-combination-test
+  (let [compatible? data-access-token/data-access-compatible?
+        ;; creator sandboxed AND impersonated
+        creator (merge sandbox-ca role-ro)]
+    (testing "every active dimension must independently pass"
+      (is (true?  (compatible? creator creator)))
+      ;; viewer unsandboxed (escape) but shares the role -> sees
+      (is (true?  (compatible? creator role-ro)))
+      ;; viewer shares the sandbox but holds a different role -> blocked
+      (is (false? (compatible? creator (merge sandbox-ca role-rw))))
+      ;; fully unrestricted viewer -> sees (superset on both)
+      (is (true?  (compatible? creator unrestricted))))))
+
+(deftest data-access-compatible?-multi-table-sandbox-test
+  (let [compatible? data-access-token/data-access-compatible?
+        creator {:sandbox {10 [:card 1 {"State" "CA"}]
+                           20 [:card 2 {"Region" "West"}]}}]
+    (testing "viewer must match (or be absent on) EVERY touched table"
+      (is (true?  (compatible? creator creator)))
+      ;; matches table 10, unsandboxed on 20 -> sees
+      (is (true?  (compatible? creator {:sandbox {10 [:card 1 {"State" "CA"}]}})))
+      ;; matches table 10 but a different sandbox on table 20 -> blocked
+      (is (false? (compatible? creator {:sandbox {10 [:card 1 {"State" "CA"}]
+                                                  20 [:card 2 {"Region" "East"}]}}))))))
+
+(deftest data-access-compatible?-oss-test
+  (testing "two empty (OSS / unrestricted) tokens are always compatible -> no gating"
+    (is (true? (data-access-token/data-access-compatible? unrestricted unrestricted)))))


### PR DESCRIPTION
Linear: [UXW-4402: Respect sandboxing / impersonation / db routing for explorations](https://linear.app/metabase/issue/UXW-4402/respect-sandboxing-impersonation-db-routing-for-explorations)

## Why

Explorations had hacky "fail closed" workarounds for our three advanced permissions: anyone sandboxed/impersonated on a database was blocked from *any* cached exploration result on it, and routed databases were excluded from explorations entirely. This replaces those with correct, per-lens handling.

## Spec

An exploration result is a **snapshot computed once under its creator's effective data-access lens** and shared; a non-creator viewer may see it only when their own lens is compatible. Creating an exploration always works, regardless of the creator's permissions.

**If you're sandboxed:**
- you can create an exploration like normal
- people who share your sandbox can see your exploration / its results
- people who have a different sandbox can NOT
- people who are not sandboxed can see your exploration / its results

**If you're impersonated:**
- you can create an exploration like normal
- people who share your role can see your exploration / its results
- people who have a different role can NOT
- people who are not impersonated can see your exploration / its results

**If the DB has routing turned on:**
- you can create an exploration like normal
- people routed to the same destination DB can see your exploration / its results
- people routed to a different DB can NOT
- admins (and anyone resolving to the router DB) can see your exploration / its results

In all cases the **exploration shell** (name, the list of queries, structure) follows normal collection permissions, like a dashboard. Only the **results** — and any result-derived text (chart/metric descriptions, the AI Summary) — are gated; an incompatible viewer gets a permission error in place of that chart, the way a dashboard shows an error for a card you can't run.

## How

**Backend**

- New `metabase.permissions.data-access-token`: a per-dimension (sandbox / impersonation / routing) fingerprint of the current user's effective access over a set of tables in a database, plus `data-access-compatible?` — for every dimension/target key, the viewer must be **absent** (unrestricted there) **or equal** to the creator. This single rule yields the whole spec, including "admins/unsandboxed see, but the reverse is blocked." Each dimension is a `defenterprise` contributor owned by its EE module, reusing the existing FieldValues `hash-input-*` resolvers (and their enforcement guards, so superusers and full-access-via-another-group users correctly get no token).
- The exploration worker now runs each query **as the creator** (so the snapshot reflects their sandbox/impersonation/routing — the QP's own middleware applies routing) and captures the creator's token onto a new `stored_result.data_access_token` column. EDN-encoded (the token has integer table/db keys that JSON would mangle); added via a **separate `addColumn` changeset** so environments that already applied the create-table changeset (e.g. the long-running PR env) don't hit a Liquibase checksum mismatch.
- Rewrote the cached-result read gate (`metabase.queries.cached-result`) to compare the viewer's freshly-computed lens against the stored creator token, keeping the orthogonal data-perms check first. This fixes both the exploration and the cardEmbed read paths from one place. A `nil` token (pre-token snapshot) stays creator+admin-only; the status-only pending/error path is no longer data-gated.
- The AI Summary document embeds verbatim result values, so it's gated too — via `Document` `can-read?`/`can-write?`, composed with an explorations-registered hook (the dependency only runs one way, explorations → documents).
- Stopped excluding routed-database metrics from the picker and the planner.

**Frontend**

- On a `403`, show a permission message instead of an endless loading skeleton (the result hook leaves `currentData` undefined on both loading and error, so the two were indistinguishable).

## Tests

- `metabase.permissions.data-access-token-test` — the same/different/unrestricted/reverse-safety matrix across all three dimensions, combinations, and multi-table.
- `metabase-enterprise.sandbox.explorations-test` — end-to-end per-lens gating on `GET /api/exploration/query/:id`: same-sandbox streams, different-attribute → 403, unsandboxed/admin streams, no-data-perms → 403, creator bypass, pending → 409, and a regression test for an **All-Users** sandbox (admins must not pick up a phantom token).
- Updated `explorations.api-test` for the routing behavior change; `ExplorationGroupVisualization` unit test for the 403 → permission-message path.
