### PR TITLE
fix(data-grid): don't hijack arrow keys when a text input is focused

### DIFF
--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
@@ -438,6 +438,48 @@ describe("DataGrid", () => {
     expect(lines[2]).toBe("Item 2\tClothing");
   });
 
+  it("does not hijack arrow keys while an input is focused", () => {
+    renderWithProviders(
+      <>
+        <TestDataGrid enableSelection={true} />
+        <input data-testid="filter-input" />
+      </>,
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const getSelectableCell = (text: string) =>
+      Array.from(
+        screen
+          .getByTestId("table-body")
+          .querySelectorAll("[data-selectable-cell]"),
+      ).find((cell) => cell.textContent === text);
+
+    const item1Cell = getSelectableCell("Item 1");
+    const electronicsCell = getSelectableCell("Electronics");
+    expect(item1Cell).toBeDefined();
+    expect(electronicsCell).toBeDefined();
+
+    // Select the "Item 1" cell so the grid's window keydown handler is active
+    fireEvent.mouseDown(item1Cell!);
+    fireEvent.mouseUp(item1Cell!);
+    expect(item1Cell).toHaveAttribute("aria-selected", "true");
+
+    // While an input is focused, arrow keys must not move the selection
+    const filterInput = screen.getByTestId<HTMLInputElement>("filter-input");
+    filterInput.focus();
+    fireEvent.keyDown(filterInput, { key: "ArrowRight" });
+    expect(item1Cell).toHaveAttribute("aria-selected", "true");
+    expect(electronicsCell).toHaveAttribute("aria-selected", "false");
+
+    // Once the input is no longer focused, arrow keys navigate the grid again
+    filterInput.blur();
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(electronicsCell).toHaveAttribute("aria-selected", "true");
+    expect(item1Cell).toHaveAttribute("aria-selected", "false");
+  });
+
   it("uses correct ARIA roles for grid structure (#70547)", () => {
     renderWithProviders(<TestDataGrid />);
 

--- a/frontend/src/metabase/data-grid/hooks/use-cell-selection.tsx
+++ b/frontend/src/metabase/data-grid/hooks/use-cell-selection.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import _ from "underscore";
 
+import { isEditableElement } from "metabase/utils/dom";
+
 import type { CellId, DataGridSelection, ScrollToDestinations } from "../types";
 import { formatCellValueForCopy } from "../utils/formatting";
 
@@ -325,6 +327,12 @@ export const useCellSelection = ({
     }
 
     const handleWindowKeyDown = (e: KeyboardEvent) => {
+      // Don't hijack keys while the user is typing elsewhere (e.g. a filter
+      // value input): let the focused field handle caret movement, copy, etc.
+      if (isEditableElement(e.target)) {
+        return;
+      }
+
       let handled = false;
 
       switch (e.key) {

--- a/frontend/src/metabase/utils/dom.ts
+++ b/frontend/src/metabase/utils/dom.ts
@@ -181,6 +181,21 @@ export function isEventOverElement(
   return y >= top && y <= bottom && x >= left && x <= right;
 }
 
+const EDITABLE_ELEMENT_TAG_NAMES = ["INPUT", "TEXTAREA", "SELECT"];
+
+/**
+ * Whether the given event target is a text-editable element (input, textarea,
+ * select, or a `contenteditable` node). Global keyboard handlers should bail out
+ * when one of these is focused so the user can type and move the caret normally.
+ */
+export function isEditableElement(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    (EDITABLE_ELEMENT_TAG_NAMES.includes(target.tagName) ||
+      target.isContentEditable)
+  );
+}
+
 export function isReducedMotionPreferred(): boolean {
   const mediaQuery = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   return mediaQuery != null && mediaQuery.matches;


### PR DESCRIPTION
Closes #75571

### Description

The data-grid cell-selection hook (`use-cell-selection.tsx`) attaches a `window` `keydown` listener while a cell is selected and unconditionally handles + `preventDefault`s the arrow keys. That stole arrow keys from any focused text field elsewhere on the page — e.g. a native-query filter/variable value input — so ← / → moved the table cell selection instead of the caret in the input. Likely a regression from arrow-key cell navigation (#53337).

The handler now bails out early when the event target is an editable element, so the focused field handles caret movement and copy normally. This adds a small shared `isEditableElement` helper (the same check is currently inlined in a few other places) and a DataGrid regression test.

### How to verify

1. New → SQL query → Sample Database
2. `SELECT count(*) FROM products WHERE category = {{category}}`, type a value into the `Category` input, then Run
3. Click a cell in the results table — it becomes selected
4. Click back into the `Category` input and press ← / →

- **Before:** the table selection moves and the caret in the input doesn't.
- **After:** the caret moves within the input, and grid arrow-navigation still works when the grid (not an input) is focused.

### Demo
<details>
<summary>demo videos before/after</summary>

https://github.com/user-attachments/assets/488985f4-c866-491f-a728-00dc5431ca97

https://github.com/user-attachments/assets/d09913e4-f318-4332-9b3c-5e3cdaac38ef
</details>




### Checklist

- [x] Tests have been added/updated to cover changes in this PR