### PR TITLE
Update driver stress test workflow to pass in necessary snowflake env.

### DIFF
--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       test:
+        # Technically this accepts anything that is accepted by Hawk:
+        # https://github.com/metabase/hawk/#leiningen-style-test-selection
+        # For example, to run everything in the tests/ dir you can do
+        # $ gh workflow run .github/workflows/drivers-stress-test.yml --field 'test=\"test/\" :only-tags [:mb/driver-tests]' --field times=2 --field driver=Snowflake
         description: 'The exact test name with its namespace.'
         type: string
         required: true
@@ -79,6 +83,7 @@ jobs:
       MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
     steps:
     - uses: actions/checkout@v6
     - name: Test BigQuery Cloud SDK driver
@@ -573,9 +578,19 @@ jobs:
       MB_SNOWFLAKE_TEST_USER: METABASE CI
       MB_SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.MB_SNOWFLAKE_TEST_ACCOUNT }}
       MB_SNOWFLAKE_TEST_PASSWORD: ${{ secrets.MB_SNOWFLAKE_TEST_PASSWORD }}
+      MB_SNOWFLAKE_TEST_PRIVATE_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PRIVATE_KEY }}
       MB_SNOWFLAKE_TEST_WAREHOUSE: ${{ secrets.MB_SNOWFLAKE_TEST_WAREHOUSE }}
       MB_SNOWFLAKE_TEST_PK_USER: METABASE PK
       MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY }}
+      MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY_2: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY_2 }}
+      MB_SNOWFLAKE_TEST_PK_PUBLIC_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PUBLIC_KEY }}
+      MB_SNOWFLAKE_TEST_PK_PUBLIC_KEY_2: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PUBLIC_KEY_2 }}
+
+      # RSA Role testing:
+      MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DEFAULT_USER: RSA_ROLE_TEST_DEFAULT_USER
+      MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_CUSTOM_USER: RSA_ROLE_TEST_CUSTOM_USER
+      MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_ROLE: RSA_ROLE_TEST_ROLE
+      MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
     steps:
     - uses: actions/checkout@v6
     - name: Test Snowflake driver

--- a/bin/dev-install
+++ b/bin/dev-install
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+unset CDPATH
+
 # Check if mise was already active in the parent shell before we do anything
 MISE_WAS_ACTIVE="${MISE_SHELL:-}"
 


### PR DESCRIPTION
Seems bad that this has to be duplicated a bunch of places.

Running the stress tests gives a bunch of errors like this:

> Javascript resource not found: frontend_client/app/dist/lib-static-viz.bundle.js {:source "frontend_client/app/dist/lib-static-viz.bundle.js

Example: https://github.com/metabase/metabase/actions/runs/27238117956/job/80435172881

So something must have changed since these were first set up; not sure what's needed here.