### PR TITLE
Fix test flake related to search analytics

### DIFF
--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -81,6 +81,8 @@ describe("scenarios > search > snowplow", () => {
             request_id: P.string,
             offset: null,
             search_term_hash: P.string,
+            // The raw term is redacted to null on every instance except Metabase's own stats instance
+            // (shouldReportSearchTerm); the salted search_term_hash above is what identifies the query.
             search_term: null,
           },
           event,

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -68,13 +68,20 @@ describe("scenarios > search > snowplow", () => {
       cy.visit("/");
       H.commandPaletteSearch("Orders", false);
 
-      //Passing a function to ensure that runtime_milliseconds is populated as a number
+      // Match the full event shape (notably a non-null search_term_hash) so this pins the user's "Orders"
+      // search specifically, and stays a count-of-1 even as more search surfaces start emitting events.
+      // Passing a function also asserts runtime_milliseconds is a number.
       H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: NEW_SEARCH_QUERY_EVENT_NAME,
             context: "command-palette",
             runtime_milliseconds: P.number,
+            search_engine: P.string,
+            request_id: P.string,
+            offset: null,
+            search_term_hash: P.string,
+            search_term: null,
           },
           event,
         ),

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -131,6 +131,7 @@ export type SearchContext =
   | "entity-picker"
   | "data-picker"
   | "type-filter"
+  | "basic-actions"
   | "browse"
   | "embedding-setup"
   | "document"

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -17,7 +17,9 @@ export const searchApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),
       onQueryStarted: (args, { queryFulfilled, requestId }) => {
-        if (isTrackedSearchContext(args.context)) {
+        // Only track searches with an actual text query. Query-less requests are filter/available-model
+        // lookups and internal existence probes, not searches the user performed.
+        if (isTrackedSearchContext(args.context) && args.q?.trim()) {
           const start = Date.now();
           return handleQueryFulfilled(queryFulfilled, (data) => {
             const duration = Date.now() - start;

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -66,7 +66,7 @@ export const useCommandPaletteBasicActions = ({
   });
   const { data: searchResults } = useSearchQuery(
     isLoggedIn
-      ? { models: ["dataset"], limit: 1, context: "command-palette" }
+      ? { models: ["dataset"], limit: 1, context: "basic-actions" }
       : skipToken,
   );
   const hasModels = (searchResults?.data?.length ?? 0) > 0;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -310,6 +310,7 @@
    :entity-picker       ; the entity-picker modal (cards, dashboards, collections, …)
    :data-picker         ; picking a data source (table/model/metric) while building a query
    :type-filter         ; the search type-filter dropdown's available-models lookup
+   :basic-actions       ; the command palette's basic-actions "do any models exist?" gate (New action), not a user search
    :browse              ; the Browse models / Browse metrics pages
    :embedding-setup     ; embedding/SDK setup and preview resource selection
    :document            ; entity references embedded in documents
@@ -335,8 +336,7 @@
 (def context->normalized-context
   "Collapses search `context` values that should rank and filter alike onto a shared normalized context.
   Only genuine remappings appear here; an unlisted context normalizes to itself and inherits `:default`.
-  The full-page search app, command palette, and type-filter lookup share `:global`, as opposed to the
-  scoped `:data-picker` / `:entity-picker` contexts."
+  Add an entry to make a surface share another's ranking/filter profile; omit it to keep the surface's own."
   ;; TODO (Chris 2026-06-08) -- the nav search bar is deliberately left off `:global` for now so it keeps
   ;; the default filters/weights; decide whether any of its behaviour should be DRYed up with the other
   ;; broad-search surfaces.


### PR DESCRIPTION
## Summary

Fixes [BOT-1673](https://linear.app/metabase/issue/BOT-1673/investigate-failing-snowplow-search-query-test), which was causing severe test flake-age.

### Root cause

When you open the Command Palette, it issues a dummy query for a single model, to see if you have any models. This determines whether you can use Basic Actions.

When we made `context` required we started passing through the `command-palette` context for this call, because that's where it was happening. That was an accidental breaking change for two reasons:

1. It means we started submitting snowplow events for this empty search.
2. It means we opted into the default user filters, which could change the result.

The Cypress test used a lenient matcher (`{event, context, runtime_milliseconds}`), which also matched this event. It was only expecting a single event, and got kinda confused.

### Fix

A bunch of independent fixes, each of which are sufficient to fix the flake, but all worthwhile IMHO.

1. Add a new `basic-actions` context to differentiate it from actual `command-palette` searches.
2. Tighten up the test so it only matches the desired event.
3. Stopped emitting Snowplow events for "searches" without a search string. 

## How to verify

CI runs `search/search-snowplow.cy.spec.js`. Locally: the command palette no longer emits a `search_query` Snowplow event on mount (only on an actual user search).