### PR TITLE
Remove legacy GET in leaflet map

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
@@ -1,7 +1,7 @@
 import L from "leaflet";
 import type { ContextType } from "react";
 
-import { GET } from "metabase/api/legacy-client";
+import { api } from "metabase/api/client";
 import { EmbeddingEntityContext } from "metabase/embedding/context";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isWithinIframe } from "metabase/utils/iframe";
@@ -185,10 +185,13 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
       const controller = new AbortController();
       tile._fetchCtrl = controller;
 
-      GET(tileUrl, {
-        signal: controller.signal,
-        rawResponse: true,
-      })()
+      api
+        .request({
+          url: tileUrl,
+          method: "GET",
+          signal: controller.signal,
+          rawResponse: true,
+        })
         .then((response) => response.blob())
         .then((blob) => {
           const reader = new FileReader();

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
@@ -185,19 +185,7 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
       const controller = new AbortController();
       tile._fetchCtrl = controller;
 
-      api
-        .request({
-          url: tileUrl,
-          method: "GET",
-          signal: controller.signal,
-          rawResponse: true,
-        })
-        .then((response) => response.blob())
-        .then((blob) => readAsDataURL(blob))
-        .then((src) => {
-          tile.src = src;
-          return tile.decode();
-        })
+      loadImage(tile, tileUrl, controller.signal)
         .then(() => {
           if (controller.signal.aborted) {
             return;
@@ -222,6 +210,25 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
       return tile;
     };
   };
+}
+
+async function loadImage(
+  img: HTMLImageElement,
+  url: string,
+  signal: AbortSignal,
+) {
+  const response = await api.request({
+    method: "GET",
+    url,
+    signal,
+    rawResponse: true,
+  });
+  const blob = await response.blob();
+  const src = await readAsDataURL(blob);
+
+  img.src = src;
+  // img.decode waits for the image to be loaded and throws if it fails
+  await img.decode();
 }
 
 function readAsDataURL(blob: Blob): Promise<string> {

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
@@ -196,6 +196,12 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
         .then((blob) => readAsDataURL(blob))
         .then((src) => {
           tile.src = src;
+          return tile.decode();
+        })
+        .then(() => {
+          if (controller.signal.aborted) {
+            return;
+          }
           done?.(undefined, tile);
         })
         .catch((error: unknown) => {

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
@@ -222,6 +222,7 @@ async function loadImage(
     url,
     signal,
     rawResponse: true,
+    retry: true,
   });
   const blob = await response.blob();
   const src = await readAsDataURL(blob);

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.tsx
@@ -193,15 +193,9 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
           rawResponse: true,
         })
         .then((response) => response.blob())
-        .then((blob) => {
-          const reader = new FileReader();
-          reader.onload = () => {
-            if (typeof reader.result === "string") {
-              tile.src = reader.result;
-            }
-          };
-
-          reader.readAsDataURL(blob);
+        .then((blob) => readAsDataURL(blob))
+        .then((src) => {
+          tile.src = src;
           done?.(undefined, tile);
         })
         .catch((error: unknown) => {
@@ -222,4 +216,23 @@ export class LeafletTilePinMap extends LeafletMap<LeafletTilePinMapProps> {
       return tile;
     };
   };
+}
+
+function readAsDataURL(blob: Blob): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Cannot read tile"));
+      }
+    };
+
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Cannot read tile"));
+    };
+
+    reader.readAsDataURL(blob);
+  });
 }


### PR DESCRIPTION
Removes the legacy `GET` helper in `LeafletTilePinMap`. 

Also cleans up the helper:
- use `async`/`await` for clarity
- actually await the loading of the image before passing it to Leaflet, which is the correct implementation according [to the Leaflet docs](https://leafletjs.com/examples/extending/extending-2-layers.html)