### PR TITLE
Remove legacy POST in internal-analytics

### DIFF
--- a/frontend/src/metabase/api/internal-analytics.ts
+++ b/frontend/src/metabase/api/internal-analytics.ts
@@ -1,4 +1,4 @@
-import { POST } from "metabase/api/legacy-client";
+import { api } from "metabase/api/client";
 
 type InternalAnalyticsEvent = {
   op: "inc" | "dec" | "set" | "observe" | "clear";
@@ -7,10 +7,13 @@ type InternalAnalyticsEvent = {
   amount?: number;
 };
 
-const postEvents = POST("/api/analytics/internal");
-
-export function postInternalAnalytics(
+export async function postInternalAnalytics(
   events: InternalAnalyticsEvent[],
 ): Promise<void> {
-  return postEvents({ events });
+  await api.request({
+    method: "POST",
+    url: "/api/analytics/internal",
+    body: { events },
+    retry: true,
+  });
 }


### PR DESCRIPTION
Removes another caller for the legacy API client.