### PR TITLE
Convert `PulseApi` to RTK hooks

### DIFF
--- a/frontend/src/metabase/api/subscription.ts
+++ b/frontend/src/metabase/api/subscription.ts
@@ -1,3 +1,4 @@
+import type { DashboardSubscriptionData } from "metabase/redux/store";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
@@ -76,6 +77,13 @@ export const subscriptionApi = Api.injectEndpoints({
           idTag("subscription", id),
         ]),
     }),
+    testSubscription: builder.mutation<void, DashboardSubscriptionData>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/pulse/test",
+        body,
+      }),
+    }),
     getChannelInfo: builder.query<ChannelApiResponse, void>({
       query: () => ({
         method: "GET",
@@ -92,5 +100,6 @@ export const {
   useCreateSubscriptionMutation,
   useUpdateSubscriptionMutation,
   useUnsubscribeMutation,
+  useTestSubscriptionMutation,
   useGetChannelInfoQuery,
 } = subscriptionApi;

--- a/frontend/src/metabase/api/subscription.ts
+++ b/frontend/src/metabase/api/subscription.ts
@@ -77,7 +77,10 @@ export const subscriptionApi = Api.injectEndpoints({
           idTag("subscription", id),
         ]),
     }),
-    testSubscription: builder.mutation<{ ok: boolean }, DashboardSubscriptionData>({
+    testSubscription: builder.mutation<
+      { ok: boolean },
+      DashboardSubscriptionData
+    >({
       query: (body) => ({
         method: "POST",
         url: "/api/pulse/test",

--- a/frontend/src/metabase/api/subscription.ts
+++ b/frontend/src/metabase/api/subscription.ts
@@ -77,7 +77,7 @@ export const subscriptionApi = Api.injectEndpoints({
           idTag("subscription", id),
         ]),
     }),
-    testSubscription: builder.mutation<void, DashboardSubscriptionData>({
+    testSubscription: builder.mutation<{ ok: boolean }, DashboardSubscriptionData>({
       query: (body) => ({
         method: "POST",
         url: "/api/pulse/test",

--- a/frontend/src/metabase/notifications/pulse/actions.ts
+++ b/frontend/src/metabase/notifications/pulse/actions.ts
@@ -6,7 +6,6 @@ import { subscriptionApi } from "metabase/api";
 import { createThunkAction } from "metabase/redux";
 import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
-import { PulseApi } from "metabase/services";
 import type {
   ChannelApiResponse,
   CreateSubscriptionRequest,
@@ -75,8 +74,10 @@ export const saveEditingPulse = createThunkAction(
 export const testPulse = createThunkAction(
   TEST_PULSE,
   function (pulse: DashboardSubscription | DraftDashboardSubscription) {
-    return async function () {
-      return await PulseApi.test(pulse);
+    return async function (dispatch) {
+      return await dispatch(
+        subscriptionApi.endpoints.testSubscription.initiate(pulse),
+      ).unwrap();
     };
   },
 );
@@ -84,9 +85,11 @@ export const testPulse = createThunkAction(
 export const fetchPulseFormInput = createThunkAction(
   FETCH_PULSE_FORM_INPUT,
   function () {
-    return async function (): Promise<ChannelApiResponse | undefined> {
+    return async function (dispatch): Promise<ChannelApiResponse | undefined> {
       try {
-        return await PulseApi.form_input();
+        return await dispatch(
+          subscriptionApi.endpoints.getChannelInfo.initiate(),
+        ).unwrap();
       } catch {
         // This request is expected to fail when the user lacks
         // "Subscriptions and Alerts" permissions. Swallow the error

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -73,16 +73,6 @@ export const ModerationReviewApi = {
   update: PUT("/api/moderation-review/:id"),
 };
 
-export const PulseApi = {
-  list: GET("/api/pulse"),
-  create: POST("/api/pulse"),
-  get: GET("/api/pulse/:pulseId"),
-  update: PUT("/api/pulse/:id"),
-  test: POST("/api/pulse/test"),
-  form_input: GET("/api/pulse/form_input"),
-  unsubscribe: DELETE("/api/pulse/:id/subscription"),
-};
-
 /// this in unauthenticated, for letting people who are not logged in unsubscribe from Alerts/DashboardSubscriptions
 export const PulseUnsubscribeApi = {
   unsubscribe: POST("/api/pulse/unsubscribe"),


### PR DESCRIPTION
Removes callers for the legacy client.