### PR TITLE
Move `metabase/setup` to feature tier

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -4,8 +4,8 @@ import { t } from "ttag";
 import { useUpsellLink } from "metabase/common/components/upsells/components/use-upsell-link";
 import { useSetting, useStoreUrl, useToast } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
+import { getIsHosted } from "metabase/selectors/settings";
 import { getUser } from "metabase/selectors/user";
-import { getIsHosted } from "metabase/setup/selectors";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
 const NOTIFICATION_TIMEOUT = 30_000;

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PythonTransformsUpsellModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/PythonTransformsUpsellModal.tsx
@@ -5,9 +5,9 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { trackUpsellViewed } from "metabase/common/components/upsells/components/analytics";
 import { useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
+import { getIsHosted } from "metabase/selectors/settings";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { getIsHosted } from "metabase/setup/selectors";
 import {
   Button,
   Center,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage.tsx
@@ -2,9 +2,9 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { DottedBackground } from "metabase/common/components/upsells/components/DottedBackground";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { useSelector } from "metabase/redux/hooks";
+import { getIsHosted } from "metabase/selectors/settings";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { getIsHosted } from "metabase/setup/selectors";
 import { TransformHeader } from "metabase/transforms/components/TransformHeader";
 import { useTransformWithPolling } from "metabase/transforms/hooks/use-transform-with-polling";
 import { Card, Center, Stack } from "metabase/ui";

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -114,7 +114,7 @@ const elements = [
     enforceOutgoing: false,
   }),
   createElement({ type: "shared", name: "search" }),
-  createElement({ type: "shared", name: "setup" }),
+  createElement({ type: "feature", name: "setup" }),
   createElement({ type: "shared", name: "status" }),
   createElement({ type: "shared", name: "styled-components" }),
   createElement({ type: "shared", name: "timelines" }),

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-usage-problem.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-usage-problem.ts
@@ -13,7 +13,7 @@ import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config"
 import { useSetting } from "metabase/common/hooks";
 import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import type { MetabaseEmbeddingSessionToken } from "metabase/embedding-sdk/types/refresh-token";
-import { getTokenFeature } from "metabase/setup/selectors";
+import { getTokenFeature } from "metabase/selectors/settings";
 
 export function useSdkUsageProblem({
   authConfig,

--- a/frontend/src/embedding-sdk-bundle/store/selectors.ts
+++ b/frontend/src/embedding-sdk-bundle/store/selectors.ts
@@ -1,8 +1,7 @@
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
 import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import type { State } from "metabase/redux/store";
-import { getSetting } from "metabase/selectors/settings";
-import { getTokenFeature } from "metabase/setup";
+import { getSetting, getTokenFeature } from "metabase/selectors/settings";
 
 export const getIsGuestEmbedRaw = (state: SdkStoreState) =>
   state.sdk?.isGuestEmbed;

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -17,8 +17,7 @@ import {
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
-import { getSetting } from "metabase/selectors/settings";
-import { getTokenFeature } from "metabase/setup";
+import { getSetting, getTokenFeature } from "metabase/selectors/settings";
 import { getResponseErrorMessage } from "metabase/utils/errors";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 import type {

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -65,7 +65,7 @@ import {
   PLUGIN_WRITABLE_CONNECTION,
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import { getTokenFeature } from "metabase/setup";
+import { getTokenFeature } from "metabase/selectors/settings";
 
 import { AISettingsPage, McpSettingsPage } from "./ai/AISettingsPage";
 import { MetabotAdminLayout } from "./ai/MetabotAdminLayout";

--- a/frontend/src/metabase/admin/upsells/UpsellEmailWhitelabel.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmailWhitelabel.tsx
@@ -4,7 +4,7 @@ import { UpsellPill } from "metabase/common/components/upsells/components";
 import { UPGRADE_URL } from "metabase/common/components/upsells/constants";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSelector } from "metabase/redux";
-import { getIsHosted } from "metabase/setup/selectors";
+import { getIsHosted } from "metabase/selectors/settings";
 
 export const UpsellEmailWhitelabelPill = ({ source }: { source: string }) => {
   const isHosted = useSelector(getIsHosted);

--- a/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
@@ -4,7 +4,7 @@ import { UpsellBanner } from "metabase/common/components/upsells/components";
 import { useSetting } from "metabase/common/hooks";
 import { getPlan, isProPlan } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/redux";
-import { getIsHosted } from "metabase/setup/selectors";
+import { getIsHosted } from "metabase/selectors/settings";
 
 export const UpsellHostingBanner = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);

--- a/frontend/src/metabase/common/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/common/components/AppBanner/AppBanner.tsx
@@ -11,8 +11,8 @@ import { ReadOnlyBanner } from "metabase/nav/components/ReadOnlyBanner";
 import { TrialBanner } from "metabase/nav/components/TrialBanner";
 import { PLUGIN_SECURITY_CENTER } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
+import { getIsHosted } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { getIsHosted } from "metabase/setup/selectors";
 import { isWithinIframe } from "metabase/utils/iframe";
 
 import { getCurrentUTCTimestamp, shouldShowTrialBanner } from "./utils";

--- a/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.tsx
+++ b/frontend/src/metabase/common/components/upsells/components/UpsellCardContent.tsx
@@ -9,9 +9,9 @@ import {
   trackUpsellViewed,
 } from "metabase/common/components/upsells/components/analytics";
 import { useSelector } from "metabase/redux";
+import { getIsHosted } from "metabase/selectors/settings";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { getIsHosted } from "metabase/setup/selectors";
 import {
   Box,
   Card,

--- a/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.ts
+++ b/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.ts
@@ -1,5 +1,5 @@
 import { useSelector } from "metabase/redux";
-import { getTokenFeature } from "metabase/setup/selectors";
+import { getTokenFeature } from "metabase/selectors/settings";
 import type { TokenFeature } from "metabase-types/api";
 
 export const useHasTokenFeature = (settingName: TokenFeature) => {

--- a/frontend/src/metabase/databases/components/DatabaseFormError/useTroubleshootingTips.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseFormError/useTroubleshootingTips.tsx
@@ -5,9 +5,8 @@ import { identity } from "underscore";
 
 import { useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import { getDocsUrl } from "metabase/selectors/settings";
+import { getDocsUrl, getIsHosted } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { getIsHosted } from "metabase/setup";
 import { Code } from "metabase/ui";
 
 import type { TipProps as _TipProps } from "./TroubleshootingTip";

--- a/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
+++ b/frontend/src/metabase/embedding/mcp/McpUiAppRoute.tsx
@@ -5,7 +5,7 @@ import { ComponentProvider } from "embedding-sdk-bundle/components/public/Compon
 import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion";
 import { getSdkStore } from "embedding-sdk-bundle/store";
 import { useSelector } from "metabase/redux";
-import { getIsHosted } from "metabase/setup";
+import { getIsHosted } from "metabase/selectors/settings";
 import { Flex } from "metabase/ui";
 import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
 

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -19,6 +19,7 @@ import { useHelpLink } from "metabase/nav/components/AppSwitcher/useHelpLink";
 import { useSelector } from "metabase/redux";
 import {
   getDocsUrl,
+  getIsHosted,
   getIsPaidPlan,
   getSetting,
 } from "metabase/selectors/settings";
@@ -27,7 +28,6 @@ import {
   getApplicationName,
   getShowMetabaseLinks,
 } from "metabase/selectors/whitelabel";
-import { getIsHosted } from "metabase/setup/selectors";
 import {
   Accordion,
   Box,

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -20,7 +20,7 @@ import {
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { DownloadsState, State } from "metabase/redux/store";
 import { createAsyncThunk } from "metabase/redux/utils";
-import { getTokenFeature } from "metabase/setup/selectors";
+import { getTokenFeature } from "metabase/selectors/settings";
 import * as Urls from "metabase/urls";
 import { openSaveDialog } from "metabase/utils/dom";
 import { isWithinIframe } from "metabase/utils/iframe";

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -2,7 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import { getPlan } from "metabase/common/utils/plan";
 import type { State } from "metabase/redux/store";
-import type { TokenStatus, Version } from "metabase-types/api";
+import type { TokenFeature, TokenStatus, Version } from "metabase-types/api";
 
 export const getSettings: <S extends State>(state: S) => GetSettings<S> =
   createSelector(
@@ -32,6 +32,15 @@ export const isSsoEnabled = (state: State) =>
   getSetting(state, "google-auth-enabled") ||
   getSetting(state, "saml-enabled") ||
   getSetting(state, "other-sso-enabled?");
+
+export const getIsHosted = (state: State): boolean => {
+  return getSetting(state, "is-hosted?");
+};
+
+export const getTokenFeature = (state: State, feature: TokenFeature) => {
+  const tokenFeatures = getSetting(state, "token-features");
+  return tokenFeatures[feature];
+};
 
 export type StorePaths =
   /** store main page */

--- a/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
+++ b/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
@@ -2,9 +2,11 @@ import { t } from "ttag";
 
 import { HelpCard } from "metabase/common/components/HelpCard";
 import { useSelector } from "metabase/redux";
-import { migrateToCloudGuideUrl } from "metabase/selectors/settings";
+import {
+  getIsHosted,
+  migrateToCloudGuideUrl,
+} from "metabase/selectors/settings";
 
-import { getIsHosted } from "../../selectors";
 import { useStep } from "../../useStep";
 import { SetupCardContainer } from "../SetupCardContainer";
 

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -2,9 +2,10 @@ import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/redux";
 import type { UserInfo } from "metabase/redux/store";
+import { getIsHosted } from "metabase/selectors/settings";
 
 import { submitUser } from "../../actions";
-import { getIsHosted, getUser } from "../../selectors";
+import { getUser } from "../../selectors";
 import { useStep } from "../../useStep";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -3,11 +3,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 import type { InviteInfo, Locale, State, UserInfo } from "metabase/redux/store";
 import { getSetting } from "metabase/selectors/settings";
-import type {
-  DatabaseData,
-  LocaleData,
-  TokenFeature,
-} from "metabase-types/api";
+import type { DatabaseData, LocaleData } from "metabase-types/api";
 
 import type { SetupStep } from "./types";
 
@@ -75,15 +71,6 @@ export const getDatabaseEngine = (state: State): string | undefined => {
 
 export const getSetupToken = (state: State) => {
   return getSetting(state, "setup-token");
-};
-
-export const getIsHosted = (state: State): boolean => {
-  return getSetting(state, "is-hosted?");
-};
-
-export const getTokenFeature = (state: State, feature: TokenFeature) => {
-  const tokenFeatures = getSetting(state, "token-features");
-  return tokenFeatures[feature];
 };
 
 export const getAvailableLocales = (state: State): LocaleData[] => {

--- a/frontend/src/metabase/transforms/selectors.ts
+++ b/frontend/src/metabase/transforms/selectors.ts
@@ -2,9 +2,12 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import { getPlan } from "metabase/common/utils/plan";
 import type { State } from "metabase/redux/store";
-import { getSetting } from "metabase/selectors/settings";
+import {
+  getIsHosted,
+  getSetting,
+  getTokenFeature,
+} from "metabase/selectors/settings";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { getIsHosted, getTokenFeature } from "metabase/setup";
 
 export const canAccessTransforms = (state: State): boolean => {
   if (getUserIsAdmin(state)) {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -26,7 +26,7 @@ import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
 import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
-import { getTokenFeature } from "metabase/setup/selectors";
+import { getTokenFeature } from "metabase/selectors/settings";
 import { getFont } from "metabase/styled-components/selectors";
 import type { IconProps } from "metabase/ui";
 import { formatNumber } from "metabase/utils/formatting";


### PR DESCRIPTION
Closes DEV-2126 

- Moves `metabase/setup` to feature tier.
- Resolves boundary issues by moving two utility selectors into `metabase/selectors/settings`