### PR TITLE
Look up load_skill ids by string instead of keywordizing

### DIFF
--- a/src/metabase/metabot/skills.clj
+++ b/src/metabase/metabot/skills.clj
@@ -48,13 +48,12 @@
    [:dialect {:optional true} :string]])
 
 (def ^:private *skills
-  "Map of skill-id (keyword) -> skill definition map."
-  (atom {}))
-
-(def ^:private *skills-by-id-string
-  "Map of skill-id *string* -> skill definition map.
-  Lets `load_skill` resolve caller-supplied ids without keywordizing them first."
-  (atom {}))
+  "Registry of skills, indexed two ways:
+   `:by-id`     skill-id (keyword) -> skill — for internal callers.
+   `:by-id-str` skill-id (string)  -> skill — lets `load_skill` resolve caller-supplied ids
+                                              without keywordizing them first.
+  Both indexes are swapped together in one `reset!` so readers always see them in sync."
+  (atom {:by-id {} :by-id-str {}}))
 
 ;;; Registration
 
@@ -155,12 +154,13 @@
   "Scan the skill resource directories and (re)populate the registry.
   Runs at namespace load; public so a REPL can refresh the registry after editing skill files."
   []
-  ;; Build the full map before touching the registry: a failed refresh (e.g. a malformed skill file)
+  ;; Build the full registry before touching the atom: a failed refresh (e.g. a malformed skill file)
   ;; throws without clobbering the existing registry, and readers never observe a partial one.
   ;; The reset! also means re-initializing drops removed or renamed skills.
-  (let [skills (concat (markdown-skills) (dialect-skills))]
-    (reset! *skills (into {} (map (juxt :id identity)) skills))
-    (reset! *skills-by-id-string (into {} (map (juxt (comp name :id) identity)) skills))))
+  ;; `vec` realizes the (lazy) skill seq once so resources aren't slurped+parsed once per index.
+  (let [skills (vec (concat (markdown-skills) (dialect-skills)))]
+    (reset! *skills {:by-id     (into {} (map (juxt :id identity)) skills)
+                     :by-id-str (into {} (map (juxt (comp name :id) identity)) skills)})))
 
 (load-skills!)
 
@@ -169,18 +169,18 @@
 (defn get-skill
   "Return the skill definition for `id` (keyword), or nil."
   [id]
-  (get @*skills id))
+  (get-in @*skills [:by-id id]))
 
 (defn get-skill-by-id-string
   "Return the skill definition for string `id`, or nil.
   Unlike [[get-skill]], looks up by string so we don't need to keywordize `id` first."
   [id]
-  (get @*skills-by-id-string id))
+  (get-in @*skills [:by-id-str id]))
 
 (defn all-skills
   "Return all registered skill definitions."
   []
-  (vals @*skills))
+  (vals (:by-id @*skills)))
 
 (defn skills-for-tool
   "Return non-dialect skills associated with `tool-name` (a string)."

--- a/src/metabase/metabot/skills.clj
+++ b/src/metabase/metabot/skills.clj
@@ -51,6 +51,11 @@
   "Map of skill-id (keyword) -> skill definition map."
   (atom {}))
 
+(def ^:private *skills-by-id-string
+  "Map of skill-id *string* -> skill definition map.
+  Lets `load_skill` resolve caller-supplied ids without keywordizing them first."
+  (atom {}))
+
 ;;; Registration
 
 (def ^:private skills-dir "metabot/skills")
@@ -153,9 +158,9 @@
   ;; Build the full map before touching the registry: a failed refresh (e.g. a malformed skill file)
   ;; throws without clobbering the existing registry, and readers never observe a partial one.
   ;; The reset! also means re-initializing drops removed or renamed skills.
-  (reset! *skills (into {}
-                        (map (juxt :id identity))
-                        (concat (markdown-skills) (dialect-skills)))))
+  (let [skills (concat (markdown-skills) (dialect-skills))]
+    (reset! *skills (into {} (map (juxt :id identity)) skills))
+    (reset! *skills-by-id-string (into {} (map (juxt (comp name :id) identity)) skills))))
 
 (load-skills!)
 
@@ -165,6 +170,12 @@
   "Return the skill definition for `id` (keyword), or nil."
   [id]
   (get @*skills id))
+
+(defn get-skill-by-id-string
+  "Return the skill definition for string `id`, or nil.
+  Unlike [[get-skill]], looks up by string so we don't need to keywordize `id` first."
+  [id]
+  (get @*skills-by-id-string id))
 
 (defn all-skills
   "Return all registered skill definitions."

--- a/src/metabase/metabot/tools/skills.clj
+++ b/src/metabase/metabot/tools/skills.clj
@@ -16,7 +16,7 @@
   "Resolve and format a single skill id, or an inline message when it is unknown
   or not available to the current user."
   [id]
-  (let [skill (skills/get-skill (keyword id))]
+  (let [skill (skills/get-skill-by-id-string id)]
     (cond
       (nil? skill)
       (do (log/info "Unknown skill requested by load_skill" {:id id})

--- a/test/metabase/metabot/skills_test.clj
+++ b/test/metabase/metabot/skills_test.clj
@@ -43,6 +43,16 @@
                    :construct-notebook-query-advanced
                    :construct-notebook-query-operators])))))
 
+(deftest ^:parallel get-skill-by-id-string-test
+  (testing "resolves a known skill by its string id"
+    (is (= :construct-notebook-query-core
+           (:id (skills/get-skill-by-id-string "construct-notebook-query-core")))))
+  (testing "an unknown id returns nil without interning a keyword"
+    (let [unseen "load-skill-never-seen-id-xyz"]
+      (is (nil? (find-keyword unseen)) "precondition: id is not yet interned")
+      (is (nil? (skills/get-skill-by-id-string unseen)))
+      (is (nil? (find-keyword unseen)) "lookup must not have interned the id"))))
+
 (deftest ^:parallel skill-shape-test
   (testing "a parsed markdown skill has frontmatter + body"
     (let [s (skills/get-skill :construct-notebook-query-core)]


### PR DESCRIPTION
Resolve `load_skill` ids against a string-keyed skill index instead of calling `(keyword id)` on the caller-supplied id, so we don't need to keywordize it first.

The keyword-keyed registry stays in place for internal callers (dialect resolution, tests); this just adds a parallel string index, populated in the same `load-skills!` pass, plus a `get-skill-by-id-string` lookup the tool uses.
