### PR TITLE
Removed deprecated header

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -357,9 +357,7 @@
                                                           (setting/get-value-of-type :string :embedding-app-origins-interactive))]
                                           (format "ALLOW-FROM %s" (-> eao (str/split #" ") first))
                                           "DENY")})
-   {;; Tell browser to block suspected XSS attacks
-    "X-XSS-Protection"                  "1; mode=block"
-    ;; Prevent Flash / PDF files from including content from site.
+   {;; Prevent Flash / PDF files from including content from site.
     "X-Permitted-Cross-Domain-Policies" "none"
     ;; Tell browser not to use MIME sniffing to guess types of files -- protect against MIME type confusion attacks
     "X-Content-Type-Options"            "nosniff"}

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -29,8 +29,7 @@
              "Strict-Transport-Security"         "max-age=31536000"
              "X-Content-Type-Options"            "nosniff"
              "X-Frame-Options"                   "DENY"
-             "X-Permitted-Cross-Domain-Policies" "none"
-             "X-XSS-Protection"                  "1; mode=block"}})
+             "X-Permitted-Cross-Domain-Policies" "none"}})
 
 (defn- mock-api-fn [response-fn]
   ((-> (fn [request respond _]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/11444

### Description

Remove the deprecated X-XSS-Protection security header. This header is non-standard and ignored by all modern browsers, so it's been deprecated in favor of Content-Security-Policy.

Drops the header from security-headers and updates the corresponding test expectation.
