### PR TITLE
[GDGT-376] [GDGT-2623] fix serdes export oom and n+1 table lookups

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
@@ -199,7 +199,7 @@
                   :include-field-values true}
             report (serdes/with-cache (serialization/store! (serialization/extract opts)
                                                             (serialization/file-writer (.getPath temp-path))))]
-        (log/info "Export complete:" (reduce + 0 (vals (:seen report))) "entities exported")
+        (log/info "Export complete:" (reduce + 0 (vals (:entity-counts report))) "entities exported")
         (when (seq (:errors report))
           (log/warn "Export had errors:" (:errors report)))
         {:report report

--- a/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
@@ -199,7 +199,7 @@
                   :include-field-values true}
             report (serdes/with-cache (serialization/store! (serialization/extract opts)
                                                             (serialization/file-writer (.getPath temp-path))))]
-        (log/info "Export complete:" (count (:seen report)) "entities exported")
+        (log/info "Export complete:" (reduce + 0 (vals (:seen report))) "entities exported")
         (when (seq (:errors report))
           (log/warn "Export had errors:" (:errors report)))
         {:report report

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -188,7 +188,7 @@
                            :direction       "export"
                            :source          "api"
                            :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
-                           :count           (count (:seen report))
+                           :count           (reduce + 0 (vals (:seen report)))
                            :error_count     (count (:errors report))
                            :collection      (str/join "," (map str collection))
                            :all_collections (and (empty? collection)

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -188,7 +188,7 @@
                            :direction       "export"
                            :source          "api"
                            :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
-                           :count           (reduce + 0 (vals (:seen report)))
+                           :count           (reduce + 0 (vals (:entity-counts report)))
                            :error_count     (count (:errors report))
                            :collection      (str/join "," (map str collection))
                            :all_collections (and (empty? collection)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -123,7 +123,7 @@
                              :direction       "export"
                              :source          "cli"
                              :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
-                             :count           (reduce + 0 (vals (:seen report)))
+                             :count           (reduce + 0 (vals (:entity-counts report)))
                              :error_count     (count (:errors report))
                              :collection      (str/join "," collection-ids)
                              :all_collections (and (empty? collection-ids)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -123,7 +123,7 @@
                              :direction       "export"
                              :source          "cli"
                              :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
-                             :count           (count (:seen report))
+                             :count           (reduce + 0 (vals (:seen report)))
                              :error_count     (count (:errors report))
                              :collection      (str/join "," collection-ids)
                              :all_collections (and (empty? collection-ids)

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
@@ -6,13 +6,14 @@
 
 (defn store!
   "Consume the entity `stream` and store each entity via the given `writer`.
-  Returns a report map with `:seen` and `:errors` vectors.
+  Returns a report map with `:seen`, a map of model name to the count of stored entities, and an
+  `:errors` vector.
 
   Uses `run!` to make elements reach the writer as they are produced and
   not materialize the entire upstream before the loop body."
   [stream writer]
   (let [settings (atom [])
-        report   (atom {:seen [] :errors []})]
+        report   (atom {:seen {} :errors []})]
     (run! (fn [entity]
             (cond
               (instance? Exception entity)
@@ -22,9 +23,10 @@
               (swap! settings conj entity)
 
               :else
-              (swap! report update :seen conj (protocols/store-entity! writer entity))))
+              (let [path (protocols/store-entity! writer entity)]
+                (swap! report update-in [:seen (-> path last :model)] (fnil inc 0)))))
           stream)
     (when (seq @settings)
       (protocols/store-settings! writer @settings)
-      (swap! report update :seen conj [{:model "Setting"}]))
+      (swap! report update-in [:seen "Setting"] (fnil inc 0)))
     @report))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
@@ -1,19 +1,20 @@
 (ns metabase-enterprise.serialization.v2.storage
   (:require
-   [metabase-enterprise.serialization.v2.protocols :as protocols]))
+   [metabase-enterprise.serialization.v2.protocols :as protocols]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
 (defn store!
   "Consume the entity `stream` and store each entity via the given `writer`.
-  Returns a report map with `:seen`, a map of model name to the count of stored entities,
-  and an `:errors` vector.
+  Returns a report map with `:entity-counts`, a map of model name to the count of stored
+  entities, and an `:errors` vector.
 
   Uses `run!` to make elements reach the writer as they are produced and
   not materialize the entire upstream before the loop body."
   [stream writer]
   (let [settings (atom [])
-        report   (atom {:seen {} :errors []})]
+        report   (atom {:entity-counts {} :errors []})]
     (run! (fn [entity]
             (cond
               (instance? Exception entity)
@@ -24,9 +25,9 @@
 
               :else
               (let [path (protocols/store-entity! writer entity)]
-                (swap! report update-in [:seen (-> path last :model)] (fnil inc 0)))))
+                (swap! report update-in [:entity-counts (-> path last :model)] u/safe-inc))))
           stream)
     (when (seq @settings)
       (protocols/store-settings! writer @settings)
-      (swap! report update-in [:seen "Setting"] (fnil inc 0)))
+      (swap! report update-in [:entity-counts "Setting"] u/safe-inc))
     @report))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
@@ -6,8 +6,8 @@
 
 (defn store!
   "Consume the entity `stream` and store each entity via the given `writer`.
-  Returns a report map with `:seen`, a map of model name to the count of stored entities, and an
-  `:errors` vector.
+  Returns a report map with `:seen`, a map of model name to the count of stored entities,
+  and an `:errors` vector.
 
   Uses `run!` to make elements reach the writer as they are produced and
   not materialize the entire upstream before the loop body."

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -146,6 +146,21 @@
                        (update :visibility_type keyword)
                        (update :base_type       keyword))))))))))
 
+(deftest seen-report-test
+  (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection coll {:name "Some Collection"}
+                         :model/Card       _    {:name "Some Card" :collection_id (:id coll)}]
+        (let [export   (into [] (extract/extract {:no-data-model true :no-transforms true}))
+              models   (map #(-> % :serdes/meta last :model) export)
+              expected (cond-> (frequencies (remove #{"Setting"} models))
+                         (some #{"Setting"} models) (assoc "Setting" 1))
+              report   (storage/store! export (storage.files/file-writer dump-dir))]
+          (testing ":seen is a {model count} map, with all settings tallied as a single entry"
+            (is (= expected (:seen report)))
+            (is (pos? (get-in report [:seen "Setting"] 0))
+                "settings should be part of this export, to exercise the Setting tally")))))))
+
 (deftest yaml-sorted-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (mt/with-empty-h2-app-db!

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -146,7 +146,7 @@
                        (update :visibility_type keyword)
                        (update :base_type       keyword))))))))))
 
-(deftest seen-report-test
+(deftest entity-counts-report-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (mt/with-empty-h2-app-db!
       (ts/with-temp-dpc [:model/Collection coll {:name "Some Collection"}
@@ -156,9 +156,9 @@
               expected (cond-> (frequencies (remove #{"Setting"} models))
                          (some #{"Setting"} models) (assoc "Setting" 1))
               report   (storage/store! export (storage.files/file-writer dump-dir))]
-          (testing ":seen is a {model count} map, with all settings tallied as a single entry"
-            (is (= expected (:seen report)))
-            (is (pos? (get-in report [:seen "Setting"] 0))
+          (testing ":entity-counts is a {model count} map, with all settings tallied as a single entry"
+            (is (= expected (:entity-counts report)))
+            (is (pos? (get-in report [:entity-counts "Setting"] 0))
                 "settings should be part of this export, to exercise the Setting tally")))))))
 
 (deftest yaml-sorted-test

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1082,7 +1082,7 @@
   [[*import-database-fk*]] is the inverse."
   [id]
   (when id
-    (t2/select-one-fn :name [:model/Database :id :name] :id id)))
+    (resolve/export-fk-keyed (export-resolver) id :model/Database :name)))
 
 (defn ^:dynamic *import-database-fk*
   "Given a portable database name, resolve it back to a numeric ID.

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1172,6 +1172,13 @@
               [:= :name field]
               [:= :parent_id (recursively-find-field-q table-id rest)]]}))
 
+;; NOTE: field lookups are intentionally NOT routed through the cached resolver, unlike the
+;; database and table exporters above. Fields are unbounded in number (millions on large
+;; instances), and the dominant traffic — each field's own path during a data-model export —
+;; has no reuse, so a cache would retain an O(field-count) map for near-zero hits and can OOM
+;; the export. Export order can't be arranged around field-fk reuse either, so even a bounded
+;; cache has no reliable hit rate. If caching is ever added here (e.g. for the reuse-heavy
+;; FK-target refs), it MUST be bounded so no O(field-count) structure can blow up memory.
 (mu/defn ^:dynamic *export-field-fk*
   "Given a numeric `field_id`, return a portable field reference.
   That has the form `[db-name schema table-name field-name]`, where the `schema` might be nil.

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1099,9 +1099,7 @@
   [[*import-table-fk*]] is the inverse."
   [table-id :- [:maybe ::lib.schema.id/table]]
   (when table-id
-    (let [{:keys [db_id name schema]} (t2/select-one [:model/Table :id :db_id :name :schema] :id table-id)
-          db-name                     (*export-database-fk* db_id)]
-      [db-name schema name])))
+    (resolve/export-table-fk (export-resolver) table-id)))
 
 (mu/defn ^:dynamic *import-table-fk*
   "Given a `table_id` as exported by [[*export-table-fk*]], resolve it back into a numeric `table_id`.

--- a/src/metabase/models/serialization/resolve/db.clj
+++ b/src/metabase/models/serialization/resolve/db.clj
@@ -44,8 +44,8 @@
   "Given a numeric table_id, return a portable table reference [db-name schema table-name]."
   [table-id]
   (when table-id
-    (let [{:keys [db_id name schema]} (t2/select-one :model/Table :id table-id)
-          db-name                     (t2/select-one-fn :name :model/Database :id db_id)]
+    (let [{:keys [db_id name schema]} (t2/select-one [:model/Table :id :db_id :name :schema] :id table-id)
+          db-name                     (t2/select-one-fn :name [:model/Database :id :name] :id db_id)]
       [db-name schema name])))
 
 (defn export-field-fk

--- a/test/metabase/models/serialization/resolve/db_test.clj
+++ b/test/metabase/models/serialization/resolve/db_test.clj
@@ -75,6 +75,36 @@
           (is (=? {:name "middle" :active false :parent_id (:id outer)}                            middle))
           (is (=? {:name "outer"  :active false :parent_id nil          :table_id table-id}        outer)))))))
 
+(deftest export-database-fk-test
+  (testing "returns the database name for an existing id"
+    (mt/with-temp [:model/Database {db-id :id} {:name "test-db"}]
+      (is (= "test-db" (serdes/*export-database-fk* db-id)))))
+  (testing "nil id returns nil"
+    (is (nil? (serdes/*export-database-fk* nil))))
+  (testing "unknown id returns nil"
+    (is (nil? (serdes/*export-database-fk* Integer/MAX_VALUE)))))
+
+(deftest export-table-fk-test
+  (testing "returns [db-name schema table-name]"
+    (mt/with-temp [:model/Database {db-id :id}    {:name "test-db"}
+                   :model/Table    {table-id :id} {:db_id db-id :name "users" :schema "public"}]
+      (is (= ["test-db" "public" "users"] (serdes/*export-table-fk* table-id)))))
+  (testing "nil schema is preserved"
+    (mt/with-temp [:model/Database {db-id :id}    {:name "test-db"}
+                   :model/Table    {table-id :id} {:db_id db-id :name "schemaless" :schema nil}]
+      (is (= ["test-db" nil "schemaless"] (serdes/*export-table-fk* table-id)))))
+  (testing "nil id returns nil"
+    (is (nil? (serdes/*export-table-fk* nil)))))
+
+(deftest cached-export-database-fk-test
+  (mt/with-temp [:model/Database {db-id :id} {:name "test-db"}]
+    (serdes/with-cache
+      (t2/with-call-count [call-count]
+        (is (= "test-db" (serdes/*export-database-fk* db-id)))
+        (is (= "test-db" (serdes/*export-database-fk* db-id)))
+        (testing "repeat lookups inside with-cache are served from the memoized resolver"
+          (is (= 1 (call-count))))))))
+
 (deftest import-field-fk-reuses-existing-parent-test
   (testing "uses an existing parent field rather than creating a duplicate"
     (mt/with-model-cleanup [:model/Field]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/57737 on the export path.

### Problem
Serializing the **export** of an instance with a very large data model (~1M+ fields - e.g. a synced warehouse with many wide tables) can OOM, and is slow. Two independent issues on the export path:

1. **Memory (OOM):** the export's `store!` accumulated an in-memory vector with **one entry per exported entity** (each a full path vector). On a 1.2M-field instance that's about 0.5 GB of live heap held for the entire export which can lead to OOM on certain instances.
2. **Throughput (N+1):** resolving each field's table reference went to the app DB uncached - a Table + Database lookup **per field**.

### Fixes
1. ** converting`:seen` report to a frequency map** `store!` now keeps a `{model count}` tally instead of a per-entity vector which was a O(n) data structure - consumers only ever needed the total count + the set of model names. 

2. **cache the table-reference resolution** `*export-table-fk*` now goes through the export resolver's existing memoized cache, so each table is resolved **once** instead of **once per
   field**.

### Impact (measured, 1.2M-field export from the original issue's fixture file)
| | Before | After |
|---|---|---|
| Peak retained heap | ~2.5–3 GB, growing with field count | flat ~1.5 GB |
| Outcome at a 2 GB heap | OOM | completes (identical output) |
| App-DB calls | 6.0M | 1.2M (−80%) |
| Wall-clock | ~21 min | ~8 min |

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
