### PR TITLE
Tolerate legacy search weight overrides

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -231,19 +231,17 @@
 
 (defn- normalize-override-keys
   "Re-key persisted weight overrides ([[search.settings/experimental-search-weight-overrides]]) by
-  [[normalized-context]], so an override saved under a context that has since been collapsed (e.g.
-  `:command-palette` -> `:global`) is still applied.
-  When a raw alias and its normalized context both carry overrides, the normalized one wins -- it's
-  what the weights API writes today.
-  Legacy overrides (pre-#50338) were a flat {scorer weight} map with no context layer, so they applied
-  to every context. Fold those bare weights into the `:default` base to preserve that, with an explicit
-  `:default` context override still winning on conflict."
+  [[normalized-context]], merging overrides whose alias has since collapsed onto the surviving context.
+  Legacy flat `{scorer weight}` overrides fold into the `:default` base, losing to an explicit `:default`."
   [overrides]
-  (let [;; legacy flat overrides are the entries whose value is a bare weight, not a per-context map
+  (let [;; legacy overrides (pre-#50338) were a flat {scorer weight} map with no context layer, so they
+        ;; applied to every context; these are the entries whose value is a bare weight, not a per-context map
         legacy (into {} (remove (comp map? val)) overrides)
         nested (reduce-kv (fn [acc context weight-overrides]
                             (let [normalized (normalized-context context)]
                               (update acc normalized
+                                      ;; when an alias and its normalized context both carry overrides the
+                                      ;; normalized one wins -- it's what the weights API writes today
                                       (if (= context normalized)
                                         #(merge % weight-overrides)
                                         #(merge weight-overrides %)))))
@@ -252,6 +250,7 @@
                           ;; normalized context (the normalized key still wins; among aliases the lowest-sorted)
                           (into (sorted-map) (filter (comp map? val)) overrides))]
     (cond-> nested
+      ;; :default feeds every context, so folding the flat weights there preserves their global reach
       (seq legacy) (update :default #(merge legacy %)))))
 
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -234,18 +234,25 @@
   [[normalized-context]], so an override saved under a context that has since been collapsed (e.g.
   `:command-palette` -> `:global`) is still applied.
   When a raw alias and its normalized context both carry overrides, the normalized one wins -- it's
-  what the weights API writes today."
+  what the weights API writes today.
+  Legacy overrides (pre-#50338) were a flat {scorer weight} map with no context layer, so they applied
+  to every context. Fold those bare weights into the `:default` base to preserve that, with an explicit
+  `:default` context override still winning on conflict."
   [overrides]
-  (reduce-kv (fn [acc context weight-overrides]
-               (let [normalized (normalized-context context)]
-                 (update acc normalized
-                         (if (= context normalized)
-                           #(merge % weight-overrides)
-                           #(merge weight-overrides %)))))
-             {}
-             ;; sorted so the winner is deterministic when several aliases collapse to one normalized
-             ;; context (the normalized key still wins; among aliases the lowest-sorted one does)
-             (into (sorted-map) overrides)))
+  (let [;; legacy flat overrides are the entries whose value is a bare weight, not a per-context map
+        legacy (into {} (remove (comp map? val)) overrides)
+        nested (reduce-kv (fn [acc context weight-overrides]
+                            (let [normalized (normalized-context context)]
+                              (update acc normalized
+                                      (if (= context normalized)
+                                        #(merge % weight-overrides)
+                                        #(merge weight-overrides %)))))
+                          {}
+                          ;; sorted so the winner is deterministic when several aliases collapse to one
+                          ;; normalized context (the normalized key still wins; among aliases the lowest-sorted)
+                          (into (sorted-map) (filter (comp map? val)) overrides))]
+    (cond-> nested
+      (seq legacy) (update :default #(merge legacy %)))))
 
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -51,7 +51,12 @@
       (is (= {:global {:text 5 :exact 9}} (normalize {:type-filter {:text 5} :global {:exact 9}}))))
     (testing "the :default base and un-remapped contexts pass through untouched"
       (is (= {:default {:text 7} :entity-picker {:exact 3}}
-             (normalize {:default {:text 7} :entity-picker {:exact 3}})))))
+             (normalize {:default {:text 7} :entity-picker {:exact 3}}))))
+    (testing "legacy flat overrides (bare weights, not per-context maps) fold into the :default base"
+      (is (= {:default {:text 7.0 :exact 3.0}} (normalize {:text 7.0 :exact 3.0})))
+      (is (= {:global {:exact 1} :default {:text 7.0}} (normalize {:command-palette {:exact 1} :text 7.0}))))
+    (testing "an explicit :default context override wins over a legacy flat weight for the same scorer"
+      (is (= {:default {:text 5.0 :exact 9}} (normalize {:text 5.0 :exact 1.0 :default {:exact 9}})))))
   (testing "several aliases collapsing to one normalized context resolve deterministically, regardless of
             input order (the lowest-sorted alias wins among aliases)"
     (let [normalize #'search.config/normalize-override-keys]


### PR DESCRIPTION
## Summary

`/api/search` was returning 500 on stats.metabase.com with `Don't know how to create ISeq from: java.lang.Double`.

`metabase.search.config/normalize-override-keys` (introduced in #75388) reduces over the persisted `experimental-search-weight-overrides` setting assuming every value is a per-context weight map (`{context {scorer weight}}`). But before #50338 the setting was a *flat* `{scorer weight}` map, and stats still has one persisted. So a bare `Double` landed where `normalize-override-keys` expected a map, and `merge` threw.

## Fix

Flat overrides used to apply to **every** context (`(merge default-weights overrides)`), so the faithful modern equivalent is the `:default` base layer that feeds every non-`:all` context. This PR folds legacy bare weights into `:default`, with an explicit `:default` context override still winning on conflict — rather than crashing (current behavior on old data) or silently dropping them.

## Note for reviewers

This *revives* overrides that have been silently ignored since #50338 (Oct 2024) on any instance carrying legacy flat data — so search ranking on those instances shifts back toward the originally-intended weights. That's the intended behavior here (honor the original admin intent), but worth a sanity check.

## Testing

- Added cases to `normalize-override-keys-test` covering a fully-flat legacy map, a mixed legacy+contextual map, and explicit-`:default`-wins precedence.
- `metabase.search.config-test` passes (29 assertions, 0 failures).

Fixes BOT-1677 / PRO-160.