### PR TITLE
GDGT-2598: Schema Viewer shows the database name for schema-less DBs (MongoDB, MySQL, …)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { push } from "react-router-redux";
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { skipToken, useGetDatabaseQuery } from "metabase/api";
@@ -8,6 +9,7 @@ import type { MiniPickerPickableItem } from "metabase/common/components/Pickers/
 import { useDispatch } from "metabase/redux";
 import { Button, FixedSizeIcon, Text } from "metabase/ui";
 import * as Urls from "metabase/urls";
+import { isNamelessSchema } from "metabase-lib/v1/metadata/utils/schema";
 import type { DatabaseId, SchemaName } from "metabase-types/api";
 
 import S from "./SchemaPickerInput.module.css";
@@ -46,20 +48,20 @@ export function SchemaPickerInput({
     [dispatch, onSchemaChange],
   );
 
+  const hasNamedSchema = schema != null && schema.length > 0;
+  // Schema-less DBs (MySQL, Mongo, …) report a single nameless schema.
+  // For this scenario we want to display DB name instead of the schema name.
+  const hasNamelessSchema = isNamelessSchema(schema) && databaseId != null;
+
   const { data: database } = useGetDatabaseQuery(
-    databaseId != null ? { id: databaseId } : skipToken,
+    hasNamelessSchema ? { id: databaseId } : skipToken,
   );
 
-  const hasNamedSchema = schema != null && schema.length > 0;
-  // Schema-less DBs (MySQL, Mongo, …) report a single nameless schema (`""`);
-  // For this scenario we want to display DB name instead of the schema name.
-  const hasNamelessSchema = schema === "" && databaseId != null;
   const isInputEmpty = !hasNamedSchema && !hasNamelessSchema;
-  const label = hasNamedSchema
-    ? schema
-    : hasNamelessSchema
-      ? database?.name
-      : null;
+  const label = match({ hasNamedSchema, hasNamelessSchema })
+    .with({ hasNamedSchema: true }, () => schema)
+    .with({ hasNamelessSchema: true }, () => database?.name)
+    .otherwise(() => null);
 
   return (
     <MiniPicker

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import { MiniPicker } from "metabase/common/components/Pickers/MiniPicker";
 import type { MiniPickerPickableItem } from "metabase/common/components/Pickers/MiniPicker/types";
 import { useDispatch } from "metabase/redux";
@@ -45,7 +46,20 @@ export function SchemaPickerInput({
     [dispatch, onSchemaChange],
   );
 
-  const hasSchema = schema != null && schema.length > 0;
+  const { data: database } = useGetDatabaseQuery(
+    databaseId != null ? { id: databaseId } : skipToken,
+  );
+
+  const hasNamedSchema = schema != null && schema.length > 0;
+  // Schema-less DBs (MySQL, Mongo, …) report a single nameless schema (`""`);
+  // For this scenario we want to display DB name instead of the schema name.
+  const hasNamelessSchema = schema === "" && databaseId != null;
+  const isInputEmpty = !hasNamedSchema && !hasNamelessSchema;
+  const label = hasNamedSchema
+    ? schema
+    : hasNamelessSchema
+      ? database?.name
+      : null;
 
   return (
     <MiniPicker
@@ -67,23 +81,23 @@ export function SchemaPickerInput({
         leftSection={
           <FixedSizeIcon
             name="database"
-            c={hasSchema ? undefined : "text-tertiary"}
+            c={isInputEmpty ? "text-tertiary" : undefined}
           />
         }
         rightSection={
           <FixedSizeIcon
             name="chevrondown"
-            c={hasSchema ? undefined : "text-tertiary"}
+            c={isInputEmpty ? "text-tertiary" : undefined}
           />
         }
         data-testid="schema-picker-button"
       >
-        {hasSchema ? (
-          schema
-        ) : (
+        {isInputEmpty ? (
           <Text c="text-secondary" fw={700}>
             {t`Pick a schema to view`}
           </Text>
+        ) : (
+          label
         )}
       </Button>
     </MiniPicker>

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
@@ -1,0 +1,190 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import type { DatabaseId, SchemaName } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockDatabase,
+  createMockTable,
+} from "metabase-types/api/mocks";
+
+import { SchemaPickerInput } from "./SchemaPickerInput";
+
+// Schema-less DB (MySQL/Mongo/…): a single nameless schema (`""`).
+const SCHEMALESS_DB = createMockDatabase({
+  id: 39,
+  name: "QA Maria",
+  tables: [
+    createMockTable({ id: 1, db_id: 39, display_name: "orders", schema: "" }),
+    createMockTable({ id: 2, db_id: 39, display_name: "people", schema: "" }),
+  ],
+});
+
+// DB with multiple named schemas.
+const MULTI_SCHEMA_DB = createMockDatabase({
+  id: 40,
+  name: "QA Postgres",
+  tables: [
+    createMockTable({
+      id: 3,
+      db_id: 40,
+      display_name: "products",
+      schema: "public",
+    }),
+    createMockTable({
+      id: 4,
+      db_id: 40,
+      display_name: "reviews",
+      schema: "public",
+    }),
+    createMockTable({
+      id: 5,
+      db_id: 40,
+      display_name: "logs",
+      schema: "internal",
+    }),
+  ],
+});
+
+const ROOT_COLLECTION = createMockCollection({
+  id: "root",
+  name: "Our analytics",
+});
+
+type SetupOpts = {
+  databaseId: DatabaseId | undefined;
+  schema: SchemaName | undefined;
+};
+
+function setup({ databaseId, schema }: SetupOpts) {
+  setupDatabasesEndpoints([SCHEMALESS_DB, MULTI_SCHEMA_DB]);
+  // These 2 are required for MiniPicker to work.
+  mockGetBoundingClientRect();
+  setupCollectionByIdEndpoint({ collections: [ROOT_COLLECTION] });
+
+  const onSchemaChange = jest.fn();
+  const { history } = renderWithProviders(
+    <Route
+      path="/"
+      component={() => (
+        <SchemaPickerInput
+          databaseId={databaseId}
+          schema={schema}
+          onSchemaChange={onSchemaChange}
+        />
+      )}
+    />,
+    { withRouter: true },
+  );
+
+  return { onSchemaChange, history };
+}
+
+describe("SchemaPickerInput", () => {
+  describe("label", () => {
+    it("shows the placeholder when no database is selected", async () => {
+      setup({ databaseId: undefined, schema: undefined });
+
+      expect(
+        await screen.findByText("Pick a schema to view"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the placeholder when a database is present but no schema is selected", async () => {
+      // Restored URL state with `database-id` but no `schema` param parses to
+      // `schema === undefined`; nothing has been chosen yet, so it must stay a
+      // placeholder rather than showing the database name.
+      setup({ databaseId: 39, schema: undefined });
+
+      expect(
+        await screen.findByText("Pick a schema to view"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("QA Maria")).not.toBeInTheDocument();
+    });
+
+    it("shows the schema name when a named schema is selected", async () => {
+      setup({ databaseId: 40, schema: "public" });
+
+      expect(
+        await screen.findByTestId("schema-picker-button"),
+      ).toHaveTextContent("public");
+      expect(
+        screen.queryByText("Pick a schema to view"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the database name when the schema is nameless (schema-less db)", async () => {
+      setup({ databaseId: 39, schema: "" });
+
+      expect(await screen.findByText("QA Maria")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Pick a schema to view"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("selection flow", () => {
+    it("auto-selects a schema-less db, navigates with an empty schema, closes, and reopens at the database list", async () => {
+      const { onSchemaChange, history } = setup({
+        databaseId: undefined,
+        schema: undefined,
+      });
+
+      // With no database selected the picker opens automatically.
+      await userEvent.click(await screen.findByText("QA Maria"));
+
+      // The lone nameless schema is auto-selected; navigation preserves the
+      // empty schema (`schema=`) rather than dropping it.
+      await waitFor(() => {
+        expect(onSchemaChange).toHaveBeenCalled();
+      });
+      const location = history?.getCurrentLocation();
+      const params = new URLSearchParams(location?.search);
+      expect(params.get("database-id")).toBe("39");
+      expect(params.get("schema")).toBe("");
+
+      // The picker closes after selecting.
+      await waitFor(() => {
+        expect(screen.queryByTestId("mini-picker")).not.toBeInTheDocument();
+      });
+
+      // Reopening lands on the database list, not stuck inside the schema-less
+      // DB (which would re-trigger the auto-select and slam the picker shut).
+      await userEvent.click(screen.getByTestId("schema-picker-button"));
+      expect(await screen.findByText("QA Postgres")).toBeInTheDocument();
+      expect(screen.getByText("QA Maria")).toBeInTheDocument();
+    });
+
+    it("routes a named schema selection with the chosen schema and closes", async () => {
+      const { onSchemaChange, history } = setup({
+        databaseId: undefined,
+        schema: undefined,
+      });
+
+      await userEvent.click(await screen.findByText("QA Postgres"));
+      await userEvent.click(await screen.findByText("public"));
+
+      await waitFor(() => {
+        expect(onSchemaChange).toHaveBeenCalled();
+      });
+      const location = history?.getCurrentLocation();
+      const params = new URLSearchParams(location?.search);
+      expect(params.get("database-id")).toBe("40");
+      expect(params.get("schema")).toBe("public");
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("mini-picker")).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SchemaPickerInput/SchemaPickerInput.unit.spec.tsx
@@ -143,7 +143,7 @@ describe("SchemaPickerInput", () => {
       // With no database selected the picker opens automatically.
       await userEvent.click(await screen.findByText("QA Maria"));
 
-      // The lone nameless schema is auto-selected; navigation preserves the
+      // Single nameless schema is auto-selected; navigation preserves the
       // empty schema (`schema=`) rather than dropping it.
       await waitFor(() => {
         expect(onSchemaChange).toHaveBeenCalled();
@@ -158,8 +158,7 @@ describe("SchemaPickerInput", () => {
         expect(screen.queryByTestId("mini-picker")).not.toBeInTheDocument();
       });
 
-      // Reopening lands on the database list, not stuck inside the schema-less
-      // DB (which would re-trigger the auto-select and slam the picker shut).
+      // Reopening shows the database list.
       await userEvent.click(screen.getByTestId("schema-picker-button"));
       expect(await screen.findByText("QA Postgres")).toBeInTheDocument();
       expect(screen.getByText("QA Maria")).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/PanelHeader/PanelHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/components/SchemaViewer/components/SelectedNodeInfoPanel/PanelHeader/PanelHeader.tsx
@@ -39,7 +39,7 @@ export function PanelHeader({
   const breadcrumbs = getBreadcrumbs(node, database);
   const metadataUrl = Urls.dataStudioData({
     databaseId: node.data.db_id,
-    schemaName: node.data.schema ?? undefined,
+    schemaName: node.data.schema ?? "",
     tableId: node.data.table_id,
   });
 

--- a/frontend/src/metabase-lib/v1/metadata/utils/schema.ts
+++ b/frontend/src/metabase-lib/v1/metadata/utils/schema.ts
@@ -1,6 +1,11 @@
 import { humanize, titleize } from "metabase/utils/formatting";
 import type { DatabaseId, SchemaId, SchemaName } from "metabase-types/api";
 
+export const UNNAMED_SCHEMA_NAME = "";
+
+export const isNamelessSchema = (name: SchemaName | null | undefined) =>
+  name === UNNAMED_SCHEMA_NAME;
+
 export const getSchemaDisplayName = (
   name: SchemaName | null | undefined,
 ): string | null => (name ? titleize(humanize(name)) : null);

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -128,6 +128,60 @@ describe("MiniPicker", () => {
     });
   });
 
+  describe("schemas", () => {
+    it("can pick a named schema from a db with multiple schemas", async () => {
+      const { onChangeSpy } = await setup({ models: ["schema"] });
+      await userEvent.click(await screen.findByText("Mini Db"));
+      await userEvent.click(await screen.findByText("public"));
+
+      expect(onChangeSpy).toHaveBeenCalledWith({
+        model: "schema",
+        id: "public",
+        database_id: 1,
+        name: "public",
+      });
+      // terminates on the schema; never drills into tables
+      expect(screen.queryByText("weather")).not.toBeInTheDocument();
+    });
+
+    it('auto-selects schema-less db (schema = "")', async () => {
+      const { onChangeSpy } = await setup({ models: ["schema"] });
+      await userEvent.click(await screen.findByText("NoSchema Db"));
+
+      // selects immediately without showing a blank schema row
+      await waitFor(() => {
+        expect(onChangeSpy).toHaveBeenCalledWith({
+          model: "schema",
+          id: "",
+          database_id: 3,
+          name: "",
+        });
+      });
+
+      // path resets back to the database list so the picker stays reopenable
+      // instead of being stuck re-triggering the auto-select
+      expect(await screen.findByText("Mini Db")).toBeInTheDocument();
+      expect(await screen.findByText("Solo Db")).toBeInTheDocument();
+    });
+
+    it("does not auto-select a single named schema", async () => {
+      const { onChangeSpy } = await setup({ models: ["schema"] });
+      await userEvent.click(await screen.findByText("Solo Db"));
+
+      // a named single schema is still a deliberate pick
+      const onlySchema = await screen.findByText("only");
+      expect(onChangeSpy).not.toHaveBeenCalled();
+
+      await userEvent.click(onlySchema);
+      expect(onChangeSpy).toHaveBeenCalledWith({
+        model: "schema",
+        id: "only",
+        database_id: 2,
+        name: "only",
+      });
+    });
+  });
+
   describe("collections", () => {
     it("can pick a model", async () => {
       const { onChangeSpy } = await setup();

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -32,6 +32,7 @@ import {
   Text,
   TextInput,
 } from "metabase/ui";
+import { isNamelessSchema } from "metabase-lib/v1/metadata/utils/schema";
 import type {
   CollectionItem,
   SchemaName,
@@ -324,7 +325,7 @@ function DatabaseItemList({
     schemasArePickable &&
     parent.model === "database" &&
     schemas?.length === 1 &&
-    schemas[0] === "";
+    isNamelessSchema(schemas[0]);
 
   useEffect(() => {
     if (shouldAutoSelectNamelessSchema) {

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -318,6 +318,21 @@ function DatabaseItemList({
         ? schemas[0] // if there's one schema, go straight to tables
         : null;
 
+  // Schema-less DBs (MySQL, Mongo, SQLite, …) report a single nameless schema.
+  // In that case, select the DB immediately instead of showing a blank row at 'schema' step.
+  const shouldAutoSelectNamelessSchema =
+    schemasArePickable &&
+    parent.model === "database" &&
+    schemas?.length === 1 &&
+    schemas[0] === "";
+
+  useEffect(() => {
+    if (shouldAutoSelectNamelessSchema) {
+      setPath([]);
+      onChange({ model: "schema", id: "", database_id: dbId, name: "" });
+    }
+  }, [shouldAutoSelectNamelessSchema, onChange, setPath, dbId]);
+
   const { data: tablesData, isLoading: isLoadingTables } =
     useListDatabaseSchemaTablesQuery(
       schemaName !== null
@@ -329,7 +344,7 @@ function DatabaseItemList({
         : skipToken,
     );
 
-  if (isLoadingSchemas) {
+  if (isLoadingSchemas || shouldAutoSelectNamelessSchema) {
     return <MiniPickerListLoader />;
   }
 

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/constants.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/constants.ts
@@ -2,8 +2,6 @@ import type { IconName } from "metabase-types/api";
 
 import type { ItemType } from "./types";
 
-export const UNNAMED_SCHEMA_NAME = "";
-
 export const TYPE_ICONS: Record<ItemType, IconName> = {
   table: "table2",
   schema: "folder",

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
@@ -8,9 +8,9 @@ import {
   useLazyListDatabasesQuery,
 } from "metabase/api";
 import { isSyncCompleted } from "metabase/utils/syncing";
+import { UNNAMED_SCHEMA_NAME } from "metabase-lib/v1/metadata/utils/schema";
 import type { DatabaseId, SchemaName } from "metabase-types/api";
 
-import { UNNAMED_SCHEMA_NAME } from "../constants";
 import type {
   DatabaseNode,
   RootNode,

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/utils.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/utils.ts
@@ -1,7 +1,7 @@
+import { UNNAMED_SCHEMA_NAME } from "metabase-lib/v1/metadata/utils/schema";
 import type { DatabaseId, TableId } from "metabase-types/api";
 
 import { getSchemaId } from "./bulk-selection.utils";
-import { UNNAMED_SCHEMA_NAME } from "./constants";
 import type {
   DatabaseNode,
   ExpandedState,

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/constants.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/constants.ts
@@ -2,8 +2,6 @@ import type { IconName } from "metabase-types/api";
 
 import type { ItemType } from "./types";
 
-export const UNNAMED_SCHEMA_NAME = "";
-
 export const CHILD_TYPES = {
   database: "schema",
   schema: "table",

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useTableLoader.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useTableLoader.ts
@@ -8,9 +8,9 @@ import {
   useLazyListDatabasesQuery,
 } from "metabase/api";
 import { isSyncCompleted } from "metabase/utils/syncing";
+import { UNNAMED_SCHEMA_NAME } from "metabase-lib/v1/metadata/utils/schema";
 import type { DatabaseId, SchemaName } from "metabase-types/api";
 
-import { UNNAMED_SCHEMA_NAME } from "../constants";
 import type {
   DatabaseNode,
   SchemaNode,

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/utils.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/utils.ts
@@ -1,4 +1,6 @@
-import { CHILD_TYPES, UNNAMED_SCHEMA_NAME } from "./constants";
+import { UNNAMED_SCHEMA_NAME } from "metabase-lib/v1/metadata/utils/schema";
+
+import { CHILD_TYPES } from "./constants";
 import type {
   DatabaseNode,
   ExpandedState,


### PR DESCRIPTION
Closes [GDGT-2598](https://linear.app/metabase/issue/GDGT-2598)

### Description

Schema-less databases (MongoDB, MySQL, SQLite, Druid) report a single nameless schema (`[""]`). The Schema Viewer's schema picker handled this poorly — it showed a blank clickable row for the `""` schema and kept the "Pick a schema to view" placeholder even after such a DB was selected.

*Also, fixed an issue with incorrect generation of URL pointing to Table metadata view with schema-less DBs.

### Solution

In those cases clicking a schema-less DB auto-selects the nameless schema instead of showing a blank row. Picker's label shows DB name instead of empty input.

### Demo

**Before**
<img width="1342" height="366" alt="image" src="https://github.com/user-attachments/assets/e2bb5e5a-81d6-414d-bb7e-ecbcf081b30a" />

**After**
<img width="589" height="329" alt="image" src="https://github.com/user-attachments/assets/3675dbcf-bfc9-40ad-bd9a-e39d3e343309" />

### How to verify

1. Connect a schema-less DB (e.g. MongoDB) and open the Schema Viewer.
2. Click the picker → clicking on MongoDB selects it immediately and the trigger shows the database name.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR