### PR TITLE
Preserve column selection on joined tables in drill through

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -48,6 +48,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
+   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [mapv empty? #?(:clj for)]]))
 
@@ -169,11 +170,6 @@
      query
      filter-clauses)))
 
-(defn- restore-implicit-join-fields [join]
-  (if (some? (:fields join))
-    join
-    (lib.join/with-join-fields join :all)))
-
 (defn drill-underlying-records
   "Drops aggregations, breakouts, orders, limits and field, then applies a filter for each of the dimensions (including
   for metrics, and aggregations that imply a filter like `:sum-where`).
@@ -208,8 +204,9 @@
 
                                  ;; Default: no filters to add.
                                  nil)))
-        ;; make all joins include all fields
-        new-joins (mapv restore-implicit-join-fields
+        ;; A join with no `:fields` contributes no columns, so default it to `:all` (#48032).
+        ;; Joins with explicit `:fields` keep the user's column selection (#69105).
+        new-joins (mapv #(u/assoc-default % :fields :all)
                         (lib.join/joins agg-filtered))]
     ;; if we have new joins to add, update query with the new joins
     (if (empty? new-joins)

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -169,6 +169,11 @@
      query
      filter-clauses)))
 
+(defn- restore-implicit-join-fields [join]
+  (if (some? (:fields join))
+    join
+    (lib.join/with-join-fields join :all)))
+
 (defn drill-underlying-records
   "Drops aggregations, breakouts, orders, limits and field, then applies a filter for each of the dimensions (including
   for metrics, and aggregations that imply a filter like `:sum-where`).
@@ -204,7 +209,7 @@
                                  ;; Default: no filters to add.
                                  nil)))
         ;; make all joins include all fields
-        new-joins (mapv #(lib.join/with-join-fields % :all)
+        new-joins (mapv restore-implicit-join-fields
                         (lib.join/joins agg-filtered))]
     ;; if we have new joins to add, update query with the new joins
     (if (empty? new-joins)

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -576,6 +576,43 @@
                   first
                   lib.join/join-fields))))))
 
+(deftest ^:parallel preserve-column-selection-after-drill-thru-test
+  (testing "underlying records should keep the join's column selection (#69105)"
+    (let [query        (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                           (lib/join (-> (lib/join-clause (meta/table-metadata :products))
+                                         (lib/with-join-fields [(meta/field-metadata :products :id)
+                                                                (meta/field-metadata :products :category)])))
+                           (lib/aggregate (lib/count)))
+          query        (lib/breakout query (m/find-first #(= (:name %) "CATEGORY")
+                                                         (lib/breakoutable-columns query)))
+          count-col    (m/find-first #(= (:name %) "count")
+                                     (lib/returned-columns query))
+          category-col (m/find-first #(= (:name %) "CATEGORY")
+                                     (lib/returned-columns query))
+          context      {:column     count-col
+                        :column-ref (lib/ref count-col)
+                        :value      4939
+                        :row        [{:column     category-col
+                                      :column-ref (lib/ref category-col)
+                                      :value      "Gadget"}
+                                     {:column     count-col
+                                      :column-ref (lib/ref count-col)
+                                      :value      4939}]
+                        :dimensions [{:column     category-col
+                                      :column-ref (lib/ref category-col)
+                                      :value      "Gadget"}]}
+          drill        (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                     (lib/available-drill-thrus query context))
+          drilled      (lib/drill-thru query drill)]
+      (is (=? [[:field {} (meta/id :products :id)]
+               [:field {} (meta/id :products :category)]]
+              (-> drilled lib.join/joins first lib.join/join-fields)))
+      (is (= #{(meta/id :products :id) (meta/id :products :category)}
+             (into #{}
+                   (comp (filter #(= (:table-id %) (meta/id :products)))
+                         (map :id))
+                   (lib/returned-columns drilled)))))))
+
 (deftest ^:parallel breakout-by-expression-test
   (testing "underlying records for a query with a breakout on an expression should produce a correct ref (#59005)"
     (let [base               (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/69105

### Description

There was an explicit decision made in https://github.com/metabase/metabase/pull/50802#discussion_r1868462142 to use all columns after drilling through on a join. This can bring over unwanted columns, so we'll just use joined fields that were selected, and fallback to using all join fields. 

### How to verify

See repro steps in original issue. The underlying records should only show the selected join columns, not all join columns. 

### Demo

<details>

<summary>demo</summary>

https://github.com/user-attachments/assets/07215456-1be1-4c0a-957a-256521c7bfec

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
