### PR TITLE
Fix replacement with field filter alias

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -15,6 +15,7 @@
    [metabase.driver.common.table-rows-sample :as table-rows-sample]
    [metabase.driver.settings :as driver.settings]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.pipeline :as qp.pipeline]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
@@ -1458,3 +1459,24 @@
     (is (nil? (bigquery.ws/ws-sa-description->created-at "")))
     (is (nil? (bigquery.ws/ws-sa-description->created-at "some other description")))
     (is (nil? (bigquery.ws/ws-sa-description->created-at "created-at:not-an-instant")))))
+
+(deftest ^:parallel bigquery-field-filter-alias-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (let [mp    (mt/metadata-provider)
+          sql   "SELECT title as title, category AS category
+                 FROM sha_c1baee7db240aa419104c2d925a07a4d4faeeb24_test_data.products p
+                 WHERE 1=1 [[ AND {{category}} ]]
+                 ORDER BY p.title ASC;"
+          product-category (lib/ref (lib.metadata/field mp (mt/id :products :category)))
+          query (-> (lib/native-query mp sql)
+                    (lib/with-template-tags {"category" {:name "category"
+                                                         :alias "p.category"
+                                                         :display-name "Category"
+                                                         :type :dimension
+                                                         :dimension product-category
+                                                         :widget-type :text}})
+                    (assoc :parameters [{:type :text
+                                         :target [:dimension [:template-tag "category"]]
+                                         :value "Gadget"}]))]
+      (is (= ["Aerodynamic Leather Computer" "Gadget"]
+             (mt/first-row (qp/process-query query)))))))

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -350,7 +350,11 @@
   [driver col alias replacement-snippet-info]
   (if (str/blank? alias)
     replacement-snippet-info
-    (let [[old-name] (->> (lib/ref col)
+    (let [field-ref  (-> (lib/ref col)
+                         (lib/update-options assoc
+                                             driver-api/qp.add.source-table (:table-id col)
+                                             ::compiling-field-filter?      true))
+          [old-name] (->> field-ref
                           (->honeysql driver)
                           (sql.qp/format-honeysql driver))]
       (update replacement-snippet-info :replacement-snippet str/replace old-name alias))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75570

### Description

We use `str/replace` when applying a field filter alias, so we need the field name we are replacing to match the field name in the field filter. In `field->field-ref` we apply these options:

```
driver-api/qp.add.source-table (:table-id col)
::compiling-field-filter?      true
```

which generates a snippet like this for bigquery:
```
(`sha_c1baee7db240aa419104c2d925a07a4d4faeeb24_test_data.products`.`category` = ?)
```

but in `replace-alias` we were generating the field name without these options which produced:
```
`sha_c1baee7db240aa419104c2d925a07a4d4faeeb24_test_data`.`products`.`category`
```

So they don't match and the snippet wasn't being replaced with the alias. The fix is to generate the field name with the same options as in `field->field-ref`. 

Similar to the fix in https://github.com/metabase/metabase/pull/74680

### How to verify

See repro steps in original issue and the unit test. The query should succeed and return the expected results. 

### Demo

<details>

<summary>demo</summary>

https://github.com/user-attachments/assets/e7179cd5-83b5-4e3c-af69-280eb58b3822

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
