### PR TITLE
Add operator knobs for the pgvector connection pool

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -65,8 +65,10 @@
 
 ;; Postgres connection properties pgjdbc recognizes on the classpath; read at runtime so it tracks the
 ;; driver version. Anything on the URL that's neither a tunable pool knob nor one of these is a typo.
+;; NB: explicit fn rather than the 1.12 `PGProperty/.getName` method value — eastwood's analyzer can't
+;; parse the latter yet.
 (def ^:private known-connection-params
-  (into #{} (map PGProperty/.getName) (PGProperty/values)))
+  (into #{} (map #(.getName ^PGProperty %)) (PGProperty/values)))
 
 (defn- url-decode ^String [^String s]
   (URLDecoder/decode s StandardCharsets/UTF_8))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -1,11 +1,12 @@
 (ns metabase-enterprise.semantic-search.db.datasource
   (:require
    [environ.core :refer [env]]
+   [metabase.config.core :as config]
    [metabase.connection-pool :as connection-pool]
    [metabase.util.log :as log]
    [next.jdbc :as jdbc])
   (:import
-   (com.mchange.v2.c3p0 DataSources)))
+   (com.mchange.v2.c3p0 DataSources PooledDataSource)))
 
 (set! *warn-on-reflection* true)
 
@@ -17,17 +18,46 @@
   "The database URL used to connect to pgvector"
   (env :mb-pgvector-db-url))
 
-;; See metabase.app-db.connection-pool-setup for more details on these properties
-;; TODO: not sure if we need the MetabaseConnectionCustomizer like in the app DB connection pool setup
-(def ^:private semantic-search-connection-pool-props
-  "Connection pool properties for semantic search database using c3p0."
-  {"idleConnectionTestPeriod"     60
-   "maxIdleTimeExcessConnections" (* 10 60)  ; 5 minutes
-   "maxConnectionAge"             (* 30 60)  ; 30 minutes
-   "maxPoolSize"                  5          ; Small pool to start
-   "minPoolSize"                  1
-   "initialPoolSize"              1
-   "dataSourceName"               "metabase-semantic-search-db"})
+;; See metabase.app-db.connection-pool-setup and metabase.driver.sql-jdbc.connection for the analogous
+;; app-db and data-warehouse pools.
+;;
+;; These knobs exist so operators can cap resource usage when many Metabase instances share one pgvector
+;; RDS instance. They are env-var driven (read once at pool construction) so a deployment can set them
+;; uniformly across the fleet. TODO: not sure if we need the MetabaseConnectionCustomizer like the app DB.
+(defn- connection-pool-props
+  "Connection pool properties for the semantic search database using c3p0."
+  []
+  (let [min-pool-size (or (config/config-int :mb-pgvector-db-min-pool-size) 0)]
+    {"idleConnectionTestPeriod"     60
+     "maxIdleTimeExcessConnections" (* 10 60)  ; cull excess idle connections after 10 minutes
+     "maxConnectionAge"             (* 30 60)  ; recycle any connection after 30 minutes
+     ;; minPoolSize/initialPoolSize 0: idle instances hold zero server-side connections, which is what
+     ;; makes a shared RDS viable. Cold start costs one TCP+TLS+auth handshake on the first search after
+     ;; 10+ idle minutes, and the query path warms the pool concurrently with the embedding round-trip
+     ;; (see semantic-search.index/query-index), so user searches don't pay it serially. Set
+     ;; MB_PGVECTOR_DB_MIN_POOL_SIZE=1 to pin a warm connection on a dedicated/hot instance.
+     "minPoolSize"                  min-pool-size
+     "initialPoolSize"              min-pool-size
+     ;; acquireIncrement 1: c3p0 defaults to acquiring 3 connections per pool miss, which triples the
+     ;; cold-start burst and idle tail on the shared RDS for no benefit at this pool size.
+     "acquireIncrement"             1
+     "maxPoolSize"                  (or (config/config-int :mb-pgvector-db-max-connection-pool-size) 5)
+     ;; checkoutTimeout: fail fast when the pool is exhausted instead of blocking forever (c3p0 default 0).
+     ;; Safe to fail fast: the semantic engine falls back to appdb search on any error
+     ;; (see semantic-search.core/results).
+     "checkoutTimeout"              (or (config/config-int :mb-pgvector-db-checkout-timeout-ms) 10000)
+     ;; unreturnedConnectionTimeout: c3p0's leak detector, off (0) by default. It destroys connections by
+     ;; checkout *duration*, so any value low enough to catch leaks also kills legitimately slow work
+     ;; (reindex DDL, bulk upserts, repair scans). Leaks are already bounded: checkoutTimeout + the appdb
+     ;; fallback degrade search rather than block it. Enable together with the stack-traces knob on a
+     ;; canary to hunt a suspected leak.
+     "unreturnedConnectionTimeout" (or (config/config-int :mb-pgvector-db-unreturned-connection-timeout-seconds) 0)
+     "debugUnreturnedConnectionStackTraces"
+     (boolean (config/config-bool :mb-pgvector-db-debug-unreturned-connection-stack-traces))
+     ;; testConnectionOnCheckout: off by default (idleConnectionTestPeriod covers idle conns); flip on if a
+     ;; shared RDS drops connections out from under the pool. Matches the app-db default.
+     "testConnectionOnCheckout"    (boolean (config/config-bool :mb-pgvector-db-test-connection-on-checkout))
+     "dataSourceName"              "metabase-semantic-search-db"}))
 
 (defn- build-db-config
   "Build database configuration from environment variables"
@@ -36,6 +66,22 @@
     {:jdbcUrl db-url}
     (throw (ex-info "MB_PGVECTOR_DB_URL environment variable is required for semantic search" {}))))
 
+(defn shutdown-db!
+  "Close the pooled data source (if any) and clear it, releasing all server-side connections.
+  Safe to call when the pool was never initialized; a later [[init-db!]] builds a fresh pool."
+  []
+  (locking data-source
+    (when-let [ds @data-source]
+      (reset! data-source nil)
+      (log/info "Closing semantic search connection pool")
+      (.close ^PooledDataSource ds))))
+
+;; Tests redef [[data-source]] and close their pools themselves; this hook only sees the root binding,
+;; so it closes at most the production pool.
+(defonce ^:private shutdown-hook
+  (delay (.addShutdownHook (Runtime/getRuntime)
+                           (Thread. ^Runnable shutdown-db! "semantic-search-pool-shutdown"))))
+
 (defn init-db!
   "Initialize c3p0 connection pool for semantic search database.
    Requires MB_PGVECTOR_DB_URL environment variable."
@@ -43,11 +89,13 @@
   (locking data-source
     (or @data-source
         (let [db-config   (build-db-config)
+              pool-props  (connection-pool-props)
               unpooled-ds (jdbc/get-datasource db-config)
               pooled-ds   (DataSources/pooledDataSource
                            ^javax.sql.DataSource unpooled-ds
-                           (connection-pool/map->properties semantic-search-connection-pool-props))]
-          (log/info "Initializing semantic search connection pool with properties:" semantic-search-connection-pool-props)
+                           (connection-pool/map->properties pool-props))]
+          (log/info "Initializing semantic search connection pool with properties:" pool-props)
+          (force shutdown-hook)
           (reset! data-source pooled-ds)))))
 
 (defn test-connection!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -18,12 +18,8 @@
   "The database URL used to connect to pgvector"
   (env :mb-pgvector-db-url))
 
-;; See metabase.app-db.connection-pool-setup and metabase.driver.sql-jdbc.connection for the analogous
-;; app-db and data-warehouse pools.
-;;
-;; These knobs exist so operators can cap resource usage when many Metabase instances share one pgvector
-;; RDS instance. They are env-var driven (read once at pool construction) so a deployment can set them
-;; uniformly across the fleet. TODO: not sure if we need the MetabaseConnectionCustomizer like the app DB.
+;; Env-var knobs (read once at pool construction) so operators can cap resource usage when many Metabase
+;; instances share one pgvector RDS. Cf. metabase.app-db.connection-pool-setup for the analogous app-db pool.
 (defn- connection-pool-props
   "Connection pool properties for the semantic search database using c3p0."
   []
@@ -31,31 +27,25 @@
     {"idleConnectionTestPeriod"     60
      "maxIdleTimeExcessConnections" (* 10 60)  ; cull excess idle connections after 10 minutes
      "maxConnectionAge"             (* 30 60)  ; recycle any connection after 30 minutes
-     ;; minPoolSize/initialPoolSize 0: idle instances hold zero server-side connections, which is what
-     ;; makes a shared RDS viable. Cold start costs one TCP+TLS+auth handshake on the first search after
-     ;; 10+ idle minutes, and the query path warms the pool concurrently with the embedding round-trip
-     ;; (see semantic-search.index/query-index), so user searches don't pay it serially. Set
-     ;; MB_PGVECTOR_DB_MIN_POOL_SIZE=1 to pin a warm connection on a dedicated/hot instance.
+     ;; 0 idle connections is what makes a shared RDS viable. Cold start costs one handshake, warmed
+     ;; concurrently with the embedding round-trip (see semantic-search.index/query-index). Set
+     ;; MB_PGVECTOR_DB_MIN_POOL_SIZE=1 to pin a warm connection on a hot instance.
      "minPoolSize"                  min-pool-size
      "initialPoolSize"              min-pool-size
-     ;; acquireIncrement 1: c3p0 defaults to acquiring 3 connections per pool miss, which triples the
-     ;; cold-start burst and idle tail on the shared RDS for no benefit at this pool size.
+     ;; c3p0 defaults to 3 per miss; 1 avoids tripling the cold-start burst on the shared RDS.
      "acquireIncrement"             1
      "maxPoolSize"                  (or (config/config-int :mb-pgvector-db-max-connection-pool-size) 5)
-     ;; checkoutTimeout: fail fast when the pool is exhausted instead of blocking forever (c3p0 default 0).
-     ;; Safe to fail fast: the semantic engine falls back to appdb search on any error
-     ;; (see semantic-search.core/results).
+     ;; Fail fast on pool exhaustion (c3p0 default 0 blocks forever); the engine falls back to appdb
+     ;; search on error (see semantic-search.core/results).
      "checkoutTimeout"              (or (config/config-int :mb-pgvector-db-checkout-timeout-ms) 10000)
-     ;; unreturnedConnectionTimeout: c3p0's leak detector, off (0) by default. It destroys connections by
-     ;; checkout *duration*, so any value low enough to catch leaks also kills legitimately slow work
-     ;; (reindex DDL, bulk upserts, repair scans). Leaks are already bounded: checkoutTimeout + the appdb
-     ;; fallback degrade search rather than block it. Enable together with the stack-traces knob on a
-     ;; canary to hunt a suspected leak.
+     ;; c3p0's leak detector, off by default: it destroys connections by checkout *duration*, so any value
+     ;; low enough to catch leaks also kills slow work (reindex DDL, bulk upserts). Enable with the
+     ;; stack-traces knob on a canary to hunt a suspected leak.
      "unreturnedConnectionTimeout" (or (config/config-int :mb-pgvector-db-unreturned-connection-timeout-seconds) 0)
      "debugUnreturnedConnectionStackTraces"
      (boolean (config/config-bool :mb-pgvector-db-debug-unreturned-connection-stack-traces))
-     ;; testConnectionOnCheckout: off by default (idleConnectionTestPeriod covers idle conns); flip on if a
-     ;; shared RDS drops connections out from under the pool. Matches the app-db default.
+     ;; Off by default (idleConnectionTestPeriod covers idle conns); matches app-db. Flip on if the shared
+     ;; RDS drops connections under the pool.
      "testConnectionOnCheckout"    (boolean (config/config-bool :mb-pgvector-db-test-connection-on-checkout))
      "dataSourceName"              "metabase-semantic-search-db"}))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -1,12 +1,16 @@
 (ns metabase-enterprise.semantic-search.db.datasource
   (:require
+   [clojure.string :as str]
    [environ.core :refer [env]]
-   [metabase.config.core :as config]
    [metabase.connection-pool :as connection-pool]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [next.jdbc :as jdbc])
   (:import
-   (com.mchange.v2.c3p0 DataSources PooledDataSource)))
+   (com.mchange.v2.c3p0 DataSources PooledDataSource)
+   (java.net URLDecoder)
+   (java.nio.charset StandardCharsets)
+   (org.postgresql PGProperty)))
 
 (set! *warn-on-reflection* true)
 
@@ -18,42 +22,103 @@
   "The database URL used to connect to pgvector"
   (env :mb-pgvector-db-url))
 
-;; Env-var knobs (read once at pool construction) so operators can cap resource usage when many Metabase
-;; instances share one pgvector RDS. Cf. metabase.app-db.connection-pool-setup for the analogous app-db pool.
-(defn- connection-pool-props
-  "Connection pool properties for the semantic search database using c3p0."
-  []
-  (let [min-pool-size (or (config/config-int :mb-pgvector-db-min-pool-size) 0)]
-    {"idleConnectionTestPeriod"     60
-     "maxIdleTimeExcessConnections" (* 10 60)  ; cull excess idle connections after 10 minutes
-     "maxConnectionAge"             (* 30 60)  ; recycle any connection after 30 minutes
-     ;; 0 idle connections is what makes a shared RDS viable. Cold start costs one handshake, warmed
-     ;; concurrently with the embedding round-trip (see semantic-search.index/query-index). Set
-     ;; MB_PGVECTOR_DB_MIN_POOL_SIZE=1 to pin a warm connection on a hot instance.
-     "minPoolSize"                  min-pool-size
-     "initialPoolSize"              min-pool-size
-     ;; c3p0 defaults to 3 per miss; 1 avoids tripling the cold-start burst on the shared RDS.
-     "acquireIncrement"             1
-     "maxPoolSize"                  (or (config/config-int :mb-pgvector-db-max-connection-pool-size) 5)
-     ;; Fail fast on pool exhaustion (c3p0 default 0 blocks forever); the engine falls back to appdb
-     ;; search on error (see semantic-search.core/results).
-     "checkoutTimeout"              (or (config/config-int :mb-pgvector-db-checkout-timeout-ms) 10000)
-     ;; c3p0's leak detector, off by default: it destroys connections by checkout *duration*, so any value
-     ;; low enough to catch leaks also kills slow work (reindex DDL, bulk upserts). Enable with the
-     ;; stack-traces knob on a canary to hunt a suspected leak.
-     "unreturnedConnectionTimeout" (or (config/config-int :mb-pgvector-db-unreturned-connection-timeout-seconds) 0)
-     "debugUnreturnedConnectionStackTraces"
-     (boolean (config/config-bool :mb-pgvector-db-debug-unreturned-connection-stack-traces))
-     ;; Off by default (idleConnectionTestPeriod covers idle conns); matches app-db. Flip on if the shared
-     ;; RDS drops connections under the pool.
-     "testConnectionOnCheckout"    (boolean (config/config-bool :mb-pgvector-db-test-connection-on-checkout))
-     "dataSourceName"              "metabase-semantic-search-db"}))
+;; All pgvector config — connection *and* connection-pool parameters — rides MB_PGVECTOR_DB_URL, so a
+;; deployment sets everything in one place (the DB secret) with no env-var-vs-URL precedence to reason
+;; about. c3p0 pool params can't ride the JDBC URL into the driver, so we parse them out here (see
+;; parse-db-url) and hand the rest to pgjdbc. pgjdbc *silently ignores* params it doesn't recognize, so we
+;; validate every param against an allowlist and throw on startup rather than let a typo become a
+;; silently-dropped setting. Cf. metabase.app-db.connection-pool-setup for the analogous app-db pool.
 
-(defn- build-db-config
-  "Build database configuration from environment variables"
+;; c3p0 props we always set and don't expose for tuning.
+(def ^:private fixed-pool-props
+  {"idleConnectionTestPeriod"     60
+   "maxIdleTimeExcessConnections" (* 10 60)  ; cull excess idle connections after 10 minutes
+   "maxConnectionAge"             (* 30 60)  ; recycle any connection after 30 minutes
+   ;; c3p0 defaults to 3 per miss; 1 avoids tripling the cold-start burst on the shared RDS.
+   "acquireIncrement"             1
+   "dataSourceName"               "metabase-semantic-search-db"})
+
+(defn- parse-bool [^String s]
+  (case (u/lower-case-en (str/trim s)) "true" true "false" false nil))
+
+;; Overridable c3p0 knobs: name -> [default parse-fn]. Operators override by setting the same key on
+;; MB_PGVECTOR_DB_URL; names match c3p0's own so they map straight onto its docs. parse-fn returns nil on a
+;; malformed value, which we surface as a startup error.
+(def ^:private tunable-pool-props
+  {;; 0 idle connections is what makes a shared RDS viable. Cold start costs one handshake, warmed
+   ;; concurrently with the embedding round-trip (see semantic-search.index/query-index). Set minPoolSize=1
+   ;; to pin a warm connection on a hot instance.
+   "minPoolSize"                          [0     parse-long]
+   "initialPoolSize"                      [0     parse-long]
+   "maxPoolSize"                          [5     parse-long]
+   ;; Fail fast on pool exhaustion (c3p0 default 0 blocks forever); the engine falls back to appdb search
+   ;; on error (see semantic-search.core/results).
+   "checkoutTimeout"                      [10000 parse-long]
+   ;; c3p0's leak detector, off by default: it destroys connections by checkout *duration*, so any value
+   ;; low enough to catch leaks also kills slow work (reindex DDL, bulk upserts). Enable with the
+   ;; stack-traces knob on a canary to hunt a suspected leak.
+   "unreturnedConnectionTimeout"          [0     parse-long]
+   "debugUnreturnedConnectionStackTraces" [false parse-bool]
+   ;; Off by default (idleConnectionTestPeriod covers idle conns); matches app-db. Flip on if the shared
+   ;; RDS drops connections under the pool.
+   "testConnectionOnCheckout"             [false parse-bool]})
+
+;; Postgres connection properties pgjdbc recognizes on the classpath; read at runtime so it tracks the
+;; driver version. Anything on the URL that's neither a tunable pool knob nor one of these is a typo.
+(def ^:private known-connection-params
+  (into #{} (map #(.getName ^PGProperty %)) (PGProperty/values)))
+
+(defn- url-decode ^String [^String s]
+  (URLDecoder/decode s StandardCharsets/UTF_8))
+
+(defn- split-query
+  "Split a JDBC URL into [base pairs], where pairs is a seq of [decoded-key raw-value]. Each pair splits on
+   its first '=' so values may themselves contain '=' (e.g. options=-c statement_timeout=5000)."
+  [^String url]
+  (let [[base query] (str/split url #"\?" 2)]
+    [base (for [pair  (some-> query (str/split #"&"))
+                :when (seq pair)
+                :let  [[k v] (str/split pair #"=" 2)]]
+            [(url-decode k) (or v "")])]))
+
+(defn- parse-db-url
+  "Parse a pgvector JDBC URL into {:jdbc-url ... :pool-props ...}. Recognized c3p0 knobs are pulled off the
+   URL and merged over the defaults; recognized Postgres connection params stay on the URL for pgjdbc; any
+   other param throws."
+  [^String url]
+  (let [[base pairs]           (split-query url)
+        default-pool           (merge fixed-pool-props
+                                      (update-vals tunable-pool-props first))
+        {:keys [pool conn]}
+        (reduce
+         (fn [acc [k raw-v]]
+           (cond
+             (contains? tunable-pool-props k)
+             (let [parse  (second (tunable-pool-props k))
+                   parsed (parse (url-decode raw-v))]
+               (when (nil? parsed)
+                 (throw (ex-info (format "Invalid value for pgvector pool parameter %s: %s" k raw-v)
+                                 {:param k, :value raw-v})))
+               (assoc-in acc [:pool k] parsed))
+
+             (contains? known-connection-params k)
+             (update acc :conn conj (str k "=" raw-v))
+
+             :else
+             (throw (ex-info (format (str "Unknown pgvector URL parameter %s. Expected a c3p0 pool knob "
+                                          "(%s) or a Postgres connection property.")
+                                     k (str/join ", " (sort (keys tunable-pool-props))))
+                             {:param k}))))
+         {:pool default-pool, :conn []}
+         pairs)]
+    {:jdbc-url   (cond-> base (seq conn) (str "?" (str/join "&" conn)))
+     :pool-props pool}))
+
+(defn- parsed-db-config
+  "Parse [[db-url]] into {:jdbc-url ... :pool-props ...}, throwing if it is unset."
   []
   (if db-url
-    {:jdbcUrl db-url}
+    (parse-db-url db-url)
     (throw (ex-info "MB_PGVECTOR_DB_URL environment variable is required for semantic search" {}))))
 
 (defn shutdown-db!
@@ -78,9 +143,8 @@
   []
   (locking data-source
     (or @data-source
-        (let [db-config   (build-db-config)
-              pool-props  (connection-pool-props)
-              unpooled-ds (jdbc/get-datasource db-config)
+        (let [{:keys [jdbc-url pool-props]} (parsed-db-config)
+              unpooled-ds (jdbc/get-datasource {:jdbcUrl jdbc-url})
               pooled-ds   (DataSources/pooledDataSource
                            ^javax.sql.DataSource unpooled-ds
                            (connection-pool/map->properties pool-props))]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -72,19 +72,18 @@
   (URLDecoder/decode s StandardCharsets/UTF_8))
 
 (defn- split-query
-  "Split a JDBC URL into [base pairs], where pairs is a seq of [decoded-key raw-value]. Each pair splits on
-   its first '=' so values may themselves contain '=' (e.g. options=-c statement_timeout=5000)."
+  "Split a JDBC URL into [base pairs], where pairs is a seq of [decoded-key raw-value]."
   [^String url]
   (let [[base query] (str/split url #"\?" 2)]
+    ;; split each pair on its first '=' only, so a value may itself contain '=' (e.g. options=-c foo=bar)
     [base (for [pair  (some-> query (str/split #"&"))
                 :when (seq pair)
                 :let  [[k v] (str/split pair #"=" 2)]]
             [(url-decode k) (or v "")])]))
 
 (defn- parse-db-url
-  "Parse a pgvector JDBC URL into {:jdbc-url ... :pool-props ...}. Recognized c3p0 knobs are pulled off the
-   URL and merged over the defaults; recognized Postgres connection params stay on the URL for pgjdbc; any
-   other param throws."
+  "Parse a pgvector JDBC URL into {:jdbc-url ... :pool-props ...}, or throw if it carries an unrecognized
+  parameter."
   [^String url]
   (let [[base pairs]           (split-query url)
         default-pool           (merge fixed-pool-props
@@ -93,6 +92,7 @@
         (reduce
          (fn [acc [k raw-v]]
            (cond
+             ;; a c3p0 knob: coerce and apply to the pool (pgjdbc can't read these off the URL)
              (contains? tunable-pool-props k)
              (let [parse  (second (tunable-pool-props k))
                    parsed (parse (url-decode raw-v))]
@@ -101,9 +101,11 @@
                                  {:param k, :value raw-v})))
                (assoc-in acc [:pool k] parsed))
 
+             ;; a recognized pgjdbc connection property: leave it on the URL for the driver
              (contains? known-connection-params k)
              (update acc :conn conj (str k "=" raw-v))
 
+             ;; pgjdbc would silently ignore anything else, so treat it as a typo and fail loudly
              :else
              (throw (ex-info (format (str "Unknown pgvector URL parameter %s. Expected a c3p0 pool knob "
                                           "(%s) or a Postgres connection property.")
@@ -115,7 +117,7 @@
      :pool-props pool}))
 
 (defn- parsed-db-config
-  "Parse [[db-url]] into {:jdbc-url ... :pool-props ...}, throwing if it is unset."
+  "Parse [[db-url]] into {:jdbc-url ... :pool-props ...}, or throw if it is unset."
   []
   (if db-url
     (parse-db-url db-url)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/datasource.clj
@@ -66,20 +66,22 @@
 ;; Postgres connection properties pgjdbc recognizes on the classpath; read at runtime so it tracks the
 ;; driver version. Anything on the URL that's neither a tunable pool knob nor one of these is a typo.
 (def ^:private known-connection-params
-  (into #{} (map #(.getName ^PGProperty %)) (PGProperty/values)))
+  (into #{} (map PGProperty/.getName) (PGProperty/values)))
 
 (defn- url-decode ^String [^String s]
   (URLDecoder/decode s StandardCharsets/UTF_8))
 
 (defn- split-query
-  "Split a JDBC URL into [base pairs], where pairs is a seq of [decoded-key raw-value]."
+  "Split a JDBC URL into [base pairs], where pairs is a seq of raw [key value] strings.
+  Pairs are left verbatim so connection params pass through to pgjdbc exactly as written; only pool-knob
+  values are decoded, in parse-db-url."
   [^String url]
   (let [[base query] (str/split url #"\?" 2)]
     ;; split each pair on its first '=' only, so a value may itself contain '=' (e.g. options=-c foo=bar)
     [base (for [pair  (some-> query (str/split #"&"))
                 :when (seq pair)
                 :let  [[k v] (str/split pair #"=" 2)]]
-            [(url-decode k) (or v "")])]))
+            [k (or v "")])]))
 
 (defn- parse-db-url
   "Parse a pgvector JDBC URL into {:jdbc-url ... :pool-props ...}, or throw if it carries an unrecognized

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -24,6 +24,7 @@
    [next.jdbc.result-set :as jdbc.rs]
    [toucan2.core :as t2])
   (:import
+   [com.mchange.v2.c3p0 PooledDataSource]
    [java.time Instant LocalDate OffsetDateTime ZonedDateTime]
    [java.util.concurrent ArrayBlockingQueue RejectedExecutionHandler RejectedExecutionException TimeUnit ThreadPoolExecutor]
    [org.postgresql.util PGobject]))
@@ -859,6 +860,18 @@
   [db query]
   (jdbc/plan db (sql-format-quoted query) {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
 
+(defn- warm-connection-pool-async!
+  "Warm `db` with one pooled connection on a background thread, unless it already holds an idle one
+  (or isn't a c3p0 pool at all, e.g. a plain datasource in tests).
+  Fire-and-forget: failures surface on the real query that follows."
+  [db]
+  (u/ignore-exceptions
+    (when (and (instance? PooledDataSource db)
+               (zero? (.getNumIdleConnectionsDefaultUser ^PooledDataSource db)))
+      (future
+        (u/ignore-exceptions
+          (with-open [_conn (.getConnection ^PooledDataSource db)]))))))
+
 (defn query-index
   "Query the index for documents similar to the search string.
   Returns a map with :results and :raw-count."
@@ -872,10 +885,8 @@
             ;; Warm the pool concurrently with the embedding round-trip: the pool holds zero idle
             ;; connections by default (see semantic-search.db.datasource), so the first search after an
             ;; idle period would otherwise pay the connection handshake serially on top of the embedding
-            ;; latency. Fire-and-forget; failures surface on the real query below.
-            _ (future (try
-                        (with-open [_conn (.getConnection ^javax.sql.DataSource db)])
-                        (catch Throwable _)))
+            ;; latency.
+            _ (warm-connection-pool-async! db)
             embedding (tracing/with-span :search "search.semantic.embedding"
                         {:search.semantic/provider   (:provider embedding-model)
                          :search.semantic/model-name (:model-name embedding-model)}

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -869,6 +869,13 @@
       {:results [] :raw-count 0}
       (let [timer (u/start-timer)
 
+            ;; Warm the pool concurrently with the embedding round-trip: the pool holds zero idle
+            ;; connections by default (see semantic-search.db.datasource), so the first search after an
+            ;; idle period would otherwise pay the connection handshake serially on top of the embedding
+            ;; latency. Fire-and-forget; failures surface on the real query below.
+            _ (future (try
+                        (with-open [_conn (.getConnection ^javax.sql.DataSource db)])
+                        (catch Throwable _)))
             embedding (tracing/with-span :search "search.semantic.embedding"
                         {:search.semantic/provider   (:provider embedding-model)
                          :search.semantic/model-name (:model-name embedding-model)}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -101,3 +101,44 @@
          clojure.lang.ExceptionInfo
          #"Invalid value for pgvector pool parameter maxPoolSize"
          (parse-db-url (str base-url "?maxPoolSize=lots"))))))
+
+(deftest pool-props-applied-by-c3p0-test
+  (testing "c3p0 actually understands and applies every pool property name we set"
+    ;; We hand c3p0 a Properties map; like pgjdbc, c3p0 silently ignores names it doesn't recognize, so a
+    ;; typo in our prop map would quietly fall back to a c3p0 default. Read the effective config back from
+    ;; the pool to prove each name took effect. The values below all differ from c3p0's own defaults, so a
+    ;; dropped property would surface as a mismatch.
+    (when semantic.db.datasource/db-url
+      (let [overrides (str "minPoolSize=2&initialPoolSize=2&maxPoolSize=9&checkoutTimeout=4321"
+                           "&unreturnedConnectionTimeout=77&debugUnreturnedConnectionStackTraces=true"
+                           "&testConnectionOnCheckout=true")
+            url       (str semantic.db.datasource/db-url
+                           (if (re-find #"\?" semantic.db.datasource/db-url) "&" "?")
+                           overrides)]
+        (with-redefs [semantic.db.datasource/db-url      url
+                      semantic.db.datasource/data-source (atom nil)]
+          (try
+            (semantic.db.datasource/init-db!)
+            (let [cpds  (.getConnectionPoolDataSource
+                         ^PoolBackedDataSource @semantic.db.datasource/data-source)
+                  props (bean cpds)]
+              (is (=? {;; tunable knobs supplied on the URL
+                       :maxPoolSize                          9
+                       :minPoolSize                          2
+                       :initialPoolSize                      2
+                       :checkoutTimeout                      4321
+                       :unreturnedConnectionTimeout          77
+                       :debugUnreturnedConnectionStackTraces true
+                       :testConnectionOnCheckout             true
+                       ;; fixed props we always set
+                       :idleConnectionTestPeriod             60
+                       :maxIdleTimeExcessConnections         600
+                       :maxConnectionAge                     1800
+                       :acquireIncrement                     1}
+                      (select-keys props [:maxPoolSize :minPoolSize :initialPoolSize :checkoutTimeout
+                                          :unreturnedConnectionTimeout :debugUnreturnedConnectionStackTraces
+                                          :testConnectionOnCheckout :idleConnectionTestPeriod
+                                          :maxIdleTimeExcessConnections :maxConnectionAge
+                                          :acquireIncrement]))))
+            (finally
+              (semantic.db.datasource/shutdown-db!))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -55,22 +55,23 @@
 
 (deftest parse-db-url-defaults-test
   (testing "a URL with no params leaves the URL untouched and uses the default pool props"
-    (is (=? {:jdbc-url   base-url
-             :pool-props {;; tunable knobs at their defaults
-                          "maxPoolSize"                          5
-                          "minPoolSize"                          0
-                          "initialPoolSize"                      0
-                          "checkoutTimeout"                      10000
-                          "unreturnedConnectionTimeout"          0
-                          "debugUnreturnedConnectionStackTraces" false
-                          "testConnectionOnCheckout"             false
-                          ;; fixed props operators can't override
-                          "idleConnectionTestPeriod"             60
-                          "maxIdleTimeExcessConnections"         600
-                          "maxConnectionAge"                     1800
-                          "acquireIncrement"                     1
-                          "dataSourceName"                       "metabase-semantic-search-db"}}
-            (parse-db-url base-url)))))
+    ;; strict = (not =?) so an unexpected extra/missing prop also fails, not just a wrong value
+    (is (= {:jdbc-url   base-url
+            :pool-props {;; tunable knobs at their defaults
+                         "maxPoolSize"                          5
+                         "minPoolSize"                          0
+                         "initialPoolSize"                      0
+                         "checkoutTimeout"                      10000
+                         "unreturnedConnectionTimeout"          0
+                         "debugUnreturnedConnectionStackTraces" false
+                         "testConnectionOnCheckout"             false
+                         ;; fixed props operators can't override
+                         "idleConnectionTestPeriod"             60
+                         "maxIdleTimeExcessConnections"         600
+                         "maxConnectionAge"                     1800
+                         "acquireIncrement"                     1
+                         "dataSourceName"                       "metabase-semantic-search-db"}}
+           (parse-db-url base-url)))))
 
 (deftest parse-db-url-pool-knob-test
   (testing "a recognized pool knob is pulled off the URL, parsed, and merged over the defaults"
@@ -121,8 +122,8 @@
                       semantic.db.datasource/data-source (atom nil)]
           (try
             (semantic.db.datasource/init-db!)
-            (let [cpds (.getConnectionPoolDataSource
-                        ^PoolBackedDataSource @semantic.db.datasource/data-source)]
+            (let [pool-ds ^PoolBackedDataSource @semantic.db.datasource/data-source
+                  cpds    (.getConnectionPoolDataSource pool-ds)]
               (is (=? {;; tunable knobs supplied on the URL
                        :maxPoolSize                          9
                        :minPoolSize                          2
@@ -131,11 +132,13 @@
                        :unreturnedConnectionTimeout          77
                        :debugUnreturnedConnectionStackTraces true
                        :testConnectionOnCheckout             true
-                       ;; fixed props we always set
+                       ;; fixed props we always set, on the connection-pool DS
                        :idleConnectionTestPeriod             60
                        :maxIdleTimeExcessConnections         600
                        :maxConnectionAge                     1800
                        :acquireIncrement                     1}
-                      (bean cpds))))
+                      (bean cpds)))
+              ;; dataSourceName is the one fixed prop that lives on the outer pooled DS, not the cpds
+              (is (= "metabase-semantic-search-db" (.getDataSourceName pool-ds))))
             (finally
               (semantic.db.datasource/shutdown-db!))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -109,19 +109,20 @@
     ;; the pool to prove each name took effect. The values below all differ from c3p0's own defaults, so a
     ;; dropped property would surface as a mismatch.
     (when semantic.db.datasource/db-url
-      (let [overrides (str "minPoolSize=2&initialPoolSize=2&maxPoolSize=9&checkoutTimeout=4321"
-                           "&unreturnedConnectionTimeout=77&debugUnreturnedConnectionStackTraces=true"
-                           "&testConnectionOnCheckout=true")
-            url       (str semantic.db.datasource/db-url
-                           (if (re-find #"\?" semantic.db.datasource/db-url) "&" "?")
-                           overrides)]
+      (let [url (str semantic.db.datasource/db-url
+                     "&minPoolSize=2"
+                     "&initialPoolSize=2"
+                     "&maxPoolSize=9"
+                     "&checkoutTimeout=4321"
+                     "&unreturnedConnectionTimeout=77"
+                     "&debugUnreturnedConnectionStackTraces=true"
+                     "&testConnectionOnCheckout=true")]
         (with-redefs [semantic.db.datasource/db-url      url
                       semantic.db.datasource/data-source (atom nil)]
           (try
             (semantic.db.datasource/init-db!)
-            (let [cpds  (.getConnectionPoolDataSource
-                         ^PoolBackedDataSource @semantic.db.datasource/data-source)
-                  props (bean cpds)]
+            (let [cpds (.getConnectionPoolDataSource
+                        ^PoolBackedDataSource @semantic.db.datasource/data-source)]
               (is (=? {;; tunable knobs supplied on the URL
                        :maxPoolSize                          9
                        :minPoolSize                          2
@@ -135,10 +136,6 @@
                        :maxIdleTimeExcessConnections         600
                        :maxConnectionAge                     1800
                        :acquireIncrement                     1}
-                      (select-keys props [:maxPoolSize :minPoolSize :initialPoolSize :checkoutTimeout
-                                          :unreturnedConnectionTimeout :debugUnreturnedConnectionStackTraces
-                                          :testConnectionOnCheckout :idleConnectionTestPeriod
-                                          :maxIdleTimeExcessConnections :maxConnectionAge
-                                          :acquireIncrement]))))
+                      (bean cpds))))
             (finally
               (semantic.db.datasource/shutdown-db!))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -56,9 +56,20 @@
 (deftest parse-db-url-defaults-test
   (testing "a URL with no params leaves the URL untouched and uses the default pool props"
     (is (=? {:jdbc-url   base-url
-             :pool-props {"maxPoolSize"              5
-                          "minPoolSize"              0
-                          "testConnectionOnCheckout" false}}
+             :pool-props {;; tunable knobs at their defaults
+                          "maxPoolSize"                          5
+                          "minPoolSize"                          0
+                          "initialPoolSize"                      0
+                          "checkoutTimeout"                      10000
+                          "unreturnedConnectionTimeout"          0
+                          "debugUnreturnedConnectionStackTraces" false
+                          "testConnectionOnCheckout"             false
+                          ;; fixed props operators can't override
+                          "idleConnectionTestPeriod"             60
+                          "maxIdleTimeExcessConnections"         600
+                          "maxConnectionAge"                     1800
+                          "acquireIncrement"                     1
+                          "dataSourceName"                       "metabase-semantic-search-db"}}
             (parse-db-url base-url)))))
 
 (deftest parse-db-url-pool-knob-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -55,30 +55,29 @@
 
 (deftest parse-db-url-defaults-test
   (testing "a URL with no params leaves the URL untouched and uses the default pool props"
-    (let [{:keys [jdbc-url pool-props]} (parse-db-url base-url)]
-      (is (= base-url jdbc-url))
-      (is (= 5 (get pool-props "maxPoolSize")))
-      (is (= 0 (get pool-props "minPoolSize")))
-      (is (false? (get pool-props "testConnectionOnCheckout"))))))
+    (is (=? {:jdbc-url   base-url
+             :pool-props {"maxPoolSize"              5
+                          "minPoolSize"              0
+                          "testConnectionOnCheckout" false}}
+            (parse-db-url base-url)))))
 
 (deftest parse-db-url-pool-knob-test
   (testing "a recognized pool knob is pulled off the URL, parsed, and merged over the defaults"
-    (let [{:keys [jdbc-url pool-props]} (parse-db-url (str base-url "?maxPoolSize=12"))]
-      (is (= base-url jdbc-url))
-      (is (= 12 (get pool-props "maxPoolSize")))))
+    (is (=? {:jdbc-url   base-url
+             :pool-props {"maxPoolSize" 12}}
+            (parse-db-url (str base-url "?maxPoolSize=12")))))
   (testing "a boolean knob coerces case-insensitively"
-    (is (true? (get (:pool-props (parse-db-url (str base-url "?testConnectionOnCheckout=TRUE")))
-                    "testConnectionOnCheckout")))))
+    (is (=? {:pool-props {"testConnectionOnCheckout" true}}
+            (parse-db-url (str base-url "?testConnectionOnCheckout=TRUE"))))))
 
 (deftest parse-db-url-connection-param-test
   (testing "a recognized Postgres connection param stays on the URL for pgjdbc"
-    (is (= (str base-url "?tcpKeepAlive=true")
-           (:jdbc-url (parse-db-url (str base-url "?tcpKeepAlive=true"))))))
+    (is (=? {:jdbc-url (str base-url "?tcpKeepAlive=true")}
+            (parse-db-url (str base-url "?tcpKeepAlive=true")))))
   (testing "pool knobs are stripped while connection params + credentials are retained, in order"
-    (let [{:keys [jdbc-url pool-props]}
-          (parse-db-url (str base-url "?user=postgres&maxPoolSize=8&tcpKeepAlive=true"))]
-      (is (= 8 (get pool-props "maxPoolSize")))
-      (is (= (str base-url "?user=postgres&tcpKeepAlive=true") jdbc-url)))))
+    (is (=? {:jdbc-url   (str base-url "?user=postgres&tcpKeepAlive=true")
+             :pool-props {"maxPoolSize" 8}}
+            (parse-db-url (str base-url "?user=postgres&maxPoolSize=8&tcpKeepAlive=true"))))))
 
 (deftest parse-db-url-validation-test
   (testing "an unrecognized param throws rather than being silently ignored by pgjdbc"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/db_test.clj
@@ -48,3 +48,46 @@
              (semantic.db.datasource/test-connection!)))
         (finally
           (reset! semantic.db.datasource/data-source orig-data-source))))))
+
+(def ^:private parse-db-url #'semantic.db.datasource/parse-db-url)
+
+(def ^:private base-url "jdbc:postgresql://localhost:5432/mb_semantic_search")
+
+(deftest parse-db-url-defaults-test
+  (testing "a URL with no params leaves the URL untouched and uses the default pool props"
+    (let [{:keys [jdbc-url pool-props]} (parse-db-url base-url)]
+      (is (= base-url jdbc-url))
+      (is (= 5 (get pool-props "maxPoolSize")))
+      (is (= 0 (get pool-props "minPoolSize")))
+      (is (false? (get pool-props "testConnectionOnCheckout"))))))
+
+(deftest parse-db-url-pool-knob-test
+  (testing "a recognized pool knob is pulled off the URL, parsed, and merged over the defaults"
+    (let [{:keys [jdbc-url pool-props]} (parse-db-url (str base-url "?maxPoolSize=12"))]
+      (is (= base-url jdbc-url))
+      (is (= 12 (get pool-props "maxPoolSize")))))
+  (testing "a boolean knob coerces case-insensitively"
+    (is (true? (get (:pool-props (parse-db-url (str base-url "?testConnectionOnCheckout=TRUE")))
+                    "testConnectionOnCheckout")))))
+
+(deftest parse-db-url-connection-param-test
+  (testing "a recognized Postgres connection param stays on the URL for pgjdbc"
+    (is (= (str base-url "?tcpKeepAlive=true")
+           (:jdbc-url (parse-db-url (str base-url "?tcpKeepAlive=true"))))))
+  (testing "pool knobs are stripped while connection params + credentials are retained, in order"
+    (let [{:keys [jdbc-url pool-props]}
+          (parse-db-url (str base-url "?user=postgres&maxPoolSize=8&tcpKeepAlive=true"))]
+      (is (= 8 (get pool-props "maxPoolSize")))
+      (is (= (str base-url "?user=postgres&tcpKeepAlive=true") jdbc-url)))))
+
+(deftest parse-db-url-validation-test
+  (testing "an unrecognized param throws rather than being silently ignored by pgjdbc"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unknown pgvector URL parameter maxPoolSizee"
+         (parse-db-url (str base-url "?maxPoolSizee=5")))))
+  (testing "a malformed pool-knob value throws"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid value for pgvector pool parameter maxPoolSize"
+         (parse-db-url (str base-url "?maxPoolSize=lots"))))))


### PR DESCRIPTION
## Description

Closes BOT-1713

Makes the semantic-search (pgvector) c3p0 connection pool configurable so operators can cap resource usage when many Metabase instances share one pgvector RDS instance.

> **Update (design pivot):** after team-cloud discussion, config moved from **separate env vars per knob** to **query params on the single `MB_PGVECTOR_DB_URL`** — so a deployment sets everything in one place (the DB secret) with no env-var-vs-URL precedence to reason about. Superseded parts below are ~~struck through~~.

### Pool knobs

~~Each knob is a separate env var:~~

~~| Env var | Default | Purpose |~~
~~|---|---|---|~~
~~| `MB_PGVECTOR_DB_MAX_CONNECTION_POOL_SIZE` | 5 | Ceiling on connections per instance |~~
~~| `MB_PGVECTOR_DB_MIN_POOL_SIZE` | 0 | Warm-vs-zero idle connections |~~
~~| `MB_PGVECTOR_DB_CHECKOUT_TIMEOUT_MS` | 10000 | Fail fast on pool exhaustion instead of blocking forever |~~
~~| `MB_PGVECTOR_DB_UNRETURNED_CONNECTION_TIMEOUT_SECONDS` | 0 (off) | Leak detector — destroy checkouts that exceed this age |~~
~~| `MB_PGVECTOR_DB_DEBUG_UNRETURNED_CONNECTION_STACK_TRACES` | false | Log the culprit when the above fires |~~
~~| `MB_PGVECTOR_DB_TEST_CONNECTION_ON_CHECKOUT` | false | Validate connections before use |~~

Knobs are now query params on `MB_PGVECTOR_DB_URL` (names match c3p0's own). Connection params (`tcpKeepAlive`, `sslmode`, …) pass straight through to pgjdbc as before.

| Param | Default | Purpose |
|---|---|---|
| `maxPoolSize` | 5 | Ceiling on connections per instance |
| `minPoolSize` | 0 | Warm-vs-zero idle connections |
| `initialPoolSize` | 0 | Connections opened at pool construction |
| `checkoutTimeout` | 10000 | Fail fast (ms) on pool exhaustion instead of blocking forever |
| `unreturnedConnectionTimeout` | 0 (off) | Leak detector — destroy checkouts older than this (seconds) |
| `debugUnreturnedConnectionStackTraces` | false | Log the culprit when the above fires |
| `testConnectionOnCheckout` | false | Validate connections before use |

Example: `jdbc:postgresql://host:5432/db?user=mb&password=...&maxPoolSize=8&tcpKeepAlive=true`

### Validation

pgjdbc **silently ignores** URL params it doesn't recognize, so a typo like `maxPoolSizee=5` would otherwise become a silently-dropped setting. `parse-db-url` validates every param against an allowlist — the tunable pool knobs above, plus `org.postgresql.PGProperty/values` (the driver's own recognized connection properties, read at runtime so it tracks the driver version) — and **throws at startup** on anything else.

### Other decisions

- **`minPoolSize` 0** — idle instances hold zero server-side connections, which is what makes a shared RDS viable at fleet scale. `query-index` warms the pool on a `future` concurrently with the embedding round-trip, so cold-start latency isn't paid serially.
- **`acquireIncrement` 1** (fixed, not exposed) — c3p0's default of 3 triples the cold-start burst on the shared RDS.
- **Shutdown teardown** — `shutdown-db!` plus a one-time JVM shutdown hook releases connections on graceful pod shutdown.
- Defaults are conservative starting points reasoned from the shared-RDS math and the app-db pool's structure (see the review thread), not load-tested numbers — the knobs exist so deployments can tune from real pool-stats.

## How to verify

```
MB_PGVECTOR_DB_URL=... ./bin/test-agent :only '[metabase-enterprise.semantic-search.db-test metabase-enterprise.semantic-search.without-init-test metabase-enterprise.semantic-search.index-test]'
```

`db-test` covers `parse-db-url` (knob stripping, connection-param passthrough, typo rejection, malformed-value rejection) plus a live pool init against the dev pgvector container. Pool properties are logged at init.

## Checklist
- [x] Tests pass locally
- [x] clj-kondo clean

## Considered and rejected

- ~~**Auto-appending `connectTimeout`/`tcpKeepAlive` to the JDBC URL** — URL munging is fragile.~~ **Adopted, inverted:** we now parse pool params *out* of the URL. Verified that pgjdbc tolerates this — it ignores unknown params rather than rejecting them — and the allowlist validation covers the resulting silent-no-op risk.
- ~~**Conditional `minPoolSize` default** (1 when enabled)~~ — moot under the URL approach; the setting defaults to `true`, so an enabled fleet would pin ~1k idle connections. Hot instances set `minPoolSize=1` on the URL instead.
- **`DISCARD ALL` check-in hook** (app-db's `MetabaseConnectionCustomizer`) — not needed: the query path issues no session-level `SET`s, and the gate uses `SET LOCAL`. Future per-query GUCs must keep to `SET LOCAL`.
- **Per-query `statement_timeout`, pool-stats metrics, server-side pooler (RDS Proxy / PgBouncer)** — out of scope; the first two are natural follow-ups, a transaction-mode pooler is the structural fix.
