### PR TITLE
Abort initial sync status when metadata fetch fails

### DIFF
--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -64,8 +64,12 @@
   "Shared core of [[sync-db-metadata!]] and [[sync-db-metadata-explicit!]]: the metadata sync work,
   without the surrounding `*-sync-operation` wrapper (which is what applies the eligibility gating)."
   [database :- i/DatabaseInstance]
-  (let [db-metadata (tracing/with-span :sync "sync.metadata.fetch-metadata" {:db/id (:id database)}
-                      (fetch-metadata/db-metadata database))]
+  (let [db-metadata (try
+                      (tracing/with-span :sync "sync.metadata.fetch-metadata" {:db/id (:id database)}
+                        (fetch-metadata/db-metadata database))
+                      (catch Throwable e
+                        (sync-util/set-initial-database-sync-aborted! database)
+                        (throw e)))]
     (u/prog1 (sync-util/run-sync-operation "sync" database (make-sync-steps db-metadata))
       (if (some sync-util/abandon-sync? (map second (:steps <>)))
         (sync-util/set-initial-database-sync-aborted! database)

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -1,12 +1,16 @@
 (ns metabase.sync.sync-metadata-test
   (:require
    [clojure.test :refer :all]
+   [metabase.sync.fetch-metadata :as fetch-metadata]
+   [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.fks :as sync-fks]
    [metabase.sync.sync-metadata.metabase-metadata :as metabase-metadata]
    [metabase.sync.sync-metadata.sync-timezone :as sync-tz]
    [metabase.sync.sync-metadata.tables :as sync-tables]
-   [metabase.test.sync :refer [sync-survives-crash?!]]))
+   [metabase.test :as mt]
+   [metabase.test.sync :refer [sync-survives-crash?!]]
+   [toucan2.core :as t2]))
 
 (deftest survive-metadata-errors
   (testing "Make sure we survive metadata sync failing"
@@ -29,3 +33,13 @@
 (deftest survive-fk-errors
   (testing "Make sure we survive FK sync failing"
     (sync-survives-crash?! sync-fks/mark-fk!)))
+
+(deftest metadata-fetch-failure-aborts-initial-sync-test
+  (testing "When fetching DB metadata throws (e.g. Athena lacking glue:GetDatabases, GHY-3534),"
+    (testing "the initial sync status is marked aborted instead of left stuck at \"incomplete\""
+      (mt/with-temp [:model/Database db {:initial_sync_status "incomplete"}]
+        (with-redefs [fetch-metadata/db-metadata (fn [_] (throw (ex-info "boom" {})))]
+          (is (thrown? Throwable
+                       (#'sync-metadata/sync-db-metadata!* db))))
+        (is (= "aborted"
+               (t2/select-one-fn :initial_sync_status :model/Database (:id db))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74092
## Summary

When a database's metadata fetch throws during sync — e.g. Athena credentials lacking the `glue:GetDatabases` IAM permission — the exception was raised before `initial_sync_status` was ever updated. The status stayed `"incomplete"` forever, so the UI kept showing **"Syncing tables…"** indefinitely (the sync wasn't actually looping; the status flag was stuck).

`sync-db-metadata!*` now wraps the metadata fetch so a throw marks the initial sync **aborted** before re-throwing. The status flips to `"aborted"`, and the existing frontend error state takes over (**"Error syncing" / "Sync failed"** with a warning icon, spinner stops). `set-initial-database-sync-aborted!` is already guarded not to downgrade a database that previously reached `"complete"`, so transient errors on healthy databases are unaffected.

This is general to any driver, not just Athena.

## Note

This delivers the ticket's "fail the sync at some point" option and unsticks the UI. The message is generic — it does **not** surface the specific cause (the `glue:GetDatabases` denial stays in the server logs). Surfacing the underlying cause in the UI is tracked separately in GHY-3856.

## Testing

- New regression test `metadata-fetch-failure-aborts-initial-sync-test`: redefs `fetch-metadata/db-metadata` to throw and asserts `initial_sync_status` becomes `"aborted"`.
- Existing `metabase.sync.sync-metadata-test` suite passes; kondo clean.

Fixes GHY-3534.