### PR TITLE
Fix a flake in `agent-lib.representations.repair-test`

### DIFF
--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -2498,8 +2498,8 @@
 ;;; Top-level entry point
 ;;; ============================================================
 
-(defn- normalize-shape*
-  "Pure-shape passes that don't require a metadata provider."
+(defn- normalize-shape-step*
+  "One application of the pure-shape passes that don't require a metadata provider."
   [parsed]
   (-> parsed
       ;; Run before Pass 1 (`ensure-clause-options*`): a values-list like
@@ -2520,6 +2520,21 @@
       normalise-fields-shape*
       normalize-expressions-shape*
       ensure-lib-types*))
+
+(defn- normalize-shape*
+  "Run the pure-shape passes to a fixpoint. This is what upholds [[repair]]'s idempotency
+  guarantee."
+  [parsed]
+  ;; One application is not enough: a later pass can expose fresh work for an earlier one.
+  ;; E.g. [[unwrap-boolean-wrappers*]] collapses ["true" {} x] to a bare x, and the enclosing
+  ;; vector then looks like an options-less clause to [[ensure-clause-options*]], which has
+  ;; already run. The iteration cap guards against a future non-converging pass; fuzzing
+  ;; converges within 2 extra iterations today.
+  (loop [parsed parsed, i 0]
+    (let [stepped (normalize-shape-step* parsed)]
+      (if (or (= parsed stepped) (>= i 10))
+        stepped
+        (recur stepped (inc i))))))
 
 (defn- stamp-top-level-database*
   "Idempotent wrapper around [[infer-top-level-database*]] that takes `[query mp]` in the

--- a/test/metabase/agent_lib/representations/repair_test.clj
+++ b/test/metabase/agent_lib/representations/repair_test.clj
@@ -1293,6 +1293,13 @@
     (= (repair/repair trivial-mp tree)
        (repair/repair trivial-mp (repair/repair trivial-mp tree)))))
 
+(deftest ^:parallel boolean-unwrap-exposed-clause-idempotent-test
+  ;; Shrunk counterexample from [[idempotency-property-test]].
+  (testing "repair is idempotent when a boolean unwrap exposes a clause-shaped vector"
+    (let [parsed [[{"" [["true" {} " "]]}]]
+          once   (repair/repair trivial-mp parsed)]
+      (is (= once (repair/repair trivial-mp once))))))
+
 ;;; ----------------------------------------------------------------
 ;;; Realistic-shape fuzz: generate query-shaped maps (top-level `stages` vector with
 ;;; aggregation / breakout / filter / order-by / joins / multi-stage) so we stress the


### PR DESCRIPTION
### Description

Fixes the flaky `metabase.agent-lib.representations.repair-test/idempotency-property-test` ([trunk report](https://app.trunk.io/metabase/flaky-tests/test/38d32ecd-0492-5b2c-9064-6fa36bb80742?repo=metabase%2Fmetabase)).

Ran into this a couple of times. Total Vibes here, but the test seemed straightforward and the fix harmless.
Follow-on to https://github.com/metabase/metabase/pull/75304.

`repair`'s docstring guarantees idempotency, but `normalize-shape*` ran the pure-shape
passes exactly once, in a fixed order. A later pass could expose fresh work for an earlier
one: `unwrap-boolean-wrappers*` collapses `["true" {} x]` to a bare `x`, and the enclosing
vector then looks like an options-less clause to `ensure-clause-options*`, which has
already run. The leftover work only gets done on the *next* `repair` call, so
`(repair (repair x)) ≠ (repair x)`.

Shrunk counterexample: `[[{"" [["true" {} " "]]}]]`
- 1st repair: `[["true" {} " "]]` → `[" "]`
- 2nd repair: `[" "]` → `[" " {}]`

The flake mechanism: `repair` is fully deterministic; the `defspec` reseeds from the wall
clock each run, and the triggering shape is rare (~2×10⁻⁵ per generated tree at size 30),
so most 200-trial runs sample zero triggering inputs and pass.

### Fix

Split the pass sequence into `normalize-shape-step*` and iterate it to a fixpoint in
`normalize-shape*` (cap 10; returns the last step if the cap is hit, so a future
non-converging pass degrades to best-effort rather than looping or dropping the query).
Also pins the shrunk counterexample as a deterministic regression test. 

Cost: inputs needing any shape repair pay one extra confirming application of the
(pure, metadata-provider-free) pass chain.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
