### PR TITLE
Dont override lib temporal types if driver type is text

### DIFF
--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -295,3 +295,23 @@
                     (lib/query mp)
                     (qp/process-query)
                     (mt/rows))))))))
+
+;; From #75204 which has a similar fix for a related issue
+(deftest ^:parallel date-bucketed-breakout-preserves-temporal-type-test
+  (testing (str "SQLite has no date type: a :month-bucketed breakout compiles to date()/strftime() whose JDBC "
+                "type is reported as TEXT. The returned column must still be typed temporally, not :type/Text, so "
+                "that date drills, date filters, and date dimension mapping are offered (GHY-3790).")
+    (mt/test-driver :sqlite
+      (let [mp       (mt/metadata-provider)
+            date-col (lib.metadata/field mp (mt/id :checkins :date))
+            query    (-> (lib/query mp (lib.metadata/table mp (mt/id :checkins)))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-temporal-bucket date-col :month)))
+            col      (-> (qp/process-query query) mt/cols first)]
+        (testing "driver reports a non-temporal JDBC storage type for the truncation output"
+          (is (= "TEXT" (:database_type col))))
+        (testing "but the column carries a temporal unit"
+          (is (= :month (:unit col))))
+        (testing "so its base/effective type stays temporal (Lib's type wins over the storage affinity)"
+          (is (isa? (:base_type col) :type/Temporal))
+          (is (isa? (:effective_type col) :type/Temporal)))))))

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -79,13 +79,13 @@
         ;; When the driver type is text but the lib type is temporal, this is usually because the driver doesn't
         ;; support temporal types natively (e.g. sqlite (#75604)). So we'll prefer the lib types in this case,
         ;; and when the driver type is missing or `:type/*`.
-        unreliable-driver-type? (or (#{nil :type/*} driver-base-type)
-                                    (and (isa? driver-base-type :type/Text)
-                                         (isa? lib-col-type :type/Temporal)))]
+        prefer-lib-type? (or (#{nil :type/*} driver-base-type)
+                             (and (isa? driver-base-type :type/Text)
+                                  (isa? lib-col-type :type/Temporal)))]
     (merge lib-col
            (m/filter-vals some? driver-col)
            ;; Prefer our inferred base type if the driver type is unreliable and ours is more specific
-           (when unreliable-driver-type?
+           (when prefer-lib-type?
              (when-let [lib-base-type (:base-type lib-col)]
                {:base-type lib-base-type}))
            ;; Prefer our `:name` if it's something different that what's returned by the driver (e.g. for named
@@ -93,7 +93,7 @@
            (u/select-non-nil-keys lib-col [:name :lib/source])
            ;; whatever type comes back from the query is by definition the effective type, but fall back to the
            ;; type calculated by Lib if the driver type is unreliable
-           {:effective-type (or (when-not unreliable-driver-type?
+           {:effective-type (or (when-not prefer-lib-type?
                                   driver-base-type)
                                 (:effective-type lib-col)
                                 (:base-type lib-col)

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -30,12 +30,15 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
+   [metabase.types.core]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.match :as match]
    [metabase.util.performance :refer [mapv select-keys some update-keys every? empty? not-empty get-in #?(:clj for)]]))
+
+(comment metabase.types.core/keep-me)
 
 (mr/def ::col
   ;; TODO (Cam 6/19/25) -- I think we should actually namespace all the keys added here (to make it clear where they
@@ -70,21 +73,28 @@
   from the driver to values calculated by Lib."
   [driver-col :- [:maybe ::col]
    lib-col    :- [:maybe ::col]]
-  (let [driver-col (update-keys driver-col u/->kebab-case-en)]
+  (let [driver-col (update-keys driver-col u/->kebab-case-en)
+        driver-base-type (:base-type driver-col)
+        lib-col-type ((some-fn :effective-type :base-type) lib-col)
+        ;; When the driver type is text but the lib type is temporal, this is usually because the driver doesn't
+        ;; support temporal types natively (e.g. sqlite (#75604)). So we'll prefer the lib types in this case,
+        ;; and when the driver type is missing or `:type/*`.
+        unreliable-driver-type? (or (#{nil :type/*} driver-base-type)
+                                    (and (isa? driver-base-type :type/Text)
+                                         (isa? lib-col-type :type/Temporal)))]
     (merge lib-col
            (m/filter-vals some? driver-col)
-           ;; Prefer our inferred base type if the driver returned `:type/*` and ours is more specific
-           (when (#{nil :type/*} (:base-type driver-col))
+           ;; Prefer our inferred base type if the driver type is unreliable and ours is more specific
+           (when unreliable-driver-type?
              (when-let [lib-base-type (:base-type lib-col)]
                {:base-type lib-base-type}))
            ;; Prefer our `:name` if it's something different that what's returned by the driver (e.g. for named
            ;; aggregations). Same for `:lib/source`
            (u/select-non-nil-keys lib-col [:name :lib/source])
-           ;; whatever type comes back from the query is by definition the effective type, otherwise fall back to the
-           ;; type calculated by Lib
-           {:effective-type (or (when-let [driver-base-type (:base-type driver-col)]
-                                  (when-not (= driver-base-type :type/*)
-                                    driver-base-type))
+           ;; whatever type comes back from the query is by definition the effective type, but fall back to the
+           ;; type calculated by Lib if the driver type is unreliable
+           {:effective-type (or (when-not unreliable-driver-type?
+                                  driver-base-type)
                                 (:effective-type lib-col)
                                 (:base-type lib-col)
                                 :type/*)})))

--- a/test/metabase/query_processor/alternative_date_test.clj
+++ b/test/metabase/query_processor/alternative_date_test.clj
@@ -654,27 +654,16 @@
                                     :result-metadata source-metadata}]}
             card-mp (lib.tu/mock-metadata-provider mp card-metadata)
             card-query     (lib/query card-mp (lib.metadata/card card-mp 1))
-            temporal-types (fn [cols]
-                             (into {}
-                                   (for [col   cols
-                                         :let  [col-name (u/lower-case-en (:name col))]
-                                         :when (#{"timestamp" "day"} col-name)]
-                                     [col-name {:effective-type (:effective_type col)
-                                                :base-type      (:base_type col)
-                                                :temporal?      (isa? (:effective_type col) :type/Temporal)}])))]
+            temporal-col-names (fn [cols]
+                                 (into #{}
+                                       (for [col   cols
+                                             :let  [col-name (u/lower-case-en (:name col))]
+                                             :when (and (#{"timestamp" "day"} col-name)
+                                                        (isa? (:effective_type col) :type/Temporal))]
+                                         col-name)))]
         (testing "the result metadata on the source query should keep the temporal types"
-          (is (= {"timestamp" {:effective-type :type/Instant
-                               :base-type :type/BigInteger
-                               :temporal? true},
-                  "day"       {:effective-type :type/Date
-                               :base-type :type/Date
-                               :temporal? true}}
-                 (temporal-types source-metadata))))
+          (is (= #{"timestamp" "day"}
+                 (temporal-col-names source-metadata))))
         (testing "a query using the source query as its source should return temporal columns"
-          (is (= {"timestamp" {:effective-type :type/Instant
-                               :base-type :type/BigInteger
-                               :temporal? true},
-                  "day"       {:effective-type :type/Date
-                               :base-type :type/Date
-                               :temporal? true}}
-                 (temporal-types (mt/cols (qp/process-query card-query))))))))))
+          (is (= #{"timestamp" "day"}
+                 (temporal-col-names (mt/cols (qp/process-query card-query))))))))))

--- a/test/metabase/query_processor/alternative_date_test.clj
+++ b/test/metabase/query_processor/alternative_date_test.clj
@@ -9,6 +9,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -639,3 +640,41 @@
                                :Coercion/ISO8601Bytes->Temporal]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not support"
                             (sql.qp/cast-temporal-byte driver/*driver* coercion-strategy nil))))))
+
+(deftest ^:parallel unix-timestamp-columns-stay-temporal-in-saved-question-metadata-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions/date :nested-queries)
+    (mt/dataset sad-toucan-incidents
+      (let [mp (mt/metadata-provider)
+            timestamp (lib.metadata/field mp (mt/id :incidents :timestamp))
+            source-query (-> (lib/query mp (lib.metadata/table mp (mt/id :incidents)))
+                             (lib/expression "day" (lib/date timestamp)))
+            source-metadata (-> (qp/process-query source-query) :data :results_metadata :columns)
+            card-metadata {:cards [{:id 1
+                                    :dataset-query source-query
+                                    :result-metadata source-metadata}]}
+            card-mp (lib.tu/mock-metadata-provider mp card-metadata)
+            card-query     (lib/query card-mp (lib.metadata/card card-mp 1))
+            temporal-types (fn [cols]
+                             (into {}
+                                   (for [col   cols
+                                         :let  [col-name (u/lower-case-en (:name col))]
+                                         :when (#{"timestamp" "day"} col-name)]
+                                     [col-name {:effective-type (:effective_type col)
+                                                :base-type      (:base_type col)
+                                                :temporal?      (isa? (:effective_type col) :type/Temporal)}])))]
+        (testing "the result metadata on the source query should keep the temporal types"
+          (is (= {"timestamp" {:effective-type :type/Instant
+                               :base-type :type/BigInteger
+                               :temporal? true},
+                  "day"       {:effective-type :type/Date
+                               :base-type :type/Date
+                               :temporal? true}}
+                 (temporal-types source-metadata))))
+        (testing "a query using the source query as its source should return temporal columns"
+          (is (= {"timestamp" {:effective-type :type/Instant
+                               :base-type :type/BigInteger
+                               :temporal? true},
+                  "day"       {:effective-type :type/Date
+                               :base-type :type/Date
+                               :temporal? true}}
+                 (temporal-types (mt/cols (qp/process-query card-query))))))))))

--- a/test/metabase/query_processor/cast_test.clj
+++ b/test/metabase/query_processor/cast_test.clj
@@ -524,10 +524,6 @@
   [_]
   :type/DateTime)
 
-(defmethod date-type-expected :sqlite
-  [_]
-  :type/Text)
-
 (defmethod date-type-expected :mongo
   [_]
   :type/*)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75604

### Description

When calculating the result_metadata by merging the driver and lib reported columns, we generally prefer the driver types over the lib types. For drivers like sqlite that don't support native temporal types, this meant we would set columns that the lib knew was temporal (e.g. a coerced column, or a `date()` expression) to be text type. This impacts things like the filter and breakout options, and the formatting of the results. The fix in this PR is to check if we have a driver reported text type and lib reported temporal type, then prefer the lib type. 

### How to verify

See repro steps in original issue. The coerced column and custom date expression should retain their temporal type when used as a source card. 

### Demo

<details>

<summary>demo</summary>

https://github.com/user-attachments/assets/e42279a4-187b-4f51-bf3b-8fb00d055289

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
