### PR TITLE
Omit case-sensitive option when DB doesn't support it

### DIFF
--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -3,6 +3,8 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
+import { useSelector } from "metabase/redux";
+import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Checkbox, Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -33,6 +35,11 @@ export function StringFilterPicker({
     () => Lib.displayInfo(query, stageIndex, column),
     [query, stageIndex, column],
   );
+
+  const metadata = useSelector(getMetadata);
+  const database = metadata.database(Lib.databaseID(query));
+  const supportsCaseSensitivity =
+    database?.hasFeature("case-sensitivity-string-filter-options") ?? true;
 
   const {
     type,
@@ -109,7 +116,7 @@ export function StringFilterPicker({
           withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         >
-          {type === "partial" && (
+          {type === "partial" && supportsCaseSensitivity && (
             <CaseSensitiveOption
               value={options.caseSensitive ?? false}
               onChange={(newValue) => setOptions({ caseSensitive: newValue })}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -4,6 +4,7 @@ import {
   setupFieldSearchValuesEndpoint,
   setupFieldsValuesEndpoints,
 } from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
 import {
   renderWithProviders,
   screen,
@@ -11,12 +12,20 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { getMetadata } from "metabase/selectors/metadata";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  createMetadataProvider,
+} from "metabase-lib/test-helpers";
+import { COMMON_DATABASE_FEATURES } from "metabase-types/api/mocks";
 import {
   PEOPLE,
   PRODUCT_CATEGORY_VALUES,
   PRODUCT_VENDOR_VALUES,
+  createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
 import {
@@ -39,11 +48,30 @@ const EXPECTED_OPERATORS = [
   "Not empty",
 ];
 
+const databaseWithoutCaseSensitivity = createSampleDatabase({
+  features: COMMON_DATABASE_FEATURES.filter(
+    (feature) => feature !== "case-sensitivity-string-filter-options",
+  ),
+});
+
+const storeStateWithoutCaseSensitivity = createMockState({
+  entities: createMockEntitiesState({
+    databases: [databaseWithoutCaseSensitivity],
+  }),
+});
+
+function createQueryWithoutCaseSensitivity() {
+  const metadata = getMetadata(storeStateWithoutCaseSensitivity);
+  const provider = createMetadataProvider({ metadata });
+  return Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
+}
+
 type SetupOpts = {
   query?: Lib.Query;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   withAddButton?: boolean;
+  state?: ReturnType<typeof createMockState>;
 };
 
 function setup({
@@ -51,6 +79,7 @@ function setup({
   column = findStringColumn(query),
   filter,
   withAddButton = false,
+  state = storeInitialState,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -70,7 +99,7 @@ function setup({
       onChange={onChange}
       onBack={onBack}
     />,
-    { storeInitialState },
+    { storeInitialState: state },
   );
 
   const getNextFilterParts = () => {
@@ -225,6 +254,25 @@ describe("StringFilterPicker", () => {
         options: { caseSensitive: true },
       });
       expect(getNextFilterColumnName()).toBe("Product → Description");
+    });
+
+    it("should show the case sensitive option for partial operators", async () => {
+      setup();
+
+      await setOperator("Contains");
+      expect(screen.getByLabelText("Case sensitive")).toBeInTheDocument();
+    });
+
+    it("should hide the case sensitive option when the database does not support it", async () => {
+      const query = createQueryWithoutCaseSensitivity();
+      setup({
+        query,
+        column: findStringColumn(query, "PRODUCTS", "VENDOR"),
+        state: storeStateWithoutCaseSensitivity,
+      });
+
+      await setOperator("Contains");
+      expect(screen.queryByLabelText("Case sensitive")).not.toBeInTheDocument();
     });
 
     it("should add a filter with multiple values", async () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -13,13 +13,9 @@ import {
   within,
 } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
-import { getMetadata } from "metabase/selectors/metadata";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
-import {
-  DEFAULT_TEST_QUERY,
-  createMetadataProvider,
-} from "metabase-lib/test-helpers";
+import type { Database } from "metabase-types/api";
 import { COMMON_DATABASE_FEATURES } from "metabase-types/api/mocks";
 import {
   PEOPLE,
@@ -32,7 +28,6 @@ import {
   createQuery,
   createQueryWithStringFilter,
   findStringColumn,
-  storeInitialState,
 } from "../test-utils";
 
 import { StringFilterPicker } from "./StringFilterPicker";
@@ -48,43 +43,29 @@ const EXPECTED_OPERATORS = [
   "Not empty",
 ];
 
-const databaseWithoutCaseSensitivity = createSampleDatabase({
-  features: COMMON_DATABASE_FEATURES.filter(
-    (feature) => feature !== "case-sensitivity-string-filter-options",
-  ),
-});
-
-const storeStateWithoutCaseSensitivity = createMockState({
-  entities: createMockEntitiesState({
-    databases: [databaseWithoutCaseSensitivity],
-  }),
-});
-
-function createQueryWithoutCaseSensitivity() {
-  const metadata = getMetadata(storeStateWithoutCaseSensitivity);
-  const provider = createMetadataProvider({ metadata });
-  return Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);
-}
-
 type SetupOpts = {
+  database?: Database;
   query?: Lib.Query;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   withAddButton?: boolean;
-  state?: ReturnType<typeof createMockState>;
 };
 
 function setup({
+  database = createSampleDatabase(),
   query = createQuery(),
   column = findStringColumn(query),
   filter,
   withAddButton = false,
-  state = storeInitialState,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
 
   setupFieldsValuesEndpoints([PRODUCT_CATEGORY_VALUES, PRODUCT_VENDOR_VALUES]);
+
+  const state = createMockState({
+    entities: createMockEntitiesState({ databases: [database] }),
+  });
 
   renderWithProviders(
     <StringFilterPicker
@@ -264,11 +245,12 @@ describe("StringFilterPicker", () => {
     });
 
     it("should hide the case sensitive option when the database does not support it", async () => {
-      const query = createQueryWithoutCaseSensitivity();
       setup({
-        query,
-        column: findStringColumn(query, "PRODUCTS", "VENDOR"),
-        state: storeStateWithoutCaseSensitivity,
+        database: createSampleDatabase({
+          features: COMMON_DATABASE_FEATURES.filter(
+            (feature) => feature !== "case-sensitivity-string-filter-options",
+          ),
+        }),
       });
 
       await setOperator("Contains");


### PR DESCRIPTION
Closes [GHY-3844: Disable case-sensitive filter option for SQLite DBs](https://linear.app/metabase/issue/GHY-3844/disable-case-sensitive-filter-option-for-sqlite-dbs)

### Description

SQLite doesn't support case-sensitive filters. We should hide that UI option when targeting a SQLite DB.

<img width="1060" height="932" alt="image" src="https://github.com/user-attachments/assets/4227a737-deb9-48d8-85b4-e6953ab0b90c" />