### PR TITLE
Fix extra divider in metric menu for non-admin users 

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsMenuItem.tsx
@@ -10,6 +10,7 @@ export const InsightsMenuItem = ({
   card,
   label,
   iconName = "external",
+  withDivider = false,
 }: InsightsMenuItemProps) => {
   const { data: auditInfo, error, isLoading } = useGetAuditInfoQuery();
 
@@ -25,13 +26,16 @@ export const InsightsMenuItem = ({
   const url = `${Urls.dashboard({ id: auditInfo.question_overview, name: "" })}?${params}`;
 
   return (
-    <Menu.Item
-      component={ForwardRefLink}
-      to={url}
-      target="_blank"
-      leftSection={<Icon name={iconName} />}
-    >
-      {label ?? t`Insights`}
-    </Menu.Item>
+    <>
+      {withDivider && <Menu.Divider role="separator" />}
+      <Menu.Item
+        component={ForwardRefLink}
+        to={url}
+        target="_blank"
+        leftSection={<Icon name={iconName} />}
+      >
+        {label ?? t`Insights`}
+      </Menu.Item>
+    </>
   );
 };

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -192,22 +192,22 @@ function MetricToolbarButtons({
           </>
         )}
 
-        {(PLUGIN_AUDIT.isEnabled || showDataStudioLink) && (
-          <Menu.Divider role="separator" />
-        )}
-
         {showDataStudioLink && (
-          <Menu.Item
-            leftSection={<Icon name="grid_bordered" />}
-            onClick={() => dispatch(openUrl(Urls.dataStudioMetric(card.id)))}
-          >
-            {t`Open in Data Studio`}
-          </Menu.Item>
+          <>
+            <Menu.Divider role="separator" />
+            <Menu.Item
+              leftSection={<Icon name="grid_bordered" />}
+              onClick={() => dispatch(openUrl(Urls.dataStudioMetric(card.id)))}
+            >
+              {t`Open in Data Studio`}
+            </Menu.Item>
+          </>
         )}
         <PLUGIN_AUDIT.InsightsMenuItem
           card={card}
           label={t`Metric usage analytics`}
           iconName="pie_slice"
+          withDivider={!showDataStudioLink}
         />
 
         {card.can_write && (

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   setupEnterpriseOnlyPlugin,
   setupEnterprisePlugins,
 } from "__support__/enterprise";
+import { setupAuditInfoEndpoint } from "__support__/server-mocks/audit";
 import { setupBookmarksEndpoints } from "__support__/server-mocks/bookmark";
 import { setupListNotificationEndpoints } from "__support__/server-mocks/notification";
 import { setupPerformanceEndpoints } from "__support__/server-mocks/performance";
@@ -47,6 +48,8 @@ interface SetupOpts {
   showDataStudioLink?: boolean;
   collectionType?: CollectionType | null;
   withModal?: boolean;
+  auditAppEnabled?: boolean;
+  hasUsageAnalyticsAccess?: boolean;
 }
 
 function setup({
@@ -56,6 +59,8 @@ function setup({
   showDataStudioLink = false,
   collectionType = null,
   withModal = false,
+  auditAppEnabled = false,
+  hasUsageAnalyticsAccess = false,
 }: SetupOpts = {}) {
   setupEnterpriseOnlyPlugin("library");
 
@@ -77,6 +82,7 @@ function setup({
     "token-features": createMockTokenFeatures({
       library: true,
       cache_granular_controls: true,
+      audit_app: auditAppEnabled,
     }),
   });
 
@@ -85,8 +91,13 @@ function setup({
     currentUser: user,
   });
 
+  if (auditAppEnabled) {
+    setupEnterprisePlugins();
+  }
+
   setupBookmarksEndpoints([]);
   setupListNotificationEndpoints({ card_id: card.id }, []);
+  setupAuditInfoEndpoint(hasUsageAnalyticsAccess ? {} : { auditInfo: {} });
   if (withModal) {
     setupPerformanceEndpoints([]);
   }
@@ -261,6 +272,43 @@ describe("MetricToolbar", () => {
       setup({ canWrite: true });
 
       expect(screen.queryByTestId("explore-link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("usage analytics", () => {
+    it("should show 'Metric usage analytics' with a divider for users with usage analytics access", async () => {
+      setup({ auditAppEnabled: true, hasUsageAnalyticsAccess: true });
+      await openMenu();
+
+      expect(
+        await screen.findByText("Metric usage analytics"),
+      ).toBeInTheDocument();
+      // Bookmark/Move/Duplicate ─ Add-to-dash/Alert ─ Caching ─ Insights ─ Trash
+      expect(getDividers()).toHaveLength(4);
+      expectNoConsecutiveOrTrailingDividers();
+    });
+
+    it("should not render an extra divider for users without usage analytics access", async () => {
+      setup({ auditAppEnabled: true, hasUsageAnalyticsAccess: false });
+      await openMenu();
+
+      expect(
+        screen.queryByText("Metric usage analytics"),
+      ).not.toBeInTheDocument();
+      expect(getDividers()).toHaveLength(3);
+      expectNoConsecutiveOrTrailingDividers();
+    });
+
+    it("should not render a trailing divider for read-only users without usage analytics access", async () => {
+      setup({
+        auditAppEnabled: true,
+        hasUsageAnalyticsAccess: false,
+        canWrite: false,
+      });
+      await openMenu();
+
+      expect(getDividers()).toHaveLength(1);
+      expectNoConsecutiveOrTrailingDividers();
     });
   });
 });

--- a/frontend/src/metabase/plugins/oss/audit.ts
+++ b/frontend/src/metabase/plugins/oss/audit.ts
@@ -38,6 +38,7 @@ export interface InsightsMenuItemProps {
   card: Pick<Card, "id" | "collection">;
   label?: string;
   iconName?: IconName;
+  withDivider?: boolean;
 }
 
 const getDefaultPluginAudit = () => ({

--- a/frontend/test/__support__/server-mocks/audit.ts
+++ b/frontend/test/__support__/server-mocks/audit.ts
@@ -22,7 +22,7 @@ export const defaultAuditInfo: AuditInfo = {
 export const setupAuditInfoEndpoint = ({
   auditInfo = defaultAuditInfo,
 }: {
-  auditInfo?: AuditInfo;
+  auditInfo?: Partial<AuditInfo>;
 } = {}) => {
   fetchMock.get("path:/api/ee/audit-app/user/audit-info", auditInfo);
 };


### PR DESCRIPTION
### Description

Fixes [UXW-4450](https://linear.app/metabase/issue/UXW-4450/extra-divider-appears-in-metric-menu-for-non-admins).

**Cause:** The divider before the "Metric usage analytics" section was gated on `PLUGIN_AUDIT.isEnabled`, which is true whenever the `audit_app` feature exists at the instance level. The menu item itself hides when the current user lacks usage analytics read access, leaving an orphan divider (and a second consecutive divider before "Move to trash" for non-admins with write access).

**Fix:** Divider ownership moves into each item's own conditional, consistent with how Caching and Move to trash already work in this menu. The insights item now renders its divider only when it actually renders itself.

### How to verify

- [ ] As a non-admin user on an EE instance, open the `...` menu on any metric and confirm no extra divider appears above "Move to trash".

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)