### PR TITLE
Allow e2e stress-test workflow to build the jar when needed

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -36,6 +36,11 @@ on:
         type: boolean
         required: false
         default: false
+      build_jar:
+        description: "Build the uberjar from this branch (required to test frontend fixes) instead of downloading a prebuilt one"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   determine-test-type:
@@ -73,6 +78,7 @@ jobs:
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `enable_network_throttling`: "${{ inputs.enable_network_throttling }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `fail_fast`: "${{ inputs.fail_fast }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- `build_jar`: "${{ inputs.build_jar }}"' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
@@ -109,15 +115,23 @@ jobs:
           mysql: ${{ inputs.qa_db }}
           mongo: ${{ inputs.qa_db }}
 
-      - name: Download Metabase ${{ matrix.edition }} uberjar
+      - name: Download Metabase ${{ inputs.mb_edition }} uberjar
+        if: ${{ !inputs.build_jar }}
         uses: ./.github/actions/e2e-download-uberjar
         with:
-          edition: "ee"
+          edition: ${{ inputs.mb_edition }}
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
+
+      - name: Build Metabase ${{ inputs.mb_edition }} uberjar from this branch
+        if: ${{ inputs.build_jar }}
+        run: ./bin/build.sh
+        env:
+          # license check is irrelevant for ephemeral e2e jars and slows the build down
+          SKIP_LICENSES: true
 
       - name: Build Embedding SDK package
         if: ${{ needs.determine-test-type.outputs.type == 'component' }}


### PR DESCRIPTION
Resolves DEV-2152

## Summary 

This is an escape hatch that allows one to still use the stress-test workflow when the source code changes.