### PR TITLE
Fix VisualizationResult violations

### DIFF
--- a/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
+++ b/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.tsx
@@ -241,6 +241,26 @@ export function ExplicitSize<T>({
           }
         }
       };
+
+      _setElementRef = (el: HTMLDivElement | null) => {
+        const { forwardedRef } = this.props;
+        if (forwardedRef) {
+          if (typeof forwardedRef === "function") {
+            forwardedRef(el);
+          } else {
+            forwardedRef.current = el;
+          }
+        }
+
+        // Measure when the element first appears: it can attach after mount
+        // (e.g. async content swapping out a placeholder)
+        const elementAttached = el != null && this.elementRef.current == null;
+        this.elementRef.current = el;
+        if (elementAttached) {
+          this.timeoutId = setTimeout(this._updateSize, 0);
+        }
+      };
+
       render() {
         const { forwardedRef, ...props } = this.props;
         if (wrapped) {
@@ -263,17 +283,7 @@ export function ExplicitSize<T>({
         } else {
           return (
             <ComposedComponent
-              ref={(el: HTMLDivElement) => {
-                if (forwardedRef) {
-                  if (typeof forwardedRef === "function") {
-                    forwardedRef(el);
-                  } else {
-                    forwardedRef.current = el;
-                  }
-                }
-
-                this.elementRef.current = el;
-              }}
+              ref={this._setElementRef}
               {...(props as unknown as T)}
               {...this.state}
             />

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -30,6 +30,7 @@ import {
   updateQuestion as updateQuestionAction,
 } from "metabase/query_builder/actions";
 import { ViewSidebar } from "metabase/query_builder/components/view/ViewSidebar";
+import { useVisualizationResultQBProps } from "metabase/query_builder/hooks";
 import {
   getDatasetEditorTab,
   getIsListViewConfigurationShown,
@@ -311,6 +312,7 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
   } = props;
 
   const dispatch = useDispatch();
+  const visualizationResultProps = useVisualizationResultQBProps();
   const { isNative, isEditable } = Lib.queryDisplayInfo(question.query());
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure();
 
@@ -744,6 +746,7 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
               ) : (
                 <QueryVisualization
                   {...props}
+                  {...visualizationResultProps}
                   rawSeries={tempRawSeries}
                   className={CS.spread}
                   noHeader

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -4,6 +4,7 @@ import cx from "classnames";
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
 import CS from "metabase/css/core/index.css";
 import { ObjectDetailSidesheet } from "metabase/query_builder/components/ObjectDetailSidesheet";
+import { useVisualizationResultQBProps } from "metabase/query_builder/hooks";
 import { QueryVisualization } from "metabase/querying/components/QueryVisualization";
 import { SyncedParametersList } from "metabase/querying/components/SyncedParametersList";
 import type { QueryModalType } from "metabase/querying/constants";
@@ -98,6 +99,8 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
     updateQuestion,
   } = props;
 
+  const visualizationResultProps = useVisualizationResultQBProps();
+
   const { ref: mainRef, height: mainHeight } = useElementSize();
   const { ref: footerRef, height: footerHeight } = useElementSize();
 
@@ -140,6 +143,7 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
       >
         <QueryVisualization
           {...props}
+          {...visualizationResultProps}
           noHeader
           className={CS.spread}
           mode={queryMode}

--- a/frontend/src/metabase/query_builder/hooks/index.ts
+++ b/frontend/src/metabase/query_builder/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./use-breakout-query-handlers";
 export * from "./use-default-query-aggregation";
+export * from "./use-visualization-result-qb-props";
 export * from "./types";

--- a/frontend/src/metabase/query_builder/hooks/use-visualization-result-qb-props.ts
+++ b/frontend/src/metabase/query_builder/hooks/use-visualization-result-qb-props.ts
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+
+import { resetRowZoom, zoomInRow } from "metabase/query_builder/actions";
+import {
+  getIsShowingRawTable,
+  getRowIndexToPKMap,
+  getUiControls,
+  getZoomedObjectId,
+} from "metabase/query_builder/selectors";
+import { useDispatch, useSelector } from "metabase/redux";
+
+/**
+ * Supplies the query-builder-specific props consumed by the shared
+ * VisualizationResult component. These derive from query_builder redux state
+ * and actions, which the shared `querying` module is not allowed to depend on,
+ * so query_builder call sites inject them via props.
+ */
+export const useVisualizationResultQBProps = () => {
+  const dispatch = useDispatch();
+  const isRawTable = useSelector(getIsShowingRawTable);
+  const scrollToLastColumn = useSelector(
+    (state) => getUiControls(state)?.scrollToLastColumn ?? false,
+  );
+  const rowIndexToPkMap = useSelector(getRowIndexToPKMap);
+  const zoomedObjectId = useSelector(getZoomedObjectId);
+
+  const onZoomRow = useCallback(
+    (rowIndex: number) => {
+      const objectId = rowIndexToPkMap?.[rowIndex] ?? rowIndex;
+      if (objectId === zoomedObjectId) {
+        dispatch(resetRowZoom());
+      } else {
+        dispatch(zoomInRow({ objectId }));
+      }
+    },
+    [dispatch, rowIndexToPkMap, zoomedObjectId],
+  );
+
+  const getExtraDataForClick = useCallback(() => ({ zoomInRow }), []);
+
+  return { isRawTable, scrollToLastColumn, onZoomRow, getExtraDataForClick };
+};

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.jsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { Component, useCallback } from "react";
+import { Component } from "react";
 import { jt, t } from "ttag";
 import _ from "underscore";
 
@@ -10,14 +10,6 @@ import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { CreateOrEditQuestionAlertModal } from "metabase/notifications/modals/CreateOrEditQuestionAlertModal";
 import { ALERT_TYPE_ROWS, getAlertType } from "metabase/notifications/utils";
-import { resetRowZoom, zoomInRow } from "metabase/query_builder/actions";
-import {
-  getIsShowingRawTable,
-  getRowIndexToPKMap,
-  getUiControls,
-  getZoomedObjectId,
-} from "metabase/query_builder/selectors";
-import { useDispatch, useSelector } from "metabase/redux";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import { datasetContainsNoResults } from "metabase-lib/v1/queries/utils/dataset";
@@ -37,36 +29,7 @@ const ALLOWED_VISUALIZATION_PROPS = [
   "hideLegend",
 ];
 
-export function VisualizationResult(props) {
-  const dispatch = useDispatch();
-  const isRawTable = useSelector(getIsShowingRawTable);
-  const scrollToLastColumn = useSelector(
-    (state) => getUiControls(state)?.scrollToLastColumn ?? false,
-  );
-  const rowIndexToPkMap = useSelector(getRowIndexToPKMap);
-  const zoomedObjectId = useSelector(getZoomedObjectId);
-  const onZoomRow = useCallback(
-    (rowIndex) => {
-      const objectId = rowIndexToPkMap?.[rowIndex] ?? rowIndex;
-      if (objectId === zoomedObjectId) {
-        dispatch(resetRowZoom());
-      } else {
-        dispatch(zoomInRow({ objectId }));
-      }
-    },
-    [dispatch, rowIndexToPkMap, zoomedObjectId],
-  );
-  return (
-    <VisualizationResultInner
-      {...props}
-      isRawTable={isRawTable}
-      scrollToLastColumn={scrollToLastColumn}
-      onZoomRow={onZoomRow}
-    />
-  );
-}
-
-class VisualizationResultInner extends Component {
+export class VisualizationResult extends Component {
   state = {
     showCreateAlertModal: false,
   };
@@ -98,6 +61,8 @@ class VisualizationResultInner extends Component {
       renderEmptyMessage,
       isRawTable,
       scrollToLastColumn,
+      onZoomRow,
+      getExtraDataForClick,
     } = this.props;
     const { showCreateAlertModal } = this.state;
 
@@ -184,8 +149,8 @@ class VisualizationResultInner extends Component {
             timelineEvents={timelineEvents}
             token={token}
             selectedTimelineEventIds={selectedTimelineEventIds}
-            getExtraDataForClick={() => ({ zoomInRow })}
-            onZoomRow={this.props.onZoomRow}
+            getExtraDataForClick={getExtraDataForClick}
+            onZoomRow={onZoomRow}
             handleVisualizationClick={this.props.handleVisualizationClick}
             onOpenTimelines={this.props.onOpenTimelines}
             onSelectTimelineEvents={this.props.selectTimelineEvents}


### PR DESCRIPTION
Injects QB props rather than importing from QB directly.

## ExplicitSize changes
We lifted the qb useSelectors out of the shared VisualizationResult into a hook used by query_builder, passing the values down as props. This removed incidental re-renders, but it exposed a bug in ExplicitSize where it was jut measuring the container on mount, but never re-measured. The custom-viz plugin loads async and swaps a placeholder for the real viz. The old re-renders were accidentally making it work.  

ExplicitSize now measures when the element attaches