### PR TITLE
Add regression test: native SQL card flagging itself as broken (GHY-3682)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -338,6 +338,36 @@
                        :bad_transforms []}
                       response)))))))))
 
+(deftest check-card-native-explicit-columns-not-broken-test
+  (testing "POST /api/ee/dependencies/check-card does not report a native card (or its consumer) as broken when an
+            edit switches SELECT * to an explicit, valid column list yielding the same columns (GHY-3682)"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/User user {:email "ghy3682@test.com"}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency :model/DependencyStatus]
+            (let [mp (mt/metadata-provider)
+                  ;; Native source card originally selecting all columns.
+                  source-card (card/create-card!
+                               (card-with-query "Products source"
+                                                (lib/native-query mp "SELECT * FROM products"))
+                               user)
+                  ;; A downstream question that consumes the source card.
+                  consumer-query (lib/native-query mp (str "select * from {{#" (:id source-card) "}} src"))
+                  consumer-card (card/create-card!
+                                 (card-with-query "Consumer" consumer-query)
+                                 user)
+                  ;; Propose editing the source to an explicit column list that yields the same columns.
+                  proposed-card {:id (:id source-card)
+                                 :type :question
+                                 :dataset_query (lib/native-query mp "SELECT id, category, price FROM products")
+                                 :result_metadata nil}
+                  _ (deps.test/synchronously-run-backfill!)
+                  response (mt/user-http-request :rasta :post 200 "ee/dependencies/check-card" proposed-card)]
+              (is (some? consumer-card))
+              (is (= {:success true :bad_cards [] :bad_transforms []}
+                     response)
+                  "Switching a native card to explicit valid columns must not report the card itself or its consumer as broken"))))))))
+
 (deftest check-transform-test
   (testing "POST /api/ee/dependencies/check-transform"
     (mt/with-premium-features #{:dependencies :transforms-basic}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67973
## Summary

Adds an endpoint-level regression test for [GHY-3682](https://linear.app/metabase/issue/GHY-3682): saving a native SQL question used to surface the *"These changes will break some other things. Save anyway?"* popup listing the **very question being edited** as broken.

### Root cause (already fixed)
`driver/validate-native-query-fields` produced false positives for explicit column selects — e.g. `NAME` from `SELECT id, name, price FROM products` was flagged as a bad reference. That made `errors-from-proposed-edits` mark the edited card as broken, and `broken-cards-response` doesn't filter the edited card out of `bad_cards`, so it appeared in the popup. The validation itself was fixed in `639c8deb` (SQLGlot-based field references). This PR adds a test pinning the **reported symptom** at the `/check-card` endpoint, which previously had no direct coverage.

## What the test does
`check-card-native-explicit-columns-not-broken-test`:
1. Creates a native SQL source card (`SELECT * FROM products`) plus a downstream card consuming it.
2. POSTs the edited source — switched to an explicit, valid column list yielding the same columns (`SELECT id, category, price FROM products`) — to `/api/ee/dependencies/check-card` with the card's own `:id`.
3. Asserts `{:success true, :bad_cards [], :bad_transforms []}` — the card you're saving must not flag itself or its consumer.

## Verification
- New test passes; full `dependencies.api-test` namespace green (99 tests, 396 assertions).
- Confirmed the test has teeth: the same endpoint path returns `:success false` and flags the card when the proposed query references a genuinely missing column, so native validation is actually exercised.
- Kondo: 0 errors, 0 warnings.