### PR TITLE
Weaken verified and official-collection search weights

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -63,13 +63,13 @@
               "custom expression examples"]
              (mapv :name (sort-by #(oss-score search-string %)
                                   (shuffle [a b c d])))))
-      ;; With :official-collection lifted to 80 in :default, the official bump dominates the
-      ;; text scorers — `d` now ranks highest, landing last under the ascending sort, despite
-      ;; having the weakest text match.
-      (is (= ["customer success stories"
+      ;; With :official-collection at 1 in :default, the official bump is only a tie-breaker —
+      ;; it can't overcome the text scorers, so `d` stays ranked by its (weakest) text match
+      ;; and the ordering matches OSS.
+      (is (= ["customer examples of bad sorting"
+              "customer success stories"
               "examples of custom expressions"
-              "custom expression examples"
-              "customer examples of bad sorting"]
+              "custom expression examples"]
              (mapv :name (sort-by #(ee-score search-string %)
                                   (shuffle [a b c (assoc d :collection_authority_level "official")]))))))))
 

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -89,12 +89,13 @@
    :text                5
    :mine                1
    ;; An exact (case-insensitive) name match is the strongest single intent signal: :exact (100) overpowers
-   ;; any one curation tier (:official-collection / :verified, and the :data-picker :library boost, 80 each).
+   ;; any one curation tier (the :data-picker boosts: :library 80, :official-collection / :verified 35 each).
    ;; Base text/recency scorers (0–5) only break ties within a tier.
    :exact               100
    :prefix              0
-   :official-collection 80
-   :verified            80
+   ;; Curation badges act as tie-breakers by default; the :data-picker context boosts them (to 35 each).
+   :official-collection 1
+   :verified            1
    ;; :library is a data-layer curation signal relevant only when picking a data source, so it is off by
    ;; default; the :data-picker context opts in, at a curation-tier level that an exact match can overpower.
    :library             0
@@ -122,9 +123,12 @@
     :model/metric   1
     :model/question 0}
    :data-picker
-   ;; Boost curated library items when picking a data source, but keep it a curation-tier signal (80, like
-   ;; :verified/:official) so an exact name match (:exact 100) can overpower it.
-   {:library 80}
+   ;; Boost curated items when picking a data source, but keep them curation-tier signals that an exact
+   ;; name match (:exact 100) can overpower. :library outweighs :official-collection and :verified even
+   ;; combined (70), so library membership trumps those badges here.
+   {:library             80
+    :official-collection 35
+    :verified            35}
    ;; TODO: lift :data-layer up to :default. It's a structural signal (every visible warehouse
    ;; table gets `data_layer "final"`), so the +33 boost flips orderings across every search
    ;; surface and breaks e2e specs that pin specific top results. To make progress:

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -84,4 +84,11 @@
     (is (= 80 (search.config/weight {:context :data-picker} :library))))
   (testing "in the data picker, an exact name match can overpower the library boost"
     (is (> (search.config/weight {:context :data-picker} :exact)
-           (search.config/weight {:context :data-picker} :library)))))
+           (search.config/weight {:context :data-picker} :library))))
+  (testing "curation badges are tie-breakers by default; the data picker boosts them, but the library boost
+            outweighs both badges combined"
+    (is (= 1 (search.config/weight {:context :global} :official-collection)))
+    (is (= 1 (search.config/weight {:context :global} :verified)))
+    (is (> (search.config/weight {:context :data-picker} :library)
+           (+ (search.config/weight {:context :data-picker} :official-collection)
+              (search.config/weight {:context :data-picker} :verified))))))


### PR DESCRIPTION
Refs [BOT-1678: Review and clean-up Search Weight overrides in Stats](https://linear.app/metabase/issue/BOT-1678/review-and-clean-up-search-weight-overrides-in-stats).

## Description

Drops the `:official-collection` and `:verified` scorer weights from 80 to 1 in the default search weights, so by default the curation badges act as tie-breakers instead of dominating the text/recency scorers. In Stats we have been running with these same overrides for some time, and are just making it official now.

The `:data-picker` context — the one context that boosts `:library` — now also boosts the badges, to 35 each. That keeps them meaningful curation signals there while preserving two invariants:

- `:library` (80) outweighs both badges even combined (70), so library membership trumps the badges when picking a data source.
- An exact name match (`:exact` 100) can still overpower any single curation signal.

## Test changes

- `weight-tuning-test` gains assertions encoding the invariants above.
- `official-collection-bumps-value-test` had pinned an ordering where the official bump (at 80) outweighed text matching; at weight 1 the EE ordering matches OSS, so the expected ordering is updated. The per-item "official scores strictly higher" assertions are unchanged.