### PR TITLE
Move `ActionApi` into RTK hooks and clean up callers

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -1,4 +1,5 @@
 import type { CardId } from "./card";
+import type { DashCardId, DashboardId } from "./dashboard";
 import type { DatabaseId } from "./database";
 import type { BaseEntityId } from "./entity-id";
 import type { Parameter, ParameterId, ParameterTarget } from "./parameters";
@@ -210,6 +211,31 @@ export interface WritebackActionListQuery {
 export interface GetActionRequest {
   id: number;
 }
+
+export interface ExecuteActionRequest {
+  id: WritebackActionId;
+  parameters: ParametersForActionExecution;
+}
+
+export interface PrefetchActionValuesRequest {
+  id: WritebackActionId;
+  parameters: ParametersForActionExecution;
+}
+
+export interface ExecuteDashcardActionRequest {
+  dashboardId: DashboardId;
+  dashcardId: DashCardId;
+  modelId?: CardId | null;
+  parameters: ParametersForActionExecution;
+}
+
+export interface PrefetchDashcardValuesRequest {
+  dashboardId: DashboardId;
+  dashcardId: DashCardId;
+  parameters: ParametersForActionExecution;
+}
+
+export type ActionExecutionResult = Record<string, unknown>;
 export type GetPublicAction = Pick<
   WritebackActionBase,
   "id" | "name" | "public_uuid" | "model_id"

--- a/frontend/src/metabase/actions/actions.ts
+++ b/frontend/src/metabase/actions/actions.ts
@@ -1,6 +1,6 @@
+import { actionApi } from "metabase/api";
 import type { Dispatch } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
-import { ActionsApi } from "metabase/services";
 import type {
   ActionFormSubmitResult,
   ParametersForActionExecution,
@@ -18,10 +18,12 @@ export const executeAction =
   ({ action, parameters }: ExecuteActionOpts) =>
   async (dispatch: Dispatch): Promise<ActionFormSubmitResult> => {
     try {
-      const result = await ActionsApi.execute({
-        id: action.id,
-        parameters,
-      });
+      const result = await dispatch(
+        actionApi.endpoints.executeAction.initiate({
+          id: action.id,
+          parameters,
+        }),
+      ).unwrap();
 
       const message = getActionExecutionMessage(action, result);
       dispatch(addUndo({ message, toastColor: "success" }));

--- a/frontend/src/metabase/actions/actions.ts
+++ b/frontend/src/metabase/actions/actions.ts
@@ -1,4 +1,5 @@
 import { actionApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import type { Dispatch } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
 import type {
@@ -18,12 +19,11 @@ export const executeAction =
   ({ action, parameters }: ExecuteActionOpts) =>
   async (dispatch: Dispatch): Promise<ActionFormSubmitResult> => {
     try {
-      const result = await dispatch(
-        actionApi.endpoints.executeAction.initiate({
-          id: action.id,
-          parameters,
-        }),
-      ).unwrap();
+      const result = await runRtkEndpoint(
+        { id: action.id, parameters },
+        dispatch,
+        actionApi.endpoints.executeAction,
+      );
 
       const message = getActionExecutionMessage(action, result);
       dispatch(addUndo({ message, toastColor: "success" }));

--- a/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.unit.spec.tsx
@@ -1,4 +1,5 @@
 import fetchMock from "fetch-mock";
+import { useCallback } from "react";
 
 import { setupActionsEndpoints } from "__support__/server-mocks";
 import {
@@ -7,7 +8,9 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
-import { ActionsApi } from "metabase/services";
+import { actionApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import { useDispatch } from "metabase/redux";
 import {
   createMockActionParameter,
   createMockImplicitQueryAction,
@@ -41,31 +44,40 @@ function setupPrefetch() {
   });
 }
 
-const fetchInitialValues = () =>
-  ActionsApi.prefetchValues({
-    id: implicitUpdateAction.id,
-    parameters: JSON.stringify({}),
-  });
+function TestActionExecuteModal(props?: Partial<ActionExecuteModalProps>) {
+  const dispatch = useDispatch();
+  const fetchInitialValues = useCallback(
+    () =>
+      runRtkEndpoint(
+        { id: implicitUpdateAction.id, parameters: {} },
+        dispatch,
+        actionApi.endpoints.prefetchActionValues,
+      ),
+    [dispatch],
+  );
+
+  return (
+    <ActionExecuteModal
+      opened
+      onClose={() => {}}
+      fetchInitialValues={fetchInitialValues}
+      {...props}
+      actionId={implicitUpdateAction.id}
+    />
+  );
+}
 
 function setup(props?: Partial<ActionExecuteModalProps>) {
   setupActionsEndpoints([implicitUpdateAction]);
   setupPrefetch();
 
-  renderWithProviders(
-    <ActionExecuteModal
-      opened
-      onClose={() => {}}
-      {...props}
-      actionId={implicitUpdateAction.id}
-    />,
-  );
+  renderWithProviders(<TestActionExecuteModal {...props} />);
 }
 
 describe("Actions > ActionExecuteModal", () => {
   it("should fetch and load existing values from API for implicit update actions", async () => {
     await setup({
       actionId: implicitUpdateAction.id,
-      fetchInitialValues,
       shouldPrefetch: true,
     });
 

--- a/frontend/src/metabase/api/action.ts
+++ b/frontend/src/metabase/api/action.ts
@@ -1,9 +1,15 @@
 import _ from "underscore";
 
 import type {
+  ActionExecutionResult,
   CreateActionRequest,
+  ExecuteActionRequest,
+  ExecuteDashcardActionRequest,
   GetActionRequest,
   ListActionsRequest,
+  ParametersForActionExecution,
+  PrefetchActionValuesRequest,
+  PrefetchDashcardValuesRequest,
   UpdateActionRequest,
   WritebackAction,
   WritebackActionId,
@@ -131,6 +137,46 @@ export const actionApi = Api.injectEndpoints({
           idTag("action", id),
         ]),
     }),
+    executeAction: builder.mutation<
+      ActionExecutionResult,
+      ExecuteActionRequest
+    >({
+      query: ({ id, parameters }) => ({
+        method: "POST",
+        url: `/api/action/${id}/execute`,
+        body: { parameters },
+      }),
+    }),
+    prefetchActionValues: builder.query<
+      ParametersForActionExecution,
+      PrefetchActionValuesRequest
+    >({
+      query: ({ id, parameters }) => ({
+        method: "GET",
+        url: `/api/action/${id}/execute`,
+        params: { parameters: JSON.stringify(parameters) },
+      }),
+    }),
+    executeDashcardAction: builder.mutation<
+      ActionExecutionResult,
+      ExecuteDashcardActionRequest
+    >({
+      query: ({ dashboardId, dashcardId, modelId, parameters }) => ({
+        method: "POST",
+        url: `/api/dashboard/${dashboardId}/dashcard/${dashcardId}/execute`,
+        body: { modelId, parameters },
+      }),
+    }),
+    prefetchDashcardValues: builder.query<
+      ParametersForActionExecution,
+      PrefetchDashcardValuesRequest
+    >({
+      query: ({ dashboardId, dashcardId, parameters }) => ({
+        method: "GET",
+        url: `/api/dashboard/${dashboardId}/dashcard/${dashcardId}/execute`,
+        params: { parameters: JSON.stringify(parameters) },
+      }),
+    }),
   }),
 });
 
@@ -143,9 +189,14 @@ export const {
   useDeleteActionMutation,
   useCreateActionPublicLinkMutation,
   useDeleteActionPublicLinkMutation,
+  useExecuteActionMutation,
   endpoints: {
     listPublicActions,
     deleteActionPublicLink,
     createActionPublicLink,
+    executeAction,
+    prefetchActionValues,
+    executeDashcardAction,
+    prefetchDashcardValues,
   },
 } = actionApi;

--- a/frontend/src/metabase/api/action.ts
+++ b/frontend/src/metabase/api/action.ts
@@ -156,6 +156,9 @@ export const actionApi = Api.injectEndpoints({
         url: `/api/action/${id}/execute`,
         params: { parameters: JSON.stringify(parameters) },
       }),
+      // Prefetch is an imperative fetch-and-discard with row-specific params
+      // that rarely repeat, so there's nothing to gain from caching entries.
+      keepUnusedDataFor: 0,
     }),
     executeDashcardAction: builder.mutation<
       ActionExecutionResult,
@@ -176,6 +179,9 @@ export const actionApi = Api.injectEndpoints({
         url: `/api/dashboard/${dashboardId}/dashcard/${dashcardId}/execute`,
         params: { parameters: JSON.stringify(parameters) },
       }),
+      // Prefetch is an imperative fetch-and-discard with per-dashcard params
+      // that rarely repeat, so there's nothing to gain from caching entries.
+      keepUnusedDataFor: 0,
     }),
   }),
 });

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -3,6 +3,7 @@ import {
   getActionExecutionMessage,
 } from "metabase/actions/utils";
 import { actionApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import type { Dispatch } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
@@ -44,11 +45,11 @@ export const executeRowAction = async ({
     const result =
       getDashboardType(dashboard.id) === "public"
         ? await PublicApi.executeDashcardAction(executeActionRequest)
-        : await dispatch(
-            actionApi.endpoints.executeDashcardAction.initiate(
-              executeActionRequest,
-            ),
-          ).unwrap();
+        : await runRtkEndpoint(
+            executeActionRequest,
+            dispatch,
+            actionApi.endpoints.executeDashcardAction,
+          );
 
     const message = getActionExecutionMessage(
       dashcard.action as WritebackAction,

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -2,10 +2,11 @@ import {
   getActionErrorMessage,
   getActionExecutionMessage,
 } from "metabase/actions/utils";
+import { actionApi } from "metabase/api";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import type { Dispatch } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
-import { ActionsApi, PublicApi } from "metabase/services";
+import { PublicApi } from "metabase/services";
 import { getDashboardType } from "metabase/utils/dashboard";
 import type {
   ActionDashboardCard,
@@ -32,18 +33,22 @@ export const executeRowAction = async ({
   dispatch,
   shouldToast = true,
 }: ExecuteRowActionPayload): Promise<ActionFormSubmitResult> => {
-  const executeAction =
-    getDashboardType(dashboard.id) === "public"
-      ? PublicApi.executeDashcardAction
-      : ActionsApi.executeDashcardAction;
+  const executeActionRequest = {
+    dashboardId: dashboard.id,
+    dashcardId: dashcard.id,
+    modelId: dashcard.card_id,
+    parameters,
+  };
 
   try {
-    const result = await executeAction({
-      dashboardId: dashboard.id,
-      dashcardId: dashcard.id,
-      modelId: dashcard.card_id,
-      parameters,
-    });
+    const result =
+      getDashboardType(dashboard.id) === "public"
+        ? await PublicApi.executeDashcardAction(executeActionRequest)
+        : await dispatch(
+            actionApi.endpoints.executeDashcardAction.initiate(
+              executeActionRequest,
+            ),
+          ).unwrap();
 
     const message = getActionExecutionMessage(
       dashcard.action as WritebackAction,

--- a/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.tsx
@@ -7,8 +7,11 @@ import ActionParametersInputForm, {
 } from "metabase/actions/containers/ActionParametersInputForm";
 import { useActionInitialValues } from "metabase/actions/hooks/use-action-initial-values";
 import { getFormTitle, isImplicitUpdateAction } from "metabase/actions/utils";
+import { actionApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { Modal } from "metabase/common/components/Modal";
-import { ActionsApi, PublicApi } from "metabase/services";
+import { useDispatch } from "metabase/redux";
+import { PublicApi } from "metabase/services";
 import { getDashboardType } from "metabase/utils/dashboard";
 import type {
   ActionDashboardCard,
@@ -57,6 +60,7 @@ function ActionVizForm({
 
   onActionEdit,
 }: ActionFormProps) {
+  const dispatch = useDispatch();
   const [showFormModal, setShowFormModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const title = getFormTitle(action);
@@ -86,23 +90,30 @@ function ActionVizForm({
   };
 
   const fetchInitialValues = useCallback(async () => {
-    const prefetchDashcardValues =
-      getDashboardType(dashboard.id) === "public"
-        ? PublicApi.prefetchDashcardValues
-        : ActionsApi.prefetchDashcardValues;
-
     const canPrefetch = Object.keys(dashcardParamValues).length > 0;
 
     if (!canPrefetch) {
       return {};
     }
 
-    return prefetchDashcardValues({
-      dashboardId: dashboard.id,
-      dashcardId: dashcard.id,
-      parameters: JSON.stringify(dashcardParamValues),
-    });
-  }, [dashboard.id, dashcard.id, dashcardParamValues]);
+    if (getDashboardType(dashboard.id) === "public") {
+      return PublicApi.prefetchDashcardValues({
+        dashboardId: dashboard.id,
+        dashcardId: dashcard.id,
+        parameters: JSON.stringify(dashcardParamValues),
+      });
+    }
+
+    return runRtkEndpoint(
+      {
+        dashboardId: dashboard.id,
+        dashcardId: dashcard.id,
+        parameters: dashcardParamValues,
+      },
+      dispatch,
+      actionApi.endpoints.prefetchDashcardValues,
+    );
+  }, [dashboard.id, dashcard.id, dashcardParamValues, dispatch]);
 
   const shouldPrefetch = isImplicitUpdateAction(action);
 

--- a/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { render, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockActionDashboardCard,
   createMockActionParameter,
@@ -84,7 +84,7 @@ const defaultProps: ActionFormProps = {
 function setup(options?: Partial<ActionFormProps>) {
   setupPrefetch();
 
-  render(<ActionVizForm {...defaultProps} {...options} />);
+  renderWithProviders(<ActionVizForm {...defaultProps} {...options} />);
 }
 
 describe("Actions > ActionVizForm", () => {

--- a/frontend/src/metabase/detail-view/components/DetailViewSidesheet/DetailViewSidesheet.tsx
+++ b/frontend/src/metabase/detail-view/components/DetailViewSidesheet/DetailViewSidesheet.tsx
@@ -5,11 +5,13 @@ import { t } from "ttag";
 
 import { ActionExecuteModal } from "metabase/actions/containers/ActionExecuteModal";
 import {
+  actionApi,
   skipToken,
   useGetAdhocQueryQuery,
   useListActionsQuery,
   useListDatabasesQuery,
 } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { EntityMenu } from "metabase/common/components/EntityMenu";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -24,7 +26,7 @@ import {
   getHeaderColumns,
   getRowName,
 } from "metabase/detail-view/utils";
-import { ActionsApi } from "metabase/services";
+import { useDispatch } from "metabase/redux";
 import {
   Box,
   Button,
@@ -86,6 +88,7 @@ export function DetailViewSidesheet({
   onNextClick,
   onPreviousClick,
 }: Props) {
+  const dispatch = useDispatch();
   const {
     data: dataset,
     error,
@@ -152,11 +155,15 @@ export function DetailViewSidesheet({
       return {};
     }
 
-    return ActionsApi.prefetchValues({
-      id: actionId,
-      parameters: JSON.stringify({ id: String(rowId) }),
-    });
-  }, [actionId, rowId]);
+    return runRtkEndpoint(
+      {
+        id: actionId,
+        parameters: { id: String(rowId) },
+      },
+      dispatch,
+      actionApi.endpoints.prefetchActionValues,
+    );
+  }, [actionId, rowId, dispatch]);
 
   const handleActionSuccess = useCallback(() => {
     onActionSuccess?.();

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -130,14 +130,3 @@ export const UserApi = {
 export const FrontendErrorsApi = {
   report: POST("/api/frontend-errors"),
 };
-
-export const ActionsApi = {
-  execute: POST("/api/action/:id/execute"),
-  prefetchValues: GET("/api/action/:id/execute"),
-  prefetchDashcardValues: GET(
-    "/api/dashboard/:dashboardId/dashcard/:dashcardId/execute",
-  ),
-  executeDashcardAction: POST(
-    "/api/dashboard/:dashboardId/dashcard/:dashcardId/execute",
-  ),
-};

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
@@ -2,9 +2,9 @@ import type { FunctionComponent } from "react";
 import { t } from "ttag";
 
 import { getActionErrorMessage } from "metabase/actions/utils";
+import { useExecuteActionMutation } from "metabase/api";
 import { ModalContent } from "metabase/common/components/ModalContent";
 import { useToast } from "metabase/common/hooks/use-toast";
-import { ActionsApi } from "metabase/services";
 import { Button } from "metabase/ui";
 import type { WritebackActionId } from "metabase-types/api";
 
@@ -24,15 +24,20 @@ export const DeleteObjectModal: FunctionComponent<Props> = ({
   onSuccess,
 }) => {
   const [sendToast] = useToast();
+  const [executeAction] = useExecuteActionMutation();
 
   const handleSubmit = async () => {
+    if (actionId == null) {
+      return;
+    }
+
     try {
-      await ActionsApi.execute({
+      await executeAction({
         id: actionId,
         parameters: {
           id: typeof objectId === "string" ? parseInt(objectId, 10) : objectId,
         },
-      });
+      }).unwrap();
 
       const message = t`Successfully deleted`;
       sendToast({ message, toastColor: "success" });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
@@ -35,7 +35,10 @@ export const DeleteObjectModal: FunctionComponent<Props> = ({
       await executeAction({
         id: actionId,
         parameters: {
-          id: typeof objectId === "string" ? parseInt(objectId, 10) : objectId,
+          id:
+            typeof objectId === "string"
+              ? parseInt(objectId, 10)
+              : (objectId ?? null),
         },
       }).unwrap();
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailPanel.tsx
@@ -4,13 +4,17 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { ActionExecuteModal } from "metabase/actions/containers/ActionExecuteModal";
-import { datasetApi, skipToken, useListActionsQuery } from "metabase/api";
+import {
+  actionApi,
+  datasetApi,
+  skipToken,
+  useListActionsQuery,
+} from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
 import { useDatabaseListQuery } from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
-import { ActionsApi } from "metabase/services";
 import { Modal } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
@@ -281,11 +285,15 @@ export function ObjectDetailPanel({
       return {};
     }
 
-    return ActionsApi.prefetchValues({
-      id: actionId,
-      parameters: JSON.stringify({ id: String(zoomedRowID) }),
-    });
-  }, [actionId, zoomedRowID]);
+    return runRtkEndpoint(
+      {
+        id: actionId,
+        parameters: { id: String(zoomedRowID) },
+      },
+      dispatch,
+      actionApi.endpoints.prefetchActionValues,
+    );
+  }, [actionId, zoomedRowID, dispatch]);
 
   const initialValues = useMemo(
     () => ({ id: zoomedRowID ?? null }),


### PR DESCRIPTION
Removes `ActionsApi` from `metabase/services`