### PR TITLE
AWS Bedrock support

### DIFF
--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -189,8 +189,16 @@ export type MetabotAgentResponse = {
 export type MetabotProvider =
   | "metabase"
   | "anthropic"
+  | "bedrock"
   | "openai"
   | "openrouter";
+
+export interface BedrockCredentials {
+  "access-key-id"?: string | null;
+  "secret-access-key"?: string | null;
+  region?: string | null;
+  "session-token"?: string | null;
+}
 
 export interface MetabotSettingsResponse {
   value: string | null;
@@ -206,6 +214,7 @@ export interface UpdateMetabotSettingsRequest {
   provider: MetabotProvider;
   model?: string;
   "api-key"?: string | null;
+  credentials?: BedrockCredentials | null;
 }
 
 /* Metabot - Suggested Prompts */

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -202,7 +202,7 @@ export interface BedrockCredentials {
 
 export interface MetabotSettingsResponse {
   value: string | null;
-  "api-key-error"?: string | null;
+  "credentials-error"?: string | null;
   models: {
     id: string;
     display_name: string;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -534,6 +534,10 @@ interface SettingsManagerSettings {
   "llm-anthropic-api-key"?: string | null;
   "llm-anthropic-api-base-url"?: string | null;
   "llm-openrouter-api-key"?: string | null;
+  "llm-bedrock-access-key-id"?: string | null;
+  "llm-bedrock-secret-access-key"?: string | null;
+  "llm-bedrock-region"?: string | null;
+  "llm-bedrock-session-token"?: string | null;
   "openai-api-key": string | null;
   "openai-available-models"?: OpenAiModel[];
   "openai-model": string | null;

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.tsx
@@ -28,8 +28,8 @@ export function AIProviderSettingsSection({ id }: { id?: string }) {
       ? { provider: connectedProvider }
       : skipToken,
   );
-  const hasApiKeyError =
-    !!connectedProviderSettingsQuery.currentData?.["api-key-error"];
+  const hasCredentialsError =
+    !!connectedProviderSettingsQuery.currentData?.["credentials-error"];
 
   return (
     <SettingsSection
@@ -41,14 +41,17 @@ export function AIProviderSettingsSection({ id }: { id?: string }) {
               <Badge
                 circle
                 size="12"
-                bg={hasApiKeyError ? "error" : "success"}
+                bg={hasCredentialsError ? "error" : "success"}
                 mr="sm"
               />
             )}
             <div>
-              {match({ connectedProvider, hasApiKeyError })
+              {match({ connectedProvider, hasCredentialsError })
                 .with(
-                  { connectedProvider: P.nonNullable, hasApiKeyError: true },
+                  {
+                    connectedProvider: P.nonNullable,
+                    hasCredentialsError: true,
+                  },
                   ({ connectedProvider }) =>
                     t`Error connecting to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`,
                 )

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -658,7 +658,7 @@ describe("AIProviderSettingsSection", () => {
       responses: {
         anthropic: {
           value: "anthropic/claude-haiku-4-5",
-          "api-key-error": "Anthropic API key expired or invalid",
+          "credentials-error": "Anthropic API key expired or invalid",
           models: [],
         },
       },
@@ -691,7 +691,7 @@ describe("AIProviderSettingsSection", () => {
       responses: {
         anthropic: {
           value: "anthropic/claude-haiku-4-5",
-          "api-key-error": "Anthropic API key expired or invalid",
+          "credentials-error": "Anthropic API key expired or invalid",
           models: [],
         },
       },
@@ -714,7 +714,7 @@ describe("AIProviderSettingsSection", () => {
       responses: {
         anthropic: {
           value: "anthropic/claude-haiku-4-5",
-          "api-key-error": "Anthropic API key expired or invalid",
+          "credentials-error": "Anthropic API key expired or invalid",
           models: [],
         },
       },
@@ -1534,7 +1534,7 @@ describe("AIProviderSettingsSection", () => {
       responses: {
         anthropic: {
           value: "anthropic/claude-haiku-4-5",
-          "api-key-error": "Anthropic API key expired or invalid",
+          "credentials-error": "Anthropic API key expired or invalid",
           models: [],
         },
       },

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -275,6 +275,7 @@ async function setup({
     }),
     "llm-bedrock-session-token": createMockSettingDefinition({
       key: "llm-bedrock-session-token",
+      value: mergedApiKeyValues.bedrock ? "**********EN" : undefined,
     }),
   };
 
@@ -376,18 +377,32 @@ async function setup({
         value ? `**********${String(value).slice(-2)}` : undefined;
 
       // `credentials: null` is an explicit clear — the backend wipes all the saved key material.
-      settingsDefinitions["llm-bedrock-access-key-id"] =
-        createMockSettingDefinition({
-          ...settingsDefinitions["llm-bedrock-access-key-id"],
-          key: "llm-bedrock-access-key-id",
-          value: mask(body.credentials?.["access-key-id"]),
+      // Fields inside the map follow the same presence contract: an absent field keeps the saved
+      // value, a null field clears it.
+      const requestCredentials = body.credentials ?? null;
+      const updateBedrockSetting = (
+        settingKey:
+          | "llm-bedrock-access-key-id"
+          | "llm-bedrock-secret-access-key"
+          | "llm-bedrock-session-token",
+        field: keyof BedrockCredentials,
+      ) => {
+        if (requestCredentials !== null && !(field in requestCredentials)) {
+          return;
+        }
+        settingsDefinitions[settingKey] = createMockSettingDefinition({
+          ...settingsDefinitions[settingKey],
+          key: settingKey,
+          value: mask(requestCredentials?.[field]),
         });
-      settingsDefinitions["llm-bedrock-secret-access-key"] =
-        createMockSettingDefinition({
-          ...settingsDefinitions["llm-bedrock-secret-access-key"],
-          key: "llm-bedrock-secret-access-key",
-          value: mask(body.credentials?.["secret-access-key"]),
-        });
+      };
+
+      updateBedrockSetting("llm-bedrock-access-key-id", "access-key-id");
+      updateBedrockSetting(
+        "llm-bedrock-secret-access-key",
+        "secret-access-key",
+      );
+      updateBedrockSetting("llm-bedrock-session-token", "session-token");
     }
 
     if ("model" in body) {
@@ -1806,6 +1821,7 @@ describe("AIProviderSettingsSection", () => {
         { method: "PUT" },
       );
 
+      // The untouched session token field is omitted entirely — only changed fields are sent.
       expect(request?.options?.body).toBe(
         JSON.stringify({
           provider: "bedrock",
@@ -1813,7 +1829,6 @@ describe("AIProviderSettingsSection", () => {
             "access-key-id": "AKIDEXAMPLE",
             "secret-access-key": "test-secret",
             region: "us-east-2",
-            "session-token": null,
           },
         }),
       );
@@ -1844,15 +1859,47 @@ describe("AIProviderSettingsSection", () => {
         { method: "PUT" },
       );
 
-      // The untouched access key and secret round-trip as obfuscated placeholders in the form, but
-      // must be sent as null so the backend leaves the real saved values (and session token) intact.
+      // The untouched access key, secret, and session token round-trip as obfuscated placeholders
+      // in the form, and must be omitted so the backend leaves the real saved values intact.
       expect(request?.options?.body).toBe(
         JSON.stringify({
           provider: "bedrock",
           credentials: {
-            "access-key-id": null,
-            "secret-access-key": null,
             region: "us-west-2",
+          },
+        }),
+      );
+    });
+
+    it("clears the session token by sending an explicit null without touching the other fields", async () => {
+      await setup({
+        savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
+        apiKeyValues: { bedrock: "**********LE" },
+      });
+
+      const sessionTokenInput = await screen.findByLabelText("Session token");
+      await userEvent.clear(sessionTokenInput);
+
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
+            method: "PUT",
+          }),
+        ).toBe(true);
+      });
+
+      const [request] = fetchMock.callHistory.calls(
+        "path:/api/metabot/settings",
+        { method: "PUT" },
+      );
+
+      // null means an explicit clear; the untouched fields are omitted so the saved keys survive.
+      expect(request?.options?.body).toBe(
+        JSON.stringify({
+          provider: "bedrock",
+          credentials: {
             "session-token": null,
           },
         }),

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -18,6 +18,7 @@ import {
 import { reinitialize } from "metabase/plugins";
 import { defer } from "metabase/utils/promise";
 import type {
+  BedrockCredentials,
   MetabotProvider,
   MetabotSettingsResponse,
   SettingDefinition,
@@ -66,6 +67,21 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
       },
     ],
   },
+  bedrock: {
+    value: "bedrock/anthropic.claude-haiku-4-5",
+    models: [
+      {
+        id: "anthropic.claude-haiku-4-5",
+        display_name: "anthropic.claude-haiku-4-5",
+        group: "Anthropic",
+      },
+      {
+        id: "openai.gpt-5.5",
+        display_name: "openai.gpt-5.5",
+        group: "OpenAI",
+      },
+    ],
+  },
   openai: {
     value: "openai/gpt-4.1-mini",
     models: [
@@ -100,13 +116,18 @@ type MetabotSettingKey =
   | "llm-metabot-provider"
   | "llm-anthropic-api-key"
   | "llm-openai-api-key"
-  | "llm-openrouter-api-key";
+  | "llm-openrouter-api-key"
+  | "llm-bedrock-access-key-id"
+  | "llm-bedrock-secret-access-key"
+  | "llm-bedrock-region"
+  | "llm-bedrock-session-token";
 
 type MetabotSettingDefinition = SettingDefinition<MetabotSettingKey>;
 type MetabotSettingsUpdateBody = {
   provider: MetabotProvider;
   model?: string;
   "api-key"?: string | null;
+  credentials?: BedrockCredentials | null;
 };
 
 type SetupOptions = {
@@ -180,6 +201,7 @@ async function setup({
 
   const mergedApiKeyValues: Record<MetabotApiKeyProvider, string | null> = {
     anthropic: "**********45",
+    bedrock: null,
     openai: null,
     openrouter: null,
     ...apiKeyValues,
@@ -232,6 +254,22 @@ async function setup({
     "llm-openrouter-api-key": createMockSettingDefinition({
       key: "llm-openrouter-api-key",
       value: mergedApiKeyValues.openrouter ?? undefined,
+    }),
+    "llm-bedrock-access-key-id": createMockSettingDefinition({
+      key: "llm-bedrock-access-key-id",
+      value: mergedApiKeyValues.bedrock ?? undefined,
+    }),
+    // The secret access key is configured whenever the access key ID is — they are saved together.
+    "llm-bedrock-secret-access-key": createMockSettingDefinition({
+      key: "llm-bedrock-secret-access-key",
+      value: mergedApiKeyValues.bedrock ? "**********ET" : undefined,
+    }),
+    "llm-bedrock-region": createMockSettingDefinition({
+      key: "llm-bedrock-region",
+      value: mergedApiKeyValues.bedrock ? "us-east-1" : undefined,
+    }),
+    "llm-bedrock-session-token": createMockSettingDefinition({
+      key: "llm-bedrock-session-token",
     }),
   };
 
@@ -322,6 +360,24 @@ async function setup({
         key: apiKeySettingKey,
         value: maskedApiKey,
       });
+    }
+
+    if (body.provider === "bedrock" && body.credentials) {
+      const mask = (value: string | null | undefined) =>
+        value ? `**********${String(value).slice(-2)}` : undefined;
+
+      settingsDefinitions["llm-bedrock-access-key-id"] =
+        createMockSettingDefinition({
+          ...settingsDefinitions["llm-bedrock-access-key-id"],
+          key: "llm-bedrock-access-key-id",
+          value: mask(body.credentials["access-key-id"]),
+        });
+      settingsDefinitions["llm-bedrock-secret-access-key"] =
+        createMockSettingDefinition({
+          ...settingsDefinitions["llm-bedrock-secret-access-key"],
+          key: "llm-bedrock-secret-access-key",
+          value: mask(body.credentials["secret-access-key"]),
+        });
     }
 
     if ("model" in body) {
@@ -1683,6 +1739,157 @@ describe("AIProviderSettingsSection", () => {
             (toast) => toast.message === "Unable to save provider settings.",
           ),
       ).toBe(true);
+    });
+  });
+
+  describe("Amazon Bedrock", () => {
+    it("shows Amazon Bedrock as selectable in the provider dropdown", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await userEvent.click(screen.getByLabelText("Provider"));
+
+      const bedrockOption = await screen.findByRole("option", {
+        name: "Amazon Bedrock",
+      });
+      expect(bedrockOption).toBeInTheDocument();
+      expect(bedrockOption).not.toHaveAttribute("data-combobox-disabled");
+    });
+
+    it("shows the AWS credential fields when Amazon Bedrock is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+
+      expect(await screen.findByLabelText("Access key ID")).toBeInTheDocument();
+      expect(screen.getByLabelText("Secret access key")).toBeInTheDocument();
+      expect(screen.getByLabelText("Region")).toBeInTheDocument();
+      expect(screen.getByLabelText("Session token")).toBeInTheDocument();
+      expect(screen.queryByLabelText("API key")).not.toBeInTheDocument();
+    });
+
+    it("connects Amazon Bedrock by sending the credentials object", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+
+      await userEvent.type(
+        await screen.findByLabelText("Access key ID"),
+        "AKIDEXAMPLE",
+      );
+      await userEvent.type(
+        screen.getByLabelText("Secret access key"),
+        "test-secret",
+      );
+      await userEvent.type(screen.getByLabelText("Region"), "us-east-2");
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
+            method: "PUT",
+          }),
+        ).toBe(true);
+      });
+
+      const [request] = fetchMock.callHistory.calls(
+        "path:/api/metabot/settings",
+        { method: "PUT" },
+      );
+
+      expect(request?.options?.body).toBe(
+        JSON.stringify({
+          provider: "bedrock",
+          credentials: {
+            "access-key-id": "AKIDEXAMPLE",
+            "secret-access-key": "test-secret",
+            region: "us-east-2",
+            "session-token": null,
+          },
+        }),
+      );
+    });
+
+    it("does not echo obfuscated credentials when editing only the region of a connected Bedrock provider", async () => {
+      await setup({
+        savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
+        apiKeyValues: { bedrock: "**********LE" },
+      });
+
+      const regionInput = await screen.findByLabelText("Region");
+      await userEvent.clear(regionInput);
+      await userEvent.type(regionInput, "us-west-2");
+
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
+            method: "PUT",
+          }),
+        ).toBe(true);
+      });
+
+      const [request] = fetchMock.callHistory.calls(
+        "path:/api/metabot/settings",
+        { method: "PUT" },
+      );
+
+      // The untouched access key and secret round-trip as obfuscated placeholders in the form, but
+      // must be sent as null so the backend leaves the real saved values (and session token) intact.
+      expect(request?.options?.body).toBe(
+        JSON.stringify({
+          provider: "bedrock",
+          credentials: {
+            "access-key-id": null,
+            "secret-access-key": null,
+            region: "us-west-2",
+            "session-token": null,
+          },
+        }),
+      );
+    });
+
+    it("shows the grouped model picker for a connected Bedrock provider", async () => {
+      await setup({
+        savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
+        apiKeyValues: { bedrock: "**********LE" },
+      });
+
+      await screen.findByLabelText("Access key ID");
+      await screen.findByLabelText("Model");
+
+      await openModelSelector();
+
+      expect(await screen.findByText("Anthropic")).toBeInTheDocument();
+      expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    });
+
+    it("disconnects Bedrock by clearing the provider and AWS credential settings", async () => {
+      await setup({
+        savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
+        apiKeyValues: { bedrock: "**********LE" },
+      });
+
+      await screen.findByLabelText("Access key ID");
+      await confirmDisconnectProvider();
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/setting", {
+            method: "PUT",
+            body: {
+              "llm-metabot-provider": null,
+              "llm-bedrock-access-key-id": null,
+              "llm-bedrock-secret-access-key": null,
+              "llm-bedrock-session-token": null,
+            },
+          }),
+        ).toBe(true);
+      });
+
+      expect(
+        await screen.findByText("Connect to an AI provider"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -201,7 +201,10 @@ async function setup({
   const purchaseCloudAddOnDeferred = defer<void>();
   const updateMetabotSettingsDeferred = defer<void>();
 
-  const mergedApiKeyValues: Record<MetabotApiKeyProvider, string | null> = {
+  const mergedApiKeyValues: Record<
+    MetabotApiKeyProvider | "bedrock",
+    string | null
+  > = {
     anthropic: "**********45",
     bedrock: null,
     openai: null,

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -155,6 +155,7 @@ type SetupOptions = {
   pauseUpdateResponse?: boolean;
   deferMetabotSettingsUpdateResponse?: boolean;
   settingUpdateResponse?: number | { status: number; body?: unknown };
+  metabotSettingsUpdateResponse?: number | { status: number; body?: unknown };
   responses?: Partial<Record<MetabotProvider, MetabotSettingsApiResponse>>;
   updateResponse?: MetabotSettingsResponse;
   renderAsModal?: boolean;
@@ -185,6 +186,7 @@ async function setup({
   pauseUpdateResponse = false,
   deferMetabotSettingsUpdateResponse = false,
   settingUpdateResponse = 204,
+  metabotSettingsUpdateResponse,
   responses,
   updateResponse = {
     value: "anthropic/claude-sonnet-4-5",
@@ -326,6 +328,10 @@ async function setup({
   }
 
   fetchMock.put("path:/api/metabot/settings", (call) => {
+    if (metabotSettingsUpdateResponse !== undefined) {
+      return metabotSettingsUpdateResponse;
+    }
+
     if (pauseUpdateResponse) {
       return new Promise(() => undefined);
     }
@@ -362,21 +368,22 @@ async function setup({
       });
     }
 
-    if (body.provider === "bedrock" && body.credentials) {
+    if (body.provider === "bedrock" && "credentials" in body) {
       const mask = (value: string | null | undefined) =>
         value ? `**********${String(value).slice(-2)}` : undefined;
 
+      // `credentials: null` is an explicit clear — the backend wipes all the saved key material.
       settingsDefinitions["llm-bedrock-access-key-id"] =
         createMockSettingDefinition({
           ...settingsDefinitions["llm-bedrock-access-key-id"],
           key: "llm-bedrock-access-key-id",
-          value: mask(body.credentials["access-key-id"]),
+          value: mask(body.credentials?.["access-key-id"]),
         });
       settingsDefinitions["llm-bedrock-secret-access-key"] =
         createMockSettingDefinition({
           ...settingsDefinitions["llm-bedrock-secret-access-key"],
           key: "llm-bedrock-secret-access-key",
-          value: mask(body.credentials["secret-access-key"]),
+          value: mask(body.credentials?.["secret-access-key"]),
         });
     }
 
@@ -1864,7 +1871,7 @@ describe("AIProviderSettingsSection", () => {
       expect(screen.getByText("OpenAI")).toBeInTheDocument();
     });
 
-    it("disconnects Bedrock by clearing the provider and AWS credential settings", async () => {
+    it("disconnects Bedrock by clearing the credentials before the provider setting", async () => {
       await setup({
         savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
         apiKeyValues: { bedrock: "**********LE" },
@@ -1875,20 +1882,72 @@ describe("AIProviderSettingsSection", () => {
 
       await waitFor(() => {
         expect(
-          fetchMock.callHistory.called("path:/api/setting", {
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
             method: "PUT",
-            body: {
-              "llm-metabot-provider": null,
-              "llm-bedrock-access-key-id": null,
-              "llm-bedrock-secret-access-key": null,
-              "llm-bedrock-session-token": null,
-            },
+            body: { provider: "bedrock", credentials: null },
           }),
         ).toBe(true);
       });
 
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/setting", {
+            method: "PUT",
+            body: { "llm-metabot-provider": null },
+          }),
+        ).toBe(true);
+      });
+
+      const callHistory = fetchMock.callHistory.calls();
+      const [credentialsRequest] = fetchMock.callHistory.calls(
+        "path:/api/metabot/settings",
+        { method: "PUT" },
+      );
+      const [providerRequest] = fetchMock.callHistory.calls(
+        "path:/api/setting",
+        { method: "PUT" },
+      );
+
+      if (!credentialsRequest || !providerRequest) {
+        throw new Error("Expected credentials and provider requests to exist");
+      }
+
+      expect(callHistory.indexOf(credentialsRequest)).toBeLessThan(
+        callHistory.indexOf(providerRequest),
+      );
+
       expect(
         await screen.findByText("Connect to an AI provider"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not clear the provider setting if clearing the Bedrock credentials fails", async () => {
+      const { store } = await setup({
+        savedProviderValue: "bedrock/anthropic.claude-haiku-4-5",
+        apiKeyValues: { bedrock: "**********LE" },
+        metabotSettingsUpdateResponse: { status: 500 },
+      });
+
+      await screen.findByLabelText("Access key ID");
+      await confirmDisconnectProvider();
+
+      await waitFor(() => {
+        expect(
+          store
+            .getState()
+            .undo.some(
+              (toast) => toast.message === "Unable to save provider settings.",
+            ),
+        ).toBe(true);
+      });
+
+      expect(
+        fetchMock.callHistory
+          .calls("path:/api/setting")
+          .some((call) => call.request?.method === "PUT"),
+      ).toBe(false);
+      expect(
+        screen.getByRole("button", { name: "Disconnect" }),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationContext.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationContext.ts
@@ -1,0 +1,69 @@
+import {
+  type MutableRefObject,
+  createContext,
+  useContext,
+  useEffect,
+} from "react";
+
+export const AIProviderConfigurationContext = createContext<{
+  connectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
+  disconnectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
+  isMutating: boolean;
+  isConnectButtonEnabled: boolean;
+  setIsConnectButtonEnabled: (enabled: boolean) => void;
+  resetProvider: VoidFunction;
+  handleDisconnect: VoidFunction;
+  isModal: boolean;
+}>({
+  isMutating: false,
+  connectHandlerRef: null,
+  disconnectHandlerRef: null,
+  isConnectButtonEnabled: false,
+  setIsConnectButtonEnabled: () => {},
+  resetProvider: () => {},
+  handleDisconnect: () => {},
+  isModal: false,
+});
+
+export function useAIProviderConfigurationContext(
+  onConnect: (() => Promise<void>) | null,
+  onDisconnect: (() => Promise<void>) | null = null,
+) {
+  const {
+    connectHandlerRef,
+    disconnectHandlerRef,
+    isMutating,
+    setIsConnectButtonEnabled,
+    resetProvider,
+    handleDisconnect,
+    isModal,
+  } = useContext(AIProviderConfigurationContext);
+
+  useEffect(() => {
+    if (!connectHandlerRef) {
+      return;
+    }
+
+    connectHandlerRef.current = onConnect;
+    setIsConnectButtonEnabled(!!onConnect);
+
+    return () => {
+      setIsConnectButtonEnabled(false);
+      connectHandlerRef.current = null;
+    };
+  }, [connectHandlerRef, onConnect, setIsConnectButtonEnabled]);
+
+  useEffect(() => {
+    if (!disconnectHandlerRef) {
+      return;
+    }
+
+    disconnectHandlerRef.current = onDisconnect;
+
+    return () => {
+      disconnectHandlerRef.current = null;
+    };
+  }, [disconnectHandlerRef, onDisconnect]);
+
+  return { isMutating, resetProvider, handleDisconnect, isModal };
+}

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -218,6 +218,7 @@ export function AIProviderConfigurationForm({
   }, [isModal, connectedProvider]);
 
   const [updateSettings, updateSettingsResult] = useUpdateSettingsMutation();
+  const [updateMetabotSettings] = useUpdateMetabotSettingsMutation();
   const disconnectHandlerRef = useRef<(() => Promise<void>) | null>(null);
 
   const { details: providerApiKeyDetails } = useAdminSettings([
@@ -242,21 +243,26 @@ export function AIProviderConfigurationForm({
       "llm-metabot-provider": null,
     };
 
-    if (connectedProvider !== "metabase") {
+    if (connectedProvider !== "metabase" && connectedProvider !== "bedrock") {
       const apiKeySettingKey = API_KEY_SETTING_BY_PROVIDER[connectedProvider];
       const apiKeySetting = providerApiKeyDetails[apiKeySettingKey];
 
       if (!apiKeySetting?.is_env_setting) {
         settingsToClear[apiKeySettingKey] = null;
       }
-
-      if (connectedProvider === "bedrock") {
-        settingsToClear["llm-bedrock-secret-access-key"] = null;
-        settingsToClear["llm-bedrock-session-token"] = null;
-      }
     }
 
     try {
+      if (connectedProvider === "bedrock") {
+        // Bedrock key material spans several settings; an explicit `credentials: null`
+        // clears them all in one call. It runs before the provider is deselected so a
+        // failure can't leave saved keys behind.
+        await updateMetabotSettings({
+          provider: "bedrock",
+          credentials: null,
+        }).unwrap();
+      }
+
       const response = await updateSettings(settingsToClear);
 
       if (response.error) {
@@ -287,6 +293,7 @@ export function AIProviderConfigurationForm({
     connectedProvider,
     disconnectHandlerRef,
     providerApiKeyDetails,
+    updateMetabotSettings,
     updateSettings,
     sendToast,
   ]);

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -1,21 +1,8 @@
-import {
-  type ChangeEvent,
-  Fragment,
-  type MutableRefObject,
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { P, match } from "ts-pattern";
-import { c, t } from "ttag";
-import _ from "underscore";
+import { t } from "ttag";
 
 import {
-  useGetMetabotSettingsQuery,
   useUpdateMetabotSettingsMutation,
   useUpdateSettingsMutation,
 } from "metabase/api";
@@ -25,156 +12,21 @@ import {
   useAdminSettings,
 } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
-import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { PLUGIN_METABOT } from "metabase/plugins";
-import {
-  Button,
-  type ComboboxItem,
-  Flex,
-  Group,
-  Select,
-  Stack,
-  Text,
-  TextInput,
-} from "metabase/ui";
-import type {
-  MetabotProvider,
-  MetabotSettingsResponse,
-  SettingDefinition,
-} from "metabase-types/api";
+import { Button, Flex, Group, Select, Stack, Text } from "metabase/ui";
+import type { MetabotProvider } from "metabase-types/api";
 
+import { AIProviderConfigurationContext } from "./AIProviderConfigurationContext";
+import { ApiKeyProviderFields } from "./ApiKeyProviderFields";
+import { BedrockProviderFields } from "./BedrockProviderFields";
 import {
   API_KEY_SETTING_BY_PROVIDER,
   getProviderOptions,
   isAvailableProvider,
   parseProviderAndModel,
 } from "./utils";
-
-type MetabotModelOption = ComboboxItem & {
-  group?: string | null;
-};
-
-type BedrockExtraField = "secretAccessKey" | "region" | "sessionToken";
-
-const BEDROCK_EXTRA_FIELDS = [
-  {
-    key: "secretAccessKey",
-    settingKey: "llm-bedrock-secret-access-key",
-    password: true,
-  },
-  { key: "region", settingKey: "llm-bedrock-region", password: false },
-  {
-    key: "sessionToken",
-    settingKey: "llm-bedrock-session-token",
-    password: true,
-  },
-] as const;
-
-const UNTOUCHED_BEDROCK_VALUES: Record<BedrockExtraField, string | null> = {
-  secretAccessKey: null,
-  region: null,
-  sessionToken: null,
-};
-
-function getBedrockFieldCopy(field: BedrockExtraField): {
-  label: string;
-  description?: string;
-  placeholder?: string;
-} {
-  switch (field) {
-    case "secretAccessKey":
-      return {
-        label: t`Secret access key`,
-        placeholder: t`Enter your AWS secret access key`,
-      };
-    case "region":
-      return {
-        label: t`Region`,
-        description: t`The AWS region to use for Bedrock.`,
-        placeholder: "us-east-1",
-      };
-    case "sessionToken":
-      return {
-        label: t`Session token`,
-        description: t`Optional. Only needed for temporary AWS credentials.`,
-        placeholder: t`Enter your AWS session token`,
-      };
-  }
-}
-
-function getModelDescription(provider: MetabotProvider | undefined) {
-  if (provider === "metabase") {
-    // eslint-disable-next-line metabase/no-literal-metabase-strings -- "Metabase" is the product name for the managed AI provider option, only shown to admins configuring AI.
-    return t`Available models are provided by Metabase.`;
-  }
-
-  return t`Available models are fetched from the selected provider using its configured credentials.`;
-}
-
-const AIProviderConfigurationContext = createContext<{
-  connectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
-  disconnectHandlerRef: MutableRefObject<(() => Promise<void>) | null> | null;
-  isMutating: boolean;
-  isConnectButtonEnabled: boolean;
-  setIsConnectButtonEnabled: (enabled: boolean) => void;
-  resetProvider: VoidFunction;
-  handleDisconnect: VoidFunction;
-  isModal: boolean;
-}>({
-  isMutating: false,
-  connectHandlerRef: null,
-  disconnectHandlerRef: null,
-  isConnectButtonEnabled: false,
-  setIsConnectButtonEnabled: () => {},
-  resetProvider: () => {},
-  handleDisconnect: () => {},
-  isModal: false,
-});
-
-export function useAIProviderConfigurationContext(
-  onConnect: (() => Promise<void>) | null,
-  onDisconnect: (() => Promise<void>) | null = null,
-) {
-  const {
-    connectHandlerRef,
-    disconnectHandlerRef,
-    isMutating,
-    setIsConnectButtonEnabled,
-    resetProvider,
-    handleDisconnect,
-    isModal,
-  } = useContext(AIProviderConfigurationContext);
-
-  useEffect(() => {
-    if (!connectHandlerRef) {
-      return;
-    }
-
-    connectHandlerRef.current = onConnect;
-    setIsConnectButtonEnabled(!!onConnect);
-
-    return () => {
-      setIsConnectButtonEnabled(false);
-      connectHandlerRef.current = null;
-    };
-  }, [connectHandlerRef, onConnect, setIsConnectButtonEnabled]);
-
-  useEffect(() => {
-    if (!disconnectHandlerRef) {
-      return;
-    }
-
-    disconnectHandlerRef.current = onDisconnect;
-
-    return () => {
-      disconnectHandlerRef.current = null;
-    };
-  }, [disconnectHandlerRef, onDisconnect]);
-
-  return { isMutating, resetProvider, handleDisconnect, isModal };
-}
 
 export function AIProviderConfigurationForm({
   isModal = false,
@@ -225,7 +77,6 @@ export function AIProviderConfigurationForm({
     "llm-anthropic-api-key",
     "llm-openai-api-key",
     "llm-openrouter-api-key",
-    "llm-bedrock-access-key-id",
   ] as const);
 
   const disconnectProvider = useCallback(async () => {
@@ -396,8 +247,16 @@ export function AIProviderConfigurationForm({
           .with("metabase", () => (
             <MetabaseAIProviderSetup onConnect={onClose} />
           ))
-          .with(P.nonNullable, (selectedProvider) => (
-            <ProviderCredentialsFields
+          .with("bedrock", () => (
+            <BedrockProviderFields
+              connectedModel={connectedModel}
+              isCurrentConfigured={isCurrentConfigured}
+              isEnvSetting={isEnvSetting}
+            />
+          ))
+          .with("anthropic", "openai", "openrouter", (selectedProvider) => (
+            <ApiKeyProviderFields
+              key={selectedProvider}
               selectedProvider={selectedProvider}
               connectedModel={connectedModel}
               isCurrentConfigured={isCurrentConfigured}
@@ -462,264 +321,3 @@ export function AIProviderConfigurationForm({
     </AIProviderConfigurationContext.Provider>
   );
 }
-
-const ProviderCredentialsFields = ({
-  selectedProvider,
-  connectedModel,
-  isCurrentConfigured,
-  isEnvSetting,
-}: {
-  selectedProvider: Exclude<MetabotProvider, "metabase">;
-  connectedModel: string | undefined;
-  isCurrentConfigured: boolean;
-  isEnvSetting: boolean;
-}) => {
-  const isBedrock = selectedProvider === "bedrock";
-  const [model, setModel] = useState<string | undefined>(connectedModel);
-  const [apiKeyLocalValue, setApiKeyLocalValue] = useState<string | null>(null);
-  const [bedrockLocalValues, setBedrockLocalValues] = useState<
-    Record<BedrockExtraField, string | null>
-  >(UNTOUCHED_BEDROCK_VALUES);
-  const [sendToast] = useToast();
-
-  useEffect(() => {
-    setModel(connectedModel);
-  }, [connectedModel]);
-
-  const [updateMetabotSettings, updateMetabotSettingsResult] =
-    useUpdateMetabotSettingsMutation();
-
-  const { details: providerApiKeyDetails } = useAdminSettings([
-    "llm-anthropic-api-key",
-    "llm-openai-api-key",
-    "llm-openrouter-api-key",
-    "llm-bedrock-access-key-id",
-    "llm-bedrock-secret-access-key",
-    "llm-bedrock-region",
-    "llm-bedrock-session-token",
-  ] as const);
-
-  const selectedApiKeySetting =
-    providerApiKeyDetails[API_KEY_SETTING_BY_PROVIDER[selectedProvider]];
-  const selectedApiKeyValue = String(selectedApiKeySetting?.value ?? "");
-  const apiKeyEnvSettingName = selectedApiKeySetting?.is_env_setting
-    ? selectedApiKeySetting.env_name
-    : undefined;
-
-  // Display values fall back to the saved settings so untouched fields round-trip unchanged
-  // when connecting.
-  const displayBedrockValues = Object.fromEntries(
-    BEDROCK_EXTRA_FIELDS.map(({ key, settingKey }) => [
-      key,
-      bedrockLocalValues[key] ??
-        String(providerApiKeyDetails[settingKey]?.value ?? ""),
-    ]),
-  ) as Record<BedrockExtraField, string>;
-
-  const onConnect = async () => {
-    if (isBedrock) {
-      await updateMetabotSettings({
-        provider: selectedProvider,
-        credentials: {
-          "access-key-id": apiKeyLocalValue || null,
-          "secret-access-key": bedrockLocalValues.secretAccessKey || null,
-          region: bedrockLocalValues.region || null,
-          "session-token": bedrockLocalValues.sessionToken || null,
-        },
-      }).unwrap();
-    } else {
-      await updateMetabotSettings({
-        provider: selectedProvider,
-        "api-key": apiKeyLocalValue || null,
-      }).unwrap();
-    }
-
-    setApiKeyLocalValue(null);
-    setBedrockLocalValues(UNTOUCHED_BEDROCK_VALUES);
-  };
-
-  const hasDirtyApiKey = apiKeyLocalValue !== null;
-  const hasDirtyBedrockCredentials =
-    isBedrock && Object.values(bedrockLocalValues).some((v) => v !== null);
-  const connectHandler =
-    !isCurrentConfigured || hasDirtyApiKey || hasDirtyBedrockCredentials
-      ? onConnect
-      : null;
-
-  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
-
-  const needsApiKey = isBedrock
-    ? !hasConfiguredSettingValue(selectedApiKeySetting) ||
-      !hasConfiguredSettingValue(
-        providerApiKeyDetails["llm-bedrock-secret-access-key"],
-      )
-    : !hasConfiguredSettingValue(selectedApiKeySetting);
-
-  const metabotSettingsQuery = useGetMetabotSettingsQuery(
-    {
-      provider: selectedProvider,
-    },
-    { skip: needsApiKey },
-  );
-
-  const modelOptions = useMemo(
-    () => getLlmModelOptions(metabotSettingsQuery.currentData?.models ?? []),
-    [metabotSettingsQuery.currentData?.models],
-  );
-
-  const modelError = getModelError(
-    metabotSettingsQuery.error,
-    selectedProvider,
-  );
-  const credentialsError = hasDirtyApiKey
-    ? undefined
-    : (metabotSettingsQuery.currentData?.["credentials-error"] ?? undefined);
-
-  const displayApiKeyValue = apiKeyLocalValue ?? selectedApiKeyValue;
-
-  useEffect(() => {
-    setApiKeyLocalValue(null);
-    setBedrockLocalValues(UNTOUCHED_BEDROCK_VALUES);
-  }, [selectedProvider, selectedApiKeySetting?.value]);
-
-  const handleApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setApiKeyLocalValue(event.target.value);
-  };
-
-  const handleBedrockFieldChange =
-    (field: BedrockExtraField) => (event: ChangeEvent<HTMLInputElement>) => {
-      setBedrockLocalValues((values) => ({
-        ...values,
-        [field]: event.target.value,
-      }));
-    };
-
-  const handleModelChange = async (value: string) => {
-    setModel(value);
-
-    if (!value) {
-      return;
-    }
-
-    await updateMetabotSettings({
-      provider: selectedProvider,
-      model: value,
-    }).unwrap();
-
-    sendToast({
-      message: t`Settings saved successfully`,
-      icon: "check",
-    });
-  };
-
-  const selectedProviderDetails = getProviderOptions(true)[selectedProvider];
-
-  return (
-    <>
-      <TextInput
-        key={selectedProvider}
-        label={isBedrock ? t`Access key ID` : t`API key`}
-        type="password"
-        description={
-          <ExternalLink
-            key={selectedProviderDetails.value}
-            href={selectedProviderDetails.apiKey.addKeyUrl}
-          >
-            {c("{0} is the name of an AI provider")
-              .t`Get or manage keys in ${selectedProviderDetails.label}`}
-          </ExternalLink>
-        }
-        placeholder={
-          selectedProviderDetails.apiKey?.placeholder ?? t`Enter your API key`
-        }
-        value={displayApiKeyValue}
-        error={credentialsError}
-        onChange={handleApiKeyChange}
-        disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
-        w="100%"
-      />
-
-      {apiKeyEnvSettingName ? (
-        <SetByEnvVar varName={apiKeyEnvSettingName} />
-      ) : null}
-
-      {isBedrock &&
-        BEDROCK_EXTRA_FIELDS.map(({ key, settingKey, password }) => {
-          const { label, description, placeholder } = getBedrockFieldCopy(key);
-          const setting = providerApiKeyDetails[settingKey];
-          const envSettingName = setting?.is_env_setting
-            ? setting.env_name
-            : undefined;
-
-          return (
-            <Fragment key={key}>
-              <TextInput
-                label={label}
-                type={password ? "password" : undefined}
-                description={description}
-                placeholder={placeholder}
-                value={displayBedrockValues[key]}
-                onChange={handleBedrockFieldChange(key)}
-                disabled={isMutating || isEnvSetting || !!envSettingName}
-                w="100%"
-              />
-              {envSettingName && <SetByEnvVar varName={envSettingName} />}
-            </Fragment>
-          );
-        })}
-
-      {!needsApiKey && !credentialsError && (
-        <Select
-          label={t`Model`}
-          placeholder={
-            metabotSettingsQuery.isLoading
-              ? t`Loading models...`
-              : t`Select a model`
-          }
-          description={getModelDescription(selectedProvider)}
-          error={modelError}
-          data={modelOptions}
-          value={model}
-          onChange={handleModelChange}
-          disabled={isEnvSetting || needsApiKey || isMutating}
-          searchable
-          nothingFoundMessage={t`No models found`}
-        />
-      )}
-
-      {updateMetabotSettingsResult.error && (
-        <Text size="sm" c="error">
-          {getErrorMessage(
-            updateMetabotSettingsResult.error,
-            t`Unable to save provider settings.`,
-          )}
-        </Text>
-      )}
-    </>
-  );
-};
-
-const getLlmModelOptions = (models: MetabotSettingsResponse["models"]) => {
-  const modelOptions = models.map((m) => ({
-    value: m.id,
-    label: m.display_name,
-    group: m.group,
-  }));
-
-  const sel = (o: MetabotModelOption) => _.pick(o, ["value", "label"]);
-  // group model options if needed
-  return _.every(modelOptions, (o) => !o.group)
-    ? modelOptions.map(sel)
-    : _.map(
-        _.groupBy(modelOptions, (o) => o.group ?? t`Other`),
-        (items, group) => ({ group, items: items.map(sel) }),
-      );
-};
-
-const hasConfiguredSettingValue = (setting: SettingDefinition | undefined) =>
-  Boolean(setting?.value || setting?.is_env_setting);
-
-const getModelError = (error: unknown, provider?: MetabotProvider) =>
-  !provider || !error
-    ? undefined
-    : getErrorMessage(error, t`Unable to load models.`);

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -1,5 +1,6 @@
 import {
   type ChangeEvent,
+  Fragment,
   type MutableRefObject,
   createContext,
   useCallback,
@@ -55,13 +56,61 @@ type MetabotModelOption = ComboboxItem & {
   group?: string | null;
 };
 
+type BedrockExtraField = "secretAccessKey" | "region" | "sessionToken";
+
+const BEDROCK_EXTRA_FIELDS = [
+  {
+    key: "secretAccessKey",
+    settingKey: "llm-bedrock-secret-access-key",
+    password: true,
+  },
+  { key: "region", settingKey: "llm-bedrock-region", password: false },
+  {
+    key: "sessionToken",
+    settingKey: "llm-bedrock-session-token",
+    password: true,
+  },
+] as const;
+
+const UNTOUCHED_BEDROCK_VALUES: Record<BedrockExtraField, string | null> = {
+  secretAccessKey: null,
+  region: null,
+  sessionToken: null,
+};
+
+function getBedrockFieldCopy(field: BedrockExtraField): {
+  label: string;
+  description?: string;
+  placeholder?: string;
+} {
+  switch (field) {
+    case "secretAccessKey":
+      return {
+        label: t`Secret access key`,
+        placeholder: t`Enter your AWS secret access key`,
+      };
+    case "region":
+      return {
+        label: t`Region`,
+        description: t`The AWS region to use for Bedrock.`,
+        placeholder: "us-east-1",
+      };
+    case "sessionToken":
+      return {
+        label: t`Session token`,
+        description: t`Optional. Only needed for temporary AWS credentials.`,
+        placeholder: t`Enter your AWS session token`,
+      };
+  }
+}
+
 function getModelDescription(provider: MetabotProvider | undefined) {
   if (provider === "metabase") {
     // eslint-disable-next-line metabase/no-literal-metabase-strings -- "Metabase" is the product name for the managed AI provider option, only shown to admins configuring AI.
     return t`Available models are provided by Metabase.`;
   }
 
-  return t`Available models are fetched from the selected provider using its configured API key.`;
+  return t`Available models are fetched from the selected provider using its configured credentials.`;
 }
 
 const AIProviderConfigurationContext = createContext<{
@@ -175,6 +224,7 @@ export function AIProviderConfigurationForm({
     "llm-anthropic-api-key",
     "llm-openai-api-key",
     "llm-openrouter-api-key",
+    "llm-bedrock-access-key-id",
   ] as const);
 
   const disconnectProvider = useCallback(async () => {
@@ -198,6 +248,11 @@ export function AIProviderConfigurationForm({
 
       if (!apiKeySetting?.is_env_setting) {
         settingsToClear[apiKeySettingKey] = null;
+      }
+
+      if (connectedProvider === "bedrock") {
+        settingsToClear["llm-bedrock-secret-access-key"] = null;
+        settingsToClear["llm-bedrock-session-token"] = null;
       }
     }
 
@@ -412,8 +467,12 @@ const ProviderCredentialsFields = ({
   isCurrentConfigured: boolean;
   isEnvSetting: boolean;
 }) => {
+  const isBedrock = selectedProvider === "bedrock";
   const [model, setModel] = useState<string | undefined>(connectedModel);
   const [apiKeyLocalValue, setApiKeyLocalValue] = useState<string | null>(null);
+  const [bedrockLocalValues, setBedrockLocalValues] = useState<
+    Record<BedrockExtraField, string | null>
+  >(UNTOUCHED_BEDROCK_VALUES);
   const [sendToast] = useToast();
 
   useEffect(() => {
@@ -423,25 +482,14 @@ const ProviderCredentialsFields = ({
   const [updateMetabotSettings, updateMetabotSettingsResult] =
     useUpdateMetabotSettingsMutation();
 
-  const onConnect = async () => {
-    await updateMetabotSettings({
-      provider: selectedProvider,
-      "api-key": apiKeyLocalValue || null,
-    }).unwrap();
-
-    setApiKeyLocalValue(null);
-  };
-
-  const hasDirtyApiKey = apiKeyLocalValue !== null;
-  const connectHandler =
-    !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
-
-  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
-
   const { details: providerApiKeyDetails } = useAdminSettings([
     "llm-anthropic-api-key",
     "llm-openai-api-key",
     "llm-openrouter-api-key",
+    "llm-bedrock-access-key-id",
+    "llm-bedrock-secret-access-key",
+    "llm-bedrock-region",
+    "llm-bedrock-session-token",
   ] as const);
 
   const selectedApiKeySetting =
@@ -450,7 +498,55 @@ const ProviderCredentialsFields = ({
   const apiKeyEnvSettingName = selectedApiKeySetting?.is_env_setting
     ? selectedApiKeySetting.env_name
     : undefined;
-  const needsApiKey = !hasConfiguredSettingValue(selectedApiKeySetting);
+
+  // Display values fall back to the saved settings so untouched fields round-trip unchanged
+  // when connecting.
+  const displayBedrockValues = Object.fromEntries(
+    BEDROCK_EXTRA_FIELDS.map(({ key, settingKey }) => [
+      key,
+      bedrockLocalValues[key] ??
+        String(providerApiKeyDetails[settingKey]?.value ?? ""),
+    ]),
+  ) as Record<BedrockExtraField, string>;
+
+  const onConnect = async () => {
+    if (isBedrock) {
+      await updateMetabotSettings({
+        provider: selectedProvider,
+        credentials: {
+          "access-key-id": apiKeyLocalValue || null,
+          "secret-access-key": bedrockLocalValues.secretAccessKey || null,
+          region: bedrockLocalValues.region || null,
+          "session-token": bedrockLocalValues.sessionToken || null,
+        },
+      }).unwrap();
+    } else {
+      await updateMetabotSettings({
+        provider: selectedProvider,
+        "api-key": apiKeyLocalValue || null,
+      }).unwrap();
+    }
+
+    setApiKeyLocalValue(null);
+    setBedrockLocalValues(UNTOUCHED_BEDROCK_VALUES);
+  };
+
+  const hasDirtyApiKey = apiKeyLocalValue !== null;
+  const hasDirtyBedrockCredentials =
+    isBedrock && Object.values(bedrockLocalValues).some((v) => v !== null);
+  const connectHandler =
+    !isCurrentConfigured || hasDirtyApiKey || hasDirtyBedrockCredentials
+      ? onConnect
+      : null;
+
+  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
+
+  const needsApiKey = isBedrock
+    ? !hasConfiguredSettingValue(selectedApiKeySetting) ||
+      !hasConfiguredSettingValue(
+        providerApiKeyDetails["llm-bedrock-secret-access-key"],
+      )
+    : !hasConfiguredSettingValue(selectedApiKeySetting);
 
   const metabotSettingsQuery = useGetMetabotSettingsQuery(
     {
@@ -476,11 +572,20 @@ const ProviderCredentialsFields = ({
 
   useEffect(() => {
     setApiKeyLocalValue(null);
+    setBedrockLocalValues(UNTOUCHED_BEDROCK_VALUES);
   }, [selectedProvider, selectedApiKeySetting?.value]);
 
   const handleApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
     setApiKeyLocalValue(event.target.value);
   };
+
+  const handleBedrockFieldChange =
+    (field: BedrockExtraField) => (event: ChangeEvent<HTMLInputElement>) => {
+      setBedrockLocalValues((values) => ({
+        ...values,
+        [field]: event.target.value,
+      }));
+    };
 
   const handleModelChange = async (value: string) => {
     setModel(value);
@@ -506,7 +611,7 @@ const ProviderCredentialsFields = ({
     <>
       <TextInput
         key={selectedProvider}
-        label={t`API key`}
+        label={isBedrock ? t`Access key ID` : t`API key`}
         type="password"
         description={
           <ExternalLink
@@ -530,6 +635,31 @@ const ProviderCredentialsFields = ({
       {apiKeyEnvSettingName ? (
         <SetByEnvVar varName={apiKeyEnvSettingName} />
       ) : null}
+
+      {isBedrock &&
+        BEDROCK_EXTRA_FIELDS.map(({ key, settingKey, password }) => {
+          const { label, description, placeholder } = getBedrockFieldCopy(key);
+          const setting = providerApiKeyDetails[settingKey];
+          const envSettingName = setting?.is_env_setting
+            ? setting.env_name
+            : undefined;
+
+          return (
+            <Fragment key={key}>
+              <TextInput
+                label={label}
+                type={password ? "password" : undefined}
+                description={description}
+                placeholder={placeholder}
+                value={displayBedrockValues[key]}
+                onChange={handleBedrockFieldChange(key)}
+                disabled={isMutating || isEnvSetting || !!envSettingName}
+                w="100%"
+              />
+              {envSettingName && <SetByEnvVar varName={envSettingName} />}
+            </Fragment>
+          );
+        })}
 
       {!needsApiKey && !apiKeyError && (
         <Select

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -571,9 +571,9 @@ const ProviderCredentialsFields = ({
     metabotSettingsQuery.error,
     selectedProvider,
   );
-  const apiKeyError = hasDirtyApiKey
+  const credentialsError = hasDirtyApiKey
     ? undefined
-    : (metabotSettingsQuery.currentData?.["api-key-error"] ?? undefined);
+    : (metabotSettingsQuery.currentData?.["credentials-error"] ?? undefined);
 
   const displayApiKeyValue = apiKeyLocalValue ?? selectedApiKeyValue;
 
@@ -633,7 +633,7 @@ const ProviderCredentialsFields = ({
           selectedProviderDetails.apiKey?.placeholder ?? t`Enter your API key`
         }
         value={displayApiKeyValue}
-        error={apiKeyError}
+        error={credentialsError}
         onChange={handleApiKeyChange}
         disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
         w="100%"
@@ -668,7 +668,7 @@ const ProviderCredentialsFields = ({
           );
         })}
 
-      {!needsApiKey && !apiKeyError && (
+      {!needsApiKey && !credentialsError && (
         <Select
           label={t`Model`}
           placeholder={

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ApiKeyProviderFields.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ApiKeyProviderFields.tsx
@@ -1,0 +1,122 @@
+import { type ChangeEvent, useEffect, useState } from "react";
+import { c, t } from "ttag";
+
+import { useUpdateMetabotSettingsMutation } from "metabase/api";
+import { getErrorMessage, useAdminSettings } from "metabase/api/utils";
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
+import { Text, TextInput } from "metabase/ui";
+
+import { useAIProviderConfigurationContext } from "./AIProviderConfigurationContext";
+import {
+  ProviderModelPicker,
+  useProviderModelsQuery,
+} from "./ProviderModelPicker";
+import {
+  API_KEY_SETTING_BY_PROVIDER,
+  type MetabotApiKeyProvider,
+  getProviderOptions,
+  hasConfiguredSettingValue,
+} from "./utils";
+
+export const ApiKeyProviderFields = ({
+  selectedProvider,
+  connectedModel,
+  isCurrentConfigured,
+  isEnvSetting,
+}: {
+  selectedProvider: MetabotApiKeyProvider;
+  connectedModel: string | undefined;
+  isCurrentConfigured: boolean;
+  isEnvSetting: boolean;
+}) => {
+  const [localApiKey, setLocalApiKey] = useState<string | null>(null);
+  const [updateMetabotSettings, updateMetabotSettingsResult] =
+    useUpdateMetabotSettingsMutation();
+
+  const { details } = useAdminSettings([
+    "llm-anthropic-api-key",
+    "llm-openai-api-key",
+    "llm-openrouter-api-key",
+  ] as const);
+  const apiKeySetting = details[API_KEY_SETTING_BY_PROVIDER[selectedProvider]];
+  const apiKeyEnvSettingName = apiKeySetting?.is_env_setting
+    ? apiKeySetting.env_name
+    : undefined;
+
+  const onConnect = async () => {
+    await updateMetabotSettings({
+      provider: selectedProvider,
+      "api-key": localApiKey || null,
+    }).unwrap();
+
+    setLocalApiKey(null);
+  };
+
+  const hasDirtyApiKey = localApiKey !== null;
+  const connectHandler =
+    !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
+  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
+
+  const needsApiKey = !hasConfiguredSettingValue(apiKeySetting);
+  const { modelsQuery, credentialsError: savedCredentialsError } =
+    useProviderModelsQuery(selectedProvider, { skip: needsApiKey });
+  const credentialsError = hasDirtyApiKey ? undefined : savedCredentialsError;
+
+  const apiKeySettingValue = apiKeySetting?.value;
+
+  useEffect(() => {
+    setLocalApiKey(null);
+  }, [apiKeySettingValue]);
+
+  const handleApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setLocalApiKey(event.target.value);
+  };
+
+  const providerDetails = getProviderOptions(true)[selectedProvider];
+
+  return (
+    <>
+      <TextInput
+        label={t`API key`}
+        type="password"
+        description={
+          <ExternalLink href={providerDetails.apiKey.addKeyUrl}>
+            {c("{0} is the name of an AI provider")
+              .t`Get or manage keys in ${providerDetails.label}`}
+          </ExternalLink>
+        }
+        placeholder={providerDetails.apiKey.placeholder}
+        value={localApiKey ?? String(apiKeySettingValue ?? "")}
+        error={credentialsError}
+        onChange={handleApiKeyChange}
+        disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
+        w="100%"
+      />
+
+      {apiKeyEnvSettingName ? (
+        <SetByEnvVar varName={apiKeyEnvSettingName} />
+      ) : null}
+
+      {!needsApiKey && !credentialsError && (
+        <ProviderModelPicker
+          provider={selectedProvider}
+          connectedModel={connectedModel}
+          models={modelsQuery.currentData?.models ?? []}
+          isLoading={modelsQuery.isLoading}
+          loadError={modelsQuery.error}
+          disabled={isEnvSetting || isMutating}
+        />
+      )}
+
+      {updateMetabotSettingsResult.error && (
+        <Text size="sm" c="error">
+          {getErrorMessage(
+            updateMetabotSettingsResult.error,
+            t`Unable to save provider settings.`,
+          )}
+        </Text>
+      )}
+    </>
+  );
+};

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/BedrockProviderFields.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/BedrockProviderFields.tsx
@@ -8,6 +8,7 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { FormErrorMessage, FormProvider, FormTextInput } from "metabase/forms";
 import { Text } from "metabase/ui";
+import type { BedrockCredentials } from "metabase-types/api";
 
 import { useAIProviderConfigurationContext } from "./AIProviderConfigurationContext";
 import {
@@ -58,17 +59,26 @@ export const BedrockProviderFields = ({
     values: BedrockCredentialValues,
     { resetForm }: FormikHelpers<BedrockCredentialValues>,
   ) => {
-    const changedValueOrNull = (field: keyof BedrockCredentialValues) =>
-      values[field] !== initialValues[field] ? values[field] || null : null;
+    // Per-field presence contract: an unchanged field is omitted so the backend keeps the saved
+    // value, while a field the user blanked is sent as an explicit null to clear the saved value.
+    const credentials: BedrockCredentials = {};
+    const setIfChanged = (
+      apiField: keyof BedrockCredentials,
+      field: keyof BedrockCredentialValues,
+    ) => {
+      if (values[field] !== initialValues[field]) {
+        credentials[apiField] = values[field] || null;
+      }
+    };
+
+    setIfChanged("access-key-id", "accessKeyId");
+    setIfChanged("secret-access-key", "secretAccessKey");
+    setIfChanged("region", "region");
+    setIfChanged("session-token", "sessionToken");
 
     await updateMetabotSettings({
       provider: "bedrock",
-      credentials: {
-        "access-key-id": changedValueOrNull("accessKeyId"),
-        "secret-access-key": changedValueOrNull("secretAccessKey"),
-        region: changedValueOrNull("region"),
-        "session-token": changedValueOrNull("sessionToken"),
-      },
+      credentials,
     }).unwrap();
 
     resetForm({ values });

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/BedrockProviderFields.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/BedrockProviderFields.tsx
@@ -1,0 +1,204 @@
+import { type FormikHelpers, useFormikContext } from "formik";
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import { useUpdateMetabotSettingsMutation } from "metabase/api";
+import { useAdminSettings } from "metabase/api/utils";
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
+import { FormErrorMessage, FormProvider, FormTextInput } from "metabase/forms";
+import { Text } from "metabase/ui";
+
+import { useAIProviderConfigurationContext } from "./AIProviderConfigurationContext";
+import {
+  ProviderModelPicker,
+  useProviderModelsQuery,
+} from "./ProviderModelPicker";
+import { getProviderOptions, hasConfiguredSettingValue } from "./utils";
+
+const BEDROCK_SETTING_KEYS = [
+  "llm-bedrock-access-key-id",
+  "llm-bedrock-secret-access-key",
+  "llm-bedrock-region",
+  "llm-bedrock-session-token",
+] as const;
+
+type BedrockCredentialValues = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  sessionToken: string;
+};
+
+export const BedrockProviderFields = ({
+  connectedModel,
+  isCurrentConfigured,
+  isEnvSetting,
+}: {
+  connectedModel: string | undefined;
+  isCurrentConfigured: boolean;
+  isEnvSetting: boolean;
+}) => {
+  const [updateMetabotSettings] = useUpdateMetabotSettingsMutation();
+  const { details } = useAdminSettings(BEDROCK_SETTING_KEYS);
+
+  const initialValues = useMemo<BedrockCredentialValues>(
+    () => ({
+      accessKeyId: String(details["llm-bedrock-access-key-id"]?.value ?? ""),
+      secretAccessKey: String(
+        details["llm-bedrock-secret-access-key"]?.value ?? "",
+      ),
+      region: String(details["llm-bedrock-region"]?.value ?? ""),
+      sessionToken: String(details["llm-bedrock-session-token"]?.value ?? ""),
+    }),
+    [details],
+  );
+
+  const handleSubmit = async (
+    values: BedrockCredentialValues,
+    { resetForm }: FormikHelpers<BedrockCredentialValues>,
+  ) => {
+    const changedValueOrNull = (field: keyof BedrockCredentialValues) =>
+      values[field] !== initialValues[field] ? values[field] || null : null;
+
+    await updateMetabotSettings({
+      provider: "bedrock",
+      credentials: {
+        "access-key-id": changedValueOrNull("accessKeyId"),
+        "secret-access-key": changedValueOrNull("secretAccessKey"),
+        region: changedValueOrNull("region"),
+        "session-token": changedValueOrNull("sessionToken"),
+      },
+    }).unwrap();
+
+    resetForm({ values });
+  };
+
+  return (
+    <FormProvider
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      enableReinitialize
+    >
+      <BedrockCredentialFields
+        connectedModel={connectedModel}
+        isCurrentConfigured={isCurrentConfigured}
+        isEnvSetting={isEnvSetting}
+      />
+    </FormProvider>
+  );
+};
+
+const BedrockCredentialFields = ({
+  connectedModel,
+  isCurrentConfigured,
+  isEnvSetting,
+}: {
+  connectedModel: string | undefined;
+  isCurrentConfigured: boolean;
+  isEnvSetting: boolean;
+}) => {
+  const { dirty, submitForm } = useFormikContext<BedrockCredentialValues>();
+  const connectHandler = !isCurrentConfigured || dirty ? submitForm : null;
+  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
+
+  const { details } = useAdminSettings(BEDROCK_SETTING_KEYS);
+  const accessKeyIdSetting = details["llm-bedrock-access-key-id"];
+  const secretAccessKeySetting = details["llm-bedrock-secret-access-key"];
+  const regionSetting = details["llm-bedrock-region"];
+  const sessionTokenSetting = details["llm-bedrock-session-token"];
+
+  const accessKeyIdEnvName = accessKeyIdSetting?.is_env_setting
+    ? accessKeyIdSetting.env_name
+    : undefined;
+  const secretAccessKeyEnvName = secretAccessKeySetting?.is_env_setting
+    ? secretAccessKeySetting.env_name
+    : undefined;
+  const regionEnvName = regionSetting?.is_env_setting
+    ? regionSetting.env_name
+    : undefined;
+  const sessionTokenEnvName = sessionTokenSetting?.is_env_setting
+    ? sessionTokenSetting.env_name
+    : undefined;
+
+  const needsCredentials =
+    !hasConfiguredSettingValue(accessKeyIdSetting) ||
+    !hasConfiguredSettingValue(secretAccessKeySetting);
+
+  const { modelsQuery, credentialsError: savedCredentialsError } =
+    useProviderModelsQuery("bedrock", { skip: needsCredentials });
+  const credentialsError = dirty ? undefined : savedCredentialsError;
+
+  const bedrockOption = getProviderOptions(true).bedrock;
+
+  return (
+    <>
+      <FormTextInput
+        name="accessKeyId"
+        label={t`Access key ID`}
+        type="password"
+        description={
+          <ExternalLink href={bedrockOption.apiKey.addKeyUrl}>
+            {t`Get or manage access keys in the AWS console`}
+          </ExternalLink>
+        }
+        placeholder={bedrockOption.apiKey.placeholder}
+        disabled={isMutating || isEnvSetting || !!accessKeyIdEnvName}
+        w="100%"
+      />
+      {accessKeyIdEnvName && <SetByEnvVar varName={accessKeyIdEnvName} />}
+      {credentialsError && (
+        <Text size="sm" c="error" role="alert">
+          {credentialsError}
+        </Text>
+      )}
+
+      <FormTextInput
+        name="secretAccessKey"
+        label={t`Secret access key`}
+        type="password"
+        description={t`Paired with the access key ID. AWS shows it only when the key is created.`}
+        placeholder={t`Enter your AWS secret access key`}
+        disabled={isMutating || isEnvSetting || !!secretAccessKeyEnvName}
+        w="100%"
+      />
+      {secretAccessKeyEnvName && (
+        <SetByEnvVar varName={secretAccessKeyEnvName} />
+      )}
+
+      <FormTextInput
+        name="region"
+        label={t`Region`}
+        description={t`The AWS region to use for Bedrock.`}
+        placeholder="us-east-1"
+        disabled={isMutating || isEnvSetting || !!regionEnvName}
+        w="100%"
+      />
+      {regionEnvName && <SetByEnvVar varName={regionEnvName} />}
+
+      <FormTextInput
+        name="sessionToken"
+        label={t`Session token`}
+        type="password"
+        description={t`Optional. Only needed for temporary AWS credentials.`}
+        placeholder={t`Enter your AWS session token`}
+        disabled={isMutating || isEnvSetting || !!sessionTokenEnvName}
+        w="100%"
+      />
+      {sessionTokenEnvName && <SetByEnvVar varName={sessionTokenEnvName} />}
+
+      {!needsCredentials && !credentialsError && (
+        <ProviderModelPicker
+          provider="bedrock"
+          connectedModel={connectedModel}
+          models={modelsQuery.currentData?.models ?? []}
+          isLoading={modelsQuery.isLoading}
+          loadError={modelsQuery.error}
+          disabled={isEnvSetting || isMutating}
+        />
+      )}
+
+      <FormErrorMessage />
+    </>
+  );
+};

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderModelPicker.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderModelPicker.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import {
+  useGetMetabotSettingsQuery,
+  useUpdateMetabotSettingsMutation,
+} from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
+import { useToast } from "metabase/common/hooks";
+import { type ComboboxItem, Select } from "metabase/ui";
+import type {
+  MetabotProvider,
+  MetabotSettingsResponse,
+} from "metabase-types/api";
+
+type MetabotModelOption = ComboboxItem & {
+  group?: string | null;
+};
+
+export function useProviderModelsQuery(
+  provider: MetabotProvider,
+  { skip }: { skip: boolean },
+) {
+  const modelsQuery = useGetMetabotSettingsQuery({ provider }, { skip });
+
+  return {
+    modelsQuery,
+    credentialsError:
+      modelsQuery.currentData?.["credentials-error"] ?? undefined,
+  };
+}
+
+export const ProviderModelPicker = ({
+  provider,
+  connectedModel,
+  models,
+  isLoading,
+  loadError,
+  disabled,
+}: {
+  provider: Exclude<MetabotProvider, "metabase">;
+  connectedModel: string | undefined;
+  models: MetabotSettingsResponse["models"];
+  isLoading: boolean;
+  loadError: unknown;
+  disabled: boolean;
+}) => {
+  const [model, setModel] = useState<string | undefined>(connectedModel);
+  const [updateMetabotSettings, updateMetabotSettingsResult] =
+    useUpdateMetabotSettingsMutation();
+  const [sendToast] = useToast();
+
+  useEffect(() => {
+    setModel(connectedModel);
+  }, [connectedModel]);
+
+  const modelOptions = useMemo(() => getLlmModelOptions(models), [models]);
+
+  const handleModelChange = async (value: string) => {
+    setModel(value);
+
+    if (!value) {
+      return;
+    }
+
+    const result = await updateMetabotSettings({ provider, model: value });
+
+    if (!result.error) {
+      sendToast({
+        message: t`Settings saved successfully`,
+        icon: "check",
+      });
+    }
+  };
+
+  const loadErrorMessage = loadError
+    ? getErrorMessage(loadError, t`Unable to load models.`)
+    : undefined;
+  const saveErrorMessage = updateMetabotSettingsResult.error
+    ? getErrorMessage(
+        updateMetabotSettingsResult.error,
+        t`Unable to save provider settings.`,
+      )
+    : undefined;
+  const error = loadErrorMessage ?? saveErrorMessage;
+
+  return (
+    <Select
+      label={t`Model`}
+      placeholder={isLoading ? t`Loading models...` : t`Select a model`}
+      description={t`Available models are fetched from the selected provider using its configured credentials.`}
+      error={error}
+      data={modelOptions}
+      value={model}
+      onChange={handleModelChange}
+      disabled={disabled}
+      searchable
+      nothingFoundMessage={t`No models found`}
+    />
+  );
+};
+
+const getLlmModelOptions = (models: MetabotSettingsResponse["models"]) => {
+  const modelOptions = models.map((m) => ({
+    value: m.id,
+    label: m.display_name,
+    group: m.group,
+  }));
+
+  const sel = (o: MetabotModelOption) => _.pick(o, ["value", "label"]);
+  // group model options if needed
+  return _.every(modelOptions, (o) => !o.group)
+    ? modelOptions.map(sel)
+    : _.map(
+        _.groupBy(modelOptions, (o) => o.group ?? t`Other`),
+        (items, group) => ({ group, items: items.map(sel) }),
+      );
+};

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/index.ts
@@ -1,6 +1,4 @@
-export {
-  AIProviderConfigurationForm,
-  useAIProviderConfigurationContext,
-} from "./AIProviderConfigurationForm";
+export { useAIProviderConfigurationContext } from "./AIProviderConfigurationContext";
+export { AIProviderConfigurationForm } from "./AIProviderConfigurationForm";
 export { getProviderOptions, parseProviderAndModel } from "./utils";
 export type { MetabotApiKeyProvider } from "./utils";

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -1,4 +1,4 @@
-import type { MetabotProvider } from "metabase-types/api";
+import type { MetabotProvider, SettingDefinition } from "metabase-types/api";
 
 type ApiKeylessProviders = "metabase";
 type ApiKeyProviders = Exclude<MetabotProvider, ApiKeylessProviders>;
@@ -71,19 +71,13 @@ export function getProviderOptions(
 
 export type MetabotApiKeyProvider = Exclude<
   MetabotProvider,
-  ApiKeylessProviders
+  "metabase" | "bedrock"
 >;
 
 export function isMetabotProvider(
   value: string | null | undefined,
 ): value is MetabotProvider {
   return !!value && value in getProviderOptions(true);
-}
-
-export function isApiKeyMetabotProvider(
-  provider: MetabotProvider,
-): provider is MetabotApiKeyProvider {
-  return "apiKey" in (getProviderOptions(true)[provider] ?? {});
 }
 
 export function isAvailableProvider(provider: MetabotProvider): boolean {
@@ -96,13 +90,9 @@ export function isAvailableProvider(provider: MetabotProvider): boolean {
 
 export const API_KEY_SETTING_BY_PROVIDER: Record<
   MetabotApiKeyProvider,
-  | "llm-anthropic-api-key"
-  | "llm-bedrock-access-key-id"
-  | "llm-openai-api-key"
-  | "llm-openrouter-api-key"
+  "llm-anthropic-api-key" | "llm-openai-api-key" | "llm-openrouter-api-key"
 > = {
   anthropic: "llm-anthropic-api-key",
-  bedrock: "llm-bedrock-access-key-id",
   openai: "llm-openai-api-key",
   openrouter: "llm-openrouter-api-key",
 };
@@ -119,3 +109,7 @@ export function parseProviderAndModel(value: string | null | undefined) {
 
   return { provider, model };
 }
+
+export const hasConfiguredSettingValue = (
+  setting: SettingDefinition | undefined,
+) => Boolean(setting?.value || setting?.is_env_setting);

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -41,6 +41,15 @@ export function getProviderOptions(
         addKeyUrl: "https://console.anthropic.com/settings/keys",
       },
     },
+    bedrock: {
+      value: "bedrock",
+      label: "Amazon Bedrock",
+      apiKey: {
+        placeholder: "AKIA...",
+        addKeyUrl:
+          "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+      },
+    },
     openai: {
       value: "openai",
       label: "OpenAI",
@@ -78,14 +87,22 @@ export function isApiKeyMetabotProvider(
 }
 
 export function isAvailableProvider(provider: MetabotProvider): boolean {
-  return provider === "anthropic" || provider === "metabase";
+  return (
+    provider === "anthropic" ||
+    provider === "bedrock" ||
+    provider === "metabase"
+  );
 }
 
 export const API_KEY_SETTING_BY_PROVIDER: Record<
   MetabotApiKeyProvider,
-  "llm-anthropic-api-key" | "llm-openai-api-key" | "llm-openrouter-api-key"
+  | "llm-anthropic-api-key"
+  | "llm-bedrock-access-key-id"
+  | "llm-openai-api-key"
+  | "llm-openrouter-api-key"
 > = {
   anthropic: "llm-anthropic-api-key",
+  bedrock: "llm-bedrock-access-key-id",
   openai: "llm-openai-api-key",
   openrouter: "llm-openrouter-api-key",
 };

--- a/mage/resources/token_scanner/token_whitelist.txt
+++ b/mage/resources/token_scanner/token_whitelist.txt
@@ -21,3 +21,10 @@ eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.invalid-signature
 
 # Used in storybook SdkError.stories.tsx
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjF9LCJwYXJhbXMiOnt9LCJleHAiOjE3NzQ2MDkyMDksImlhdCI6MTc3NDYwOTE5OX0.-S3eLFi_XZeb9ltaorP7_k52fXW_jhtb1oG-BuOVSWw
+
+# Fake AWS access keys used in Bedrock provider tests. AKIAIOSFODNN7EXAMPLE is
+# AWS's own documentation placeholder; the others are obviously synthetic fixtures.
+AKIAIOSFODNN7EXAMPLE
+AKIAOVERRIDEOVERRID1
+AKIANEWNEWNEWNEWNEW1
+AKIAOLDOLDOLDOLDOLD1

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -4,7 +4,16 @@
    [clojure.string :as str]
    [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.i18n :refer [deferred-tru tru]])
+  (:import
+   (software.amazon.awssdk.regions Region)))
+
+(set! *warn-on-reflection* true)
+
+(def known-aws-regions
+  "The set of AWS region ids known to the bundled AWS SDK, e.g. `\"us-east-1\"`.
+  Used to validate [[llm-bedrock-region]]."
+  (into #{} (map str) (Region/regions)))
 
 (defn- trimmed-string
   [value]
@@ -119,6 +128,55 @@
                              "sk-or-v1-"
                              (deferred-tru "Invalid OpenRouter API key format. Key must start with ''sk-or-v1-''."))
   :doc              false)
+
+;;; ----------------------------------------------- Amazon Bedrock ----------------------------------------------
+
+(defsetting llm-bedrock-access-key-id
+  (deferred-tru "The AWS Access Key ID for Amazon Bedrock.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-secret-access-key
+  (deferred-tru "The AWS Secret Access Key for Amazon Bedrock.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-session-token
+  (deferred-tru "The AWS Session Token for Amazon Bedrock. Only needed for temporary credentials.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defn- set-bedrock-region!
+  [new-value]
+  (let [region (trimmed-string new-value)]
+    (when (and region (not (contains? known-aws-regions region)))
+      (throw (ex-info (tru "Invalid AWS region {0}." (pr-str region)) {:status-code 400})))
+    (setting/set-value-of-type! :string :llm-bedrock-region region)))
+
+(defsetting llm-bedrock-region
+  (deferred-tru "The AWS region for Amazon Bedrock (e.g. us-east-1).")
+  :encryption  :no
+  :visibility  :settings-manager
+  :default     "us-east-1"
+  :export?     false
+  :doc         false
+  :setter      set-bedrock-region!)
+
+(defsetting llm-bedrock-configured?
+  "Whether the required AWS Bedrock credentials are configured."
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :export?    false
+  :getter     #(boolean (and (some? (llm-bedrock-access-key-id))
+                             (some? (llm-bedrock-secret-access-key))))
+  :doc        false)
 
 ;;; --------------------------------------------------- Proxy ---------------------------------------------------
 

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -1,5 +1,5 @@
 (ns metabase.llm.settings
-  "Settings for LLM integration (API keys, model defaults, provider configuration)."
+  "Settings for LLM integration (provider credentials, model defaults, provider configuration)."
   (:require
    [clojure.string :as str]
    [metabase.premium-features.core :as premium-features]
@@ -19,6 +19,11 @@
   [value]
   (when (string? value)
     (not-empty (str/trim value))))
+
+(defn- set-trimmed-string!
+  "Set a string setting to the trimmed `new-value`; blank values are stored as nil."
+  [setting-key new-value]
+  (setting/set-value-of-type! :string setting-key (trimmed-string new-value)))
 
 (defn- set-prefixed-api-key!
   [setting-key prefix deferred-message new-value]
@@ -136,21 +141,24 @@
   :sensitive?  true
   :visibility  :settings-manager
   :export?     false
-  :doc         false)
+  :doc         false
+  :setter      (partial set-trimmed-string! :llm-bedrock-access-key-id))
 
 (defsetting llm-bedrock-secret-access-key
   (deferred-tru "The AWS Secret Access Key for Amazon Bedrock.")
   :sensitive?  true
   :visibility  :settings-manager
   :export?     false
-  :doc         false)
+  :doc         false
+  :setter      (partial set-trimmed-string! :llm-bedrock-secret-access-key))
 
 (defsetting llm-bedrock-session-token
   (deferred-tru "The AWS Session Token for Amazon Bedrock. Only needed for temporary credentials.")
   :sensitive?  true
   :visibility  :settings-manager
   :export?     false
-  :doc         false)
+  :doc         false
+  :setter      (partial set-trimmed-string! :llm-bedrock-session-token))
 
 (defn- set-bedrock-region!
   [new-value]
@@ -174,8 +182,8 @@
   :visibility :public
   :setter     :none
   :export?    false
-  :getter     #(boolean (and (some? (llm-bedrock-access-key-id))
-                             (some? (llm-bedrock-secret-access-key))))
+  :getter     #(boolean (and (trimmed-string (llm-bedrock-access-key-id))
+                             (trimmed-string (llm-bedrock-secret-access-key))))
   :doc        false)
 
 ;;; --------------------------------------------------- Proxy ---------------------------------------------------

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -301,7 +301,7 @@
 (def ^:private metabot-settings-response-schema
   [:map
    [:value [:maybe :string]]
-   [:api-key-error {:optional true} [:maybe :string]]
+   [:credentials-error {:optional true} [:maybe :string]]
    [:models [:sequential llm-model-response-schema]]])
 
 (def ^:private bedrock-credentials-schema
@@ -341,10 +341,8 @@
 (def ^:private invalid-api-key-statuses
   #{401 403})
 
-(defn- invalid-api-key-error?
-  "Whether a provider api-error means the credentials were rejected (or missing).
-  Named for the `api-key-error` response field it feeds, which carries credential errors for every provider, including
-  ones like Bedrock whose credentials are not a single API key."
+(defn- invalid-credentials-error?
+  "Whether a provider api-error means the credentials were rejected (or missing)."
   [error]
   (let [status (or (:status (ex-data error))
                    (:status-code (ex-data error)))]
@@ -438,9 +436,9 @@
                      provider
                      (:models (metabot.self/list-models provider {:credentials credentials})))}
            (catch clojure.lang.ExceptionInfo e
-             (if (invalid-api-key-error? e)
+             (if (invalid-credentials-error? e)
                {:models []
-                :api-key-error (.getMessage e)}
+                :credentials-error (.getMessage e)}
                (throw e))))
          {:models []})))))
 
@@ -460,10 +458,10 @@
   []
   (provider-util/provider-and-model->outer-provider (metabot.settings/llm-metabot-provider)))
 
-(defn- throw-api-key-error!
+(defn- throw-credentials-error!
   [response]
-  (when-let [api-key-error (:api-key-error response)]
-    (throw (ex-info api-key-error
+  (when-let [credentials-error (:credentials-error response)]
+    (throw (ex-info credentials-error
                     {:status-code 400
                      :api-error true})))
   response)
@@ -563,7 +561,7 @@
                             nil)
         ;; The model listing validates the request credentials before anything is saved.
         response          (-> (settings-response provider credentials)
-                              throw-api-key-error!)]
+                              throw-credentials-error!)]
     (when credentials
       (save-credentials! provider credentials))
     (when model

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -475,23 +475,22 @@
   (perms/check-has-application-permission :setting)
   (settings-response (or provider (current-provider))))
 
+(def ^:private bedrock-credential-fields
+  [:access-key-id :secret-access-key :region :session-token])
+
 (defn- effective-bedrock-credentials
   "The Bedrock credentials a settings request resolves to.
 
-  Non-blank request fields are layered over the saved `llm-bedrock-*` settings.
-
-  The session token pairs with the access key it was issued for, so whenever new key material is supplied the token
-  is taken from the request — even when blank — rather than from the saved settings. That way a key rotation can't
-  leave a stale token behind, while editing an unrelated field (e.g. region) can't strand a still-valid one."
-  [{:keys [access-key-id secret-access-key region session-token]}]
-  (let [new-access-key (non-blank-string access-key-id)
-        new-secret     (non-blank-string secret-access-key)
-        new-region     (non-blank-string region)]
-    (cond-> (metabot.settings/configured-provider-credentials "bedrock")
-      new-access-key (assoc :access-key-id new-access-key)
-      new-secret     (assoc :secret-access-key new-secret)
-      new-region     (assoc :region new-region)
-      (or new-access-key new-secret) (assoc :session-token (non-blank-string session-token)))))
+  Each field follows the same presence contract as the top-level `:credentials` key: a field present in the request
+  replaces the saved `llm-bedrock-*` value, while an absent field keeps the saved value. Nil or blank means an
+  explicit clear. So an admin can blank a stale session token without re-entering the keys, and a region-only edit
+  doesn't touch anything else."
+  [supplied-creds]
+  (reduce (fn [creds field]
+            (cond-> creds
+              (contains? supplied-creds field) (assoc field (non-blank-string (get supplied-creds field)))))
+          (metabot.settings/configured-provider-credentials "bedrock")
+          bedrock-credential-fields))
 
 (defn- request-credentials
   "The credentials override carried by a `PUT /api/metabot/settings` request body as a provider credentials map.
@@ -499,9 +498,9 @@
   nil when the request does not touch credentials for `provider`.
 
   An explicitly nil credential field in the body — `:api-key` for API-key providers, `:credentials` for Bedrock —
-  resolves to a credentials map whose key material is nil: an explicit clear. (Blank *fields inside* the Bedrock
-  credentials map are not a clear; they mean \"keep the saved value\", so e.g. a region-only edit can't wipe the
-  keys.) Throws a 400 when non-nil Bedrock credentials don't resolve to a complete set."
+  resolves to a credentials map whose key material is nil: an explicit clear. Fields *inside* the Bedrock credentials
+  map follow the same presence contract (see [[effective-bedrock-credentials]]). Throws a 400 when non-nil Bedrock
+  credentials don't resolve to a complete set."
   [provider {:keys [api-key credentials] :as body}]
   (if (= provider "bedrock")
     (when (contains? body :credentials)
@@ -522,13 +521,14 @@
 
 (defn- save-bedrock-credentials!
   "Persist a Bedrock credentials map resolved by [[request-credentials]]; nil key material clears those settings.
-  The region is written only when present, so an explicit credentials clear leaves it in place for the next connect."
-  [{:keys [access-key-id secret-access-key region session-token]}]
+  The region is written only when the map carries it — a nil region resets the setting to its default, while a
+  top-level credentials clear (whose map has no `:region` key) leaves it in place for the next connect."
+  [{:keys [access-key-id secret-access-key session-token] :as credentials}]
   (setting/set! :llm-bedrock-access-key-id access-key-id)
   (setting/set! :llm-bedrock-secret-access-key secret-access-key)
   (setting/set! :llm-bedrock-session-token session-token)
-  (when region
-    (setting/set! :llm-bedrock-region region)))
+  (when (contains? credentials :region)
+    (setting/set! :llm-bedrock-region (:region credentials))))
 
 (defn- save-credentials!
   "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched."

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -303,16 +303,25 @@
    [:api-key-error {:optional true} [:maybe :string]]
    [:models [:sequential llm-model-response-schema]]])
 
+(def ^:private bedrock-credentials-schema
+  [:map
+   [:access-key-id     {:optional true} [:maybe :string]]
+   [:secret-access-key {:optional true} [:maybe :string]]
+   [:region            {:optional true} [:maybe :string]]
+   [:session-token     {:optional true} [:maybe :string]]])
+
 (def ^:private metabot-settings-request-schema
   [:map
    [:provider metabot-provider-schema]
    [:model {:optional true} [:maybe :string]]
-   [:api-key {:optional true} [:maybe :string]]])
+   [:api-key {:optional true} [:maybe :string]]
+   [:credentials {:optional true} [:maybe bedrock-credentials-schema]]])
 
 (defn- provider-api-key-setting-key
   [provider]
   (case provider
     "anthropic"  :llm-anthropic-api-key
+    "bedrock"    :llm-bedrock-access-key-id
     "openai"     :llm-openai-api-key
     "openrouter" :llm-openrouter-api-key))
 
@@ -359,6 +368,13 @@
                  (map title-case-token)
                  (str/join " ")))))
 
+(defn- bedrock-model-group
+  [{:keys [id]}]
+  (cond
+    (str/starts-with? id "anthropic.") "Anthropic"
+    (str/starts-with? id "openai.")    "OpenAI"
+    :else                              nil))
+
 (defn- openrouter-model-group
   [{:keys [display_name id]}]
   (or (some-> display_name
@@ -373,6 +389,7 @@
   [provider model]
   (case provider
     "anthropic"  (assoc model :group (anthropic-model-group model))
+    "bedrock"    (assoc model :group (bedrock-model-group model))
     "openrouter" (assoc model :group (openrouter-model-group model))
     model))
 
@@ -390,7 +407,7 @@
                            (map normalize-metabase-model models)
                            models)
         decorated-models (map #(decorate-provider-model provider %) models)]
-    (if (contains? #{"anthropic" "openrouter"} provider)
+    (if (contains? #{"anthropic" "bedrock" "openrouter"} provider)
       (let [grouped-models (group-by :group decorated-models)]
         (->> grouped-models
              keys
@@ -455,6 +472,25 @@
   (perms/check-has-application-permission :setting)
   (settings-response (or provider (current-provider))))
 
+(defn- save-bedrock-credentials!
+  "Persist AWS Bedrock credentials from a settings request.
+
+  Blank/omitted access key, secret, and region leave the existing values untouched. The session token pairs with the
+  access key it was issued for, so it is rewritten only when new key material is supplied — that way editing an
+  unrelated field (e.g. region) can't strand a still-valid token, and a key rotation can't leave a stale token behind."
+  [{:keys [access-key-id secret-access-key region session-token]}]
+  (let [new-access-key (non-blank-string access-key-id)
+        new-secret     (non-blank-string secret-access-key)
+        new-region     (non-blank-string region)]
+    (when new-access-key
+      (setting/set! :llm-bedrock-access-key-id new-access-key))
+    (when new-secret
+      (setting/set! :llm-bedrock-secret-access-key new-secret))
+    (when new-region
+      (setting/set! :llm-bedrock-region new-region))
+    (when (or new-access-key new-secret)
+      (setting/set! :llm-bedrock-session-token (non-blank-string session-token)))))
+
 (api.macros/defendpoint :put "/settings"
   :- metabot-settings-response-schema
   "Update the Metabot provider API key and/or model setting and return the refreshed settings payload."
@@ -462,26 +498,30 @@
    _query-params
    body :- metabot-settings-request-schema]
   (perms/check-has-application-permission :setting)
-  (let [{:keys [provider api-key] request-model :model} body
-        current-provider (current-setting-provider)
+  (let [{:keys [provider api-key credentials] request-model :model} body
+        current-provider  (current-setting-provider)
         provider-changed? (not= current-provider provider)
-        model (cond
-                (non-blank-string request-model)
-                (effective-provider-model provider request-model)
+        model             (cond
+                            (non-blank-string request-model)
+                            (effective-provider-model provider request-model)
 
-                provider-changed?
-                (or (effective-provider-model provider request-model)
-                    (metabot.settings/default-model-for-provider provider))
+                            provider-changed?
+                            (or (effective-provider-model provider request-model)
+                                (metabot.settings/default-model-for-provider provider))
 
-                :else
-                nil)
-        response (-> (settings-response provider api-key)
-                     throw-api-key-error!)]
-    (when (contains? body :api-key)
-      (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))
-    (when model
-      (setting/set! :llm-metabot-provider (str provider "/" model)))
-    (assoc response :value (metabot.settings/llm-metabot-provider))))
+                            :else
+                            nil)]
+    ;; FIXME Bedrock credentials are saved before building the response so the model listing below
+    ;; validates against them.
+    (when (and (= provider "bedrock") credentials)
+      (save-bedrock-credentials! credentials))
+    (let [response (-> (settings-response provider api-key)
+                       throw-api-key-error!)]
+      (when (and (not= provider "bedrock") (contains? body :api-key))
+        (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))
+      (when model
+        (setting/set! :llm-metabot-provider (str provider "/" model)))
+      (assoc response :value (metabot.settings/llm-metabot-provider)))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/metabot` routes."

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -35,6 +35,7 @@
    [metabase.settings.core :as setting]
    [metabase.slackbot.api]
    [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -321,7 +322,6 @@
   [provider]
   (case provider
     "anthropic"  :llm-anthropic-api-key
-    "bedrock"    :llm-bedrock-access-key-id
     "openai"     :llm-openai-api-key
     "openrouter" :llm-openrouter-api-key))
 
@@ -342,6 +342,9 @@
   #{401 403})
 
 (defn- invalid-api-key-error?
+  "Whether a provider api-error means the credentials were rejected (or missing).
+  Named for the `api-key-error` response field it feeds, which carries credential errors for every provider, including
+  ones like Bedrock whose credentials are not a single API key."
   [error]
   (let [status (or (:status (ex-data error))
                    (:status-code (ex-data error)))]
@@ -417,21 +420,23 @@
       (vec decorated-models))))
 
 (defn- provider-models-response
+  "List a provider's models.
+  Validate against `credentials-override` when provided and the provider's saved credentials otherwise. The shape of
+  the credentials map varies by provider. See [[metabot.settings/configured-provider-credentials]]."
   ([provider]
    (provider-models-response provider nil))
-  ([provider api-key-override]
+  ([provider credentials-override]
    (if (= provider provider-util/metabase-provider-prefix)
      {:models (decorate-provider-models
                provider
                (:models (metabot.self/list-models "anthropic" {:ai-proxy? true})))}
-     (let [effective-api-key (or (non-blank-string api-key-override)
-                                 (non-blank-string
-                                  (metabot.settings/configured-provider-api-key provider)))]
-       (if (and provider effective-api-key)
+     (let [credentials (or credentials-override
+                           (metabot.settings/configured-provider-credentials provider))]
+       (if (and provider (metabot.settings/provider-credentials-complete? provider credentials))
          (try
            {:models (decorate-provider-models
                      provider
-                     (:models (metabot.self/list-models provider {:api-key effective-api-key})))}
+                     (:models (metabot.self/list-models provider {:credentials credentials})))}
            (catch clojure.lang.ExceptionInfo e
              (if (invalid-api-key-error? e)
                {:models []
@@ -442,10 +447,10 @@
 (defn- settings-response
   ([provider]
    (settings-response provider nil))
-  ([provider api-key-override]
+  ([provider credentials-override]
    (merge
     {:value (metabot.settings/llm-metabot-provider)}
-    (provider-models-response provider api-key-override))))
+    (provider-models-response provider credentials-override))))
 
 (defn- current-provider
   []
@@ -465,40 +470,85 @@
 
 (api.macros/defendpoint :get "/settings"
   :- metabot-settings-response-schema
-  "Return available models for a provider using its configured API key."
+  "Return available models for a provider using its configured credentials."
   [_route-params
    {:keys [provider]} :- [:map
                           [:provider {:optional true} metabot-provider-schema]]]
   (perms/check-has-application-permission :setting)
   (settings-response (or provider (current-provider))))
 
-(defn- save-bedrock-credentials!
-  "Persist AWS Bedrock credentials from a settings request.
+(defn- effective-bedrock-credentials
+  "The Bedrock credentials a settings request resolves to.
 
-  Blank/omitted access key, secret, and region leave the existing values untouched. The session token pairs with the
-  access key it was issued for, so it is rewritten only when new key material is supplied — that way editing an
-  unrelated field (e.g. region) can't strand a still-valid token, and a key rotation can't leave a stale token behind."
+  Non-blank request fields are layered over the saved `llm-bedrock-*` settings.
+
+  The session token pairs with the access key it was issued for, so whenever new key material is supplied the token
+  is taken from the request — even when blank — rather than from the saved settings. That way a key rotation can't
+  leave a stale token behind, while editing an unrelated field (e.g. region) can't strand a still-valid one."
   [{:keys [access-key-id secret-access-key region session-token]}]
   (let [new-access-key (non-blank-string access-key-id)
         new-secret     (non-blank-string secret-access-key)
         new-region     (non-blank-string region)]
-    (when new-access-key
-      (setting/set! :llm-bedrock-access-key-id new-access-key))
-    (when new-secret
-      (setting/set! :llm-bedrock-secret-access-key new-secret))
-    (when new-region
-      (setting/set! :llm-bedrock-region new-region))
-    (when (or new-access-key new-secret)
-      (setting/set! :llm-bedrock-session-token (non-blank-string session-token)))))
+    (cond-> (metabot.settings/configured-provider-credentials "bedrock")
+      new-access-key (assoc :access-key-id new-access-key)
+      new-secret     (assoc :secret-access-key new-secret)
+      new-region     (assoc :region new-region)
+      (or new-access-key new-secret) (assoc :session-token (non-blank-string session-token)))))
+
+(defn- request-credentials
+  "The credentials override carried by a `PUT /api/metabot/settings` request body as a provider credentials map.
+
+  nil when the request does not touch credentials for `provider`.
+
+  An explicitly nil credential field in the body — `:api-key` for API-key providers, `:credentials` for Bedrock —
+  resolves to a credentials map whose key material is nil: an explicit clear. (Blank *fields inside* the Bedrock
+  credentials map are not a clear; they mean \"keep the saved value\", so e.g. a region-only edit can't wipe the
+  keys.) Throws a 400 when non-nil Bedrock credentials don't resolve to a complete set."
+  [provider {:keys [api-key credentials] :as body}]
+  (if (= provider "bedrock")
+    (when (contains? body :credentials)
+      (if (nil? credentials)
+        {:access-key-id     nil
+         :secret-access-key nil
+         :session-token     nil}
+        (let [creds (effective-bedrock-credentials credentials)]
+          (when-not (metabot.settings/provider-credentials-complete? provider creds)
+            (throw (ex-info (tru "AWS Bedrock credentials are incomplete.")
+                            {:status-code  400
+                             :api-error    true
+                             :missing-keys (vec (remove #(non-blank-string (get creds %))
+                                                        [:access-key-id :secret-access-key]))})))
+          creds)))
+    (when (contains? body :api-key)
+      {:api-key (non-blank-string api-key)})))
+
+(defn- save-bedrock-credentials!
+  "Persist a Bedrock credentials map resolved by [[request-credentials]]; nil key material clears those settings.
+  The region is written only when present, so an explicit credentials clear leaves it in place for the next connect."
+  [{:keys [access-key-id secret-access-key region session-token]}]
+  (setting/set! :llm-bedrock-access-key-id access-key-id)
+  (setting/set! :llm-bedrock-secret-access-key secret-access-key)
+  (setting/set! :llm-bedrock-session-token session-token)
+  (when region
+    (setting/set! :llm-bedrock-region region)))
+
+(defn- save-credentials!
+  "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched."
+  [provider credentials]
+  (when credentials
+    (if (= provider "bedrock")
+      (save-bedrock-credentials! credentials)
+      (setting/set! (provider-api-key-setting-key provider) (:api-key credentials)))))
 
 (api.macros/defendpoint :put "/settings"
   :- metabot-settings-response-schema
-  "Update the Metabot provider API key and/or model setting and return the refreshed settings payload."
+  "Update the Metabot provider credentials and/or model setting and return the refreshed settings payload."
   [_route-params
    _query-params
    body :- metabot-settings-request-schema]
   (perms/check-has-application-permission :setting)
-  (let [{:keys [provider api-key credentials] request-model :model} body
+  (let [{:keys [provider] request-model :model} body
+        credentials       (request-credentials provider body)
         current-provider  (current-setting-provider)
         provider-changed? (not= current-provider provider)
         model             (cond
@@ -510,18 +560,15 @@
                                 (metabot.settings/default-model-for-provider provider))
 
                             :else
-                            nil)]
-    ;; FIXME Bedrock credentials are saved before building the response so the model listing below
-    ;; validates against them.
-    (when (and (= provider "bedrock") credentials)
-      (save-bedrock-credentials! credentials))
-    (let [response (-> (settings-response provider api-key)
-                       throw-api-key-error!)]
-      (when (and (not= provider "bedrock") (contains? body :api-key))
-        (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))
-      (when model
-        (setting/set! :llm-metabot-provider (str provider "/" model)))
-      (assoc response :value (metabot.settings/llm-metabot-provider)))))
+                            nil)
+        ;; The model listing validates the request credentials before anything is saved.
+        response          (-> (settings-response provider credentials)
+                              throw-api-key-error!)]
+    (when credentials
+      (save-credentials! provider credentials))
+    (when model
+      (setting/set! :llm-metabot-provider (str provider "/" model)))
+    (assoc response :value (metabot.settings/llm-metabot-provider))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/metabot` routes."

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -507,7 +507,8 @@
       (if (nil? credentials)
         {:access-key-id     nil
          :secret-access-key nil
-         :session-token     nil}
+         :session-token     nil
+         :region            nil}
         (let [creds (effective-bedrock-credentials credentials)]
           (when-not (metabot.settings/provider-credentials-complete? provider creds)
             (throw (ex-info (tru "AWS Bedrock credentials are incomplete.")
@@ -521,8 +522,9 @@
 
 (defn- save-bedrock-credentials!
   "Persist a Bedrock credentials map resolved by [[request-credentials]]; nil key material clears those settings.
-  The region is written only when the map carries it — a nil region resets the setting to its default, while a
-  top-level credentials clear (whose map has no `:region` key) leaves it in place for the next connect."
+  The region is written only when the map carries it — a nil region resets the setting to its default. A top-level
+  credentials clear (disconnect) carries `:region nil`, so it resets the region too; a field-level edit that omits
+  `:region` leaves the saved value in place."
   [{:keys [access-key-id secret-access-key session-token] :as credentials}]
   (setting/set! :llm-bedrock-access-key-id access-key-id)
   (setting/set! :llm-bedrock-secret-access-key secret-access-key)

--- a/src/metabase/metabot/example_question_generator.clj
+++ b/src/metabase/metabot/example_question_generator.clj
@@ -97,12 +97,9 @@
 (def ^:private temperature 0.3)
 
 (def ^:private max-tokens
-  "Output-token ceiling for a single generation. The answer itself is tiny (a
-  handful of short questions), but reasoning models (e.g. Bedrock gpt-oss) spend
-  output tokens reasoning *before* emitting the forced structured_output tool
-  call, so the cap must leave room for that or the call returns no tool call.
-  Non-reasoning providers stop well under this, so the higher ceiling costs them
-  nothing."
+  "Output-token ceiling for a single generation. The answer itself is tiny, but reasoning models spend output tokens
+  reasoning *before* emitting the forced structured_output tool call, so the cap must leave room for that or the call
+  returns no tool call.  Non-reasoning providers stop well under this, so the higher ceiling costs them nothing."
   2048)
 
 (defn- call-llm

--- a/src/metabase/metabot/example_question_generator.clj
+++ b/src/metabase/metabot/example_question_generator.clj
@@ -96,6 +96,15 @@
 
 (def ^:private temperature 0.3)
 
+(def ^:private max-tokens
+  "Output-token ceiling for a single generation. The answer itself is tiny (a
+  handful of short questions), but reasoning models (e.g. Bedrock gpt-oss) spend
+  output tokens reasoning *before* emitting the forced structured_output tool
+  call, so the cap must leave room for that or the call returns no tool call.
+  Non-reasoning providers stop well under this, so the higher ceiling costs them
+  nothing."
+  2048)
+
 (defn- call-llm
   "Make a structured LLM call for example question generation.
   Delegates to the shared self/call-llm-structured infrastructure which provides
@@ -106,7 +115,7 @@
    [{:role "user" :content rendered-prompt}]
    questions-json-schema
    temperature
-   300
+   max-tokens
    {:request-id (str (random-uuid))
     ;; example_question_generation_batch was the name of the old ai-service api endpoint
     :source     "example_question_generation_batch"

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -54,8 +54,9 @@
      :ai-proxy?  (provider-util/metabase-provider? s)}))
 
 (defn list-models
-  "List available models for a provider using its configured API key,
-  or an override API key when provided."
+  "List available models for a provider using its configured credentials, or `:credentials` in `opts`.
+  The shape of the credentials map varies by provider: API-key providers take `{:api-key ...}`, while Bedrock takes
+  AWS key material and region (see [[bedrock/list-models]])."
   ([provider]
    ((resolve-model-lister provider)))
   ([provider opts]

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -14,6 +14,7 @@
    [metabase.analytics.core :as analytics.core]
    [metabase.api.common :as api]
    [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.self.bedrock :as bedrock]
    [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.openai :as openai]
@@ -29,6 +30,7 @@
   ;; a `case` inside of function instead of a map so that with-redefs work well
   (case provider
     "anthropic"  claude/claude
+    "bedrock"    bedrock/bedrock
     "openai"     openai/openai
     "openrouter" openrouter/openrouter
     (throw (ex-info (str "Unknown LLM provider: " provider)
@@ -38,6 +40,7 @@
   ;; a `case` inside of function instead of a map so that with-redefs work well
   (case provider
     "anthropic"  claude/list-models
+    "bedrock"    bedrock/list-models
     "openai"     openai/list-models
     "openrouter" openrouter/list-models
     (throw (ex-info (str "Unknown LLM provider: " provider)

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -23,6 +23,7 @@
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
    [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -99,26 +100,28 @@
     (throw (invalid-region-ex region)))
   region)
 
-(defn- credentials
-  "AWS credentials and region from the `llm-bedrock-*` settings, or nil when not configured."
+(defn- settings-credentials
+  "AWS credentials and region from the `llm-bedrock-*` settings."
   []
-  (let [access-key-id     (not-empty (llm/llm-bedrock-access-key-id))
-        secret-access-key (not-empty (llm/llm-bedrock-secret-access-key))
-        session-token     (not-empty (llm/llm-bedrock-session-token))
-        region            (-> (or (not-empty (llm/llm-bedrock-region))
-                                  "us-east-1")
-                              validate-region)]
-    (when (and access-key-id secret-access-key)
-      {:access-key-id     access-key-id
-       :secret-access-key secret-access-key
-       :session-token     session-token
-       :region            region})))
+  {:access-key-id     (not-empty (llm/llm-bedrock-access-key-id))
+   :secret-access-key (not-empty (llm/llm-bedrock-secret-access-key))
+   :session-token     (not-empty (llm/llm-bedrock-session-token))
+   :region            (not-empty (llm/llm-bedrock-region))})
 
 (defn- missing-credentials-ex []
   (ex-info (tru "AWS Bedrock credentials are not configured")
            {:api-error   true
             :error-code  :api-key-missing
             :status-code 403}))
+
+(defn- ensure-credentials
+  "Validate a Bedrock credentials map, falling back to [[settings-credentials]] when nil.
+  Throws when the access key pair is incomplete or the region is unknown; the region defaults to us-east-1."
+  [credentials]
+  (let [creds (or credentials (settings-credentials))]
+    (when-not (metabot.settings/provider-credentials-complete? "bedrock" creds)
+      (throw (missing-credentials-ex)))
+    (update creds :region #(validate-region (or (not-empty %) "us-east-1")))))
 
 (defn- bedrock-error-msg
   "Canonical, status-specific Bedrock error message."
@@ -134,9 +137,10 @@
 
 (defn- bedrock-request
   "Perform a SigV4-signed HTTP request against the Bedrock mantle endpoint.
-  `headers` are extra *unsigned* headers (e.g. `anthropic-version`)."
-  [{:keys [method path body as headers]}]
-  (let [{:keys [region] :as creds} (or (credentials) (throw (missing-credentials-ex)))
+  `headers` are extra *unsigned* headers (e.g. `anthropic-version`). `credentials` is an optional
+  AWS credentials map; when nil, the `llm-bedrock-*` settings are used."
+  [{:keys [method path body as headers credentials]}]
+  (let [{:keys [region] :as creds} (ensure-credentials credentials)
         url          (str "https://bedrock-mantle." region ".api.aws" path)
         content-type (when body "application/json")
         sig-headers  (signed-headers (merge creds {:method       method
@@ -153,30 +157,32 @@
 
 (defn- list-all-models
   "Fetch the full mantle model catalog (`GET /v1/models`), every vendor included."
-  []
+  [credentials]
   (try
-    (let [res (bedrock-request {:method :get :path "/v1/models" :as :json})]
+    (let [res (bedrock-request {:method :get :path "/v1/models" :as :json :credentials credentials})]
       (get-in res [:body :data]))
     (catch Exception e
       (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))
 
 (defn- supported-model?
   "Whether a catalog model is supported by this adapter: Anthropic and OpenAI models only.
+  Excludes `anthropic.*fable*` pending further testing.
   Excludes `openai.gpt-oss*`, which appear in the catalog but are not invokable through the mantle /openai/v1 routes."
   [{:keys [id]}]
   (boolean
    (and id
-        (or (str/starts-with? id "anthropic.")
+        (or (and (str/starts-with? id "anthropic.")
+                 (not (str/includes? id "fable")))
             (and (str/starts-with? id "openai.")
                  (not (str/starts-with? id "openai.gpt-oss")))))))
 
 (defn list-models
   "List the Bedrock models supported by this adapter (see [[supported-model?]]).
-  Accepts an (ignored) opts map for signature parity with the other providers' model listers.  Bedrock auth always
-  comes from the `llm-bedrock-*` settings."
+  No-arg uses the `llm-bedrock-*` settings. The opts map supports `:credentials`, a map of `:access-key-id`,
+  `:secret-access-key`, `:region`, and (for temporary credentials) `:session-token`."
   ([] (list-models {}))
-  ([_opts]
-   {:models (->> (list-all-models)
+  ([{:keys [credentials]}]
+   {:models (->> (list-all-models credentials)
                  (filter supported-model?)
                  (sort-by :id)
                  (mapv (fn [{:keys [id]}]

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -16,7 +16,6 @@
   Requests are authenticated with AWS Signature Version 4 computed from the `llm-bedrock-*` settings:
   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html"
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.llm.settings :as llm]
    [metabase.metabot.self.claude :as claude]
@@ -114,6 +113,11 @@
             :error-code  :api-key-missing
             :status-code 403}))
 
+(defn- ai-proxy-unsupported-ex []
+  (ex-info (tru "AI proxy is not supported for AWS Bedrock")
+           {:api-error  true
+            :error-code :proxy-unsupported}))
+
 (defn- ensure-credentials
   "Validate a Bedrock credentials map, falling back to [[settings-credentials]] when nil.
   Throws when the access key pair is incomplete or the region is unknown; the region defaults to us-east-1."
@@ -138,18 +142,25 @@
 (defn- bedrock-request
   "Perform a SigV4-signed HTTP request against the Bedrock mantle endpoint.
   `headers` are extra *unsigned* headers (e.g. `anthropic-version`). `credentials` is an optional
-  AWS credentials map; when nil, the `llm-bedrock-*` settings are used."
-  [{:keys [method path body as headers credentials]}]
+  AWS credentials map; when nil, the `llm-bedrock-*` settings are used. `ai-proxy?` is accepted
+  for parity with the other provider adapters but is not supported: throws when true."
+  [{:keys [method path body as headers credentials ai-proxy?]}]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
   (let [{:keys [region] :as creds} (ensure-credentials credentials)
-        url          (str "https://bedrock-mantle." region ".api.aws" path)
+        base-url     (str "https://bedrock-mantle." region ".api.aws")
         content-type (when body "application/json")
         sig-headers  (signed-headers (merge creds {:method       method
-                                                   :url          url
+                                                   :url          (str base-url path)
                                                    :body         body
-                                                   :content-type content-type}))]
-    (http/request (cond-> {:method  method
-                           :url     url
-                           :headers (merge headers sig-headers)}
+                                                   :content-type content-type}))
+        auth         (core/resolve-auth "bedrock" "AWS Bedrock"
+                                        {:url base-url :headers sig-headers}
+                                        ai-proxy?)]
+    (core/request auth
+                  (cond-> {:method  method
+                           :url     path
+                           :headers headers}
                     as   (assoc :as as)
                     body (assoc :body body)))))
 
@@ -157,9 +168,13 @@
 
 (defn- list-all-models
   "Fetch the full mantle model catalog (`GET /v1/models`), every vendor included."
-  [credentials]
+  [{:keys [credentials ai-proxy?]}]
   (try
-    (let [res (bedrock-request {:method :get :path "/v1/models" :as :json :credentials credentials})]
+    (let [res (bedrock-request {:method      :get
+                                :path        "/v1/models"
+                                :as          :json
+                                :credentials credentials
+                                :ai-proxy?   ai-proxy?})]
       (get-in res [:body :data]))
     (catch Exception e
       (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))
@@ -179,10 +194,11 @@
 (defn list-models
   "List the Bedrock models supported by this adapter (see [[supported-model?]]).
   No-arg uses the `llm-bedrock-*` settings. The opts map supports `:credentials`, a map of `:access-key-id`,
-  `:secret-access-key`, `:region`, and (for temporary credentials) `:session-token`."
+  `:secret-access-key`, `:region`, and (for temporary credentials) `:session-token`, plus `:ai-proxy?`,
+  which is not supported for Bedrock and throws when true."
   ([] (list-models {}))
-  ([{:keys [credentials]}]
-   {:models (->> (list-all-models credentials)
+  ([opts]
+   {:models (->> (list-all-models opts)
                  (filter supported-model?)
                  (sort-by :id)
                  (mapv (fn [{:keys [id]}]
@@ -215,8 +231,9 @@
   (dissoc body :cache_control))
 
 (mu/defn bedrock-raw
-  "Perform a streaming request to the Bedrock mantle endpoint."
-  [{:keys [model input tools] :as opts
+  "Perform a streaming request to the Bedrock mantle endpoint.
+  `:ai-proxy?` is not supported for Bedrock and throws when true."
+  [{:keys [model input tools ai-proxy?] :as opts
     :or   {model default-model}} :- core/LLMRequestOpts]
   (let [opts   (assoc opts :model model)
         family (model->family model)
@@ -233,11 +250,12 @@
                       :msg-count  (count input)
                       :tool-count (count tools)}
       (try
-        (let [response (bedrock-request {:method  :post
-                                         :path    path
-                                         :as      :stream
-                                         :headers headers
-                                         :body    (json/encode req)})]
+        (let [response (bedrock-request {:method    :post
+                                         :path      path
+                                         :as        :stream
+                                         :headers   headers
+                                         :body      (json/encode req)
+                                         :ai-proxy? ai-proxy?})]
           (-> (core/sse-reducible (:body response))
               (debug/capture-stream {:provider "bedrock"
                                      :model    model

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -1,0 +1,272 @@
+(ns metabase.metabot.self.bedrock
+  "Amazon Bedrock LLM provider adapter.
+
+  Talks to the Bedrock \"mantle\" endpoint (`https://bedrock-mantle.{region}.api.aws`), which
+  exposes vendor-compatible API surfaces for models hosted on Bedrock:
+
+    - `GET  /v1/models`              — OpenAI-style catalog of every mantle model
+    - `POST /anthropic/v1/messages`  — Anthropic Messages API, for `anthropic.*` models
+    - `POST /openai/v1/responses`    — OpenAI Responses API, for `openai.*` models
+
+  Because these are the same wire protocols the direct Anthropic/OpenAI adapters speak, this
+  namespace reuses [[claude/claude-request-body]] + [[claude/claude->aisdk-chunks-xf]] and
+  [[openai/openai-request-body]] + [[openai/openai->aisdk-chunks-xf]]; the vendor prefix on the
+  model id (e.g. `anthropic.claude-haiku-4-5`, `openai.gpt-5.5`) selects the API family.
+
+  Requests are authenticated with AWS Signature Version 4 computed from the `llm-bedrock-*` settings:
+  https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html"
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [buddy.core.mac :as mac]
+   [clj-http.client :as http]
+   [clojure.string :as str]
+   [metabase.llm.settings :as llm]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.openai :as openai]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
+   [metabase.util.malli :as mu]
+   [metabase.util.o11y :refer [with-span]])
+  (:import
+   (java.time ZoneOffset ZonedDateTime)
+   (java.time.format DateTimeFormatter)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------ AWS Signature Version 4 ------------------------------------------
+
+(def ^:private ^DateTimeFormatter amz-date-formatter
+  "SigV4 timestamp format (ISO 8601 basic), e.g. `20260609T120000Z`."
+  (.withZone (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'") ZoneOffset/UTC))
+
+(defn- hmac-sha256 ^bytes [key ^String s]
+  (mac/hash s {:key key :alg :hmac+sha256}))
+
+(defn- sha256-hex ^String [^String s]
+  (codecs/bytes->hex (buddy-hash/sha256 (or s ""))))
+
+(defn- signing-key
+  "Derive the SigV4 signing key: HMAC chain over date, region, and service, rooted at the secret."
+  ^bytes [secret-access-key date-stamp region service]
+  (-> (str "AWS4" secret-access-key)
+      (hmac-sha256 date-stamp)
+      (hmac-sha256 region)
+      (hmac-sha256 service)
+      (hmac-sha256 "aws4_request")))
+
+(defn sigv4-headers
+  "Compute AWS SigV4 request headers for a Bedrock mantle request.
+
+  Returns the map of headers to send: `host`, `x-amz-date`, `authorization`, plus `content-type`
+  and `x-amz-security-token` when given. Every returned header except `authorization` itself is
+  signed, so callers must send them byte-for-byte as returned (additional *unsigned* headers may
+  be added freely).
+
+  `amz-date` (a string in [[amz-date-formatter]] format) is injectable for deterministic tests;
+  it defaults to the current UTC time."
+  [{:keys [access-key-id secret-access-key session-token region service method path body content-type host amz-date]
+    :or   {service "bedrock"}}]
+  (let [amz-date     (or amz-date (.format amz-date-formatter (ZonedDateTime/now ZoneOffset/UTC)))
+        date-stamp   (subs amz-date 0 8)
+        headers      (cond-> (sorted-map "host"       host
+                                         "x-amz-date" amz-date)
+                       content-type  (assoc "content-type" content-type)
+                       session-token (assoc "x-amz-security-token" session-token))
+        signed-names (str/join ";" (keys headers))
+        canonical    (str (u/upper-case-en (name method)) "\n"
+                          path "\n"
+                          ;; canonical query string — mantle requests carry no query params
+                          "\n"
+                          (str/join (map (fn [[k v]] (str k ":" v "\n")) headers))
+                          "\n"
+                          signed-names "\n"
+                          (sha256-hex body))
+        scope        (str date-stamp "/" region "/" service "/aws4_request")
+        to-sign      (str "AWS4-HMAC-SHA256\n" amz-date "\n" scope "\n" (sha256-hex canonical))
+        signature    (-> secret-access-key
+                         (signing-key date-stamp region service)
+                         (hmac-sha256 to-sign)
+                         codecs/bytes->hex)]
+    (assoc headers
+           "authorization" (str "AWS4-HMAC-SHA256 "
+                                "Credential=" access-key-id "/" scope ", "
+                                "SignedHeaders=" signed-names ", "
+                                "Signature=" signature))))
+
+;;; ------------------------------------------------ HTTP plumbing ----------------------------------------------
+
+(defn- invalid-region-ex [region]
+  (ex-info (tru "Invalid AWS Bedrock region {0}" (pr-str region))
+           {:api-error   true
+            :error-code  :invalid-region
+            :status-code 400}))
+
+(defn- validate-region
+  "Throw if region is not a known AWS region.
+  The region becomes a host label in the mantle URL, so anything outside the AWS SDK's
+  known region set is rejected before it can be spliced in. The [[llm/llm-bedrock-region]] setter rejects
+  bad values at write time, but env-var/direct sets bypass that setter — this is the second layer."
+  [region]
+  (when-not (contains? llm/known-aws-regions region)
+    (throw (invalid-region-ex region)))
+  region)
+
+(defn- credentials
+  "AWS credentials and region from the `llm-bedrock-*` settings, or nil when not configured."
+  []
+  (let [access-key-id     (not-empty (llm/llm-bedrock-access-key-id))
+        secret-access-key (not-empty (llm/llm-bedrock-secret-access-key))
+        session-token     (not-empty (llm/llm-bedrock-session-token))
+        region            (-> (or (not-empty (llm/llm-bedrock-region))
+                                  "us-east-1")
+                              validate-region)]
+    (when (and access-key-id secret-access-key)
+      {:access-key-id     access-key-id
+       :secret-access-key secret-access-key
+       :session-token     session-token
+       :region            region})))
+
+(defn- missing-credentials-ex []
+  (ex-info (tru "AWS Bedrock credentials are not configured")
+           {:api-error   true
+            :error-code  :api-key-missing
+            :status-code 403}))
+
+(defn- bedrock-error-msg
+  "Canonical, status-specific Bedrock error message."
+  [res]
+  (let [status (long (:status res 0))]
+    (case status
+      401 (tru "AWS Bedrock rejected our credentials or request signature")
+      403 (tru "AWS Bedrock credentials lack permission for this model or action")
+      404 (tru "AWS Bedrock model or endpoint is unavailable in the configured region")
+      429 (tru "AWS Bedrock has rate limited us")
+      500 (tru "AWS Bedrock is not working but not saying why")
+      (tru "AWS Bedrock API error (HTTP {0})" status))))
+
+(defn- bedrock-request
+  "Perform a SigV4-signed HTTP request against the Bedrock mantle endpoint.
+  `headers` are extra *unsigned* headers (e.g. `anthropic-version`)."
+  [{:keys [method path body as headers]}]
+  (let [{:keys [region] :as creds} (or (credentials) (throw (missing-credentials-ex)))
+        host         (str "bedrock-mantle." region ".api.aws")
+        content-type (when body "application/json")
+        sig-headers  (sigv4-headers (merge creds {:method       method
+                                                  :path         path
+                                                  :body         body
+                                                  :content-type content-type
+                                                  :host         host}))]
+    (http/request (cond-> {:method  method
+                           :url     (str "https://" host path)
+                           :headers (merge headers sig-headers)}
+                    as   (assoc :as as)
+                    body (assoc :body body)))))
+
+;;; ------------------------------------------------ Model listing ----------------------------------------------
+
+(defn- list-all-models
+  "Fetch the full mantle model catalog (`GET /v1/models`), every vendor included."
+  []
+  (try
+    (let [res (bedrock-request {:method :get :path "/v1/models" :as :json})]
+      (get-in res [:body :data]))
+    (catch Exception e
+      (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))
+
+(defn- supported-model?
+  "Whether a catalog model is supported by this adapter: Anthropic and OpenAI models only.
+  Excludes `openai.gpt-oss*`, which appear in the catalog but are not invokable through the mantle /openai/v1 routes."
+  [{:keys [id]}]
+  (boolean
+   (and id
+        (or (str/starts-with? id "anthropic.")
+            (and (str/starts-with? id "openai.")
+                 (not (str/starts-with? id "openai.gpt-oss")))))))
+
+(defn list-models
+  "List the Bedrock models supported by this adapter (see [[supported-model?]]).
+  Accepts an (ignored) opts map for signature parity with the other providers' model listers.  Bedrock auth always
+  comes from the `llm-bedrock-*` settings."
+  ([] (list-models {}))
+  ([_opts]
+   {:models (->> (list-all-models)
+                 (filter supported-model?)
+                 (sort-by :id)
+                 (mapv (fn [{:keys [id]}]
+                         {:id id :display_name id})))}))
+
+;;; --------------------------------------------- API family dispatch -------------------------------------------
+
+(def ^:private default-model "anthropic.claude-opus-4-8")
+
+(def ^:private anthropic-version "2023-06-01")
+
+(defn- model->family
+  "Which mantle API family serves `model`, by vendor prefix: `:anthropic` or `:openai`."
+  [model]
+  (cond
+    (str/starts-with? model "anthropic.") :anthropic
+    (str/starts-with? model "openai.")    :openai
+    :else
+    (throw (ex-info (tru "Unsupported Bedrock model {0}. Only anthropic.* and openai.* models are supported." model)
+                    {:api-error  true
+                     :error-code :unsupported-model
+                     :model      model}))))
+
+(defn ->mantle-anthropic-body
+  "Adapt a canonical Anthropic Messages request body for the mantle endpoint.
+
+  Bedrock mantle rejects the top-level `cache_control` key. Content-block-level `cache_control` markers are accepted
+  and left alone."
+  [body]
+  (dissoc body :cache_control))
+
+(mu/defn bedrock-raw
+  "Perform a streaming request to the Bedrock mantle endpoint."
+  [{:keys [model input tools] :as opts
+    :or   {model default-model}} :- core/LLMRequestOpts]
+  (let [opts   (assoc opts :model model)
+        family (model->family model)
+        {:keys [path headers req]}
+        (case family
+          :anthropic {:path    "/anthropic/v1/messages"
+                      :headers {"anthropic-version" anthropic-version}
+                      :req     (->mantle-anthropic-body (claude/claude-request-body opts))}
+          :openai    {:path    "/openai/v1/responses"
+                      :req     (openai/openai-request-body opts)})]
+    (with-span :info {:name       :metabot.bedrock/request
+                      :model      model
+                      :family     family
+                      :msg-count  (count input)
+                      :tool-count (count tools)}
+      (try
+        (let [response (bedrock-request {:method  :post
+                                         :path    path
+                                         :as      :stream
+                                         :headers headers
+                                         :body    (json/encode req)})]
+          (-> (core/sse-reducible (:body response))
+              (debug/capture-stream {:provider "bedrock"
+                                     :model    model
+                                     :url      path
+                                     :request  req})))
+        (catch Exception e
+          (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))))
+
+(defn- model->aisdk-chunks-xf
+  "The SSE->AISDK translating transducer for a Bedrock model id.
+  Claude's for `anthropic.*` models, OpenAI's for `openai.*` models."
+  [model]
+  (case (model->family model)
+    :anthropic (claude/claude->aisdk-chunks-xf)
+    :openai    (openai/openai->aisdk-chunks-xf)))
+
+(defn bedrock
+  "Call AWS Bedrock (mantle endpoint), return AISDK stream."
+  [& [{:keys [model] :or {model default-model}} :as args]]
+  (let [raw (apply bedrock-raw args)]
+    (eduction (model->aisdk-chunks-xf model) raw)))

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -16,9 +16,6 @@
   Requests are authenticated with AWS Signature Version 4 computed from the `llm-bedrock-*` settings:
   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html"
   (:require
-   [buddy.core.codecs :as codecs]
-   [buddy.core.hash :as buddy-hash]
-   [buddy.core.mac :as mac]
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.llm.settings :as llm]
@@ -32,70 +29,57 @@
    [metabase.util.malli :as mu]
    [metabase.util.o11y :refer [with-span]])
   (:import
-   (java.time ZoneOffset ZonedDateTime)
-   (java.time.format DateTimeFormatter)))
+   (java.net URI)
+   (java.util.function Consumer)
+   (software.amazon.awssdk.http ContentStreamProvider SdkHttpMethod SdkHttpRequest SdkHttpRequest$Builder)
+   (software.amazon.awssdk.http.auth.aws.signer AwsV4HttpSigner)
+   (software.amazon.awssdk.http.auth.spi.signer SignRequest$Builder SignedRequest)
+   (software.amazon.awssdk.identity.spi AwsCredentialsIdentity AwsSessionCredentialsIdentity)))
 
 (set! *warn-on-reflection* true)
 
 ;;; ------------------------------------------ AWS Signature Version 4 ------------------------------------------
 
-(def ^:private ^DateTimeFormatter amz-date-formatter
-  "SigV4 timestamp format (ISO 8601 basic), e.g. `20260609T120000Z`."
-  (.withZone (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'") ZoneOffset/UTC))
+(defn- aws-identity
+  "An AWS credentials identity, carrying the session token when one is present."
+  [{:keys [access-key-id secret-access-key session-token]}]
+  (if session-token
+    (AwsSessionCredentialsIdentity/create access-key-id secret-access-key session-token)
+    (AwsCredentialsIdentity/create access-key-id secret-access-key)))
 
-(defn- hmac-sha256 ^bytes [key ^String s]
-  (mac/hash s {:key key :alg :hmac+sha256}))
+(defn- unsigned-request
+  "The bare `SdkHttpRequest` (method, URL, content-type) the signer signs over. Host is derived from `url`."
+  ^SdkHttpRequest [{:keys [method url content-type]}]
+  (let [^SdkHttpRequest$Builder b (-> (SdkHttpRequest/builder)
+                                      (.method (SdkHttpMethod/fromValue (u/upper-case-en (name method))))
+                                      (.uri (URI/create url)))]
+    (when content-type
+      (.putHeader b "Content-Type" ^String content-type))
+    (.build b)))
 
-(defn- sha256-hex ^String [^String s]
-  (codecs/bytes->hex (buddy-hash/sha256 (or s ""))))
+(defn- signed-headers
+  "AWS SigV4 request headers for a Bedrock mantle request, computed by the AWS SDK's [[AwsV4HttpSigner]].
 
-(defn- signing-key
-  "Derive the SigV4 signing key: HMAC chain over date, region, and service, rooted at the secret."
-  ^bytes [secret-access-key date-stamp region service]
-  (-> (str "AWS4" secret-access-key)
-      (hmac-sha256 date-stamp)
-      (hmac-sha256 region)
-      (hmac-sha256 service)
-      (hmac-sha256 "aws4_request")))
-
-(defn sigv4-headers
-  "Compute AWS SigV4 request headers for a Bedrock mantle request.
-
-  Returns the map of headers to send: `host`, `x-amz-date`, `authorization`, plus `content-type`
-  and `x-amz-security-token` when given. Every returned header except `authorization` itself is
-  signed, so callers must send them byte-for-byte as returned (additional *unsigned* headers may
-  be added freely).
-
-  `amz-date` (a string in [[amz-date-formatter]] format) is injectable for deterministic tests;
-  it defaults to the current UTC time."
-  [{:keys [access-key-id secret-access-key session-token region service method path body content-type host amz-date]
-    :or   {service "bedrock"}}]
-  (let [amz-date     (or amz-date (.format amz-date-formatter (ZonedDateTime/now ZoneOffset/UTC)))
-        date-stamp   (subs amz-date 0 8)
-        headers      (cond-> (sorted-map "host"       host
-                                         "x-amz-date" amz-date)
-                       content-type  (assoc "content-type" content-type)
-                       session-token (assoc "x-amz-security-token" session-token))
-        signed-names (str/join ";" (keys headers))
-        canonical    (str (u/upper-case-en (name method)) "\n"
-                          path "\n"
-                          ;; canonical query string — mantle requests carry no query params
-                          "\n"
-                          (str/join (map (fn [[k v]] (str k ":" v "\n")) headers))
-                          "\n"
-                          signed-names "\n"
-                          (sha256-hex body))
-        scope        (str date-stamp "/" region "/" service "/aws4_request")
-        to-sign      (str "AWS4-HMAC-SHA256\n" amz-date "\n" scope "\n" (sha256-hex canonical))
-        signature    (-> secret-access-key
-                         (signing-key date-stamp region service)
-                         (hmac-sha256 to-sign)
-                         codecs/bytes->hex)]
-    (assoc headers
-           "authorization" (str "AWS4-HMAC-SHA256 "
-                                "Credential=" access-key-id "/" scope ", "
-                                "SignedHeaders=" signed-names ", "
-                                "Signature=" signature))))
+  Returns a `{header-name header-value}` map carrying `Host`, `X-Amz-Date`, `Authorization`,
+  `x-amz-content-sha256`, plus `Content-Type` and `X-Amz-Security-Token` when applicable. Additional
+  *unsigned* headers (e.g. `anthropic-version`) may be added to the outgoing request freely."
+  [{:keys [region body] :as creds}]
+  (let [request               (unsigned-request creds)
+        payload               (some-> body ContentStreamProvider/fromUtf8String)
+        ^SignedRequest signed (.sign (AwsV4HttpSigner/create)
+                                     (reify Consumer
+                                       (accept [_ b]
+                                         (let [^SignRequest$Builder b b]
+                                           (.identity b (aws-identity creds))
+                                           (.request b request)
+                                           (when payload
+                                             (.payload b payload))
+                                           (.putProperty b AwsV4HttpSigner/SERVICE_SIGNING_NAME "bedrock")
+                                           (.putProperty b AwsV4HttpSigner/REGION_NAME region)))))
+        ^SdkHttpRequest req   (.request signed)]
+    (into {}
+          (map (fn [[k vs]] [k (first vs)]))
+          (.headers req))))
 
 ;;; ------------------------------------------------ HTTP plumbing ----------------------------------------------
 
@@ -153,15 +137,14 @@
   `headers` are extra *unsigned* headers (e.g. `anthropic-version`)."
   [{:keys [method path body as headers]}]
   (let [{:keys [region] :as creds} (or (credentials) (throw (missing-credentials-ex)))
-        host         (str "bedrock-mantle." region ".api.aws")
+        url          (str "https://bedrock-mantle." region ".api.aws" path)
         content-type (when body "application/json")
-        sig-headers  (sigv4-headers (merge creds {:method       method
-                                                  :path         path
-                                                  :body         body
-                                                  :content-type content-type
-                                                  :host         host}))]
+        sig-headers  (signed-headers (merge creds {:method       method
+                                                   :url          url
+                                                   :body         body
+                                                   :content-type content-type}))]
     (http/request (cond-> {:method  method
-                           :url     (str "https://" host path)
+                           :url     url
                            :headers (merge headers sig-headers)}
                     as   (assoc :as as)
                     body (assoc :body body)))))

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -91,9 +91,10 @@
 
 (defn- validate-region
   "Throw if region is not a known AWS region.
-  The region becomes a host label in the mantle URL, so anything outside the AWS SDK's
-  known region set is rejected before it can be spliced in. The [[llm/llm-bedrock-region]] setter rejects
-  bad values at write time, but env-var/direct sets bypass that setter — this is the second layer."
+
+  The region becomes a host label in the mantle URL, so anything outside the AWS SDK's known region set is rejected
+  before it can be spliced in. The [[llm/llm-bedrock-region]] setter rejects bad values at write time, but we also
+  want to validate caller-provided args."
   [region]
   (when-not (contains? llm/known-aws-regions region)
     (throw (invalid-region-ex region)))

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -296,32 +296,55 @@
      (catch Exception e
        (core/rethrow-api-error! "anthropic" anthropic-error-msg e)))))
 
-(mu/defn claude-raw
-  "Perform a streaming request to Claude API."
-  [{:keys [model system input tools schema tool_choice temperature max-tokens ai-proxy?]
+(defn- model-supports-temperature?
+  "Whether `model` accepts an explicit `temperature` parameter.
+
+  Sampling parameters (`temperature`, `top_p`, `top_k`) were removed starting with Claude Opus 4.7.  Strips an
+  optional vendor prefix (e.g. Bedrock's `anthropic.`) before checking."
+  [model]
+  (let [model (str/replace-first (str model) #"^anthropic\." "")]
+    (not (or (str/starts-with? model "claude-fable")
+             (when-let [[_ major minor] (re-find #"^claude-opus-(\d+)(?:-(\d+))?" model)]
+               (let [major (parse-long major)
+                     minor (or (some-> minor parse-long) 0)]
+                 (or (> major 4)
+                     (and (= major 4) (>= minor 7)))))))))
+
+(mu/defn claude-request-body
+  "Build the Anthropic Messages API request body for an LLM request."
+  [{:keys [model system input tools schema tool_choice temperature max-tokens]
     :or   {model "claude-haiku-4-5"}} :- core/LLMRequestOpts]
   (let [messages  (parts->claude-messages input)
         all-tools (when (seq tools) (mapv tool->claude tools))
         all-tools (if (and all-tools (not schema))
                     (add-tools-cache-breakpoint all-tools)
-                    all-tools)
-        req       (cond-> {:model         model
-                           :max_tokens    (or max-tokens 4096)
-                           :stream        true
-                           :cache_control {:type "ephemeral"}
-                           :messages      messages}
-                    system            (assoc :system (system->cached-content-blocks system))
-                    all-tools         (assoc :tools all-tools)
-                    (and all-tools
-                         tool_choice) (assoc :tool_choice (case (name tool_choice)
-                                                            "auto"     {:type "auto"}
-                                                            "required" {:type "any"}))
-                    temperature       (assoc :temperature temperature)
-                    schema            (assoc :tool_choice {:type "tool"
-                                                           :name "structured_output"}
-                                             :tools [{:name         "structured_output"
-                                                      :description  "Output structured data"
-                                                      :input_schema schema}]))]
+                    all-tools)]
+    (cond-> {:model         model
+             :max_tokens    (or max-tokens 4096)
+             :stream        true
+             :cache_control {:type "ephemeral"}
+             :messages      messages}
+      system            (assoc :system (system->cached-content-blocks system))
+      all-tools         (assoc :tools all-tools)
+      schema            (assoc :tool_choice {:type "tool"
+                                             :name "structured_output"}
+                               :tools [{:name         "structured_output"
+                                        :description  "Output structured data"
+                                        :input_schema schema}])
+
+      (and all-tools tool_choice)
+      (assoc :tool_choice (case (name tool_choice)
+                            "auto"     {:type "auto"}
+                            "required" {:type "any"}))
+
+      (and temperature (model-supports-temperature? model))
+      (assoc :temperature temperature))))
+
+(mu/defn claude-raw
+  "Perform a streaming request to Claude API."
+  [{:keys [model input tools ai-proxy?] :as opts
+    :or   {model "claude-haiku-4-5"}} :- core/LLMRequestOpts]
+  (let [req (claude-request-body opts)]
     (with-span :info {:name       :metabot.claude/request
                       :model      model
                       :msg-count  (count input)

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -276,14 +276,15 @@
 
 (defn list-models
   "List available Anthropic models.
-  No-arg uses the configured API key. Opts map supports `:api-key` and `:ai-proxy?`."
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   ([] (list-models {}))
-  ([{:keys [api-key ai-proxy?]}]
-   (when (and api-key (str/blank? api-key))
+  ([{:keys [credentials ai-proxy?]}]
+   (when (and credentials (str/blank? (:api-key credentials)))
      (throw (core/missing-api-key-ex "Anthropic")))
    (try
      (let [auth   (core/resolve-auth "anthropic" "Anthropic"
-                                     (when-let [k (or (not-empty api-key) (not-empty (llm/llm-anthropic-api-key)))]
+                                     (when-let [k (or (not-empty (:api-key credentials))
+                                                      (not-empty (llm/llm-anthropic-api-key)))]
                                        {:url     (llm/llm-anthropic-api-base-url)
                                         :headers {"x-api-key" k}})
                                      ai-proxy?)

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -186,14 +186,15 @@
 
 (defn list-models
   "List available OpenAI models.
-  No-arg uses the configured API key. Opts map supports `:api-key` and `:ai-proxy?`."
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   ([] (list-models {}))
-  ([{:keys [api-key ai-proxy?]}]
-   (when (and api-key (str/blank? api-key))
+  ([{:keys [credentials ai-proxy?]}]
+   (when (and credentials (str/blank? (:api-key credentials)))
      (throw (core/missing-api-key-ex "OpenAI")))
    (try
      (let [auth (core/resolve-auth "openai" "OpenAI"
-                                   (when-let [k (or (not-empty api-key) (not-empty (llm/llm-openai-api-key)))]
+                                   (when-let [k (or (not-empty (:api-key credentials))
+                                                    (not-empty (llm/llm-openai-api-key)))]
                                      {:url     (llm/llm-openai-api-base-url)
                                       :headers {"Authorization" (str "Bearer " k)}})
                                    ai-proxy?)

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -218,7 +218,7 @@
                                                       :else       "auto")
                                        :tools       all-tools)
                     temperature (assoc :temperature temperature)
-                    max-tokens  (assoc :max_tokens max-tokens))]
+                    max-tokens  (assoc :max_output_tokens max-tokens))]
     (try
       (let [api-key  (not-empty (llm/llm-openai-api-key))
             auth     (core/resolve-auth "openai" "OpenAI"

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -13,6 +13,11 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private translated-chunk-type?
+  "Output item types we translate into AI SDK chunks. Other types (e.g. reasoning summaries) are ignored so we
+  don't emit garbage or blow up on an unmatched `case` clause."
+  #{:text :function_call})
+
 (defn openai->aisdk-chunks-xf
   "Translates OpenAI /v1/responses streaming events into AI SDK v5 protocol chunks.
 
@@ -34,10 +39,14 @@
           model-name   (volatile! nil)
           payload      (volatile! {})
           close!       (fn [result]
-                         (u/prog1 (rf result (merge {:type (case @current-type
-                                                             :text          :text-end
-                                                             :function_call :tool-input-available)}
-                                                    @payload))
+                         ;; only emit an end marker for chunk types we translate; reasoning (and any other
+                         ;; output item types) are ignored so we don't blow up on an unmatched `case` clause.
+                         (u/prog1 (if-let [end-type (case @current-type
+                                                      :text          :text-end
+                                                      :function_call :tool-input-available
+                                                      nil)]
+                                    (rf result (merge {:type end-type} @payload))
+                                    result)
                            (vreset! current-type nil)
                            (vreset! current-id nil)
                            (vreset! payload {})))]
@@ -79,29 +88,32 @@
                  (and @current-id
                       (not= chunk-id
                             @current-id)))      (close!)
-             ;; start of a new chunk
-             (= t "response.output_item.added") (-> (u/prog1
-                                                      (vreset! current-type chunk-type)
-                                                      (vreset! current-id chunk-id)
-                                                      (vreset! payload
-                                                               (case @current-type
-                                                                 ;; no :type in payloads since we'll use that for finish msg too
-                                                                 :text          {:id chunk-id}
-                                                                 :function_call {:toolCallId chunk-id
-                                                                                 :toolName   (:name item)}
-                                                                 nil)))
-                                                    (rf (merge (case @current-type
-                                                                 :text          {:type :text-start}
-                                                                 :function_call {:type :tool-input-start})
-                                                               @payload)))
-             ;; just a middle of a chunk
-             delta                              (rf (case @current-type
-                                                      :text          {:type  :text-delta
-                                                                      :id    @current-id
-                                                                      :delta delta}
-                                                      :function_call {:type           :tool-input-delta
-                                                                      :toolCallId     (:toolCallId @payload)
-                                                                      :inputTextDelta delta}))
+             ;; start of a new chunk — only for types we translate; reasoning items are ignored
+             (and (= t "response.output_item.added")
+                  (translated-chunk-type? chunk-type)) (-> (u/prog1
+                                                             (vreset! current-type chunk-type)
+                                                             (vreset! current-id chunk-id)
+                                                             (vreset! payload
+                                                                      (case @current-type
+                                                                        ;; no :type in payloads since we'll use that for finish msg too
+                                                                        :text          {:id chunk-id}
+                                                                        :function_call {:toolCallId chunk-id
+                                                                                        :toolName   (:name item)}
+                                                                        nil)))
+                                                           (rf (merge (case @current-type
+                                                                        :text          {:type :text-start}
+                                                                        :function_call {:type :tool-input-start}
+                                                                        nil)
+                                                                      @payload)))
+             ;; just a middle of a chunk — ignore deltas for types we don't translate (e.g. reasoning summaries)
+             (and delta
+                  (translated-chunk-type? @current-type)) (rf (case @current-type
+                                                                :text          {:type  :text-delta
+                                                                                :id    @current-id
+                                                                                :delta delta}
+                                                                :function_call {:type           :tool-input-delta
+                                                                                :toolCallId     (:toolCallId @payload)
+                                                                                :inputTextDelta delta}))
              (= (:type chunk)
                 "response.completed")           (rf {:type  :usage
                                                      :usage (let [u (:usage response)]

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -196,6 +196,16 @@
      (catch Exception e
        (core/rethrow-api-error! "openai" openai-error-msg e)))))
 
+(defn- model-supports-temperature?
+  "Whether `model` accepts an explicit `temperature` parameter.
+
+  The GPT-5 family and the o-series reasoning models only support the default temperature and return a 400
+  (\"Unsupported parameter: 'temperature' is not supported with this model.\") when one is sent, so we omit it for them."
+  [model]
+  (let [model (str model)]
+    (not (or (str/starts-with? model "gpt-5")
+             (re-find #"^o\d" model)))))
+
 (mu/defn openai-raw
   "Perform a streaming request to OpenAI Responses API."
   [{:keys [model system input tools schema tool_choice temperature max-tokens ai-proxy?]
@@ -217,7 +227,8 @@
                                                       tool_choice tool_choice
                                                       :else       "auto")
                                        :tools       all-tools)
-                    temperature (assoc :temperature temperature)
+                    (and temperature
+                         (model-supports-temperature? model)) (assoc :temperature temperature)
                     max-tokens  (assoc :max_output_tokens max-tokens))]
     (try
       (let [api-key  (not-empty (llm/llm-openai-api-key))

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -211,16 +211,15 @@
 (defn- model-supports-temperature?
   "Whether `model` accepts an explicit `temperature` parameter.
 
-  The GPT-5 family and the o-series reasoning models only support the default temperature and return a 400
-  (\"Unsupported parameter: 'temperature' is not supported with this model.\") when one is sent, so we omit it for them."
+  The GPT-5 family and the o-series reasoning models only support the default temperature."
   [model]
-  (let [model (str model)]
+  (let [model (str/replace-first (str model) #"^openai\." "")]
     (not (or (str/starts-with? model "gpt-5")
              (re-find #"^o\d" model)))))
 
-(mu/defn openai-raw
-  "Perform a streaming request to OpenAI Responses API."
-  [{:keys [model system input tools schema tool_choice temperature max-tokens ai-proxy?]
+(mu/defn openai-request-body
+  "Build the OpenAI Responses API request body for an LLM request."
+  [{:keys [model system input tools schema tool_choice temperature max-tokens]
     :or   {model "gpt-4.1-mini"}} :- core/LLMRequestOpts]
   (let [all-tools (or (when schema
                         ;; Structured output: force a tool call with the given JSON schema
@@ -228,20 +227,27 @@
                           :name        "structured_output"
                           :description "Output structured data"
                           :parameters  schema}])
-                      (when (seq tools) (mapv tool->openai tools)))
-        req       (cond-> {:model        model
-                           :stream       true
-                           :store        false
-                           :instructions system
-                           :input        (parts->openai-input input)}
-                    all-tools   (assoc :tool_choice (cond
-                                                      schema      "required"
-                                                      tool_choice tool_choice
-                                                      :else       "auto")
-                                       :tools       all-tools)
-                    (and temperature
-                         (model-supports-temperature? model)) (assoc :temperature temperature)
-                    max-tokens  (assoc :max_output_tokens max-tokens))]
+                      (when (seq tools) (mapv tool->openai tools)))]
+    (cond-> {:model        model
+             :stream       true
+             :store        false
+             :instructions system
+             :input        (parts->openai-input input)}
+      all-tools   (assoc :tool_choice (cond
+                                        schema      "required"
+                                        tool_choice tool_choice
+                                        :else       "auto")
+                         :tools       all-tools)
+      max-tokens  (assoc :max_output_tokens max-tokens)
+
+      (and temperature (model-supports-temperature? model))
+      (assoc :temperature temperature))))
+
+(mu/defn openai-raw
+  "Perform a streaming request to OpenAI Responses API."
+  [{:keys [model ai-proxy?] :as opts
+    :or   {model "gpt-4.1-mini"}} :- core/LLMRequestOpts]
+  (let [req (openai-request-body opts)]
     (try
       (let [api-key  (not-empty (llm/llm-openai-api-key))
             auth     (core/resolve-auth "openai" "OpenAI"

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -14,8 +14,8 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private translated-chunk-type?
-  "Output item types we translate into AI SDK chunks. Other types (e.g. reasoning summaries) are ignored so we
-  don't emit garbage or blow up on an unmatched `case` clause."
+  "Output item types we translate into AI SDK chunks.
+  Other types (e.g. reasoning summaries) are ignored."
   #{:text :function_call})
 
 (defn openai->aisdk-chunks-xf
@@ -39,8 +39,8 @@
           model-name   (volatile! nil)
           payload      (volatile! {})
           close!       (fn [result]
-                         ;; only emit an end marker for chunk types we translate; reasoning (and any other
-                         ;; output item types) are ignored so we don't blow up on an unmatched `case` clause.
+                         ;; only emit an end marker for chunk types we translate; reasoning and other
+                         ;; output item types are ignored.
                          (u/prog1 (if-let [end-type (case @current-type
                                                       :text          :text-end
                                                       :function_call :tool-input-available

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -109,14 +109,15 @@
 
 (defn list-models
   "List available OpenRouter models.
-  No-arg uses the configured API key. Opts map supports `:api-key` and `:ai-proxy?`."
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   ([] (list-models {}))
-  ([{:keys [api-key ai-proxy?]}]
-   (when (and api-key (str/blank? api-key))
+  ([{:keys [credentials ai-proxy?]}]
+   (when (and credentials (str/blank? (:api-key credentials)))
      (throw (core/missing-api-key-ex "OpenRouter")))
    (try
      (let [auth (core/resolve-auth "openrouter" "OpenRouter"
-                                   (when-let [k (or (not-empty api-key) (not-empty (llm/llm-openrouter-api-key)))]
+                                   (when-let [k (or (not-empty (:api-key credentials))
+                                                    (not-empty (llm/llm-openrouter-api-key)))]
                                      {:url     (llm/llm-openrouter-api-base-url)
                                       :headers {"Authorization" (str "Bearer " k)}})
                                    ai-proxy?)

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -104,11 +104,15 @@
 
 (def ^:private direct-providers
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
-  #{"anthropic" "openai" "openrouter"})
+  #{"anthropic" "bedrock" "openai" "openrouter"})
 
 (def ^:private default-anthropic-llm-metabot-model
   "Default Anthropic model used for Metabot when no explicit model is selected."
   "claude-sonnet-4-6")
+
+(def ^:private default-bedrock-llm-metabot-model
+  "Default Bedrock model used for Metabot when no explicit model is selected."
+  "anthropic.claude-opus-4-8")
 
 (def default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
@@ -119,7 +123,8 @@
 
   Values match the shape expected in the request body for each provider: direct providers use a bare model ID, while the
   managed `metabase` provider uses the proxied `provider/model` form."
-  {"anthropic"                       default-anthropic-llm-metabot-model
+  {"anthropic"                            default-anthropic-llm-metabot-model
+   "bedrock"                              default-bedrock-llm-metabot-model
    provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider
@@ -234,10 +239,17 @@
                 (not (str/blank? token)))))
 
 (defn configured-provider-api-key
-  "Returns the configured API key for the given provider, or nil if unrecognized."
+  "Returns the configured API key for the given provider, or nil if unrecognized or unconfigured.
+
+  Bedrock has no single API key — it authenticates with AWS SigV4 from several `llm-bedrock-*`
+  settings. We return the access key ID as a presence sentinel, but only when Bedrock is fully
+  configured (both the access key ID and secret access key are set), so callers that use this as a
+  truthiness gate don't attempt requests that would fail on the missing secret."
   [provider]
   (case provider
     "anthropic"  (llm.settings/llm-anthropic-api-key)
+    "bedrock"    (when (llm.settings/llm-bedrock-configured?)
+                   (llm.settings/llm-bedrock-access-key-id))
     "openai"     (llm.settings/llm-openai-api-key)
     "openrouter" (llm.settings/llm-openrouter-api-key)
     nil))
@@ -245,11 +257,18 @@
 (defn- llm-provider-configured?
   "Check if a provider-and-model string has the necessary configuration.
   For `metabase/*` providers, checks that the proxy URL is set.
-  For direct providers, checks that a BYOK API key is set."
+  For Bedrock, checks that both the AWS access key ID and secret access key are set.
+  For other direct providers, checks that a BYOK API key is set."
   [provider-and-model]
   (boolean
-   (if (provider-util/metabase-provider? provider-and-model)
+   (cond
+     (provider-util/metabase-provider? provider-and-model)
      (some? (llm.settings/llm-proxy-base-url))
+
+     (= (provider-util/provider-and-model->provider provider-and-model) "bedrock")
+     (llm.settings/llm-bedrock-configured?)
+
+     :else
      (some-> provider-and-model
              provider-util/provider-and-model->provider
              configured-provider-api-key

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -233,49 +233,60 @@
                         (validate-metabot-provider! new-value))
                       (setting/set-value-of-type! :string :llm-metabot-provider new-value)))
 
-(defn- token-configured?
-  [token]
-  (boolean (and (string? token)
-                (not (str/blank? token)))))
+(defn- non-blank
+  [value]
+  (when (string? value)
+    (let [trimmed (str/trim value)]
+      (when-not (str/blank? trimmed)
+        trimmed))))
 
-(defn configured-provider-api-key
-  "Returns the configured API key for the given provider, or nil if unrecognized or unconfigured.
+(defn- configured-api-key-credentials
+  [api-key]
+  (when-let [k (non-blank api-key)]
+    {:api-key k}))
 
-  Bedrock has no single API key — it authenticates with AWS SigV4 from several `llm-bedrock-*`
-  settings. We return the access key ID as a presence sentinel, but only when Bedrock is fully
-  configured (both the access key ID and secret access key are set), so callers that use this as a
-  truthiness gate don't attempt requests that would fail on the missing secret."
+(defn configured-provider-credentials
+  "Returns the configured credentials map for the given provider, or nil if unrecognized or unconfigured.
+
+  The shape of the map varies by provider: API-key providers return `{:api-key ...}`, while Bedrock returns
+  `:access-key-id`, `:secret-access-key`, `:session-token`, and `:region` from the `llm-bedrock-*` settings. Bedrock
+  counts as configured only when both the access key ID and secret access key are set."
   [provider]
   (case provider
-    "anthropic"  (llm.settings/llm-anthropic-api-key)
+    "anthropic"  (configured-api-key-credentials (llm.settings/llm-anthropic-api-key))
     "bedrock"    (when (llm.settings/llm-bedrock-configured?)
-                   (llm.settings/llm-bedrock-access-key-id))
-    "openai"     (llm.settings/llm-openai-api-key)
-    "openrouter" (llm.settings/llm-openrouter-api-key)
+                   {:access-key-id     (non-blank (llm.settings/llm-bedrock-access-key-id))
+                    :secret-access-key (non-blank (llm.settings/llm-bedrock-secret-access-key))
+                    :session-token     (non-blank (llm.settings/llm-bedrock-session-token))
+                    :region            (non-blank (llm.settings/llm-bedrock-region))})
+    "openai"     (configured-api-key-credentials (llm.settings/llm-openai-api-key))
+    "openrouter" (configured-api-key-credentials (llm.settings/llm-openrouter-api-key))
     nil))
+
+(defn provider-credentials-complete?
+  "Whether a credentials map carries everything `provider` needs to make requests: both the AWS access key ID and
+  secret access key for Bedrock, an `:api-key` for the other direct providers."
+  [provider credentials]
+  (boolean
+   (if (= provider "bedrock")
+     (and (non-blank (:access-key-id credentials))
+          (non-blank (:secret-access-key credentials)))
+     (non-blank (:api-key credentials)))))
 
 (defn- llm-provider-configured?
   "Check if a provider-and-model string has the necessary configuration.
   For `metabase/*` providers, checks that the proxy URL is set.
-  For Bedrock, checks that both the AWS access key ID and secret access key are set.
-  For other direct providers, checks that a BYOK API key is set."
+  For direct providers, checks that credentials are configured (see [[configured-provider-credentials]])."
   [provider-and-model]
   (boolean
-   (cond
-     (provider-util/metabase-provider? provider-and-model)
+   (if (provider-util/metabase-provider? provider-and-model)
      (some? (llm.settings/llm-proxy-base-url))
-
-     (= (provider-util/provider-and-model->provider provider-and-model) "bedrock")
-     (llm.settings/llm-bedrock-configured?)
-
-     :else
      (some-> provider-and-model
              provider-util/provider-and-model->provider
-             configured-provider-api-key
-             token-configured?))))
+             configured-provider-credentials))))
 
 (defsetting llm-metabot-configured?
-  "Whether the API key for the selected Metabot provider is configured."
+  "Whether credentials for the selected Metabot provider are configured."
   :type       :boolean
   :visibility :public
   :setter     :none

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -36,6 +36,50 @@
     (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-ant-test"]
       (is (true? (llm.settings/llm-anthropic-api-key-configured?))))))
 
+;;; ------------------------------------------- llm-bedrock-configured? Tests -------------------------------------------
+
+(deftest llm-bedrock-configured?-test
+  (testing "returns false when neither credential is set"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id nil
+                                       llm-bedrock-secret-access-key nil]
+      (is (false? (llm.settings/llm-bedrock-configured?)))))
+  (testing "returns false when only the access key id is set"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key nil]
+      (is (false? (llm.settings/llm-bedrock-configured?)))))
+  (testing "returns false when only the secret access key is set"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id nil
+                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (is (false? (llm.settings/llm-bedrock-configured?)))))
+  (testing "returns true when both credentials are set"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (is (true? (llm.settings/llm-bedrock-configured?))))))
+
+;;; ------------------------------------------- llm-bedrock-region Setter Tests -------------------------------------------
+
+(deftest llm-bedrock-region-setter-accepts-known-region-test
+  (testing "accepts a known AWS region and trims whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-region nil]
+      (mt/discard-setting-changes [llm-bedrock-region]
+        (llm.settings/llm-bedrock-region! "  us-west-2  ")
+        (is (= "us-west-2" (llm.settings/llm-bedrock-region)))))))
+
+(deftest llm-bedrock-region-setter-rejects-unknown-region-test
+  (testing "rejects a region not in the AWS SDK's known set"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid AWS region \"evil\.example/\?x=\""
+         (llm.settings/llm-bedrock-region! "evil.example/?x=")))))
+
+(deftest llm-bedrock-region-setter-clears-on-empty-test
+  (testing "empty/nil clears the setting, falling back to the default"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-region nil]
+      (mt/discard-setting-changes [llm-bedrock-region]
+        (llm.settings/llm-bedrock-region! "us-west-2")
+        (llm.settings/llm-bedrock-region! "")
+        (is (= "us-east-1" (llm.settings/llm-bedrock-region)))))))
+
 ;;; ------------------------------------------- llm-proxy-base-url Feature Guard Tests -------------------------------------------
 
 (deftest llm-proxy-base-url-feature-guard-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -44,17 +44,61 @@
                                        llm-bedrock-secret-access-key nil]
       (is (false? (llm.settings/llm-bedrock-configured?)))))
   (testing "returns false when only the access key id is set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIDEXAMPLE"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                        llm-bedrock-secret-access-key nil]
       (is (false? (llm.settings/llm-bedrock-configured?)))))
   (testing "returns false when only the secret access key is set"
     (mt/with-temporary-setting-values [llm-bedrock-access-key-id nil
                                        llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
       (is (false? (llm.settings/llm-bedrock-configured?)))))
+  (testing "returns false when a credential is blank rather than absent"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "   "
+                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (is (false? (llm.settings/llm-bedrock-configured?)))))
   (testing "returns true when both credentials are set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIDEXAMPLE"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                        llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
       (is (true? (llm.settings/llm-bedrock-configured?))))))
+
+;;; ------------------------------------------- llm-bedrock credential Setter Tests -------------------------------------------
+
+(deftest llm-bedrock-access-key-id-setter-accepts-valid-key-test
+  (testing "accepts a valid access key ID and trims whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-access-key-id nil]
+      (mt/discard-setting-changes [llm-bedrock-access-key-id]
+        (llm.settings/llm-bedrock-access-key-id! "  AKIAIOSFODNN7EXAMPLE  ")
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))))))
+
+(deftest llm-bedrock-access-key-id-setter-clears-on-empty-test
+  (testing "empty/nil clears the setting"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-access-key-id nil]
+      (mt/discard-setting-changes [llm-bedrock-access-key-id]
+        (llm.settings/llm-bedrock-access-key-id! "AKIAIOSFODNN7EXAMPLE")
+        (llm.settings/llm-bedrock-access-key-id! "")
+        (is (nil? (llm.settings/llm-bedrock-access-key-id)))))))
+
+(deftest llm-bedrock-secret-access-key-setter-accepts-valid-key-test
+  (testing "accepts a secret access key and trims surrounding whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-secret-access-key nil]
+      (mt/discard-setting-changes [llm-bedrock-secret-access-key]
+        (llm.settings/llm-bedrock-secret-access-key! "  wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY  ")
+        (is (= "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest llm-bedrock-secret-access-key-setter-clears-on-blank-test
+  (testing "a whitespace-only value clears the setting"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-secret-access-key nil]
+      (mt/discard-setting-changes [llm-bedrock-secret-access-key]
+        (llm.settings/llm-bedrock-secret-access-key! "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+        (llm.settings/llm-bedrock-secret-access-key! "   ")
+        (is (nil? (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest llm-bedrock-session-token-setter-accepts-valid-token-test
+  (testing "accepts a session token and trims surrounding whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-bedrock-session-token nil]
+      (mt/discard-setting-changes [llm-bedrock-session-token]
+        (llm.settings/llm-bedrock-session-token! "  AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE=  ")
+        (is (= "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE="
+               (llm.settings/llm-bedrock-session-token)))))))
 
 ;;; ------------------------------------------- llm-bedrock-region Setter Tests -------------------------------------------
 

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -257,9 +257,9 @@
                                                             (is (= "anthropic" provider))
                                                             {:models [{:id "claude-haiku-4-5"
                                                                        :display_name "Claude Haiku 4.5"}]})
-                                                           ([provider {:keys [api-key]}]
+                                                           ([provider {:keys [credentials]}]
                                                             (is (= "anthropic" provider))
-                                                            (is (= "sk-ant-valid" api-key))
+                                                            (is (= {:api-key "sk-ant-valid"} credentials))
                                                             {:models [{:id "claude-sonnet-4-5"
                                                                        :display_name "Claude Sonnet 4.5"}
                                                                       {:id "claude-haiku-4-5"
@@ -285,8 +285,8 @@
 
 (deftest settings-get-normalizes-legacy-anthropic-ids-test
   (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-valid"]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [api-key]}]
-                                                           (is (= "sk-ant-valid" api-key))
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                           (is (= {:api-key "sk-ant-valid"} credentials))
                                                            {:models [{:id "claude-3-haiku-20240307"
                                                                       :display_name "Claude 3 Haiku"}
                                                                      {:id "claude-haiku-4-5"
@@ -303,8 +303,8 @@
 
 (deftest settings-get-groups-openrouter-models-test
   (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-valid"]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [api-key]}]
-                                                           (is (= "sk-or-v1-valid" api-key))
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                           (is (= {:api-key "sk-or-v1-valid"} credentials))
                                                            {:models [{:id "openai/gpt-4.1-mini"
                                                                       :display_name "OpenAI: GPT-4.1 mini"}
                                                                      {:id "anthropic/claude-sonnet-4.5"
@@ -345,9 +345,9 @@
                                                             (is (= "openai" provider))
                                                             {:models [{:id "gpt-4.1-mini"
                                                                        :display_name "GPT-4.1 mini"}]})
-                                                           ([provider {:keys [api-key]}]
+                                                           ([provider {:keys [credentials]}]
                                                             (is (= "openai" provider))
-                                                            (is (= "sk-valid" api-key))
+                                                            (is (= {:api-key "sk-valid"} credentials))
                                                             {:models [{:id "gpt-4.1-mini"
                                                                        :display_name "GPT-4.1 mini"}]}))]
       (is (= {:value  "openai/gpt-4.1-mini"
@@ -405,10 +405,10 @@
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
     (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
-        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                                (swap! calls inc)
                                                                (is (= "anthropic" provider))
-                                                               (is (= "sk-ant-valid" api-key))
+                                                               (is (= {:api-key "sk-ant-valid"} credentials))
                                                                (is (nil? (llm.settings/llm-anthropic-api-key))
                                                                    "verification should happen before saving the key")
                                                                {:models [{:id "claude-haiku-4-5"
@@ -430,10 +430,10 @@
     (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
                                        llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
-        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                                (swap! calls inc)
                                                                (is (= "anthropic" provider))
-                                                               (is (= "sk-ant-valid" api-key))
+                                                               (is (= {:api-key "sk-ant-valid"} credentials))
                                                                (is (nil? (llm.settings/llm-anthropic-api-key))
                                                                    "verification should happen before saving the key")
                                                                {:models [{:id "claude-opus-4-1"
@@ -459,10 +459,10 @@
     (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
                                        llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
-        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                                (swap! calls inc)
                                                                (is (= "anthropic" provider))
-                                                               (is (= "sk-ant-valid" api-key))
+                                                               (is (= {:api-key "sk-ant-valid"} credentials))
                                                                (is (nil? (llm.settings/llm-anthropic-api-key))
                                                                    "verification should happen before saving the key")
                                                                {:models [{:id "claude-sonnet-4-6"
@@ -492,9 +492,9 @@
 (deftest settings-put-blank-model-does-not-reset-when-provider-is-unchanged-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
                                      llm.settings/llm-anthropic-api-key "sk-ant-valid"]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                            (is (= "anthropic" provider))
-                                                           (is (= "sk-ant-valid" api-key))
+                                                           (is (= {:api-key "sk-ant-valid"} credentials))
                                                            {:models [{:id "claude-sonnet-4-6"
                                                                       :display_name "Claude Sonnet 4.6"}
                                                                      {:id "claude-opus-4-1"
@@ -516,10 +516,10 @@
 (deftest settings-put-rejects-invalid-api-key-test
   (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
     (let [calls (atom 0)]
-      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                              (swap! calls inc)
                                                              (is (= "openai" provider))
-                                                             (is (= "sk-invalid" api-key))
+                                                             (is (= {:api-key "sk-invalid"} credentials))
                                                              (is (nil? (llm.settings/llm-openai-api-key))
                                                                  "failed verification should not save the key")
                                                              (throw (ex-info "OpenAI API key expired or invalid"
@@ -533,11 +533,25 @@
               "should stop after the failed verification call")
           (is (nil? (llm.settings/llm-openai-api-key))))))))
 
+(deftest settings-put-blank-api-key-clears-saved-key-test
+  (mt/with-temp-env-var-value! [mb-llm-openai-api-key nil]
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "openai/gpt-4.1-mini"
+                                       llm.settings/llm-openai-api-key       "sk-valid"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an explicit nil api-key clears the saved key without validating against the old one"
+          (is (=? {:value  "openai/gpt-4.1-mini"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider "openai"
+                                         :api-key  nil})))
+          (is (nil? (llm.settings/llm-openai-api-key))))))))
+
 (deftest settings-put-does-not-treat-outages-as-invalid-keys-test
   (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                            (is (= "openai" provider))
-                                                           (is (= "sk-valid" api-key))
+                                                           (is (= {:api-key "sk-valid"} credentials))
                                                            (throw (ex-info "OpenAI API is not working but not saying why"
                                                                            {:api-error true
                                                                             :status-code 500})))]
@@ -550,9 +564,9 @@
 (deftest settings-put-does-not-save-model-when-preflight-fails-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
                                      llm.settings/llm-anthropic-api-key      "sk-ant-valid"]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                            (is (= "anthropic" provider))
-                                                           (is (= "sk-ant-valid" api-key))
+                                                           (is (= {:api-key "sk-ant-valid"} credentials))
                                                            (throw (ex-info "Anthropic API key has insufficient permissions"
                                                                            {:api-error true
                                                                             :status-code 403})))]
@@ -1174,10 +1188,14 @@
 ;;; ------------------------------------------------ Bedrock settings ------------------------------------------------
 
 (deftest settings-get-groups-bedrock-models-test
-  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDEXAMPLE"
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                      llm.settings/llm-bedrock-secret-access-key "test-secret"]
-    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                            (is (= "bedrock" provider))
+                                                           (is (=? {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                                    :secret-access-key "test-secret"}
+                                                                   credentials)
+                                                               "the configured AWS credentials are passed to the model lister")
                                                            {:models [{:id "openai.gpt-5.5"
                                                                       :display_name "openai.gpt-5.5"}
                                                                      {:id "anthropic.claude-haiku-4-5"
@@ -1202,42 +1220,84 @@
                                        llm.settings/llm-bedrock-session-token     nil
                                        llm.settings/llm-bedrock-region            "us-east-1"
                                        metabot.settings/llm-metabot-provider      "anthropic/claude-sonnet-4-6"]
-      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                              (is (= "bedrock" provider))
-                                                             (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id))
-                                                                 "credentials should be saved before model verification")
+                                                             (is (= {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                                     :secret-access-key "test-secret"
+                                                                     :region            "us-east-2"
+                                                                     :session-token     "test-token"}
+                                                                    credentials)
+                                                                 "model verification should run against the request credentials")
+                                                             (is (nil? (llm.settings/llm-bedrock-access-key-id))
+                                                                 "verification should happen before saving the credentials")
                                                              {:models [{:id "anthropic.claude-haiku-4-5"
                                                                         :display_name "anthropic.claude-haiku-4-5"}]})]
         (testing "connecting bedrock saves the credentials and selects the default bedrock model"
           (is (=? {:value "bedrock/anthropic.claude-opus-4-8"}
                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                         {:provider    "bedrock"
-                                         :credentials {:access-key-id     "AKIDEXAMPLE"
+                                         :credentials {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                                        :secret-access-key "test-secret"
                                                        :region            "us-east-2"
                                                        :session-token     "test-token"}}))))
-        (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
         (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))
         (is (= "us-east-2" (llm.settings/llm-bedrock-region)))
         (is (= "test-token" (llm.settings/llm-bedrock-session-token)))))))
+
+(deftest settings-put-bedrock-rejects-incomplete-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                       llm.settings/llm-bedrock-secret-access-key nil
+                                       metabot.settings/llm-metabot-provider      "anthropic/claude-sonnet-4-6"]
+      (testing "credentials missing the secret access key fail verification and nothing is saved"
+        (is (=? {:message      "AWS Bedrock credentials are incomplete."
+                 :missing-keys ["secret-access-key"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "bedrock"
+                                       :credentials {:access-key-id "AKIAIOSFODNN7EXAMPLE"}})))
+        (is (nil? (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-bedrock-rejects-blank-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                       llm.settings/llm-bedrock-secret-access-key nil
+                                       metabot.settings/llm-metabot-provider      "anthropic/claude-sonnet-4-6"]
+      (testing "all-blank credentials with nothing saved fail verification instead of throwing a 500"
+        (is (=? {:message      "AWS Bedrock credentials are incomplete."
+                 :missing-keys ["access-key-id" "secret-access-key"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "bedrock"
+                                       :credentials {:access-key-id     ""
+                                                     :secret-access-key ""
+                                                     :session-token     ""
+                                                     :region            ""}})))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
 
 (deftest settings-put-bedrock-clears-stale-session-token-test
   (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
                                 mb-llm-bedrock-access-key-id     nil
                                 mb-llm-bedrock-secret-access-key nil
                                 mb-llm-bedrock-session-token     nil]
-    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDOLD"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAOLDOLDOLDOLDOLD1"
                                        llm.settings/llm-bedrock-secret-access-key "old-secret"
                                        llm.settings/llm-bedrock-session-token     "old-token"
                                        metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
       (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
         (mt/user-http-request :crowberto :put 200 "metabot/settings"
                               {:provider    "bedrock"
-                               :credentials {:access-key-id     "AKIDNEW"
+                               :credentials {:access-key-id     "AKIANEWNEWNEWNEWNEW1"
                                              :secret-access-key "new-secret"}})
         (testing "a session token from the previous key pair does not survive rotation"
           (is (nil? (llm.settings/llm-bedrock-session-token))))
-        (is (= "AKIDNEW" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "AKIANEWNEWNEWNEWNEW1" (llm.settings/llm-bedrock-access-key-id)))
         (is (= "new-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
 
 (deftest settings-put-bedrock-preserves-session-token-without-new-key-test
@@ -1246,7 +1306,7 @@
                                 mb-llm-bedrock-secret-access-key nil
                                 mb-llm-bedrock-session-token     nil
                                 mb-llm-bedrock-region            nil]
-    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDEXAMPLE"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                        llm.settings/llm-bedrock-secret-access-key "test-secret"
                                        llm.settings/llm-bedrock-session-token     "test-token"
                                        llm.settings/llm-bedrock-region            "us-east-1"
@@ -1258,5 +1318,61 @@
         (testing "editing an unrelated field without new key material leaves the session token intact"
           (is (= "test-token" (llm.settings/llm-bedrock-session-token))))
         (is (= "us-east-2" (llm.settings/llm-bedrock-region)))
-        (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
         (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest settings-put-nil-bedrock-credentials-clears-saved-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "test-token"
+                                       llm.settings/llm-bedrock-region            "us-east-2"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an explicit nil credentials clears the saved key material without validating against it"
+          (is (=? {:value  "bedrock/anthropic.claude-opus-4-8"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "bedrock"
+                                         :credentials nil})))
+          (is (nil? (llm.settings/llm-bedrock-access-key-id)))
+          (is (nil? (llm.settings/llm-bedrock-secret-access-key)))
+          (is (nil? (llm.settings/llm-bedrock-session-token))))
+        (testing "the region is not secret and survives the clear for the next connect"
+          (is (= "us-east-2" (llm.settings/llm-bedrock-region))))))))
+
+(deftest settings-put-bedrock-absent-credentials-leaves-saved-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "test-token"
+                                       llm.settings/llm-bedrock-region            "us-east-2"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
+                                                             (is (= "bedrock" provider))
+                                                             (is (= {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                                     :secret-access-key "test-secret"
+                                                                     :session-token     "test-token"
+                                                                     :region            "us-east-2"}
+                                                                    credentials)
+                                                                 "a model-only change validates against the saved credentials")
+                                                             {:models [{:id "anthropic.claude-haiku-4-5"
+                                                                        :display_name "anthropic.claude-haiku-4-5"}]})]
+        (testing "a body without a credentials key leaves the saved credentials untouched"
+          (is (=? {:value "bedrock/anthropic.claude-haiku-4-5"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider "bedrock"
+                                         :model    "anthropic.claude-haiku-4-5"})))
+          (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+          (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))
+          (is (= "test-token" (llm.settings/llm-bedrock-session-token)))
+          (is (= "us-east-2" (llm.settings/llm-bedrock-region))))))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -1434,8 +1434,8 @@
           (is (nil? (llm.settings/llm-bedrock-access-key-id)))
           (is (nil? (llm.settings/llm-bedrock-secret-access-key)))
           (is (nil? (llm.settings/llm-bedrock-session-token))))
-        (testing "the region is not secret and survives the clear for the next connect"
-          (is (= "us-east-2" (llm.settings/llm-bedrock-region))))))))
+        (testing "the clear also resets the region to its default"
+          (is (= "us-east-1" (llm.settings/llm-bedrock-region))))))))
 
 (deftest settings-put-bedrock-absent-credentials-leaves-saved-credentials-test
   (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -1170,3 +1170,93 @@
                              :conversation_id (str (random-uuid))
                              :history         []
                              :state           {}}))))
+
+;;; ------------------------------------------------ Bedrock settings ------------------------------------------------
+
+(deftest settings-get-groups-bedrock-models-test
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                     llm.settings/llm-bedrock-secret-access-key "test-secret"]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                           (is (= "bedrock" provider))
+                                                           {:models [{:id "openai.gpt-5.5"
+                                                                      :display_name "openai.gpt-5.5"}
+                                                                     {:id "anthropic.claude-haiku-4-5"
+                                                                      :display_name "anthropic.claude-haiku-4-5"}]})]
+      (is (= {:value  (metabot.settings/llm-metabot-provider)
+              :models [{:id           "anthropic.claude-haiku-4-5"
+                        :display_name "anthropic.claude-haiku-4-5"
+                        :group        "Anthropic"}
+                       {:id           "openai.gpt-5.5"
+                        :display_name "openai.gpt-5.5"
+                        :group        "OpenAI"}]}
+             (mt/user-http-request :crowberto :get 200 "metabot/settings" :provider "bedrock"))))))
+
+(deftest settings-put-saves-bedrock-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                       llm.settings/llm-bedrock-secret-access-key nil
+                                       llm.settings/llm-bedrock-session-token     nil
+                                       llm.settings/llm-bedrock-region            "us-east-1"
+                                       metabot.settings/llm-metabot-provider      "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is (= "bedrock" provider))
+                                                             (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id))
+                                                                 "credentials should be saved before model verification")
+                                                             {:models [{:id "anthropic.claude-haiku-4-5"
+                                                                        :display_name "anthropic.claude-haiku-4-5"}]})]
+        (testing "connecting bedrock saves the credentials and selects the default bedrock model"
+          (is (=? {:value "bedrock/anthropic.claude-opus-4-8"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "bedrock"
+                                         :credentials {:access-key-id     "AKIDEXAMPLE"
+                                                       :secret-access-key "test-secret"
+                                                       :region            "us-east-2"
+                                                       :session-token     "test-token"}}))))
+        (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))
+        (is (= "us-east-2" (llm.settings/llm-bedrock-region)))
+        (is (= "test-token" (llm.settings/llm-bedrock-session-token)))))))
+
+(deftest settings-put-bedrock-clears-stale-session-token-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDOLD"
+                                       llm.settings/llm-bedrock-secret-access-key "old-secret"
+                                       llm.settings/llm-bedrock-session-token     "old-token"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:access-key-id     "AKIDNEW"
+                                             :secret-access-key "new-secret"}})
+        (testing "a session token from the previous key pair does not survive rotation"
+          (is (nil? (llm.settings/llm-bedrock-session-token))))
+        (is (= "AKIDNEW" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "new-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest settings-put-bedrock-preserves-session-token-without-new-key-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "test-token"
+                                       llm.settings/llm-bedrock-region            "us-east-1"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:region "us-east-2"}})
+        (testing "editing an unrelated field without new key material leaves the session token intact"
+          (is (= "test-token" (llm.settings/llm-bedrock-session-token))))
+        (is (= "us-east-2" (llm.settings/llm-bedrock-region)))
+        (is (= "AKIDEXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -403,7 +403,8 @@
 
 (deftest settings-put-verifies-and-saves-api-keys-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-    (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key nil]
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
+                                       llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
         (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
                                                                (swap! calls inc)
@@ -413,7 +414,7 @@
                                                                    "verification should happen before saving the key")
                                                                {:models [{:id "claude-haiku-4-5"
                                                                           :display_name "Claude Haiku 4.5"}]})]
-          (is (= {:value  (metabot.settings/llm-metabot-provider)
+          (is (= {:value  "anthropic/claude-haiku-4-5"
                   :models [{:id "claude-haiku-4-5"
                             :display_name "Claude Haiku 4.5"
                             :group "Haiku"}]}
@@ -577,15 +578,15 @@
         (is (= "anthropic/claude-haiku-4-5"
                (metabot.settings/llm-metabot-provider)))))))
 
-(deftest settings-get-surfaces-invalid-api-key-error-test
+(deftest settings-get-surfaces-credentials-error-test
   (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-invalid"]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts]
                                                            (throw (ex-info "OpenAI API key expired or invalid"
                                                                            {:api-error true
                                                                             :status-code 401})))]
-      (is (= {:value         (metabot.settings/llm-metabot-provider)
-              :api-key-error "OpenAI API key expired or invalid"
-              :models        []}
+      (is (= {:value             (metabot.settings/llm-metabot-provider)
+              :credentials-error "OpenAI API key expired or invalid"
+              :models            []}
              (mt/user-http-request :crowberto :get 200 "metabot/settings"
                                    :provider "openai"))))))
 

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -1295,11 +1295,101 @@
         (mt/user-http-request :crowberto :put 200 "metabot/settings"
                               {:provider    "bedrock"
                                :credentials {:access-key-id     "AKIANEWNEWNEWNEWNEW1"
-                                             :secret-access-key "new-secret"}})
-        (testing "a session token from the previous key pair does not survive rotation"
+                                             :secret-access-key "new-secret"
+                                             :session-token     nil}})
+        (testing "an explicit nil session token sent alongside rotated keys clears the saved token"
           (is (nil? (llm.settings/llm-bedrock-session-token))))
         (is (= "AKIANEWNEWNEWNEWNEW1" (llm.settings/llm-bedrock-access-key-id)))
         (is (= "new-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest settings-put-bedrock-rotation-without-session-token-field-keeps-token-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAOLDOLDOLDOLDOLD1"
+                                       llm.settings/llm-bedrock-secret-access-key "old-secret"
+                                       llm.settings/llm-bedrock-session-token     "old-token"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:access-key-id     "AKIANEWNEWNEWNEWNEW1"
+                                             :secret-access-key "new-secret"}})
+        (testing "new key material without a session-token field keeps the saved token; clearing it takes an explicit nil"
+          (is (= "old-token" (llm.settings/llm-bedrock-session-token))))
+        (is (= "AKIANEWNEWNEWNEWNEW1" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "new-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest settings-put-bedrock-nil-session-token-clears-token-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "stale-token"
+                                       llm.settings/llm-bedrock-region            "us-east-2"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
+                                                             (is (= "bedrock" provider))
+                                                             (is (= {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                                                     :secret-access-key "test-secret"
+                                                                     :session-token     nil
+                                                                     :region            "us-east-2"}
+                                                                    credentials)
+                                                                 "validation should run without the cleared session token")
+                                                             {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:session-token nil}})
+        (testing "an explicit nil session token clears the saved token without touching the keys"
+          (is (nil? (llm.settings/llm-bedrock-session-token))))
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))
+        (is (= "us-east-2" (llm.settings/llm-bedrock-region)))))))
+
+(deftest settings-put-bedrock-blank-session-token-clears-token-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "stale-token"
+                                       llm.settings/llm-bedrock-region            "us-east-2"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:session-token ""}})
+        (testing "a blank session token field counts as an explicit clear, same as nil"
+          (is (nil? (llm.settings/llm-bedrock-session-token))))
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))))))
+
+(deftest settings-put-bedrock-nil-region-resets-to-default-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "test-token"
+                                       llm.settings/llm-bedrock-region            "us-east-2"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+        (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                              {:provider    "bedrock"
+                               :credentials {:region nil}})
+        (testing "an explicit nil region resets the setting to its default"
+          (is (= "us-east-1" (llm.settings/llm-bedrock-region))))
+        (is (= "AKIAIOSFODNN7EXAMPLE" (llm.settings/llm-bedrock-access-key-id)))
+        (is (= "test-secret" (llm.settings/llm-bedrock-secret-access-key)))
+        (is (= "test-token" (llm.settings/llm-bedrock-session-token)))))))
 
 (deftest settings-put-bedrock-preserves-session-token-without-new-key-test
   (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -88,6 +88,32 @@
                                                :region            "evil.example/?x="}}))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
+;;; AI proxy (unsupported)
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest list-models-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                       llm.settings/llm-bedrock-secret-access-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for AWS Bedrock"
+             (bedrock/list-models {:ai-proxy? true})))))))
+
+(deftest bedrock-raw-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                       llm.settings/llm-bedrock-secret-access-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for AWS Bedrock"
+             (bedrock/bedrock-raw {:model     "anthropic.claude-haiku-4-5"
+                                   :input     [{:role :user :content "hi"}]
+                                   :ai-proxy? true})))))))
+
+;;; ──────────────────────────────────────────────────────────────────
 ;;; API family dispatch
 ;;; ──────────────────────────────────────────────────────────────────
 

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -13,66 +13,6 @@
 (set! *warn-on-reflection* true)
 
 ;;; ──────────────────────────────────────────────────────────────────
-;;; SigV4 signing
-;;; ──────────────────────────────────────────────────────────────────
-
-;; Golden values cross-checked against an independent Python implementation of the SigV4 spec
-;; (hashlib/hmac); the same signing code is also validated live against the real mantle endpoint.
-
-(def ^:private golden-creds
-  {:access-key-id     "AKIDEXAMPLE"
-   :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-   :region            "us-east-1"
-   :host              "bedrock-mantle.us-east-1.api.aws"
-   :amz-date          "20260101T120000Z"})
-
-(deftest ^:parallel sigv4-headers-post-golden-test
-  (let [headers (bedrock/sigv4-headers (merge golden-creds
-                                              {:method       :post
-                                               :path         "/anthropic/v1/messages"
-                                               :body         "{\"hello\":\"world\"}"
-                                               :content-type "application/json"}))]
-    (is (= {"host"          "bedrock-mantle.us-east-1.api.aws"
-            "x-amz-date"    "20260101T120000Z"
-            "content-type"  "application/json"
-            "authorization" (str "AWS4-HMAC-SHA256 "
-                                 "Credential=AKIDEXAMPLE/20260101/us-east-1/bedrock/aws4_request, "
-                                 "SignedHeaders=content-type;host;x-amz-date, "
-                                 "Signature=6c735dfbbe3d7a69a35684b2f677f041cebce02703c7286c7b26b56a224bf0df")}
-           (into {} headers)))))
-
-(deftest ^:parallel sigv4-headers-session-token-golden-test
-  (let [headers (bedrock/sigv4-headers (merge golden-creds
-                                              {:session-token "FwoGZXIvYXdzEXAMPLETOKEN"
-                                               :method        :post
-                                               :path          "/anthropic/v1/messages"
-                                               :body          "{\"hello\":\"world\"}"
-                                               :content-type  "application/json"}))]
-    (testing "the session token is sent and included in the signed headers"
-      (is (= "FwoGZXIvYXdzEXAMPLETOKEN" (get headers "x-amz-security-token"))))
-    (is (= (str "AWS4-HMAC-SHA256 "
-                "Credential=AKIDEXAMPLE/20260101/us-east-1/bedrock/aws4_request, "
-                "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, "
-                "Signature=9ca737aa04b4f91a973acbcc65f71541cb2d874b368927d6a1d1a9c8e1376294")
-           (get headers "authorization")))))
-
-(deftest ^:parallel sigv4-headers-get-no-body-golden-test
-  (let [headers (bedrock/sigv4-headers {:access-key-id     "AKIDEXAMPLE"
-                                        :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-                                        :region            "us-east-2"
-                                        :host              "bedrock-mantle.us-east-2.api.aws"
-                                        :amz-date          "20260101T120000Z"
-                                        :method            :get
-                                        :path              "/v1/models"})]
-    (testing "no content-type header is signed for a body-less request"
-      (is (not (contains? headers "content-type"))))
-    (is (= (str "AWS4-HMAC-SHA256 "
-                "Credential=AKIDEXAMPLE/20260101/us-east-2/bedrock/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=15abca797f32148262ccdf66baceabbc75f3177154b8a5593536323974db8419")
-           (get headers "authorization")))))
-
-;;; ──────────────────────────────────────────────────────────────────
 ;;; Model listing
 ;;; ──────────────────────────────────────────────────────────────────
 
@@ -133,10 +73,11 @@
         body (json/decode+kw (:body req))]
     (is (= "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages" (:url req)))
     (testing "the unsigned anthropic-version header is sent alongside the signed SigV4 headers"
-      (is (=? {"anthropic-version" "2023-06-01"
-               "host"              "bedrock-mantle.us-east-1.api.aws"
-               "content-type"      "application/json"
-               "authorization"     #"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/.*"}
+      (is (=? {"anthropic-version"    "2023-06-01"
+               "Host"                 "bedrock-mantle.us-east-1.api.aws"
+               "Content-Type"         "application/json"
+               "x-amz-content-sha256" #"^[0-9a-f]{64}$"
+               "Authorization"        #"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/.*SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date.*"}
               (:headers req))))
     (testing "body is an Anthropic Messages request without the top-level cache_control mantle rejects"
       (is (=? {:model    "anthropic.claude-haiku-4-5"

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -23,11 +23,12 @@
    {:id "openai.gpt-oss-120b" :object "model"}
    {:id "deepseek.v3.2" :object "model"}
    {:id "anthropic.claude-opus-4-8" :object "model"}
+   {:id "anthropic.claude-fable-5" :object "model"}
    {:id "openai.gpt-5.4" :object "model"}])
 
 (deftest list-models-filters-to-supported-vendors-test
   (mt/with-dynamic-fn-redefs [bedrock/list-all-models (constantly fake-catalog)]
-    (testing "only anthropic.* and openai.* models survive, gpt-oss excluded, sorted by id"
+    (testing "only anthropic.* and openai.* models survive, gpt-oss and fable excluded, sorted by id"
       (is (= {:models [{:id "anthropic.claude-haiku-4-5" :display_name "anthropic.claude-haiku-4-5"}
                        {:id "anthropic.claude-opus-4-8" :display_name "anthropic.claude-opus-4-8"}
                        {:id "openai.gpt-5.4" :display_name "openai.gpt-5.4"}
@@ -43,12 +44,48 @@
          (bedrock/list-models)))))
 
 (deftest list-models-requires-both-keys-test
-  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                      llm.settings/llm-bedrock-secret-access-key nil]
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"AWS Bedrock credentials are not configured"
          (bedrock/list-models)))))
+
+(deftest list-models-accepts-credentials-override-test
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     nil
+                                     llm.settings/llm-bedrock-secret-access-key nil]
+    (testing "credentials passed in opts are used without requiring saved settings"
+      (let [captured (atom nil)]
+        (with-redefs [http/request (fn [req] (reset! captured req) {:body {:data fake-catalog}})]
+          (is (=? {:models [{:id "anthropic.claude-haiku-4-5"}
+                            {:id "anthropic.claude-opus-4-8"}
+                            {:id "openai.gpt-5.4"}
+                            {:id "openai.gpt-5.5"}]}
+                  (bedrock/list-models {:credentials {:access-key-id     "AKIAOVERRIDEOVERRID1"
+                                                      :secret-access-key "override-secret"
+                                                      :session-token     "override-token"
+                                                      :region            "eu-west-1"}})))
+          (is (=? {:url     "https://bedrock-mantle.eu-west-1.api.aws/v1/models"
+                   :headers {"Authorization"        #".*Credential=AKIAOVERRIDEOVERRID1/.*"
+                             "X-Amz-Security-Token" "override-token"}}
+                  @captured)))))))
+
+(deftest list-models-credentials-override-must-be-complete-test
+  (testing "an override missing the secret access key throws without falling back to saved settings"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"AWS Bedrock credentials are not configured"
+         (bedrock/list-models {:credentials {:access-key-id "AKIAOVERRIDEOVERRID1"}})))))
+
+(deftest list-models-credentials-override-region-validated-test
+  (testing "a bogus region in override credentials is rejected before the mantle URL is built"
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid AWS Bedrock region \"evil\.example/\?x=\""
+           (bedrock/list-models {:credentials {:access-key-id     "AKIAOVERRIDEOVERRID1"
+                                               :secret-access-key "override-secret"
+                                               :region            "evil.example/?x="}}))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; API family dispatch
@@ -57,7 +94,7 @@
 (defn- captured-raw-request!
   "Run `bedrock-raw` with HTTP stubbed out and return the clj-http request map it would send."
   [opts]
-  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                      llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
                                      llm.settings/llm-bedrock-session-token nil
                                      llm.settings/llm-bedrock-region "us-east-1"]
@@ -77,7 +114,7 @@
                "Host"                 "bedrock-mantle.us-east-1.api.aws"
                "Content-Type"         "application/json"
                "x-amz-content-sha256" #"^[0-9a-f]{64}$"
-               "Authorization"        #"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/.*SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date.*"}
+               "Authorization"        #"^AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/.*SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date.*"}
               (:headers req))))
     (testing "body is an Anthropic Messages request without the top-level cache_control mantle rejects"
       (is (=? {:model    "anthropic.claude-haiku-4-5"
@@ -132,7 +169,7 @@
             (.getBytes (str/join (map #(str "data: " (json/encode %) "\n\n") events)) "UTF-8"))})
 
 (defn- aisdk-parts-for! [model events]
-  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                      llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
                                      llm.settings/llm-bedrock-region "us-east-1"]
     (with-redefs [debug/capture-stream (fn [r _] r)
@@ -173,7 +210,7 @@
 
 (deftest invalid-region-rejected-before-request-test
   (testing "a bogus region set via env var is rejected before the mantle URL is built"
-    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                        llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
       (mt/with-temp-env-var-value! [mb-llm-bedrock-region "evil.example/?x="]
         (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
@@ -189,7 +226,7 @@
 (defn- list-models-error-message!
   "The translated message `list-models` throws when the HTTP layer fails with `status`/`body`."
   [status body]
-  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
                                      llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
                                      llm.settings/llm-bedrock-region "us-east-1"]
     (with-redefs [http/request (fn [_] (throw (ex-info "HTTP error" {:status  status

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -1,0 +1,269 @@
+(ns metabase.metabot.self.bedrock-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.self.bedrock :as bedrock]
+   [metabase.metabot.self.core :as self.core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; SigV4 signing
+;;; ──────────────────────────────────────────────────────────────────
+
+;; Golden values cross-checked against an independent Python implementation of the SigV4 spec
+;; (hashlib/hmac); the same signing code is also validated live against the real mantle endpoint.
+
+(def ^:private golden-creds
+  {:access-key-id     "AKIDEXAMPLE"
+   :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+   :region            "us-east-1"
+   :host              "bedrock-mantle.us-east-1.api.aws"
+   :amz-date          "20260101T120000Z"})
+
+(deftest ^:parallel sigv4-headers-post-golden-test
+  (let [headers (bedrock/sigv4-headers (merge golden-creds
+                                              {:method       :post
+                                               :path         "/anthropic/v1/messages"
+                                               :body         "{\"hello\":\"world\"}"
+                                               :content-type "application/json"}))]
+    (is (= {"host"          "bedrock-mantle.us-east-1.api.aws"
+            "x-amz-date"    "20260101T120000Z"
+            "content-type"  "application/json"
+            "authorization" (str "AWS4-HMAC-SHA256 "
+                                 "Credential=AKIDEXAMPLE/20260101/us-east-1/bedrock/aws4_request, "
+                                 "SignedHeaders=content-type;host;x-amz-date, "
+                                 "Signature=6c735dfbbe3d7a69a35684b2f677f041cebce02703c7286c7b26b56a224bf0df")}
+           (into {} headers)))))
+
+(deftest ^:parallel sigv4-headers-session-token-golden-test
+  (let [headers (bedrock/sigv4-headers (merge golden-creds
+                                              {:session-token "FwoGZXIvYXdzEXAMPLETOKEN"
+                                               :method        :post
+                                               :path          "/anthropic/v1/messages"
+                                               :body          "{\"hello\":\"world\"}"
+                                               :content-type  "application/json"}))]
+    (testing "the session token is sent and included in the signed headers"
+      (is (= "FwoGZXIvYXdzEXAMPLETOKEN" (get headers "x-amz-security-token"))))
+    (is (= (str "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20260101/us-east-1/bedrock/aws4_request, "
+                "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, "
+                "Signature=9ca737aa04b4f91a973acbcc65f71541cb2d874b368927d6a1d1a9c8e1376294")
+           (get headers "authorization")))))
+
+(deftest ^:parallel sigv4-headers-get-no-body-golden-test
+  (let [headers (bedrock/sigv4-headers {:access-key-id     "AKIDEXAMPLE"
+                                        :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                        :region            "us-east-2"
+                                        :host              "bedrock-mantle.us-east-2.api.aws"
+                                        :amz-date          "20260101T120000Z"
+                                        :method            :get
+                                        :path              "/v1/models"})]
+    (testing "no content-type header is signed for a body-less request"
+      (is (not (contains? headers "content-type"))))
+    (is (= (str "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20260101/us-east-2/bedrock/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=15abca797f32148262ccdf66baceabbc75f3177154b8a5593536323974db8419")
+           (get headers "authorization")))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Model listing
+;;; ──────────────────────────────────────────────────────────────────
+
+(def ^:private fake-catalog
+  [{:id "qwen.qwen3-next-80b-a3b-instruct" :object "model"}
+   {:id "openai.gpt-5.5" :object "model"}
+   {:id "anthropic.claude-haiku-4-5" :object "model"}
+   {:id "openai.gpt-oss-120b" :object "model"}
+   {:id "deepseek.v3.2" :object "model"}
+   {:id "anthropic.claude-opus-4-8" :object "model"}
+   {:id "openai.gpt-5.4" :object "model"}])
+
+(deftest list-models-filters-to-supported-vendors-test
+  (mt/with-dynamic-fn-redefs [bedrock/list-all-models (constantly fake-catalog)]
+    (testing "only anthropic.* and openai.* models survive, gpt-oss excluded, sorted by id"
+      (is (= {:models [{:id "anthropic.claude-haiku-4-5" :display_name "anthropic.claude-haiku-4-5"}
+                       {:id "anthropic.claude-opus-4-8" :display_name "anthropic.claude-opus-4-8"}
+                       {:id "openai.gpt-5.4" :display_name "openai.gpt-5.4"}
+                       {:id "openai.gpt-5.5" :display_name "openai.gpt-5.5"}]}
+             (bedrock/list-models))))))
+
+(deftest list-models-missing-credentials-test
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id nil
+                                     llm.settings/llm-bedrock-secret-access-key nil]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"AWS Bedrock credentials are not configured"
+         (bedrock/list-models)))))
+
+(deftest list-models-requires-both-keys-test
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                     llm.settings/llm-bedrock-secret-access-key nil]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"AWS Bedrock credentials are not configured"
+         (bedrock/list-models)))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; API family dispatch
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- captured-raw-request!
+  "Run `bedrock-raw` with HTTP stubbed out and return the clj-http request map it would send."
+  [opts]
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                     llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                     llm.settings/llm-bedrock-session-token nil
+                                     llm.settings/llm-bedrock-region "us-east-1"]
+    (with-redefs [self.core/sse-reducible identity
+                  debug/capture-stream    (fn [r _] r)
+                  http/request            (fn [req] {:body req})]
+      (bedrock/bedrock-raw opts))))
+
+(deftest anthropic-model-dispatches-to-messages-api-test
+  (let [req  (captured-raw-request! {:model "anthropic.claude-haiku-4-5"
+                                     :system "be brief"
+                                     :input  [{:role :user :content "hi"}]})
+        body (json/decode+kw (:body req))]
+    (is (= "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages" (:url req)))
+    (testing "the unsigned anthropic-version header is sent alongside the signed SigV4 headers"
+      (is (=? {"anthropic-version" "2023-06-01"
+               "host"              "bedrock-mantle.us-east-1.api.aws"
+               "content-type"      "application/json"
+               "authorization"     #"^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/.*"}
+              (:headers req))))
+    (testing "body is an Anthropic Messages request without the top-level cache_control mantle rejects"
+      (is (=? {:model    "anthropic.claude-haiku-4-5"
+               :stream   true
+               :system   [{:type "text" :text "be brief" :cache_control {:type "ephemeral"}}]
+               :messages [{:role "user" :content [{:type "text" :text "hi"}]}]}
+              body))
+      (is (not (contains? body :cache_control))))))
+
+(deftest openai-model-dispatches-to-responses-api-test
+  (let [req  (captured-raw-request! {:model      "openai.gpt-5.5"
+                                     :system      "be brief"
+                                     :input       [{:role :user :content "hi"}]
+                                     :temperature 0.3
+                                     :max-tokens  128})
+        body (json/decode+kw (:body req))]
+    (is (= "https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses" (:url req)))
+    (is (=? {:model             "openai.gpt-5.5"
+             :stream            true
+             :instructions      "be brief"
+             :max_output_tokens 128
+             :input             [{:role "user" :content "hi"}]}
+            body))
+    (testing "temperature is omitted for openai.-prefixed reasoning models"
+      (is (not (contains? body :temperature))))))
+
+(deftest unsupported-model-throws-test
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"Unsupported Bedrock model deepseek.v3.2. Only anthropic.\* and openai.\* models are supported."
+       (captured-raw-request! {:model "deepseek.v3.2"
+                               :input [{:role :user :content "hi"}]}))))
+
+(deftest ^:parallel mantle-anthropic-body-test
+  (testing "drops only the top-level cache_control, preserving content-block-level markers"
+    (is (= {:model "anthropic.claude-haiku-4-5"
+            :system [{:type "text" :text "s" :cache_control {:type "ephemeral"}}]}
+           (bedrock/->mantle-anthropic-body
+            {:model         "anthropic.claude-haiku-4-5"
+             :cache_control {:type "ephemeral"}
+             :system        [{:type "text" :text "s" :cache_control {:type "ephemeral"}}]})))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Stream translation (xf selection by model family)
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- sse-response-for
+  "A stubbed clj-http response whose body is an SSE stream of `events`."
+  [events]
+  {:status 200
+   :body   (java.io.ByteArrayInputStream.
+            (.getBytes (str/join (map #(str "data: " (json/encode %) "\n\n") events)) "UTF-8"))})
+
+(defn- aisdk-parts-for! [model events]
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                     llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                     llm.settings/llm-bedrock-region "us-east-1"]
+    (with-redefs [debug/capture-stream (fn [r _] r)
+                  http/request         (fn [_] (sse-response-for events))]
+      (into [] (self.core/aisdk-xf)
+            (bedrock/bedrock {:model model
+                              :input [{:role :user :content "hi"}]})))))
+
+(deftest anthropic-model-uses-claude-stream-translation-test
+  (is (=? [{:type :start :id "msg_1"}
+           {:type :text :text "pong"}
+           {:type :usage :usage {:promptTokens 3 :completionTokens 2}}]
+          (aisdk-parts-for!
+           "anthropic.claude-haiku-4-5"
+           [{:type "message_start" :message {:id "msg_1" :model "claude-haiku-4-5" :usage {:input_tokens 3}}}
+            {:type "content_block_start" :index 0 :content_block {:type "text"}}
+            {:type "content_block_delta" :index 0 :delta {:type "text_delta" :text "pong"}}
+            {:type "content_block_stop" :index 0}
+            {:type "message_delta" :delta {:stop_reason "end_turn"} :usage {:input_tokens 3 :output_tokens 2}}
+            {:type "message_stop"}]))))
+
+(deftest openai-model-uses-openai-stream-translation-test
+  (is (=? [{:type :start :id "resp_1"}
+           {:type :text :text "pong"}
+           {:type :usage :usage {:promptTokens 3 :completionTokens 2}}]
+          (aisdk-parts-for!
+           "openai.gpt-5.5"
+           [{:type "response.created" :response {:id "resp_1" :model "openai.gpt-5.5"}}
+            {:type "response.output_item.added" :item {:type "message" :id "item_1"} :id "item_1"}
+            {:type "response.output_text.delta" :delta "pong" :id "item_1"}
+            {:type "response.output_item.done" :item {:type "message" :id "item_1"} :id "item_1"}
+            {:type "response.completed"
+             :response {:id "resp_1" :usage {:input_tokens 3 :output_tokens 2}}}]))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Region validation (host-injection backstop)
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest invalid-region-rejected-before-request-test
+  (testing "a bogus region set via env var is rejected before the mantle URL is built"
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (mt/with-temp-env-var-value! [mb-llm-bedrock-region "evil.example/?x="]
+        (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Invalid AWS Bedrock region \"evil\.example/\?x=\""
+               (bedrock/list-models))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Error translation
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- list-models-error-message!
+  "The translated message `list-models` throws when the HTTP layer fails with `status`/`body`."
+  [status body]
+  (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id "AKIDEXAMPLE"
+                                     llm.settings/llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                     llm.settings/llm-bedrock-region "us-east-1"]
+    (with-redefs [http/request (fn [_] (throw (ex-info "HTTP error" {:status  status
+                                                                     :headers {"content-type" "application/json"}
+                                                                     :body    body})))]
+      (try
+        (bedrock/list-models)
+        (catch Exception e
+          (ex-message e))))))
+
+(deftest auth-error-is-translated-without-body-preview-test
+  (testing "403s get the canonical message; the upstream body is withheld (may carry auth detail)"
+    (is (= "AWS Bedrock credentials lack permission for this model or action"
+           (list-models-error-message! 403 "{\"message\":\"secret account detail\"}")))))
+
+(deftest not-found-error-is-translated-with-body-preview-test
+  (is (= "AWS Bedrock model or endpoint is unavailable in the configured region — no such model"
+         (list-models-error-message! 404 "{\"message\":\"no such model\"}"))))

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -399,3 +399,36 @@
                    clojure.lang.ExceptionInfo
                    #"No Anthropic API key is set"
                    (claude/list-models {}))))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; temperature support tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel model-supports-temperature?-test
+  (testing "models that accept an explicit temperature"
+    (doseq [model ["claude-haiku-4-5" "claude-sonnet-4-6" "claude-sonnet-4-5"
+                   "claude-opus-4-5" "claude-opus-4-6" "claude-opus-4-1"]]
+      (is (true? (#'claude/model-supports-temperature? model))
+          model)))
+  (testing "sampling parameters were removed starting with Opus 4.7 and on Fable models"
+    (doseq [model ["claude-opus-4-7" "claude-opus-4-8" "claude-opus-4-8-20260415"
+                   "claude-opus-5" "claude-opus-5-0" "claude-fable-5"]]
+      (is (false? (#'claude/model-supports-temperature? model))
+          model))))
+
+(deftest ^:parallel model-supports-temperature?-bedrock-prefixed-test
+  (testing "Bedrock mantle ids carry an anthropic. vendor prefix that is stripped before the check"
+    (doseq [model ["anthropic.claude-opus-4-8" "anthropic.claude-opus-4-7" "anthropic.claude-fable-5"]]
+      (is (false? (#'claude/model-supports-temperature? model))
+          model))
+    (is (true? (#'claude/model-supports-temperature? "anthropic.claude-haiku-4-5")))))
+
+(deftest ^:parallel temperature-omitted-for-removed-sampling-models-test
+  (let [request-body #(claude/claude-request-body {:model       %
+                                                   :input       [{:role :user :content "hi"}]
+                                                   :temperature 0.3})]
+    (testing "temperature is sent for models that accept it"
+      (is (= 0.3 (:temperature (request-body "claude-haiku-4-5")))))
+    (testing "temperature is omitted for models that reject sampling parameters"
+      (is (not (contains? (request-body "claude-opus-4-8") :temperature)))
+      (is (not (contains? (request-body "anthropic.claude-opus-4-8") :temperature))))))

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -9,7 +9,8 @@
    [metabase.metabot.self.openai :as openai]
    [metabase.metabot.test-util :as metabot.tu]
    [metabase.premium-features.core :as premium-features]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
@@ -90,6 +91,30 @@
                 :usage {:promptTokens     pos-int?
                         :completionTokens pos-int?}}]
               (into [] (comp (openai/openai->aisdk-chunks-xf) (self.core/aisdk-xf)) raw-chunks))))))
+
+(deftest ^:parallel openai-reasoning-items-are-ignored-test
+  (testing "reasoning output items (emitted by GPT-5 / o-series models) are skipped without breaking the stream"
+    (let [base      (fixture "openai-text"
+                             {:input [{:role :user :content "Say hello briefly, in under 10 words."}]})
+          ;; GPT-5 reasoning models emit a reasoning output item before the text message item
+          reasoning [{:type "response.output_item.added" :item {:type "reasoning" :id "rs_1"}}
+                     {:type "response.output_item.done"  :item {:type "reasoning" :id "rs_1"}}]
+          ;; splice the reasoning events in right after response.created
+          patched   (into [] (mapcat (fn [chunk]
+                                       (if (= (:type chunk) "response.created")
+                                         (cons chunk reasoning)
+                                         [chunk])))
+                          base)]
+      (testing "no reasoning artifacts leak into the translated chunk types"
+        (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+                (into [] (comp (openai/openai->aisdk-chunks-xf) (m/distinct-by :type)) patched))))
+      (testing "full pipeline still produces text + usage"
+        (is (=? [{:type :start}
+                 {:type :text :text string?}
+                 {:type  :usage
+                  :usage {:promptTokens     pos-int?
+                          :completionTokens pos-int?}}]
+                (into [] (comp (openai/openai->aisdk-chunks-xf) (self.core/aisdk-xf)) patched)))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Usage normalization tests

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -205,6 +205,13 @@
       (is (false? (#'openai/model-supports-temperature? model))
           model))))
 
+(deftest ^:parallel model-supports-temperature?-bedrock-prefixed-test
+  (testing "Bedrock mantle ids carry an openai. vendor prefix that is stripped before the check"
+    (doseq [model ["openai.gpt-5.5" "openai.gpt-5.4" "openai.gpt-5.5-2026-04-23" "openai.o3-mini"]]
+      (is (false? (#'openai/model-supports-temperature? model))
+          model))
+    (is (true? (#'openai/model-supports-temperature? "openai.gpt-4.1-mini")))))
+
 (deftest temperature-omitted-for-reasoning-models-test
   (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-test"]
     (let [request-body (fn [opts]

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -165,6 +165,38 @@
             (openai/parts->openai-input
              [{:type :tool-output :id "call-1" :error {:message "Tool failed"}}])))))
 
+;;; ──────────────────────────────────────────────────────────────────
+;;; temperature support tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel model-supports-temperature?-test
+  (testing "non-reasoning models accept an explicit temperature"
+    (doseq [model ["gpt-4.1-mini" "gpt-4.1" "gpt-4o" "gpt-3.5-turbo"]]
+      (is (true? (#'openai/model-supports-temperature? model))
+          model)))
+  (testing "GPT-5 family and o-series reasoning models do not"
+    (doseq [model ["gpt-5" "gpt-5-mini" "gpt-5-nano" "gpt-5-2025-08-07"
+                   "o1" "o1-mini" "o3" "o3-mini" "o4-mini"]]
+      (is (false? (#'openai/model-supports-temperature? model))
+          model))))
+
+(deftest temperature-omitted-for-reasoning-models-test
+  (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-test"]
+    (let [request-body (fn [opts]
+                         (with-redefs [self.core/sse-reducible identity
+                                       debug/capture-stream    (fn [r _] r)
+                                       http/request            (fn [req] {:body req})]
+                           (json/decode+kw (:body (openai/openai-raw
+                                                   (merge {:input [{:role :user :content "hi"}]
+                                                           :temperature 0.3}
+                                                          opts))))))]
+      (testing "temperature is sent for a non-reasoning model"
+        (is (= 0.3 (:temperature (request-body {:model "gpt-4.1-mini"})))))
+      (testing "temperature is omitted for a GPT-5 model"
+        (is (not (contains? (request-body {:model "gpt-5"}) :temperature))))
+      (testing "temperature is omitted for an o-series model"
+        (is (not (contains? (request-body {:model "o3-mini"}) :temperature)))))))
+
 (deftest openai-auth-preferences-test
   (mt/with-premium-features #{:metabase-ai-managed}
     (mt/with-dynamic-fn-redefs [premium-features/premium-embedding-token (constantly "proxy-token")]

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -217,3 +217,34 @@
          java.lang.UnsupportedOperationException
          #"You cannot set ai-usage-max-retention-days"
          (setting/set! :ai-usage-max-retention-days 30)))))
+
+(deftest validate-metabot-provider-accepts-valid-direct-bedrock-test
+  (testing "accepts valid direct bedrock provider string"
+    (mt/with-temporary-setting-values [llm-metabot-provider "bedrock/anthropic.claude-haiku-4-5"]
+      (is (= "bedrock/anthropic.claude-haiku-4-5" (metabot.settings/llm-metabot-provider))))))
+
+(deftest metabot-configured-with-bedrock-credentials-test
+  (testing "returns true when bedrock has both the access key ID and secret access key set"
+    (mt/with-temporary-setting-values [llm-metabot-provider           "bedrock/anthropic.claude-haiku-4-5"
+                                       llm-bedrock-access-key-id      "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key  "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (is (true? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest metabot-configured-with-partial-bedrock-credentials-test
+  (testing "returns false when bedrock has an access key ID but no secret access key"
+    (mt/with-temporary-setting-values [llm-metabot-provider          "bedrock/anthropic.claude-haiku-4-5"
+                                       llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key nil]
+      (is (false? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest configured-provider-api-key-bedrock-fully-configured-test
+  (testing "returns the access key ID as a presence sentinel when bedrock is fully configured"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
+      (is (= "AKIDEXAMPLE" (metabot.settings/configured-provider-api-key "bedrock"))))))
+
+(deftest configured-provider-api-key-bedrock-partial-credentials-test
+  (testing "returns nil when bedrock has an access key ID but no secret access key"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                       llm-bedrock-secret-access-key nil]
+      (is (nil? (metabot.settings/configured-provider-api-key "bedrock"))))))

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -226,25 +226,68 @@
 (deftest metabot-configured-with-bedrock-credentials-test
   (testing "returns true when bedrock has both the access key ID and secret access key set"
     (mt/with-temporary-setting-values [llm-metabot-provider           "bedrock/anthropic.claude-haiku-4-5"
-                                       llm-bedrock-access-key-id      "AKIDEXAMPLE"
+                                       llm-bedrock-access-key-id      "AKIAIOSFODNN7EXAMPLE"
                                        llm-bedrock-secret-access-key  "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
       (is (true? (metabot.settings/llm-metabot-configured?))))))
 
 (deftest metabot-configured-with-partial-bedrock-credentials-test
   (testing "returns false when bedrock has an access key ID but no secret access key"
     (mt/with-temporary-setting-values [llm-metabot-provider          "bedrock/anthropic.claude-haiku-4-5"
-                                       llm-bedrock-access-key-id     "AKIDEXAMPLE"
+                                       llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                        llm-bedrock-secret-access-key nil]
       (is (false? (metabot.settings/llm-metabot-configured?))))))
 
-(deftest configured-provider-api-key-bedrock-fully-configured-test
-  (testing "returns the access key ID as a presence sentinel when bedrock is fully configured"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIDEXAMPLE"
-                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
-      (is (= "AKIDEXAMPLE" (metabot.settings/configured-provider-api-key "bedrock"))))))
+(deftest configured-provider-credentials-bedrock-fully-configured-test
+  (testing "returns the AWS credentials map when bedrock is fully configured"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                       llm-bedrock-session-token     nil
+                                       llm-bedrock-region            "us-east-2"]
+      (is (= {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+              :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+              :session-token     nil
+              :region            "us-east-2"}
+             (metabot.settings/configured-provider-credentials "bedrock"))))))
 
-(deftest configured-provider-api-key-bedrock-partial-credentials-test
+(deftest configured-provider-credentials-bedrock-partial-credentials-test
   (testing "returns nil when bedrock has an access key ID but no secret access key"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIDEXAMPLE"
+    (mt/with-temporary-setting-values [llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
                                        llm-bedrock-secret-access-key nil]
-      (is (nil? (metabot.settings/configured-provider-api-key "bedrock"))))))
+      (is (nil? (metabot.settings/configured-provider-credentials "bedrock"))))))
+
+(deftest provider-credentials-complete?-bedrock-test
+  (testing "bedrock credentials are complete only with both the access key ID and secret access key"
+    (is (true? (metabot.settings/provider-credentials-complete?
+                "bedrock"
+                {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                 :secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"})))
+    (is (false? (metabot.settings/provider-credentials-complete?
+                 "bedrock"
+                 {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                  :secret-access-key ""})))
+    (is (false? (metabot.settings/provider-credentials-complete?
+                 "bedrock"
+                 {:access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                  :secret-access-key nil})))
+    (is (false? (metabot.settings/provider-credentials-complete?
+                 "bedrock"
+                 {:access-key-id "AKIAIOSFODNN7EXAMPLE"})))
+    (is (false? (metabot.settings/provider-credentials-complete?
+                 "bedrock"
+                 {:secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "bedrock" nil)))))
+
+(deftest provider-credentials-complete?-api-key-provider-test
+  (testing "API-key provider credentials are complete only with a non-blank :api-key"
+    (is (true? (metabot.settings/provider-credentials-complete? "openai" {:api-key "sk-valid"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "openai" {:api-key ""})))
+    (is (false? (metabot.settings/provider-credentials-complete? "openai" {:api-key nil})))
+    (is (false? (metabot.settings/provider-credentials-complete? "openai" nil)))))
+
+(deftest configured-provider-credentials-api-key-provider-test
+  (testing "API-key providers return an {:api-key ...} credentials map, or nil when unset"
+    (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-ant-valid"]
+      (is (= {:api-key "sk-ant-valid"}
+             (metabot.settings/configured-provider-credentials "anthropic"))))
+    (mt/with-temporary-setting-values [llm-anthropic-api-key nil]
+      (is (nil? (metabot.settings/configured-provider-credentials "anthropic"))))))

--- a/test/metabase/metabot/used_tables_test.clj
+++ b/test/metabase/metabot/used_tables_test.clj
@@ -723,18 +723,23 @@
         ;; slot; the third can be neither run nor queued, so the default AbortPolicy rejects it -> dropped.
         (let [release (CountDownLatch. 1)
               full    (ThreadPoolExecutor. 1 1 0 TimeUnit/MILLISECONDS (ArrayBlockingQueue. 1))]
-          (try
-            (with-redefs [used-tables/waiter-executor    (delay full)
-                          used-tables/extract-and-insert! (fn [_ _] (.await release))]
+          (with-redefs [used-tables/waiter-executor    (delay full)
+                        used-tables/extract-and-insert! (fn [_ _] (.await release))]
+            (try
               (log.capture/with-log-messages-for-level [messages [metabase.metabot.used-tables :warn]]
                 (used-tables/record-used-tables! 1 [])         ; accepted: runs, parks on `release`
                 (used-tables/record-used-tables! 2 [])         ; accepted: occupies the lone queue slot
                 (is (nil? (used-tables/record-used-tables! 3 []))) ; rejected: nowhere to run or queue
                 (is (= 1.0 (mt/metric-value system :metabase-metabot/used-tables-extraction-dropped)))
-                (is (some #(re-find #"queue full" (:message %)) (messages)))))
-            (finally
-              (.countDown release)
-              (.shutdownNow full)))))
+                (is (some #(re-find #"queue full" (:message %)) (messages))))
+              (finally
+                ;; `shutdownNow` before releasing the latch, so the queued task 2 is drained without ever running.
+                ;; Await termination inside `with-redefs`: a task still in flight when the redefs unwind would hit
+                ;; the real `extract-and-insert!`, whose failure path can bump the errors counter after the next
+                ;; testing block has reset the metrics.
+                (.shutdownNow full)
+                (.countDown release)
+                (is (.awaitTermination full 2 TimeUnit/SECONDS)))))))
       (reset!)
       (testing "extract-used-tables-with-timing! counts a timeout, warns, and returns nil when extraction exceeds the cap"
         ;; Shrink extraction-timeout-ms and make extraction outlast it: the async path's `.get` times out, the worker


### PR DESCRIPTION
Closes [BOT-1663: Support LLM models on Bedrock](https://linear.app/metabase/issue/BOT-1663/support-llm-models-on-bedrock)

### Description

Adds Amazon Bedrock as a provider in the admin AI settings, letting customers run Anthropic or OpenAI models hosted on Bedrock with their own AWS credentials. Bedrock's "mantle" endpoint exposes Anthropic
  Messages and OpenAI Responses compatible API surfaces, so the existing Claude/OpenAI support in `claude.clj` and `openai.clj` is reused; the vendor prefix on the model id (e.g. `anthropic.*`, `openai.*`) selects the API family. Requests are signed with AWS Signature Version 4 using the AWS SDK's `AwsV4HttpSigner` rather than a hand-rolled implementation.

  Changes include:

  - `llm-metabot-provider` accepts `bedrock/{anthropic|openai}.{model}`
  - New env vars 
    - `MB_LLM_BEDROCK_ACCESS_KEY_ID`
    - `MB_LLM_BEDROCK_SECRET_ACCESS_KEY`
    - `MB_LLM_BEDROCK_SESSION_TOKEN` (optional, for temporary crews)
    - `MB_LLM_BEDROCK_REGION` (validated against the AWS SDK's known regions)
  - New provider in `metabot/self/bedrock.clj`
    - Auth via SigV4-signed requests against the bedrock-mantle endpoint
    - reuses the shared Claude/OpenAI request-body builders and streaming transducers
  - `PUT /api/metabot/settings` accepts a `credentials` map alongside the existing single `api-key`.
    - Bedrock credentials are validated (by listing models) before save
    - `credentials: null` disconnects the provider
    - error fields renamed from "api-key" to "credentials" on both BE and FE to match.
  - Requests via the ai-service proxy are rejected (not yet supported on the ai-service proxy side)
  - Some generic OpenAI provider fixes that Bedrock-hosted OpenAI models also need
    - use `max_output_tokens` instead of the removed `max_tokens`
    - skip `temperature` on models that don't support it (gpt-5, o-series)
    - ignore reasoning chunks in the stream transducer
- Admin UI (pending additional FE review/changes): "Amazon Bedrock" provider option with access key, secret key, session token, and region fields; the model dropdown is grouped by Anthropic/OpenAI

### Admin UI

<img width="802" height="664" alt="Screenshot 2026-06-15 at 10 14 28 AM" src="https://github.com/user-attachments/assets/2076d0c7-a38e-4af1-94ac-514d888b0546" />

### Benchmarks

Benchmark results with Claude Opus 4.8 via Bedrock compared to master with Opus 4.8 direct via Anthropic.

<img width="1544" height="398" alt="Screenshot 2026-06-15 at 8 33 33 AM" src="https://github.com/user-attachments/assets/d379c048-b8ef-4c34-a1a3-4c75064c35d8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)