### PR TITLE
Fix flaky read-only column resize test (metabase#9772)

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -297,13 +297,23 @@ describe("scenarios > question > saved", () => {
     cy.signIn("readonly");
     H.visitQuestion(ORDERS_QUESTION_ID);
 
-    cy.findAllByTestId("header-cell")
-      .filter(":contains(Tax)")
-      .as("headerCell")
-      .then(($cell) => {
-        const originalWidth = $cell[0].getBoundingClientRect().width;
-        cy.wrap(originalWidth).as("originalWidth");
-      });
+    const taxHeaderCell = () =>
+      cy.findAllByTestId("header-cell").filter(":contains(Tax)").first();
+
+    // The data grid first paints every column at the TanStack default width and
+    // then asynchronously measures content to shrink columns to fit. Wait for
+    // that measurement to land before capturing the baseline, otherwise the drag
+    // is compared against the stale (wider) default width.
+    const DEFAULT_COLUMN_WIDTH = 150;
+    taxHeaderCell().should(($cell) => {
+      expect($cell[0].getBoundingClientRect().width).to.be.lessThan(
+        DEFAULT_COLUMN_WIDTH,
+      );
+    });
+
+    taxHeaderCell().then(($cell) => {
+      cy.wrap($cell[0].getBoundingClientRect().width).as("originalWidth");
+    });
 
     cy.findByTestId("resize-handle-TAX").trigger("mousedown", {
       button: 0,
@@ -324,11 +334,8 @@ describe("scenarios > question > saved", () => {
       });
     cy.get("body").trigger("mouseup", { force: true });
 
-    // Wait until column width gets updated
-    cy.wait(10);
-
     cy.get("@originalWidth").then((originalWidth) => {
-      cy.get("@headerCell").should(($newCell) => {
+      taxHeaderCell().should(($newCell) => {
         const newWidth = $newCell[0].getBoundingClientRect().width;
         expect(newWidth).to.be.gte(originalWidth + stepX * 2);
       });


### PR DESCRIPTION
## What

Fixes the flaky `'read-only' user should be able to resize column width (metabase#9772)`
e2e test in `e2e/test/scenarios/question/saved.cy.spec.js`. Test-only change, no
product code touched.

## Root cause

The test captured the column's baseline width immediately after loading the
question, before the data grid's asynchronous column auto-measurement had run.
A column first paints at the TanStack default width (150px) and then shrinks to
fit its content (Tax settles at ~75px). When the baseline was read during that
provisional window, it recorded 150px; the column then shrank, and the +20px
drag (to ~95px) could never beat the stale `150 + 20 = 170` expectation, so the
assertion failed. CI/network throttling widened the window, making it
intermittent.

## Fix

- Wait for the measured width to land (Tax header width drops below the 150px
  default) before capturing the baseline, so the drag is compared against the
  settled width.
- Re-query the header cell for each assertion instead of reusing a cached alias,
  which can detach across the grid's re-render.
- Drop the fixed `cy.wait(10)`; the final `.should` already retries.

## Verification

Stress test (burn_in=50, single test via grep), network throttling on + off:
- network throttling ON: <run URL>
- network throttling OFF: <run URL>