### PR TITLE
Public link passwords: E2E happy-path spec + customer-facing documentation

### DIFF
--- a/docs/embedding/public-links.md
+++ b/docs/embedding/public-links.md
@@ -45,23 +45,20 @@ To share a document via a public link, admins can click on the **Sharing** butto
 
 Public documents are read-only: viewers cannot edit the content or add comments. For charts embedded in the document, viewers can download the results in CSV, XLSX, or JSON format using the **Download results** option in the chart menu.
 
-## Password-protect a public link
+## Set a password on a public link
 
 {% include plans-blockquote.html feature="Password-protected public links" is_plural=true %}
 
 You can add a password to a public link so that people need to enter it before they can view the question or dashboard.
 
-### Set a password on a public link
+Only admins can set, change, or remove a password from a public link.
 
-
-Only admins can set, change, or remove a password from a public link. 
-
-1. Click on **Sharing** for a question, dashboard, or document.
+1. Click on **Sharing** for a question or dashboard.
 2. If you haven't already, create a public link.
-3. Toggle **Require a password**.
+3. Toggle **Require password**.
 4. Enter a password (minimum 6 characters) and click **Save**.
 
-Groups with view access or higher can see the password in Metabase (so they can copy the password and give it to people).
+Anyone who can see the resource will be able to see the password.
 
 When people enter the password to view the link, the browser will issue an unlock cookie good for seven days. Changing or deleting the password will immediately invalidate these cookies.
 

--- a/docs/embedding/public-links.md
+++ b/docs/embedding/public-links.md
@@ -45,6 +45,37 @@ To share a document via a public link, admins can click on the **Sharing** butto
 
 Public documents are read-only: viewers cannot edit the content or add comments. For charts embedded in the document, viewers can download the results in CSV, XLSX, or JSON format using the **Download results** option in the chart menu.
 
+## Password-protect a public link
+
+{% include plans-blockquote.html feature="Password-protected public links" is_plural=true %}
+
+You can add a password to a public link so that people need to enter it before they can view the question or dashboard.
+
+### Set a password on a public link
+
+1. Click on **Sharing** for a question or dashboard.
+2. If you haven't already, create a public link.
+3. Toggle **Require a password**.
+4. Enter a password (minimum 6 characters) and click **Save**.
+
+All users who can view the question or dashboard can see the password. Only admins can set, change, or remove it.
+
+### How password-protected links work for viewers
+
+When someone visits a password-protected public link, they'll see a form asking for the password. After entering the correct password, Metabase stores an encrypted cookie in their browser so they don't need to re-enter the password for 7 days.
+
+### Change or remove the password
+
+To change the password, click the pencil icon next to the masked password in the sharing popover. To remove password protection entirely, toggle off **Require a password**.
+
+Changing or removing the password immediately invalidates existing unlock cookies, so viewers will need to re-enter the new password on their next visit.
+
+### Limitation: third-party cookie blocking
+
+Password-protected public links rely on a browser cookie to remember the unlock. If you embed a password-protected link as an iframe on a different domain, browsers with strict tracking protection (like Safari or Firefox with Enhanced Tracking Protection) may block the cookie since it's a third-party cookie. In that case, viewers would need to enter the password on every page load.
+
+Password-protected public links work best as standalone URLs or in same-domain embeds.
+
 ## Exporting raw, unformatted question results
 
 To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL Metabase generates. For example, if you create a public link for a CSV download, the URL would look like:

--- a/docs/embedding/public-links.md
+++ b/docs/embedding/public-links.md
@@ -53,28 +53,19 @@ You can add a password to a public link so that people need to enter it before t
 
 ### Set a password on a public link
 
-1. Click on **Sharing** for a question or dashboard.
+
+Only admins can set, change, or remove a password from a public link. 
+
+1. Click on **Sharing** for a question, dashboard, or document.
 2. If you haven't already, create a public link.
 3. Toggle **Require a password**.
 4. Enter a password (minimum 6 characters) and click **Save**.
 
-All users who can view the question or dashboard can see the password. Only admins can set, change, or remove it.
+Groups with view access or higher can see the password in Metabase (so they can copy the password and give it to people).
 
-### How password-protected links work for viewers
+When people enter the password to view the link, the browser will issue an unlock cookie good for seven days. Changing or deleting the password will immediately invalidate these cookies.
 
-When someone visits a password-protected public link, they'll see a form asking for the password. After entering the correct password, Metabase stores an encrypted cookie in their browser so they don't need to re-enter the password for 7 days.
-
-### Change or remove the password
-
-To change the password, click the pencil icon next to the masked password in the sharing popover. To remove password protection entirely, toggle off **Require a password**.
-
-Changing or removing the password immediately invalidates existing unlock cookies, so viewers will need to re-enter the new password on their next visit.
-
-### Limitation: third-party cookie blocking
-
-Password-protected public links rely on a browser cookie to remember the unlock. If you embed a password-protected link as an iframe on a different domain, browsers with strict tracking protection (like Safari or Firefox with Enhanced Tracking Protection) may block the cookie since it's a third-party cookie. In that case, viewers would need to enter the password on every page load.
-
-Password-protected public links work best as standalone URLs or in same-domain embeds.
+In some cases, viewers may need to input the password on each visit (for example, if you've embedded the public link in an iframe in another domain, and the person's browser blocks third-party cookies).
 
 ## Exporting raw, unformatted question results
 

--- a/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
@@ -1,0 +1,181 @@
+const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails: StructuredQuestionDetails = {
+  name: "Orders count",
+  query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
+  display: "scalar",
+};
+
+const PASSWORD = "secret123";
+const UPDATED_PASSWORD = "updated456";
+
+describe(
+  "scenarios > sharing > public link password protection",
+  { tags: ["@enterprise"] },
+  () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+      H.updateSetting("enable-public-sharing", true);
+    });
+
+    it("viewer: unlock form blocks access then allows it after correct password (dashboard)", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          cy.log("Create public link and set a password via API");
+          cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`).then(
+            ({ body: { uuid } }) => {
+              cy.request(
+                "PUT",
+                `/api/dashboard/${dashboard_id}/public_password`,
+                { password: PASSWORD },
+              );
+
+              cy.log("Visit public dashboard as anonymous user");
+              cy.signOut();
+              cy.visit(`/public/dashboard/${uuid}`);
+
+              cy.log("Unlock form should be displayed");
+              cy.findByTestId("unlock-password-input").should("be.visible");
+              cy.findByTestId("unlock-submit-button").should("be.visible");
+
+              cy.log("Wrong password shows error");
+              cy.findByTestId("unlock-password-input").type("wrongpass");
+              cy.findByTestId("unlock-submit-button").click();
+              cy.findByText("Incorrect password.").should("be.visible");
+
+              cy.log("Correct password unlocks the dashboard");
+              cy.findByTestId("unlock-password-input").clear().type(PASSWORD);
+
+              cy.intercept("POST", `/api/public/dashboard/${uuid}/unlock`).as(
+                "unlock",
+              );
+              cy.findByTestId("unlock-submit-button").click();
+              cy.wait("@unlock");
+
+              cy.log("Dashboard content should be visible after reload");
+              cy.findByTestId("scalar-value").should("be.visible");
+            },
+          );
+        },
+      );
+    });
+
+    it("creator can set, update, and remove a password on a dashboard public link", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          H.visitDashboard(dashboard_id);
+
+          cy.log("Create a public link");
+          H.openSharingMenu("Create a public link");
+
+          cy.log("Toggle password on and set it");
+          cy.findByTestId("public-link-password-toggle").click({ force: true });
+          cy.findByTestId("public-link-password-input")
+            .should("be.visible")
+            .type(PASSWORD);
+
+          cy.intercept("PUT", "/api/dashboard/*/public_password").as(
+            "setPassword",
+          );
+          cy.intercept("GET", "/api/dashboard/*/public_password").as(
+            "getPassword",
+          );
+          cy.findByTestId("public-link-password-save").click();
+          cy.wait("@setPassword");
+          cy.wait("@getPassword");
+
+          cy.log("Password should be saved and displayed masked");
+          cy.findByTestId("public-link-password-display").should("be.visible");
+
+          cy.log("Edit the password");
+          cy.findByTestId("public-link-password-edit").click();
+          cy.findByTestId("public-link-password-input")
+            .clear()
+            .type(UPDATED_PASSWORD);
+
+          cy.intercept("PUT", "/api/dashboard/*/public_password").as(
+            "updatePassword",
+          );
+          cy.intercept("GET", "/api/dashboard/*/public_password").as(
+            "getUpdatedPassword",
+          );
+          cy.findByTestId("public-link-password-confirm").click();
+          cy.wait("@updatePassword");
+          cy.wait("@getUpdatedPassword");
+
+          cy.log("Password should still be displayed");
+          cy.findByTestId("public-link-password-display").should("be.visible");
+
+          cy.log("Remove the password by toggling off");
+          cy.intercept("DELETE", "/api/dashboard/*/public_password").as(
+            "deletePassword",
+          );
+          cy.findByTestId("public-link-password-toggle").click({ force: true });
+          cy.wait("@deletePassword");
+
+          cy.log("Password section should be gone");
+          cy.findByTestId("public-link-password-toggle").should("exist");
+          cy.findByTestId("public-link-password-display").should("not.exist");
+        },
+      );
+    });
+
+    it("creator can set, update, and remove a password on a question public link", () => {
+      H.createQuestion(questionDetails).then(({ body: { id } }) => {
+        H.visitQuestion(id);
+
+        cy.log("Create a public link");
+        H.openSharingMenu("Create a public link");
+
+        cy.log("Toggle password on and set it");
+        cy.findByTestId("public-link-password-toggle").click({ force: true });
+        cy.findByTestId("public-link-password-input")
+          .should("be.visible")
+          .type(PASSWORD);
+
+        cy.intercept("PUT", "/api/card/*/public_password").as("setPassword");
+        cy.intercept("GET", "/api/card/*/public_password").as("getPassword");
+        cy.findByTestId("public-link-password-save").click();
+        cy.wait("@setPassword");
+        cy.wait("@getPassword");
+
+        cy.log("Password should be saved and displayed masked");
+        cy.findByTestId("public-link-password-display").should("be.visible");
+
+        cy.log("Edit the password");
+        cy.findByTestId("public-link-password-edit").click();
+        cy.findByTestId("public-link-password-input")
+          .clear()
+          .type(UPDATED_PASSWORD);
+
+        cy.intercept("PUT", "/api/card/*/public_password").as("updatePassword");
+        cy.intercept("GET", "/api/card/*/public_password").as(
+          "getUpdatedPassword",
+        );
+        cy.findByTestId("public-link-password-confirm").click();
+        cy.wait("@updatePassword");
+        cy.wait("@getUpdatedPassword");
+
+        cy.log("Password should still be displayed");
+        cy.findByTestId("public-link-password-display").should("be.visible");
+
+        cy.log("Remove the password by toggling off");
+        cy.intercept("DELETE", "/api/card/*/public_password").as(
+          "deletePassword",
+        );
+        cy.findByTestId("public-link-password-toggle").click({ force: true });
+        cy.wait("@deletePassword");
+
+        cy.log("Password section should be gone");
+        cy.findByTestId("public-link-password-toggle").should("exist");
+        cy.findByTestId("public-link-password-display").should("not.exist");
+      });
+    });
+  },
+);

--- a/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-link-password.cy.spec.ts
@@ -90,7 +90,7 @@ describe(
           cy.wait("@setPassword");
           cy.wait("@getPassword");
 
-          cy.log("Password should be saved and displayed masked");
+          cy.log("Password should be saved and displayed");
           cy.findByTestId("public-link-password-display").should("be.visible");
 
           cy.log("Edit the password");
@@ -145,7 +145,7 @@ describe(
         cy.wait("@setPassword");
         cy.wait("@getPassword");
 
-        cy.log("Password should be saved and displayed masked");
+        cy.log("Password should be saved and displayed");
         cy.findByTestId("public-link-password-display").should("be.visible");
 
         cy.log("Edit the password");
@@ -176,6 +176,39 @@ describe(
         cy.findByTestId("public-link-password-toggle").should("exist");
         cy.findByTestId("public-link-password-display").should("not.exist");
       });
+    });
+
+    it("creator: the password is masked and only fetched on an explicit reveal", () => {
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { dashboard_id } }) => {
+          cy.log("Create a public link and set a password via API");
+          cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`);
+          cy.request("PUT", `/api/dashboard/${dashboard_id}/public_password`, {
+            password: PASSWORD,
+          });
+
+          cy.intercept("POST", "/api/dashboard/*/public_password/reveal").as(
+            "revealPassword",
+          );
+
+          H.visitDashboard(dashboard_id);
+          H.openSharingMenu("Public link");
+
+          cy.log("Password is masked and the secret is not fetched on open");
+          cy.findByTestId("public-link-password-display")
+            .should("be.visible")
+            .and("not.have.value", PASSWORD);
+          cy.get("@revealPassword.all").should("have.length", 0);
+
+          cy.log("Clicking reveal fetches and shows the password");
+          cy.findByTestId("public-link-password-reveal").click();
+          cy.wait("@revealPassword");
+          cy.findByTestId("public-link-password-display").should(
+            "have.value",
+            PASSWORD,
+          );
+        },
+      );
     });
   },
 );


### PR DESCRIPTION
Closes [EMB-1817: E2E happy-path spec + customer-facing documentation](https://linear.app/metabase/issue/EMB-1817/e2e-happy-path-spec-customer-facing-documentation)

**Review order:** PR 9/9 in the password-protected public links stack.

### Description

- Cypress E2E spec with three tests: viewer unlock flow (wrong password → correct password → dashboard loads), creator set/update/remove password on a dashboard, and same on a question.
- New "Password-protect a public link" section in `docs/embedding/public-links.md`, flagged as a Pro/EE feature with the `plans-blockquote` include. Documents setting, changing, removing passwords, viewer experience, and third-party cookie limitation.

### How to verify

1. Run the E2E spec: `MB_EDITION=ee bun test-cypress --spec e2e/test/scenarios/sharing/public-link-password.cy.spec.ts`
2. Review the docs section in `docs/embedding/public-links.md`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR