### PR TITLE
Fix inconsistent db defaults for data_layer / data_authority

### DIFF
--- a/resources/migrations/063/20260610_table_curation_column_defaults.yaml
+++ b/resources/migrations/063/20260610_table_curation_column_defaults.yaml
@@ -1,12 +1,8 @@
-## Make metabase_table.data_layer and data_authority default consistently across app DBs.
-##
-## These two curation columns previously relied on different defaulting mechanisms:
-## - data_layer (added in v58) had no DB-level default (NULL), only a Clojure before-insert default.
-## - data_authority (added in v57) had a DB-level defaultValue but no Clojure default.
-## As a result the same logical table could end up with different values depending on the insert path
-## and the app DB (e.g. data_authority came back NULL on MySQL/MariaDB but "unconfigured" on H2/Postgres).
-## The model before-insert now sets both; here we (re)assert the matching DB-level defaults so non-model
-## insert paths are consistent too.
+## Default metabase_table.data_layer and data_authority consistently across app DBs.
+## Each column had only one defaulting mechanism — data_layer a Clojure before-insert default (DB column
+## NULL), data_authority a DB-level default (no Clojure default) — so values diverged by app DB
+## (data_authority was NULL on MySQL/MariaDB but "unconfigured" on H2/Postgres). The model now sets both;
+## this reasserts the matching DB-level defaults for non-model insert paths.
 
 databaseChangeLog:
   - changeSet:

--- a/resources/migrations/063/20260610_table_curation_column_defaults.yaml
+++ b/resources/migrations/063/20260610_table_curation_column_defaults.yaml
@@ -1,8 +1,5 @@
-## Default metabase_table.data_layer and data_authority consistently across app DBs.
-## Each column had only one defaulting mechanism — data_layer a Clojure before-insert default (DB column
-## NULL), data_authority a DB-level default (no Clojure default) — so values diverged by app DB
-## (data_authority was NULL on MySQL/MariaDB but "unconfigured" on H2/Postgres). The model now sets both;
-## this reasserts the matching DB-level defaults for non-model insert paths.
+## Assert DB-level defaults for metabase_table.data_layer / data_authority so they're consistent across
+## app DBs (data_authority was NULL on MySQL/MariaDB). The model before-insert sets both for model inserts.
 
 databaseChangeLog:
   - changeSet:

--- a/resources/migrations/063/20260610_table_curation_column_defaults.yaml
+++ b/resources/migrations/063/20260610_table_curation_column_defaults.yaml
@@ -1,0 +1,32 @@
+## Make metabase_table.data_layer and data_authority default consistently across app DBs.
+##
+## These two curation columns previously relied on different defaulting mechanisms:
+## - data_layer (added in v58) had no DB-level default (NULL), only a Clojure before-insert default.
+## - data_authority (added in v57) had a DB-level defaultValue but no Clojure default.
+## As a result the same logical table could end up with different values depending on the insert path
+## and the app DB (e.g. data_authority came back NULL on MySQL/MariaDB but "unconfigured" on H2/Postgres).
+## The model before-insert now sets both; here we (re)assert the matching DB-level defaults so non-model
+## insert paths are consistent too.
+
+databaseChangeLog:
+  - changeSet:
+      id: v63.2026-06-10T10:00:00
+      author: chris
+      comment: Default metabase_table.data_layer to "internal" at the DB level
+      changes:
+        - addDefaultValue:
+            tableName: metabase_table
+            columnName: data_layer
+            columnDataType: varchar(254)
+            defaultValue: internal
+
+  - changeSet:
+      id: v63.2026-06-10T10:00:01
+      author: chris
+      comment: Reassert metabase_table.data_authority DB default of "unconfigured" (was inconsistent on MySQL/MariaDB)
+      changes:
+        - addDefaultValue:
+            tableName: metabase_table
+            columnName: data_authority
+            columnDataType: varchar(20)
+            defaultValue: unconfigured

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -172,10 +172,8 @@
 
 (t2/define-before-insert :model/Table
   [table]
-  ;; Default both curation columns at the model level so every insert path gets the same value
-  ;; regardless of app DB. `data_layer` and `data_authority` previously relied on different mechanisms
-  ;; (Clojure default vs. a DB-level defaultValue), which left them inconsistent across app DBs — the
-  ;; DB-level defaults are also reasserted in a migration for non-model insert paths.
+  ;; Default both curation columns here so model inserts are consistent across app DBs; a migration
+  ;; reasserts matching DB-level defaults for non-model insert paths.
   (let [defaults {:display_name   (humanization/name->human-readable-name (:name table))
                   :field_order    (driver/default-field-order (t2/select-one-fn :engine :model/Database :id (:db_id table)))
                   :data_layer     :internal

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -172,9 +172,14 @@
 
 (t2/define-before-insert :model/Table
   [table]
-  (let [defaults {:display_name (humanization/name->human-readable-name (:name table))
-                  :field_order  (driver/default-field-order (t2/select-one-fn :engine :model/Database :id (:db_id table)))
-                  :data_layer   :internal}]
+  ;; Default both curation columns at the model level so every insert path gets the same value
+  ;; regardless of app DB. `data_layer` and `data_authority` previously relied on different mechanisms
+  ;; (Clojure default vs. a DB-level defaultValue), which left them inconsistent across app DBs — the
+  ;; DB-level defaults are also reasserted in a migration for non-model insert paths.
+  (let [defaults {:display_name   (humanization/name->human-readable-name (:name table))
+                  :field_order    (driver/default-field-order (t2/select-one-fn :engine :model/Database :id (:db_id table)))
+                  :data_layer     :internal
+                  :data_authority :unconfigured}]
     (collection/check-allowed-content :table (:collection_id table))
     (merge defaults table)))
 

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -752,8 +752,7 @@
         (is (=? {:data_layer :internal :data_authority :unconfigured}
                 (t2/select-one [:model/Table :data_layer :data_authority] :id table-id)))))
     (testing "via the DB-level column default when before-insert is bypassed (raw insert)"
-      ;; Mirrors non-model insert paths; guards the migration that (re)asserts the column defaults so
-      ;; they're consistent across app DBs (data_authority was NULL on MySQL/MariaDB before this).
+      ;; Exercises the non-model insert path, guarding the migration that asserts the DB-level defaults.
       (mt/with-temp [:model/Database {db-id :id} {}]
         (t2/query-one {:insert-into :metabase_table
                        :values      [{:name       "raw-insert-probe"

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -743,3 +743,24 @@
               (serdes/load-one! ingested table)
               (is (= (keyword expected)
                      (t2/select-one-fn :data_layer :model/Table :id table-id))))))))))
+
+(deftest curation-column-defaults-test
+  (testing "a new table gets consistent non-null data_layer and data_authority defaults"
+    (testing "via the model before-insert (the path sync uses)"
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Table {table-id :id} {:db_id db-id}]
+        (is (=? {:data_layer :internal :data_authority :unconfigured}
+                (t2/select-one [:model/Table :data_layer :data_authority] :id table-id)))))
+    (testing "via the DB-level column default when before-insert is bypassed (raw insert)"
+      ;; Mirrors non-model insert paths; guards the migration that (re)asserts the column defaults so
+      ;; they're consistent across app DBs (data_authority was NULL on MySQL/MariaDB before this).
+      (mt/with-temp [:model/Database {db-id :id} {}]
+        (t2/query-one {:insert-into :metabase_table
+                       :values      [{:name       "raw-insert-probe"
+                                      :db_id      db-id
+                                      :active     true
+                                      :created_at :%now
+                                      :updated_at :%now}]})
+        (is (=? {:data_layer :internal :data_authority :unconfigured}
+                (t2/select-one [:model/Table :data_layer :data_authority]
+                               :name "raw-insert-probe" :db_id db-id)))))))


### PR DESCRIPTION
## Problem

`metabase_table.data_layer` and `data_authority` could hold **different values for the same logical table depending on whether the AppDb is MySQL or not. The two columns each had only *one* defaulting mechanism:

- `data_layer` (v58): a Clojure `before-insert` default of `:internal`; the **DB column default is NULL**.
- `data_authority` (v57): a **DB-level `defaultValue` of `"unconfigured"`**; no Clojure default.

MySQL/MariaDB didn't apply `data_authority`'s DB default unlike H2/Postgres, so it set it to **NULL** as opposed to Postgres/H2 setting `"unconfigured"`.

## Fix

Give both columns **both** mechanisms:

- Model `before-insert` now defaults `data_authority` to `:unconfigured` for model based insert paths.
- A migration reapplies the DB-level defaults (`data_layer "internal"`, `data_authority "unconfigured"`) for non-model insert paths.

Why do we need both? We probably don't, but I am loathe to remove either existing mechanism from the model already using it. The model hooks are also more visible to developers and agents, while the database defaults cover raw SQL usage too. The risk of them falling out of sync is mitigated by tests.

## Tests

`curation-column-defaults-test` asserts both defaults via the model path and a raw insert.