### PR TITLE
GDGT-2617 Hide Security Center setup prompt from non-admins

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.tsx
@@ -8,6 +8,8 @@ import {
 import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
 import { NavbarPromoCard } from "metabase/nav/components/NavbarPromoCard";
+import { useSelector } from "metabase/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Icon } from "metabase/ui";
 
 import { isAffected } from "../../utils";
@@ -28,13 +30,19 @@ function useDismissed() {
 }
 
 export function SecurityCenterPromoCard() {
+  const isAdmin = useSelector(getUserIsAdmin);
   const tokenFeatures = useSetting("token-features");
   const plan = getPlan(tokenFeatures);
   const { data: channelInfo, isLoading: isChannelInfoLoading } =
-    useGetChannelInfoQuery();
+    useGetChannelInfoQuery(undefined, { skip: !isAdmin });
   const { data: advisoriesResponse, isLoading: isAdvisoriesLoading } =
-    useListSecurityAdvisoriesQuery();
+    useListSecurityAdvisoriesQuery(undefined, { skip: !isAdmin });
   const { dismissed, dismiss } = useDismissed();
+
+  // The promo links to /admin/security-center, so only admins should see it.
+  if (!isAdmin) {
+    return null;
+  }
 
   if (plan !== "pro-self-hosted") {
     return null;

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.tsx
@@ -1,3 +1,4 @@
+import { skipToken } from "@reduxjs/toolkit/query/react";
 import { useCallback, useState } from "react";
 import { t } from "ttag";
 
@@ -34,9 +35,9 @@ export function SecurityCenterPromoCard() {
   const tokenFeatures = useSetting("token-features");
   const plan = getPlan(tokenFeatures);
   const { data: channelInfo, isLoading: isChannelInfoLoading } =
-    useGetChannelInfoQuery(undefined, { skip: !isAdmin });
+    useGetChannelInfoQuery(isAdmin ? undefined : skipToken);
   const { data: advisoriesResponse, isLoading: isAdvisoriesLoading } =
-    useListSecurityAdvisoriesQuery(undefined, { skip: !isAdmin });
+    useListSecurityAdvisoriesQuery(isAdmin ? undefined : skipToken);
   const { dismissed, dismiss } = useDismissed();
 
   // The promo links to /admin/security-center, so only admins should see it.

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.unit.spec.tsx
@@ -17,6 +17,7 @@ import { SecurityCenterPromoCard } from "./SecurityCenterPromoCard";
 const DISMISSED_KEY = "security-center-promo-dismissed";
 
 interface SetupOpts {
+  isAdmin?: boolean;
   isProSelfHosted?: boolean;
   emailConfigured?: boolean;
   slackConfigured?: boolean;
@@ -24,6 +25,7 @@ interface SetupOpts {
 }
 
 function setup({
+  isAdmin = true,
   isProSelfHosted = true,
   emailConfigured = false,
   slackConfigured = false,
@@ -46,7 +48,7 @@ function setup({
   });
 
   const state = createMockState({
-    currentUser: createMockUser({ is_superuser: true }),
+    currentUser: createMockUser({ is_superuser: isAdmin }),
     settings: mockSettings({
       "token-features": tokenFeatures,
     }),
@@ -91,6 +93,20 @@ describe("SecurityCenterPromoCard", () => {
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not render or fire admin-only requests for non-admin users", async () => {
+    setup({ isAdmin: false });
+
+    await screen.findByText(() => false).catch(() => {});
+    expect(
+      screen.queryByText(/Stay safe with security alerts/),
+    ).not.toBeInTheDocument();
+
+    // Non-admins must not trigger admin-only endpoints.
+    expect(fetchMock.callHistory.called("path:/api/ee/security-center")).toBe(
+      false,
+    );
   });
 
   it("does not render for non-pro-self-hosted plans", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPromoCard/SecurityCenterPromoCard.unit.spec.tsx
@@ -1,9 +1,11 @@
+import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
 import { setupNotificationChannelsEndpoints } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { securityCenterApi, subscriptionApi } from "metabase/api";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { Advisory } from "metabase-types/api";
 import {
@@ -38,8 +40,8 @@ function setup({
   );
 
   setupNotificationChannelsEndpoints({
-    email: { configured: emailConfigured } as any,
-    slack: { configured: slackConfigured } as any,
+    email: { configured: emailConfigured },
+    slack: { configured: slackConfigured },
   });
 
   fetchMock.get("path:/api/ee/security-center", {
@@ -54,11 +56,42 @@ function setup({
     }),
   });
 
-  renderWithProviders(<Route path="*" component={SecurityCenterPromoCard} />, {
-    initialRoute: "/",
-    storeInitialState: state,
-    withRouter: true,
+  return renderWithProviders(
+    <Route path="*" component={SecurityCenterPromoCard} />,
+    {
+      initialRoute: "/",
+      storeInitialState: state,
+      withRouter: true,
+    },
+  );
+}
+
+type SetupResult = ReturnType<typeof setup>;
+
+async function waitForAdminQueriesToFinish({ store }: SetupResult) {
+  await waitFor(() => {
+    expect(
+      subscriptionApi.endpoints.getChannelInfo.select()(store.getState())
+        .isSuccess,
+    ).toBe(true);
+    expect(
+      securityCenterApi.endpoints.listSecurityAdvisories.select()(
+        store.getState(),
+      ).isSuccess,
+    ).toBe(true);
   });
+}
+
+function expectAdminQueriesToBeSkipped({ store }: SetupResult) {
+  expect(
+    subscriptionApi.endpoints.getChannelInfo.select()(store.getState())
+      .isUninitialized,
+  ).toBe(true);
+  expect(
+    securityCenterApi.endpoints.listSecurityAdvisories.select()(
+      store.getState(),
+    ).isUninitialized,
+  ).toBe(true);
 }
 
 describe("SecurityCenterPromoCard", () => {
@@ -78,27 +111,27 @@ describe("SecurityCenterPromoCard", () => {
   });
 
   it("does not render when email is configured", async () => {
-    setup({ emailConfigured: true });
+    const view = setup({ emailConfigured: true });
 
-    await screen.findByText(() => false).catch(() => {});
+    await waitForAdminQueriesToFinish(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
   });
 
   it("does not render when slack is configured", async () => {
-    setup({ slackConfigured: true });
+    const view = setup({ slackConfigured: true });
 
-    await screen.findByText(() => false).catch(() => {});
+    await waitForAdminQueriesToFinish(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
   });
 
-  it("does not render or fire admin-only requests for non-admin users", async () => {
-    setup({ isAdmin: false });
+  it("does not render or fire admin-only requests for non-admin users", () => {
+    const view = setup({ isAdmin: false });
 
-    await screen.findByText(() => false).catch(() => {});
+    expectAdminQueriesToBeSkipped(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
@@ -110,20 +143,20 @@ describe("SecurityCenterPromoCard", () => {
   });
 
   it("does not render for non-pro-self-hosted plans", async () => {
-    setup({ isProSelfHosted: false });
+    const view = setup({ isProSelfHosted: false });
 
-    await screen.findByText(() => false).catch(() => {});
+    await waitForAdminQueriesToFinish(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
   });
 
   it("does not render when there is an active advisory (red banner takes over)", async () => {
-    setup({
+    const view = setup({
       advisories: [createAdvisory({ match_status: "active" })],
     });
 
-    await screen.findByText(() => false).catch(() => {});
+    await waitForAdminQueriesToFinish(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();
@@ -134,7 +167,7 @@ describe("SecurityCenterPromoCard", () => {
 
     await screen.findByText(/Stay safe with security alerts/);
     const close = screen.getByRole("button", { name: /close/i });
-    close.click();
+    await userEvent.click(close);
 
     await waitFor(() => {
       expect(
@@ -147,9 +180,9 @@ describe("SecurityCenterPromoCard", () => {
   it("stays hidden after dismissal", async () => {
     localStorage.setItem(DISMISSED_KEY, "true");
 
-    setup();
+    const view = setup();
 
-    await screen.findByText(() => false).catch(() => {});
+    await waitForAdminQueriesToFinish(view);
     expect(
       screen.queryByText(/Stay safe with security alerts/),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75678

[GDGT-2617](https://linear.app/metabase/issue/GDGT-2617)

### Important
This should be **backported to 62, 61 and 60.**

### Description

"Stay safe with security alerts" promo card was visible to admins and led to a permission error.

### How to verify

1. Log in as a non-admin user on a pro-self-hosted instance.
2. Confirm the "Stay safe with security alerts" prompt no longer appears in the left navbar.
4. Log in as an admin (no notification channels configured, no active advisory) → the prompt still appears and links to the Security Center.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
