### PR TITLE
Wire transform target indexes into the full transform run

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -184,7 +184,7 @@
         (do
           (log/info "New table")
           (create-table-and-insert-data! driver db-id
-                                         (table-schema table-name metadata (transforms-base.u/target-indexes target))
+                                         (table-schema table-name metadata (:indexes target))
                                          data-source))
         ;; Append into an existing table: no create, so no inline indexes to apply.
         (insert-data! driver db-id (table-schema table-name metadata nil) data-source)))))
@@ -195,7 +195,7 @@
    metadata temp-file]
   (let [table-name (transforms-base.u/qualified-table-name driver target)
         table-exists? (transforms-base.u/target-table-exists? transform)
-        indexes (transforms-base.u/target-indexes target)
+        indexes (:indexes target)
         data-source {:type :jsonl-file
                      :file temp-file}]
     (cond

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -100,8 +100,7 @@
                              :type (python-runner/restricted-insert-type base_type)
                              :nullable? true})
                           (:fields metadata))}
-    ;; Inline indexes so `create-table-from-schema!` -> `create-table!` can render them (e.g. Redshift SORTKEY).
-    ;; Python transforms create the table here rather than via CTAS, so this is the only place they get inlined.
+    ;; Python builds the table via `create-table!` (not a CTAS), so this is where inline indexes get rendered.
     (seq indexes) (assoc :indexes indexes)))
 
 (defn- insert-data!

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -93,13 +93,16 @@
 
 ;;; ------------------------------------------------- Transfer Strategies -------------------------------------------------
 
-(defn- table-schema [table-name metadata]
-  {:name (if (keyword? table-name) table-name (keyword table-name))
-   :columns (mapv (fn [{:keys [name base_type]}]
-                    {:name name
-                     :type (python-runner/restricted-insert-type base_type)
-                     :nullable? true})
-                  (:fields metadata))})
+(defn- table-schema [table-name metadata indexes]
+  (cond-> {:name (if (keyword? table-name) table-name (keyword table-name))
+           :columns (mapv (fn [{:keys [name base_type]}]
+                            {:name name
+                             :type (python-runner/restricted-insert-type base_type)
+                             :nullable? true})
+                          (:fields metadata))}
+    ;; Inline indexes so `create-table-from-schema!` -> `create-table!` can render them (e.g. Redshift SORTKEY).
+    ;; Python transforms create the table here rather than via CTAS, so this is the only place they get inlined.
+    (seq indexes) (assoc :indexes indexes)))
 
 (defn- insert-data!
   "Insert data from source into an existing table."
@@ -115,14 +118,14 @@
 
 (defn- transfer-with-rename-tables-strategy!
   "Transfer data using the rename-tables*! multimethod with atomicity guarantees."
-  [driver db-id table-name metadata data-source]
+  [driver db-id table-name metadata indexes data-source]
   (let [source-table-name (transforms-base.u/temp-table-name driver (namespace table-name))
         temp-table-name (u/poll {:thunk #(transforms-base.u/temp-table-name driver (namespace table-name))
                                  :done? #(not= source-table-name %)
                                  :interval-ms 1})]
     (log/info "Using rename-tables strategy with atomicity guarantees")
     (try
-      (create-table-and-insert-data! driver db-id (table-schema source-table-name metadata) data-source)
+      (create-table-and-insert-data! driver db-id (table-schema source-table-name metadata indexes) data-source)
       (transforms-base.u/rename-tables! driver db-id {table-name temp-table-name
                                                       source-table-name table-name})
       (transforms-base.u/drop-table! driver db-id temp-table-name)
@@ -135,11 +138,11 @@
 
 (defn- transfer-with-create-drop-rename-strategy!
   "Transfer data using create + drop + rename to minimize time without data."
-  [driver db-id table-name metadata data-source]
+  [driver db-id table-name metadata indexes data-source]
   (let [source-table-name (transforms-base.u/temp-table-name driver (namespace table-name))]
     (log/info "Using create-drop-rename strategy to minimize downtime")
     (try
-      (create-table-and-insert-data! driver db-id (table-schema source-table-name metadata) data-source)
+      (create-table-and-insert-data! driver db-id (table-schema source-table-name metadata indexes) data-source)
       (transforms-base.u/drop-table! driver db-id table-name)
       (driver/rename-table! driver db-id source-table-name table-name)
       (catch Exception e
@@ -151,11 +154,11 @@
 
 (defn- transfer-with-drop-create-fallback-strategy!
   "Transfer data using drop + create fallback strategy."
-  [driver db-id table-name metadata data-source]
+  [driver db-id table-name metadata indexes data-source]
   (log/info "Using drop-create fallback strategy")
   (try
     (transforms-base.u/drop-table! driver db-id table-name)
-    (create-table-and-insert-data! driver db-id (table-schema table-name metadata) data-source)
+    (create-table-and-insert-data! driver db-id (table-schema table-name metadata indexes) data-source)
     (catch Exception e
       (log/error e "Failed to transfer data using drop-create fallback strategy")
       (throw e))))
@@ -180,8 +183,11 @@
       (if (not table-exists?)
         (do
           (log/info "New table")
-          (create-table-and-insert-data! driver db-id (table-schema table-name metadata) data-source))
-        (insert-data! driver db-id (table-schema table-name metadata) data-source)))))
+          (create-table-and-insert-data! driver db-id
+                                         (table-schema table-name metadata (transforms-base.u/target-indexes target))
+                                         data-source))
+        ;; Append into an existing table: no create, so no inline indexes to apply.
+        (insert-data! driver db-id (table-schema table-name metadata nil) data-source)))))
 
 (defmethod transfer-file-to-db :table
   [driver {db-id :id :as db}
@@ -189,22 +195,23 @@
    metadata temp-file]
   (let [table-name (transforms-base.u/qualified-table-name driver target)
         table-exists? (transforms-base.u/target-table-exists? transform)
+        indexes (transforms-base.u/target-indexes target)
         data-source {:type :jsonl-file
                      :file temp-file}]
     (cond
       (not table-exists?)
       (do
         (log/info "New table")
-        (create-table-and-insert-data! driver db-id (table-schema table-name metadata) data-source))
+        (create-table-and-insert-data! driver db-id (table-schema table-name metadata indexes) data-source))
 
       (driver.u/supports? driver :atomic-renames db)
-      (transfer-with-rename-tables-strategy! driver db-id table-name metadata data-source)
+      (transfer-with-rename-tables-strategy! driver db-id table-name metadata indexes data-source)
 
       (driver.u/supports? driver :rename db)
-      (transfer-with-create-drop-rename-strategy! driver db-id table-name metadata data-source)
+      (transfer-with-create-drop-rename-strategy! driver db-id table-name metadata indexes data-source)
 
       :else
-      (transfer-with-drop-create-fallback-strategy! driver db-id table-name metadata data-source))))
+      (transfer-with-drop-create-fallback-strategy! driver db-id table-name metadata indexes data-source))))
 
 ;;; ------------------------------------------------- Cancellation -------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -675,3 +675,39 @@
                                   checkpoint (get-checkpoint-value (:id transform))]
                               (is (= 17 row-count) "Should append 1 new row (16 + 1 = 17)")
                               (is (some? checkpoint) "Checkpoint should be updated"))))))))))))))))
+
+(defn- pg-index-names
+  [schema table]
+  (->> (next.jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/id))
+                           ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table]
+                           {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+       (map :indexname)
+       set))
+
+(deftest ^:synchronized incremental-append-preserves-declared-indexes-test
+  (testing "the first incremental run creates the target's standalone indexes; an append run leaves them untouched"
+    ;; The gating in `complete-execution!` (re)applies standalone indexes only on a full-create run: a `:table` run,
+    ;; or a first/full-reset incremental run. A plain append must skip it, otherwise it re-issues `CREATE INDEX`
+    ;; against the live table (no IF NOT EXISTS) and `execute!` throws. So a broken gate fails the append run below,
+    ;; not just the index assertion.
+    (mt/test-drivers #{:postgres}
+      (mt/with-premium-features #{:transforms-basic}
+        (mt/dataset transforms-dataset/transforms-test
+          (let [checkpoint-config (:integer checkpoint-configs)
+                indexed-target    (assoc (target-table-gen "incremental_index")
+                                         :indexes [{:kind :btree :name "incr_by_category" :columns [{:name "category"}]}])]
+            (with-transform-cleanup! [target indexed-target]
+              (let [payload (make-incremental-transform-payload "Incremental Index Transform" target :mbql checkpoint-config)
+                    schema  (:schema target)
+                    table   (:name target)]
+                (mt/with-temp [:model/Transform transform payload]
+                  (testing "first (full) run creates the declared btree"
+                    (transforms.execute/execute! transform {:run-method :manual})
+                    (transforms.tu/wait-for-table table 10000)
+                    (is (contains? (pg-index-names schema table) "incr_by_category")))
+                  (testing "append run preserves the btree without re-creating it"
+                    (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
+                                                  :price 379.99 :created-at "2024-01-20T10:00:00"}]
+                      (let [transform (t2/select-one :model/Transform (:id transform))]
+                        (transforms.execute/execute! transform {:run-method :manual})
+                        (is (contains? (pg-index-names schema table) "incr_by_category"))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -18,6 +18,7 @@
    [metabase.test :as mt]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.index-test-util :as index-util]
    [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
    [next.jdbc :as next.jdbc]
@@ -676,39 +677,42 @@
                               (is (= 17 row-count) "Should append 1 new row (16 + 1 = 17)")
                               (is (some? checkpoint) "Checkpoint should be updated"))))))))))))))))
 
-(defn- pg-index-names
-  [schema table]
-  (->> (next.jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/id))
-                           ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table]
-                           {:builder-fn jdbc.rs/as-unqualified-lower-maps})
-       (map :indexname)
-       set))
+(defn- incremental-index-test-drivers
+  "Index-supporting drivers that also run incremental transforms (the incremental suite excludes redshift/clickhouse/
+  sqlserver, so today this is effectively postgres)."
+  []
+  (into #{} (filter (index-util/index-test-drivers)) (test-drivers)))
 
-(deftest ^:synchronized incremental-append-preserves-declared-indexes-test
-  (testing "the first incremental run creates the target's standalone indexes; an append run leaves them untouched"
-    ;; The gating in `complete-execution!` (re)applies standalone indexes only on a full-create run: a `:table` run,
-    ;; or a first/full-reset incremental run. A plain append must skip it, otherwise it re-issues `CREATE INDEX`
-    ;; against the live table (no IF NOT EXISTS) and `execute!` throws. So a broken gate fails the append run below,
-    ;; not just the index assertion.
-    (mt/test-drivers #{:postgres}
-      (mt/with-premium-features #{:transforms-basic}
+(deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-on-incremental-transform-test
+  (testing "incremental: the first (full) run creates the target's declared indexes; an append run preserves them"
+    ;; The first run has no watermark, so it's a full rebuild that creates the table and its indexes. An append run
+    ;; keeps the live table, so `apply-target-indexes!`'s full-rebuild gate skips it and the indexes stay put.
+    ;; (Re-issuing would be a safe no-op now that standalone creates use IF NOT EXISTS, but skipping avoids the
+    ;; churn.) A broken gate would re-run index creation against the live table on the append.
+    ;; Indexes reach the run via `execute!`'s hydration seam, stubbed until the index-request model lands.
+    (mt/test-drivers (incremental-index-test-drivers)
+      (mt/with-premium-features #{:transforms-basic :transforms-python}
         (mt/dataset transforms-dataset/transforms-test
-          (let [checkpoint-config (:integer checkpoint-configs)
-                ;; Indexes reach the run via `execute!`'s hydration seam (stubbed until the index-request model lands).
-                indexes           [{:kind :btree :name "incr_by_category" :columns [{:name "category"}]}]]
-            (with-transform-cleanup! [target (target-table-gen "incremental_index")]
-              (let [payload (make-incremental-transform-payload "Incremental Index Transform" target :mbql checkpoint-config)
-                    schema  (:schema target)
-                    table   (:name target)]
-                (mt/with-temp [:model/Transform transform payload]
-                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
-                    (testing "first (full) run creates the declared btree"
-                      (transforms.execute/execute! transform {:run-method :manual})
-                      (transforms.tu/wait-for-table table 10000)
-                      (is (contains? (pg-index-names schema table) "incr_by_category")))
-                    (testing "append run preserves the btree without re-creating it"
-                      (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
-                                                    :price 379.99 :created-at "2024-01-20T10:00:00"}]
-                        (let [transform (t2/select-one :model/Transform (:id transform))]
-                          (transforms.execute/execute! transform {:run-method :manual})
-                          (is (contains? (pg-index-names schema table) "incr_by_category")))))))))))))))
+          (let [{:keys [indexes expected physical-indexes]} (index-util/driver-cases driver/*driver*)
+                checkpoint-config (:integer checkpoint-configs)
+                checkpoint-field  (:field-name checkpoint-config)]
+            (doseq [transform-type [:mbql :python]]
+              (testing (str "transform-type " transform-type)
+                (with-transform-cleanup! [{table-name :name :as target} (target-table-gen "incremental_index")]
+                  (let [payload (make-incremental-transform-payload "Incremental Index Transform"
+                                                                    target transform-type checkpoint-config)
+                        schema  (:schema target)]
+                    (mt/with-temp [:model/Transform transform payload]
+                      (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
+                        (testing "first (full) run creates the declared indexes"
+                          (execute-transform-with-ordering! transform transform-type checkpoint-field
+                                                            {:run-method :manual})
+                          (transforms.tu/wait-for-table table-name 10000)
+                          (is (= expected (physical-indexes (mt/db) schema table-name))))
+                        (testing "append run preserves the indexes"
+                          (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
+                                                        :price 379.99 :created-at "2024-01-20T10:00:00"}]
+                            (let [transform (t2/select-one :model/Transform (:id transform))]
+                              (execute-transform-with-ordering! transform transform-type checkpoint-field
+                                                                {:run-method :manual})
+                              (is (= expected (physical-indexes (mt/db) schema table-name))))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -678,18 +678,15 @@
                               (is (some? checkpoint) "Checkpoint should be updated"))))))))))))))))
 
 (defn- incremental-index-test-drivers
-  "Index-supporting drivers that also run incremental transforms (the incremental suite excludes redshift/clickhouse/
-  sqlserver, so today this is effectively postgres)."
+  "Index-supporting drivers that also run incremental transforms (effectively postgres today; the incremental suite
+  excludes redshift/clickhouse/sqlserver)."
   []
   (into #{} (filter (index-util/index-test-drivers)) (test-drivers)))
 
 (deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-on-incremental-transform-test
   (testing "incremental: the first (full) run creates the target's declared indexes; an append run preserves them"
-    ;; The first run has no watermark, so it's a full rebuild that creates the table and its indexes. An append run
-    ;; keeps the live table, so `apply-target-indexes!`'s full-rebuild gate skips it and the indexes stay put.
-    ;; (Re-issuing would be a safe no-op now that standalone creates use IF NOT EXISTS, but skipping avoids the
-    ;; churn.) A broken gate would re-run index creation against the live table on the append.
-    ;; Indexes reach the run via `execute!`'s hydration seam, stubbed until the index-request model lands.
+    ;; The first run has no watermark, so it's a full rebuild that creates the indexes. The append run keeps the
+    ;; live table, so `apply-target-indexes!`'s full-rebuild gate skips it (a broken gate would re-create them).
     (mt/test-drivers (incremental-index-test-drivers)
       (mt/with-premium-features #{:transforms-basic :transforms-python}
         (mt/dataset transforms-dataset/transforms-test

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -694,20 +694,21 @@
       (mt/with-premium-features #{:transforms-basic}
         (mt/dataset transforms-dataset/transforms-test
           (let [checkpoint-config (:integer checkpoint-configs)
-                indexed-target    (assoc (target-table-gen "incremental_index")
-                                         :indexes [{:kind :btree :name "incr_by_category" :columns [{:name "category"}]}])]
-            (with-transform-cleanup! [target indexed-target]
+                ;; Indexes reach the run via `execute!`'s hydration seam (stubbed until the index-request model lands).
+                indexes           [{:kind :btree :name "incr_by_category" :columns [{:name "category"}]}]]
+            (with-transform-cleanup! [target (target-table-gen "incremental_index")]
               (let [payload (make-incremental-transform-payload "Incremental Index Transform" target :mbql checkpoint-config)
                     schema  (:schema target)
                     table   (:name target)]
                 (mt/with-temp [:model/Transform transform payload]
-                  (testing "first (full) run creates the declared btree"
-                    (transforms.execute/execute! transform {:run-method :manual})
-                    (transforms.tu/wait-for-table table 10000)
-                    (is (contains? (pg-index-names schema table) "incr_by_category")))
-                  (testing "append run preserves the btree without re-creating it"
-                    (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
-                                                  :price 379.99 :created-at "2024-01-20T10:00:00"}]
-                      (let [transform (t2/select-one :model/Transform (:id transform))]
-                        (transforms.execute/execute! transform {:run-method :manual})
-                        (is (contains? (pg-index-names schema table) "incr_by_category"))))))))))))))
+                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
+                    (testing "first (full) run creates the declared btree"
+                      (transforms.execute/execute! transform {:run-method :manual})
+                      (transforms.tu/wait-for-table table 10000)
+                      (is (contains? (pg-index-names schema table) "incr_by_category")))
+                    (testing "append run preserves the btree without re-creating it"
+                      (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
+                                                    :price 379.99 :created-at "2024-01-20T10:00:00"}]
+                        (let [transform (t2/select-one :model/Transform (:id transform))]
+                          (transforms.execute/execute! transform {:run-method :manual})
+                          (is (contains? (pg-index-names schema table) "incr_by_category")))))))))))))))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -287,9 +287,8 @@
   (format "ORDER BY (%s)" (str/join ", " (map quote-name (order-by-columns opts)))))
 
 (defn- allow-nullable-key-setting
-  "The `allow_nullable_key = 1` MergeTree setting, or nil when the table has no sorting key. Transform target columns
-  are nullable (the Python path marks every column nullable; a CTAS inherits the source's nullability), and MergeTree
-  rejects a nullable sorting key unless this is set. So any target with an ORDER BY needs it."
+  "The `allow_nullable_key = 1` MergeTree setting, or nil when there's no sorting key. Transform target columns are
+  nullable, and MergeTree rejects a nullable sorting key without this."
   [opts]
   (when (seq (order-by-columns opts))
     "allow_nullable_key = 1"))
@@ -428,9 +427,7 @@
 (defmethod driver/compile-transform :clickhouse
   [driver {:keys [query output-table indexes]}]
   (let [{sql-query :query sql-params :params} query
-        ;; MergeTree requires an ORDER BY. With an inline `:order-by` index we use its columns as the sorting key;
-        ;; otherwise it stays the empty tuple `ORDER BY ()` (an unsorted table). A sorting key needs
-        ;; `allow_nullable_key` (see `allow-nullable-key-setting`); the SETTINGS clause goes before `AS SELECT`.
+        ;; A sorting key needs `allow_nullable_key`; the SETTINGS clause has to go before `AS SELECT`.
         settings (when-let [s (allow-nullable-key-setting {:indexes indexes})]
                    (sql.qp/format-honeysql driver {:raw (str "SETTINGS " s)}))
         pieces (cond-> [(sql.qp/format-honeysql driver {:create-table output-table})

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -286,6 +286,14 @@
   [opts]
   (format "ORDER BY (%s)" (str/join ", " (map quote-name (order-by-columns opts)))))
 
+(defn- allow-nullable-key-setting
+  "The `allow_nullable_key = 1` MergeTree setting, or nil when the table has no sorting key. Transform target columns
+  are nullable (the Python path marks every column nullable; a CTAS inherits the source's nullability), and MergeTree
+  rejects a nullable sorting key unless this is set. So any target with an ORDER BY needs it."
+  [opts]
+  (when (seq (order-by-columns opts))
+    "allow_nullable_key = 1"))
+
 (defn- skip-index-type-sql
   [type type-args]
   (if (seq type-args)
@@ -312,8 +320,10 @@
             [(#'sql-jdbc/create-table!-sql :sql-jdbc table-name column-definitions opts)
              "ENGINE = MergeTree"
              (order-by-clause opts)
-             ;; disable insert idempotency to allow duplicate inserts
-             "SETTINGS replicated_deduplication_window = 0"]))
+             ;; disable insert idempotency to allow duplicate inserts; permit a nullable sorting key (see
+             ;; `allow-nullable-key-setting`).
+             (str "SETTINGS replicated_deduplication_window = 0"
+                  (when-let [s (allow-nullable-key-setting opts)] (str ", " s)))]))
 
 (defmethod driver/create-table! :clickhouse
   [driver db-id table-name column-definitions & {:as opts}]
@@ -419,11 +429,14 @@
   [driver {:keys [query output-table indexes]}]
   (let [{sql-query :query sql-params :params} query
         ;; MergeTree requires an ORDER BY. With an inline `:order-by` index we use its columns as the sorting key;
-        ;; otherwise it stays the empty tuple `ORDER BY ()` (an unsorted table).
-        pieces [(sql.qp/format-honeysql driver {:create-table output-table})
-                (sql.qp/format-honeysql driver {:raw (order-by-clause {:indexes indexes})})
-                ["AS"]
-                [sql-query sql-params]]
+        ;; otherwise it stays the empty tuple `ORDER BY ()` (an unsorted table). A sorting key needs
+        ;; `allow_nullable_key` (see `allow-nullable-key-setting`); the SETTINGS clause goes before `AS SELECT`.
+        settings (when-let [s (allow-nullable-key-setting {:indexes indexes})]
+                   (sql.qp/format-honeysql driver {:raw (str "SETTINGS " s)}))
+        pieces (cond-> [(sql.qp/format-honeysql driver {:create-table output-table})
+                        (sql.qp/format-honeysql driver {:raw (order-by-clause {:indexes indexes})})]
+                 settings (conj settings)
+                 :always  (conj ["AS"] [sql-query sql-params]))
         sql (str/join " " (map first pieces))]
     (into [sql] (mapcat rest) pieces)))
 

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
@@ -34,11 +34,13 @@
 (def ^:private order-by-cases
   ;; The table/column identifiers come from the shared `:sql-jdbc` renderer (double-quoted); the ORDER BY columns are
   ;; rendered with ClickHouse `quote-name` (backticks), matching the driver's pre-existing ORDER BY rendering.
-  [{:label        "order-by index sets the MergeTree sorting key"
+  ;; A sorting key gets `allow_nullable_key = 1`, since transform target columns are nullable and MergeTree otherwise
+  ;; rejects a nullable sorting key. The unsorted `ORDER BY ()` case has no key, so it doesn't.
+  [{:label        "order-by index sets the MergeTree sorting key and allows a nullable key"
     :indexes      [{:kind :order-by :columns [{:name "a"} {:name "b"}]}]
-    :ctas         "CREATE TABLE `events` ORDER BY (`a`, `b`) AS SELECT 1"
-    :create-table "CREATE TABLE \"events\" (\"a\" Int64, \"b\" Int64)\nENGINE = MergeTree\nORDER BY (`a`, `b`)\nSETTINGS replicated_deduplication_window = 0"}
-   {:label        "no order-by index -> empty ORDER BY () (unsorted)"
+    :ctas         "CREATE TABLE `events` ORDER BY (`a`, `b`) SETTINGS allow_nullable_key = 1 AS SELECT 1"
+    :create-table "CREATE TABLE \"events\" (\"a\" Int64, \"b\" Int64)\nENGINE = MergeTree\nORDER BY (`a`, `b`)\nSETTINGS replicated_deduplication_window = 0, allow_nullable_key = 1"}
+   {:label        "no order-by index -> empty ORDER BY () (unsorted), no nullable-key setting"
     :indexes      []
     :ctas         "CREATE TABLE `events` ORDER BY () AS SELECT 1"
     :create-table "CREATE TABLE \"events\" (\"a\" Int64, \"b\" Int64)\nENGINE = MergeTree\nORDER BY ()\nSETTINGS replicated_deduplication_window = 0"}])

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -26,8 +26,8 @@
   identify a target DB), the hook is skipped — workspace rewriting requires a
   known DB id to look up `db-workspace-namespace`.
 
-  Also hydrates the declared indexes onto the target so the model-free base reads
-  them off `(:indexes target)` at every table-creation seam."
+  Also hydrates the declared indexes onto the target so the base reads them off
+  `(:indexes target)` at every table-creation seam."
   [transform]
   (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
         (assoc transform :target

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -6,6 +6,11 @@
 
 (set! *warn-on-reflection* true)
 
+(defn hydrate-transform-indexes
+  "Declared indexes for `transform`. Stub until the index-request model lands; tests `with-redefs` it."
+  [_transform]
+  [])
+
 (defn- resolve-target
   "Apply the workspace target-rewrite hook before dispatch. On a workspaced child
   instance for `(:database target)`, the hook rewrites `:schema` to the workspace
@@ -19,12 +24,16 @@
 
   When `target-db-id` returns nil (no per-type impl, or transform shape doesn't
   identify a target DB), the hook is skipped — workspace rewriting requires a
-  known DB id to look up `db-workspace-namespace`."
+  known DB id to look up `db-workspace-namespace`.
+
+  Also hydrates the declared indexes onto the target so the model-free base reads
+  them off `(:indexes target)` at every table-creation seam."
   [transform]
-  (if-let [db-id (transforms-base.i/target-db-id transform)]
-    (assoc transform :target
-           (transforms.query-impl/resolve-transform-target db-id (:target transform)))
-    transform))
+  (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
+        (assoc transform :target
+               (transforms.query-impl/resolve-transform-target db-id (:target transform)))
+        transform)
+      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))))
 
 (defn execute!
   "Run `transform` and sync its target table.

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -154,9 +154,8 @@
                             driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms* transform-timeout-ms)]
                     (canceling/chan-start-run! run-id cancel-chan)
                     (run-transform! cancel-chan source-range-params)))]
-        ;; Create the target's standalone indexes now that the table exists, before saving the watermark and
-        ;; marking the run succeeded. A failure here goes through the catch below and fails the run; doing it
-        ;; before the watermark means a retry is still a full rebuild that re-attempts the index.
+        ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
+        ;; stays a full rebuild that re-attempts the index).
         (transforms-base.u/apply-target-indexes! transform)
         (transforms-base.u/save-watermark! (:id transform) source-range-params)
         (transform-run/succeed-started-run! run-id)

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -154,6 +154,10 @@
                             driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms* transform-timeout-ms)]
                     (canceling/chan-start-run! run-id cancel-chan)
                     (run-transform! cancel-chan source-range-params)))]
+        ;; Create the target's standalone indexes now that the table exists, before saving the watermark and
+        ;; marking the run succeeded. A failure here goes through the catch below and fails the run; doing it
+        ;; before the watermark means a retry is still a full rebuild that re-attempts the index.
+        (transforms-base.u/apply-target-indexes! transform)
         (transforms-base.u/save-watermark! (:id transform) source-range-params)
         (transform-run/succeed-started-run! run-id)
         ;; Narrow try/catch so an emission throw doesn't trigger the outer catch's

--- a/src/metabase/transforms_base/core.clj
+++ b/src/metabase/transforms_base/core.clj
@@ -42,9 +42,5 @@
   ([transform opts]
    (let [result (transforms-base.i/execute-base! transform opts)]
      (when (= :succeeded (:status result))
-       ;; This path has no run record, so apply indexes here (the run-tracked path does it in
-       ;; `run-cancelable-transform!` before marking the run succeeded). Mirrors that ordering: indexes first,
-       ;; then sync + events.
-       (transforms-base.u/apply-target-indexes! transform)
        (transforms-base.u/complete-execution! transform opts))
      result)))

--- a/src/metabase/transforms_base/core.clj
+++ b/src/metabase/transforms_base/core.clj
@@ -42,5 +42,9 @@
   ([transform opts]
    (let [result (transforms-base.i/execute-base! transform opts)]
      (when (= :succeeded (:status result))
+       ;; This path has no run record, so apply indexes here (the run-tracked path does it in
+       ;; `run-cancelable-transform!` before marking the run succeeded). Mirrors that ordering: indexes first,
+       ;; then sync + events.
+       (transforms-base.u/apply-target-indexes! transform)
        (transforms-base.u/complete-execution! transform opts))
      result)))

--- a/src/metabase/transforms_base/query.clj
+++ b/src/metabase/transforms_base/query.clj
@@ -41,7 +41,10 @@
    [:transform-type [:enum {:decode/normalize schema.common/normalize-keyword} :table :table-incremental]]
    [:conn-spec :any]
    [:query ::qp.compile/compiled]
-   [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]])
+   [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]
+   ;; Indexes declared on the target table. The driver's `compile-transform` inlines the ones it renders inside
+   ;; the CTAS (e.g. Redshift SORTKEY, ClickHouse ORDER BY) and ignores the rest (those are created standalone).
+   [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform-opts
   [:map
@@ -119,7 +122,10 @@
                              ;; the CTAS table name. See
                              ;; `metabase.driver.sql.query-processor/compile-transform :sql`.
                              :output-db (:db target)
-                             :output-table (transforms-base.u/qualified-table-name driver target)}
+                             :output-table (transforms-base.u/qualified-table-name driver target)
+                             ;; Inline indexes ride along to `compile-transform`, which renders the ones it
+                             ;; handles inside the CTAS. No-op for drivers/kinds that don't inline.
+                             :indexes (transforms-base.u/target-indexes target)}
           opts (transform-opts transform-details)
           features (transforms-base.u/required-database-features transform)]
       (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)

--- a/src/metabase/transforms_base/query.clj
+++ b/src/metabase/transforms_base/query.clj
@@ -123,7 +123,6 @@
                              ;; `metabase.driver.sql.query-processor/compile-transform :sql`.
                              :output-db (:db target)
                              :output-table (transforms-base.u/qualified-table-name driver target)
-                             ;; `compile-transform` inlines whichever of these it handles into the CTAS.
                              :indexes (:indexes target)}
           opts (transform-opts transform-details)
           features (transforms-base.u/required-database-features transform)]

--- a/src/metabase/transforms_base/query.clj
+++ b/src/metabase/transforms_base/query.clj
@@ -42,8 +42,8 @@
    [:conn-spec :any]
    [:query ::qp.compile/compiled]
    [:output-table [:keyword {:decode/normalize schema.common/normalize-keyword}]]
-   ;; Indexes declared on the target table. The driver's `compile-transform` inlines the ones it renders inside
-   ;; the CTAS (e.g. Redshift SORTKEY, ClickHouse ORDER BY) and ignores the rest (those are created standalone).
+   ;; Declared target indexes. `compile-transform` inlines the ones it can into the CTAS (e.g. Redshift SORTKEY,
+   ;; ClickHouse ORDER BY); the rest are created standalone.
    [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform-opts
@@ -123,9 +123,7 @@
                              ;; `metabase.driver.sql.query-processor/compile-transform :sql`.
                              :output-db (:db target)
                              :output-table (transforms-base.u/qualified-table-name driver target)
-                             ;; Inline indexes ride along to `compile-transform`, which renders the ones it
-                             ;; handles inside the CTAS. No-op for drivers/kinds that don't inline. Hydrated onto
-                             ;; the target one layer up by `metabase.transforms.execute/execute!`.
+                             ;; `compile-transform` inlines whichever of these it handles into the CTAS.
                              :indexes (:indexes target)}
           opts (transform-opts transform-details)
           features (transforms-base.u/required-database-features transform)]

--- a/src/metabase/transforms_base/query.clj
+++ b/src/metabase/transforms_base/query.clj
@@ -124,8 +124,9 @@
                              :output-db (:db target)
                              :output-table (transforms-base.u/qualified-table-name driver target)
                              ;; Inline indexes ride along to `compile-transform`, which renders the ones it
-                             ;; handles inside the CTAS. No-op for drivers/kinds that don't inline.
-                             :indexes (transforms-base.u/target-indexes target)}
+                             ;; handles inside the CTAS. No-op for drivers/kinds that don't inline. Hydrated onto
+                             ;; the target one layer up by `metabase.transforms.execute/execute!`.
+                             :indexes (:indexes target)}
           opts (transform-opts transform-details)
           features (transforms-base.u/required-database-features transform)]
       (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)

--- a/src/metabase/transforms_base/schema.clj
+++ b/src/metabase/transforms_base/schema.clj
@@ -30,10 +30,11 @@
    [:database {:optional true} :int]
    [:schema {:optional true} [:maybe :string]]
    [:name :string]
-   ;; Indexes declared on the target table, applied on every full run. Each is a structured index map (see
+   ;; Indexes to apply to the target table on every full run. Each is a structured index map (see
    ;; [[metabase.driver/compile-create-index]]); the driver's `supported-index-methods` decides each kind's
-   ;; lifecycle (`:inline` at table creation vs `:standalone` afterwards). Phase 1 reads these straight off the
-   ;; target JSON; they later move to the `metabase_index_request` table.
+   ;; lifecycle (`:inline` at table creation vs `:standalone` afterwards). Not persisted on the target: hydrated
+   ;; onto it before a run by `metabase.transforms.execute/hydrate-transform-indexes` (a stub today, a
+   ;; `metabase_index_request` read once that model lands).
    [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform

--- a/src/metabase/transforms_base/schema.clj
+++ b/src/metabase/transforms_base/schema.clj
@@ -30,11 +30,8 @@
    [:database {:optional true} :int]
    [:schema {:optional true} [:maybe :string]]
    [:name :string]
-   ;; Indexes to apply to the target table on every full run. Each is a structured index map (see
-   ;; [[metabase.driver/compile-create-index]]); the driver's `supported-index-methods` decides each kind's
-   ;; lifecycle (`:inline` at table creation vs `:standalone` afterwards). Not persisted on the target: hydrated
-   ;; onto it before a run by `metabase.transforms.execute/hydrate-transform-indexes` (a stub today, a
-   ;; `metabase_index_request` read once that model lands).
+   ;; Indexes to apply on every full run (see [[metabase.driver/compile-create-index]]). Not persisted here:
+   ;; hydrated onto the target before a run by `metabase.transforms.execute/hydrate-transform-indexes`.
    [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform

--- a/src/metabase/transforms_base/schema.clj
+++ b/src/metabase/transforms_base/schema.clj
@@ -29,7 +29,12 @@
    [:type :string]
    [:database {:optional true} :int]
    [:schema {:optional true} [:maybe :string]]
-   [:name :string]])
+   [:name :string]
+   ;; Indexes declared on the target table, applied on every full run. Each is a structured index map (see
+   ;; [[metabase.driver/compile-create-index]]); the driver's `supported-index-methods` decides each kind's
+   ;; lifecycle (`:inline` at table creation vs `:standalone` afterwards). Phase 1 reads these straight off the
+   ;; target JSON; they later move to the `metabase_index_request` table.
+   [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform
   "A transform map as expected by execute-base! implementations."

--- a/src/metabase/transforms_base/schema.clj
+++ b/src/metabase/transforms_base/schema.clj
@@ -30,8 +30,6 @@
    [:database {:optional true} :int]
    [:schema {:optional true} [:maybe :string]]
    [:name :string]
-   ;; Indexes to apply on every full run (see [[metabase.driver/compile-create-index]]). Not persisted here:
-   ;; hydrated onto the target before a run by `metabase.transforms.execute/hydrate-transform-indexes`.
    [:indexes {:optional true} [:sequential :map]]])
 
 (mr/def ::transform

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -610,16 +610,17 @@
          :or   {publish-events? true}} opts
         db-id (transforms-base.i/target-db-id transform)
         database (t2/select-one :model/Database db-id)]
+    ;; Apply standalone indexes once the table exists, before sync so the synced metadata sees them. Only on
+    ;; full-create runs: a full `:table` run recreates the table (so indexes must be reinstalled), as does a
+    ;; first/full-reset incremental run. Plain append runs preserve the existing table and its live indexes, so they
+    ;; skip this. No-op for inline-only drivers/kinds.
+    (when (or (= :table (keyword (:type target)))
+              (full-incremental-run? transform))
+      (apply-standalone-indexes! database target))
     ;; Sync target table, set target_table_id on transform, and mark table as owned by this transform
     (when-let [table (sync-target! target database)]
       (t2/update! :model/Transform (:id transform) {:target_table_id (:id table)})
       (t2/update! :model/Table (:id table) {:transform_id (:id transform)}))
-    ;; Apply standalone indexes once the table exists. Only on full-create runs: a full `:table` run recreates the
-    ;; table (so indexes must be reinstalled), as does a first/full-reset incremental run. Plain append runs preserve
-    ;; the existing table and its live indexes, so they skip this. No-op for inline-only drivers/kinds.
-    (when (or (= :table (keyword (:type target)))
-              (full-incremental-run? transform))
-      (apply-standalone-indexes! database target))
     ;; Publish event after sync so the table exists in AppDB.
     (when publish-events?
       (events/publish-event! :event/transform-run-complete

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -560,14 +560,9 @@
 ;;; ------------------------------------------------- Post-Execution Completion -------------------------------------------------
 
 (defn- apply-standalone-indexes!
-  "Create the target table's `:standalone` indexes as separate DDL statements, now that the table exists. Each
-  driver's `supported-index-methods` decides which index kinds it applies this way; `:inline` kinds (and inline-only
-  drivers) render inside the table-creation statement and are skipped here, so passing the full index list is safe.
-  Reads the indexes hydrated onto the target by `metabase.transforms.execute/execute!`. Runs synchronously and is
-  required, not best-effort: a failure here propagates and fails the run.
-
-  Each create is emitted with `:if-not-exists` so a rebuild that finds the index already there is a no-op rather
-  than an error."
+  "Create the target's `:standalone` indexes as separate DDL, now that the table exists. `:inline` kinds render at
+  table creation, so they're filtered out here and passing the full list is safe. Each create uses `:if-not-exists`,
+  so re-applying is a no-op. Throws on failure."
   [database target]
   (when-let [indexes (not-empty (:indexes target))]
     (let [driver     (:engine database)
@@ -583,13 +578,9 @@
                                                                       (assoc index :if-not-exists true)))))))))
 
 (defn apply-target-indexes!
-  "Create the target table's standalone indexes, on full-create runs only: a full `:table` run recreates the table
-  (so indexes must be reinstalled), as does a first/full-reset incremental run. Plain append runs preserve the
-  existing table and its live indexes, so they skip this. No-op for inline-only drivers/kinds, or a target with no
-  declared indexes.
-
-  Called inside the run's cancelable scope, *before* the run is marked succeeded and before the target is synced, so
-  a failure fails the run record (not just the `execute!` call) and the synced metadata sees the indexes."
+  "Apply the target's standalone indexes, on full-create runs only (a `:table` run or a full-reset incremental run
+  recreates the table; appends keep the live table and its indexes). Runs before the run is marked succeeded, so a
+  failure fails the run record, not just `execute!`."
   [transform]
   (when (or (= :table (keyword (:type (:target transform))))
             (full-incremental-run? transform))
@@ -606,8 +597,8 @@
 
    This is called after the core execution completes. Callers that use
    `run-cancelable-transform!` should call this AFTER `succeed-started-run!`
-   to preserve the correct order of operations. Standalone indexes are applied earlier, by
-   `apply-target-indexes!`, so a failure there can still fail the run."
+   to preserve the correct order of operations. (Standalone indexes are applied earlier, by
+   `apply-target-indexes!`, so a failure there still fails the run.)"
   [transform opts]
   (let [{:keys [target]} transform
         {:keys [publish-events?]

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -563,27 +563,25 @@
   "Create the target's `:standalone` indexes as separate DDL, now that the table exists. `:inline` kinds render at
   table creation, so they're filtered out here and passing the full list is safe. Each create uses `:if-not-exists`,
   so re-applying is a no-op. Throws on failure."
-  [database target]
-  (when-let [indexes (not-empty (:indexes target))]
-    (let [driver     (:engine database)
-          methods    (driver/supported-index-methods driver database)
-          standalone (filter #(= :standalone (get-in methods [(:kind %) :lifecycle])) indexes)]
-      (when (seq standalone)
-        (let [conn-spec (driver/connection-spec driver database)
-              schema    (:schema target)
-              table     (:name target)]
-          (doseq [index standalone]
-            (driver/execute-raw-queries! driver conn-spec
-                                         (driver/compile-create-index driver schema table
-                                                                      (assoc index :if-not-exists true)))))))))
+  [database {:keys [indexes schema] table-name :name}]
+  (let [driver     (:engine database)
+        methods    (driver/supported-index-methods driver database)
+        standalone (filter #(= :standalone (get-in methods [(:kind %) :lifecycle])) indexes)]
+    (when (seq standalone)
+      (let [conn-spec (driver/connection-spec driver database)]
+        (doseq [index standalone]
+          (driver/execute-raw-queries! driver conn-spec
+                                       (driver/compile-create-index driver schema table-name
+                                                                    (assoc index :if-not-exists true))))))))
 
 (defn apply-target-indexes!
   "Apply the target's standalone indexes, on full-create runs only (a `:table` run or a full-reset incremental run
   recreates the table; appends keep the live table and its indexes). Runs before the run is marked succeeded, so a
-  failure fails the run record, not just `execute!`."
+  failure fails the run record."
   [transform]
-  (when (or (= :table (keyword (:type (:target transform))))
-            (full-incremental-run? transform))
+  (when (and (seq (:indexes (:target transform)))
+             (or (= :table (keyword (:type (:target transform))))
+                 (full-incremental-run? transform)))
     (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))]
       (apply-standalone-indexes! database (:target transform)))))
 

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -564,7 +564,10 @@
   driver's `supported-index-methods` decides which index kinds it applies this way; `:inline` kinds (and inline-only
   drivers) render inside the table-creation statement and are skipped here, so passing the full index list is safe.
   Reads the indexes hydrated onto the target by `metabase.transforms.execute/execute!`. Runs synchronously and is
-  required, not best-effort: a failure here propagates and fails the run."
+  required, not best-effort: a failure here propagates and fails the run.
+
+  Each create is emitted with `:if-not-exists` so a rebuild that finds the index already there is a no-op rather
+  than an error."
   [database target]
   (when-let [indexes (not-empty (:indexes target))]
     (let [driver     (:engine database)
@@ -576,7 +579,22 @@
               table     (:name target)]
           (doseq [index standalone]
             (driver/execute-raw-queries! driver conn-spec
-                                         (driver/compile-create-index driver schema table index))))))))
+                                         (driver/compile-create-index driver schema table
+                                                                      (assoc index :if-not-exists true)))))))))
+
+(defn apply-target-indexes!
+  "Create the target table's standalone indexes, on full-create runs only: a full `:table` run recreates the table
+  (so indexes must be reinstalled), as does a first/full-reset incremental run. Plain append runs preserve the
+  existing table and its live indexes, so they skip this. No-op for inline-only drivers/kinds, or a target with no
+  declared indexes.
+
+  Called inside the run's cancelable scope, *before* the run is marked succeeded and before the target is synced, so
+  a failure fails the run record (not just the `execute!` call) and the synced metadata sees the indexes."
+  [transform]
+  (when (or (= :table (keyword (:type (:target transform))))
+            (full-incremental-run? transform))
+    (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))]
+      (apply-standalone-indexes! database (:target transform)))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.
@@ -585,24 +603,17 @@
    - Sync target table to AppDB
    - Set `transform_id` on the target table
    - Publish Metabase events (unless `:publish-events?` is false)
-   - Create/drop secondary indexes
 
    This is called after the core execution completes. Callers that use
    `run-cancelable-transform!` should call this AFTER `succeed-started-run!`
-   to preserve the correct order of operations."
+   to preserve the correct order of operations. Standalone indexes are applied earlier, by
+   `apply-target-indexes!`, so a failure there can still fail the run."
   [transform opts]
   (let [{:keys [target]} transform
         {:keys [publish-events?]
          :or   {publish-events? true}} opts
         db-id (transforms-base.i/target-db-id transform)
         database (t2/select-one :model/Database db-id)]
-    ;; Apply standalone indexes once the table exists, before sync so the synced metadata sees them. Only on
-    ;; full-create runs: a full `:table` run recreates the table (so indexes must be reinstalled), as does a
-    ;; first/full-reset incremental run. Plain append runs preserve the existing table and its live indexes, so they
-    ;; skip this. No-op for inline-only drivers/kinds.
-    (when (or (= :table (keyword (:type target)))
-              (full-incremental-run? transform))
-      (apply-standalone-indexes! database target))
     ;; Sync target table, set target_table_id on transform, and mark table as owned by this transform
     (when-let [table (sync-target! target database)]
       (t2/update! :model/Transform (:id transform) {:target_table_id (:id table)})

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -559,28 +559,14 @@
 
 ;;; ------------------------------------------------- Post-Execution Completion -------------------------------------------------
 
-(defn target-indexes
-  "The indexes declared on a transform `target`, normalized into the structured shape drivers expect. They are
-  stored on the target JSON, so keyword-valued fields (`:kind`, `:style`, `:type`, and each column's `:direction`)
-  come back as strings and must be re-keywordized before a driver can dispatch on them. This is the single
-  declared-indexes read used at every creation seam; it becomes a `metabase_index_request` read later."
-  [target]
-  (mapv (fn [index]
-          (cond-> index
-            (:kind index)    (update :kind keyword)
-            (:style index)   (update :style keyword)
-            (:type index)    (update :type keyword)
-            (:columns index) (update :columns (fn [cols]
-                                                (mapv #(cond-> % (:direction %) (update :direction keyword)) cols)))))
-        (:indexes target)))
-
 (defn- apply-standalone-indexes!
   "Create the target table's `:standalone` indexes as separate DDL statements, now that the table exists. Each
   driver's `supported-index-methods` decides which index kinds it applies this way; `:inline` kinds (and inline-only
   drivers) render inside the table-creation statement and are skipped here, so passing the full index list is safe.
-  Runs synchronously and is required, not best-effort: a failure here propagates and fails the run."
+  Reads the indexes hydrated onto the target by `metabase.transforms.execute/execute!`. Runs synchronously and is
+  required, not best-effort: a failure here propagates and fails the run."
   [database target]
-  (when-let [indexes (not-empty (target-indexes target))]
+  (when-let [indexes (not-empty (:indexes target))]
     (let [driver     (:engine database)
           methods    (driver/supported-index-methods driver database)
           standalone (filter #(= :standalone (get-in methods [(:kind %) :lifecycle])) indexes)]

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -559,6 +559,39 @@
 
 ;;; ------------------------------------------------- Post-Execution Completion -------------------------------------------------
 
+(defn target-indexes
+  "The indexes declared on a transform `target`, normalized into the structured shape drivers expect. They are
+  stored on the target JSON, so keyword-valued fields (`:kind`, `:style`, `:type`, and each column's `:direction`)
+  come back as strings and must be re-keywordized before a driver can dispatch on them. This is the single
+  declared-indexes read used at every creation seam; it becomes a `metabase_index_request` read later."
+  [target]
+  (mapv (fn [index]
+          (cond-> index
+            (:kind index)    (update :kind keyword)
+            (:style index)   (update :style keyword)
+            (:type index)    (update :type keyword)
+            (:columns index) (update :columns (fn [cols]
+                                                (mapv #(cond-> % (:direction %) (update :direction keyword)) cols)))))
+        (:indexes target)))
+
+(defn- apply-standalone-indexes!
+  "Create the target table's `:standalone` indexes as separate DDL statements, now that the table exists. Each
+  driver's `supported-index-methods` decides which index kinds it applies this way; `:inline` kinds (and inline-only
+  drivers) render inside the table-creation statement and are skipped here, so passing the full index list is safe.
+  Runs synchronously and is required, not best-effort: a failure here propagates and fails the run."
+  [database target]
+  (when-let [indexes (not-empty (target-indexes target))]
+    (let [driver     (:engine database)
+          methods    (driver/supported-index-methods driver database)
+          standalone (filter #(= :standalone (get-in methods [(:kind %) :lifecycle])) indexes)]
+      (when (seq standalone)
+        (let [conn-spec (driver/connection-spec driver database)
+              schema    (:schema target)
+              table     (:name target)]
+          (doseq [index standalone]
+            (driver/execute-raw-queries! driver conn-spec
+                                         (driver/compile-create-index driver schema table index))))))))
+
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.
 
@@ -581,6 +614,12 @@
     (when-let [table (sync-target! target database)]
       (t2/update! :model/Transform (:id transform) {:target_table_id (:id table)})
       (t2/update! :model/Table (:id table) {:transform_id (:id transform)}))
+    ;; Apply standalone indexes once the table exists. Only on full-create runs: a full `:table` run recreates the
+    ;; table (so indexes must be reinstalled), as does a first/full-reset incremental run. Plain append runs preserve
+    ;; the existing table and its live indexes, so they skip this. No-op for inline-only drivers/kinds.
+    (when (or (= :table (keyword (:type target)))
+              (full-incremental-run? transform))
+      (apply-standalone-indexes! database target))
     ;; Publish event after sync so the table exists in AppDB.
     (when publish-events?
       (events/publish-event! :event/transform-run-complete

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,99 +1,29 @@
 (ns ^:mb/driver-tests metabase.transforms.index-test
-  "End-to-end test that indexes declared on a transform target are applied to the physical target table when the
-  transform runs, and re-applied when it runs again. Proves the Phase 1 wiring: `target.indexes` flows out of the
-  target and through the creation lifecycle, whatever the driver's mix of `:inline` and `:standalone` index methods.
+  "End-to-end tests that indexes declared on a transform target are applied to the physical target table when the
+  transform runs, and behave correctly across re-runs and failures. Proves the Phase 1 wiring: declared indexes
+  flow out of the hydration seam and through the creation lifecycle, whatever the driver's mix of `:inline` and
+  `:standalone` index methods.
 
-  The same assertions run for both transform kinds, since the target table is built at a different seam for each: a
-  SQL transform creates it with a CTAS, a Python transform with `create-table!`. [[test-declared-indexes!]] is the
-  shared body; [[declared-indexes-applied-and-replayed-test]] drives it with a SQL source and
-  [[declared-indexes-applied-on-python-transform-test]] with a Python one.
+  The per-driver cases, catalog readers, and driver selectors live in [[metabase.transforms.index-test-util]] and
+  are shared with the incremental suite. The same assertions run for both transform kinds, since the target table
+  is built at a different seam for each: a SQL transform creates it with a CTAS, a Python transform with
+  `create-table!`.
 
-  The test is driver-generic and selects drivers by feature, so it starts running for a driver the moment it
-  declares `:index/inline-create` or `:index/standalone-create`. To add a driver, add an entry to [[driver-cases]];
-  until then the test fails for that driver with instructions."
+  Indexes reach a run via `execute!`'s hydration seam (the `metabase_index_request` store doesn't exist yet), so
+  each test stubs [[metabase.transforms.execute/hydrate-transform-indexes]] to inject its case."
   (:require
-   [clojure.java.jdbc :as jdbc]
-   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.index-test-util :as index-util]
    [metabase.transforms.query-test-util :as query-test-util]
    [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
-
-(defn- postgres-indexes
-  [database schema table]
-  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                   ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
-       (map :indexname)
-       set))
-
-(defn- redshift-sortkey
-  [database schema table]
-  ;; `svv_redshift_columns.sortkey` encodes both facts in one column: a positive value is the column's 1-based
-  ;; position in a COMPOUND key; an INTERLEAVED key alternates the sign, so any negative value marks the whole key
-  ;; interleaved while `abs` still gives the position.
-  (let [rows (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                         [(str "SELECT column_name, sortkey FROM svv_redshift_columns "
-                               "WHERE schema_name = ? AND table_name = ? AND sortkey <> 0 ORDER BY abs(sortkey)")
-                          schema table])]
-    (when (seq rows)
-      {:columns (mapv :column_name rows)
-       :style   (if (some (comp neg? :sortkey) rows) :interleaved :compound)})))
-
-(defn- clickhouse-indexes
-  [database schema table]
-  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
-    {:sorting-key  (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
-                                         schema table])
-                       first :sorting_key)
-     :skip-indexes (->> (jdbc/query spec [(str "SELECT name, type, expr, granularity FROM"
-                                               " system.data_skipping_indices WHERE database = ? AND table = ?")
-                                          schema table])
-                        (mapv #(update % :granularity long)))}))
-
-(def ^:private driver-cases
-  "Driver -> the test case for it: `:indexes` to declare on the transform target (should exercise every index method
-  the driver supports), `:physical-indexes` a `(fn [database schema table])` that reads the indexes back out of the
-  database's system catalog, and `:expected` the value it must return once they took effect. The target table is
-  built from the transforms-test dataset's `transforms_products` (columns include `category` text and `price`
-  float)."
-  {;; Postgres: standalone btree
-   :postgres   {:indexes          [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
-                :expected         #{"by_category"}
-                :physical-indexes postgres-indexes}
-   ;; Redshift: inline sortkey
-   :redshift   {:indexes          [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
-                :expected         {:columns ["category" "price"] :style :interleaved}
-                :physical-indexes redshift-sortkey}
-   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse normalizes the index
-   ;; expression in the catalog and reports a single column wrapped in parens, so `expr` reads back as "(price)".
-   :clickhouse {:indexes          [{:kind :order-by :columns [{:name "category"}]}
-                                   {:kind    :skip-index :name "by_price" :type :minmax
-                                    :columns [{:name "price"}] :granularity 1}]
-                :expected         {:sorting-key  "category"
-                                   :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
-                :physical-indexes clickhouse-indexes}})
-
-(defn- index-test-drivers
-  "Drivers that run transforms and declare any index support."
-  []
-  (set/union (mt/normal-driver-select {:+features [:transforms/table :index/inline-create]})
-             (mt/normal-driver-select {:+features [:transforms/table :index/standalone-create]})))
-
-(defn- python-index-test-drivers
-  "Index-supporting drivers that also run Python transforms."
-  []
-  (set/intersection (index-test-drivers) (mt/normal-drivers-with-feature :transforms/python)))
-
-(defn- missing-case-message [driver]
-  (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but has no test "
-       "coverage here. Add an entry for it to `driver-cases`."))
 
 (defn- query-source
   "A SQL transform source that selects the whole `transforms_products` table (built via a CTAS)."
@@ -114,11 +44,7 @@
 (defn- test-declared-indexes!
   "Shared body for both transform kinds: run a transform whose source is built by the 0-arg `make-source` with the
   driver's `:indexes` hydrated onto its target, and assert `:physical-indexes` reads `:expected` back from the
-  catalog. Runs twice to prove the indexes survive a full rebuild.
-
-  Indexes reach the run via `execute!`'s hydration seam, not the target JSON. The `metabase_index_request` store
-  doesn't exist yet, so stub the hydration read to inject this case's indexes; the next PR swaps the stub for the
-  real read and seeds rows instead."
+  catalog. Runs twice to prove the indexes survive a full rebuild unchanged."
   [{:keys [indexes expected physical-indexes]} make-source]
   (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
     (with-transform-cleanup! [{table-name :name :as target}
@@ -133,23 +59,80 @@
             (transforms.execute/execute! transform {:run-method :manual})
             (transforms.tu/wait-for-table table-name 10000)
             (is (= expected (physical-indexes (mt/db) schema table-name))))
-          (testing "a re-run rebuilds the table and the indexes come back with it"
+          (testing "a re-run rebuilds the table and the indexes come back the same"
             (transforms.execute/execute! transform {:run-method :manual})
             (is (= expected (physical-indexes (mt/db) schema table-name)))))))))
 
 (deftest ^:synchronized declared-indexes-applied-and-replayed-test
-  (mt/test-drivers (index-test-drivers)
+  (mt/test-drivers (index-util/index-test-drivers)
     (mt/dataset transforms-dataset/transforms-test
-      (let [test-case (driver-cases driver/*driver*)]
-        (is (some? test-case) (missing-case-message driver/*driver*))
+      (let [test-case (index-util/driver-cases driver/*driver*)]
+        (is (some? test-case) (index-util/missing-case-message driver/*driver*))
         (when test-case
           (test-declared-indexes! test-case query-source))))))
 
 (deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-applied-on-python-transform-test
-  (mt/test-drivers (python-index-test-drivers)
+  (mt/test-drivers (index-util/python-index-test-drivers)
     (mt/with-premium-features #{:transforms-basic :transforms-python}
       (mt/dataset transforms-dataset/transforms-test
-        (let [test-case (driver-cases driver/*driver*)]
-          (is (some? test-case) (missing-case-message driver/*driver*))
+        (let [test-case (index-util/driver-cases driver/*driver*)]
+          (is (some? test-case) (index-util/missing-case-message driver/*driver*))
           (when test-case
             (test-declared-indexes! test-case python-source)))))))
+
+(deftest ^:synchronized declared-index-failure-fails-the-run-test
+  (testing "a bad index declaration fails the whole run instead of being silently skipped"
+    ;; A column the table doesn't have. For an inline kind the CTAS fails; for a standalone kind the post-create
+    ;; `CREATE INDEX` fails. Either way `apply-target-indexes!` runs inside the cancelable scope before the run is
+    ;; marked succeeded, so the throw both surfaces from `execute!` and records the run as `:failed`.
+    (mt/test-drivers (index-util/index-test-drivers)
+      (mt/dataset transforms-dataset/transforms-test
+        (let [test-case (index-util/driver-cases driver/*driver*)]
+          (is (some? test-case) (index-util/missing-case-message driver/*driver*))
+          (when test-case
+            (let [bogus  (index-util/bogus-indexes (:indexes test-case))
+                  schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+              (with-transform-cleanup! [target {:type   "table"
+                                                :schema schema
+                                                :name   "idx_fail_products"}]
+                (mt/with-temp [:model/Transform transform {:name   "index-fail-transform"
+                                                           :source (query-source)
+                                                           :target target}]
+                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly bogus)]
+                    (testing "execute! throws"
+                      (is (thrown? Throwable
+                                   (transforms.execute/execute! transform {:run-method :manual}))))
+                    (testing "and the run is recorded as failed"
+                      (is (= :failed
+                             (t2/select-one-fn :status :model/TransformRun
+                                               :transform_id (:id transform)
+                                               {:order-by [[:id :desc]]}))))))))))))))
+
+(deftest ^:synchronized declared-index-creation-is-idempotent-test
+  (testing "re-applying a target's indexes is a no-op (CREATE INDEX IF NOT EXISTS), not an error"
+    ;; The standalone create path is gated to full rebuilds, so it normally meets a freshly-created table. This
+    ;; pins the belt-and-suspenders idempotency: re-running `apply-target-indexes!` against the live table (where
+    ;; the index already exists) must not throw. No-op for inline-only drivers, whose idempotency comes from the
+    ;; table recreation covered by `declared-indexes-applied-and-replayed-test`.
+    (mt/test-drivers (index-util/index-test-drivers)
+      (mt/dataset transforms-dataset/transforms-test
+        (let [{:keys [indexes expected physical-indexes] :as test-case} (index-util/driver-cases driver/*driver*)]
+          (is (some? test-case) (index-util/missing-case-message driver/*driver*))
+          (when test-case
+            (let [db     (mt/db)
+                  schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+              (with-transform-cleanup! [{table-name :name :as target}
+                                        {:type   "table"
+                                         :schema schema
+                                         :name   "idx_idempotent_products"}]
+                (mt/with-temp [:model/Transform transform {:name   "index-idempotent-transform"
+                                                           :source (query-source)
+                                                           :target target}]
+                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
+                    (transforms.execute/execute! transform {:run-method :manual})
+                    (transforms.tu/wait-for-table table-name 10000)
+                    (is (= expected (physical-indexes db schema table-name)) "indexes present after the run")
+                    (testing "re-applying the same indexes leaves the catalog unchanged and does not throw"
+                      (transforms-base.u/apply-target-indexes!
+                       (assoc-in transform [:target :indexes] indexes))
+                      (is (= expected (physical-indexes db schema table-name))))))))))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,16 +1,8 @@
 (ns ^:mb/driver-tests metabase.transforms.index-test
-  "End-to-end tests that indexes declared on a transform target are applied to the physical target table when the
-  transform runs, and behave correctly across re-runs and failures. Proves the Phase 1 wiring: declared indexes
-  flow out of the hydration seam and through the creation lifecycle, whatever the driver's mix of `:inline` and
-  `:standalone` index methods.
-
-  The per-driver cases, catalog readers, and driver selectors live in [[metabase.transforms.index-test-util]] and
-  are shared with the incremental suite. The same assertions run for both transform kinds, since the target table
-  is built at a different seam for each: a SQL transform creates it with a CTAS, a Python transform with
-  `create-table!`.
-
-  Indexes reach a run via `execute!`'s hydration seam (the `metabase_index_request` store doesn't exist yet), so
-  each test stubs [[metabase.transforms.execute/hydrate-transform-indexes]] to inject its case."
+  "End-to-end: indexes declared on a transform target reach the physical table when the transform runs, across
+  re-runs and failures, for both transform kinds (SQL builds the table with a CTAS, Python with `create-table!`).
+  Per-driver cases and helpers live in [[metabase.transforms.index-test-util]]. Each test stubs
+  [[metabase.transforms.execute/hydrate-transform-indexes]] to inject its case."
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
@@ -33,8 +25,7 @@
            {:source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))})})
 
 (defn- python-source
-  "A Python transform source that returns `transforms_products` unchanged (built via `create-table!`), so the target
-  carries the same columns the driver-cases indexes reference."
+  "A Python transform source that returns `transforms_products` unchanged (built via `create-table!`)."
   []
   {:type            "python"
    :source-database (mt/id)
@@ -42,9 +33,8 @@
    :body            "def transform(transforms_products):\n    return transforms_products"})
 
 (defn- test-declared-indexes!
-  "Shared body for both transform kinds: run a transform whose source is built by the 0-arg `make-source` with the
-  driver's `:indexes` hydrated onto its target, and assert `:physical-indexes` reads `:expected` back from the
-  catalog. Runs twice to prove the indexes survive a full rebuild unchanged."
+  "Run a transform (source from the 0-arg `make-source`) with the driver's `:indexes` hydrated onto its target, then
+  assert `:physical-indexes` reads `:expected` from the catalog. Runs twice to check they survive a rebuild."
   [{:keys [indexes expected physical-indexes]} make-source]
   (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
     (with-transform-cleanup! [{table-name :name :as target}
@@ -83,9 +73,8 @@
 
 (deftest ^:synchronized declared-index-failure-fails-the-run-test
   (testing "a bad index declaration fails the whole run instead of being silently skipped"
-    ;; A column the table doesn't have. For an inline kind the CTAS fails; for a standalone kind the post-create
-    ;; `CREATE INDEX` fails. Either way `apply-target-indexes!` runs inside the cancelable scope before the run is
-    ;; marked succeeded, so the throw both surfaces from `execute!` and records the run as `:failed`.
+    ;; The index points at a missing column, so creation fails (inline: the CTAS; standalone: the CREATE INDEX).
+    ;; Either way it runs before the run is marked succeeded, so the throw surfaces and the run is recorded :failed.
     (mt/test-drivers (index-util/index-test-drivers)
       (mt/dataset transforms-dataset/transforms-test
         (let [test-case (index-util/driver-cases driver/*driver*)]
@@ -112,10 +101,8 @@
 
 (deftest ^:synchronized declared-index-creation-is-idempotent-test
   (testing "re-applying a target's indexes is a no-op (CREATE INDEX IF NOT EXISTS), not an error"
-    ;; The standalone create path is gated to full rebuilds, so it normally meets a freshly-created table. This
-    ;; pins the belt-and-suspenders idempotency: re-running `apply-target-indexes!` against the live table (where
-    ;; the index already exists) must not throw. No-op for inline-only drivers, whose idempotency comes from the
-    ;; table recreation covered by `declared-indexes-applied-and-replayed-test`.
+    ;; The standalone path normally meets a fresh table; this pins that re-running it against the live table (index
+    ;; already there) doesn't throw. No-op for inline-only drivers (covered by the replay test above).
     (mt/test-drivers (index-util/index-test-drivers)
       (mt/dataset transforms-dataset/transforms-test
         (let [{:keys [indexes expected physical-indexes] :as test-case} (index-util/driver-cases driver/*driver*)]

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,0 +1,46 @@
+(ns ^:mb/driver-tests metabase.transforms.index-test
+  "End-to-end test that indexes declared on a transform target are applied to the physical target table when the
+  transform runs. Proves the Phase 1 wiring: `target.indexes` flows out of the target and through the creation
+  lifecycle. Postgres exercises the standalone path, where the index is a btree created via `compile-create-index`
+  after the table exists (in `complete-execution!`)."
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.test :refer :all]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.test :as mt]
+   [metabase.transforms.execute :as transforms.execute]
+   [metabase.transforms.query-test-util :as query-test-util]
+   [metabase.transforms.test-dataset :as transforms-dataset]
+   [metabase.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- table-index-names
+  "Names of the indexes on `schema`.`table`, read back out of the Postgres catalog."
+  [spec schema table]
+  (->> (jdbc/query spec ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
+       (map :indexname)
+       set))
+
+(deftest ^:synchronized standalone-index-applied-on-full-run-test
+  (testing "a btree index declared on a transform target is created on the physical table after a full run"
+    (mt/test-driver :postgres
+      (mt/dataset transforms-dataset/transforms-test
+        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+          (with-transform-cleanup! [{table-name :name :as target}
+                                    {:type    "table"
+                                     :schema  schema
+                                     :name    "idx_products"
+                                     :indexes [{:kind :btree :name "by_category" :columns [{:name "category"}]}]}]
+            (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+                  query        (query-test-util/make-query {:source-table source-table})]
+              (mt/with-temp [:model/Transform transform {:name   "index-transform"
+                                                         :source {:type :query :query query}
+                                                         :target target}]
+                (transforms.execute/execute! transform {:run-method :manual})
+                (transforms.tu/wait-for-table table-name 10000)
+                (let [spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
+                  (is (contains? (table-index-names spec schema table-name) "by_category")
+                      (str "expected by_category on " table-name
+                           ", got " (pr-str (table-index-names spec schema table-name)))))))))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,8 +1,9 @@
 (ns ^:mb/driver-tests metabase.transforms.index-test
-  "End-to-end test that indexes declared on a transform target are applied to the physical target table when the
+  "End-to-end tests that indexes declared on a transform target are applied to the physical target table when the
   transform runs. Proves the Phase 1 wiring: `target.indexes` flows out of the target and through the creation
   lifecycle. Postgres exercises the standalone path, where the index is a btree created via `compile-create-index`
-  after the table exists (in `complete-execution!`)."
+  after the table exists (in `complete-execution!`). ClickHouse exercises a mixed-kind target through one run: the
+  inline order-by must ride the CTAS while the standalone skip-index is created afterwards."
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
@@ -44,3 +45,38 @@
                   (is (contains? (table-index-names spec schema table-name) "by_category")
                       (str "expected by_category on " table-name
                            ", got " (pr-str (table-index-names spec schema table-name)))))))))))))
+
+(deftest ^:synchronized mixed-kind-indexes-applied-on-full-run-test
+  (testing "a ClickHouse target with an inline order-by and a standalone skip-index gets both after a full run"
+    (mt/test-driver :clickhouse
+      (mt/dataset transforms-dataset/transforms-test
+        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+          (with-transform-cleanup! [{table-name :name :as target}
+                                    {:type    "table"
+                                     :schema  schema
+                                     :name    "idx_products"
+                                     :indexes [{:kind :order-by :columns [{:name "category"}]}
+                                               {:kind    :skip-index :name "by_price" :type :minmax
+                                                :columns [{:name "price"}] :granularity 1}]}]
+            (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+                  query        (query-test-util/make-query {:source-table source-table})]
+              (mt/with-temp [:model/Transform transform {:name   "index-transform"
+                                                         :source {:type :query :query query}
+                                                         :target target}]
+                (transforms.execute/execute! transform {:run-method :manual})
+                (transforms.tu/wait-for-table table-name 10000)
+                (let [spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
+                  (testing "the inline order-by set the MergeTree sorting key"
+                    (is (= "category"
+                           (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
+                                                 schema table-name])
+                               first :sorting_key))))
+                  (testing "the standalone skip-index exists with the declared shape"
+                    ;; ClickHouse normalizes the index expression in the catalog and reports a single column wrapped
+                    ;; in parens, so `expr` reads back as "(price)".
+                    (is (= {:name "by_price" :type "minmax" :expr "(price)" :granularity 1}
+                           (some-> (jdbc/query spec [(str "SELECT name, type, expr, granularity FROM"
+                                                          " system.data_skipping_indices WHERE database = ? AND table = ?")
+                                                     schema table-name])
+                                   first
+                                   (update :granularity long))))))))))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -4,8 +4,8 @@
   target and through the creation lifecycle, whatever the driver's mix of `:inline` and `:standalone` index methods.
 
   The test is driver-generic and selects drivers by feature, so it starts running for a driver the moment it
-  declares `:index/inline-create` or `:index/standalone-create`. To add a driver, implement [[index-fixture]] and
-  [[physical-indexes]] below; until then the `:default` methods fail the test with instructions."
+  declares `:index/inline-create` or `:index/standalone-create`. To add a driver, add an entry to [[driver-cases]];
+  until then the test fails for that driver with instructions."
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -21,59 +21,15 @@
 
 (set! *warn-on-reflection* true)
 
-;;; Both multimethods dispatch on the exact driver keyword, deliberately without the driver hierarchy: a child driver
-;;; (e.g. Redshift under Postgres) supports different index methods than its parent, so inheriting the parent's
-;;; fixture would assert the wrong thing. Every driver gets its own explicit pair.
-
-(defmulti index-fixture
-  "The indexes to declare on the transform target for `driver`, and the value [[physical-indexes]] must read back
-  once they took effect: `{:indexes [...], :expected ...}`. Should exercise every index method the driver supports.
-  The target table is built from the transforms-test dataset's `transforms_products` (columns include `category`
-  text and `price` float)."
-  {:arglists '([driver])}
-  identity)
-
-(defmulti physical-indexes
-  "Read the indexes on `schema`.`table` back out of `database`'s system catalog, in the same shape as the
-  `:expected` value of this driver's [[index-fixture]]."
-  {:arglists '([driver database schema table])}
-  (fn [driver _database _schema _table] driver))
-
-(defmethod index-fixture :default
-  [driver]
-  (throw (ex-info (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but "
-                       "has no test coverage here. Implement `index-fixture` and `physical-indexes` for it in "
-                       (namespace `index-fixture) ".")
-                  {:driver driver})))
-
-(defmethod physical-indexes :default
-  [driver _database _schema _table]
-  (throw (ex-info (str "No `physical-indexes` implementation for " driver " in " (namespace `index-fixture) ".")
-                  {:driver driver})))
-
-;;; --- Postgres: standalone btree ---
-
-(defmethod index-fixture :postgres
-  [_driver]
-  {:indexes  [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
-   :expected #{"by_category"}})
-
-(defmethod physical-indexes :postgres
-  [_driver database schema table]
+(defn- postgres-indexes
+  [database schema table]
   (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                    ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
        (map :indexname)
        set))
 
-;;; --- Redshift: inline sortkey ---
-
-(defmethod index-fixture :redshift
-  [_driver]
-  {:indexes  [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
-   :expected {:columns ["category" "price"] :style :interleaved}})
-
-(defmethod physical-indexes :redshift
-  [_driver database schema table]
+(defn- redshift-sortkey
+  [database schema table]
   ;; `svv_redshift_columns.sortkey` encodes both facts in one column: a positive value is the column's 1-based
   ;; position in a COMPOUND key; an INTERLEAVED key alternates the sign, so any negative value marks the whole key
   ;; interleaved while `abs` still gives the position.
@@ -85,20 +41,8 @@
       {:columns (mapv :column_name rows)
        :style   (if (some (comp neg? :sortkey) rows) :interleaved :compound)})))
 
-;;; --- ClickHouse: inline order-by + standalone skip-index, both in one target ---
-
-(defmethod index-fixture :clickhouse
-  [_driver]
-  {:indexes  [{:kind :order-by :columns [{:name "category"}]}
-              {:kind    :skip-index :name "by_price" :type :minmax
-               :columns [{:name "price"}] :granularity 1}]
-   ;; ClickHouse normalizes the index expression in the catalog and reports a single column wrapped in parens, so
-   ;; `expr` reads back as "(price)".
-   :expected {:sorting-key  "category"
-              :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}})
-
-(defmethod physical-indexes :clickhouse
-  [_driver database schema table]
+(defn- clickhouse-indexes
+  [database schema table]
   (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
     {:sorting-key  (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
                                          schema table])
@@ -108,7 +52,28 @@
                                           schema table])
                         (mapv #(update % :granularity long)))}))
 
-;;; --- the test ---
+(def ^:private driver-cases
+  "Driver -> the test case for it: `:indexes` to declare on the transform target (should exercise every index method
+  the driver supports), `:physical-indexes` a `(fn [database schema table])` that reads the indexes back out of the
+  database's system catalog, and `:expected` the value it must return once they took effect. The target table is
+  built from the transforms-test dataset's `transforms_products` (columns include `category` text and `price`
+  float)."
+  {;; Postgres: standalone btree
+   :postgres   {:indexes          [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
+                :expected         #{"by_category"}
+                :physical-indexes postgres-indexes}
+   ;; Redshift: inline sortkey
+   :redshift   {:indexes          [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
+                :expected         {:columns ["category" "price"] :style :interleaved}
+                :physical-indexes redshift-sortkey}
+   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse normalizes the index
+   ;; expression in the catalog and reports a single column wrapped in parens, so `expr` reads back as "(price)".
+   :clickhouse {:indexes          [{:kind :order-by :columns [{:name "category"}]}
+                                   {:kind    :skip-index :name "by_price" :type :minmax
+                                    :columns [{:name "price"}] :granularity 1}]
+                :expected         {:sorting-key  "category"
+                                   :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
+                :physical-indexes clickhouse-indexes}})
 
 (defn- index-test-drivers
   "Drivers that run transforms and declare any index support."
@@ -120,22 +85,26 @@
   (mt/test-drivers (index-test-drivers)
     (mt/dataset transforms-dataset/transforms-test
       (let [driver driver/*driver*
-            {:keys [indexes expected]} (index-fixture driver)
-            schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
-        (with-transform-cleanup! [{table-name :name :as target}
-                                  {:type    "table"
-                                   :schema  schema
-                                   :name    "idx_products"
-                                   :indexes indexes}]
-          (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
-                query        (query-test-util/make-query {:source-table source-table})]
-            (mt/with-temp [:model/Transform transform {:name   "index-transform"
-                                                       :source {:type :query :query query}
-                                                       :target target}]
-              (testing "a full run applies the declared indexes to the physical table"
-                (transforms.execute/execute! transform {:run-method :manual})
-                (transforms.tu/wait-for-table table-name 10000)
-                (is (= expected (physical-indexes driver (mt/db) schema table-name))))
-              (testing "a re-run rebuilds the table and the indexes come back with it"
-                (transforms.execute/execute! transform {:run-method :manual})
-                (is (= expected (physical-indexes driver (mt/db) schema table-name)))))))))))
+            {:keys [indexes expected physical-indexes] :as test-case} (driver-cases driver)]
+        (is (some? test-case)
+            (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but has no "
+                 "test coverage here. Add an entry for it to `driver-cases`."))
+        (when test-case
+          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+            (with-transform-cleanup! [{table-name :name :as target}
+                                      {:type    "table"
+                                       :schema  schema
+                                       :name    "idx_products"
+                                       :indexes indexes}]
+              (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+                    query        (query-test-util/make-query {:source-table source-table})]
+                (mt/with-temp [:model/Transform transform {:name   "index-transform"
+                                                           :source {:type :query :query query}
+                                                           :target target}]
+                  (testing "a full run applies the declared indexes to the physical table"
+                    (transforms.execute/execute! transform {:run-method :manual})
+                    (transforms.tu/wait-for-table table-name 10000)
+                    (is (= expected (physical-indexes (mt/db) schema table-name))))
+                  (testing "a re-run rebuilds the table and the indexes come back with it"
+                    (transforms.execute/execute! transform {:run-method :manual})
+                    (is (= expected (physical-indexes (mt/db) schema table-name)))))))))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -112,26 +112,30 @@
    :body            "def transform(transforms_products):\n    return transforms_products"})
 
 (defn- test-declared-indexes!
-  "Shared body for both transform kinds: declare the driver's `:indexes` on a fresh target, run a transform whose
-  source is built by the 0-arg `make-source`, and assert `:physical-indexes` reads `:expected` back from the
-  catalog. Runs twice to prove the indexes survive a full rebuild."
+  "Shared body for both transform kinds: run a transform whose source is built by the 0-arg `make-source` with the
+  driver's `:indexes` hydrated onto its target, and assert `:physical-indexes` reads `:expected` back from the
+  catalog. Runs twice to prove the indexes survive a full rebuild.
+
+  Indexes reach the run via `execute!`'s hydration seam, not the target JSON. The `metabase_index_request` store
+  doesn't exist yet, so stub the hydration read to inject this case's indexes; the next PR swaps the stub for the
+  real read and seeds rows instead."
   [{:keys [indexes expected physical-indexes]} make-source]
   (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
     (with-transform-cleanup! [{table-name :name :as target}
-                              {:type    "table"
-                               :schema  schema
-                               :name    "idx_products"
-                               :indexes indexes}]
+                              {:type   "table"
+                               :schema schema
+                               :name   "idx_products"}]
       (mt/with-temp [:model/Transform transform {:name   "index-transform"
                                                  :source (make-source)
                                                  :target target}]
-        (testing "a full run applies the declared indexes to the physical table"
-          (transforms.execute/execute! transform {:run-method :manual})
-          (transforms.tu/wait-for-table table-name 10000)
-          (is (= expected (physical-indexes (mt/db) schema table-name))))
-        (testing "a re-run rebuilds the table and the indexes come back with it"
-          (transforms.execute/execute! transform {:run-method :manual})
-          (is (= expected (physical-indexes (mt/db) schema table-name))))))))
+        (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
+          (testing "a full run applies the declared indexes to the physical table"
+            (transforms.execute/execute! transform {:run-method :manual})
+            (transforms.tu/wait-for-table table-name 10000)
+            (is (= expected (physical-indexes (mt/db) schema table-name))))
+          (testing "a re-run rebuilds the table and the indexes come back with it"
+            (transforms.execute/execute! transform {:run-method :manual})
+            (is (= expected (physical-indexes (mt/db) schema table-name)))))))))
 
 (deftest ^:synchronized declared-indexes-applied-and-replayed-test
   (mt/test-drivers (index-test-drivers)

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -3,6 +3,11 @@
   transform runs, and re-applied when it runs again. Proves the Phase 1 wiring: `target.indexes` flows out of the
   target and through the creation lifecycle, whatever the driver's mix of `:inline` and `:standalone` index methods.
 
+  The same assertions run for both transform kinds, since the target table is built at a different seam for each: a
+  SQL transform creates it with a CTAS, a Python transform with `create-table!`. [[test-declared-indexes!]] is the
+  shared body; [[declared-indexes-applied-and-replayed-test]] drives it with a SQL source and
+  [[declared-indexes-applied-on-python-transform-test]] with a Python one.
+
   The test is driver-generic and selects drivers by feature, so it starts running for a driver the moment it
   declares `:index/inline-create` or `:index/standalone-create`. To add a driver, add an entry to [[driver-cases]];
   until then the test fails for that driver with instructions."
@@ -81,30 +86,66 @@
   (set/union (mt/normal-driver-select {:+features [:transforms/table :index/inline-create]})
              (mt/normal-driver-select {:+features [:transforms/table :index/standalone-create]})))
 
+(defn- python-index-test-drivers
+  "Index-supporting drivers that also run Python transforms."
+  []
+  (set/intersection (index-test-drivers) (mt/normal-drivers-with-feature :transforms/python)))
+
+(defn- missing-case-message [driver]
+  (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but has no test "
+       "coverage here. Add an entry for it to `driver-cases`."))
+
+(defn- query-source
+  "A SQL transform source that selects the whole `transforms_products` table (built via a CTAS)."
+  []
+  {:type  :query
+   :query (query-test-util/make-query
+           {:source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))})})
+
+(defn- python-source
+  "A Python transform source that returns `transforms_products` unchanged (built via `create-table!`), so the target
+  carries the same columns the driver-cases indexes reference."
+  []
+  {:type            "python"
+   :source-database (mt/id)
+   :source-tables   [(transforms.tu/source-table-entry "transforms_products" (mt/id :transforms_products))]
+   :body            "def transform(transforms_products):\n    return transforms_products"})
+
+(defn- test-declared-indexes!
+  "Shared body for both transform kinds: declare the driver's `:indexes` on a fresh target, run a transform whose
+  source is built by the 0-arg `make-source`, and assert `:physical-indexes` reads `:expected` back from the
+  catalog. Runs twice to prove the indexes survive a full rebuild."
+  [{:keys [indexes expected physical-indexes]} make-source]
+  (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+    (with-transform-cleanup! [{table-name :name :as target}
+                              {:type    "table"
+                               :schema  schema
+                               :name    "idx_products"
+                               :indexes indexes}]
+      (mt/with-temp [:model/Transform transform {:name   "index-transform"
+                                                 :source (make-source)
+                                                 :target target}]
+        (testing "a full run applies the declared indexes to the physical table"
+          (transforms.execute/execute! transform {:run-method :manual})
+          (transforms.tu/wait-for-table table-name 10000)
+          (is (= expected (physical-indexes (mt/db) schema table-name))))
+        (testing "a re-run rebuilds the table and the indexes come back with it"
+          (transforms.execute/execute! transform {:run-method :manual})
+          (is (= expected (physical-indexes (mt/db) schema table-name))))))))
+
 (deftest ^:synchronized declared-indexes-applied-and-replayed-test
   (mt/test-drivers (index-test-drivers)
     (mt/dataset transforms-dataset/transforms-test
-      (let [driver driver/*driver*
-            {:keys [indexes expected physical-indexes] :as test-case} (driver-cases driver)]
-        (is (some? test-case)
-            (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but has no "
-                 "test coverage here. Add an entry for it to `driver-cases`."))
+      (let [test-case (driver-cases driver/*driver*)]
+        (is (some? test-case) (missing-case-message driver/*driver*))
         (when test-case
-          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
-            (with-transform-cleanup! [{table-name :name :as target}
-                                      {:type    "table"
-                                       :schema  schema
-                                       :name    "idx_products"
-                                       :indexes indexes}]
-              (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
-                    query        (query-test-util/make-query {:source-table source-table})]
-                (mt/with-temp [:model/Transform transform {:name   "index-transform"
-                                                           :source {:type :query :query query}
-                                                           :target target}]
-                  (testing "a full run applies the declared indexes to the physical table"
-                    (transforms.execute/execute! transform {:run-method :manual})
-                    (transforms.tu/wait-for-table table-name 10000)
-                    (is (= expected (physical-indexes (mt/db) schema table-name))))
-                  (testing "a re-run rebuilds the table and the indexes come back with it"
-                    (transforms.execute/execute! transform {:run-method :manual})
-                    (is (= expected (physical-indexes (mt/db) schema table-name)))))))))))))
+          (test-declared-indexes! test-case query-source))))))
+
+(deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-applied-on-python-transform-test
+  (mt/test-drivers (python-index-test-drivers)
+    (mt/with-premium-features #{:transforms-basic :transforms-python}
+      (mt/dataset transforms-dataset/transforms-test
+        (let [test-case (driver-cases driver/*driver*)]
+          (is (some? test-case) (missing-case-message driver/*driver*))
+          (when test-case
+            (test-declared-indexes! test-case python-source)))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -48,9 +48,10 @@
   [{:keys [indexes expected physical-indexes]} make-source]
   (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
     (with-transform-cleanup! [{table-name :name :as target}
-                              {:type   "table"
-                               :schema schema
-                               :name   "idx_products"}]
+                              {:type     "table"
+                               :schema   schema
+                               :name     "idx_products"
+                               :database (mt/id)}]
       (mt/with-temp [:model/Transform transform {:name   "index-transform"
                                                  :source (make-source)
                                                  :target target}]
@@ -92,9 +93,10 @@
           (when test-case
             (let [bogus  (index-util/bogus-indexes (:indexes test-case))
                   schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
-              (with-transform-cleanup! [target {:type   "table"
-                                                :schema schema
-                                                :name   "idx_fail_products"}]
+              (with-transform-cleanup! [target {:type     "table"
+                                                :schema   schema
+                                                :name     "idx_fail_products"
+                                                :database (mt/id)}]
                 (mt/with-temp [:model/Transform transform {:name   "index-fail-transform"
                                                            :source (query-source)
                                                            :target target}]
@@ -122,9 +124,10 @@
             (let [db     (mt/db)
                   schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
               (with-transform-cleanup! [{table-name :name :as target}
-                                        {:type   "table"
-                                         :schema schema
-                                         :name   "idx_idempotent_products"}]
+                                        {:type     "table"
+                                         :schema   schema
+                                         :name     "idx_idempotent_products"
+                                         :database (mt/id)}]
                 (mt/with-temp [:model/Transform transform {:name   "index-idempotent-transform"
                                                            :source (query-source)
                                                            :target target}]

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,12 +1,16 @@
 (ns ^:mb/driver-tests metabase.transforms.index-test
-  "End-to-end tests that indexes declared on a transform target are applied to the physical target table when the
-  transform runs. Proves the Phase 1 wiring: `target.indexes` flows out of the target and through the creation
-  lifecycle. Postgres exercises the standalone path, where the index is a btree created via `compile-create-index`
-  after the table exists (in `complete-execution!`). ClickHouse exercises a mixed-kind target through one run: the
-  inline order-by must ride the CTAS while the standalone skip-index is created afterwards."
+  "End-to-end test that indexes declared on a transform target are applied to the physical target table when the
+  transform runs, and re-applied when it runs again. Proves the Phase 1 wiring: `target.indexes` flows out of the
+  target and through the creation lifecycle, whatever the driver's mix of `:inline` and `:standalone` index methods.
+
+  The test is driver-generic and selects drivers by feature, so it starts running for a driver the moment it
+  declares `:index/inline-create` or `:index/standalone-create`. To add a driver, implement [[index-fixture]] and
+  [[physical-indexes]] below; until then the `:default` methods fail the test with instructions."
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.test :refer :all]
+   [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]
    [metabase.transforms.execute :as transforms.execute]
@@ -17,66 +21,121 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- table-index-names
-  "Names of the indexes on `schema`.`table`, read back out of the Postgres catalog."
-  [spec schema table]
-  (->> (jdbc/query spec ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
+;;; Both multimethods dispatch on the exact driver keyword, deliberately without the driver hierarchy: a child driver
+;;; (e.g. Redshift under Postgres) supports different index methods than its parent, so inheriting the parent's
+;;; fixture would assert the wrong thing. Every driver gets its own explicit pair.
+
+(defmulti index-fixture
+  "The indexes to declare on the transform target for `driver`, and the value [[physical-indexes]] must read back
+  once they took effect: `{:indexes [...], :expected ...}`. Should exercise every index method the driver supports.
+  The target table is built from the transforms-test dataset's `transforms_products` (columns include `category`
+  text and `price` float)."
+  {:arglists '([driver])}
+  identity)
+
+(defmulti physical-indexes
+  "Read the indexes on `schema`.`table` back out of `database`'s system catalog, in the same shape as the
+  `:expected` value of this driver's [[index-fixture]]."
+  {:arglists '([driver database schema table])}
+  (fn [driver _database _schema _table] driver))
+
+(defmethod index-fixture :default
+  [driver]
+  (throw (ex-info (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but "
+                       "has no test coverage here. Implement `index-fixture` and `physical-indexes` for it in "
+                       (namespace `index-fixture) ".")
+                  {:driver driver})))
+
+(defmethod physical-indexes :default
+  [driver _database _schema _table]
+  (throw (ex-info (str "No `physical-indexes` implementation for " driver " in " (namespace `index-fixture) ".")
+                  {:driver driver})))
+
+;;; --- Postgres: standalone btree ---
+
+(defmethod index-fixture :postgres
+  [_driver]
+  {:indexes  [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
+   :expected #{"by_category"}})
+
+(defmethod physical-indexes :postgres
+  [_driver database schema table]
+  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                   ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
        (map :indexname)
        set))
 
-(deftest ^:synchronized standalone-index-applied-on-full-run-test
-  (testing "a btree index declared on a transform target is created on the physical table after a full run"
-    (mt/test-driver :postgres
-      (mt/dataset transforms-dataset/transforms-test
-        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
-          (with-transform-cleanup! [{table-name :name :as target}
-                                    {:type    "table"
-                                     :schema  schema
-                                     :name    "idx_products"
-                                     :indexes [{:kind :btree :name "by_category" :columns [{:name "category"}]}]}]
-            (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
-                  query        (query-test-util/make-query {:source-table source-table})]
-              (mt/with-temp [:model/Transform transform {:name   "index-transform"
-                                                         :source {:type :query :query query}
-                                                         :target target}]
-                (transforms.execute/execute! transform {:run-method :manual})
-                (transforms.tu/wait-for-table table-name 10000)
-                (let [spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
-                  (is (contains? (table-index-names spec schema table-name) "by_category")
-                      (str "expected by_category on " table-name
-                           ", got " (pr-str (table-index-names spec schema table-name)))))))))))))
+;;; --- Redshift: inline sortkey ---
 
-(deftest ^:synchronized mixed-kind-indexes-applied-on-full-run-test
-  (testing "a ClickHouse target with an inline order-by and a standalone skip-index gets both after a full run"
-    (mt/test-driver :clickhouse
-      (mt/dataset transforms-dataset/transforms-test
-        (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
-          (with-transform-cleanup! [{table-name :name :as target}
-                                    {:type    "table"
-                                     :schema  schema
-                                     :name    "idx_products"
-                                     :indexes [{:kind :order-by :columns [{:name "category"}]}
-                                               {:kind    :skip-index :name "by_price" :type :minmax
-                                                :columns [{:name "price"}] :granularity 1}]}]
-            (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
-                  query        (query-test-util/make-query {:source-table source-table})]
-              (mt/with-temp [:model/Transform transform {:name   "index-transform"
-                                                         :source {:type :query :query query}
-                                                         :target target}]
+(defmethod index-fixture :redshift
+  [_driver]
+  {:indexes  [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
+   :expected {:columns ["category" "price"] :style :interleaved}})
+
+(defmethod physical-indexes :redshift
+  [_driver database schema table]
+  ;; `svv_redshift_columns.sortkey` encodes both facts in one column: a positive value is the column's 1-based
+  ;; position in a COMPOUND key; an INTERLEAVED key alternates the sign, so any negative value marks the whole key
+  ;; interleaved while `abs` still gives the position.
+  (let [rows (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                         [(str "SELECT column_name, sortkey FROM svv_redshift_columns "
+                               "WHERE schema_name = ? AND table_name = ? AND sortkey <> 0 ORDER BY abs(sortkey)")
+                          schema table])]
+    (when (seq rows)
+      {:columns (mapv :column_name rows)
+       :style   (if (some (comp neg? :sortkey) rows) :interleaved :compound)})))
+
+;;; --- ClickHouse: inline order-by + standalone skip-index, both in one target ---
+
+(defmethod index-fixture :clickhouse
+  [_driver]
+  {:indexes  [{:kind :order-by :columns [{:name "category"}]}
+              {:kind    :skip-index :name "by_price" :type :minmax
+               :columns [{:name "price"}] :granularity 1}]
+   ;; ClickHouse normalizes the index expression in the catalog and reports a single column wrapped in parens, so
+   ;; `expr` reads back as "(price)".
+   :expected {:sorting-key  "category"
+              :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}})
+
+(defmethod physical-indexes :clickhouse
+  [_driver database schema table]
+  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+    {:sorting-key  (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
+                                         schema table])
+                       first :sorting_key)
+     :skip-indexes (->> (jdbc/query spec [(str "SELECT name, type, expr, granularity FROM"
+                                               " system.data_skipping_indices WHERE database = ? AND table = ?")
+                                          schema table])
+                        (mapv #(update % :granularity long)))}))
+
+;;; --- the test ---
+
+(defn- index-test-drivers
+  "Drivers that run transforms and declare any index support."
+  []
+  (set/union (mt/normal-driver-select {:+features [:transforms/table :index/inline-create]})
+             (mt/normal-driver-select {:+features [:transforms/table :index/standalone-create]})))
+
+(deftest ^:synchronized declared-indexes-applied-and-replayed-test
+  (mt/test-drivers (index-test-drivers)
+    (mt/dataset transforms-dataset/transforms-test
+      (let [driver driver/*driver*
+            {:keys [indexes expected]} (index-fixture driver)
+            schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+        (with-transform-cleanup! [{table-name :name :as target}
+                                  {:type    "table"
+                                   :schema  schema
+                                   :name    "idx_products"
+                                   :indexes indexes}]
+          (let [source-table (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+                query        (query-test-util/make-query {:source-table source-table})]
+            (mt/with-temp [:model/Transform transform {:name   "index-transform"
+                                                       :source {:type :query :query query}
+                                                       :target target}]
+              (testing "a full run applies the declared indexes to the physical table"
                 (transforms.execute/execute! transform {:run-method :manual})
                 (transforms.tu/wait-for-table table-name 10000)
-                (let [spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
-                  (testing "the inline order-by set the MergeTree sorting key"
-                    (is (= "category"
-                           (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
-                                                 schema table-name])
-                               first :sorting_key))))
-                  (testing "the standalone skip-index exists with the declared shape"
-                    ;; ClickHouse normalizes the index expression in the catalog and reports a single column wrapped
-                    ;; in parens, so `expr` reads back as "(price)".
-                    (is (= {:name "by_price" :type "minmax" :expr "(price)" :granularity 1}
-                           (some-> (jdbc/query spec [(str "SELECT name, type, expr, granularity FROM"
-                                                          " system.data_skipping_indices WHERE database = ? AND table = ?")
-                                                     schema table-name])
-                                   first
-                                   (update :granularity long))))))))))))))
+                (is (= expected (physical-indexes driver (mt/db) schema table-name))))
+              (testing "a re-run rebuilds the table and the indexes come back with it"
+                (transforms.execute/execute! transform {:run-method :manual})
+                (is (= expected (physical-indexes driver (mt/db) schema table-name)))))))))))

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -56,12 +56,13 @@
    :redshift   {:indexes          [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
                 :expected         {:columns ["category" "price"] :style :interleaved}
                 :physical-indexes redshift-sortkey}
-   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse normalizes the index
-   ;; expression in the catalog and reports a single column wrapped in parens, so `expr` reads back as "(price)".
+   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse echoes a single-column key
+   ;; or index expression back wrapped in parens: `sorting_key` reads "(category)" (a multi-column key would render
+   ;; as a bare "a, b") and the skip-index `expr` reads "(price)".
    :clickhouse {:indexes          [{:kind :order-by :columns [{:name "category"}]}
                                    {:kind    :skip-index :name "by_price" :type :minmax
                                     :columns [{:name "price"}] :granularity 1}]
-                :expected         {:sorting-key  "category"
+                :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
                 :physical-indexes clickhouse-indexes}})
 

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -1,0 +1,87 @@
+(ns metabase.transforms.index-test-util
+  "Shared fixtures for the transform-index e2e tests: the per-driver test cases (what to declare, how to read the
+  physical indexes back, what to expect) and the driver selectors. Used by both the `:table` suite
+  ([[metabase.transforms.index-test]]) and the incremental suite
+  ([[metabase-enterprise.transforms.incremental-test]]) so the two stay in sync on one set of cases."
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn- postgres-indexes
+  [database schema table]
+  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                   ["SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?" schema table])
+       (map :indexname)
+       set))
+
+(defn- redshift-sortkey
+  [database schema table]
+  ;; `svv_redshift_columns.sortkey` encodes both facts in one column: a positive value is the column's 1-based
+  ;; position in a COMPOUND key; an INTERLEAVED key alternates the sign, so any negative value marks the whole key
+  ;; interleaved while `abs` still gives the position.
+  (let [rows (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                         [(str "SELECT column_name, sortkey FROM svv_redshift_columns "
+                               "WHERE schema_name = ? AND table_name = ? AND sortkey <> 0 ORDER BY abs(sortkey)")
+                          schema table])]
+    (when (seq rows)
+      {:columns (mapv :column_name rows)
+       :style   (if (some (comp neg? :sortkey) rows) :interleaved :compound)})))
+
+(defn- clickhouse-indexes
+  [database schema table]
+  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+    {:sorting-key  (-> (jdbc/query spec ["SELECT sorting_key FROM system.tables WHERE database = ? AND name = ?"
+                                         schema table])
+                       first :sorting_key)
+     :skip-indexes (->> (jdbc/query spec [(str "SELECT name, type, expr, granularity FROM"
+                                               " system.data_skipping_indices WHERE database = ? AND table = ?")
+                                          schema table])
+                        (mapv #(update % :granularity long)))}))
+
+(def driver-cases
+  "Driver -> the test case for it: `:indexes` to declare on the transform target (should exercise every index method
+  the driver supports), `:physical-indexes` a `(fn [database schema table])` that reads the indexes back out of the
+  database's system catalog, and `:expected` the value it must return once they took effect. The target table is
+  built from the transforms-test dataset's `transforms_products` (columns include `category` text and `price`
+  float)."
+  {;; Postgres: standalone btree
+   :postgres   {:indexes          [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
+                :expected         #{"by_category"}
+                :physical-indexes postgres-indexes}
+   ;; Redshift: inline sortkey
+   :redshift   {:indexes          [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
+                :expected         {:columns ["category" "price"] :style :interleaved}
+                :physical-indexes redshift-sortkey}
+   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse normalizes the index
+   ;; expression in the catalog and reports a single column wrapped in parens, so `expr` reads back as "(price)".
+   :clickhouse {:indexes          [{:kind :order-by :columns [{:name "category"}]}
+                                   {:kind    :skip-index :name "by_price" :type :minmax
+                                    :columns [{:name "price"}] :granularity 1}]
+                :expected         {:sorting-key  "category"
+                                   :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
+                :physical-indexes clickhouse-indexes}})
+
+(defn index-test-drivers
+  "Drivers that run transforms and declare any index support."
+  []
+  (set/union (mt/normal-driver-select {:+features [:transforms/table :index/inline-create]})
+             (mt/normal-driver-select {:+features [:transforms/table :index/standalone-create]})))
+
+(defn python-index-test-drivers
+  "Index-supporting drivers that also run Python transforms."
+  []
+  (set/intersection (index-test-drivers) (mt/normal-drivers-with-feature :transforms/python)))
+
+(defn missing-case-message [driver]
+  (str driver " declares index support (`:index/inline-create` or `:index/standalone-create`) but has no test "
+       "coverage here. Add an entry for it to `driver-cases`."))
+
+(defn bogus-indexes
+  "`indexes` rewritten to point every column at a non-existent column, so applying them must fail (whether the
+  driver inlines them into the CTAS or creates them standalone)."
+  [indexes]
+  (mapv #(assoc % :columns [{:name "definitely_not_a_real_column"}]) indexes))

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -1,8 +1,6 @@
 (ns metabase.transforms.index-test-util
-  "Shared fixtures for the transform-index e2e tests: the per-driver test cases (what to declare, how to read the
-  physical indexes back, what to expect) and the driver selectors. Used by both the `:table` suite
-  ([[metabase.transforms.index-test]]) and the incremental suite
-  ([[metabase-enterprise.transforms.incremental-test]]) so the two stay in sync on one set of cases."
+  "Shared per-driver cases and driver selectors for the transform-index e2e tests, used by both the `:table` suite
+  ([[metabase.transforms.index-test]]) and the incremental suite ([[metabase-enterprise.transforms.incremental-test]])."
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -20,9 +18,8 @@
 
 (defn- redshift-sortkey
   [database schema table]
-  ;; `svv_redshift_columns.sortkey` encodes both facts in one column: a positive value is the column's 1-based
-  ;; position in a COMPOUND key; an INTERLEAVED key alternates the sign, so any negative value marks the whole key
-  ;; interleaved while `abs` still gives the position.
+  ;; `sortkey` is the column's 1-based position in the key; an interleaved key alternates the sign, so a negative
+  ;; value anywhere means interleaved while `abs` still gives the position.
   (let [rows (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                          [(str "SELECT column_name, sortkey FROM svv_redshift_columns "
                                "WHERE schema_name = ? AND table_name = ? AND sortkey <> 0 ORDER BY abs(sortkey)")
@@ -43,11 +40,9 @@
                         (mapv #(update % :granularity long)))}))
 
 (def driver-cases
-  "Driver -> the test case for it: `:indexes` to declare on the transform target (should exercise every index method
-  the driver supports), `:physical-indexes` a `(fn [database schema table])` that reads the indexes back out of the
-  database's system catalog, and `:expected` the value it must return once they took effect. The target table is
-  built from the transforms-test dataset's `transforms_products` (columns include `category` text and `price`
-  float)."
+  "Driver -> test case: `:indexes` to declare (covering every index method the driver supports), `:physical-indexes`
+  a `(fn [database schema table])` reading them back from the system catalog, and `:expected` what it should return.
+  Target columns come from the transforms-test `transforms_products` (`category` text, `price` float)."
   {;; Postgres: standalone btree
    :postgres   {:indexes          [{:kind :btree :name "by_category" :columns [{:name "category"}]}]
                 :expected         #{"by_category"}
@@ -56,9 +51,8 @@
    :redshift   {:indexes          [{:kind :sortkey :style :interleaved :columns [{:name "category"} {:name "price"}]}]
                 :expected         {:columns ["category" "price"] :style :interleaved}
                 :physical-indexes redshift-sortkey}
-   ;; ClickHouse: inline order-by + standalone skip-index, both in one target. ClickHouse echoes a single-column key
-   ;; or index expression back wrapped in parens: `sorting_key` reads "(category)" (a multi-column key would render
-   ;; as a bare "a, b") and the skip-index `expr` reads "(price)".
+   ;; ClickHouse: inline order-by + standalone skip-index in one target. It echoes a single-column key/expr back in
+   ;; parens, hence "(category)" and "(price)" (a multi-column key would read as a bare "a, b").
    :clickhouse {:indexes          [{:kind :order-by :columns [{:name "category"}]}
                                    {:kind    :skip-index :name "by_price" :type :minmax
                                     :columns [{:name "price"}] :granularity 1}]
@@ -82,7 +76,6 @@
        "coverage here. Add an entry for it to `driver-cases`."))
 
 (defn bogus-indexes
-  "`indexes` rewritten to point every column at a non-existent column, so applying them must fail (whether the
-  driver inlines them into the CTAS or creates them standalone)."
+  "`indexes` rewritten to reference a non-existent column, so applying them must fail."
   [indexes]
   (mapv #(assoc % :columns [{:name "definitely_not_a_real_column"}]) indexes))


### PR DESCRIPTION
milestone 1: actually apply the indexes a transform declares on its target, end to end. the milestone 0 driver methods only render the DDL, this wires them into the run.

declared indexes are read once through a hydration seam (`hydrate-transform-indexes`) and injected onto the target in `execute!`. it's a stub that returns nothing for now. every place the target table gets built reads them off `(:indexes target)`:

- sql transforms: inline indexes go into compile-transform's CTAS.
- python transforms build the table with create-table!, so the same indexes thread into the python table-schema.
- standalone indexes (postgres btree, clickhouse skip-index) get created once the table exists, with IF NOT EXISTS so a rebuild that finds them is a no-op.

the stub is the only thing the next PR touches: it'll read from `metabase_index_request` keyed by transform_id and the wiring stays put. tests mock the stub to inject their cases.

one design call worth a look, since it isn't obvious from the diff. standalone index creation runs inside `run-cancelable-transform!`, before `succeed-started-run!`, not in `complete-execution!`. here is why: complete-execution! runs after the run is already marked succeeded, and a succeeded run is sealed (is_active nil), so fail-started-run! can't flip it. a CREATE INDEX failure there would throw out of execute! but leave the run record :succeeded. applying before the success mark means an index failure fails the run, same as an inline index failure already fails the CTAS. complete-execution! keeps the genuinely post-success work (sync + events).

append runs skip re-applying standalone indexes (the live table keeps them); only full rebuilds re-install.

tests: all 3 drivers for table runs (sql + python, create + replay), a bad index fails the run (run ends :failed), idempotent re-apply, and incremental (sql + python, postgres only since the incremental suite excludes redshift/clickhouse).

