### PR TITLE
Fix history.back 404 when Metabase is under a sub-path in interactive embedding

### DIFF
--- a/frontend/src/metabase/embedding/interactive-embedding/initialize.ts
+++ b/frontend/src/metabase/embedding/interactive-embedding/initialize.ts
@@ -37,12 +37,37 @@ export function initializeInteractiveEmbedding(dispatch: Dispatch) {
     window.addEventListener("message", (e) => {
       if (e.source === window.parent && e.data.metabase) {
         if (e.data.metabase.type === "location") {
-          dispatch(push(e.data.metabase.location));
+          dispatch(push(getLocationWithoutBasename(e.data.metabase.location)));
         }
       }
     });
     dispatch(setInitialUrlOptions(window.location));
   }
+}
+
+/**
+ * The location synced from the parent frame is the iframe's `window.location`,
+ * whose `pathname` already includes the sub-path Metabase is mounted under
+ * (the react-router basename, e.g. `/metabase`). Because `push` re-prepends the
+ * basename, pushing the raw pathname would double the sub-path
+ * (`/metabase/metabase/...`) and 404 — once per back/forward navigation. Strip
+ * the basename so `push` re-adds it exactly once. (metabase EMB-106)
+ */
+export function getLocationWithoutBasename(
+  location: Partial<Location>,
+): Partial<Location> {
+  const basename = (window.MetabaseRoot ?? "/").replace(/\/+$/, "");
+  const { pathname } = location;
+
+  if (!basename || pathname == null) {
+    return location;
+  }
+
+  if (pathname === basename || pathname.startsWith(`${basename}/`)) {
+    return { ...location, pathname: pathname.slice(basename.length) || "/" };
+  }
+
+  return location;
 }
 
 type LocationMessage = {

--- a/frontend/src/metabase/embedding/interactive-embedding/initialize.unit.spec.ts
+++ b/frontend/src/metabase/embedding/interactive-embedding/initialize.unit.spec.ts
@@ -1,0 +1,74 @@
+import { getLocationWithoutBasename } from "./initialize";
+
+describe("getLocationWithoutBasename", () => {
+  const originalMetabaseRoot = window.MetabaseRoot;
+
+  afterEach(() => {
+    window.MetabaseRoot = originalMetabaseRoot;
+  });
+
+  it("strips the sub-path basename so push doesn't double it (metabase EMB-106)", () => {
+    window.MetabaseRoot = "/metabase/";
+
+    expect(
+      getLocationWithoutBasename({ pathname: "/metabase/auto/dashboard/1" }),
+    ).toEqual({ pathname: "/auto/dashboard/1" });
+  });
+
+  it("tolerates a basename without a trailing slash", () => {
+    window.MetabaseRoot = "/metabase";
+
+    expect(
+      getLocationWithoutBasename({ pathname: "/metabase/auto/dashboard/1" }),
+    ).toEqual({ pathname: "/auto/dashboard/1" });
+  });
+
+  it("maps the basename root to '/'", () => {
+    window.MetabaseRoot = "/metabase/";
+
+    expect(getLocationWithoutBasename({ pathname: "/metabase" })).toEqual({
+      pathname: "/",
+    });
+  });
+
+  it("preserves search and hash while stripping the basename", () => {
+    window.MetabaseRoot = "/metabase/";
+
+    expect(
+      getLocationWithoutBasename({
+        pathname: "/metabase/auto/dashboard/1",
+        search: "?foo=bar",
+        hash: "#baz",
+      }),
+    ).toEqual({
+      pathname: "/auto/dashboard/1",
+      search: "?foo=bar",
+      hash: "#baz",
+    });
+  });
+
+  it("does not strip when there is no sub-path", () => {
+    window.MetabaseRoot = "/";
+
+    expect(
+      getLocationWithoutBasename({ pathname: "/auto/dashboard/1" }),
+    ).toEqual({ pathname: "/auto/dashboard/1" });
+  });
+
+  it("does not strip a path that only shares a prefix with the basename", () => {
+    window.MetabaseRoot = "/metabase/";
+
+    // `/metabased` is not under the `/metabase` basename
+    expect(
+      getLocationWithoutBasename({ pathname: "/metabased/auto/dashboard/1" }),
+    ).toEqual({ pathname: "/metabased/auto/dashboard/1" });
+  });
+
+  it("leaves the location untouched when there is no pathname", () => {
+    window.MetabaseRoot = "/metabase/";
+
+    expect(getLocationWithoutBasename({ search: "?foo=bar" })).toEqual({
+      search: "?foo=bar",
+    });
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #45186
Closes [EMB-106: history.back in the browser will go to a 404 when metabase lives in a sub-path (probably only on interactive embedding?)](https://linear.app/metabase/issue/EMB-106/historyback-in-the-browser-will-go-to-a-404-when-metabase-lives-in-a)

### Description

When Metabase is mounted under a URL sub-path (e.g. `example.com/metabase`) and shown through interactive (full-app) embedding, using the browser **Back/Forward** button sent the user to a 404. Each navigation appended the sub-path again, producing doubled paths like `/metabase/metabase/auto/dashboard/…` (most visible after creating an x-ray and pressing Back).

**Cause.** In interactive embedding the iframe and the host page keep their URLs in sync via `postMessage`. The iframe posts its `window.location`, whose `pathname` already includes the sub-path Metabase is mounted under — i.e. the react-router `basename` (`window.MetabaseRoot`). When the host replays a location back to the iframe (e.g. on browser Back), `initialize.ts` did `dispatch(push(location))`. The app's history is created with that `basename` (`app.js`), so `push` **re-prepends** it, doubling the sub-path. It compounds once per round-trip — exactly the reported "every back history will append the sub-path on the path."

**Fix.** Strip the basename from the incoming `pathname` before `push` re-adds it (`getLocationWithoutBasename`). It keys off `window.MetabaseRoot` — the literal value react-router uses as `basename` — rather than the Site-URL-derived sub-path, because sub-path deployments frequently don't update the Site URL setting (the frontend bootstrap even logs a warning when the two mismatch). It's a no-op when there's no sub-path, so the common case is unaffected.

### How to verify

Reproducing requires three things together: Metabase genuinely mounted under a sub-path (so the react-router basename is non-empty), interactive embedding, and an x-ray navigation.

**1. Install a reverse proxy (Caddy)**

```bash
brew install caddy
```

**2. Run the three servers**

| Server | Port | Command |
|---|---|---|
| rspack dev server | 8080 | `yarn build-hot` |
| Metabase backend | 3000 | (your usual backend) |
| Caddy proxy | 4000 | `caddy run` (in the dir holding the files below) |

In hot mode the JS bundles load directly from rspack (`localhost:8080`, absolute publicPath), so the proxy only needs to front the **backend**. `Caddyfile`:

```
:4000 {
    handle /host.html {
        root * .
        file_server
    }
    handle_path /metabase/* {
        reverse_proxy localhost:3000
    }
}
```

This mounts Metabase under `/metabase/` and strips the prefix, so `window.MetabaseRoot` resolves to `/metabase/`.

**3. Configure Metabase** (visit `http://localhost:4000/metabase`, log in as admin)

- **Admin → Settings → General → Site URL** → `http://localhost:4000/metabase`
- **Admin → Settings → Embedding** → enable **Interactive embedding** (needs a Pro/EE token)
- **Authorized origins (interactive)** → add `http://localhost:4000` (otherwise the `frame-ancestors` CSP blocks all framing)

**4. Add a host page** — `host.html` next to the `Caddyfile`:

```html
<!doctype html>
<html>
  <head><meta charset="utf-8" /><title>MB embed host</title></head>
  <body style="margin: 0">
    <iframe id="mb" style="border: 0; width: 100vw; height: 100vh"
            src="http://localhost:4000/metabase/dashboard/1"></iframe>
    <script>
      const iframe = document.getElementById("mb");
      let lastPath = null;
      window.addEventListener("message", (e) => {
        const msg = e.data && e.data.metabase;
        if (!msg || msg.type !== "location") return;
        const loc = msg.location;
        if (loc.pathname === lastPath) return;
        lastPath = loc.pathname;
        history.pushState(loc, "");
      });
      window.addEventListener("popstate", (e) => {
        if (!e.state) return;
        lastPath = e.state.pathname;
        iframe.contentWindow.postMessage(
          { metabase: { type: "location", location: e.state } },
          "*",
        );
      });
    </script>
  </body>
</html>
```

**5. Reproduce / verify**

> ⚠️ Use a **normal browser window, not Incognito.** Incognito blocks third-party cookies, which drops the session inside the iframe and bounces you to the login page. Also log in **through the proxy** (`http://localhost:4000/metabase`) so the session cookie is present for that origin.

1. Open `http://localhost:4000/host.html` — the dashboard loads; confirm the iframe URL has a single `/metabase`.
2. In the iframe, x-ray something (click a cell → **"Automatic insights…" → "X-ray"**) → URL becomes `…/metabase/auto/dashboard/…`.
3. Press **Back** once.
   - **Before this fix:** iframe URL becomes `…/metabase/metabase/auto/dashboard/…` → **404**.
   - **After this fix:** returns cleanly to the dashboard.

Unit tests: `yarn jest frontend/src/metabase/embedding/interactive-embedding/initialize.unit.spec.ts`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
