### PR TITLE
GDGT-2597 Order Schema Viewer fields to match the table metadata view

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3094,7 +3094,8 @@
    :api  #{metabase-enterprise.erd.api}
    :uses #{api
            models
-           util}
+           util
+           warehouse-schema}
    :model-imports #{:model/Database
                     :model/Field
                     :model/Table}}

--- a/enterprise/backend/src/metabase_enterprise/erd/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/erd/impl.clj
@@ -9,6 +9,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.warehouse-schema.models.table :as schema.table]
    [toucan2.core :as t2]))
 
 ;;; -------------------------------------------------- Schema --------------------------------------------------
@@ -118,13 +119,15 @@
 
 (defn- fetch-fields-for-tables
   "Fetch all active fields for the given table IDs.
-   Returns a vector of field maps."
+   Returns a vector of field maps ordered by the same ordering
+   as table metadata view (`/api/table/:id/query_metadata`)."
   [table-ids]
   (when (seq table-ids)
     (t2/select :model/Field
-               {:where [:and
-                        [:in :table_id table-ids]
-                        [:= :active true]]})))
+               {:where    [:and
+                           [:in :table_id table-ids]
+                           [:= :active true]]
+                :order-by schema.table/field-order-rule})))
 
 (defn- fetch-fields-by-ids
   "Fetch active fields by ID."

--- a/enterprise/backend/test/metabase_enterprise/erd/erd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/erd/erd_test.clj
@@ -90,6 +90,29 @@
         (is (nil? (:fk_target_field_id pk-field)))
         (is (nil? (:fk_target_table_id pk-field)))))))
 
+(deftest erd-graph-field-order-test
+  (mt/with-premium-features #{:schema-viewer}
+    (testing "fields come back ordered by [position asc, lower(name) asc] — same as /api/table/:id/query_metadata"
+      ;; Insertion order deliberately scrambled relative to the expected order so
+      ;; an unsorted DB read would not accidentally pass. `position` is the primary
+      ;; key; `lower(name)` breaks ties (and proves the sort is case-insensitive).
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Table {tid :id} {:db_id db-id :name "t" :schema "PUBLIC"}
+                     :model/Field _ {:table_id tid :name "zulu"   :position 2
+                                     :database_type "INTEGER" :base_type :type/Integer}
+                     :model/Field _ {:table_id tid :name "Bravo"  :position 1
+                                     :database_type "INTEGER" :base_type :type/Integer}
+                     :model/Field _ {:table_id tid :name "alpha"  :position 1
+                                     :database_type "INTEGER" :base_type :type/Integer}
+                     :model/Field _ {:table_id tid :name "yankee" :position 0
+                                     :database_type "INTEGER" :base_type :type/Integer}]
+        (let [response (mt/user-http-request :rasta :get 200 "ee/erd"
+                                             :database-id db-id
+                                             :table-ids tid)
+              node     (first (filter #(= tid (:table_id %)) (:nodes response)))]
+          (is (= ["yankee" "alpha" "Bravo" "zulu"]
+                 (mapv :name (:fields node)))))))))
+
 (deftest erd-external-fk-target-resolution-test
   (mt/with-premium-features #{:schema-viewer}
     (testing "FK field pointing to a readable table beyond the hop budget still carries the target IDs"


### PR DESCRIPTION
[GDGT-2597](https://linear.app/metabase/issue/GDGT-2597)

### Description

The Schema Viewer (`/api/ee/erd`) fetched table's fields with no `:order-by`, so columns came back in unsorted  (the frontend only lifted PKs/FKs to the top, leaving the rest arbitrary). And in some cases order could change after semantic type changes.

This PR introduces the exact ordering as`/api/table/:id/query_metadata` (the table metadata view) shows (reusing it's definition).

The frontend PK/FK lift is unchanged.

### How to verify

1. Schema Viewer → open a database/schema with a table with multiple fields.
2. Select table node, click "View metadata" in top-right
3. Open "Fields" tab, compare the ordering of fields. Apart from PK/FK fields, the order should match.

### Demo

<img width="1462" height="903" alt="image" src="https://github.com/user-attachments/assets/3eaa5940-4976-4e21-aab7-d29e55c9eae4" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR