### PR TITLE
Add Amazon Bedrock AI provider support

### DIFF
--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -190,7 +190,8 @@ export type MetabotProvider =
   | "metabase"
   | "anthropic"
   | "openai"
-  | "openrouter";
+  | "openrouter"
+  | "bedrock";
 
 export interface MetabotSettingsResponse {
   value: string | null;
@@ -200,12 +201,21 @@ export interface MetabotSettingsResponse {
     display_name: string;
     group?: string | null;
   }[];
+  // Bedrock-specific settings echoed from server
+  "bedrock-region"?: string | null;
+  "bedrock-auth-type"?: string | null;
 }
 
 export interface UpdateMetabotSettingsRequest {
   provider: MetabotProvider;
   model?: string;
   "api-key"?: string | null;
+  // Bedrock-specific fields
+  "secret-key"?: string | null;
+  region?: string | null;
+  "auth-type"?: "api-key" | "iam-credentials" | "session-token" | "iam-role" | null;
+  "session-token"?: string | null;
+  "role-arn"?: string | null;
 }
 
 /* Metabot - Suggested Prompts */

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -534,6 +534,13 @@ interface SettingsManagerSettings {
   "llm-anthropic-api-key"?: string | null;
   "llm-anthropic-api-base-url"?: string | null;
   "llm-openrouter-api-key"?: string | null;
+  "llm-bedrock-api-key"?: string | null;
+  "llm-bedrock-access-key-id"?: string | null;
+  "llm-bedrock-secret-access-key"?: string | null;
+  "llm-bedrock-session-token"?: string | null;
+  "llm-bedrock-auth-type"?: string | null;
+  "llm-bedrock-role-arn"?: string | null;
+  "llm-bedrock-region"?: string | null;
   "openai-api-key": string | null;
   "openai-available-models"?: OpenAiModel[];
   "openai-model": string | null;
@@ -757,6 +764,13 @@ export interface EnterpriseSettings extends Settings {
   "llm-openai-model"?: string;
   "llm-metabot-configured?"?: boolean | null;
   "llm-openrouter-api-key"?: string | null;
+  "llm-bedrock-api-key"?: string | null;
+  "llm-bedrock-access-key-id"?: string | null;
+  "llm-bedrock-secret-access-key"?: string | null;
+  "llm-bedrock-session-token"?: string | null;
+  "llm-bedrock-auth-type"?: string | null;
+  "llm-bedrock-role-arn"?: string | null;
+  "llm-bedrock-region"?: string | null;
   "session-timeout": TimeoutValue | null;
   "search-engine": SearchEngineSettingValue | null;
   "scim-enabled"?: boolean | null;

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -83,6 +83,23 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
       },
     ],
   },
+  bedrock: {
+    value: "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+    models: [
+      {
+        id: "anthropic.claude-sonnet-4-20250514-v1:0",
+        display_name: "Claude Sonnet 4",
+        group: "Anthropic",
+      },
+      {
+        id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+        display_name: "Claude Haiku 4.5",
+        group: "Anthropic",
+      },
+    ],
+    "bedrock-region": "us-east-1",
+    "bedrock-auth-type": "api-key",
+  },
 };
 
 type MetabotUsageQuota = {
@@ -100,7 +117,9 @@ type MetabotSettingKey =
   | "llm-metabot-provider"
   | "llm-anthropic-api-key"
   | "llm-openai-api-key"
-  | "llm-openrouter-api-key";
+  | "llm-openrouter-api-key"
+  | "llm-bedrock-api-key"
+  | "llm-bedrock-access-key-id";
 
 type MetabotSettingDefinition = SettingDefinition<MetabotSettingKey>;
 type MetabotSettingsUpdateBody = {
@@ -182,6 +201,7 @@ async function setup({
     anthropic: "**********45",
     openai: null,
     openrouter: null,
+    bedrock: null,
     ...apiKeyValues,
   };
 
@@ -232,6 +252,14 @@ async function setup({
     "llm-openrouter-api-key": createMockSettingDefinition({
       key: "llm-openrouter-api-key",
       value: mergedApiKeyValues.openrouter ?? undefined,
+    }),
+    "llm-bedrock-api-key": createMockSettingDefinition({
+      key: "llm-bedrock-api-key",
+      value: mergedApiKeyValues.bedrock ?? undefined,
+    }),
+    "llm-bedrock-access-key-id": createMockSettingDefinition({
+      key: "llm-bedrock-access-key-id",
+      value: undefined,
     }),
   };
 
@@ -312,7 +340,9 @@ async function setup({
           ? "llm-anthropic-api-key"
           : body.provider === "openai"
             ? "llm-openai-api-key"
-            : "llm-openrouter-api-key";
+            : body.provider === "bedrock"
+              ? "llm-bedrock-api-key"
+              : "llm-openrouter-api-key";
       const maskedApiKey = body["api-key"]
         ? `**********${String(body["api-key"]).slice(-2)}`
         : undefined;
@@ -1683,6 +1713,237 @@ describe("AIProviderSettingsSection", () => {
             (toast) => toast.message === "Unable to save provider settings.",
           ),
       ).toBe(true);
+    });
+  });
+
+  describe("Amazon Bedrock provider", () => {
+    it("shows Amazon Bedrock as selectable (not Coming soon) in the provider dropdown", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await userEvent.click(screen.getByLabelText("Provider"));
+
+      const bedrockOption = await screen.findByRole("option", {
+        name: "Amazon Bedrock",
+      });
+      expect(bedrockOption).toBeInTheDocument();
+      expect(bedrockOption).not.toHaveAttribute("data-combobox-disabled");
+    });
+
+    it("shows the auth type segmented control when Bedrock is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+
+      expect(screen.getByText("API Key")).toBeInTheDocument();
+      expect(screen.getByText("IAM Credentials")).toBeInTheDocument();
+      expect(screen.getByText("Session Token")).toBeInTheDocument();
+      expect(screen.getByText("IAM Role (auto)")).toBeInTheDocument();
+    });
+
+    it("shows the Bedrock API Key field when api-key auth type is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+
+      expect(screen.getByLabelText("Bedrock API Key")).toBeInTheDocument();
+    });
+
+    it("shows the region selector when Bedrock is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+
+      expect(screen.getByLabelText("Region")).toBeInTheDocument();
+    });
+
+    it("shows connected state for a saved Bedrock provider", async () => {
+      await setup({
+        savedProviderValue: "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+        isConfigured: true,
+        apiKeyValues: { bedrock: "**********ey" },
+      });
+
+      expect(
+        await screen.findByText("Connected to Amazon Bedrock"),
+      ).toBeInTheDocument();
+    });
+
+    it("sends bedrock-specific fields in the connect request", async () => {
+      await setup({
+        savedProviderValue: null,
+        isConfigured: false,
+        updateResponse: {
+          value: "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+          models: DEFAULT_RESPONSES.bedrock.models,
+        },
+      });
+
+      await selectProvider("Amazon Bedrock");
+
+      const apiKeyInput = screen.getByLabelText("Bedrock API Key");
+      await userEvent.type(apiKeyInput, "test-bedrock-key");
+
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        const putCalls = fetchMock.callHistory
+          .calls("path:/api/metabot/settings")
+          .filter(
+            (call) =>
+              call.request?.method === "PUT" || call.options?.method === "PUT",
+          );
+        expect(putCalls.length).toBeGreaterThan(0);
+      });
+
+      const putCall = fetchMock.callHistory
+        .calls("path:/api/metabot/settings")
+        .find(
+          (call) =>
+            call.request?.method === "PUT" || call.options?.method === "PUT",
+        );
+
+      const body = JSON.parse(String(putCall?.options?.body ?? "{}"));
+      expect(body.provider).toBe("bedrock");
+      expect(body["api-key"]).toBe("test-bedrock-key");
+      expect(body.region).toBe("us-east-1");
+      expect(body["auth-type"]).toBe("api-key");
+    });
+
+    it("shows the IAM Role fields and hides the API key field when IAM Role auth is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+      await userEvent.click(screen.getByText("IAM Role (auto)"));
+
+      expect(
+        screen.getByText(/Credentials will be fetched automatically/),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Role ARN (optional)")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Bedrock API Key"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the access key and secret key fields when IAM Credentials auth is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+      await userEvent.click(screen.getByText("IAM Credentials"));
+
+      expect(screen.getByLabelText("Access Key ID")).toBeInTheDocument();
+      expect(screen.getByLabelText("Secret Access Key")).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText("Enter your AWS session token"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the session token field when Session Token auth is selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Amazon Bedrock");
+      await userEvent.click(screen.getByText("Session Token"));
+
+      expect(screen.getByLabelText("Access Key ID")).toBeInTheDocument();
+      expect(screen.getByLabelText("Secret Access Key")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Enter your AWS session token"),
+      ).toBeInTheDocument();
+    });
+
+    it("sends IAM Role auth fields in the connect request", async () => {
+      await setup({
+        savedProviderValue: null,
+        isConfigured: false,
+        updateResponse: {
+          value: "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+          models: DEFAULT_RESPONSES.bedrock.models,
+        },
+      });
+
+      await selectProvider("Amazon Bedrock");
+      await userEvent.click(screen.getByText("IAM Role (auto)"));
+
+      await userEvent.type(
+        screen.getByLabelText("Role ARN (optional)"),
+        "arn:aws:iam::123456789012:role/BedrockAccess",
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        const putCalls = fetchMock.callHistory
+          .calls("path:/api/metabot/settings")
+          .filter(
+            (call) =>
+              call.request?.method === "PUT" || call.options?.method === "PUT",
+          );
+        expect(putCalls.length).toBeGreaterThan(0);
+      });
+
+      const putCall = fetchMock.callHistory
+        .calls("path:/api/metabot/settings")
+        .find(
+          (call) =>
+            call.request?.method === "PUT" || call.options?.method === "PUT",
+        );
+
+      const body = JSON.parse(String(putCall?.options?.body ?? "{}"));
+      expect(body.provider).toBe("bedrock");
+      expect(body["auth-type"]).toBe("iam-role");
+      expect(body["role-arn"]).toBe(
+        "arn:aws:iam::123456789012:role/BedrockAccess",
+      );
+      expect(body["api-key"]).toBeNull();
+    });
+
+    it("sends Session Token auth fields in the connect request", async () => {
+      await setup({
+        savedProviderValue: null,
+        isConfigured: false,
+        updateResponse: {
+          value: "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+          models: DEFAULT_RESPONSES.bedrock.models,
+        },
+      });
+
+      await selectProvider("Amazon Bedrock");
+      await userEvent.click(screen.getByText("Session Token"));
+
+      await userEvent.type(screen.getByLabelText("Access Key ID"), "AKIATEST");
+      await userEvent.type(
+        screen.getByLabelText("Secret Access Key"),
+        "secret-value",
+      );
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter your AWS session token"),
+        "session-token-value",
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        const putCalls = fetchMock.callHistory
+          .calls("path:/api/metabot/settings")
+          .filter(
+            (call) =>
+              call.request?.method === "PUT" || call.options?.method === "PUT",
+          );
+        expect(putCalls.length).toBeGreaterThan(0);
+      });
+
+      const putCall = fetchMock.callHistory
+        .calls("path:/api/metabot/settings")
+        .find(
+          (call) =>
+            call.request?.method === "PUT" || call.options?.method === "PUT",
+        );
+
+      const body = JSON.parse(String(putCall?.options?.body ?? "{}"));
+      expect(body.provider).toBe("bedrock");
+      expect(body["auth-type"]).toBe("session-token");
+      expect(body["api-key"]).toBe("AKIATEST");
+      expect(body["secret-key"]).toBe("secret-value");
+      expect(body["session-token"]).toBe("session-token-value");
     });
   });
 });

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -14,6 +14,7 @@ import { c, t } from "ttag";
 import _ from "underscore";
 
 import {
+  skipToken,
   useGetMetabotSettingsQuery,
   useUpdateMetabotSettingsMutation,
   useUpdateSettingsMutation,
@@ -29,10 +30,12 @@ import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { PLUGIN_METABOT } from "metabase/plugins";
 import {
+  Alert,
   Button,
   type ComboboxItem,
   Flex,
   Group,
+  SegmentedControl,
   Select,
   Stack,
   Text,
@@ -159,6 +162,12 @@ export function AIProviderConfigurationForm({
     isModal ? undefined : connectedProvider,
   );
 
+  const connectedProviderSettingsQuery = useGetMetabotSettingsQuery(
+    connectedProvider && connectedProvider !== "metabase"
+      ? { provider: connectedProvider }
+      : skipToken,
+  );
+
   const isCurrentConfigured = connectedProvider === provider && isConfigured;
 
   useEffect(() => {
@@ -175,6 +184,8 @@ export function AIProviderConfigurationForm({
     "llm-anthropic-api-key",
     "llm-openai-api-key",
     "llm-openrouter-api-key",
+    "llm-bedrock-api-key",
+    "llm-bedrock-access-key-id",
   ] as const);
 
   const disconnectProvider = useCallback(async () => {
@@ -199,6 +210,15 @@ export function AIProviderConfigurationForm({
       if (!apiKeySetting?.is_env_setting) {
         settingsToClear[apiKeySettingKey] = null;
       }
+    }
+
+    if (connectedProvider === "bedrock") {
+      settingsToClear["llm-bedrock-api-key"] = null;
+      settingsToClear["llm-bedrock-secret-access-key"] = null;
+      settingsToClear["llm-bedrock-session-token"] = null;
+      settingsToClear["llm-bedrock-auth-type"] = null;
+      settingsToClear["llm-bedrock-role-arn"] = null;
+      settingsToClear["llm-bedrock-region"] = null;
     }
 
     try {
@@ -340,6 +360,16 @@ export function AIProviderConfigurationForm({
               connectedModel={connectedModel}
               isCurrentConfigured={isCurrentConfigured}
               isEnvSetting={isEnvSetting}
+              savedBedrockRegion={
+                connectedProviderSettingsQuery.currentData?.[
+                  "bedrock-region"
+                ] ?? undefined
+              }
+              savedBedrockAuthType={
+                connectedProviderSettingsQuery.currentData?.[
+                  "bedrock-auth-type"
+                ] ?? undefined
+              }
             />
           ))
           .with(P.nullish, () => null)
@@ -401,20 +431,76 @@ export function AIProviderConfigurationForm({
   );
 }
 
+type BedrockAuthType =
+  | "api-key"
+  | "iam-credentials"
+  | "session-token"
+  | "iam-role";
+
+const BEDROCK_REGIONS = [
+  // US
+  { value: "us-east-1", label: "US East (N. Virginia)" },
+  { value: "us-east-2", label: "US East (Ohio)" },
+  { value: "us-west-1", label: "US West (N. California)" },
+  { value: "us-west-2", label: "US West (Oregon)" },
+  // Canada
+  { value: "ca-central-1", label: "Canada (Central)" },
+  // South America
+  { value: "sa-east-1", label: "South America (São Paulo)" },
+  // Europe
+  { value: "eu-west-1", label: "EU (Ireland)" },
+  { value: "eu-west-2", label: "EU (London)" },
+  { value: "eu-west-3", label: "EU (Paris)" },
+  { value: "eu-central-1", label: "EU (Frankfurt)" },
+  { value: "eu-central-2", label: "EU (Zurich)" },
+  { value: "eu-north-1", label: "EU (Stockholm)" },
+  // Asia Pacific
+  { value: "ap-south-1", label: "Asia Pacific (Mumbai)" },
+  { value: "ap-southeast-1", label: "Asia Pacific (Singapore)" },
+  { value: "ap-southeast-2", label: "Asia Pacific (Sydney)" },
+  { value: "ap-northeast-1", label: "Asia Pacific (Tokyo)" },
+  { value: "ap-northeast-2", label: "Asia Pacific (Seoul)" },
+  // Middle East
+  { value: "me-south-1", label: "Middle East (Bahrain)" },
+  { value: "me-central-1", label: "Middle East (UAE)" },
+  // Africa
+  { value: "af-south-1", label: "Africa (Cape Town)" },
+  // GovCloud
+  { value: "us-gov-west-1", label: "AWS GovCloud (US-West)" },
+];
+
 const ProviderCredentialsFields = ({
   selectedProvider,
   connectedModel,
   isCurrentConfigured,
   isEnvSetting,
+  savedBedrockRegion,
+  savedBedrockAuthType,
 }: {
   selectedProvider: Exclude<MetabotProvider, "metabase">;
   connectedModel: string | undefined;
   isCurrentConfigured: boolean;
   isEnvSetting: boolean;
+  savedBedrockRegion?: string;
+  savedBedrockAuthType?: string;
 }) => {
   const [model, setModel] = useState<string | undefined>(connectedModel);
   const [apiKeyLocalValue, setApiKeyLocalValue] = useState<string | null>(null);
   const [sendToast] = useToast();
+
+  // Bedrock-specific local state
+  const isBedrock = selectedProvider === "bedrock";
+  const [bedrockSecretKey, setBedrockSecretKey] = useState<string | null>(null);
+  const [bedrockAuthType, setBedrockAuthType] = useState<BedrockAuthType>(
+    (savedBedrockAuthType as BedrockAuthType) || "api-key",
+  );
+  const [bedrockRegion, setBedrockRegion] = useState<string>(
+    savedBedrockRegion || "us-east-1",
+  );
+  const [bedrockSessionToken, setBedrockSessionToken] = useState<string | null>(
+    null,
+  );
+  const [bedrockRoleArn, setBedrockRoleArn] = useState<string | null>(null);
 
   useEffect(() => {
     setModel(connectedModel);
@@ -424,17 +510,34 @@ const ProviderCredentialsFields = ({
     useUpdateMetabotSettingsMutation();
 
   const onConnect = async () => {
-    await updateMetabotSettings({
-      provider: selectedProvider,
-      "api-key": apiKeyLocalValue || null,
-    }).unwrap();
+    if (isBedrock) {
+      await updateMetabotSettings({
+        provider: selectedProvider,
+        "api-key": apiKeyLocalValue || null,
+        "secret-key": bedrockSecretKey || null,
+        region: bedrockRegion,
+        "auth-type": bedrockAuthType,
+        "session-token":
+          bedrockAuthType === "session-token" ? bedrockSessionToken : null,
+        "role-arn": bedrockAuthType === "iam-role" ? bedrockRoleArn : null,
+      }).unwrap();
+    } else {
+      await updateMetabotSettings({
+        provider: selectedProvider,
+        "api-key": apiKeyLocalValue || null,
+      }).unwrap();
+    }
 
     setApiKeyLocalValue(null);
+    setBedrockSecretKey(null);
   };
 
   const hasDirtyApiKey = apiKeyLocalValue !== null;
+  const hasDirtyBedrockFields = isBedrock && bedrockSecretKey !== null;
   const connectHandler =
-    !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
+    !isCurrentConfigured || hasDirtyApiKey || hasDirtyBedrockFields
+      ? onConnect
+      : null;
 
   const { isMutating } = useAIProviderConfigurationContext(connectHandler);
 
@@ -442,15 +545,28 @@ const ProviderCredentialsFields = ({
     "llm-anthropic-api-key",
     "llm-openai-api-key",
     "llm-openrouter-api-key",
+    "llm-bedrock-api-key",
+    "llm-bedrock-access-key-id",
   ] as const);
 
   const selectedApiKeySetting =
     providerApiKeyDetails[API_KEY_SETTING_BY_PROVIDER[selectedProvider]];
+  const bedrockAccessKeySetting =
+    providerApiKeyDetails["llm-bedrock-access-key-id"];
   const selectedApiKeyValue = String(selectedApiKeySetting?.value ?? "");
   const apiKeyEnvSettingName = selectedApiKeySetting?.is_env_setting
     ? selectedApiKeySetting.env_name
     : undefined;
-  const needsApiKey = !hasConfiguredSettingValue(selectedApiKeySetting);
+  // For bedrock with IAM/session-token auth, check the access key setting instead of the API key
+  const effectiveKeySetting =
+    selectedProvider === "bedrock" &&
+    (bedrockAuthType === "iam-credentials" ||
+      bedrockAuthType === "session-token")
+      ? bedrockAccessKeySetting
+      : selectedApiKeySetting;
+  const needsApiKey =
+    bedrockAuthType !== "iam-role" &&
+    !hasConfiguredSettingValue(effectiveKeySetting);
 
   const metabotSettingsQuery = useGetMetabotSettingsQuery(
     {
@@ -476,6 +592,7 @@ const ProviderCredentialsFields = ({
 
   useEffect(() => {
     setApiKeyLocalValue(null);
+    setBedrockSecretKey(null);
   }, [selectedProvider, selectedApiKeySetting?.value]);
 
   const handleApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -504,32 +621,129 @@ const ProviderCredentialsFields = ({
 
   return (
     <>
-      <TextInput
-        key={selectedProvider}
-        label={t`API key`}
-        type="password"
-        description={
-          <ExternalLink
-            key={selectedProviderDetails.value}
-            href={selectedProviderDetails.apiKey.addKeyUrl}
-          >
-            {c("{0} is the name of an AI provider")
-              .t`Get or manage keys in ${selectedProviderDetails.label}`}
-          </ExternalLink>
-        }
-        placeholder={
-          selectedProviderDetails.apiKey?.placeholder ?? t`Enter your API key`
-        }
-        value={displayApiKeyValue}
-        error={apiKeyError}
-        onChange={handleApiKeyChange}
-        disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
-        w="100%"
-      />
+      {isBedrock && (
+        <>
+          <Text fw={500} size="sm">{t`Authentication type`}</Text>
+          <SegmentedControl
+            value={bedrockAuthType}
+            onChange={(value) => setBedrockAuthType(value as BedrockAuthType)}
+            disabled={isMutating || isEnvSetting}
+            data={[
+              { value: "api-key", label: t`API Key` },
+              { value: "iam-credentials", label: t`IAM Credentials` },
+              { value: "session-token", label: t`Session Token` },
+              { value: "iam-role", label: t`IAM Role (auto)` },
+            ]}
+          />
+        </>
+      )}
 
-      {apiKeyEnvSettingName ? (
-        <SetByEnvVar varName={apiKeyEnvSettingName} />
-      ) : null}
+      {isBedrock && bedrockAuthType === "iam-role" ? (
+        <>
+          <Alert color="info" title={t`Automatic credential resolution`}>
+            {t`Credentials will be fetched automatically from the EC2/ECS instance metadata service (IMDS). Optionally provide a Role ARN for STS AssumeRole.`}
+          </Alert>
+          <TextInput
+            label={t`Role ARN (optional)`}
+            placeholder="arn:aws:iam::123456789012:role/BedrockAccess"
+            value={bedrockRoleArn ?? ""}
+            onChange={(e) => setBedrockRoleArn(e.target.value)}
+            disabled={isMutating || isEnvSetting}
+            w="100%"
+          />
+        </>
+      ) : isBedrock && bedrockAuthType === "api-key" ? (
+        <>
+          <TextInput
+            key={`${selectedProvider}-api-key`}
+            label={t`Bedrock API Key`}
+            type="password"
+            description={
+              <ExternalLink
+                key={selectedProviderDetails.value}
+                href="https://console.aws.amazon.com/bedrock/home#/api-keys"
+              >
+                {t`Generate a Bedrock API key in the AWS Console`}
+              </ExternalLink>
+            }
+            placeholder={t`Enter your Bedrock API key`}
+            value={displayApiKeyValue}
+            error={apiKeyError}
+            onChange={handleApiKeyChange}
+            disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
+            w="100%"
+          />
+
+          {apiKeyEnvSettingName ? (
+            <SetByEnvVar varName={apiKeyEnvSettingName} />
+          ) : null}
+        </>
+      ) : (
+        <>
+          <TextInput
+            key={selectedProvider}
+            label={isBedrock ? t`Access Key ID` : t`API key`}
+            type="password"
+            description={
+              <ExternalLink
+                key={selectedProviderDetails.value}
+                href={selectedProviderDetails.apiKey.addKeyUrl}
+              >
+                {c("{0} is the name of an AI provider")
+                  .t`Get or manage keys in ${selectedProviderDetails.label}`}
+              </ExternalLink>
+            }
+            placeholder={
+              selectedProviderDetails.apiKey?.placeholder ??
+              t`Enter your API key`
+            }
+            value={displayApiKeyValue}
+            error={apiKeyError}
+            onChange={handleApiKeyChange}
+            disabled={isMutating || isEnvSetting || !!apiKeyEnvSettingName}
+            w="100%"
+          />
+
+          {apiKeyEnvSettingName ? (
+            <SetByEnvVar varName={apiKeyEnvSettingName} />
+          ) : null}
+
+          {isBedrock && (
+            <TextInput
+              label={t`Secret Access Key`}
+              type="password"
+              placeholder={t`Enter your AWS secret access key`}
+              value={bedrockSecretKey ?? ""}
+              onChange={(e) => setBedrockSecretKey(e.target.value)}
+              disabled={isMutating || isEnvSetting}
+              w="100%"
+            />
+          )}
+
+          {isBedrock && bedrockAuthType === "session-token" && (
+            <TextInput
+              label={t`Session Token`}
+              type="password"
+              placeholder={t`Enter your AWS session token`}
+              value={bedrockSessionToken ?? ""}
+              onChange={(e) => setBedrockSessionToken(e.target.value)}
+              disabled={isMutating || isEnvSetting}
+              w="100%"
+            />
+          )}
+        </>
+      )}
+
+      {isBedrock && (
+        <Select
+          label={t`Region`}
+          data={BEDROCK_REGIONS}
+          value={bedrockRegion}
+          onChange={(value) => setBedrockRegion(value ?? "us-east-1")}
+          disabled={isMutating || isEnvSetting}
+          searchable
+        />
+      )}
 
       {!needsApiKey && !apiKeyError && (
         <Select

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -57,6 +57,14 @@ export function getProviderOptions(
         addKeyUrl: "https://openrouter.ai/keys",
       },
     },
+    bedrock: {
+      value: "bedrock",
+      label: "Amazon Bedrock",
+      apiKey: {
+        placeholder: "AKIA...",
+        addKeyUrl: "https://console.aws.amazon.com/iam/home#/security_credentials",
+      },
+    },
   };
 }
 
@@ -78,16 +86,21 @@ export function isApiKeyMetabotProvider(
 }
 
 export function isAvailableProvider(provider: MetabotProvider): boolean {
-  return provider === "anthropic" || provider === "metabase";
+  return provider === "anthropic" || provider === "metabase" || provider === "bedrock";
 }
 
 export const API_KEY_SETTING_BY_PROVIDER: Record<
   MetabotApiKeyProvider,
-  "llm-anthropic-api-key" | "llm-openai-api-key" | "llm-openrouter-api-key"
+  | "llm-anthropic-api-key"
+  | "llm-openai-api-key"
+  | "llm-openrouter-api-key"
+  | "llm-bedrock-api-key"
+  | "llm-bedrock-access-key-id"
 > = {
   anthropic: "llm-anthropic-api-key",
   openai: "llm-openai-api-key",
   openrouter: "llm-openrouter-api-key",
+  bedrock: "llm-bedrock-api-key",
 };
 
 export function parseProviderAndModel(value: string | null | undefined) {

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -120,6 +120,67 @@
                              (deferred-tru "Invalid OpenRouter API key format. Key must start with ''sk-or-v1-''."))
   :doc              false)
 
+;;; ------------------------------------------------- Bedrock ---------------------------------------------------
+
+(defsetting llm-bedrock-api-key
+  (deferred-tru "The Bedrock API Key (Bearer token). When set, uses simple Bearer auth instead of SigV4 signing.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-access-key-id
+  (deferred-tru "The AWS Access Key ID for Amazon Bedrock.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-secret-access-key
+  (deferred-tru "The AWS Secret Access Key for Amazon Bedrock.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-session-token
+  (deferred-tru "The AWS Session Token for Amazon Bedrock (optional, for temporary credentials).")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-auth-type
+  (deferred-tru "The authentication type for Amazon Bedrock: api-key, iam-credentials, session-token, or iam-role.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :default     "api-key"
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-role-arn
+  (deferred-tru "The AWS IAM Role ARN for Amazon Bedrock (optional, for STS AssumeRole).")
+  :encryption  :no
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-region
+  (deferred-tru "The AWS region for Amazon Bedrock (e.g. us-east-1).")
+  :encryption  :no
+  :visibility  :settings-manager
+  :default     "us-east-1"
+  :export?     false
+  :doc         false)
+
+(defsetting llm-bedrock-model
+  (deferred-tru "The Amazon Bedrock model ID.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :default     "anthropic.claude-sonnet-4-20250514-v1:0"
+  :export?     false
+  :doc         false)
+
 ;;; --------------------------------------------------- Proxy ---------------------------------------------------
 
 (defsetting llm-proxy-base-url

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -12,6 +12,7 @@
    [metabase.config.core :as config]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.llm.settings :as llm.settings]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.api.conversations]
    [metabase.metabot.api.document]
@@ -301,20 +302,30 @@
   [:map
    [:value [:maybe :string]]
    [:api-key-error {:optional true} [:maybe :string]]
-   [:models [:sequential llm-model-response-schema]]])
+   [:models [:sequential llm-model-response-schema]]
+   ;; Bedrock-specific settings echoed back for frontend state hydration
+   [:bedrock-region {:optional true} [:maybe :string]]
+   [:bedrock-auth-type {:optional true} [:maybe :string]]])
 
 (def ^:private metabot-settings-request-schema
   [:map
    [:provider metabot-provider-schema]
    [:model {:optional true} [:maybe :string]]
-   [:api-key {:optional true} [:maybe :string]]])
+   [:api-key {:optional true} [:maybe :string]]
+   ;; Bedrock-specific fields
+   [:secret-key {:optional true} [:maybe :string]]
+   [:region {:optional true} [:maybe :string]]
+   [:auth-type {:optional true} [:maybe [:enum "api-key" "iam-credentials" "session-token" "iam-role"]]]
+   [:session-token {:optional true} [:maybe :string]]
+   [:role-arn {:optional true} [:maybe :string]]])
 
 (defn- provider-api-key-setting-key
   [provider]
   (case provider
     "anthropic"  :llm-anthropic-api-key
     "openai"     :llm-openai-api-key
-    "openrouter" :llm-openrouter-api-key))
+    "openrouter" :llm-openrouter-api-key
+    "bedrock"    :llm-bedrock-access-key-id))
 
 (defn- non-blank-string
   [value]
@@ -426,9 +437,12 @@
   ([provider]
    (settings-response provider nil))
   ([provider api-key-override]
-   (merge
-    {:value (metabot.settings/llm-metabot-provider)}
-    (provider-models-response provider api-key-override))))
+   (cond-> (merge
+            {:value (metabot.settings/llm-metabot-provider)}
+            (provider-models-response provider api-key-override))
+     (= provider "bedrock")
+     (assoc :bedrock-region    (llm.settings/llm-bedrock-region)
+            :bedrock-auth-type (llm.settings/llm-bedrock-auth-type)))))
 
 (defn- current-provider
   []
@@ -462,7 +476,8 @@
    _query-params
    body :- metabot-settings-request-schema]
   (perms/check-has-application-permission :setting)
-  (let [{:keys [provider api-key] request-model :model} body
+  (let [{:keys [provider api-key secret-key region auth-type session-token role-arn]
+         request-model :model} body
         current-provider (current-setting-provider)
         provider-changed? (not= current-provider provider)
         model (cond
@@ -475,10 +490,30 @@
 
                 :else
                 nil)
+        ;; Save Bedrock-specific settings BEFORE calling settings-response,
+        ;; so list-models uses the correct auth type and credentials.
+        _ (when (= provider "bedrock")
+            (when (contains? body :auth-type)
+              (setting/set! :llm-bedrock-auth-type (or (non-blank-string auth-type) "api-key")))
+            (when (contains? body :secret-key)
+              (setting/set! :llm-bedrock-secret-access-key (non-blank-string secret-key)))
+            (when (contains? body :region)
+              (setting/set! :llm-bedrock-region (or (non-blank-string region) "us-east-1")))
+            (when (contains? body :session-token)
+              (setting/set! :llm-bedrock-session-token (non-blank-string session-token)))
+            (when (contains? body :role-arn)
+              (setting/set! :llm-bedrock-role-arn (non-blank-string role-arn)))
+            ;; Save Bedrock API key BEFORE settings-response so list-models can use it
+            (if (= auth-type "api-key")
+              (when (contains? body :api-key)
+                (setting/set! :llm-bedrock-api-key (non-blank-string api-key)))
+              (when (contains? body :api-key)
+                (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))))
+        ;; For non-bedrock providers, save api-key before settings-response too
+        _ (when (and (not= provider "bedrock") (contains? body :api-key))
+            (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))
         response (-> (settings-response provider api-key)
                      throw-api-key-error!)]
-    (when (contains? body :api-key)
-      (setting/set! (provider-api-key-setting-key provider) (non-blank-string api-key)))
     (when model
       (setting/set! :llm-metabot-provider (str provider "/" model)))
     (assoc response :value (metabot.settings/llm-metabot-provider))))

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -14,6 +14,7 @@
    [metabase.analytics.core :as analytics.core]
    [metabase.api.common :as api]
    [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.self.bedrock :as bedrock]
    [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.openai :as openai]
@@ -31,6 +32,7 @@
     "anthropic"  claude/claude
     "openai"     openai/openai
     "openrouter" openrouter/openrouter
+    "bedrock"    bedrock/bedrock
     (throw (ex-info (str "Unknown LLM provider: " provider)
                     {:provider provider}))))
 
@@ -40,6 +42,7 @@
     "anthropic"  claude/list-models
     "openai"     openai/list-models
     "openrouter" openrouter/list-models
+    "bedrock"    bedrock/list-models
     (throw (ex-info (str "Unknown LLM provider: " provider)
                     {:provider provider}))))
 

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -1,0 +1,616 @@
+(ns metabase.metabot.self.bedrock
+  "Amazon Bedrock provider adapter using the Converse Stream API.
+
+  Uses self-contained AWS Signature V4 signing (no AWS SDK dependency).
+  Supports 3 auth modes: IAM credentials, session token, and IAM role (auto via IMDS/STS)."
+  (:require
+   [clj-http.client :as http]
+   [clojure.string :as str]
+   [malli.json-schema :as mjs]
+   [metabase.llm.settings :as llm]
+   [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.schema :as schema]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [metabase.util.o11y :refer [with-span]])
+  (:import
+   (java.io InputStream)
+   (java.nio.charset StandardCharsets)
+   (java.security MessageDigest)
+   (java.time Instant ZoneOffset)
+   (java.time.format DateTimeFormatter)
+   (javax.crypto Mac)
+   (javax.crypto.spec SecretKeySpec)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ AWS SigV4 Signing ------------------------------------------------
+
+(defn- sha256-hex
+  "Compute SHA-256 hex digest of a string."
+  ^String [^String s]
+  (let [md (MessageDigest/getInstance "SHA-256")
+        digest (.digest md (.getBytes (or s "") StandardCharsets/UTF_8))]
+    (str/join (map #(format "%02x" %) digest))))
+
+(defn- hmac-sha256
+  "Compute HMAC-SHA256, returning raw bytes."
+  ^bytes [^bytes key-bytes ^String data]
+  (let [mac (Mac/getInstance "HmacSHA256")
+        spec (SecretKeySpec. key-bytes "HmacSHA256")]
+    (.init mac spec)
+    (.doFinal mac (.getBytes data StandardCharsets/UTF_8))))
+
+(defn- derive-signing-key
+  "Derive the AWS SigV4 signing key."
+  ^bytes [^String secret-key ^String date-stamp ^String region ^String service]
+  (-> (.getBytes (str "AWS4" secret-key) StandardCharsets/UTF_8)
+      (hmac-sha256 date-stamp)
+      (hmac-sha256 region)
+      (hmac-sha256 service)
+      (hmac-sha256 "aws4_request")))
+
+(defn- bytes->hex
+  ^String [^bytes b]
+  (str/join (map #(format "%02x" %) b)))
+
+(defn- sign-request
+  "Sign an HTTP request with AWS Signature V4.
+  Returns a map of headers to add to the request."
+  [{:keys [method uri query-string headers body
+           access-key secret-key session-token
+           region service]}]
+  (let [now          (Instant/now)
+        amz-date     (.format (.withZone (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'")
+                                         ZoneOffset/UTC)
+                              now)
+        date-stamp   (.format (.withZone (DateTimeFormatter/ofPattern "yyyyMMdd")
+                                         ZoneOffset/UTC)
+                              now)
+        payload-hash (sha256-hex (or body ""))
+        ;; Build headers to sign
+        base-headers (sorted-map
+                      "content-type"          (get headers "content-type" "application/json")
+                      "host"                  (get headers "host")
+                      "x-amz-content-sha256"  payload-hash
+                      "x-amz-date"            amz-date)
+        sign-headers (if session-token
+                       (assoc base-headers "x-amz-security-token" session-token)
+                       base-headers)
+        signed-headers-str (str/join ";" (keys sign-headers))
+        canonical-headers  (str/join (map (fn [[k v]] (str k ":" v "\n")) sign-headers))
+        ;; AWS SigV4 requires the canonical URI to be URI-encoded per RFC 3986.
+        ;; Encode each path segment individually (preserving "/") to match what
+        ;; clj-http/Apache HttpClient sends on the wire.
+        canonical-uri      (->> (str/split uri #"/")
+                                (map #(-> (java.net.URLEncoder/encode ^String % "UTF-8")
+                                          (str/replace "+" "%20")))
+                                (str/join "/"))
+        canonical-request  (str/join "\n"
+                                     [(u/upper-case-en (name method))
+                                      canonical-uri
+                                      (or query-string "")
+                                      canonical-headers
+                                      signed-headers-str
+                                      payload-hash])
+        scope              (str date-stamp "/" region "/" service "/aws4_request")
+        string-to-sign     (str/join "\n"
+                                     ["AWS4-HMAC-SHA256"
+                                      amz-date
+                                      scope
+                                      (sha256-hex canonical-request)])
+        signing-key        (derive-signing-key secret-key date-stamp region service)
+        signature          (bytes->hex (hmac-sha256 signing-key string-to-sign))
+        auth-header        (str "AWS4-HMAC-SHA256 "
+                                "Credential=" access-key "/" scope ", "
+                                "SignedHeaders=" signed-headers-str ", "
+                                "Signature=" signature)]
+    (log/debugf "SigV4 canonical request:\n%s" canonical-request)
+    (log/debugf "SigV4 string-to-sign:\n%s" string-to-sign)
+    (cond-> {"Authorization"        auth-header
+             "content-type"         (get headers "content-type" "application/json")
+             "x-amz-date"           amz-date
+             "x-amz-content-sha256" payload-hash}
+      session-token (assoc "x-amz-security-token" session-token))))
+
+;;; ------------------------------------------ Credential Resolution ------------------------------------------
+
+(defonce ^:private credential-cache
+  (atom {:access-key-id     nil
+         :secret-access-key nil
+         :session-token     nil
+         :expiration        nil}))
+
+(defn- credentials-expired?
+  "Check if cached credentials are within 5 minutes of expiry."
+  [{:keys [expiration]}]
+  (or (nil? expiration)
+      (.isBefore ^Instant expiration
+                 (.plusSeconds (Instant/now) 300))))
+
+(defn- fetch-imds-token
+  "Fetch an IMDSv2 session token. Returns nil if IMDS is unavailable."
+  []
+  (try
+    (:body (http/put "http://169.254.169.254/latest/api/token"
+                     {:headers {"X-aws-ec2-metadata-token-ttl-seconds" "21600"}
+                      :socket-timeout 2000
+                      :connection-timeout 1000}))
+    (catch Exception _ nil)))
+
+(defn- fetch-imds-credentials
+  "Fetch credentials from EC2/ECS instance metadata service."
+  []
+  (let [imds-token (fetch-imds-token)
+        imds-headers (when imds-token
+                       {"X-aws-ec2-metadata-token" imds-token})
+        role-name (str/trim
+                   (:body (http/get "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+                                    {:headers imds-headers
+                                     :socket-timeout 2000
+                                     :connection-timeout 1000})))
+        creds-body (json/decode+kw
+                    (:body (http/get (str "http://169.254.169.254/latest/meta-data/iam/security-credentials/" role-name)
+                                     {:headers imds-headers
+                                      :socket-timeout 2000
+                                      :connection-timeout 1000})))]
+    {:access-key-id     (:AccessKeyId creds-body)
+     :secret-access-key (:SecretAccessKey creds-body)
+     :session-token     (:Token creds-body)
+     :expiration        (Instant/parse (:Expiration creds-body))}))
+
+(defn- assume-role
+  "Call STS AssumeRole to get temporary credentials."
+  [role-arn region base-creds]
+  (let [sts-host   (str "sts." region ".amazonaws.com")
+        body-str   (str "Action=AssumeRole"
+                        "&Version=2011-06-15"
+                        "&RoleArn=" (java.net.URLEncoder/encode ^String role-arn "UTF-8")
+                        "&RoleSessionName=metabase-bedrock"
+                        "&DurationSeconds=3600")
+        sig-headers (sign-request {:method     :post
+                                   :uri        "/"
+                                   :headers    {"host"         sts-host
+                                                "content-type" "application/x-www-form-urlencoded"}
+                                   :body       body-str
+                                   :access-key (:access-key-id base-creds)
+                                   :secret-key (:secret-access-key base-creds)
+                                   :session-token (:session-token base-creds)
+                                   :region     region
+                                   :service    "sts"})
+        response   (http/post (str "https://" sts-host "/")
+                              {:headers (merge {"content-type" "application/x-www-form-urlencoded"
+                                                "host"         sts-host}
+                                               sig-headers)
+                               :body    body-str
+                               :socket-timeout  10000
+                               :connection-timeout 5000})
+        ;; Parse the XML response for credentials
+        body       (:body response)
+        extract    (fn [tag]
+                     (second (re-find (re-pattern (str "<" tag ">([^<]+)</" tag ">")) body)))]
+    {:access-key-id     (extract "AccessKeyId")
+     :secret-access-key (extract "SecretAccessKey")
+     :session-token     (extract "SessionToken")
+     :expiration        (Instant/parse (extract "Expiration"))}))
+
+(defn- resolve-bedrock-credentials
+  "Resolve AWS credentials based on the configured auth type.
+  Returns {:bearer-token ...} for API key auth, or
+  {:access-key-id, :secret-access-key, :session-token (optional)} for SigV4 auth."
+  []
+  (let [auth-type (llm/llm-bedrock-auth-type)]
+    (case auth-type
+      "api-key"
+      {:bearer-token (llm/llm-bedrock-api-key)}
+
+      "iam-credentials"
+      {:access-key-id     (llm/llm-bedrock-access-key-id)
+       :secret-access-key (llm/llm-bedrock-secret-access-key)}
+
+      "session-token"
+      {:access-key-id     (llm/llm-bedrock-access-key-id)
+       :secret-access-key (llm/llm-bedrock-secret-access-key)
+       :session-token     (llm/llm-bedrock-session-token)}
+
+      "iam-role"
+      (let [cached @credential-cache]
+        (if (and (:access-key-id cached) (not (credentials-expired? cached)))
+          cached
+          (let [region   (llm/llm-bedrock-region)
+                role-arn (llm/llm-bedrock-role-arn)
+                creds    (if (not-empty role-arn)
+                           (let [base-creds (fetch-imds-credentials)]
+                             (assume-role role-arn region base-creds))
+                           (fetch-imds-credentials))]
+            (reset! credential-cache creds)
+            creds)))
+
+      ;; default fallback — try API key first, then IAM
+      (if-let [bearer (not-empty (llm/llm-bedrock-api-key))]
+        {:bearer-token bearer}
+        {:access-key-id     (llm/llm-bedrock-access-key-id)
+         :secret-access-key (llm/llm-bedrock-secret-access-key)}))))
+
+;;; ------------------------------------------ AISDK ↔ Bedrock Conversion ------------------------------------------
+
+(defn- bedrock-usage->aisdk-usage
+  "Convert a Bedrock usage block to AISDK usage shape."
+  [u]
+  {:promptTokens     (:inputTokens u 0)
+   :completionTokens (:outputTokens u 0)})
+
+(defn bedrock->aisdk-chunks-xf
+  "Translates Bedrock ConverseStream events into AI SDK v5 protocol chunks.
+
+  Bedrock Converse Stream events:
+    messageStart      -> {role: \"assistant\"}
+    contentBlockStart -> {contentBlockIndex, start: {text: \"\"} | {toolUse: {toolUseId, name}}}
+    contentBlockDelta -> {contentBlockIndex, delta: {text: \"...\"} | {toolUse: {input: \"...\"}}}
+    contentBlockStop  -> {contentBlockIndex}
+    metadata          -> {usage: {inputTokens, outputTokens}, metrics: {latencyMs}}
+    messageStop       -> {stopReason: \"end_turn\"}"
+  []
+  (fn [rf]
+    (let [current-type (volatile! nil)
+          current-id   (volatile! nil)
+          message-id   (volatile! nil)
+          payload      (volatile! {})
+          close!       (fn [result]
+                         (u/prog1 (rf result (merge {:type (case @current-type
+                                                             :text     :text-end
+                                                             :tool_use :tool-input-available)}
+                                                    @payload))
+                           (vreset! current-type nil)
+                           (vreset! current-id nil)
+                           (vreset! payload {})))]
+      (fn
+        ([result]
+         (cond-> result
+           @current-type (close!)
+           true          (rf)))
+        ([result chunk]
+         ;; Bedrock wraps each event in a top-level key matching the event type
+         (let [event-type (some #{:messageStart :contentBlockStart :contentBlockDelta
+                                  :contentBlockStop :metadata :messageStop}
+                                (keys chunk))]
+           (case event-type
+             :messageStart
+             (let [mid (core/mkid)]
+               (vreset! message-id mid)
+               (rf result {:type :start :messageId mid}))
+
+             :contentBlockStart
+             (let [start    (get-in chunk [:contentBlockStart :start])
+                   tool-use (:toolUse start)
+                   chunk-id (or (:toolUseId tool-use) (core/mkid))]
+               (if tool-use
+                 (do
+                   (vreset! current-type :tool_use)
+                   (vreset! current-id chunk-id)
+                   (vreset! payload {:toolCallId chunk-id
+                                     :toolName   (:name tool-use)})
+                   (rf result {:type :tool-input-start
+                               :toolCallId chunk-id
+                               :toolName   (:name tool-use)}))
+                 (do
+                   (vreset! current-type :text)
+                   (vreset! current-id chunk-id)
+                   (vreset! payload {:id chunk-id})
+                   (rf result {:type :text-start :id chunk-id}))))
+
+             :contentBlockDelta
+             (let [delta (get-in chunk [:contentBlockDelta :delta])]
+               (cond
+                 (:text delta)
+                 (rf result {:type  :text-delta
+                             :id    (:id @payload)
+                             :delta (:text delta)})
+
+                 (:toolUse delta)
+                 (rf result {:type           :tool-input-delta
+                             :toolCallId     (:toolCallId @payload)
+                             :inputTextDelta (:input (:toolUse delta))})))
+
+             :contentBlockStop
+             (if @current-type
+               (close! result)
+               result)
+
+             :metadata
+             (let [usage (get-in chunk [:metadata :usage])]
+               (if usage
+                 (rf result {:type  :usage
+                             :usage (bedrock-usage->aisdk-usage usage)
+                             :id    @message-id})
+                 result))
+
+             :messageStop
+             result
+
+             ;; Unknown event type — pass through
+             result)))))))
+
+;;; ------------------------------------------ AISDK parts → Bedrock messages ------------------------------------------
+
+(defn parts->bedrock-messages
+  "Convert AISDK parts into Bedrock Converse message format."
+  [parts]
+  (->> parts
+       (mapv (fn [part]
+               (case (:type part)
+                 :text        {:role    "assistant"
+                               :content [{:text (:text part)}]}
+                 :tool-input  {:role    "assistant"
+                               :content [{:toolUse {:toolUseId (:id part)
+                                                    :name      (:function part)
+                                                    :input     (or (:arguments part) {})}}]}
+                 :tool-output {:role    "user"
+                               :content [{:toolResult {:toolUseId (:id part)
+                                                       :content   [{:text (or (get-in part [:result :output])
+                                                                              (when-let [err (:error part)]
+                                                                                (str "Error: " (:message err)))
+                                                                              (pr-str (:result part)))}]}}]}
+                 ;; User messages
+                 {:role    (name (or (:role part) "user"))
+                  :content [{:text (or (:content part) "")}]})))
+       ;; Merge consecutive same-role messages
+       (partition-by :role)
+       (mapcat (fn [group]
+                 [{:role    (:role (first group))
+                   :content (into [] (mapcat :content) group)}]))
+       vec))
+
+;;; ------------------------------------------ Tool definition format ------------------------------------------
+
+(defn- tool->bedrock
+  "Convert a ToolEntry to Bedrock toolSpec format."
+  [{:keys [tool-name doc schema]}]
+  (let [[_:=> [_:cat params] _out] schema
+        params (schema/filter-schema-by-features params)]
+    {:toolSpec {:name        (or tool-name "unknown")
+                :description doc
+                :inputSchema {:json (mjs/transform params {:additionalProperties false})}}}))
+
+;;; ------------------------------------------ Error handling ------------------------------------------
+
+(defn- bedrock-error-msg
+  "Canonical, status-specific Bedrock error message.
+  Includes the actual AWS error message when available."
+  [res]
+  (let [status  (long (:status res 0))
+        ;; AWS returns error in :message or :Message
+        aws-msg (or (get-in res [:body :message])
+                    (get-in res [:body :Message]))
+        base    (case status
+                  400 (tru "Bedrock request failed")
+                  401 (tru "AWS credentials are invalid or expired")
+                  403 (tru "Bedrock authentication/authorization failed")
+                  404 (tru "Bedrock model not found or not available in this region")
+                  429 (tru "Bedrock rate limit exceeded — try again later")
+                  500 (tru "Bedrock internal server error")
+                  (tru "Bedrock API error (HTTP {0})" status))]
+    (if (not-empty aws-msg)
+      (str base " — " aws-msg)
+      base)))
+
+;;; ------------------------------------------ Model listing ------------------------------------------
+
+(defn list-models
+  "List available Bedrock foundation models.
+  No-arg uses configured credentials. Opts map supports :api-key and :ai-proxy?."
+  ([] (list-models {}))
+  ([{:keys [api-key ai-proxy?]}]
+   (when ai-proxy?
+     (throw (ex-info (tru "Bedrock does not support AI proxy mode")
+                     {:api-error true :error-code :proxy-not-supported})))
+   (let [creds   (case (llm/llm-bedrock-auth-type)
+                   "api-key"
+                   (if (not-empty api-key)
+                     {:bearer-token api-key}
+                     {:bearer-token (llm/llm-bedrock-api-key)})
+
+                   ("iam-credentials" "session-token")
+                   {:access-key-id     (or (not-empty api-key) (llm/llm-bedrock-access-key-id))
+                    :secret-access-key (llm/llm-bedrock-secret-access-key)
+                    :session-token     (when (= "session-token" (llm/llm-bedrock-auth-type))
+                                         (llm/llm-bedrock-session-token))}
+
+                   ;; iam-role or unknown — use auto-resolution
+                   (resolve-bedrock-credentials))
+         region  (llm/llm-bedrock-region)
+         _       (log/debugf "list-models: auth-type=%s region=%s" (llm/llm-bedrock-auth-type) region)
+         host    (str "bedrock." region ".amazonaws.com")
+         uri     "/foundation-models"
+         qs      "byInferenceType=ON_DEMAND&byOutputModality=TEXT"
+         headers (if (:bearer-token creds)
+                   {"host"          host
+                    "Authorization" (str "Bearer " (:bearer-token creds))}
+                   (merge {"host" host}
+                          (sign-request {:method        :get
+                                         :uri           uri
+                                         :query-string  qs
+                                         :headers       {"host" host}
+                                         :body          ""
+                                         :access-key    (:access-key-id creds)
+                                         :secret-key    (:secret-access-key creds)
+                                         :session-token (:session-token creds)
+                                         :region        region
+                                         :service       "bedrock"})))]
+     (try
+       (let [response (http/get (str "https://" host uri "?" qs)
+                                {:headers headers
+                                 :socket-timeout  10000
+                                 :connection-timeout 5000})
+             body     (json/decode+kw (:body response))
+             models   (:modelSummaries body)
+             ;; Include all models that support streaming text I/O via the ConverseStream API.
+             ;; Exclude image-only models (e.g. Stable Diffusion) and legacy/deprecated ones.
+             converse-models (filter (fn [m]
+                                       (and (:responseStreamingSupported m)
+                                            (some #{"TEXT"} (:outputModalities m))
+                                            (some #{"TEXT"} (:inputModalities m))
+                                            ;; Exclude legacy/deprecated models
+                                            (not= "LEGACY" (get-in m [:modelLifecycle :status]))))
+                                     models)]
+         (log/debugf "Bedrock models: total=%d filtered=%d" (count models) (count converse-models))
+         {:models (mapv (fn [m]
+                          {:id           (:modelId m)
+                           :display_name (or (:modelName m) (:modelId m))
+                           :group        (:providerName m)})
+                        converse-models)})
+       (catch Exception e
+         (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))))
+
+;;; ------------------------------------------ Streaming ------------------------------------------
+
+(defn- read-int32
+  "Read a big-endian 32-bit integer from a DataInputStream. Returns nil on EOF."
+  [^java.io.DataInputStream dis]
+  (try
+    (.readInt dis)
+    (catch java.io.EOFException _ nil)))
+
+(defn- read-bytes
+  "Read exactly n bytes from a DataInputStream."
+  ^bytes [^java.io.DataInputStream dis ^long n]
+  (let [buf (byte-array n)]
+    (.readFully dis buf)
+    buf))
+
+(defn- parse-event-stream-headers
+  "Parse AWS event stream headers from a byte array.
+  Each header: 1-byte name length, name bytes, 1-byte type (7=string),
+  2-byte value length (big-endian), value bytes."
+  [^bytes header-bytes]
+  (let [bb (java.nio.ByteBuffer/wrap header-bytes)]
+    (loop [headers {}]
+      (if (.hasRemaining bb)
+        (let [name-len (Byte/toUnsignedInt (.get bb))
+              name-buf (byte-array name-len)
+              _        (.get bb name-buf)
+              name     (String. name-buf StandardCharsets/UTF_8)
+              type-id  (.get bb)]
+          (if (= type-id 7) ;; type 7 = string
+            (let [val-len (Short/toUnsignedInt (.getShort bb))
+                  val-buf (byte-array val-len)
+                  _       (.get bb val-buf)
+                  val     (String. val-buf StandardCharsets/UTF_8)]
+              (recur (assoc headers name val)))
+            ;; Skip unknown types — shouldn't happen for Bedrock but be safe
+            headers))
+        headers))))
+
+(defn- bedrock-event-reducible
+  "Turn a Bedrock ConverseStream response InputStream into a reducible source of parsed events.
+
+  Bedrock ConverseStream returns the AWS event stream binary encoding:
+  each message is [4B total-len][4B headers-len][4B prelude-crc][headers][payload][4B msg-crc]."
+  [^InputStream body]
+  (reify clojure.lang.IReduceInit
+    (reduce [_ rf init]
+      (let [dis (java.io.DataInputStream. body)]
+        (loop [acc init]
+          (if (reduced? acc)
+            @acc
+            (let [total-len (read-int32 dis)]
+              (if (nil? total-len)
+                acc ;; EOF
+                (let [headers-len (.readInt dis)
+                      _prelude-crc (read-bytes dis 4)
+                      header-bytes (read-bytes dis headers-len)
+                      ;; payload = total - 4(total) - 4(headers-len) - 4(prelude-crc) - headers - 4(msg-crc)
+                      payload-len  (- (int total-len) 12 (int headers-len) 4)
+                      payload      (read-bytes dis payload-len)
+                      _msg-crc     (read-bytes dis 4)
+                      headers      (parse-event-stream-headers header-bytes)
+                      event-type   (get headers ":event-type")]
+                  (if (and event-type (pos? payload-len))
+                    (let [json-str (String. payload StandardCharsets/UTF_8)
+                          parsed   (try (json/decode+kw json-str)
+                                        (catch Exception _ nil))
+                          ;; Wrap the payload with the event type for downstream processing
+                          event    (when parsed {(keyword event-type) parsed})]
+                      (if event
+                        (recur (rf acc event))
+                        (recur acc)))
+                    (recur acc)))))))))))
+
+(mu/defn bedrock-raw
+  "Perform a streaming request to Bedrock ConverseStream API."
+  [{:keys [model system input tools schema tool_choice temperature max-tokens ai-proxy?]
+    :or   {model "anthropic.claude-sonnet-4-20250514-v1:0"}} :- core/LLMRequestOpts]
+  (when ai-proxy?
+    (throw (ex-info (tru "Bedrock does not support AI proxy mode")
+                    {:api-error true :error-code :proxy-not-supported})))
+  (let [messages  (parts->bedrock-messages input)
+        all-tools (when (seq tools) (mapv tool->bedrock tools))
+        req       (cond-> {:messages messages}
+                    system      (assoc :system [{:text system}])
+                    all-tools   (assoc :toolConfig {:tools all-tools})
+                    (and all-tools
+                         tool_choice) (assoc-in [:toolConfig :toolChoice]
+                                                (case (name tool_choice)
+                                                  "auto"     {:auto {}}
+                                                  "required" {:any {}}))
+                    true        (assoc :inferenceConfig
+                                       (cond-> {:maxTokens (or max-tokens 4096)}
+                                         temperature (assoc :temperature temperature)))
+                    schema      (assoc :toolConfig
+                                       {:tools [{:toolSpec {:name        "structured_output"
+                                                            :description "Output structured data"
+                                                            :inputSchema {:json schema}}}]
+                                        :toolChoice {:tool {:name "structured_output"}}}))]
+    (with-span :info {:name       :metabot.bedrock/request
+                      :model      model
+                      :msg-count  (count input)
+                      :tool-count (count tools)}
+      (try
+        (let [creds    (resolve-bedrock-credentials)
+              region   (llm/llm-bedrock-region)
+              host     (str "bedrock-runtime." region ".amazonaws.com")
+              ;; Use raw model ID — clj-http/Apache HttpClient will URI-encode on the wire.
+              uri      (str "/model/" model "/converse-stream")
+              body-str (json/encode req)
+              ;; Use Bearer token for API key auth, SigV4 for IAM auth
+              headers  (if (:bearer-token creds)
+                         {"host"          host
+                          "content-type"  "application/json"
+                          "Authorization" (str "Bearer " (:bearer-token creds))}
+                         (merge {"host"         host
+                                 "content-type" "application/json"}
+                                (sign-request {:method        :post
+                                               :uri           uri
+                                               :headers       {"host"         host
+                                                               "content-type" "application/json"}
+                                               :body          body-str
+                                               :access-key    (:access-key-id creds)
+                                               :secret-key    (:secret-access-key creds)
+                                               :session-token (:session-token creds)
+                                               :region        region
+                                               :service       "bedrock"})))
+              url      (str "https://" host uri)
+              _        (log/debugf "Bedrock request: model=%s url=%s" model url)
+              response (http/post url
+                                  {:headers headers
+                                   :body    body-str
+                                   :as      :stream
+                                   :socket-timeout  60000
+                                   :connection-timeout 5000})]
+          (-> (bedrock-event-reducible (:body response))
+              (debug/capture-stream {:provider "bedrock"
+                                     :model    model
+                                     :url      uri
+                                     :request  req})))
+        (catch Exception e
+          (core/rethrow-api-error! "bedrock" bedrock-error-msg e))))))
+
+(defn bedrock
+  "Call Bedrock ConverseStream API, return AISDK stream."
+  [& args]
+  (let [raw (apply bedrock-raw args)]
+    (eduction (bedrock->aisdk-chunks-xf) raw)))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -104,7 +104,7 @@
 
 (def ^:private direct-providers
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
-  #{"anthropic" "openai" "openrouter"})
+  #{"anthropic" "openai" "openrouter" "bedrock"})
 
 (def ^:private default-anthropic-llm-metabot-model
   "Default Anthropic model used for Metabot when no explicit model is selected."
@@ -120,6 +120,7 @@
   Values match the shape expected in the request body for each provider: direct providers use a bare model ID, while the
   managed `metabase` provider uses the proxied `provider/model` form."
   {"anthropic"                       default-anthropic-llm-metabot-model
+   "bedrock"                         "anthropic.claude-sonnet-4-20250514-v1:0"
    provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider
@@ -240,6 +241,15 @@
     "anthropic"  (llm.settings/llm-anthropic-api-key)
     "openai"     (llm.settings/llm-openai-api-key)
     "openrouter" (llm.settings/llm-openrouter-api-key)
+    "bedrock"    (case (llm.settings/llm-bedrock-auth-type)
+                   "api-key" (llm.settings/llm-bedrock-api-key)
+                   ;; For IAM-based auth types, the access key ID is the relevant credential
+                   ("iam-credentials" "session-token") (llm.settings/llm-bedrock-access-key-id)
+                   ;; For IAM role (auto), no user-provided key needed — always "configured"
+                   "iam-role" "iam-role-auto"
+                   ;; Default fallback
+                   (or (llm.settings/llm-bedrock-api-key)
+                       (llm.settings/llm-bedrock-access-key-id)))
     nil))
 
 (defn- llm-provider-configured?

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -1,0 +1,145 @@
+(ns metabase.metabot.self.bedrock-test
+  (:require
+   [clojure.test :refer :all]
+   [medley.core :as m]
+   [metabase.metabot.self.bedrock :as bedrock]
+   [metabase.metabot.self.core :as self.core]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; parts->bedrock-messages
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel parts->bedrock-messages-text-test
+  (testing "text parts are converted to assistant messages"
+    (is (= [{:role "assistant"
+             :content [{:text "Hello, world!"}]}]
+           (bedrock/parts->bedrock-messages
+            [{:type :text :text "Hello, world!"}])))))
+
+(deftest ^:parallel parts->bedrock-messages-tool-input-test
+  (testing "tool-input parts become assistant toolUse messages"
+    (is (= [{:role "assistant"
+             :content [{:toolUse {:toolUseId "t1"
+                                  :name "get-time"
+                                  :input {:tz "UTC"}}}]}]
+           (bedrock/parts->bedrock-messages
+            [{:type :tool-input :id "t1" :function "get-time" :arguments {:tz "UTC"}}])))))
+
+(deftest ^:parallel parts->bedrock-messages-tool-output-test
+  (testing "tool-output parts become user toolResult messages"
+    (is (= [{:role "user"
+             :content [{:toolResult {:toolUseId "t1"
+                                     :content [{:text "12:00 PM"}]}}]}]
+           (bedrock/parts->bedrock-messages
+            [{:type :tool-output :id "t1" :result {:output "12:00 PM"}}])))))
+
+(deftest ^:parallel parts->bedrock-messages-merge-consecutive-test
+  (testing "consecutive same-role messages are merged"
+    (let [result (bedrock/parts->bedrock-messages
+                  [{:type :text :text "Hello"}
+                   {:type :text :text "World"}])]
+      (is (= 1 (count result)))
+      (is (= "assistant" (:role (first result))))
+      (is (= 2 (count (:content (first result))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; bedrock->aisdk-chunks-xf transducer
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- run-xf
+  "Run the Bedrock→AISDK transducer over a sequence of Bedrock events."
+  [events]
+  (into [] (bedrock/bedrock->aisdk-chunks-xf) events))
+
+(deftest ^:parallel bedrock-text-streaming-test
+  (testing "messageStart + text contentBlock produces start → text-start → text-delta → text-end"
+    (let [events [{:messageStart {:role "assistant"}}
+                  {:contentBlockStart {:contentBlockIndex 0
+                                       :start {:text ""}}}
+                  {:contentBlockDelta {:contentBlockIndex 0
+                                       :delta {:text "Hello"}}}
+                  {:contentBlockDelta {:contentBlockIndex 0
+                                       :delta {:text " world"}}}
+                  {:contentBlockStop {:contentBlockIndex 0}}
+                  {:metadata {:usage {:inputTokens 10 :outputTokens 5}}}
+                  {:messageStop {:stopReason "end_turn"}}]
+          chunks (run-xf events)]
+      (is (= [:start :text-start :text-delta :text-delta :text-end :usage]
+             (mapv :type chunks)))
+      (is (= "Hello" (:delta (nth chunks 2))))
+      (is (= " world" (:delta (nth chunks 3))))
+      (is (= {:promptTokens 10 :completionTokens 5}
+             (:usage (last chunks)))))))
+
+(deftest ^:parallel bedrock-tool-input-streaming-test
+  (testing "tool use contentBlock produces tool-input-start → tool-input-delta → tool-input-available"
+    (let [events [{:messageStart {:role "assistant"}}
+                  {:contentBlockStart {:contentBlockIndex 0
+                                       :start {:toolUse {:toolUseId "t1"
+                                                         :name "get-time"}}}}
+                  {:contentBlockDelta {:contentBlockIndex 0
+                                       :delta {:toolUse {:input "{\"tz\":\"UTC\"}"}}}}
+                  {:contentBlockStop {:contentBlockIndex 0}}
+                  {:metadata {:usage {:inputTokens 20 :outputTokens 10}}}
+                  {:messageStop {:stopReason "tool_use"}}]
+          chunks (run-xf events)]
+      (is (= [:start :tool-input-start :tool-input-delta :tool-input-available :usage]
+             (mapv :type chunks)))
+      (is (= "get-time" (:toolName (nth chunks 1))))
+      (is (= "t1" (:toolCallId (nth chunks 1))))
+      (is (= "{\"tz\":\"UTC\"}" (:inputTextDelta (nth chunks 2)))))))
+
+(deftest ^:parallel bedrock-text-and-tool-streaming-test
+  (testing "text followed by tool use produces correct event sequence"
+    (let [events [{:messageStart {:role "assistant"}}
+                  {:contentBlockStart {:contentBlockIndex 0
+                                       :start {:text ""}}}
+                  {:contentBlockDelta {:contentBlockIndex 0
+                                       :delta {:text "Let me check"}}}
+                  {:contentBlockStop {:contentBlockIndex 0}}
+                  {:contentBlockStart {:contentBlockIndex 1
+                                       :start {:toolUse {:toolUseId "t1"
+                                                         :name "lookup"}}}}
+                  {:contentBlockDelta {:contentBlockIndex 1
+                                       :delta {:toolUse {:input "{}"}}}}
+                  {:contentBlockStop {:contentBlockIndex 1}}
+                  {:metadata {:usage {:inputTokens 30 :outputTokens 15}}}
+                  {:messageStop {:stopReason "tool_use"}}]
+          chunks (run-xf events)
+          types  (mapv :type chunks)]
+      (is (= [:start :text-start :text-delta :text-end
+              :tool-input-start :tool-input-delta :tool-input-available
+              :usage]
+             types)))))
+
+(deftest ^:parallel bedrock-distinct-chunk-types-test
+  (testing "distinct chunk types through pipeline"
+    (let [events [{:messageStart {:role "assistant"}}
+                  {:contentBlockStart {:contentBlockIndex 0 :start {:text ""}}}
+                  {:contentBlockDelta {:contentBlockIndex 0 :delta {:text "Hi"}}}
+                  {:contentBlockStop {:contentBlockIndex 0}}
+                  {:metadata {:usage {:inputTokens 5 :outputTokens 2}}}
+                  {:messageStop {:stopReason "end_turn"}}]
+          distinct-types (into [] (comp (bedrock/bedrock->aisdk-chunks-xf)
+                                        (m/distinct-by :type))
+                               events)]
+      (is (= [:start :text-start :text-delta :text-end :usage]
+             (mapv :type distinct-types))))))
+
+(deftest ^:parallel bedrock-through-aisdk-pipeline-test
+  (testing "text events through full AISDK pipeline produce text + usage"
+    (let [events [{:messageStart {:role "assistant"}}
+                  {:contentBlockStart {:contentBlockIndex 0 :start {:text ""}}}
+                  {:contentBlockDelta {:contentBlockIndex 0 :delta {:text "Hello"}}}
+                  {:contentBlockStop {:contentBlockIndex 0}}
+                  {:metadata {:usage {:inputTokens 10 :outputTokens 3}}}
+                  {:messageStop {:stopReason "end_turn"}}]
+          result (into [] (comp (bedrock/bedrock->aisdk-chunks-xf)
+                                (self.core/aisdk-xf))
+                       events)]
+      (is (=? [{:type :start :id string?}
+               {:type :text :text "Hello"}
+               {:type :usage :usage {:promptTokens 10 :completionTokens 3}}]
+              result)))))


### PR DESCRIPTION
 > [!IMPORTANT]
  > For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the
  [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If
  you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

  > **Warning**
  >
  > If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a
  translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

  Closes #71474
  
  ### Description

  Adds **Amazon Bedrock** as a selectable AI provider for Metabot, alongside the existing Anthropic / OpenAI / OpenRouter providers. This lets self-hosted Metabase instances run AI features against their own AWS account instead of sending data
  to a third-party provider — the compliance / data-residency need raised in #71474. The issue thread specifically asked for **IAM-role auth with minimal config** (@dragonsahead, confirmed by OP @Xusifob), which this supports.

  **Backend**
  - New `metabase.metabot.self.bedrock` provider implementing the self-agent interface against the Bedrock Converse / ConverseStream runtime API
  - Self-contained AWS SigV4 request signing (no AWS SDK dependency)
  - Four auth modes: API key, static IAM credentials, session token, and **IAM role auto-resolved via IMDS** (the zero-config case)
  - Registers the provider in `metabot.self`, wires request handling in `metabot.api`, and adds Bedrock settings (region, credentials, model) to `llm.settings` / `metabot.settings`

  **Frontend**
  - Bedrock option + auth-type control, region selector, and credential fields in the AI provider configuration UI (`metabot/components/AIProviderConfigurationForm`), with supporting types/utils

  **Open questions for maintainers**
  1. **OSS vs EE** — implemented in OSS since the `metabot.self` abstraction lives there; happy to move to enterprise if you consider this EE scope.
  2. **Settings naming / credentials** — followed existing provider conventions; glad to adjust.

  ### How to verify

  1. Set up AWS Bedrock access (an API key, or IAM credentials, or an instance IAM role with `bedrock:InvokeModel*` permissions) in a region with Bedrock models enabled.
  2. In Metabase, go to **Admin → Metabot** (`/admin/metabot`) → the **Setup** section.
  3. Open the **Provider** dropdown → select **Amazon Bedrock**.
  4. Choose an **auth type** (API Key / IAM Credentials / Session Token / IAM Role), enter credentials as needed, pick a **Region**, and click **Connect**.
  5. Confirm the model list loads and the provider shows **"Connected to Amazon Bedrock."**
  6. Open Metabot and ask a question to confirm a live Bedrock response.

  ### Demo

  _Screenshots of the Bedrock provider configuration UI (provider dropdown + auth-type modes + region selector)._
  
<img width="860" height="652" alt="Screenshot 2026-06-11 at 9 02 20 PM" src="https://github.com/user-attachments/assets/47271b8c-8186-4eb6-a129-d6559c4638e0" />
<img width="842" height="813" alt="Screenshot 2026-06-11 at 9 02 27 PM" src="https://github.com/user-attachments/assets/c0e9481d-7328-4db9-83b5-73af650022fd" />
<img width="819" height="736" alt="Screenshot 2026-06-11 at 9 02 36 PM" src="https://github.com/user-attachments/assets/5619743c-669e-4b13-b017-2c4edbda5faf" />
<img width="1722" height="901" alt="Screenshot 2026-06-11 at 9 02 53 PM" src="https://github.com/user-attachments/assets/651bad11-2b94-46c5-89e9-829f56963745" />
  ### Checklist
  
  - [x] Tests have been added/updated to cover changes in this PR
  - [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

