### PR TITLE
Prefix semantic search queries with `query:` for Arctic embedding models

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -361,6 +361,30 @@
 (defmethod pull-model "openai" [_]
   (log/debug "OpenAI provider does not require pulling a model"))
 
+;;;; Query prefixes for asymmetric retrieval models
+
+(def ^:private model-family-query-prefixes
+  "Query prefixes for embedding-model families trained for asymmetric retrieval.
+  These models expect search queries — but not the indexed documents — to carry a fixed prefix."
+  [[#"(?i)snowflake-arctic-embed" "query: "]])
+
+(defn- default-query-prefix
+  [model-name]
+  (when model-name
+    (some (fn [[pattern prefix]]
+            (when (re-find pattern model-name)
+              prefix))
+          model-family-query-prefixes)))
+
+(defn prefix-search-query
+  "Prepend the query prefix expected by `embedding-model` to `search-string`.
+  The `ee-embedding-query-prefix` setting overrides the per-model-family default and is prepended verbatim.
+  Returns `search-string` unchanged when neither applies."
+  [embedding-model search-string]
+  (str (or (not-empty (semantic-settings/ee-embedding-query-prefix))
+           (default-query-prefix (:model-name embedding-model)))
+       search-string))
+
 ;;;; Global embedding model
 
 (defn get-configured-model

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -365,10 +365,10 @@
 
 (def ^:private model-family-query-prefixes
   "Query prefixes for embedding-model families trained for asymmetric retrieval.
-  These models expect search queries — but not the indexed documents — to carry a fixed prefix.
-  Patterns must be mutually exclusive: lookup scans entries in unspecified order.
-  Keep patterns narrow: a false positive is unfixable without a code change.
-  The `ee-embedding-query-prefix` setting can only replace a matched prefix, never suppress it."
+  These models expect search queries — but not the indexed documents — to carry a fixed prefix."
+  ;; Patterns must be mutually exclusive: lookup scans entries in unspecified order.
+  ;; Keep patterns narrow: a false positive is unfixable without a code change, since the
+  ;; `ee-embedding-query-prefix` setting can only replace a matched prefix, never suppress it.
   {#"(?i)snowflake-arctic-embed" "query: "})
 
 (defn- default-query-prefix

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -365,8 +365,9 @@
 
 (def ^:private model-family-query-prefixes
   "Query prefixes for embedding-model families trained for asymmetric retrieval.
-  These models expect search queries — but not the indexed documents — to carry a fixed prefix."
-  [[#"(?i)snowflake-arctic-embed" "query: "]])
+  These models expect search queries — but not the indexed documents — to carry a fixed prefix.
+  Patterns must be mutually exclusive: lookup scans entries in unspecified order."
+  {#"(?i)snowflake-arctic-embed" "query: "})
 
 (defn- default-query-prefix
   [model-name]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -366,7 +366,10 @@
 (def ^:private model-family-query-prefixes
   "Query prefixes for embedding-model families trained for asymmetric retrieval.
   These models expect search queries — but not the indexed documents — to carry a fixed prefix.
-  Patterns must be mutually exclusive: lookup scans entries in unspecified order."
+  Patterns must be mutually exclusive: lookup scans entries in unspecified order.
+  Keep patterns narrow — there is deliberately no way to suppress a matched prefix via config
+  (the `ee-embedding-query-prefix` setting can only replace it), so a false positive is unfixable
+  without a code change."
   {#"(?i)snowflake-arctic-embed" "query: "})
 
 (defn- default-query-prefix

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -367,9 +367,8 @@
   "Query prefixes for embedding-model families trained for asymmetric retrieval.
   These models expect search queries — but not the indexed documents — to carry a fixed prefix.
   Patterns must be mutually exclusive: lookup scans entries in unspecified order.
-  Keep patterns narrow — there is deliberately no way to suppress a matched prefix via config
-  (the `ee-embedding-query-prefix` setting can only replace it), so a false positive is unfixable
-  without a code change."
+  Keep patterns narrow: a false positive is unfixable without a code change.
+  The `ee-embedding-query-prefix` setting can only replace a matched prefix, never suppress it."
   {#"(?i)snowflake-arctic-embed" "query: "})
 
 (defn- default-query-prefix

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -872,7 +872,8 @@
             embedding (tracing/with-span :search "search.semantic.embedding"
                         {:search.semantic/provider   (:provider embedding-model)
                          :search.semantic/model-name (:model-name embedding-model)}
-                        (embedding/get-embedding embedding-model search-string
+                        (embedding/get-embedding embedding-model
+                                                 (embedding/prefix-search-query embedding-model search-string)
                                                  {:type :query :record-tokens? true}))
             embedding-time-ms (u/since-ms timer)
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -41,10 +41,10 @@
         "verbatim, so include any trailing separator. Leave empty to use the default for the model family."))
   :encryption :no
   :visibility :settings-manager
-  :default nil
-  :type :string
-  :export? false
-  :doc false)
+  :default    nil
+  :type       :string
+  :export?    false
+  :doc        false)
 
 (defsetting ee-embedding-model-dimensions
   (deferred-tru "Set the dimension size for the selected embedding model")

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -34,6 +34,18 @@
   :export? false
   :doc false)
 
+(defsetting ee-embedding-query-prefix
+  (deferred-tru
+   (str "Prefix prepended to search queries (but not indexed documents) before embedding them, as expected by "
+        "asymmetric retrieval models such as the snowflake-arctic-embed family (`query: `). It is prepended "
+        "verbatim, so include any trailing separator. Leave empty to use the default for the model family."))
+  :encryption :no
+  :visibility :settings-manager
+  :default nil
+  :type :string
+  :export? false
+  :doc false)
+
 (defsetting ee-embedding-model-dimensions
   (deferred-tru "Set the dimension size for the selected embedding model")
   :encryption :no

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -57,6 +57,19 @@
     (mt/with-temporary-setting-values [ee-embedding-model-dimensions 768]
       (is (= 768 (:vector-dimensions (embedding/get-configured-model)))))))
 
+(deftest prefix-search-query-test
+  (let [arctic {:provider "ai-service" :model-name "Snowflake/snowflake-arctic-embed-l-v2.0" :vector-dimensions 1024}
+        openai {:provider "openai" :model-name "text-embedding-3-small" :vector-dimensions 1536}]
+    (mt/with-temporary-setting-values [ee-embedding-query-prefix nil]
+      (testing "arctic-family models get the `query: ` prefix by default"
+        (is (= "query: hello" (embedding/prefix-search-query arctic "hello"))))
+      (testing "models without a known family default are left unprefixed"
+        (is (= "hello" (embedding/prefix-search-query openai "hello")))))
+    (testing "the setting overrides the model-family default, verbatim"
+      (mt/with-temporary-setting-values [ee-embedding-query-prefix "search_query: "]
+        (is (= "search_query: hello" (embedding/prefix-search-query arctic "hello")))
+        (is (= "search_query: hello" (embedding/prefix-search-query openai "hello")))))))
+
 (deftest test-openai-provider-validation
   (testing "OpenAIProvider throws when API key not configured"
     (let [embedding-model {:provider "openai"


### PR DESCRIPTION
### Description

Our default embedding model (`snowflake-arctic-embed-l-v2.0`) wants search queries prefixed with `query: ` — documents are embedded as-is, queries get the prefix. We weren't doing this, so we've been leaving retrieval quality on the table.

Now `query-index` prepends the prefix when embedding the search string. The prefix comes from a small model-family → prefix table (just Arctic for now), with a new `ee-embedding-query-prefix` setting to override it for models we don't know about.[^1]

Only retrieval queries are affected — indexing and the symmetric name-similarity embedders are untouched, and changing the prefix never forces a reindex.[^2]

[^1]: Why a family table instead of just defaulting the setting to `query: `? A defaulted setting is a footgun: change the embedding model and you have to *know* to unset the prefix. And "unset" is hard to express anyway — settings arrive via env vars, where empty string means null. With the table, no configuration is the correct configuration.

[^2]: The prefix is derived from the active index's model name at query time, not stored in the embedding-model map — so it can't perturb index identity, and it always matches the model the index was actually built with, even mid-reindex.

### How to verify

1. With semantic search enabled, run a search and check the embedding request (e.g. embedding-service logs): the query should arrive as `query: <search string>`, indexed documents unprefixed.
2. Set `ee-embedding-query-prefix` and confirm it wins over the family default.
3. `prefix-search-query-test` covers the resolution logic.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
