### PR TITLE
Remove module dependency cycles around utils

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -859,6 +859,11 @@
   metabase.util.time-test
   {:linters {:metabase/prefer-with-dynamic-fn-redefs {:level :off}}}
 
+  ;; classloader sits below `util` in the module graph, so it can't use `metabase.util.log` without creating
+  ;; a cycle; it gets to use tools.logging directly.
+  metabase.classloader.impl
+  {:linters {:discouraged-namespace {clojure.tools.logging {:level :off}}}}
+
   source-namespaces
   {:linters
    {:metabase/discourage-millis-duration               {:level :warning}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -539,7 +539,7 @@
   {:team "DevEx"
    :api  #{metabase.classloader.core
            metabase.classloader.init}
-   :uses #{util}}
+   :uses #{}}
 
   cloud-migration
   {:team "UX West"
@@ -2653,8 +2653,7 @@
    :api  :any
    :uses #{classloader
            config
-           settings
-           system}}
+           settings}}
 
   version
   {:team "UX West"

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -16,7 +16,7 @@
                  :discouraged-var                                                     106
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
-                 :metabase/defsetting-namespace                                       7
+                 :metabase/defsetting-namespace                                       2
                  :metabase/disallow-hardcoded-driver-names-in-tests                   34
                  :metabase/discourage-millis-duration                                 1
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13

--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -13,6 +13,7 @@
    [metabase.channel.render.style :as style]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.query-processor.core :as qp]
+   [metabase.system.core :as system]
    [metabase.test :as mt]
    [metabase.util.markdown :as markdown]
    [toucan2.core :as t2])
@@ -85,7 +86,7 @@
                                                                   :font-style              "normal"
                                                                   :color                   "#4c5773"
                                                                   :-moz-osx-font-smoothing "grayscale"})}
-                                       (markdown/process-markdown (:text dashboard-result) :html)]
+                                       (markdown/process-markdown (:text dashboard-result) :html (system/site-url))]
                          :attachments nil})
             png-bytes (-> render (png/render-html-to-png 1000))
             tmp-file  (java.io.File/createTempFile "card-png" ".png")]
@@ -150,7 +151,7 @@
                                     :font-style              "normal"
                                     :color                   "#4c5773"
                                     :-moz-osx-font-smoothing "grayscale"})}
-         (markdown/process-markdown (:text dashboard-result) :html)])
+         (markdown/process-markdown (:text dashboard-result) :html (system/site-url))])
        (cellfn nil)])))
 
 (defn render-dashboard-to-hiccup

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -185,7 +185,7 @@
 (mu/defn send-email-retrying!
   "Like [[send-message-or-throw!]] but retries sending on errors according to the retry settings."
   [email :- EmailMessage]
-  (retry/with-retry (retry/retry-configuration)
+  (retry/with-retry (channel.settings/retry-configuration)
     (send-message-or-throw! email)))
 
 (def ^:private SMTPStatus

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -24,6 +24,7 @@
    [metabase.channel.template.handlebars :as handlebars]
    [metabase.channel.urls :as urls]
    [metabase.notification.models :as models.notification]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
@@ -110,7 +111,7 @@
     :text
     (let [inline-params   (:inline_parameters part)
           rendered-params (when (seq inline-params) (render.util/render-parameters inline-params))]
-      {:content (str (markdown/process-markdown (:text part) :html)
+      {:content (str (markdown/process-markdown (:text part) :html (system/site-url))
                      rendered-params)})
 
     :heading
@@ -121,7 +122,7 @@
       {:content (str (html [:h2 {:style style} heading-text])
                      rendered-params)})
     :tab-title
-    {:content (markdown/process-markdown (format "# %s\n---" (:text part)) :html)}))
+    {:content (markdown/process-markdown (format "# %s\n---" (:text part)) :html (system/site-url))}))
 
 (defn- render-body
   [{:keys [details] :as _template} payload]
@@ -360,7 +361,7 @@
                                                                           (some-> (seq parameters)
                                                                                   (impl.util/remove-inline-parameters dashboard_parts)
                                                                                   (render.util/render-parameters)))})
-                                  (m/update-existing-in [:payload :dashboard :description] #(markdown/process-markdown % :html))))]
+                                  (m/update-existing-in [:payload :dashboard :description] #(markdown/process-markdown % :html (system/site-url)))))]
     (construct-emails template message-context-fn attachments recipients)))
 
 ;; ------------------------------------------------------------------------------------------------;;

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -77,7 +77,7 @@
 
 (defn- text->markdown-section
   [text]
-  (let [mrkdwn (markdown/process-markdown text :slack)]
+  (let [mrkdwn (markdown/process-markdown text :slack (system/site-url))]
     (when (not (str/blank? mrkdwn))
       {:type "section"
        :text {:type "mrkdwn"

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -9,6 +9,7 @@
    [metabase.channel.urls :as urls]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -81,7 +82,7 @@
        :content [:div {:style (style/style {:color style/color-text-medium
                                             :font-size :12px
                                             :margin-bottom :8px})}
-                 (markdown/process-markdown description :html)]})))
+                 (markdown/process-markdown description :html (system/site-url))]})))
 
 (defn- has-lat-lng-columns?
   "True when the result has both a Latitude and a Longitude column (a coordinate-based map)."

--- a/src/metabase/channel/render/preview.clj
+++ b/src/metabase/channel/render/preview.clj
@@ -15,6 +15,7 @@
    [metabase.channel.render.png :as png]
    [metabase.channel.render.style :as style]
    [metabase.notification.payload.core :as notification.payload]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.markdown :as markdown]
    [toucan2.core :as t2]))
@@ -75,7 +76,7 @@
                                     :font-style              "normal"
                                     :color                   "#4c5773"
                                     :-moz-osx-font-smoothing "grayscale"})}
-         (markdown/process-markdown (:text dashboard-result) :html)])
+         (markdown/process-markdown (:text dashboard-result) :html (system/site-url))])
        (cellfn nil)])))
 
 (defn- render-dashboard-to-hiccup

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
+   [metabase.config.core :as config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli.registry :as mr]
@@ -337,3 +338,42 @@
   :getter     (fn [] (boolean (slack-app-token)))
   :export?    false
   :setter     :none)
+
+;;; Retry settings for delivering notifications via channels. The retry machinery itself lives in
+;;; [[metabase.util.retry]]; the settings live here so `util` stays settings-free.
+
+(defsetting retry-max-retries
+  (deferred-tru "The maximum number of retries for an event.")
+  :type :integer
+  :default (if config/is-dev?
+             0
+             6))
+
+(defsetting retry-initial-interval
+  (deferred-tru "The initial retry delay in milliseconds.")
+  :type :integer
+  :default 500)
+
+(defsetting retry-multiplier
+  (deferred-tru "The delay multiplier between attempts.")
+  :type :double
+  :default 2.0)
+
+(defsetting retry-jitter-factor
+  (deferred-tru "The jitter factor of the retry delay.")
+  :type :double
+  :default 0.1)
+
+(defsetting retry-max-interval-millis
+  (deferred-tru "The maximum delay between attempts.")
+  :type :integer
+  :default 30000)
+
+(defn retry-configuration
+  "Returns a map with the default retry configuration, suitable for [[metabase.util.retry/with-retry]]."
+  []
+  {:max-retries             (retry-max-retries)
+   :initial-interval-millis (retry-initial-interval)
+   :multiplier              (retry-multiplier)
+   :jitter-factor           (retry-jitter-factor)
+   :max-interval-millis     (retry-max-interval-millis)})

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -341,6 +341,10 @@
 
 ;;; Retry settings for delivering notifications via channels. The retry machinery itself lives in
 ;;; [[metabase.util.retry]]; the settings live here so `util` stays settings-free.
+;;;
+;;; TODO (Chris 2026-07-30) -- rename these to `channel-retry-*`: the bare `retry-` names read as global retry
+;;; policy, but they only configure channel delivery. Needs a deprecation alias for the existing names, since
+;;; `MB_RETRY_MAX_RETRIES` and friends are user-facing.
 
 (defsetting retry-max-retries
   (deferred-tru "The maximum number of retries for an event.")

--- a/src/metabase/classloader/impl.clj
+++ b/src/metabase/classloader/impl.clj
@@ -14,8 +14,11 @@
   (:refer-clojure :exclude [require])
   (:require
    [clojure.string :as str]
-   [dynapath.util :as dynapath]
-   [metabase.util.log :as log])
+   ;; classloader sits below `util` in the module graph (util's i18n and quick-task need `the-classloader`),
+   ;; so using `metabase.util.log` here would create a module cycle; plain tools.logging hits the same log4j2
+   ;; backend, we just lose test log capture for these handful of trace messages.
+   [clojure.tools.logging :as log]
+   [dynapath.util :as dynapath])
   (:import
    (clojure.lang DynamicClassLoader RT)
    (java.net URL)))

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -100,7 +100,7 @@
      :applicationName        (hiccup.util/escape-html (appearance/application-name))
      :uri                    (hiccup.util/escape-html uri)
      :baseHref               (hiccup.util/escape-html (base-href))
-     :embedCode              (when embeddable? (embed/head uri))
+     :embedCode              (when embeddable? (embed/head (system/site-url) uri))
      :enableGoogleAuth       (boolean google-auth-client-id)
      :enableAnonTracking     (boolean anon-tracking-enabled)}))
 

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -2,7 +2,6 @@
   "Utility functions for public links and embedding."
   (:require
    [hiccup.core :refer [html]]
-   [metabase.system.core :as system]
    [ring.util.codec :as codec]))
 
 (set! *warn-on-reflection* true)
@@ -10,20 +9,20 @@
 (defn- oembed-url
   "Return an oEmbed URL for the `relative-path`.
 
-     (oembed-url \"/x\") -> \"http://localhost:3000/api/public/oembed?url=x&format=json\""
-  ^String [^String relative-url]
-  (str (system/site-url)
+     (oembed-url \"http://localhost:3000\" \"/x\") -> \"http://localhost:3000/api/public/oembed?url=x&format=json\""
+  ^String [^String site-url ^String relative-url]
+  (str site-url
        "/api/public/oembed"
        ;; NOTE: some oEmbed consumers require `url` be the first param???
-       "?url=" (codec/url-encode (str (system/site-url) relative-url))
+       "?url=" (codec/url-encode (str site-url relative-url))
        "&format=json"))
 
 (defn- oembed-link
   "Returns a `<link>` tag for oEmbed support."
-  ^String [^String url]
+  ^String [^String site-url ^String url]
   (html [:link {:rel   "alternate"
                 :type  "application/json+oembed"
-                :href  (oembed-url url)
+                :href  (oembed-url site-url url)
                 :title "Metabase"}]))
 
 (def ^:private ^:const ^String embedly-meta
@@ -31,9 +30,10 @@
   (html [:meta {:name "generator", :content "Metabase"}]))
 
 (defn head
-  "Returns the `<meta>`/`<link>` tags for an embeddable public page."
-  ^String [^String url]
-  (str embedly-meta (oembed-link url)))
+  "Returns the `<meta>`/`<link>` tags for an embeddable public page.
+  `site-url` is the instance's site URL; callers look it up so this namespace stays settings-free."
+  ^String [^String site-url ^String url]
+  (str embedly-meta (oembed-link site-url url)))
 
 (defn maybe-populate-initially-published-at
   "Populate `initially_published_at` if embedding is set to true"

--- a/src/metabase/util/markdown.clj
+++ b/src/metabase/util/markdown.clj
@@ -4,7 +4,6 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
-   [metabase.system.core :as system]
    [metabase.util :as u])
   (:import
    (com.vladsch.flexmark.ast AutoLink BlockQuote BulletList BulletListItem Code Emphasis FencedCodeBlock HardLineBreak
@@ -197,6 +196,12 @@
       (str/replace "`" "\u00ad`\u00ad")
       (str/replace "~" "\u00ad~\u00ad")))
 
+(def ^:private ^:dynamic *site-url*
+  "The instance's site URL, bound by [[process-markdown]] from its `site-url` argument. A dynamic var rather
+  than a threaded parameter because [[resolve-uri]] is reached through the AST multimethods and flexmark's
+  link-resolver callback."
+  nil)
+
 (defn- resolve-uri
   "If the provided URI is a relative path, resolve it relative to the site URL so that links work
   correctly in Slack/Email."
@@ -205,7 +210,7 @@
                                       (cond-> s
                                         (not (str/ends-with? s "/")) (str "/"))))]
     (when uri
-      (if-let [site-url (ensure-slash (system/site-url))]
+      (if-let [site-url (ensure-slash *site-url*)]
         (.. (URI. site-url) (resolve uri) toString)
         uri))))
 
@@ -410,20 +415,23 @@
 
 (defmulti process-markdown
   "Converts a markdown string from a virtual card into a form that can be sent to a channel
-  (Slack's markup language, or HTML for email)."
-  {:arglists '([markdown channel-type])}
-  (fn [_markdown channel-type] channel-type))
+  (Slack's markup language, or HTML for email). `site-url` is the instance's site URL, used to absolutize
+  relative links; callers look it up so this namespace stays settings-free."
+  {:arglists '([markdown channel-type site-url])}
+  (fn [_markdown channel-type _site-url] channel-type))
 
 (defmethod process-markdown :slack
-  [markdown _channel-type]
-  (-> (.parse ^Parser parser ^String markdown)
-      to-clojure
-      ast->slack
-      flatten
-      str/join
-      str/trim))
+  [markdown _channel-type site-url]
+  (binding [*site-url* site-url]
+    (-> (.parse ^Parser parser ^String markdown)
+        to-clojure
+        ast->slack
+        flatten
+        str/join
+        str/trim)))
 
 (defmethod process-markdown :html
-  [markdown _channel-type]
-  (let [ast (.parse ^Parser parser ^String markdown)]
-    (.render ^HtmlRenderer renderer ^Document ast)))
+  [markdown _channel-type site-url]
+  (binding [*site-url* site-url]
+    (let [ast (.parse ^Parser parser ^String markdown)]
+      (.render ^HtmlRenderer renderer ^Document ast))))

--- a/src/metabase/util/retry.clj
+++ b/src/metabase/util/retry.clj
@@ -1,11 +1,10 @@
 (ns metabase.util.retry
-  "Support for in-memory, thread-blocking retrying."
+  "Support for in-memory, thread-blocking retrying. This namespace is just the retry machinery; callers
+  pass a full config map (see [[metabase.channel.settings/retry-configuration]] for the settings-backed
+  default), so `util` stays settings-free."
   (:require
    [diehard.core :as dh]
    [malli.util :as mut]
-   [metabase.config.core :as config]
-   [metabase.settings.core :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli.registry :as mr]))
 
 (set! *warn-on-reflection* true)
@@ -20,50 +19,6 @@
 
 (mr/def ::retry-overrides
   (mut/optional-keys [:ref ::retry-config]))
-
-;;; these kondo warnings are ignored for now because I'm planning on moving this namespace out of `util` to eliminate
-;;; the dependency of `util` of `settings` -- will fix them after this namespace gets moved. -- Cam
-
-#_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
-(defsetting retry-max-retries
-  (deferred-tru "The maximum number of retries for an event.")
-  :type :integer
-  :default (if config/is-dev?
-             0
-             6))
-
-#_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
-(defsetting retry-initial-interval
-  (deferred-tru "The initial retry delay in milliseconds.")
-  :type :integer
-  :default 500)
-
-#_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
-(defsetting retry-multiplier
-  (deferred-tru "The delay multiplier between attempts.")
-  :type :double
-  :default 2.0)
-
-#_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
-(defsetting retry-jitter-factor
-  (deferred-tru "The jitter factor of the retry delay.")
-  :type :double
-  :default 0.1)
-
-#_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
-(defsetting retry-max-interval-millis
-  (deferred-tru "The maximum delay between attempts.")
-  :type :integer
-  :default 30000)
-
-(defn retry-configuration
-  "Returns a map with the default retry configuration."
-  []
-  {:max-retries (retry-max-retries)
-   :initial-interval-millis (retry-initial-interval)
-   :multiplier (retry-multiplier)
-   :jitter-factor (retry-jitter-factor)
-   :max-interval-millis (retry-max-interval-millis)})
 
 (defn retry-configuration->diehard-map
   "Transform retry configuration map into a format understood by Diehard."
@@ -80,7 +35,8 @@
   identity)
 
 (defmacro with-retry
-  "Execute `body`, retrying on thrown exceptions or certain values if requested. See `retry-configuration` for default
-  configuration, and also `diehard.core/with-retry` which is used underneath this macro."
+  "Execute `body`, retrying on thrown exceptions or certain values if requested. `options-map` should
+  conform to `::retry-config` (plus any extra Diehard options); see also `diehard.core/with-retry` which
+  is used underneath this macro."
   [options-map & body]
   `(dh/with-retry (retry-configuration->diehard-map (*test-time-config-hook* ~options-map)) ~@body))

--- a/test/metabase/util/markdown_test.clj
+++ b/test/metabase/util/markdown_test.clj
@@ -1,12 +1,13 @@
 (ns metabase.util.markdown-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test.util :as tu]
    [metabase.util.markdown :as markdown]))
 
 (defn- slack
-  [markdown]
-  (markdown/process-markdown markdown :slack))
+  ([markdown]
+   (slack markdown nil))
+  ([markdown site-url]
+   (markdown/process-markdown markdown :slack site-url)))
 
 (defn- escape
   [text]
@@ -86,10 +87,9 @@
     (is (= "<https://metabase.com|*Metabase*>" (slack "[__Metabase__](https://metabase.com)")))
     (is (= "<https://metabase.com|`Metabase`>" (slack "[`Metabase`](https://metabase.com)")))))
 
-(deftest process-markdown-slack-test-9
-  (testing "Relative links are resolved to the current site URL"
-    (tu/with-temporary-setting-values [site-url "https://example.com"]
-      (is (= "<https://example.com/foo|Metabase>"   (slack "[Metabase](/foo)"))))))
+(deftest ^:parallel process-markdown-slack-test-9
+  (testing "Relative links are resolved to the provided site URL"
+    (is (= "<https://example.com/foo|Metabase>" (slack "[Metabase](/foo)" "https://example.com")))))
 
 (deftest ^:parallel process-markdown-slack-test-10
   (testing "Auto-links are preserved"
@@ -203,10 +203,12 @@
     (is (= "[test]" (slack "[test]")))))
 
 (defn- html
-  [markdown]
-  (markdown/process-markdown markdown :html))
+  ([markdown]
+   (html markdown nil))
+  ([markdown site-url]
+   (markdown/process-markdown markdown :html site-url)))
 
-(deftest process-markdown-email-test
+(deftest ^:parallel process-markdown-email-test
   (testing "HTML is generated correctly from Markdown input for emails. Not an exhaustive test suite since parsing and
            rendering is fully handled by flexmark."
     (is (= "<h1>header</h1>\n"
@@ -219,14 +221,13 @@
            (html "1. foo\n   1. bar")))
     (is (= "<p>/</p>\n"
            (html "\\/")))
-    (doseq [temp-setting ["https://example.com" "https://example.com/"]]
-      (tu/with-temporary-setting-values [site-url temp-setting]
-        (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
-               (html "![alt-text](/image.png)")))
-        (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
-               (html "![alt-text](image.png)")))
-        (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
-               (html "[dashboard 1](/dashboard/1)")))))))
+    (doseq [site-url ["https://example.com" "https://example.com/"]]
+      (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
+             (html "![alt-text](/image.png)" site-url)))
+      (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
+             (html "![alt-text](image.png)" site-url)))
+      (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
+             (html "[dashboard 1](/dashboard/1)" site-url))))))
 
 (deftest ^:parallel process-markdown-email-test-2
   (testing "Bare URLs and email addresses are converted to links"

--- a/test/metabase/util/retry_test.clj
+++ b/test/metabase/util/retry_test.clj
@@ -6,6 +6,15 @@
   (:import
    (clojure.lang ExceptionInfo)))
 
+(def ^:private retry-configuration
+  "A config map like [[metabase.channel.settings/retry-configuration]] returns, so these tests don't need
+  the settings system."
+  {:max-retries             6
+   :initial-interval-millis 500
+   :multiplier              2.0
+   :jitter-factor           0.1
+   :max-interval-millis     30000})
+
 (deftest retrying-on-exception-test
   (testing "recovery possible"
     (let [f +
@@ -13,7 +22,7 @@
           works-after 3
           flaky-f (tu/works-after works-after f)]
       (is (= (apply f params)
-             (retry/with-retry (assoc (retry/retry-configuration)
+             (retry/with-retry (assoc retry-configuration
                                       :max-retries works-after
                                       :initial-interval-millis 1)
                (apply flaky-f params))))))
@@ -23,7 +32,7 @@
           works-after 3
           flaky-f (tu/works-after works-after f)]
       (is (thrown? ExceptionInfo
-                   (retry/with-retry (assoc (retry/retry-configuration)
+                   (retry/with-retry (assoc retry-configuration
                                             :max-retries (dec works-after)
                                             :initial-interval-millis 1)
                      (apply flaky-f params)))))))
@@ -32,14 +41,14 @@
   (testing "recovery possible"
     (let [a (atom 0)
           f #(swap! a inc)]
-      (is (= 2 (retry/with-retry (assoc (retry/retry-configuration)
+      (is (= 2 (retry/with-retry (assoc retry-configuration
                                         :max-retries 1
                                         :retry-if (fn [val _] (odd? val))
                                         :initial-interval-millis 1)
                  (f))))))
   (testing "recovery impossible"
     (let [f (constantly 1)]
-      (is (= 1 (retry/with-retry (assoc (retry/retry-configuration)
+      (is (= 1 (retry/with-retry (assoc retry-configuration
                                         :max-retries 1
                                         :retry-if (fn [val _] (odd? val))
                                         :initial-interval-millis 1)


### PR DESCRIPTION
## Why

The module dependency graph has one strongly-connected component of **94 modules**, which is why a change to the median module invalidates ~1236 of ~1243 test files in CI . This PR is the first, cheapest step of carving that component apart.

- **`classloader → util`** (its only back-edge): `classloader.impl` used `metabase.util.log` for four trace messages. util's `i18n.impl`/`quick-task` legitimately need `the-classloader`, so the `util ↔ classloader` 2-cycle is broken on the classloader side: plain `clojure.tools.logging` with a scoped `:config-in-ns` lint exemption. **classloader is now pure upstream.**
- **`util → system`** (×2): `util.embed/head` and `util.markdown/process-markdown` read `site-url` from `metabase.system.core`. Both now take `site-url` as an argument and the callers (one in `server`, six in `channel`) do the lookup — util code takes values as input instead of reading global state. Side benefit: the site-url-dependent markdown tests no longer need `with-temporary-setting-values` and run parallel.

- **`util.retry` settings** (second commit): the five `retry-*` `defsetting`s (and the settings-reading `retry-configuration`) move to `metabase.channel.settings` — their only production consumer is `channel/email.clj` — resolving the lint-ignored `defsetting`s and the TODO comment in that namespace. The retry machinery stays in `util.retry`, now settings-free. Setting names/defaults unchanged. util's remaining edge into `settings` is down to the `start-of-week` lookups in `date-2`/`time.impl`.
