### PR TITLE
Fix filter not respected when downloading visualizer-affected card from dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -446,7 +446,9 @@ export function DashCardVisualization({
     });
 
   const actionButtons = useMemo(() => {
-    const result = series[0] as unknown as Dataset;
+    const cardId = dashcard.card_id ?? dashcard.card?.id;
+    const cardResult = cardId ? datasets?.[cardId] : undefined;
+    const result = cardResult ?? (series[0] as unknown as Dataset);
 
     const showMenu =
       question &&
@@ -457,9 +459,6 @@ export function DashCardVisualization({
         result,
       });
 
-    const cardResult = dashcard.card_id
-      ? datasets?.[dashcard.card_id]
-      : undefined;
     const errorStatus =
       cardResult?.error && typeof cardResult.error === "object"
         ? cardResult.error.status

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { setupLastDownloadFormatEndpoints } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
@@ -9,6 +10,7 @@ import {
   queryIcon,
   renderWithProviders,
   screen,
+  waitFor,
   within,
 } from "__support__/ui";
 import {
@@ -27,6 +29,7 @@ import type { DashCardDataMap } from "metabase-types/api";
 import {
   createMockActionDashboardCard,
   createMockCard,
+  createMockColumn,
   createMockDashboard,
   createMockDashboardCard,
   createMockDatabase,
@@ -38,6 +41,7 @@ import {
   createMockNativeCard,
   createMockParameter,
   createMockPlaceholderDashboardCard,
+  createMockStructuredDatasetQuery,
   createMockTable,
   createMockTextDashboardCard,
 } from "metabase-types/api/mocks";
@@ -410,6 +414,132 @@ describe("DashCard", () => {
     expect(
       screen.queryByText(/Some columns are missing/),
     ).not.toBeInTheDocument();
+  });
+
+  it("should include dashboard filters when downloading a multi-source visualizer dashcard as xlsx (#71638)", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const firstCard = createMockCard({
+      id: 49,
+      name: "Analytic Events, Count 1",
+      display: "line",
+    });
+    const secondCard = createMockCard({
+      id: 115,
+      name: "Analytic Events, Count 2",
+      display: "line",
+    });
+    const dashboardParameter = createMockParameter({
+      id: "ae55857f",
+      name: "Date 1",
+      slug: "date_1",
+      type: "date/all-options",
+      value: "2022-05-01~",
+      target: [
+        "dimension",
+        ["field", "TIMESTAMP", { "base-type": "type/DateTime" }],
+        { "stage-number": 1 },
+      ],
+    });
+    const visualizerDashcard = createMockDashboardCard({
+      card_id: firstCard.id,
+      card: firstCard,
+      series: [secondCard],
+      visualization_settings: {
+        visualization: {
+          display: "line",
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: `card:${firstCard.id}`,
+                originalName: "TIMESTAMP",
+                name: "COLUMN_1",
+              },
+            ],
+            COLUMN_2: [
+              {
+                sourceId: `card:${firstCard.id}`,
+                originalName: "count",
+                name: "COLUMN_2",
+              },
+            ],
+            COLUMN_3: [
+              {
+                sourceId: `card:${secondCard.id}`,
+                originalName: "count",
+                name: "COLUMN_3",
+              },
+            ],
+            COLUMN_4: [
+              {
+                sourceId: `card:${secondCard.id}`,
+                originalName: "TIMESTAMP",
+                name: "COLUMN_4",
+              },
+            ],
+          },
+          settings: {
+            "graph.x_axis.scale": "timeseries",
+            "graph.dimensions": ["COLUMN_1", "COLUMN_4"],
+            "graph.metrics": ["COLUMN_2", "COLUMN_3"],
+          },
+        },
+      },
+    });
+    const datasetData = {
+      cols: [
+        createMockColumn({ name: "TIMESTAMP", display_name: "Timestamp" }),
+        createMockColumn({ name: "count", display_name: "Count" }),
+      ],
+      rows: [["2022-05-02T00:00:00-03:00", 545]],
+    };
+    const dashboard = createMockDashboard({
+      dashcards: [visualizerDashcard],
+      parameters: [dashboardParameter],
+    });
+    const downloadPath = `path:/api/dashboard/${dashboard.id}/dashcard/${visualizerDashcard.id}/card/${firstCard.id}/query/xlsx`;
+    fetchMock.post(downloadPath, {
+      status: 200,
+      body: "",
+      headers: {
+        "Content-Disposition": 'attachment; filename="results.xlsx"',
+      },
+    });
+
+    setup({
+      dashboard,
+      dashcard: visualizerDashcard,
+      dashcardData: {
+        [visualizerDashcard.id]: {
+          [firstCard.id]: createMockDataset({
+            data: datasetData,
+            json_query: {
+              ...createMockStructuredDatasetQuery(),
+              parameters: [dashboardParameter],
+            },
+            status: "completed",
+          }),
+          [secondCard.id]: createMockDataset({
+            data: datasetData,
+            status: "completed",
+          }),
+        },
+      },
+    });
+
+    await user.click(getIcon("ellipsis"));
+    await user.click(await screen.findByText("Download results"));
+    await user.click(await screen.findByRole("radio", { name: ".xlsx" }));
+    await user.click(screen.getByTestId("download-results-button"));
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.calls(downloadPath)).toHaveLength(1);
+    });
+
+    const call = fetchMock.callHistory.lastCall(downloadPath);
+    const body = new URLSearchParams(await call?.request?.text());
+    expect(JSON.parse(body.get("parameters") ?? "[]")).toEqual([
+      dashboardParameter,
+    ]);
   });
 
   describe("edit mode", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71638

### Description

Fixes dashboard XLSX downloads for multi-source visualizer dashcards so applied dashboard filters are preserved in the download request.

The dashboard-card export endpoint already accepts `parameters`, but visualizer dashcards were passing transformed series data into the download menu. For combo visualizer cards, that data can omit `json_query.parameters`, causing downloads to send `parameters=[]`. This change uses the stored primary card dataset from `dashcardData` when available, falling back to the previous series result otherwise.

### How to verify

1. Create a dashboard with a multi-source visualizer line chart.
  - For the example I used, I created a question against Analytics Events → Count by Timestamp, and the second question was just the same but with a filter (Active Subscripion=true)
  <img height="200" alt="image" src="https://github.com/user-attachments/assets/a6b75c75-d9df-41cb-bd9f-02cad4344387" />
2. Add a dashboard date filter mapped to the source cards.
3. Apply the date filter.
4. Download the visualizer dashcard results as `.xlsx`.
5. Confirm the XLSX data respects the applied dashboard filter.

### Demo
https://www.loom.com/share/96bb25e1b6544cf291a09afade20653a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
