### PR TITLE
Add aggregations support for breakouts in query hooks

### DIFF
--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -11,13 +11,13 @@ Keep the semantic layer and presentation layer separate.
 
 - All Metabase context must come from the generated schema file, usually `src/metabase.data.ts` or `src/*.metabase.data.ts`.
 - Do not discover data through MCP tools, create questions, create metrics, create tables, or edit the semantic layer while building the React UI.
-- Use `useMetabaseQuery`, `filter(...)`, and `breakout(...)` from `@metabase/embedding-sdk-react/data-app`.
+- Use `useMetabaseQuery`, `useMetabaseQueryObject`, `filter(...)`, and `breakout(...)` from `@metabase/embedding-sdk-react/data-app`.
 - Prefer generated schema objects over raw IDs or strings. Extract local constants for top-level semantic objects.
 - Prefer semantically rich queries over shallow table dumps. Use curated metrics, table measures, segments, filters, and breakouts when they make the generated app more useful.
 - Prefer semantic-layer definitions over React-side inference. If the schema has a segment or measure for a concept, use it in the query instead of manually recreating the concept from raw rows.
 - Never invent aggregation or measure objects such as `{ name: "count" }` or `{ name: "sum", field: ... }`. Measures must come from `schema.tables.*.measures.*`; metrics must come from `schema.metrics.*`.
 - Only render values returned by Metabase or deterministic transforms of returned values. Do not invent KPI values, trends, labels, statuses, ratings, timestamps, rankings, insights, customer segments, or chart series.
-- Visualization data must be derived from `useMetabaseQuery` results. Do not hardcode chart-ready arrays, sample data, demo values, or schema-shaped mock values.
+- Visualization data must come from Metabase through `useMetabaseQuery`, `useMetabaseQueryObject` with `InteractiveQuestion`/`StaticQuestion`, or saved-question SDK components. Do not hardcode chart-ready arrays, sample data, demo values, or schema-shaped mock values.
 - Before rendering a field, verify it exists in the generated schema object and is returned by the query. Do not guess column names from business intuition or old mock data.
 - Avoid unsupported freshness or operational claims such as "real-time", "live", "understaffed", or "risk" unless the returned data or curated semantic-layer definition supports them.
 - Before claiming the work is done or preparing a final handoff, run a TypeScript type-only check and report the command/result. If the check fails, fix the type errors before any final summary.
@@ -168,9 +168,9 @@ Measures must come from tables in the metric's `mappedTableIds`.
 
 ## Interactive Metabase Views
 
-Use Metabase's SDK `InteractiveQuestion` by default when the UI can be expressed as a normal Metabase question visualization. Build a table-backed semantic query with `useMetabaseQueryObject`, then pass the query object to `InteractiveQuestion`.
+Use Metabase's SDK `InteractiveQuestion` or `StaticQuestion` by default when the UI can be expressed as a normal Metabase question visualization. Build a semantic query with `useMetabaseQueryObject`, then pass the query object to the SDK question component.
 
-Current constraint: `useMetabaseQueryObject` is for table-backed queries. Do not pass `metric` or `metricId` to `useMetabaseQueryObject`. If the desired view is metric-backed but can be expressed from a generated table plus measures, filters, and breakouts, prefer that table-backed `InteractiveQuestion` query. Use `useMetabaseQuery` and custom rendering for metrics only when there is no table-backed equivalent or the UI needs direct row data.
+`useMetabaseQueryObject` supports generated table objects and generated metric objects. Use `useMetabaseQuery` when custom React needs direct row data; use `useMetabaseQueryObject` when Metabase should render or manage the visualization.
 
 Metabase supports these question displays: `table`, `bar`, `line`, `pie`, `scalar`, `row`, `area`, `combo`, `pivot`, `smartscalar`, `gauge`, `progress`, `funnel`, `object`, `map`, `scatter`, `boxplot`, `waterfall`, `sankey`, and `list`.
 
@@ -200,6 +200,7 @@ Chart only, without the toolbar:
 ```tsx
 import {
   InteractiveQuestion,
+  StaticQuestion,
   breakout,
   count,
   useMetabaseQueryObject,
@@ -232,7 +233,38 @@ const revenueQuery = useMetabaseQueryObject({
 return <InteractiveQuestion query={revenueQuery} />;
 ```
 
-Do not wrap `InteractiveQuestion` in containers that clip or move on hover. Avoid `overflow: hidden`, hover transforms, and hover-driven layout shifts around embedded Metabase UI; popovers, menus, and chart tooltips need stable geometry and visible overflow.
+Static question:
+
+```tsx
+const revenueQuery = useMetabaseQueryObject({
+  table: dailyRevenue,
+  aggregations: [dailyRevenue.measures.sumOfNetRevenue],
+  breakouts: [breakout(dailyRevenue.fields.orderDate, { bucket: "month" })],
+});
+
+return <StaticQuestion query={revenueQuery} />;
+```
+
+Metric-backed SDK question:
+
+```tsx
+const revenueMetric = schema.metrics.revenue;
+const ordersTable = schema.tables.orders;
+
+const revenueByMonthQuery = useMetabaseQueryObject({
+  metric: revenueMetric,
+  measures: [ordersTable.measures.totalRevenue],
+  breakouts: [breakout(revenueMetric.dimensions.createdAt, { bucket: "month" })],
+});
+
+return (
+  <InteractiveQuestion query={revenueByMonthQuery}>
+    <InteractiveQuestion.QuestionVisualization />
+  </InteractiveQuestion>
+);
+```
+
+Do not wrap `InteractiveQuestion` or `StaticQuestion` in containers that clip or move on hover. Avoid `overflow: hidden`, hover transforms, and hover-driven layout shifts around embedded Metabase UI; popovers, menus, and chart tooltips need stable geometry and visible overflow.
 
 ## Filters And Breakouts
 

--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -47,6 +47,7 @@ Use `libraryCollections` for semantic-layer tables, segments, measures, and metr
 ```ts
 import {
   breakout,
+  count,
   filter,
   useMetabaseQuery,
   useMetabaseQueryObject,
@@ -101,13 +102,24 @@ const { data } = useMetabaseQuery<OrdersTable>({
     ordersTable.segments.completedOrders,
     filter(ordersTable.fields.total, ">", 100),
   ],
-  measures: [ordersTable.measures.revenue],
+  aggregations: [ordersTable.measures.revenue],
   breakouts: [breakout(ordersTable.fields.createdAt, { bucket: "month" })],
 });
 ```
 
-Table fields, segments, and measures must come from the queried table.
-When table queries use `fields`, `segments`, `measures`, or `breakouts`, pass the table schema generic (`useMetabaseQuery<OrdersTable>`) so TypeScript can validate the query.
+For grouped counts, use `count()`:
+
+```ts
+useMetabaseQuery({
+  table: ordersTable,
+  filters: [ordersTable.segments.completedOrders],
+  aggregations: [count()],
+  breakouts: [breakout(ordersTable.fields.paymentMethod)],
+});
+```
+
+Table fields, segments, and measure aggregations must come from the queried table.
+When table queries use `fields`, `segments`, `aggregations`, or `breakouts`, pass the table schema generic (`useMetabaseQuery<OrdersTable>`) so TypeScript can validate the query.
 
 ### Metrics
 
@@ -177,6 +189,7 @@ Chart only, without the toolbar:
 import {
   InteractiveQuestion,
   breakout,
+  count,
   useMetabaseQueryObject,
 } from "@metabase/embedding-sdk-react/data-app";
 
@@ -184,7 +197,7 @@ const dailyRevenue = schema.tables.dailyStoreRevenue;
 
 const revenueQuery = useMetabaseQueryObject({
   table: dailyRevenue,
-  measures: [dailyRevenue.measures.sumOfNetRevenue],
+  aggregations: [dailyRevenue.measures.sumOfNetRevenue],
   breakouts: [breakout(dailyRevenue.fields.orderDate, { bucket: "month" })],
 });
 
@@ -200,7 +213,7 @@ Full interactive question, with the query toolbar:
 ```tsx
 const revenueQuery = useMetabaseQueryObject({
   table: dailyRevenue,
-  measures: [dailyRevenue.measures.sumOfNetRevenue],
+  aggregations: [dailyRevenue.measures.sumOfNetRevenue],
   breakouts: [breakout(dailyRevenue.fields.orderDate, { bucket: "month" })],
 });
 
@@ -256,7 +269,7 @@ const { data } = useMetabaseQuery<DailyRevenue>({
     dailyRevenue.segments.ordersFromThisMonth,
     filter(dailyRevenue.fields.netRevenue, ">", 1000),
   ],
-  measures: [dailyRevenue.measures.sumOfNetRevenue],
+  aggregations: [dailyRevenue.measures.sumOfNetRevenue],
   breakouts: [breakout(dailyRevenue.fields.orderDate, { bucket: "day" })],
 });
 ```

--- a/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
+++ b/.claude/skills/metabase-semantic-schema-data-apps/SKILL.md
@@ -46,9 +46,11 @@ Use `libraryCollections` for semantic-layer tables, segments, measures, and metr
 
 ```ts
 import {
+  avg,
   breakout,
   count,
   filter,
+  sum,
   useMetabaseQuery,
   useMetabaseQueryObject,
 } from "@metabase/embedding-sdk-react/data-app";
@@ -115,6 +117,16 @@ useMetabaseQuery({
   filters: [ordersTable.segments.completedOrders],
   aggregations: [count()],
   breakouts: [breakout(ordersTable.fields.paymentMethod)],
+});
+```
+
+For basic field aggregations, use helpers such as `sum(field)`, `avg(field)`, `median(field)`, `distinct(field)`, `min(field)`, and `max(field)`:
+
+```ts
+useMetabaseQuery({
+  table: ordersTable,
+  aggregations: [sum(ordersTable.fields.total), avg(ordersTable.fields.total)],
+  breakouts: [breakout(ordersTable.fields.createdAt, { bucket: "month" })],
 });
 ```
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -28,6 +28,7 @@ export type QuestionSchema = {
 
 export type MetricDimensionSchema = SchemaColumn & {
   id: string | number;
+  fieldId?: number;
   metricId: string | number;
   tableId?: number;
 };
@@ -62,6 +63,8 @@ export type TableSchema = {
 
 export type MetricSchema = {
   id: number;
+  databaseId?: number;
+  sourceTableId?: number;
   columns: readonly SchemaColumn[];
   mappedTableIds?: readonly number[];
   dimensions?: Record<string, MetricDimensionSchema>;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
@@ -100,6 +100,18 @@ export function getMetricMappedTableIds(
   return isMetricReference(query.metric) ? query.metric.mappedTableIds : null;
 }
 
+export function getMetricDatabaseId(query: MetricQueryRuntime): ID | null {
+  return isMetricReference(query.metric) && query.metric.databaseId != null
+    ? query.metric.databaseId
+    : null;
+}
+
+export function getMetricSourceTableId(query: MetricQueryRuntime): ID | null {
+  return isMetricReference(query.metric) && query.metric.sourceTableId != null
+    ? query.metric.sourceTableId
+    : null;
+}
+
 export function isDimensionFilter(
   value: unknown,
 ): value is DimensionFilterRuntime {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
@@ -5,6 +5,7 @@ import type {
 } from "../data-schema";
 
 import type {
+  CountAggregationRuntime,
   DimensionFilterRuntime,
   ID,
   MeasureReferenceRuntime,
@@ -135,6 +136,17 @@ export function isMeasureSchema(
     value != null &&
     "kind" in value &&
     value.kind === "measure"
+  );
+}
+
+export function isCountAggregation(
+  value: unknown,
+): value is CountAggregationRuntime {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "type" in value &&
+    value.type === "count"
   );
 }
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/guards.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   CountAggregationRuntime,
   DimensionFilterRuntime,
+  FieldAggregationRuntime,
   ID,
   MeasureReferenceRuntime,
   MetabaseQueryRuntime,
@@ -147,6 +148,23 @@ export function isCountAggregation(
     value != null &&
     "type" in value &&
     value.type === "count"
+  );
+}
+
+export function isFieldAggregation(
+  value: unknown,
+): value is FieldAggregationRuntime {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "type" in value &&
+    "dimension" in value &&
+    (value.type === "sum" ||
+      value.type === "avg" ||
+      value.type === "median" ||
+      value.type === "distinct" ||
+      value.type === "min" ||
+      value.type === "max")
   );
 }
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
@@ -1,5 +1,6 @@
 export {
   breakout,
+  count,
   createMetabaseQuery,
   filter,
   useMetabaseQuery,

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/index.ts
@@ -1,8 +1,14 @@
 export {
+  avg,
   breakout,
   count,
   createMetabaseQuery,
+  distinct,
   filter,
+  max,
+  median,
+  min,
+  sum,
   useMetabaseQuery,
   useMetabaseQueryObject,
 } from "./use-metabase-query";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/metric-query-builder.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/metric-query-builder.ts
@@ -1,4 +1,11 @@
-import type { MetricId } from "metabase-types/api";
+import type {
+  Aggregation,
+  ConcreteFieldReference,
+  FieldReference,
+  Filter,
+  MetricId,
+  StructuredDatasetQuery,
+} from "metabase-types/api";
 import type {
   InstanceFilter,
   JsMetricDefinition,
@@ -6,7 +13,9 @@ import type {
 } from "metabase-types/api/metric";
 
 import {
+  getMetricDatabaseId,
   getMetricId,
+  getMetricSourceTableId,
   isFieldSchema,
   isMeasureSchema,
   isMetricDimensionFilter,
@@ -18,6 +27,7 @@ import {
 } from "./guards";
 import type {
   BreakoutObjectRuntime,
+  DimensionFilterRuntime,
   MetricDimensionFilterRuntime,
   MetricQueryRuntime,
 } from "./runtime-types";
@@ -60,6 +70,50 @@ export function buildMetricDefinition(query: MetricQueryRuntime) {
   }
 
   return definition;
+}
+
+export function buildMetricDatasetQuery(
+  query: MetricQueryRuntime,
+): StructuredDatasetQuery {
+  validateMetricTableScopedInputs(query);
+
+  const metricId = getMetricId(query);
+  const databaseId = getMetricDatabaseId(query);
+  const sourceTableId = getMetricSourceTableId(query);
+
+  if (metricId == null || databaseId == null || sourceTableId == null) {
+    throw new Error(
+      "Metric query object creation requires a generated metric schema with databaseId and sourceTableId.",
+    );
+  }
+
+  const mbql: StructuredDatasetQuery["query"] = {
+    "source-table": Number(sourceTableId),
+    aggregation: [
+      ["metric", Number(metricId)],
+      ...buildMetricDatasetMeasureClauses(query),
+    ],
+  };
+
+  const filters = query.filters?.map(buildMetricDatasetFilter);
+  const breakouts = query.breakouts?.map(buildMetricDatasetBreakout);
+
+  if (filters?.length === 1) {
+    mbql.filter = filters[0] as Filter;
+  } else if (filters && filters.length > 1) {
+    mbql.filter = ["and", ...(filters as Filter[])];
+  }
+
+  if (breakouts?.length) {
+    mbql.breakout = breakouts;
+  }
+
+  return {
+    type: "query",
+    database: Number(databaseId),
+    query: mbql,
+    parameters: [],
+  };
 }
 
 function buildMetricFilter(
@@ -109,6 +163,48 @@ function buildMetricFilterClause(filter: MetricDimensionFilterRuntime) {
   }
 
   return [operator, {}, dimension, ...values];
+}
+
+function buildMetricDatasetFilter(filter: unknown) {
+  if (isSegmentSchema(filter)) {
+    return ["segment", filter.id];
+  }
+
+  if (isMetricDimensionFilter(filter) || isTableDimensionFilter(filter)) {
+    return buildMetricDatasetFilterClause(filter);
+  }
+
+  throw new Error(
+    "Metric query object filters must use generated metric dimensions, mapped table fields, or segments.",
+  );
+}
+
+function buildMetricDatasetFilterClause(filter: DimensionFilterRuntime) {
+  const operator = filter.operator;
+  const dimension = buildDatasetFieldReference(filter.dimension);
+  const values = filter.values ?? [filter.value];
+
+  if (operator === "between") {
+    return [operator, dimension, ...values.slice(0, 2)];
+  }
+
+  if (isUnaryOperator(operator)) {
+    return [operator, dimension];
+  }
+
+  return [operator, dimension, ...values];
+}
+
+function buildMetricDatasetMeasureClauses(
+  query: MetricQueryRuntime,
+): Aggregation[] {
+  const measures = query.measures?.filter(isMeasureSchema);
+
+  return (
+    measures?.map((measure) => {
+      return ["measure", {}, measure.id] as Aggregation;
+    }) ?? []
+  );
 }
 
 function findMetricDimensionForTableField(
@@ -199,6 +295,32 @@ function buildMetricDimensionReference(
   ];
 }
 
+function buildMetricDatasetBreakout(breakout: unknown): ConcreteFieldReference {
+  const { dimension, options } = normalizeBreakout(breakout);
+
+  return buildDatasetFieldReference(
+    dimension,
+    options,
+  ) as ConcreteFieldReference;
+}
+
+function buildDatasetFieldReference(
+  field: unknown,
+  options: Record<string, unknown> = {},
+): FieldReference {
+  if (isMetricDimensionSchema(field) && typeof field.fieldId === "number") {
+    return ["field", field.fieldId, options] as FieldReference;
+  }
+
+  if (hasFieldId(field)) {
+    return ["field", field.fieldId, options] as FieldReference;
+  }
+
+  throw new Error(
+    "Metric query objects for InteractiveQuestion require generated dimensions with fieldId. Use schema.tables.*.fields.* or regenerate the typed schema.",
+  );
+}
+
 function normalizeBreakout(breakout: unknown) {
   if (
     typeof breakout === "string" ||
@@ -229,4 +351,13 @@ function normalizeBreakout(breakout: unknown) {
 
 function isBreakoutObject(value: unknown): value is BreakoutObjectRuntime {
   return typeof value === "object" && value != null && "dimension" in value;
+}
+
+function hasFieldId(value: unknown): value is { fieldId: number } {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "fieldId" in value &&
+    typeof value.fieldId === "number"
+  );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
@@ -34,6 +34,7 @@ export type TableQueryRuntime = {
   metric?: never;
   metricId?: never;
   filters?: readonly unknown[];
+  aggregations?: readonly unknown[];
   measures?: readonly unknown[];
   breakouts?: readonly unknown[];
   enabled?: boolean;
@@ -67,6 +68,10 @@ export type MeasureReferenceRuntime = {
   id: number;
   tableId: number;
   columns?: readonly unknown[];
+};
+
+export type CountAggregationRuntime = {
+  type: "count";
 };
 
 export type MetricReferenceRuntime = {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
@@ -74,6 +74,11 @@ export type CountAggregationRuntime = {
   type: "count";
 };
 
+export type FieldAggregationRuntime = {
+  type: "sum" | "avg" | "median" | "distinct" | "min" | "max";
+  dimension: unknown;
+};
+
 export type MetricReferenceRuntime = {
   id: ID;
   mappedTableIds: readonly number[];

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/runtime-types.ts
@@ -81,6 +81,8 @@ export type FieldAggregationRuntime = {
 
 export type MetricReferenceRuntime = {
   id: ID;
+  databaseId?: ID;
+  sourceTableId?: ID;
   mappedTableIds: readonly number[];
 };
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/table-query-builder.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/table-query-builder.ts
@@ -8,6 +8,7 @@ import type {
 
 import {
   getTableId,
+  isCountAggregation,
   isDimensionFilter,
   isMeasureSchema,
   isMetricDimensionSchema,
@@ -36,7 +37,7 @@ export function buildTableDatasetQuery(
   validateTableScopedInputs({
     allowedTableIds: [Number(tableId)],
     filters: query.filters,
-    measures: query.measures,
+    measures: query.aggregations ?? query.measures,
     context: "Table query",
   });
 
@@ -45,7 +46,7 @@ export function buildTableDatasetQuery(
   };
 
   const filters = query.filters?.map(buildTableFilter).filter(Boolean);
-  const measures = query.measures?.map(buildMeasureClause).filter(isNotNull);
+  const aggregations = buildTableAggregationClauses(query);
   const breakouts = query.breakouts?.map(buildTableBreakout).filter(Boolean);
 
   if (filters?.length === 1) {
@@ -54,8 +55,8 @@ export function buildTableDatasetQuery(
     mbql.filter = ["and", ...(filters as Filter[])];
   }
 
-  if (measures?.length) {
-    mbql.aggregation = measures;
+  if (aggregations.length > 0) {
+    mbql.aggregation = aggregations;
   }
 
   if (breakouts?.length) {
@@ -81,12 +82,31 @@ function buildTableFilter(filter: unknown) {
   return null;
 }
 
-function buildMeasureClause(measure: unknown): Aggregation | null {
-  if (!isMeasureSchema(measure)) {
+function buildTableAggregationClauses(query: TableQueryRuntime): Aggregation[] {
+  const aggregations = query.aggregations ?? query.measures;
+  const clauses = aggregations?.map(buildAggregationClause).filter(isNotNull);
+
+  if (clauses?.length) {
+    return clauses;
+  }
+
+  return query.breakouts?.length ? [buildCountClause()] : [];
+}
+
+function buildAggregationClause(aggregation: unknown): Aggregation | null {
+  if (isCountAggregation(aggregation)) {
+    return buildCountClause();
+  }
+
+  if (!isMeasureSchema(aggregation)) {
     return null;
   }
 
-  return ["measure", {}, measure.id] as Aggregation;
+  return ["measure", {}, aggregation.id] as Aggregation;
+}
+
+function buildCountClause(): Aggregation {
+  return ["count"] as Aggregation;
 }
 
 function buildTableBreakout(breakout: unknown): ConcreteFieldReference {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/table-query-builder.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/table-query-builder.ts
@@ -10,6 +10,7 @@ import {
   getTableId,
   isCountAggregation,
   isDimensionFilter,
+  isFieldAggregation,
   isMeasureSchema,
   isMetricDimensionSchema,
   isSegmentSchema,
@@ -96,6 +97,13 @@ function buildTableAggregationClauses(query: TableQueryRuntime): Aggregation[] {
 function buildAggregationClause(aggregation: unknown): Aggregation | null {
   if (isCountAggregation(aggregation)) {
     return buildCountClause();
+  }
+
+  if (isFieldAggregation(aggregation)) {
+    return [
+      aggregation.type,
+      buildFieldReference(aggregation.dimension),
+    ] as Aggregation;
   }
 
   if (!isMeasureSchema(aggregation)) {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -50,6 +50,8 @@ type DimensionInput<TEntity> = [DimensionValues<TEntity>] extends [never]
 
 export type MetricReference<TMappedTableId extends number = number> = {
   id: ID;
+  databaseId?: ID;
+  sourceTableId?: ID;
   mappedTableIds: readonly TMappedTableId[];
   columns?: readonly SchemaColumn[];
   dimensions?: Record<string, MetricDimensionSchema>;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -67,6 +67,22 @@ export type MeasureReference<TTableId extends number = number> = {
   columns?: readonly SchemaColumn[];
 };
 
+export type CountAggregation = {
+  type: "count";
+};
+
+export type CountAggregationSchema = CountAggregation & {
+  columns: readonly [
+    {
+      name: "count";
+      displayName: "Count";
+      jsType: "number";
+    },
+  ];
+};
+
+type CountAggregationColumn = CountAggregationSchema["columns"][number];
+
 type TableId<TTable> = TTable extends { id: infer TId extends number }
   ? TId
   : number;
@@ -363,6 +379,13 @@ export type TableQuery<TTable> = TableReference<TTable> & {
         | MetabaseDimensionFilter<TTable>
       )[]
     : readonly unknown[];
+  aggregations?: TTable extends TableSchema
+    ? readonly (
+        | MeasureReference<TableId<TTable>>
+        | CountAggregation
+        | CountAggregationSchema
+      )[]
+    : readonly (MeasureReference | CountAggregation | CountAggregationSchema)[];
   measures?: TTable extends TableSchema
     ? readonly MeasureReference<TableId<TTable>>[]
     : readonly MeasureReference[];
@@ -446,12 +469,40 @@ type QueryMeasureColumns<TQuery> = TQuery extends {
     : never
   : never;
 
+type QueryAggregationColumns<TQuery> = TQuery extends {
+  aggregations?: infer TAggregations;
+}
+  ? TupleElement<NonNullable<TAggregations>> extends infer TAggregation
+    ? TAggregation extends {
+        columns: infer TColumns;
+      }
+      ? TupleElement<NonNullable<TColumns>>
+      : TAggregation extends CountAggregation
+        ? CountAggregationColumn
+        : never
+    : never
+  : never;
+
+type QueryDefaultAggregationColumns<TQuery> =
+  "aggregations" extends keyof TQuery
+    ? never
+    : "measures" extends keyof TQuery
+      ? never
+      : TQuery extends { breakouts: readonly unknown[] }
+        ? CountAggregationColumn
+        : never;
+
 /** @notExported InferQuerySchema */
 type InferQuerySchema<TEntity, TQuery> = InferSchema<
   TEntity,
   Record<string, unknown>
 > &
-  RowsFromColumns<QueryBreakoutColumns<TQuery> | QueryMeasureColumns<TQuery>>;
+  RowsFromColumns<
+    | QueryBreakoutColumns<TQuery>
+    | QueryMeasureColumns<TQuery>
+    | QueryAggregationColumns<TQuery>
+    | QueryDefaultAggregationColumns<TQuery>
+  >;
 
 type InferQueryEntity<TQuery> = TQuery extends { metric: infer TMetric }
   ? TMetric

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/types.ts
@@ -11,6 +11,7 @@ import type {
   QueryData,
   QuestionSchema,
   SchemaColumn,
+  SchemaJavaScriptType,
   SchemaValue,
   TableSchema,
 } from "../data-schema";
@@ -82,6 +83,86 @@ export type CountAggregationSchema = CountAggregation & {
 };
 
 type CountAggregationColumn = CountAggregationSchema["columns"][number];
+
+export type FieldAggregationOperator =
+  | "sum"
+  | "avg"
+  | "median"
+  | "distinct"
+  | "min"
+  | "max";
+
+export type FieldAggregation<
+  TOperator extends FieldAggregationOperator = FieldAggregationOperator,
+  TDimension = unknown,
+> = {
+  type: TOperator;
+  dimension: TDimension;
+};
+
+type AggregationDimensionWithJavaScriptType<
+  TDimension,
+  TJavaScriptType extends SchemaJavaScriptType,
+> = TDimension extends unknown
+  ? TDimension extends { jsType?: infer TDimensionJavaScriptType }
+    ? Extract<
+        NonNullable<TDimensionJavaScriptType>,
+        TJavaScriptType
+      > extends never
+      ? never
+      : TDimension
+    : TDimension
+  : never;
+
+export type NumericAggregationDimension<TDimension> =
+  AggregationDimensionWithJavaScriptType<TDimension, "number">;
+
+export type OrderableAggregationDimension<TDimension> =
+  AggregationDimensionWithJavaScriptType<
+    TDimension,
+    "string" | "number" | "boolean" | "Date"
+  >;
+
+type FieldAggregationColumnJavaScriptType<
+  TOperator extends FieldAggregationOperator,
+  TDimension,
+> = TOperator extends "min" | "max"
+  ? TDimension extends { jsType?: infer TJavaScriptType }
+    ? Extract<
+        NonNullable<TJavaScriptType>,
+        "string" | "number" | "boolean" | "Date"
+      > extends never
+      ? "number"
+      : Extract<
+          NonNullable<TJavaScriptType>,
+          "string" | "number" | "boolean" | "Date"
+        >
+    : "number"
+  : "number";
+
+type FieldAggregationColumnName<TOperator extends FieldAggregationOperator> =
+  TOperator extends "distinct" ? "count" : TOperator;
+
+export type FieldAggregationSchema<
+  TOperator extends FieldAggregationOperator = FieldAggregationOperator,
+  TDimension = unknown,
+  TJavaScriptType extends SchemaJavaScriptType =
+    FieldAggregationColumnJavaScriptType<TOperator, TDimension>,
+> = FieldAggregation<TOperator, TDimension> & {
+  columns: readonly [
+    {
+      name: FieldAggregationColumnName<TOperator>;
+      displayName: string;
+      jsType: TJavaScriptType;
+    },
+  ];
+};
+
+type AnyAggregation<TDimension = unknown> =
+  | CountAggregation
+  | CountAggregationSchema
+  | FieldAggregation<FieldAggregationOperator, TDimension>
+  | FieldAggregationSchema<FieldAggregationOperator, TDimension>;
 
 type TableId<TTable> = TTable extends { id: infer TId extends number }
   ? TId
@@ -382,10 +463,9 @@ export type TableQuery<TTable> = TableReference<TTable> & {
   aggregations?: TTable extends TableSchema
     ? readonly (
         | MeasureReference<TableId<TTable>>
-        | CountAggregation
-        | CountAggregationSchema
+        | AnyAggregation<FieldValues<TTable>>
       )[]
-    : readonly (MeasureReference | CountAggregation | CountAggregationSchema)[];
+    : readonly (MeasureReference | AnyAggregation)[];
   measures?: TTable extends TableSchema
     ? readonly MeasureReference<TableId<TTable>>[]
     : readonly MeasureReference[];
@@ -479,7 +559,11 @@ type QueryAggregationColumns<TQuery> = TQuery extends {
       ? TupleElement<NonNullable<TColumns>>
       : TAggregation extends CountAggregation
         ? CountAggregationColumn
-        : never
+        : TAggregation extends FieldAggregationSchema
+          ? TupleElement<NonNullable<TAggregation["columns"]>>
+          : TAggregation extends FieldAggregation<infer TOperator>
+            ? FieldAggregationSchema<TOperator>["columns"][number]
+            : never
     : never
   : never;
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -20,7 +20,10 @@ import {
   isUnaryOperator,
 } from "./guards";
 import { mapDatasetQueryData } from "./map-dataset-query-data";
-import { buildMetricDefinition } from "./metric-query-builder";
+import {
+  buildMetricDatasetQuery,
+  buildMetricDefinition,
+} from "./metric-query-builder";
 import { stableStringifyQuery } from "./stable-query-key";
 import { buildTableDatasetQuery } from "./table-query-builder";
 import type {
@@ -32,6 +35,7 @@ import type {
   FilterOperator,
   MetabaseDimensionFilterForOperator,
   MetabaseQueryOptions,
+  MetricQuery,
   MetricReference,
   NumericAggregationDimension,
   OrderableAggregationDimension,
@@ -339,7 +343,7 @@ export const useMetabaseQuery = useMetabaseQueryImpl as UseMetabaseQuery;
 
 /** @internal */
 export function useMetabaseQueryObject(
-  query: TableQuery<unknown>,
+  query: TableQuery<unknown> | MetricQuery<unknown>,
 ): StructuredDatasetQuery {
   const queryKey = useMemo(() => stableStringifyQuery(query), [query]);
   const queryRef = useRef(query);
@@ -352,13 +356,17 @@ export function useMetabaseQueryObject(
 
 /** @internal */
 export function createMetabaseQuery(
-  query: TableQuery<unknown>,
+  query: TableQuery<unknown> | MetricQuery<unknown>,
 ): StructuredDatasetQuery {
+  if (isMetricQuery(query)) {
+    return buildMetricDatasetQuery(query);
+  }
+
   const databaseId = getTableDatabaseId(query);
 
   if (databaseId == null) {
     throw new Error(
-      "Query creation requires a generated table schema or databaseId.",
+      "Query creation requires a generated table schema, generated metric schema, or databaseId.",
     );
   }
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -5,7 +5,11 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 import type { StructuredDatasetQuery } from "metabase-types/api";
 
-import type { QuestionSchema, TableSchema } from "../data-schema";
+import type {
+  QuestionSchema,
+  SchemaJavaScriptType,
+  TableSchema,
+} from "../data-schema";
 import { mapQueryData } from "../data-schema";
 
 import {
@@ -23,10 +27,14 @@ import type {
   BetweenFilterOperatorForDimension,
   BreakoutOptionsArgument,
   CountAggregationSchema,
+  FieldAggregationOperator,
+  FieldAggregationSchema,
   FilterOperator,
   MetabaseDimensionFilterForOperator,
   MetabaseQueryOptions,
   MetricReference,
+  NumericAggregationDimension,
+  OrderableAggregationDimension,
   TableQuery,
   UnaryFilterOperatorForDimension,
   UseMetabaseQuery,
@@ -36,6 +44,9 @@ import type {
 export type {
   CountAggregation,
   CountAggregationSchema,
+  FieldAggregation,
+  FieldAggregationOperator,
+  FieldAggregationSchema,
   MetabaseBreakout,
   MetabaseDimensionFilter,
   MetabaseMetricBreakout,
@@ -50,6 +61,105 @@ export function count(): CountAggregationSchema {
     type: "count",
     columns: [{ name: "count", displayName: "Count", jsType: "number" }],
   };
+}
+
+/** @internal */
+export function sum<TDimension>(
+  dimension: NumericAggregationDimension<TDimension>,
+): FieldAggregationSchema<"sum", NumericAggregationDimension<TDimension>> {
+  return fieldAggregation("sum", "Sum", dimension);
+}
+
+/** @internal */
+export function avg<TDimension>(
+  dimension: NumericAggregationDimension<TDimension>,
+): FieldAggregationSchema<"avg", NumericAggregationDimension<TDimension>> {
+  return fieldAggregation("avg", "Average", dimension);
+}
+
+/** @internal */
+export function median<TDimension>(
+  dimension: NumericAggregationDimension<TDimension>,
+): FieldAggregationSchema<"median", NumericAggregationDimension<TDimension>> {
+  return fieldAggregation("median", "Median", dimension);
+}
+
+/** @internal */
+export function distinct<TDimension>(
+  dimension: TDimension,
+): FieldAggregationSchema<"distinct", TDimension> {
+  return fieldAggregation("distinct", "Distinct values", dimension);
+}
+
+/** @internal */
+export function min<TDimension>(
+  dimension: OrderableAggregationDimension<TDimension>,
+): FieldAggregationSchema<"min", OrderableAggregationDimension<TDimension>> {
+  return fieldAggregation("min", "Minimum", dimension);
+}
+
+/** @internal */
+export function max<TDimension>(
+  dimension: OrderableAggregationDimension<TDimension>,
+): FieldAggregationSchema<"max", OrderableAggregationDimension<TDimension>> {
+  return fieldAggregation("max", "Maximum", dimension);
+}
+
+function fieldAggregation<
+  TOperator extends FieldAggregationOperator,
+  TDimension,
+>(
+  type: TOperator,
+  displayName: string,
+  dimension: TDimension,
+): FieldAggregationSchema<TOperator, TDimension> {
+  return {
+    type,
+    dimension,
+    columns: [
+      {
+        name: getFieldAggregationColumnName(type),
+        displayName,
+        jsType: getFieldAggregationColumnJavaScriptType(type, dimension),
+      },
+    ],
+  } as unknown as FieldAggregationSchema<TOperator, TDimension>;
+}
+
+function getFieldAggregationColumnName(type: FieldAggregationOperator): string {
+  return type === "distinct" ? "count" : type;
+}
+
+function getFieldAggregationColumnJavaScriptType(
+  type: FieldAggregationOperator,
+  dimension: unknown,
+): SchemaJavaScriptType {
+  if (type !== "min" && type !== "max") {
+    return "number";
+  }
+
+  if (dimension == null || typeof dimension !== "object") {
+    return "number";
+  }
+
+  const jsType = (dimension as { jsType?: unknown }).jsType;
+
+  if (isOrderableJavaScriptType(jsType)) {
+    return jsType;
+  }
+
+  return "number";
+}
+
+function isOrderableJavaScriptType(
+  value: unknown,
+): value is Exclude<SchemaJavaScriptType, "unknown"> {
+  return (
+    value === "string" ||
+    value === "number" ||
+    value === "boolean" ||
+    value === "Date"
+  );
 }
 
 /** @internal */

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -22,6 +22,7 @@ import { buildTableDatasetQuery } from "./table-query-builder";
 import type {
   BetweenFilterOperatorForDimension,
   BreakoutOptionsArgument,
+  CountAggregationSchema,
   FilterOperator,
   MetabaseDimensionFilterForOperator,
   MetabaseQueryOptions,
@@ -33,6 +34,8 @@ import type {
   ValueFilterOperatorForDimension,
 } from "./types";
 export type {
+  CountAggregation,
+  CountAggregationSchema,
   MetabaseBreakout,
   MetabaseDimensionFilter,
   MetabaseMetricBreakout,
@@ -40,6 +43,14 @@ export type {
   MetabaseQueryOptions,
   UseMetabaseQueryResult,
 } from "./types";
+
+/** @internal */
+export function count(): CountAggregationSchema {
+  return {
+    type: "count",
+    columns: [{ name: "count", displayName: "Count", jsType: "number" }],
+  };
+}
 
 /** @internal */
 export function filter<

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
@@ -9,6 +9,7 @@ import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
 import type { MetabaseQueryOptions } from "./use-metabase-query";
 import {
   breakout,
+  count,
   createMetabaseQuery,
   filter,
   useMetabaseQuery,
@@ -399,6 +400,7 @@ describe("useMetabaseQuery", () => {
       query: {
         "source-table": 1,
         filter: ["=", ["field", 101, {}], "paid"],
+        aggregation: [["count"]],
         breakout: [["field", 103, {}]],
       },
       parameters: [],
@@ -422,6 +424,39 @@ describe("useMetabaseQuery", () => {
       expect(
         JSON.parse(screen.getByTestId("query-object").textContent ?? ""),
       ).toEqual(expectedOrdersQuery);
+    });
+
+    it("builds explicit count aggregations", () => {
+      expect(
+        createMetabaseQuery({
+          table: TEST_SCHEMA.tables.orders,
+          aggregations: [count()],
+          breakouts: [breakout(TEST_SCHEMA.tables.orders.fields.status)],
+        }),
+      ).toEqual({
+        type: "query",
+        database: 1,
+        query: {
+          "source-table": 1,
+          aggregation: [["count"]],
+          breakout: [["field", 101, {}]],
+        },
+        parameters: [],
+      });
+    });
+
+    it("supports count aggregation object literals", () => {
+      expect(
+        createMetabaseQuery({
+          table: TEST_SCHEMA.tables.orders,
+          aggregations: [{ type: "count" }],
+          breakouts: [breakout(TEST_SCHEMA.tables.orders.fields.status)],
+        }),
+      ).toMatchObject({
+        query: {
+          aggregation: [["count"]],
+        },
+      });
     });
   });
 
@@ -479,6 +514,7 @@ describe("useMetabaseQuery", () => {
           query: {
             "source-table": 1,
             filter: ["=", ["field", 101, {}], "paid"],
+            aggregation: [["count"]],
             breakout: [["field", 101, {}]],
           },
           parameters: [],

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
@@ -8,13 +8,25 @@ import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
 
 import type { MetabaseQueryOptions } from "./use-metabase-query";
 import {
+  avg,
   breakout,
   count,
   createMetabaseQuery,
+  distinct,
   filter,
+  max,
+  median,
+  min,
+  sum,
   useMetabaseQuery,
   useMetabaseQueryObject,
 } from "./use-metabase-query";
+
+type Equals<TLeft, TRight> =
+  (<T>() => T extends TLeft ? 1 : 2) extends <T>() => T extends TRight ? 1 : 2
+    ? true
+    : false;
+type Expect<TValue extends true> = TValue;
 
 const TEST_SCHEMA = {
   tables: {
@@ -238,6 +250,29 @@ const _invalidTableCustomFilterQuery = {
   ],
 } satisfies MetabaseQueryOptions<OrdersTable>;
 
+const _validTableAggregationQuery = {
+  tableId: TEST_SCHEMA.tables.orders.id,
+  aggregations: [
+    sum(TEST_SCHEMA.tables.orders.fields.amount),
+    avg(TEST_SCHEMA.tables.orders.fields.amount),
+    median(TEST_SCHEMA.tables.orders.fields.amount),
+    min(TEST_SCHEMA.tables.orders.fields.status),
+    max(TEST_SCHEMA.tables.orders.fields.createdAt),
+  ],
+} satisfies MetabaseQueryOptions<OrdersTable>;
+
+const _invalidTableAggregationQuery = {
+  tableId: TEST_SCHEMA.tables.orders.id,
+  aggregations: [
+    // @ts-expect-error sum only supports numeric dimensions
+    sum(TEST_SCHEMA.tables.orders.fields.status),
+    // @ts-expect-error avg only supports numeric dimensions
+    avg(TEST_SCHEMA.tables.orders.fields.createdAt),
+    // @ts-expect-error median only supports numeric dimensions
+    median(TEST_SCHEMA.tables.orders.fields.status),
+  ],
+} satisfies MetabaseQueryOptions<OrdersTable>;
+
 const _validMetricScopedQuery = {
   metric: TEST_SCHEMA.metrics.orderCount,
   filters: [TEST_SCHEMA.tables.orders.segments.completed],
@@ -372,6 +407,27 @@ function useMetricFilterOperatorTypeFixtures() {
 
 void useMetricFilterOperatorTypeFixtures;
 
+function useAggregationResultTypeFixtures() {
+  const _result = useMetabaseQuery({
+    table: TEST_SCHEMA.tables.orders,
+    aggregations: [
+      min(TEST_SCHEMA.tables.orders.fields.status),
+      max(TEST_SCHEMA.tables.orders.fields.createdAt),
+      distinct(TEST_SCHEMA.tables.orders.fields.status),
+    ],
+  });
+
+  type Row = NonNullable<typeof _result.data>["rows"][number];
+  type _ExpectMinResult = Expect<Equals<Row["min"], string | null>>;
+  type _ExpectMaxResult = Expect<Equals<Row["max"], string | Date | null>>;
+  type _ExpectDistinctResult = Expect<Equals<Row["count"], number | null>>;
+  type _ExpectDistinctNameFallsBackToUnknown = Expect<
+    Equals<Row["distinct"], unknown>
+  >;
+}
+
+void useAggregationResultTypeFixtures;
+
 const _invalidMetricSegmentQuery = {
   metric: TEST_SCHEMA.metrics.orderCount,
   // @ts-expect-error segments must belong to the metric's mapped tables
@@ -455,6 +511,44 @@ describe("useMetabaseQuery", () => {
       ).toMatchObject({
         query: {
           aggregation: [["count"]],
+        },
+      });
+    });
+
+    it("builds field aggregation helpers", () => {
+      expect(
+        createMetabaseQuery({
+          table: TEST_SCHEMA.tables.orders,
+          aggregations: [
+            sum(TEST_SCHEMA.tables.orders.fields.amount),
+            avg(TEST_SCHEMA.tables.orders.fields.amount),
+            distinct(TEST_SCHEMA.tables.orders.fields.status),
+          ],
+          breakouts: [breakout(TEST_SCHEMA.tables.orders.fields.status)],
+        }),
+      ).toMatchObject({
+        query: {
+          aggregation: [
+            ["sum", ["field", 102, {}]],
+            ["avg", ["field", 102, {}]],
+            ["distinct", ["field", 101, {}]],
+          ],
+          breakout: [["field", 101, {}]],
+        },
+      });
+    });
+
+    it("supports field aggregation object literals", () => {
+      expect(
+        createMetabaseQuery({
+          table: TEST_SCHEMA.tables.orders,
+          aggregations: [
+            { type: "max", dimension: TEST_SCHEMA.tables.orders.fields.amount },
+          ],
+        }),
+      ).toMatchObject({
+        query: {
+          aggregation: [["max", ["field", 102, {}]]],
         },
       });
     });

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
@@ -96,10 +96,13 @@ const TEST_SCHEMA = {
   metrics: {
     orderCount: {
       id: 34,
+      databaseId: 1,
+      sourceTableId: 1,
       columns: [{ name: "count", displayName: "Count", jsType: "number" }],
       dimensions: {
         createdAt: {
           id: "metric-created-at",
+          fieldId: 103,
           metricId: 34,
           tableId: 1,
           name: "created_at",
@@ -108,6 +111,7 @@ const TEST_SCHEMA = {
         },
         status: {
           id: "metric-status",
+          fieldId: 101,
           metricId: 34,
           tableId: 1,
           name: "status",
@@ -116,6 +120,7 @@ const TEST_SCHEMA = {
         },
         amount: {
           id: "metric-amount",
+          fieldId: 102,
           metricId: 34,
           tableId: 1,
           name: "amount",
@@ -127,10 +132,13 @@ const TEST_SCHEMA = {
     },
     orderValue: {
       id: 35,
+      databaseId: 1,
+      sourceTableId: 1,
       columns: [{ name: "sum", displayName: "Sum", jsType: "number" }],
       dimensions: {
         amount: {
           id: "metric-order-value-amount",
+          fieldId: 102,
           metricId: 35,
           tableId: 1,
           name: "amount",
@@ -552,6 +560,53 @@ describe("useMetabaseQuery", () => {
         },
       });
     });
+
+    it("builds a complete dataset query from a generated metric schema", () => {
+      expect(
+        createMetabaseQuery({
+          metric: TEST_SCHEMA.metrics.orderCount,
+          filters: [
+            filter(TEST_SCHEMA.tables.orders.fields.status, "=", "paid"),
+          ],
+          measures: [TEST_SCHEMA.tables.orders.measures.revenue],
+          breakouts: [
+            breakout(TEST_SCHEMA.metrics.orderCount.dimensions.createdAt, {
+              bucket: "month",
+            }),
+          ],
+        }),
+      ).toEqual({
+        type: "query",
+        database: 1,
+        query: {
+          "source-table": 1,
+          aggregation: [
+            ["metric", 34],
+            ["measure", {}, 21],
+          ],
+          filter: ["=", ["field", 101, {}], "paid"],
+          breakout: [["field", 103, { "temporal-unit": "month" }]],
+        },
+        parameters: [],
+      });
+    });
+
+    it("memoizes a complete dataset query from a generated metric schema", () => {
+      render(<MetricQueryObjectComponent />);
+
+      expect(
+        JSON.parse(screen.getByTestId("query-object").textContent ?? ""),
+      ).toEqual({
+        type: "query",
+        database: 1,
+        query: {
+          "source-table": 1,
+          aggregation: [["metric", 34]],
+          breakout: [["field", 101, {}]],
+        },
+        parameters: [],
+      });
+    });
   });
 
   it("raises a runtime error when metric segments are not from mapped tables", async () => {
@@ -776,6 +831,15 @@ const MetabaseQueryObjectComponent = () => {
     table: TEST_SCHEMA.tables.orders,
     filters: [filter(TEST_SCHEMA.tables.orders.fields.status, "=", "paid")],
     breakouts: [breakout(TEST_SCHEMA.tables.orders.fields.createdAt)],
+  });
+
+  return <div data-testid="query-object">{JSON.stringify(query)}</div>;
+};
+
+const MetricQueryObjectComponent = () => {
+  const query = useMetabaseQueryObject({
+    metric: TEST_SCHEMA.metrics.orderCount,
+    breakouts: [breakout(TEST_SCHEMA.tables.orders.fields.status)],
   });
 
   return <div data-testid="query-object">{JSON.stringify(query)}</div>;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/validation.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/validation.ts
@@ -1,6 +1,7 @@
 import {
   getMetricMappedTableIds,
   isCountAggregation,
+  isFieldAggregation,
   isMeasureSchema,
   isSegmentSchema,
   isTableDimensionFilter,
@@ -69,6 +70,18 @@ export function validateTableScopedInputs({
         context: `${context} measures`,
       });
     }
+
+    if (
+      isFieldAggregation(measure) &&
+      isTableFieldSchema(measure.dimension) &&
+      typeof measure.dimension.tableId === "number"
+    ) {
+      validateGeneratedTableId({
+        tableId: measure.dimension.tableId,
+        allowedTableIds,
+        context: `${context} aggregations`,
+      });
+    }
   });
 
   breakouts?.forEach((breakout) => {
@@ -108,7 +121,11 @@ function validateGeneratedMeasure({
   measure: unknown;
   context: string;
 }) {
-  if (isMeasureSchema(measure) || isCountAggregation(measure)) {
+  if (
+    isMeasureSchema(measure) ||
+    isCountAggregation(measure) ||
+    isFieldAggregation(measure)
+  ) {
     return;
   }
 

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/validation.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/validation.ts
@@ -1,5 +1,6 @@
 import {
   getMetricMappedTableIds,
+  isCountAggregation,
   isMeasureSchema,
   isSegmentSchema,
   isTableDimensionFilter,
@@ -107,7 +108,7 @@ function validateGeneratedMeasure({
   measure: unknown;
   context: string;
 }) {
-  if (isMeasureSchema(measure)) {
+  if (isMeasureSchema(measure) || isCountAggregation(measure)) {
     return;
   }
 

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -34,6 +34,7 @@ export { useMetricQuery } from "./hooks/public/use-metric-query";
 /** @internal */
 export {
   breakout,
+  count,
   createMetabaseQuery,
   filter,
   useMetabaseQuery,

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -33,10 +33,16 @@ export { useQuestionQuery } from "./hooks/public/use-question-query";
 export { useMetricQuery } from "./hooks/public/use-metric-query";
 /** @internal */
 export {
+  avg,
   breakout,
   count,
   createMetabaseQuery,
+  distinct,
   filter,
+  max,
+  median,
+  min,
+  sum,
   useMetabaseQuery,
   useMetabaseQueryObject,
 } from "./hooks/public/use-metabase-query";

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -19,6 +19,7 @@ import { useAction } from "embedding-sdk-package/hooks/public/use-action";
 // eslint-disable-next-line no-restricted-imports
 import {
   breakout,
+  count,
   createMetabaseQuery,
   filter,
   useMetabaseQuery,
@@ -82,6 +83,7 @@ export function createDataAppSandbox(
           useAction,
           // Query helpers
           breakout,
+          count,
           createMetabaseQuery,
           filter,
           useMetabaseQueryObject,

--- a/frontend/src/metabase/data_apps/sandbox.ts
+++ b/frontend/src/metabase/data_apps/sandbox.ts
@@ -18,10 +18,16 @@ import {
 import { useAction } from "embedding-sdk-package/hooks/public/use-action";
 // eslint-disable-next-line no-restricted-imports
 import {
+  avg,
   breakout,
   count,
   createMetabaseQuery,
+  distinct,
   filter,
+  max,
+  median,
+  min,
+  sum,
   useMetabaseQuery,
   useMetabaseQueryObject,
 } from "embedding-sdk-package/hooks/public/use-metabase-query";
@@ -82,10 +88,16 @@ export function createDataAppSandbox(
           // Custom actions
           useAction,
           // Query helpers
+          avg,
           breakout,
           count,
           createMetabaseQuery,
+          distinct,
           filter,
+          max,
+          median,
+          min,
+          sum,
           useMetabaseQueryObject,
           // Configuration helpers
           defineMetabaseAuthConfig,

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -46,9 +46,9 @@
                       :comment [:key :entityId :description]}
    :measure          {:runtime [:kind :id :tableId :name :columns]
                       :comment [:key :entityId :description]}
-   :metric           {:runtime [:kind :id :name :mappedTableIds :columns :dimensions]
+   :metric           {:runtime [:kind :id :name :databaseId :sourceTableId :mappedTableIds :columns :dimensions]
                       :comment [:key :entityId :description :verified :sourceTable]}
-   :metric-dimension {:runtime [:id :metricId :tableId :name :jsType :defaultTemporalBucket]
+   :metric-dimension {:runtime [:id :fieldId :metricId :tableId :name :jsType :defaultTemporalBucket]
                       :comment [:key :displayName :description :baseType :effectiveType :semanticType :unit]}
    :column           {:runtime [:name :jsType]
                       :comment [:displayName :description :baseType :effectiveType :semanticType :unit]}})
@@ -527,6 +527,7 @@
       (assoc (column-schema column)
              :key (generated-key (:name column) dimension-id)
              :id (str dimension-id))
+      :fieldId (when (integer? field-id) field-id)
       :tableId (when (integer? table-id) table-id)
       :metricId metric-id
       :keyDisambiguator (when (integer? table-id)
@@ -564,6 +565,13 @@
     {:databaseName database-name
      :schemaName   schema-name
      :tableName    table-name}))
+
+(defn- source-table-id
+  [card]
+  (let [source-table (or (get-in card [:dataset_query :query :source-table])
+                         (get-in card [:dataset_query :stages 0 :source-table]))]
+    (when (integer? source-table)
+      source-table)))
 
 (defn- fallback-metric-column
   [{:keys [name]}]
@@ -613,6 +621,8 @@
       :id         id
       :name       name
       :columns    [result-column]}
+     :databaseId (:database_id card)
+     :sourceTableId (source-table-id card)
      :entityId portable_entity_id
      :description description
      :verified (when verified true)

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -27,6 +27,7 @@
           :jsType        "string"
           :key           "category"
           :id            "550e8400-e29b-41d4-a716-446655440001"
+          :fieldId       3815
           :tableId       12
           :metricId      247}
          (#'typed-schemas.api/dimension-schema
@@ -136,6 +137,7 @@
                                        :jsType      "number"
                                        :key         "orders"
                                        :id          "550e8400-e29b-41d4-a716-446655440001"
+                                       :fieldId     42
                                        :tableId     10
                                        :metricId    247}}}
            (#'typed-schemas.api/metric-schema
@@ -220,6 +222,8 @@
                                           :key            "revenue"
                                           :id             5
                                           :name           "Revenue"
+                                          :databaseId     1
+                                          :sourceTableId  10
                                           :description    "Total order revenue"
                                           :mappedTableIds [10]
                                           :dimensions     {"createdAt" {:name        "created_at"
@@ -228,6 +232,7 @@
                                                                         :jsType      "Date"
                                                                         :key         "createdAt"
                                                                         :id          "dimension-uuid"
+                                                                        :fieldId     3971
                                                                         :tableId     10
                                                                         :metricId    5}}}}})]
     (is (str/includes? body (str "/" "/ Display name: Payment Method")))
@@ -238,7 +243,10 @@
     (is (not (str/includes? body "displayName: \"Payment Method\"")))
     (is (not (str/includes? body "baseType: \"type/Text\"")))
     (is (str/includes? body (str "/" "/ Description: Total order revenue")))
+    (is (str/includes? body "databaseId: 1"))
+    (is (str/includes? body "sourceTableId: 10"))
     (is (str/includes? body "createdAt: {\n          id: \"dimension-uuid\""))
+    (is (str/includes? body "fieldId: 3971"))
     (is (str/includes? body "metricId: 5"))))
 
 (deftest json-endpoint-test


### PR DESCRIPTION
Closes EMB-1873

Breakouts right now does not have aggregations like count(), so the visualizations become tables rather than bar or line charts. Let's add it, and ideally default to count() if no explicit aggregations.