### PR TITLE
Respect explicit null collection_id in MCP creation

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -755,6 +755,7 @@
   or a base64-encoded MBQL string. MCP callers should always use the handle.
   Optionally specify display type, description, collection, and visualization settings.
   If `collection_id` is omitted the question is saved to the caller's personal collection.
+  Pass an explicit `null` to save it to the root collection.
   The response `collection_path` is the saved location."
   {:scope metabot/agent-question-create
    :tool  {:name "create_question"
@@ -762,15 +763,21 @@
                              "Pass the `query_handle` returned by `construct_query`. "
                              "Optionally set display type (table, bar, line, pie, etc.), "
                              "description, and target collection. "
-                             "If you omit collection_id it's saved to the user's personal collection. "
+                             "If you omit collection_id it's saved to the user's personal collection; "
+                             "pass an explicit null to save it to the root collection. "
                              "Report the saved location from the response `collection_path`.")}}
   [_route-params
    _query-params
-   {:keys [query display description collection_id visualization_settings]
-    question-name :name}
+   {:keys [query display description visualization_settings]
+    question-name :name
+    :as body}
    :- ::create-question-request]
   (let [dataset-query (-> query u/decode-base64 json/decode+kw)
-        collection_id (or collection_id (personal-collection-id))]
+        ;; `nil` means the root collection, so only default to the personal collection when the
+        ;; key is absent. `(or ...)` would silently turn an explicit `null` into personal.
+        collection_id (if (contains? body :collection_id)
+                        (:collection_id body)
+                        (personal-collection-id))]
     ;; Mirror REST `POST /api/card/` pre-checks before calling `queries/create-card!`.
     ;; `create-card!` itself does NOT run permissions checks; without these mirroring the
     ;; REST endpoint, an LLM caller could (a) save a card whose query references data the
@@ -939,21 +946,28 @@
   Pass `question_ids` to add existing saved questions as cards on the dashboard.
   Cards are automatically positioned on the grid based on their display type.
   If `collection_id` is omitted the dashboard is saved to the caller's personal collection.
+  Pass an explicit `null` to save it to the root collection.
   The response `collection_path` is the saved location."
   {:scope metabot/agent-dashboard-create
    :tool  {:name "create_dashboard"
            :description (str "Create a dashboard in Metabase. "
                              "Optionally pass question_ids to add saved questions as cards. "
                              "Cards are auto-positioned on the dashboard grid. "
-                             "If you omit collection_id it's saved to the user's personal collection. "
+                             "If you omit collection_id it's saved to the user's personal collection; "
+                             "pass an explicit null to save it to the root collection. "
                              "Report the saved location from the response `collection_path`. "
                              "Returns the dashboard URL.")}}
   [_route-params
    _query-params
-   {:keys [description collection_id question_ids]
-    dashboard-name :name}
+   {:keys [description question_ids]
+    dashboard-name :name
+    :as body}
    :- ::create-dashboard-request]
-  (let [collection_id (or collection_id (personal-collection-id))]
+  ;; `nil` means the root collection, so only default to the personal collection when the
+  ;; key is absent. `(or ...)` would silently turn an explicit `null` into personal.
+  (let [collection_id (if (contains? body :collection_id)
+                        (:collection_id body)
+                        (personal-collection-id))]
     (api/create-check :model/Dashboard {:collection_id collection_id})
     (let [cards (when (seq question_ids)
                   (mapv #(api/read-check :model/Card %) question_ids))

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -548,17 +548,6 @@
               create-resp))
       (is (t2/exists? :model/Card :id (:id create-resp)))
       (t2/delete! :model/Card :id (:id create-resp))))
-  (testing "An explicit null collection_id saves to the root collection, not the personal default"
-    (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v2/construct-query"
-                                               {:query (orders-query :limit 10)})
-          create-resp    (mt/user-http-request :rasta :post 200 "agent/v1/question"
-                                               {:name          "Agent Root Question"
-                                                :query         (:query construct-resp)
-                                                :collection_id nil})]
-      (is (=? {:collection_id   nil
-               :collection_path "Our analytics"}
-              create-resp))
-      (t2/delete! :model/Card :id (:id create-resp))))
   (testing "Creates a question with optional fields"
     (mt/with-temp [:model/Collection {coll-id :id} {:name "Agent Question Collection"}]
       (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v2/construct-query"
@@ -601,6 +590,19 @@
                                 {:name          "Should Not Save"
                                  :query         (:query construct-resp)
                                  :collection_id locked-id}))))))
+
+(deftest create-question-explicit-null-collection-test
+  (testing "An explicit null collection_id saves to the root collection, not the personal default"
+    (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v2/construct-query"
+                                               {:query (orders-query :limit 10)})
+          create-resp    (mt/user-http-request :rasta :post 200 "agent/v1/question"
+                                               {:name          "Agent Root Question"
+                                                :query         (:query construct-resp)
+                                                :collection_id nil})]
+      (is (=? {:collection_id   nil
+               :collection_path "Our analytics"}
+              create-resp))
+      (t2/delete! :model/Card :id (:id create-resp)))))
 
 (deftest create-question-collection-path-test
   (testing "collection_path is the full breadcrumb, mirroring the app's location"
@@ -660,14 +662,6 @@
                :dashcard_ids    []}
               resp))
       (t2/delete! :model/Dashboard :id (:id resp))))
-  (testing "An explicit null collection_id saves to the root collection, not the personal default"
-    (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
-                                     {:name          "Agent Root Dashboard"
-                                      :collection_id nil})]
-      (is (=? {:collection_id   nil
-               :collection_path "Our analytics"}
-              resp))
-      (t2/delete! :model/Dashboard :id (:id resp))))
   (testing "Creates a dashboard with questions"
     (mt/with-temp [:model/Card {card1-id :id} {:name          "DashQ1"
                                                :dataset_query (orders-count-query)
@@ -704,6 +698,16 @@
     (mt/user-http-request :rasta :post 404 "agent/v1/dashboard"
                           {:name         "Bad Dashboard"
                            :question_ids [999999]})))
+
+(deftest create-dashboard-explicit-null-collection-test
+  (testing "An explicit null collection_id saves to the root collection, not the personal default"
+    (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
+                                     {:name          "Agent Root Dashboard"
+                                      :collection_id nil})]
+      (is (=? {:collection_id   nil
+               :collection_path "Our analytics"}
+              resp))
+      (t2/delete! :model/Dashboard :id (:id resp)))))
 
 (deftest create-entity-url-test
   (testing "create question/dashboard return a frontend URL"

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -548,6 +548,17 @@
               create-resp))
       (is (t2/exists? :model/Card :id (:id create-resp)))
       (t2/delete! :model/Card :id (:id create-resp))))
+  (testing "An explicit null collection_id saves to the root collection, not the personal default"
+    (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v2/construct-query"
+                                               {:query (orders-query :limit 10)})
+          create-resp    (mt/user-http-request :rasta :post 200 "agent/v1/question"
+                                               {:name          "Agent Root Question"
+                                                :query         (:query construct-resp)
+                                                :collection_id nil})]
+      (is (=? {:collection_id   nil
+               :collection_path "Our analytics"}
+              create-resp))
+      (t2/delete! :model/Card :id (:id create-resp))))
   (testing "Creates a question with optional fields"
     (mt/with-temp [:model/Collection {coll-id :id} {:name "Agent Question Collection"}]
       (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v2/construct-query"
@@ -647,6 +658,14 @@
                :collection_path personal-name
                :description     nil
                :dashcard_ids    []}
+              resp))
+      (t2/delete! :model/Dashboard :id (:id resp))))
+  (testing "An explicit null collection_id saves to the root collection, not the personal default"
+    (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
+                                     {:name          "Agent Root Dashboard"
+                                      :collection_id nil})]
+      (is (=? {:collection_id   nil
+               :collection_path "Our analytics"}
               resp))
       (t2/delete! :model/Dashboard :id (:id resp))))
   (testing "Creates a dashboard with questions"


### PR DESCRIPTION
## What this fixes

The Agent API's `create_question` and `create_dashboard` endpoints save to the caller's personal collection when no `collection_id` is given. That default was too eager: it also kicked in when the caller *explicitly* sent `"collection_id": null`, which in Metabase means "put it in the root collection"[^1]. So there was no way to deliberately create a question or dashboard in root through these endpoints — the request would succeed, but the item quietly landed in the personal collection instead.

## What changed

The personal-collection default now applies only when the request body doesn't mention `collection_id` at all:

- **Key omitted** → personal collection (unchanged)
- **Explicit `null`** → root collection (fixed — previously personal)
- **Explicit id** → that collection (unchanged)

This matches how the `update_question` and `update_dashboard` endpoints in the same file already distinguish "absent" from "null"[^2]. Endpoint docstrings and MCP tool descriptions now spell out both behaviors, and both endpoints have explicit-null regression tests.

Found by roborev review 2060 on #75491.

[^1]: A `nil`/`null` `collection_id` is the root collection ("Our analytics") throughout the Metabase API, so JSON `null` and a missing key mean different things here. `(or collection_id ...)` can't tell them apart, which is exactly how the bug happened.

[^2]: The update endpoints use `(contains? body :collection_id)` to detect whether the key was sent; the create endpoints now do the same. Permission checks are unaffected — creating in root still goes through `api/create-check`, which requires root-collection write access, same as the REST `POST /api/card` path.
