### PR TITLE
Use *driver* to test h2/postgres with and without mbql5

### DIFF
--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.driver.h2-test
+(ns ^:mb/driver-tests metabase.driver.h2-test
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.h2-test]}}}}}}
   (:require
    [clojure.java.jdbc :as jdbc]
@@ -22,38 +22,18 @@
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
-   [metabase.test.data.datasets :as mtd]
-   [metabase.test.data.env :as tx.env]
-   [metabase.test.data.interface :as tx]
    [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
-;; temporary hack to run all tests against both the old :h2 and new mbql5 :h2
-;; remove this once :h2 does mbql5 by default!
-(defn- test-driver [driver thunk]
-  (when (contains? (tx.env/test-drivers) driver)
-    (testing (str "\n" driver "\n")
-      (driver/with-driver (tx/the-driver-with-test-extensions driver)
-        (thunk))
-      ;; the above is the original definition of test-driver, but we add in
-      ;; this clause to avoid having to rewrite all the tests below twice:
-      (when (= driver :h2)
-        (driver/with-driver (tx/the-driver-with-test-extensions :h2-mbql5)
-          (thunk))))))
+;; drop this once h2 is mbql5-compliant by default
+(def ^:dynamic *driver* :h2)
 
-(use-fixtures :each (fn [f]
-                      ;; NB: because of test parallelism, this *will* affect other non-h2
-                      ;; tests, but the check above in the test-driver function will
-                      ;; prevent it from actually doing anything different in those tests.
-                      ;; The kondo ignore is the exemption: this `with-redefs` is
-                      ;; parallel-safe by construction (the redef target is a no-op
-                      ;; identity for h2, and the inner conditional in `test-driver`
-                      ;; prevents it from affecting non-h2 tests).
-                      #_{:clj-kondo/ignore [:metabase/validate-deftest]}
-                      (with-redefs [mtd/-test-driver test-driver]
-                        (f))))
+(use-fixtures :each (fn [thunk]
+                      (thunk)
+                      (binding [*driver* :h2-mbql5]
+                        (thunk))))
 
 (deftest ^:parallel parse-connection-string-test
   (testing "Check that the functions for exploding a connection string's options work as expected"
@@ -134,7 +114,7 @@
           (is (= {:invalid-keys #{"classname"}} (ex-data result))))))))
 
 (deftest ^:parallel db-default-timezone-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (is (= (t/zone-id "Z")
            (-> (driver/db-default-timezone :h2 (mt/db))
                t/zone-id
@@ -178,7 +158,7 @@
            (sql.qp/add-interval-honeysql-form :h2 (sql.qp/current-datetime-honeysql-form :h2) 100.0 :second)))))
 
 (deftest ^:parallel clob-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (testing "Make sure we properly handle rows that come back as `org.h2.jdbc.JdbcClob`"
       (let [results (qp/process-query (mt/native-query {:query "SELECT cast('Conchúr Tihomir' AS clob) AS name;"}))]
         (testing "rows"
@@ -194,7 +174,7 @@
                   (mt/cols results))))))))
 
 (deftest ^:parallel native-query-date-trunc-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (testing "A native query that doesn't return a column class name metadata should work correctly (#12150)"
       (is (=? [{:display_name "D"
                 :base_type    :type/Date
@@ -233,7 +213,7 @@
       (str/replace #"PUBLIC\." "")))
 
 (deftest ^:parallel do-not-cast-to-date-if-column-is-already-a-date-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (testing "Don't wrap Field in date() if it's already a DATE (#11502)"
       (mt/dataset attempted-murders
         (let [query (mt/mbql-query attempts
@@ -246,7 +226,7 @@
                  (some-> (qp.compile/compile query) :query pretty-sql))))))))
 
 (deftest ^:parallel do-not-cast-to-date-binned-by-week-to-datetime
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (testing "Don't cast date binned by week"
       (mt/dataset attempted-murders
         (let [query (mt/mbql-query attempts
@@ -256,7 +236,7 @@
           (is (not (re-find #"CAST\([^)]+\s+AS\s+datetime\)" compiled))))))))
 
 (deftest ^:parallel check-action-commands-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     #_{:clj-kondo/ignore [:equals-true]}
     (are [query] (= true (#'h2/every-command-allowed-for-actions? (#'h2/classify-query (mt/id) query)))
       "select 1"
@@ -383,7 +363,7 @@
       "CALL LINK_SCHEMA('LK','org.h2.Driver','jdbc:h2:mem:t','sa','','PUBLIC')")))
 
 (deftest disallowed-commands-in-action-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (mt/with-actions-test-data-and-actions-enabled
       (testing "Should not be able to execute query actions with disallowed commands"
         (let [sql "select * from categories; update categories set name = 'stomp';
@@ -399,7 +379,7 @@
                                           (format "action/%s/execute" action-id))))))))))
 
 (deftest disallowed-commands-in-action-test-2
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (mt/with-actions-test-data-and-actions-enabled
       (testing "Should be able to execute query actions with allowed commands"
         (let [sql "update categories set name = 'stomp' where id = 1; update categories set name = 'stomp' where id = 2;"]
@@ -413,14 +393,14 @@
                                           (format "action/%s/execute" action-id))))))))))
 
 (deftest ^:parallel syncable-schemas-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (testing "`syncable-schemas` should return schemas that should be synced"
       (mt/with-empty-db
         (is (= #{"PUBLIC"}
                (driver/syncable-schemas driver/*driver* (mt/db))))))))
 
 (deftest syncable-audit-db-test
-  (mt/test-driver :h2
+  (mt/test-driver *driver*
     (when config/ee-available?
       (let [audit-db-expected-id 13371337
             original-audit-db    (t2/select-one :model/Database :is_audit true)]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -52,8 +52,6 @@
    [metabase.sync.sync-metadata.tables :as sync-tables]
    [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
-   [metabase.test.data.datasets :as mtd]
-   [metabase.test.data.env :as tx.env]
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -69,17 +67,8 @@
 
 (set! *warn-on-reflection* true)
 
-;; TODO: once h2-mbql5 is on master, share code with that
-(defn- test-driver [driver thunk]
-  (when (contains? (tx.env/test-drivers) driver)
-    (testing (str "\n" driver "\n")
-      (driver/with-driver (tx/the-driver-with-test-extensions driver)
-        (thunk))
-      ;; the above is the original definition of test-driver, but we add in
-      ;; this clause to avoid having to rewrite all the tests below twice:
-      (when (= driver :postgres)
-        (driver/with-driver (tx/the-driver-with-test-extensions :postgres-mbql5)
-          (thunk))))))
+;; drop this once postgres is mbql5-compliant by default
+(def ^:dynamic *driver* :postgres)
 
 (use-fixtures :each (fn [thunk]
                       ;; 1. If sync fails when loading a test dataset, don't swallow the error; throw an Exception so we
@@ -88,20 +77,8 @@
                       ;; 2. Make sure we're in Honey SQL 2 mode for all the little SQL snippets we're compiling in these
                       ;;    tests.
                       (binding [sync-util/*log-exceptions-and-continue?* false]
-                        ;; NB: because of test parallelism, this *will* affect other non-pg
-                        ;; tests, but the check above in the test-driver function will
-                        ;; prevent it from actually doing anything different in those tests.
-                        ;;
-                        ;; The linter (`:metabase/validate-deftest`) flags `with-redefs` inside a
-                        ;; `use-fixtures` body because it isn't parallel-safe -- the root var is
-                        ;; mutated globally across threads. We accept the hazard here for the
-                        ;; duration of the `:postgres-mbql5` equivalence experiment: this fixture
-                        ;; reruns every `:postgres` test under the `:postgres-mbql5` dispatch so
-                        ;; we can confirm behavioral parity. Once the experiment concludes and
-                        ;; `:postgres-mbql5` becomes `:postgres`, this entire `with-redefs` goes
-                        ;; away (see Phil's note in #ee-querying-platform 2026-05-21).
-                        #_{:clj-kondo/ignore [:metabase/validate-deftest]}
-                        (with-redefs [mtd/-test-driver test-driver]
+                        (mt/with-test-user :rasta (thunk))
+                        (binding [*driver* :postgres-mbql5]
                           (mt/with-test-user :rasta (thunk))))))
 
 (deftest ^:parallel extract-test
@@ -214,7 +191,7 @@
 ;;; ------------------------------------------- Tests for sync edge cases --------------------------------------------
 
 (deftest ^:sequential edge-case-identifiers-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Make sure that Tables / Fields with dots in their names get escaped properly"
       (mt/dataset dots-in-names
         (is (= {:columns ["id" "dotted.name"]
@@ -265,7 +242,7 @@
     [["Cam" 1]]]])
 
 (deftest duplicate-names-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Make sure that duplicate column names (e.g. caused by using a FK) still return both columns"
       (mt/dataset duplicate-names
         (is (= {:columns ["name" "name_2"]
@@ -293,7 +270,7 @@
        (sort-by :name)))
 
 (deftest materialized-views-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing (str "Check that we properly fetch materialized views. As discussed in #2355 they don't come back from "
                   "JDBC `DatabaseMetadata` so we have to fetch them manually.")
       (tx/drop-if-exists-and-create-db! driver/*driver* "materialized_views_test")
@@ -308,7 +285,7 @@
                   (describe-database->tables :postgres database))))))))
 
 (deftest foreign-tables-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Check that we properly fetch foreign tables."
       (tx/drop-if-exists-and-create-db! driver/*driver* "fdw_test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "fdw_test"})]
@@ -342,7 +319,7 @@
                   (describe-database->tables :postgres database))))))))
 
 (deftest estimated-row-count-hides-zero-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Check that tables with n_live_tup = 0 return nil for estimated_row_count to avoid confusion with stale stats"
       (tx/drop-if-exists-and-create-db! driver/*driver* "estimated_count_test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "estimated_count_test"})]
@@ -354,7 +331,7 @@
                   (describe-database->tables :postgres database))))))))
 
 (deftest recreated-views-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing (str "make sure that if a view is dropped and recreated that the original Table object is marked active "
                   "rather than a new one being created (#3331)")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "dropped_views_test"})
@@ -386,7 +363,7 @@
                         (t2/select [:model/Table :name :active] :db_id (u/the-id database), :name "angry_birds"))))))))))
 
 (deftest partitioned-table-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing (str "Make sure that partitioned tables (in addition to the individual partitions themselves) are"
                   " synced properly (#15049)")
       (let [db-name "partitioned_table_test"
@@ -466,7 +443,7 @@
                "rather than on the array path argument:\n  " out-sql)))))
 
 (deftest ^:parallel json-field-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Deal with complicated identifier (#22967)"
       (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
                                         {:database (assoc meta/database :engine driver/*driver*, :id 1)
@@ -516,7 +493,7 @@
                        :database-type "VARCHAR"})]}))
 
 (deftest ^:parallel json-alias-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "json breakouts and order bys have alias coercion"
       (qp.store/with-metadata-provider (json-alias-mock-metadata-provider driver/*driver*)
         ;; need to make this a function to avoid a duplicate `:lib/uuid` error when we use it in `compile-res`
@@ -557,7 +534,7 @@
                  (:params compile-res))))))))
 
 (deftest ^:parallel json-alias-test-2
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "json breakouts and order bys have alias coercion"
       (qp.store/with-metadata-provider (json-alias-mock-metadata-provider driver/*driver*)
         (let [field-ordinary (sql.qp/mbql-clause-with-opts driver/*driver* :field nil 1)
@@ -591,7 +568,7 @@
                                           :breakout     [[:field 1 nil]]}})}]}))
 
 (deftest ^:parallel json-breakout-in-model-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "JSON columns in inner queries are referenced properly in outer queries #34930"
       (qp.store/with-metadata-provider (json-alias-in-model-mock-metadata-provider driver/*driver*)
         (let [nested (maybe-convert-and-compile
@@ -625,7 +602,7 @@
 ;;; `Unterminated string literal started at position N` before the SQL ever reaches the server
 ;;; (#73721).
 (deftest contains-filter-jdbc-parser-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "PGJDBC parses :contains/:starts-with/:ends-with SQL regardless of standard_conforming_strings (#73721)"
       (let [mp       (mt/metadata-provider)
             venues   (lib.metadata/table mp (mt/id :venues))
@@ -655,7 +632,7 @@
                          (str "PGJDBC should prepare the SQL; got SQL: " sql)))))))))))))
 
 (deftest describe-nested-field-columns-identifier-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "sync goes and runs with identifier if there is a schema other than default public one"
       (tx/drop-if-exists-and-create-db! driver/*driver* "describe-json-with-schema-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name  "describe-json-with-schema-test"
@@ -680,7 +657,7 @@
                     {:schema "bobdobbs" :name "describe_json_table" :id (mt/id "describe_json_table")})))))))))
 
 (deftest describe-funky-name-table-nested-field-columns-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "sync goes and still works with funky schema and table names, including caps and special chars (#23026, #23027)"
       (tx/drop-if-exists-and-create-db! driver/*driver* "describe-json-funky-names-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name  "describe-json-funky-names-test"
@@ -714,7 +691,7 @@
      [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]]])
 
 (deftest uuid-columns-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (mt/dataset with-uuid
       (testing "Check that we can load a Postgres Database with a :type/UUID"
         (is (= [{:name "id", :base_type :type/Integer}
@@ -821,7 +798,7 @@
      [[:raw "'10.4.4.15'::inet"]]]]])
 
 (deftest inet-columns-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing (str "Filtering by inet columns should add the appropriate SQL cast, e.g. `cast('192.168.1.1' AS inet)` "
                   "(otherwise this wouldn't work)")
       (mt/dataset ip-addresses
@@ -849,7 +826,7 @@
         (thunk)))))
 
 (deftest ^:parallel money-columns-in-results-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "It should be possible to return money column results (#3754)"
       (sql-jdbc.execute/do-with-connection-with-options
        :postgres
@@ -863,7 +840,7 @@
                     (row-thunk))))))))))
 
 (deftest money-columns-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "We should support the Postgres MONEY type"
       (do-with-money-test-db!
        (fn []
@@ -944,14 +921,14 @@
     (driver/notify-database-updated :postgres database)))
 
 (deftest ^:parallel enums-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "check that values for enum types get wrapped in appropriate CAST() fn calls in `->honeysql`"
       (is (= (h2x/with-database-type-info [:cast "toucan" (h2x/identifier :type-name "bird type")]
                                           "bird type")
              (sql.qp/->honeysql driver/*driver* (sql.qp/mbql-clause-with-opts driver/*driver* :value {:database_type "bird type", :base_type :type/PostgresEnum} "toucan")))))))
 
 (deftest enums-test-2
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (do-with-enums-db!
      (fn [db]
        (testing "check that we can actually fetch the enum types from a DB"
@@ -1031,7 +1008,7 @@
                       (select-keys [:rows :native_form]))))))))))
 
 (deftest enums-test-3
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (do-with-enums-db!
      (fn [db]
        (tx/create-view-of-table! driver/*driver* db "birds_m" "birds" true)
@@ -1110,7 +1087,7 @@
                       (select-keys [:rows :native_form]))))))))))
 
 (deftest enums-actions-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "actions with enums"
       (do-with-enums-db!
        (fn [enums-db]
@@ -1307,7 +1284,7 @@
 ;; this contains special tests case for postgres
 ;; for generic tests, check [[metabase.driver.sql-jdbc.actions-test/action-error-handling-test]]
 (deftest check-constraint-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "violate check constraints"
       (tx/drop-if-exists-and-create-db! driver/*driver* "check-constraint-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "check-constraint-test"})]
@@ -1337,7 +1314,7 @@
 ;; this contains special tests case for postgres
 ;; for generic tests, check [[metabase.driver.sql-jdbc.actions-test/action-error-handling-test]]
 (deftest action-error-handling-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "violate not-null constraints with multiple columns"
       (tx/drop-if-exists-and-create-db! driver/*driver* "not-null-constraint-on-multiple-cols")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "not-null-constraint-on-multiple-cols"})]
@@ -1383,7 +1360,7 @@
 ;;; ------------------------------------------------ Timezone-related ------------------------------------------------
 
 (deftest timezone-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (letfn [(get-timezone-with-report-timezone [report-timezone]
               (mt/with-temporary-setting-values [report-timezone report-timezone]
                 (ffirst
@@ -1403,7 +1380,7 @@
                (get-timezone-with-report-timezone "Crunk Burger")))))))
 
 (deftest fingerprint-time-fields-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Make sure we're able to fingerprint TIME fields (#5911)"
       (tx/drop-if-exists-and-create-db! driver/*driver* "time_field_test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "time_field_test"})]
@@ -1446,7 +1423,7 @@
 ;;; ----------------------------------------------------- Other ------------------------------------------------------
 
 (deftest ^:parallel exception-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing (str "If the DB throws an exception, is it properly returned by the query processor? Is it status "
                   ":failed? (#9942)")
       (is (thrown-with-msg?
@@ -1471,7 +1448,7 @@
 ;;; see [[metabase.query-processor.middleware.annotate-test/native-query-infer-effective-type-test]] for a test that
 ;;; just makes sure metadata is calculated correctly.
 (deftest ^:parallel pgobject-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Make sure PGobjects are decoded correctly"
       (let [results (qp/process-query (mt/native-query {:query "SELECT pg_sleep(0.01) AS sleep;"}))]
         (testing "rows"
@@ -1488,7 +1465,7 @@
                   (mt/cols results))))))))
 
 (deftest ^:parallel id-field-parameter-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "We should be able to filter a PK column with a String value -- should get parsed automatically (#13263)"
       (is (= [[2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]
              (mt/rows
@@ -1497,7 +1474,7 @@
 
 (deftest dont-sync-tables-with-no-select-permissions-test
   (testing "Make sure we only sync databases for which the current user has SELECT permissions"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (tx/drop-if-exists-and-create-db! driver/*driver* "no-select-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "no-select-test"})
             spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
@@ -1520,7 +1497,7 @@
 
 (deftest json-operator-?-works
   (testing "Make sure the Postgres ? operators (for JSON types) work in native queries"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (tx/drop-if-exists-and-create-db! driver/*driver* "json-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
             spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
@@ -1559,7 +1536,7 @@
 
 (deftest sync-json-with-composite-pks-test
   (testing "Make sure sync a table with json columns that have composite pks works"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (tx/drop-if-exists-and-create-db! driver/*driver* "composite-pks-test")
       (with-redefs [table-rows-sample/nested-field-sample-limit 4]
         (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name "composite-pks-test"})
@@ -1595,7 +1572,7 @@
 
 (deftest ^:parallel do-not-cast-to-date-if-column-is-already-a-date-test
   (testing "Don't wrap Field in date() if it's already a DATE (#11502)"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (mt/dataset attempted-murders
         (let [query (mt/mbql-query attempts
                       {:aggregation [[:count]]
@@ -1608,7 +1585,7 @@
 
 (deftest ^:parallel do-not-cast-to-timestamp-if-column-if-timestamp-tz-or-date-test
   (testing "Don't cast a DATE or TIMESTAMPTZ to TIMESTAMP, it's not necessary (#19816)"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (mt/dataset test-data
         (let [query (mt/mbql-query people
                       {:fields [!month.birth_date
@@ -1630,7 +1607,7 @@
                      (update :query #(str/split-lines (driver/prettify-native-form :postgres %)))))))))))
 
 (deftest postgres-ssl-connectivity-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (if (config/config-bool :mb-postgres-ssl-test-ssl)
       (testing "We should be able to connect to a Postgres instance, providing our own root CA via a secret property"
         (mt/with-env-keys-renamed-by #(str/replace-first % "mb-postgres-ssl-test" "mb-postgres-test")
@@ -1645,7 +1622,7 @@
        "-----END CERTIFICATE-----"))
 
 (deftest handle-nil-client-ssl-properties-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "Setting only one of the client SSL params doesn't result in an NPE error (#19984)"
       (mt/with-temp-file [dummy-root-cert   "dummy-root-cert.pem"
                           dummy-client-cert "dummy-client-cert.pem"]
@@ -1717,7 +1694,7 @@
               (str/ends-with? ".p12"))))))
 
 (deftest syncable-schemas-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "`syncable-schemas` should return schemas that should be synced"
       (mt/with-empty-db
         (is (= #{"public"}
@@ -1737,7 +1714,7 @@
                               (driver/syncable-schemas driver/*driver* (mt/db))))))))))))
 
 (deftest table-privileges-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "`table-privileges` should return the correct data for current_user and role privileges"
       (mt/with-empty-db
         (let [conn-spec      (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -1813,7 +1790,7 @@
 
 (deftest query-canceled?-test
   (testing "Recognizes timeout exceptions from postgres"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (mt/dataset test-data
         (let [long-sleep-sql "select pg_sleep(5)"]
           (sql-jdbc.execute/do-with-connection-with-options
@@ -1829,7 +1806,7 @@
 
 (deftest ^:parallel set-role-statement-test
   (testing "set-role-statement should return a SET ROLE command, with the role quoted if it contains special characters"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (sql-jdbc.execute/do-with-connection-with-options
        :postgres (mt/id) nil
        (fn [conn]
@@ -1847,7 +1824,7 @@
 
 (deftest get-tables-parity-with-jdbc-test
   (testing "make sure our get-tables return result consistent with jdbc getTables"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (mt/with-empty-db
         (sql-jdbc.execute/do-with-connection-with-options
          :postgres
@@ -1885,7 +1862,7 @@
 
 (deftest ^:parallel date-plus-integer-test
   (testing "Can we add a {{date}} template tag parameter to an integer in SQL queries? (#40755)"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (is (= [[#t "2024-07-03"]]
              (mt/rows
               (qp/process-query
@@ -1901,7 +1878,7 @@
                 :middleware {:format-rows? false}})))))))
 
 (deftest ^:parallel xml-column-is-readable-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (let [xml-str "<abc>abc</abc>"]
       (is (= [[xml-str]]
              (mt/rows
@@ -1911,7 +1888,7 @@
                 :native {:query (format "SELECT '%s'::xml" xml-str)}})))))))
 
 (deftest ^:parallel temporal-column-with-binning-keeps-type
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (let [mp (mt/metadata-provider)]
       (doseq [[field bins] [[:birth_date [:year :quarter :month :week :day]]
                             [:created_at [:year :quarter :month :week :day :hour :minute]]]
@@ -1927,7 +1904,7 @@
                    (->> binned-query   qp/process-query mt/cols (map :database_type))))))))))
 
 (deftest ^:parallel datetime-diff-works-for-all-units
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (let [mp (mt/metadata-provider)]
       (doseq [[field units] [[:birth_date [:year :quarter :month :week :day]]
                              [:created_at [:year :quarter :month :week :day :hour :minute :second]]]
@@ -1942,7 +1919,7 @@
             (is (->> query qp/process-query mt/rows))))))))
 
 (deftest have-select-privelege?-timeout-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (let [{schema :schema, table-name :name} (t2/select-one :model/Table (mt/id :checkins))]
       (qp.store/with-metadata-provider (mt/id)
         (testing "checking select privilege defaults to allow on timeout (#56737)"
@@ -1957,7 +1934,7 @@
                              driver/*driver* conn schema table-name))))))))))))
 
 (deftest sync-writable-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "`sync-tables-and-database!` should set is_writable correctly based on table privileges"
       (let [db-name "sync_writable_test"
             details (tx/dbdef->connection-details :postgres :db {:database-name db-name})]
@@ -2000,7 +1977,7 @@
 
 (deftest ^:parallel null-array-query-test
   (testing "queries with nulls in arrays should be returned in a readable format"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (is (= [[[nil]
                [nil nil]
                [1 nil 3]
@@ -2016,7 +1993,7 @@
 
 (deftest ^:parallel arrays-have-base-type
   (testing "queries with pg arrays have a base type on column metadata (#63909)"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (is (=? [{:name "id"
                 :database_type "int4"
                 :base_type :type/Integer}
@@ -2035,7 +2012,7 @@
 
 (deftest can-edit-model-metadata
   (testing "queries with pg arrays have a base type on column metadata (#63909)"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (let [query "SELECT *
                    FROM (
                      VALUES
@@ -2087,7 +2064,7 @@
           (is (= provider (provider-detection/detect-provider-from-database database))))))))
 
 (deftest ^:parallel complex-types-in-notification-payload
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "we handle complex types in notifications"
       (let [sql "SELECT
                     i AS id,
@@ -2149,7 +2126,7 @@
 
 (deftest bytea-column-not-truncated-test
   (testing "fix for #30671"
-    (mt/test-driver :postgres
+    (mt/test-driver *driver*
       (mt/dataset (mt/dataset-definition
                    "bytea_dataset"
                    [["bytea_table"
@@ -2183,7 +2160,7 @@
         (test-pgobject-caching pg-obj-map)))))
 
 (deftest canceled-query-no-stacktrace-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (letfn [(catch-exceptions [run]
               (let [query    (cond-> {:type :query, :database 1}
                                (= driver/*driver* :postgres-mbql5) (lib.convert/->mbql5))
@@ -2239,7 +2216,7 @@
                   (is (empty? bad-messages)))))))))))
 
 (deftest bit-strings-can-be-filtered
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (mt/dataset (mt/dataset-definition
                  "bit_string_dataset"
                  [["bit_string_table"
@@ -2306,7 +2283,7 @@
                      (mt/rows (qp/process-query query)))))))))))
 
 (deftest set-network-timeout-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (let [db-name (u/lower-case-en (format "network-timeout-%s-%s" (name driver/*driver*) (mt/random-name)))
           spec    (sql-jdbc.conn/connection-details->spec
                    driver/*driver*
@@ -2335,7 +2312,7 @@
             (is (true? (run-pg-sleep)))))))))
 
 (deftest ^:parallel parse-final-identifier-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "`final` is allowed as identifier and parsed correctly"
       (mt/with-temp [:model/Database db {:engine "postgres"
                                          :name "final"
@@ -2382,7 +2359,7 @@
                                (sql.u/quote-name :postgres :field ~role))]))))
 
 (deftest workspace-precondition-usage-grant-option-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "assert-has-usage-grant-option! throws when current_user lacks USAGE WITH GRANT OPTION on the schema"
       (mt/with-empty-db
         (let [admin-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -2413,7 +2390,7 @@
                     (is (nil? (postgres/assert-has-usage-grant-option! user-spec schema)))))))))))))
 
 (deftest workspace-precondition-table-grant-option-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "assert-has-grant-option! throws when current_user lacks SELECT WITH GRANT OPTION on a schema table"
       (mt/with-empty-db
         (let [admin-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -2450,7 +2427,7 @@
                     (is (nil? (postgres/assert-has-grant-option! user-spec schema)))))))))))))
 
 (deftest workspace-precondition-alter-default-privileges-test
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "assert-can-alter-default-privileges! throws when an object owner is not a role the current_user belongs to"
       (mt/with-empty-db
         (let [admin-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -2496,7 +2473,7 @@
   ;; row targeting the iso-user and confirm `destroy-workspace-isolation!`
   ;; still cleans up without raising "user cannot be dropped because some
   ;; objects depend on it".
-  (mt/test-driver :postgres
+  (mt/test-driver *driver*
     (testing "destroy succeeds when a non-current_user grantor seeded a default-priv targeting the iso-user"
       (mt/with-empty-db
         (let [admin-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))


### PR DESCRIPTION
Consider this atonement for my crimes of having used with-redefs.