### PR TITLE
Audit-log background and startup remote-sync imports

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -22,16 +22,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- publish-sync-event!
-  "Publishes an audit-log event for a completed remote-sync task. Called from
-  the `:on-success` callback so the task already has its version set."
-  [topic task-id branch user-id]
-  (let [task (t2/select-one :model/RemoteSyncTask task-id)]
-    (events/publish-event! topic
-                           {:object  task
-                            :details {:branch branch}
-                            :user-id user-id})))
-
 (api.macros/defendpoint :post "/import" :- remote-sync.schema/ImportResponse
   "Import Metabase content from configured Remote Sync source.
 
@@ -54,7 +44,8 @@
         {task-id :id}
         (impl/async-import!
          branch-name force {}
-         :on-success #(publish-sync-event! :event/remote-sync-import %1 branch-name user-id))]
+         :on-success (fn [task-id _result]
+                       (impl/publish-sync-event! :event/remote-sync-import task-id {:branch branch-name} user-id)))]
     {:status :success
      :task_id task-id
      :message (when-not task-id "No changes since last import")}))
@@ -124,7 +115,8 @@
          branch-name
          (or force false)
          (or message "Exported from Metabase")
-         :on-success #(publish-sync-event! :event/remote-sync-export %1 branch-name user-id))]
+         :on-success (fn [task-id _result]
+                       (impl/publish-sync-event! :event/remote-sync-export task-id {:branch branch-name} user-id)))]
     {:message "Export task started"
      :task_id task-id}))
 
@@ -294,7 +286,8 @@
   (try
     (let [user-id       api/*current-user-id*
           {task-id :id} (impl/stash! new-branch message
-                                     :on-success #(publish-sync-event! :event/remote-sync-stash %1 new-branch user-id))]
+                                     :on-success (fn [task-id _result]
+                                                   (impl/publish-sync-event! :event/remote-sync-stash task-id {:branch new-branch} user-id)))]
       {:status "success"
        :message (str "Stashing to " new-branch)
        :task_id task-id})

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -16,6 +16,7 @@
    [metabase.api.common :as api]
    [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.collections.models.collection :as collection]
+   [metabase.events.core :as events]
    [metabase.models.serialization :as serdes]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -748,6 +749,18 @@
                 true))))]
     (when (and proceed? (= (:status result) :success))
       (invalidate-remote-changes-cache!))))
+
+(defn publish-sync-event!
+  "Publishes an audit-log event for a completed remote-sync task. Call after the task result has been
+  handled so the task row already has its version set. `details` is the audit-log details map
+  (e.g. `{:branch \"main\"}`, plus `:auto true` for system-triggered syncs); `user-id` is nil for
+  system-triggered syncs."
+  [topic task-id details user-id]
+  (let [task (t2/select-one :model/RemoteSyncTask task-id)]
+    (events/publish-event! topic
+                           {:object  task
+                            :details details
+                            :user-id user-id})))
 
 (defn- run-async!
   "Executes a remote sync task asynchronously in a virtual thread.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/init.clj
@@ -47,14 +47,20 @@
             (throw (ex-info "Remote sync is enabled with read-only type, but no branch is set." {})))
           (when (remote-sync.object/dirty?)
             (if (some-> (settings/remote-sync-allow) (str/includes? "overwrite-unpublished"))
-              (impl/async-import! branch true {})
+              (impl/async-import! branch true {}
+                                  :on-success (fn [task-id _result]
+                                                (impl/publish-sync-event! :event/remote-sync-import task-id
+                                                                          {:branch branch :auto true} nil)))
               (throw (ex-info "Remote sync is enabled with read-only type, but there are unpublished changes. To force an overwrite, set `MB_REMOTE_SYNC_ALLOW=overwrite-unpublished`" {}))))))
       (when-not (collection/has-remote-synced-collection?)
         (if (nil? (settings/remote-sync-branch))
           (log/warn "Remote sync is enabled but no remote-sync branch is set. Cannot do initial import.")
-          (do
+          (let [branch (settings/remote-sync-branch)]
             (log/info "Remote sync is enabled but no remote-sync collection exists. Importing")
-            (impl/async-import! (settings/remote-sync-branch) true {})))))
+            (impl/async-import! branch true {}
+                                :on-success (fn [task-id _result]
+                                              (impl/publish-sync-event! :event/remote-sync-import task-id
+                                                                        {:branch branch :auto true} nil)))))))
     (when (collection/has-remote-synced-collection?)
       (log/info "Remote sync is disabled but a remote-synced collection exists. Marking collections as not remote-sync.")
       (collection/clear-remote-synced-collection!))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
@@ -36,7 +36,11 @@
               (dh/with-timeout {:interrupt? true
                                 :timeout-ms (* (settings/remote-sync-task-time-limit-ms) 10)}
                 (log/info "Auto-importing remote-sync collections")
-                (impl/handle-task-result! (impl/import! snapshot task-id) task-id)))))))))
+                (let [result (impl/import! snapshot task-id)]
+                  (impl/handle-task-result! result task-id)
+                  (when (= :success (:status result))
+                    (impl/publish-sync-event! :event/remote-sync-import task-id
+                                              {:branch branch :auto true} nil)))))))))))
 
 (task/defjob ^{:doc "Auto-imports any remote collections."} AutoImport [_]
   (auto-import!))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/task/import.clj
@@ -39,8 +39,13 @@
                 (let [result (impl/import! snapshot task-id)]
                   (impl/handle-task-result! result task-id)
                   (when (= :success (:status result))
-                    (impl/publish-sync-event! :event/remote-sync-import task-id
-                                              {:branch branch :auto true} nil)))))))))))
+                    ;; events/publish-event! rethrows handler exceptions; don't let an audit-log
+                    ;; failure mark an already-successful import as failed
+                    (try
+                      (impl/publish-sync-event! :event/remote-sync-import task-id
+                                                {:branch branch :auto true} nil)
+                      (catch Exception e
+                        (log/error e "Failed to publish remote-sync audit event")))))))))))))
 
 (task/defjob ^{:doc "Auto-imports any remote collections."} AutoImport [_]
   (auto-import!))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -216,6 +216,30 @@
             (is (= "success" (:status response)))
             (is (remote-sync.task/successful? completed-task))))))))
 
+(deftest import-creates-audit-log-entry-test
+  (testing "POST /api/ee/remote-sync/import records a remote-sync-import audit log entry (#73335)"
+    ;; :audit-app is needed for events to actually be recorded to the audit log
+    (mt/with-premium-features #{:remote-sync :audit-app}
+      (let [mock-main (test-helpers/create-mock-source)]
+        (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                           remote-sync-token "test-token"
+                                           remote-sync-branch "main"]
+          (mt/with-dynamic-fn-redefs [source/source-from-settings (constantly mock-main)]
+            (let [before            (t2/count :model/AuditLog :topic "remote-sync-import")
+                  {:keys [task_id]} (mt/user-http-request :crowberto :post 200 "ee/remote-sync/import" {})]
+              (wait-for-task-completion task_id)
+              ;; the audit event publishes after the task's ended_at is set, so poll for the row
+              (let [entry (dh/with-retry {:max-retries 10
+                                          :delay-ms 200}
+                            (u/prog1 (t2/select-one :model/AuditLog :topic "remote-sync-import" {:order-by [[:id :desc]]})
+                              (when (<= (t2/count :model/AuditLog :topic "remote-sync-import") before)
+                                (throw (ex-info "Audit log entry not written yet" {})))))]
+                (testing "attributed to the user who triggered it"
+                  (is (= (mt/user->id :crowberto) (:user_id entry))))
+                (testing "branch recorded, no :auto flag for manual imports"
+                  (is (= "main" (get-in entry [:details :branch])))
+                  (is (not (contains? (:details entry) :auto))))))))))))
+
 (deftest import-requires-superuser-test
   (testing "POST /api/ee/remote-sync/import requires superuser permissions"
     (mt/with-temporary-setting-values [remote-sync-enabled true]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/init_test.clj
@@ -9,7 +9,7 @@
 
 (defn- capture-async-import! []
   (let [calls (atom [])]
-    [calls (fn [branch force? args] (swap! calls conj [branch force? args]) nil)]))
+    [calls (fn [branch force? args & _opts] (swap! calls conj [branch force? args]) nil)]))
 
 (deftest remote-sync-init-disabled-with-remote-synced-collection-clears-test
   (testing "When remote sync is disabled, existing remote-synced collections are cleared"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/task/import_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/task/import_test.clj
@@ -1,0 +1,45 @@
+(ns metabase-enterprise.remote-sync.task.import-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.remote-sync.source :as source]
+   [metabase-enterprise.remote-sync.task.import :as task.import]
+   [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once
+  (fixtures/initialize :db)
+  ;; the mock source's card yaml references the test-data database, so it must exist for import to succeed
+  (fn [f] (mt/dataset test-data
+            (mt/id)
+            (f))))
+
+(use-fixtures :each
+  test-helpers/clean-remote-sync-state
+  (fn [f]
+    ;; :audit-app is needed for events to actually be recorded to the audit log
+    (mt/with-premium-features #{:remote-sync :audit-app}
+      (f))))
+
+(deftest auto-import-writes-audit-log-entry-test
+  (testing "GHY-3819: the background auto-import job publishes :event/remote-sync-import so the activity log records the pull"
+    (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                       remote-sync-token "test-token"
+                                       remote-sync-branch "main"
+                                       remote-sync-type :read-only
+                                       remote-sync-auto-import true]
+      (mt/with-dynamic-fn-redefs [source/source-from-settings (fn [& _] (test-helpers/create-mock-source))]
+        (let [before (t2/count :model/AuditLog :topic "remote-sync-import")]
+          (#'task.import/auto-import!)
+          (is (= (inc before) (t2/count :model/AuditLog :topic "remote-sync-import")))
+          (let [entry (t2/select-one :model/AuditLog :topic "remote-sync-import" {:order-by [[:id :desc]]})]
+            (testing "system-triggered, so no user"
+              (is (nil? (:user_id entry))))
+            (testing "marked as automatic so it can be distinguished from manual imports"
+              (is (true? (get-in entry [:details :auto]))))
+            (testing "branch recorded in details"
+              (is (= "main" (get-in entry [:details :branch])))))
+          (testing "a no-op run (source version unchanged) does not log another entry"
+            (#'task.import/auto-import!)
+            (is (= (inc before) (t2/count :model/AuditLog :topic "remote-sync-import")))))))))


### PR DESCRIPTION
Fixes #73335 
fixes GHY-3819


## Description

 background sync jobs were not tracked in Usage Analytics. On a read-only instance, automatic pulls from the remote sync repo never created `remote-sync-import` activity log entries, making forensics on a broken instance nearly impossible.

## How

- Moved `publish-sync-event!` from `api.clj` into `impl.clj` so non-API call sites can use it (it now takes a `details` map instead of a branch name).
- The Quartz `auto-import!` job now publishes `:event/remote-sync-import` after a successful import, with `:user-id nil` (system-triggered) and `:details {:branch ... :auto true}` so automatic pulls are distinguishable from manual ones in the activity log.
- The two startup import paths in `init.clj` (dirty + `overwrite-unpublished`, and initial import) now pass `:on-success` callbacks that publish the same event.
- **Also fixes the manual paths**: the `:on-success` callbacks in `api.clj` were written as `#(... %1 ...)` (arity 1), but `run-async!` invokes `(on-success task-id result)` with two args — every manual sync's audit event threw an `ArityException` that was silently swallowed, so manual import/export/stash events were never recorded either (the "partly broken" logging referenced in #73329).

Since the event is published after `handle-task-result!` sets the task version, the new entries carry the git version (per #73329's fix).

## Tests

New `metabase-enterprise.remote-sync.task.import-test` runs `auto-import!` against a mock source and asserts the `AuditLog` row is created with `user_id` nil, `:auto true`, and the branch in details, and that a no-op run (unchanged source version) doesn't log a duplicate.