### PR TITLE
size tables to fit their allowed space

### DIFF
--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -50,6 +50,7 @@
    [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.http :as u.http]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
@@ -1429,16 +1430,22 @@
   "Logical-pixel height of the `N rows` footer row at the bottom of a table image."
   32)
 
-(def ^:private table-border-color
-  "CSS colour for the in-image footer divider (`border-top` above the `N rows` row)."
-  "#F0F0F0")
-
 (def ^:private table-frame-color
   "Colour of the card's outer frame, stroked natively -- CSSBox's raster is 1px shorter than the
-  bordered box, so an HTML bottom border would be clipped."
+  bordered box, so an HTML bottom border would be clipped. Also the in-image footer divider, as CSS
+  via [[table-border-color]]."
   (Color. 0xF0 0xF0 0xF0))
 
-(defn- th-cell? [x] (and (vector? x) (= :th (first x))))
+(def ^:private table-border-color
+  "CSS form of [[table-frame-color]] for the in-image footer divider (`border-top` above the `N rows` row)."
+  (format "#%06X" (bit-and (.getRGB ^Color table-frame-color) 0xFFFFFF)))
+
+(defn- element?
+  "Whether `form` is a Hiccup element with tag `tag`, i.e. `[tag ...]`."
+  [form tag]
+  (and (vector? form) (= tag (first form))))
+
+(defn- th-cell? [el] (element? el :th))
 
 (defn- header-row?
   "Whether a `:tr` holds header (`:th`) cells -- which `render-table-head` nests inside a lazy seq."
@@ -1465,10 +1472,10 @@
   (walk/postwalk
    (fn [form]
      (cond
-       (and (vector? form) (= :table (first form)) (map? (second form)))
+       (and (element? form :table) (map? (second form)))
        (update-in form [1 :style] str ";width:100%;box-sizing:border-box;border:none;border-radius:0;margin:0;")
 
-       (and (vector? form) (= :tr (first form)) (header-row? form))
+       (and (element? form :tr) (header-row? form))
        (add-header-dividers form)
 
        :else form))
@@ -1490,9 +1497,17 @@
                                                     "font-size:12.5px;text-align:right;padding-right:16px;"
                                                     "color:#696E7B;border-top:1px solid %2$s")
                                                table-footer-px table-border-color)}
-                          (format "%,d rows" (long n-rows))]])
+                          (tru "{0} rows" (format "%,d" (long n-rows)))]])
         bytes    (png/render-html-to-png wrapped px-w {:channel.render/scale table-supersample})]
     (ImageIO/read (ByteArrayInputStream. bytes))))
+
+(defn- move-to! [^PDPageContentStream cs x y] (.moveTo cs (float x) (float y)))
+(defn- line-to! [^PDPageContentStream cs x y] (.lineTo cs (float x) (float y)))
+
+(defn- curve-to!
+  "Append a cubic Bézier from the current point via control points `[x1 y1]` and `[x2 y2]` to `[x3 y3]`."
+  [^PDPageContentStream cs x1 y1 x2 y2 x3 y3]
+  (.curveTo cs (float x1) (float y1) (float x2) (float y2) (float x3) (float y3)))
 
 (defn- stroke-round-rect!
   "Stroke a rounded-rectangle outline whose top-left is `[x, top-y]` (and is `w` x `h`) with `color`
@@ -1507,15 +1522,15 @@
         c  (* r 0.5523)]
     (.setStrokingColor cs color)
     (.setLineWidth cs (float line-w))
-    (.moveTo  cs (float (+ l r)) (float t))
-    (.lineTo  cs (float (- rt r)) (float t))                                               ; top edge
-    (.curveTo cs (float (+ (- rt r) c)) (float t) (float rt) (float (- t (- r c))) (float rt) (float (- t r))) ; TR
-    (.lineTo  cs (float rt) (float (+ b r)))                                               ; right edge
-    (.curveTo cs (float rt) (float (- (+ b r) c)) (float (- rt (- r c))) (float b) (float (- rt r)) (float b)) ; BR
-    (.lineTo  cs (float (+ l r)) (float b))                                                ; bottom edge
-    (.curveTo cs (float (- (+ l r) c)) (float b) (float l) (float (- (+ b r) c)) (float l) (float (+ b r)))    ; BL
-    (.lineTo  cs (float l) (float (- t r)))                                                ; left edge
-    (.curveTo cs (float l) (float (- (+ (- t r) c) 0.0)) (float (- (+ l r) c)) (float t) (float (+ l r)) (float t)) ; TL
+    (move-to!  cs (+ l r) t)
+    (line-to!  cs (- rt r) t)                                       ; top edge
+    (curve-to! cs (+ (- rt r) c) t   rt (- t (- r c))   rt (- t r)) ; TR
+    (line-to!  cs rt (+ b r))                                       ; right edge
+    (curve-to! cs rt (- (+ b r) c)   (- rt (- r c)) b   (- rt r) b) ; BR
+    (line-to!  cs (+ l r) b)                                        ; bottom edge
+    (curve-to! cs (- (+ l r) c) b    l (- (+ b r) c)    l (+ b r))  ; BL
+    (line-to!  cs l (- t r))                                        ; left edge
+    (curve-to! cs l (+ (- t r) c)    (- (+ l r) c) t    (+ l r) t)  ; TL
     (.stroke cs)
     (.setStrokingColor cs Color/BLACK)
     (.setLineWidth cs (float 1.0))))

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -37,9 +37,12 @@
    [better-cond.core :as b]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [clojure.walk :as walk]
    [medley.core :as m]
+   [metabase.channel.render.body :as body]
    [metabase.channel.render.card :as render.card]
    [metabase.channel.render.js.svg :as js.svg]
+   [metabase.channel.render.png :as png]
    [metabase.channel.render.util :as render.util]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.notification.payload.core :as notification.payload]
@@ -1220,6 +1223,7 @@
     (.drawImage cs img (float x) (float (- (double top-y) dh)) (float dw) (float dh))))
 
 (defn- pt->px [pt] (long (Math/round (* (double pt) (/ dpi 72.0)))))
+(defn- px->pt ^double [px] (* (double px) (/ 72.0 dpi)))
 
 (defn- card-title [card dashcard]
   (or (get-in dashcard [:visualization_settings :card.title]) (:name card)))
@@ -1411,6 +1415,124 @@
   (.fill cs)
   (.setNonStrokingColor cs Color/BLACK))
 
+;; --------------------------------------------------------------------------------------------
+;; Tables. Render the card's HTML table width-filled inside a height-capped wrapper with a row-count
+;; footer, supersampled; the outer frame is stroked natively (see [[draw-table-card!]]).
+;; --------------------------------------------------------------------------------------------
+
+(def ^:private table-supersample
+  "Supersampling factor for table rasters: laid out at logical size but rendered to this many times
+  more device pixels for crisp text at the same on-page size. Mirrors [[chart-supersample]]."
+  2.0)
+
+(def ^:private table-footer-px
+  "Logical-pixel height of the `N rows` footer row at the bottom of a table image."
+  32)
+
+(def ^:private table-border-color
+  "CSS colour for the in-image footer divider (`border-top` above the `N rows` row)."
+  "#F0F0F0")
+
+(def ^:private table-frame-color
+  "Colour of the card's outer frame, stroked natively -- CSSBox's raster is 1px shorter than the
+  bordered box, so an HTML bottom border would be clipped."
+  (Color. 0xF0 0xF0 0xF0))
+
+(defn- th-cell? [x] (and (vector? x) (= :th (first x))))
+
+(defn- header-row?
+  "Whether a `:tr` holds header (`:th`) cells -- which `render-table-head` nests inside a lazy seq."
+  [tr]
+  (some (fn [el] (or (th-cell? el) (and (seq? el) (some th-cell? el)))) tr))
+
+(defn- add-header-dividers
+  "Add a `border-right` to each header cell but the last, matching the body (the renderer leaves
+  header cells border-less). They arrive spliced in a nested seq, so flatten the row first."
+  [tr]
+  (let [items   (vec (mapcat (fn [el] (if (seq? el) el [el])) tr))
+        last-th (->> items (keep-indexed (fn [i el] (when (th-cell? el) i))) last)]
+    (vec (map-indexed
+          (fn [i el]
+            (if (and (th-cell? el) (map? (second el)) (not= i last-th))
+              (update-in el [1 :style] str (format ";border-right:1px solid %s;" table-border-color))
+              el))
+          items))))
+
+(defn- restyle-table
+  "Restyle the inner `<table>` to fit the card frame: fill the width, drop its own border/radius/margin
+  (the native frame and per-cell dividers remain), and add header dividers to match the body."
+  [content]
+  (walk/postwalk
+   (fn [form]
+     (cond
+       (and (vector? form) (= :table (first form)) (map? (second form)))
+       (update-in form [1 :style] str ";width:100%;box-sizing:border-box;border:none;border-radius:0;margin:0;")
+
+       (and (vector? form) (= :tr (first form)) (header-row? form))
+       (add-header-dividers form)
+
+       :else form))
+   content))
+
+(defn- table-body-image
+  "Render a table card body to a [[BufferedImage]] sized to the `px-w` x `px-h` cell (logical pixels):
+  width-filled, height-capped, with a row-count footer, supersampled at [[table-supersample]]x."
+  ^BufferedImage [timezone {:keys [card dashcard result]} px-w px-h n-rows]
+  (let [;; Render directly, not via render-pulse-card: its <p>/.pulse-body margins escape CSSBox's
+        ;; height clip and push the image past the cell. body/render gives the bare table.
+        info     (body/render :table :inline timezone card dashcard (:data result))
+        clip-css (format "max-height:%dpx;overflow:hidden" (max 0 (- (long px-h) table-footer-px 2)))
+        ;; the frame is stroked natively in draw-table-card!, so this wrapper has no border
+        wrapped  (assoc info :content
+                        [:div
+                         [:div {:style clip-css} (restyle-table (:content info))]
+                         [:div {:style (format (str "height:%1$dpx;line-height:%1$dpx;box-sizing:border-box;"
+                                                    "font-size:12.5px;text-align:right;padding-right:16px;"
+                                                    "color:#696E7B;border-top:1px solid %2$s")
+                                               table-footer-px table-border-color)}
+                          (format "%,d rows" (long n-rows))]])
+        bytes    (png/render-html-to-png wrapped px-w {:channel.render/scale table-supersample})]
+    (ImageIO/read (ByteArrayInputStream. bytes))))
+
+(defn- stroke-round-rect!
+  "Stroke a rounded-rectangle outline whose top-left is `[x, top-y]` (and is `w` x `h`) with `color`
+  at `line-w` points and corner radius `r` points, then reset to a black hairline. Corners are
+  quarter-circle cubic Béziers (control distance = r * kappa)."
+  [^PDPageContentStream cs ^Color color line-w r x top-y w h]
+  (let [l  (double x)
+        t  (double top-y)
+        rt (+ l (double w))
+        b  (- t (double h))
+        r  (min (double r) (/ (double w) 2.0) (/ (double h) 2.0))
+        c  (* r 0.5523)]
+    (.setStrokingColor cs color)
+    (.setLineWidth cs (float line-w))
+    (.moveTo  cs (float (+ l r)) (float t))
+    (.lineTo  cs (float (- rt r)) (float t))                                               ; top edge
+    (.curveTo cs (float (+ (- rt r) c)) (float t) (float rt) (float (- t (- r c))) (float rt) (float (- t r))) ; TR
+    (.lineTo  cs (float rt) (float (+ b r)))                                               ; right edge
+    (.curveTo cs (float rt) (float (- (+ b r) c)) (float (- rt (- r c))) (float b) (float (- rt r)) (float b)) ; BR
+    (.lineTo  cs (float (+ l r)) (float b))                                                ; bottom edge
+    (.curveTo cs (float (- (+ l r) c)) (float b) (float l) (float (- (+ b r) c)) (float l) (float (+ b r)))    ; BL
+    (.lineTo  cs (float l) (float (- t r)))                                                ; left edge
+    (.curveTo cs (float l) (float (- (+ (- t r) c) 0.0)) (float (- (+ l r) c)) (float t) (float (+ l r)) (float t)) ; TL
+    (.stroke cs)
+    (.setStrokingColor cs Color/BLACK)
+    (.setLineWidth cs (float 1.0))))
+
+(defn- draw-table-card!
+  "Draw the table card body fitted to `[x, body-top]` x `cell-w` x `body-h`, with the card's outer
+  frame stroked natively around the image."
+  [^PDDocument doc ^PDPageContentStream cs timezone part x body-top cell-w body-h]
+  (let [n-rows (count (get-in part [:result :data :rows]))
+        img    (table-body-image timezone part (pt->px cell-w) (pt->px body-h) n-rows)
+        ;; image is at table-supersample x logical pixels -> divide back to points
+        dw     (px->pt (/ (.getWidth img) table-supersample))
+        dh     (px->pt (/ (.getHeight img) table-supersample))]
+    (.drawImage cs (LosslessFactory/createFromImage doc img)
+                (float x) (float (- (double body-top) dh)) (float dw) (float dh))
+    (stroke-round-rect! cs table-frame-color 0.5 4.0 x body-top dw dh)))
+
 (defn- render-card-cell!
   "Render a chart/query card into its cell rectangle. The title is drawn natively at the PDF level
   (crisp text) and the space it consumes is reserved before the body is rendered. (Card
@@ -1434,7 +1556,9 @@
         ;; Rectangular charts always fill their box; pies fill (and move their legend to the
         ;; side) only when the body area is square-or-wider, otherwise they keep a bottom legend.
         fill?      (or (contains? rectangular-displays display)
-                       (and (= :pie display) (>= cell-w body-h)))]
+                       (and (= :pie display) (>= cell-w body-h)))
+        ;; tables, pivots, and table fallbacks (map/object/unknown) all detect as :table
+        table?     (= :table (render.card/detect-pulse-chart-type card dashcard data))]
     ;; Debug overlays (drawn first, so content sits on top): the full title box (blue) and the full
     ;; chart-body box (red) -- the *allocated* space, regardless of how much the content fills.
     (when *debug-boxes*
@@ -1448,12 +1572,18 @@
       ;; in debug mode render charts transparently, so the red box behind them shows through the
       ;; whitespace ECharts/visx leave inside the image.
       (binding [js.svg/*svg-background-color* (if *debug-boxes* nil js.svg/*svg-background-color*)]
-        (if-let [png (when fill?
-                       (sized-chart-png card dashcard data (pt->px cell-w) (pt->px body-h)))]
-          ;; rendered at exactly cell-w x body-h px -> draw to fill the body area exactly
-          (.drawImage cs (PDImageXObject/createFromByteArray doc png "chart")
-                      (float x) (float (- body-top body-h)) (float cell-w) (float body-h))
-          ;; fallback: title-less body PNG, fit preserving aspect into the body area
+        (cond
+          ;; rectangular charts (and wide pies): fill the body area exactly
+          fill?
+          (when-let [png (sized-chart-png card dashcard data (pt->px cell-w) (pt->px body-h))]
+            (.drawImage cs (PDImageXObject/createFromByteArray doc png "chart")
+                        (float x) (float (- body-top body-h)) (float cell-w) (float body-h)))
+
+          table?
+          (draw-table-card! doc cs timezone part x body-top cell-w body-h)
+
+          ;; other types: title-less body PNG, fit preserving aspect
+          :else
           (when-let [body (card-body-png timezone part (long (max 240 (min 2200 (pt->px cell-w)))))]
             (draw-image-in-cell! cs (PDImageXObject/createFromByteArray doc body "card") x body-top cell-w body-h)))))))
 

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -50,7 +50,7 @@
    [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.http :as u.http]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n :refer [trun]]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
@@ -1423,8 +1423,8 @@
 
 (def ^:private table-supersample
   "Supersampling factor for table rasters: laid out at logical size but rendered to this many times
-  more device pixels for crisp text at the same on-page size. Mirrors [[chart-supersample]]."
-  2.0)
+  more device pixels for crisp text at the same on-page size. Shares [[chart-supersample]]'s magnitude."
+  chart-supersample)
 
 (def ^:private table-footer-px
   "Logical-pixel height of the `N rows` footer row at the bottom of a table image."
@@ -1440,6 +1440,15 @@
   "CSS form of [[table-frame-color]] for the in-image footer divider (`border-top` above the `N rows` row)."
   (format "#%06X" (bit-and (.getRGB ^Color table-frame-color) 0xFFFFFF)))
 
+(def ^:private table-css
+  "CSS appended to the inner `<table>` so it fits the card frame: fill the width, no border/radius/
+  margin of its own (the native frame and per-cell dividers remain)."
+  ";width:100%;box-sizing:border-box;border:none;border-radius:0;margin:0;")
+
+(def ^:private header-divider-css
+  "CSS appended to a header cell for the divider after it, matching the body cells' dividers."
+  (format ";border-right:1px solid %s;" table-border-color))
+
 (defn- element?
   "Whether `form` is a Hiccup element with tag `tag`, i.e. `[tag ...]`."
   [form tag]
@@ -1452,54 +1461,64 @@
   [tr]
   (some (fn [el] (or (th-cell? el) (and (seq? el) (some th-cell? el)))) tr))
 
+(defn- append-style
+  "Append `css` to the `:style` of Hiccup element `el`'s attrs map."
+  [el css]
+  (update-in el [1 :style] str css))
+
 (defn- add-header-dividers
   "Add a `border-right` to each header cell but the last, matching the body (the renderer leaves
   header cells border-less). They arrive spliced in a nested seq, so flatten the row first."
   [tr]
-  (let [items   (vec (mapcat (fn [el] (if (seq? el) el [el])) tr))
+  (let [items   (into [] (mapcat (fn [el] (if (seq? el) el [el]))) tr)
         last-th (->> items (keep-indexed (fn [i el] (when (th-cell? el) i))) last)]
-    (vec (map-indexed
-          (fn [i el]
-            (if (and (th-cell? el) (map? (second el)) (not= i last-th))
-              (update-in el [1 :style] str (format ";border-right:1px solid %s;" table-border-color))
-              el))
-          items))))
+    (into []
+          (map-indexed (fn [i el]
+                         (cond-> el
+                           (and (th-cell? el) (map? (second el)) (not= i last-th))
+                           (append-style header-divider-css))))
+          items)))
+
+(defn- restyle-form
+  "Restyle one walked Hiccup form: the `<table>` gets [[table-css]]; header rows get per-cell
+  dividers. Everything else passes through."
+  [form]
+  (cond
+    (and (element? form :table) (map? (second form)))
+    (append-style form table-css)
+
+    (and (element? form :tr) (header-row? form))
+    (add-header-dividers form)
+
+    :else form))
 
 (defn- restyle-table
   "Restyle the inner `<table>` to fit the card frame: fill the width, drop its own border/radius/margin
   (the native frame and per-cell dividers remain), and add header dividers to match the body."
   [content]
-  (walk/postwalk
-   (fn [form]
-     (cond
-       (and (element? form :table) (map? (second form)))
-       (update-in form [1 :style] str ";width:100%;box-sizing:border-box;border:none;border-radius:0;margin:0;")
+  (walk/postwalk restyle-form content))
 
-       (and (element? form :tr) (header-row? form))
-       (add-header-dividers form)
+(def ^:private table-footer-css
+  "Style of the `N rows` footer row at the bottom of a table image."
+  (format (str "height:%1$dpx;line-height:%1$dpx;box-sizing:border-box;"
+               "font-size:12.5px;text-align:right;padding-right:16px;"
+               "color:#696E7B;border-top:1px solid %2$s")
+          table-footer-px table-border-color))
 
-       :else form))
-   content))
-
-(defn- table-body-image
-  "Render a table card body to a [[BufferedImage]] sized to the `px-w` x `px-h` cell (logical pixels):
+(defn- table-body-png
+  "Render a table card body to PNG bytes sized to the `px-w` x `px-h` cell (logical pixels):
   width-filled, height-capped, with a row-count footer, supersampled at [[table-supersample]]x."
-  ^BufferedImage [timezone {:keys [card dashcard result]} px-w px-h n-rows]
+  ^bytes [timezone {:keys [card dashcard result]} px-w px-h]
   (let [;; Render directly, not via render-pulse-card: its <p>/.pulse-body margins escape CSSBox's
         ;; height clip and push the image past the cell. body/render gives the bare table.
         info     (body/render :table :inline timezone card dashcard (:data result))
+        n-rows   (count (get-in result [:data :rows]))
         clip-css (format "max-height:%dpx;overflow:hidden" (max 0 (- (long px-h) table-footer-px 2)))
         ;; the frame is stroked natively in draw-table-card!, so this wrapper has no border
-        wrapped  (assoc info :content
-                        [:div
-                         [:div {:style clip-css} (restyle-table (:content info))]
-                         [:div {:style (format (str "height:%1$dpx;line-height:%1$dpx;box-sizing:border-box;"
-                                                    "font-size:12.5px;text-align:right;padding-right:16px;"
-                                                    "color:#696E7B;border-top:1px solid %2$s")
-                                               table-footer-px table-border-color)}
-                          (tru "{0} rows" (format "%,d" (long n-rows)))]])
-        bytes    (png/render-html-to-png wrapped px-w {:channel.render/scale table-supersample})]
-    (ImageIO/read (ByteArrayInputStream. bytes))))
+        content  [:div
+                  [:div {:style clip-css} (restyle-table (:content info))]
+                  [:div {:style table-footer-css} (trun "{0} row" "{0} rows" n-rows)]]]
+    (png/render-html-to-png (assoc info :content content) px-w {:channel.render/scale table-supersample})))
 
 (defn- move-to! [^PDPageContentStream cs x y] (.moveTo cs (float x) (float y)))
 (defn- line-to! [^PDPageContentStream cs x y] (.lineTo cs (float x) (float y)))
@@ -1509,43 +1528,64 @@
   [^PDPageContentStream cs x1 y1 x2 y2 x3 y3]
   (.curveTo cs (float x1) (float y1) (float x2) (float y2) (float x3) (float y3)))
 
+(def ^:private bezier-circle-kappa
+  "Control-point distance, as a fraction of the radius, at which a cubic Bézier best approximates a
+  quarter circle."
+  0.5523)
+
+(defn- corner-to!
+  "Append a quarter-circle corner around the rectangle corner `[ax ay]`: a cubic Bézier from the
+  current point (`r` before the corner along incoming-edge direction `[dx1 dy1]`) to the point `r`
+  past it along outgoing-edge direction `[dx2 dy2]`, with control points `c` short of the corner."
+  [cs r c ax ay dx1 dy1 dx2 dy2]
+  (let [r  (double r)
+        rc (- r (double c))]
+    (curve-to! cs
+               (- ax (* rc dx1)) (- ay (* rc dy1))
+               (+ ax (* rc dx2)) (+ ay (* rc dy2))
+               (+ ax (* r  dx2)) (+ ay (* r  dy2)))))
+
 (defn- stroke-round-rect!
   "Stroke a rounded-rectangle outline whose top-left is `[x, top-y]` (and is `w` x `h`) with `color`
   at `line-w` points and corner radius `r` points, then reset to a black hairline. Corners are
-  quarter-circle cubic Béziers (control distance = r * kappa)."
+  quarter-circle cubic Béziers (see [[corner-to!]])."
   [^PDPageContentStream cs ^Color color line-w r x top-y w h]
   (let [l  (double x)
         t  (double top-y)
         rt (+ l (double w))
         b  (- t (double h))
         r  (min (double r) (/ (double w) 2.0) (/ (double h) 2.0))
-        c  (* r 0.5523)]
+        c  (* r bezier-circle-kappa)]
     (.setStrokingColor cs color)
     (.setLineWidth cs (float line-w))
-    (move-to!  cs (+ l r) t)
-    (line-to!  cs (- rt r) t)                                       ; top edge
-    (curve-to! cs (+ (- rt r) c) t   rt (- t (- r c))   rt (- t r)) ; TR
-    (line-to!  cs rt (+ b r))                                       ; right edge
-    (curve-to! cs rt (- (+ b r) c)   (- rt (- r c)) b   (- rt r) b) ; BR
-    (line-to!  cs (+ l r) b)                                        ; bottom edge
-    (curve-to! cs (- (+ l r) c) b    l (- (+ b r) c)    l (+ b r))  ; BL
-    (line-to!  cs l (- t r))                                        ; left edge
-    (curve-to! cs l (+ (- t r) c)    (- (+ l r) c) t    (+ l r) t)  ; TL
+    (move-to!   cs (+ l r) t)
+    (line-to!   cs (- rt r) t)               ; top edge
+    (corner-to! cs r c rt t   1  0   0 -1)   ; TR
+    (line-to!   cs rt (+ b r))               ; right edge
+    (corner-to! cs r c rt b   0 -1  -1  0)   ; BR
+    (line-to!   cs (+ l r) b)                ; bottom edge
+    (corner-to! cs r c l  b  -1  0   0  1)   ; BL
+    (line-to!   cs l (- t r))                ; left edge
+    (corner-to! cs r c l  t   0  1   1  0)   ; TL
     (.stroke cs)
     (.setStrokingColor cs Color/BLACK)
     (.setLineWidth cs (float 1.0))))
+
+(defn- supersampled-px->pt
+  "Points spanned on the page by `px` device pixels of a [[table-supersample]]-rastered image."
+  ^double [px]
+  (px->pt (/ (double px) table-supersample)))
 
 (defn- draw-table-card!
   "Draw the table card body fitted to `[x, body-top]` x `cell-w` x `body-h`, with the card's outer
   frame stroked natively around the image."
   [^PDDocument doc ^PDPageContentStream cs timezone part x body-top cell-w body-h]
-  (let [n-rows (count (get-in part [:result :data :rows]))
-        img    (table-body-image timezone part (pt->px cell-w) (pt->px body-h) n-rows)
+  (let [img (PDImageXObject/createFromByteArray
+             doc (table-body-png timezone part (pt->px cell-w) (pt->px body-h)) "table")
         ;; image is at table-supersample x logical pixels -> divide back to points
-        dw     (px->pt (/ (.getWidth img) table-supersample))
-        dh     (px->pt (/ (.getHeight img) table-supersample))]
-    (.drawImage cs (LosslessFactory/createFromImage doc img)
-                (float x) (float (- (double body-top) dh)) (float dw) (float dh))
+        dw  (supersampled-px->pt (.getWidth img))
+        dh  (supersampled-px->pt (.getHeight img))]
+    (.drawImage cs img (float x) (float (- (double body-top) dh)) (float dw) (float dh))
     (stroke-round-rect! cs table-frame-color 0.5 4.0 x body-top dw dh)))
 
 (defn- render-card-cell!
@@ -1587,17 +1627,19 @@
       ;; in debug mode render charts transparently, so the red box behind them shows through the
       ;; whitespace ECharts/visx leave inside the image.
       (binding [js.svg/*svg-background-color* (if *debug-boxes* nil js.svg/*svg-background-color*)]
-        (cond
+        (b/cond
+          :let [png (when fill? (sized-chart-png card dashcard data (pt->px cell-w) (pt->px body-h)))]
+
           ;; rectangular charts (and wide pies): fill the body area exactly
-          fill?
-          (when-let [png (sized-chart-png card dashcard data (pt->px cell-w) (pt->px body-h))]
-            (.drawImage cs (PDImageXObject/createFromByteArray doc png "chart")
-                        (float x) (float (- body-top body-h)) (float cell-w) (float body-h)))
+          png
+          (.drawImage cs (PDImageXObject/createFromByteArray doc png "chart")
+                      (float x) (float (- body-top body-h)) (float cell-w) (float body-h))
 
           table?
           (draw-table-card! doc cs timezone part x body-top cell-w body-h)
 
-          ;; other types: title-less body PNG, fit preserving aspect
+          ;; other types (and charts whose render produced no SVG): title-less body PNG,
+          ;; fit preserving aspect
           :else
           (when-let [body (card-body-png timezone part (long (max 240 (min 2200 (pt->px cell-w)))))]
             (draw-image-in-cell! cs (PDImageXObject/createFromByteArray doc body "card") x body-top cell-w body-h)))))))

--- a/src/metabase/channel/render/png.clj
+++ b/src/metabase/channel/render/png.clj
@@ -44,12 +44,17 @@
     (.addStyleSheet nil (CSSNorm/formsStyleSheet) DOMAnalyzer$Origin/AGENT)
     .getStyleSheets))
 
-(defn- redraw-at-scale
+(defn- scale-px
+  "`px` scaled by `scale`, rounded to the nearest whole pixel."
+  ^long [px scale]
+  (Math/round (* (double px) (double scale))))
+
+(defn- redraw-at-scale!
   "Re-render the already-laid-out boxes of `graphics-engine` into a fresh image `scale`x the device size
   of `base`, for crisp supersampled output. Returns the new [[BufferedImage]]."
-  ^java.awt.image.BufferedImage [^GraphicsEngine graphics-engine ^java.awt.image.BufferedImage base ^double scale]
-  (let [big (BufferedImage. (int (Math/round (* (.getWidth base) scale)))
-                            (int (Math/round (* (.getHeight base) scale)))
+  ^java.awt.image.BufferedImage [^GraphicsEngine graphics-engine ^java.awt.image.BufferedImage base scale]
+  (let [big (BufferedImage. (scale-px (.getWidth base) scale)
+                            (scale-px (.getHeight base) scale)
                             BufferedImage/TYPE_INT_ARGB)]
     (.setImage graphics-engine big)
     (.redrawBoxes graphics-engine)
@@ -89,8 +94,8 @@
                                 (int (.getMaximalWidth viewport)))
              image         (if (= 1.0 scale)
                              base
-                             (redraw-at-scale graphics-engine base scale))
-             crop-width    (int (Math/round (* content-width scale)))]
+                             (redraw-at-scale! graphics-engine base scale))
+             crop-width    (scale-px content-width scale)]
          ;; Crop the image to the actual size of the rendered content so that tables don't have a ton of whitespace.
          (if (< crop-width (.getWidth image))
            (.getSubimage image 0 0 crop-width (.getHeight image))

--- a/src/metabase/channel/render/png.clj
+++ b/src/metabase/channel/render/png.clj
@@ -44,6 +44,17 @@
     (.addStyleSheet nil (CSSNorm/formsStyleSheet) DOMAnalyzer$Origin/AGENT)
     .getStyleSheets))
 
+(defn- redraw-at-scale
+  "Re-render the already-laid-out boxes of `graphics-engine` into a fresh image `scale`x the device size
+  of `base`, for crisp supersampled output. Returns the new [[BufferedImage]]."
+  ^java.awt.image.BufferedImage [^GraphicsEngine graphics-engine ^java.awt.image.BufferedImage base ^double scale]
+  (let [big (BufferedImage. (int (Math/round (* (.getWidth base) scale)))
+                            (int (Math/round (* (.getHeight base) scale)))
+                            BufferedImage/TYPE_INT_ARGB)]
+    (.setImage graphics-engine big)
+    (.redrawBoxes graphics-engine)
+    big))
+
 (defn- render-to-png
   "Render `html` to a [[BufferedImage]] at `width` logical pixels. `scale` > 1 rasterizes to that many
   device pixels for crispness (via scaled device graphics, since CSSBox ignores CSS `zoom`/`transform`)."
@@ -78,13 +89,7 @@
                                 (int (.getMaximalWidth viewport)))
              image         (if (= 1.0 scale)
                              base
-                             ;; re-render the laid-out boxes into a `scale`x device-pixel image
-                             (let [big (BufferedImage. (int (Math/round (* (.getWidth base) scale)))
-                                                       (int (Math/round (* (.getHeight base) scale)))
-                                                       BufferedImage/TYPE_INT_ARGB)]
-                               (.setImage graphics-engine big)
-                               (.redrawBoxes graphics-engine)
-                               big))
+                             (redraw-at-scale graphics-engine base scale))
              crop-width    (int (Math/round (* content-width scale)))]
          ;; Crop the image to the actual size of the rendered content so that tables don't have a ton of whitespace.
          (if (< crop-width (.getWidth image))

--- a/src/metabase/channel/render/png.clj
+++ b/src/metabase/channel/render/png.clj
@@ -45,34 +45,51 @@
     .getStyleSheets))
 
 (defn- render-to-png
-  ^java.awt.image.BufferedImage [^String html width]
-  (style/register-fonts-if-needed!)
-  (with-open [is         (ByteArrayInputStream. (.getBytes html StandardCharsets/UTF_8))
-              doc-source (StreamDocumentSource. is nil "text/html; charset=utf-8")]
-    (let [dimension       (Dimension. width 1)
-          doc             (.parse (DefaultDOMSource. doc-source))
-          da              (dom-analyzer doc doc-source dimension)
-          graphics-engine (proxy [GraphicsEngine] [(.getRoot da) da (.getURL doc-source)]
-                            (setupGraphics [^Graphics2D g]
-                              (doto g
-                                (.setRenderingHint RenderingHints/KEY_RENDERING
-                                                   RenderingHints/VALUE_RENDER_QUALITY)
-                                (.setRenderingHint RenderingHints/KEY_ALPHA_INTERPOLATION
-                                                   RenderingHints/VALUE_ALPHA_INTERPOLATION_QUALITY)
-                                (.setRenderingHint RenderingHints/KEY_TEXT_ANTIALIASING
-                                                   RenderingHints/VALUE_TEXT_ANTIALIAS_GASP)
-                                (.setRenderingHint RenderingHints/KEY_FRACTIONALMETRICS
-                                                   RenderingHints/VALUE_FRACTIONALMETRICS_ON))))]
-      (.createLayout graphics-engine dimension)
-      (let [image         (.getImage graphics-engine)
-            viewport      (.getViewport graphics-engine)
-            ;; CSSBox voodoo -- sometimes maximal width < minimal width, no idea why
-            content-width (max (int (.getMinimalWidth viewport))
-                               (int (.getMaximalWidth viewport)))]
-        ;; Crop the image to the actual size of the rendered content so that tables don't have a ton of whitespace.
-        (if (< content-width (.getWidth image))
-          (.getSubimage image 0 0 content-width (.getHeight image))
-          image)))))
+  "Render `html` to a [[BufferedImage]] at `width` logical pixels. `scale` > 1 rasterizes to that many
+  device pixels for crispness (via scaled device graphics, since CSSBox ignores CSS `zoom`/`transform`)."
+  (^java.awt.image.BufferedImage [^String html width]
+   (render-to-png html width 1.0))
+  (^java.awt.image.BufferedImage [^String html width scale]
+   (style/register-fonts-if-needed!)
+   (with-open [is         (ByteArrayInputStream. (.getBytes html StandardCharsets/UTF_8))
+               doc-source (StreamDocumentSource. is nil "text/html; charset=utf-8")]
+     (let [scale           (double scale)
+           dimension       (Dimension. width 1)
+           doc             (.parse (DefaultDOMSource. doc-source))
+           da              (dom-analyzer doc doc-source dimension)
+           graphics-engine (proxy [GraphicsEngine] [(.getRoot da) da (.getURL doc-source)]
+                             (setupGraphics [^Graphics2D g]
+                               (when (not= 1.0 scale)
+                                 (.scale g scale scale))
+                               (doto g
+                                 (.setRenderingHint RenderingHints/KEY_RENDERING
+                                                    RenderingHints/VALUE_RENDER_QUALITY)
+                                 (.setRenderingHint RenderingHints/KEY_ALPHA_INTERPOLATION
+                                                    RenderingHints/VALUE_ALPHA_INTERPOLATION_QUALITY)
+                                 (.setRenderingHint RenderingHints/KEY_TEXT_ANTIALIASING
+                                                    RenderingHints/VALUE_TEXT_ANTIALIAS_GASP)
+                                 (.setRenderingHint RenderingHints/KEY_FRACTIONALMETRICS
+                                                    RenderingHints/VALUE_FRACTIONALMETRICS_ON))))]
+       (.createLayout graphics-engine dimension)
+       (let [base          (.getImage graphics-engine)
+             viewport      (.getViewport graphics-engine)
+             ;; CSSBox voodoo -- sometimes maximal width < minimal width, no idea why
+             content-width (max (int (.getMinimalWidth viewport))
+                                (int (.getMaximalWidth viewport)))
+             image         (if (= 1.0 scale)
+                             base
+                             ;; re-render the laid-out boxes into a `scale`x device-pixel image
+                             (let [big (BufferedImage. (int (Math/round (* (.getWidth base) scale)))
+                                                       (int (Math/round (* (.getHeight base) scale)))
+                                                       BufferedImage/TYPE_INT_ARGB)]
+                               (.setImage graphics-engine big)
+                               (.redrawBoxes graphics-engine)
+                               big))
+             crop-width    (int (Math/round (* content-width scale)))]
+         ;; Crop the image to the actual size of the rendered content so that tables don't have a ton of whitespace.
+         (if (< crop-width (.getWidth image))
+           (.getSubimage image 0 0 crop-width (.getHeight image))
+           image))))))
 
 (defn- font-can-fully-render?
   [^Font font s]
@@ -133,6 +150,7 @@
    (try
      (let [padding-x (or (:channel.render/padding-x options) 0)
            padding-y (or (:channel.render/padding-y options) 0)
+           scale     (or (:channel.render/scale options) 1.0)
            padding-css (str padding-y "px " padding-x "px")
            ;; Wrap content in a container div with padding to ensure padding is included in content-width
            ;; calculation (body padding gets cropped off by render-to-png)
@@ -149,7 +167,7 @@
                                         :background-color :white})}
                         (wrap-non-lato-chars padded-content)]])]
        (with-open [os (ByteArrayOutputStream.)]
-         (-> (render-to-png html width)
+         (-> (render-to-png html width scale)
              (write-image! "png" os))
          (.toByteArray os)))
      (catch Throwable e

--- a/src/metabase/channel/render/png.clj
+++ b/src/metabase/channel/render/png.clj
@@ -45,9 +45,10 @@
     .getStyleSheets))
 
 (defn- scale-px
-  "`px` scaled by `scale`, rounded to the nearest whole pixel."
+  "`px` scaled by `scale`, rounded *up* to a whole pixel so the scaled box never falls short of the
+  content it has to hold."
   ^long [px scale]
-  (Math/round (* (double px) (double scale))))
+  (long (Math/ceil (* (double px) (double scale)))))
 
 (defn- redraw-at-scale!
   "Re-render the already-laid-out boxes of `graphics-engine` into a fresh image `scale`x the device size

--- a/test/metabase/channel/render/pdf_test.clj
+++ b/test/metabase/channel/render/pdf_test.clj
@@ -6,11 +6,15 @@
   flaky. The SSRF-safe image-fetch defenses now live in `metabase.util.http` (see
   `metabase.util.http-test`)."
   (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
    [metabase.channel.render.pdf :as pdf]
    [metabase.test.util.dynamic-redefs :as dynamic-redefs])
   (:import
+   (java.awt.image BufferedImage)
+   (javax.imageio ImageIO)
    (org.apache.pdfbox.pdmodel PDDocument PDPage PDPageContentStream)
    (org.apache.pdfbox.pdmodel.common PDRectangle)
    (org.apache.pdfbox.pdmodel.interactive.action PDActionURI)
@@ -349,3 +353,57 @@
             (binding [pdf/*width-cache* cache]
               (is (= (* 2.0 (width "Hello world" 10.0))
                      (width "Hello world" 20.0))))))))))
+
+;; --------------------------------------------------------------------------------------------
+;; Tables: restyling the email table hiccup to fit the PDF card frame
+;; --------------------------------------------------------------------------------------------
+
+(defn- divider?
+  "Whether a restyled header cell carries the border-right divider."
+  [th]
+  (str/includes? (get-in th [1 :style] "") "border-right"))
+
+(deftest ^:parallel restyle-table-test
+  (let [th    (fn [label] [:th {:style "color: #949AAB;"} label])
+        ;; render-table-head splices the header cells into the :tr as a seq, like `for` output
+        table [:table {:style "border: 1px solid #F0F0F0; border-radius: 6px; margin: 16px;"}
+               [:thead [:tr {} (list (th "a") (th "b") (th "c"))]]
+               [:tbody [:tr {} [:td {:style "x"} "1"]]]]
+        [_ attrs [_ [_ _ th-a th-b th-c]] tbody] (#'pdf/restyle-table table)]
+    (testing "the <table> fills its frame and drops its own border/radius/margin"
+      (is (str/includes? (:style attrs) "width:100%"))
+      (is (str/includes? (:style attrs) "border:none")))
+    (testing "header cells get a divider, except the last"
+      (is (divider? th-a))
+      (is (divider? th-b))
+      (is (not (divider? th-c))))
+    (testing "body rows pass through untouched"
+      (is (= [:tbody [:tr {} [:td {:style "x"} "1"]]] tbody)))))
+
+(deftest ^:parallel add-header-dividers-test
+  (testing "spliced seqs are flattened and all header cells but the last get the divider"
+    (let [[_ _ a b] (#'pdf/add-header-dividers
+                     [:tr {} (list [:th {:style ""} "a"] [:th {:style ""} "b"])])]
+      (is (divider? a))
+      (is (not (divider? b)))))
+  (testing "a th without an attrs map is left alone"
+    (let [tr [:tr {} [:th "bare"] [:th {:style ""} "last"]]]
+      (is (= tr (#'pdf/add-header-dividers tr))))))
+
+;; not ^:parallel: exercises the real CSSBox HTML rendering path
+(deftest table-body-png-sizing-test
+  (let [data               {:cols [{:name         "n"
+                                    :display_name "N"
+                                    :base_type    :type/Integer}]
+                            :rows (mapv vector (range 50))}
+        part               {:card     {}
+                            :dashcard nil
+                            :result   {:data data}}
+        px-w               400
+        px-h               300
+        ss                 (long @#'pdf/table-supersample)
+        ^BufferedImage img (ImageIO/read (io/input-stream (#'pdf/table-body-png nil part px-w px-h)))]
+    (testing "width fills the cell at the supersampled scale"
+      (is (<= (* ss (- px-w 8)) (.getWidth img) (* ss px-w))))
+    (testing "height is capped to the cell even though 50 rows don't fit"
+      (is (<= 1 (.getHeight img) (* ss px-h))))))

--- a/test/metabase/channel/render/pdf_test.clj
+++ b/test/metabase/channel/render/pdf_test.clj
@@ -369,7 +369,7 @@
         table [:table {:style "border: 1px solid #F0F0F0; border-radius: 6px; margin: 16px;"}
                [:thead [:tr {} (list (th "a") (th "b") (th "c"))]]
                [:tbody [:tr {} [:td {:style "x"} "1"]]]]
-        [_ attrs [_ [_ _ th-a th-b th-c]] tbody] (#'pdf/restyle-table table)]
+        [_table attrs [_thead [_tr _tr-attrs th-a th-b th-c]] tbody] (#'pdf/restyle-table table)]
     (testing "the <table> fills its frame and drops its own border/radius/margin"
       (is (str/includes? (:style attrs) "width:100%"))
       (is (str/includes? (:style attrs) "border:none")))

--- a/test/metabase/channel/render/png_test.clj
+++ b/test/metabase/channel/render/png_test.clj
@@ -51,11 +51,13 @@
       (#'png/render-to-png width)))
 
 (defn- render-with-wrapping
-  [content width]
-  (-> {:content     content
-       :attachments {}}
-      (png/render-html-to-png width)
-      bytes->image))
+  ([content width]
+   (render-with-wrapping content width nil))
+  ([content width options]
+   (-> {:content     content
+        :attachments {}}
+       (png/render-html-to-png width options)
+       bytes->image)))
 
 (deftest wrap-non-lato-characters-test
   (testing "HTML Content inside tables with characters not supported by the Lato font are wrapped in a span."
@@ -83,3 +85,11 @@
       ;; We assert that the working render is wider based on the assumption (verified manually by
       ;; actually looking at the rendered images) that the correctly rendered glyphs are wider.
       (is (< (.getWidth broken-render) (.getWidth working-render))))))
+
+(deftest render-html-to-png-scale-test
+  (testing "the :channel.render/scale option supersamples the raster without changing layout"
+    (let [content              [:div {:style "width: 100px; height: 40px;"} "hello"]
+          ^BufferedImage png1x (render-with-wrapping content 200)
+          ^BufferedImage png2x (render-with-wrapping content 200 {:channel.render/scale 2.0})]
+      (is (= (* 2 (.getWidth png1x)) (.getWidth png2x)))
+      (is (= (* 2 (.getHeight png1x)) (.getHeight png2x))))))


### PR DESCRIPTION
### Description

Updates table rendering in PDFs to use all available space, and upscales the produced image for crisper text. Also applies to when table is a fallback viz type

<img width="749" height="467" alt="image" src="https://github.com/user-attachments/assets/5a0f883f-d03e-4550-87d1-c212d0c3d9d3" />
<img width="722" height="527" alt="image" src="https://github.com/user-attachments/assets/303f9075-f019-4468-8a31-6272ca650f08" />
