### PR TITLE
Fix param values from joined source card

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1397,6 +1397,7 @@
   binning
   with-binning]
  [metabase.lib.card
+  ->card-metadata-columns
   card->underlying-query
   model-preserved-keys]
  [lib.column-group

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -16,7 +16,6 @@
    [metabase.models.interface :as mi]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -75,45 +74,48 @@
    ;; remapped label for a single selected value)
    [:exact-value {:optional true} :any]])
 
-(mu/defn- values-from-card-query :- [:maybe ::lib.schema/query]
-  [{query :dataset_query, :keys [id], :as _card} :- [:and
-                                                     :metabase.queries.schema/card
-                                                     [:map
-                                                      [:id ::lib.schema.id/card]]]
-   field-ref                                    :- [:or :mbql.clause/field :mbql.clause/expression]
-   {:keys [query-string label-field exact-value] :as _opts} :- [:maybe ::values-from-card-query.options]]
+(defn- card-query
+  [{query :dataset_query, :keys [id], :as _card}]
   (when (seq query)
-    ;; start a new query using this Card as a starting point
-    (let [query (lib/query query (lib.metadata/card query id))]
-      (when-let [visible-columns (or (not-empty (lib/visible-columns query))
-                                     (log/warnf "Cannot get values from Card %d: Card query has no visible columns"
-                                                id))]
-        (when-let [value-column (or (lib/find-matching-column query -1 field-ref visible-columns)
-                                    (log/warnf "Cannot get values from Card %d: failed to find column for ref %s\nFound: %s"
-                                               id
-                                               (pr-str field-ref)
-                                               (pr-str (map (some-fn :lib/source-column-alias :name) visible-columns))))]
-          (let [label-column   (when label-field
-                                 (or (lib/find-matching-column query -1 label-field visible-columns)
-                                     (log/warnf "Cannot get labels from Card %d: failed to find column for ref %s"
-                                                id
-                                                (pr-str label-field))))
-                search-column   (or label-column value-column)
-                value-textual?  (lib.types.isa/string? value-column)
-                search-textual? (lib.types.isa/string? search-column)
-                nonempty        ((if value-textual? lib/not-empty lib/not-null) value-column)
-                query-filter    (cond
-                                  (some? exact-value) (lib/= value-column exact-value)
-                                  query-string        (if search-textual?
-                                                        (lib/ignore-case (lib/contains search-column query-string))
-                                                        (lib/= search-column query-string)))]
-            (-> query
-                (lib/limit *max-rows*)
-                (lib/filter nonempty)
-                (cond-> query-filter (lib/filter query-filter))
-                (lib/breakout value-column)
-                ;; add the label as a second breakout so each row is a [value label] pair
-                (cond-> label-column (lib/breakout label-column)))))))))
+    (lib/query query (lib.metadata/card query id))))
+
+(mu/defn- values-from-card-query :- [:maybe ::lib.schema/query]
+  [{:keys [id], :as card} :- [:and
+                              :metabase.queries.schema/card
+                              [:map
+                               [:id ::lib.schema.id/card]]]
+   field-ref              :- [:or :mbql.clause/field :mbql.clause/expression]
+   {:keys [query-string label-field exact-value] :as _opts} :- [:maybe ::values-from-card-query.options]]
+  (when-let [query (card-query card)]
+    (when-let [visible-columns (or (not-empty (lib/visible-columns query))
+                                   (log/warnf "Cannot get values from Card %d: Card query has no visible columns"
+                                              id))]
+      (when-let [value-column (or (lib/find-matching-column query -1 field-ref visible-columns)
+                                  (log/warnf "Cannot get values from Card %d: failed to find column for ref %s\nFound: %s"
+                                             id
+                                             (pr-str field-ref)
+                                             (pr-str (map (some-fn :lib/source-column-alias :name) visible-columns))))]
+        (let [label-column   (when label-field
+                               (or (lib/find-matching-column query -1 label-field visible-columns)
+                                   (log/warnf "Cannot get labels from Card %d: failed to find column for ref %s"
+                                              id
+                                              (pr-str label-field))))
+              search-column   (or label-column value-column)
+              value-textual?  (lib.types.isa/string? value-column)
+              search-textual? (lib.types.isa/string? search-column)
+              nonempty        ((if value-textual? lib/not-empty lib/not-null) value-column)
+              query-filter    (cond
+                                (some? exact-value) (lib/= value-column exact-value)
+                                query-string        (if search-textual?
+                                                      (lib/ignore-case (lib/contains search-column query-string))
+                                                      (lib/= search-column query-string)))]
+          (-> query
+              (lib/limit *max-rows*)
+              (lib/filter nonempty)
+              (cond-> query-filter (lib/filter query-filter))
+              (lib/breakout value-column)
+              ;; add the label as a second breakout so each row is a [value label] pair
+              (cond-> label-column (lib/breakout label-column))))))))
 
 (defn- result->rows
   "Extract rows from a QP result, dropping values for any display columns the QP injected for
@@ -171,9 +173,9 @@
   [card value-field]
   (boolean
    (and (not (:archived card))
-        ;; existing usage -- do not use this in new code
-        #_{:clj-kondo/ignore [:deprecated-var]}
-        (some? (qp.util/field->field-info value-field (:result_metadata card))))))
+        (when-let [query (card-query card)]
+          (some? (lib/find-matching-column query -1 (lib/->mbql5 value-field)
+                                           (lib/visible-columns query)))))))
 
 ;;; --------------------------------------------- Putting it together ----------------------------------------------
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -40,7 +40,6 @@
    [metabase.queries.models.query :as query]
    [metabase.queries.schema :as queries.schema]
    [metabase.query-permissions.core :as query-perms]
-   [metabase.query-processor.util :as qp.util]
    [metabase.search.core :as search]
    [metabase.util :as u]
    [metabase.util.embed :refer [maybe-populate-initially-published-at]]
@@ -531,15 +530,25 @@
   metabase-enterprise.sandbox.models.sandbox
   [_ _])
 
+(defn- value-field-gone?
+  [metadata-columns value-field]
+  (or (nil? value-field)
+      (empty? metadata-columns)
+      (nil? (lib/find-matching-column (lib/->mbql5 value-field) metadata-columns))))
+
 (defn- update-parameters-using-card-as-values-source
   "Update the config of parameter on any Dashboard/Card use this `card` as values source .
 
   Remove parameter.values_source_type and set parameter.values_source_type to nil ( the default type ) when:
   - card is archived
   - card.result_metadata changes and the parameter values source field can't be found anymore"
-  [{:keys [id]} changes]
+  [{:keys [id database_id]} changes]
   (when (some #{:archived :result_metadata} (keys changes))
-    (let [parameter-cards (t2/select :model/ParameterCard :card_id id)]
+    (let [parameter-cards  (t2/select :model/ParameterCard :card_id id)
+          metadata-columns (when-let [result-metadata (:result_metadata changes)]
+                             (lib/->card-metadata-columns
+                              (lib-be/application-database-metadata-provider database_id)
+                              result-metadata))]
       (doseq [[[po-type po-id] param-cards]
               (group-by (juxt :parameterized_object_type :parameterized_object_id) parameter-cards)]
         (let [model                  (case po-type :card 'Card :dashboard 'Dashboard)
@@ -556,11 +565,10 @@
                                               (filter (fn [param-card]
                                                         ;; if can't find the value-field in result_metadata, then we should
                                                         ;; remove it
-                                                        ;; existing usage -- do not use this in new code
-                                                        #_{:clj-kondo/ignore [:deprecated-var]}
-                                                        (nil? (qp.util/field->field-info
-                                                               (get-in (param-id->parameter (:parameter_id param-card)) [:values_source_config :value_field])
-                                                               (:result_metadata changes)))))
+                                                        (value-field-gone?
+                                                         metadata-columns
+                                                         (get-in (param-id->parameter (:parameter_id param-card))
+                                                                 [:values_source_config :value_field]))))
                                               (map :parameter_id)
                                               set))
 

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -6,9 +6,6 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.driver :as driver]
-   ;; legacy usage -- don't use Legacy MBQL utils in QP code going forward, prefer Lib. This will be updated to use
-   ;; Lib only soon
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib-be.core]
    [metabase.lib.core :as lib]
    [metabase.query-processor.schema :as qp.schema]
@@ -75,41 +72,6 @@
       u/lower-case-en
       (str/replace #"_" "-")
       keyword))
-
-(def ^:private ^{:deprecated "0.57.0"} field-options-for-identification
-  "Set of FieldOptions that only mattered for identification purposes." ;; base-type is required for field that use name instead of id
-  #{:source-field :join-alias})
-
-(defn- field-normalizer
-  {:deprecated "0.57.0"}
-  [field]
-  (let [[type id-or-name options] (lib/normalize ::mbql.s/field field)]
-    #_{:clj-kondo/ignore [:deprecated-var]}
-    [type id-or-name (select-keys options field-options-for-identification)]))
-
-;;; TODO (Cam 9/10/25) -- this logic is all wrong and needs to use Lib instead
-(defn field->field-info
-  "Given a field ref and result_metadata, return a map of information about the field if result_metadata contains a
-  matched field.
-
-  DEPRECATED -- this is broken, please use Lib instead going forward."
-  {:deprecated "0.57.0"}
-  [field-ref cols]
-  #_{:clj-kondo/ignore [:deprecated-var]}
-  (let [[_ttype id-or-name _options :as field-ref] (field-normalizer field-ref)]
-    (or
-     ;; try match field_ref first
-     (first (filter (fn [field-info]
-                      (= field-ref
-                         (-> field-info
-                             :field_ref
-                             field-normalizer)))
-                    cols))
-     ;; if not match name for aggregation or field with string id
-     (first (filter (fn [col]
-                      (= (:name col)
-                         id-or-name))
-                    cols)))))
 
 (def ^:private ^{:deprecated "0.57.0"} preserved-keys
   "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -369,6 +370,32 @@
                                             :value_field [:field Integer/MAX_VALUE nil]}}
                     nil
                     (constantly mock-default-result))))))))))
+
+(deftest ^:parallel parameter->values-join-aliased-value-field-test
+  (let [mp    (mt/metadata-provider)
+        venue-table (lib.metadata/table mp (mt/id :venues))
+        categories-table (lib.metadata/table mp (mt/id :categories))
+        venue-category-id (lib.metadata/field mp (mt/id :venues :category_id))
+        category-id (lib.metadata/field mp (mt/id :categories :id))
+        query (-> (lib/query mp venue-table)
+                  (lib/join (lib/join-clause categories-table
+                                             [(lib/= venue-category-id category-id)])))]
+    (binding [custom-values/*max-rows* 3]
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {card-id :id} (mt/card-with-source-metadata-for-query query)]
+          (is (= {:has_more_values true
+                  :values          [["American"] ["Artisan"] ["Asian"]]}
+                 (custom-values/parameter->values
+                  {:name                 "Category name"
+                   :slug                 "category_name"
+                   :id                   (str (random-uuid))
+                   :type                 :string/=
+                   :values_query_type    :list
+                   :values_source_type   :card
+                   :values_source_config {:card_id     card-id
+                                          :value_field [:field "Categories__NAME" {:base-type :type/Text}]}}
+                  nil
+                  (fn [] (throw (ex-info "Couldn't get parameter values unexpectedly" {})))))))))))
 
 (deftest ^:parallel parameter->values-with-label-field-test
   ;; bind to an admin to bypass the permissions check

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -372,7 +372,7 @@
                     (constantly mock-default-result))))))))))
 
 (deftest ^:parallel parameter->values-join-aliased-value-field-test
-  (let [mp    (mt/metadata-provider)
+  (let [mp (mt/metadata-provider)
         venue-table (lib.metadata/table mp (mt/id :venues))
         categories-table (lib.metadata/table mp (mt/id :categories))
         venue-category-id (lib.metadata/field mp (mt/id :venues :category_id))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -680,6 +680,46 @@
                     :type :category}]
                   (t2/select-one-fn :parameters :model/Card :id (:id card)))))))))
 
+(deftest cleanup-parameter-join-aliased-value-field-test
+  (let [mp                (mt/metadata-provider)
+        venue-table       (lib.metadata/table mp (mt/id :venues))
+        categories-table  (lib.metadata/table mp (mt/id :categories))
+        venue-category-id (lib.metadata/field mp (mt/id :venues :category_id))
+        categories-id     (lib.metadata/field mp (mt/id :categories :id))
+        categories-name   (lib.metadata/field mp (mt/id :categories :name))
+        venues-query      (lib/query mp venue-table)
+        source-query-1    (lib/join venues-query
+                                    (lib/join-clause categories-table
+                                                     [(lib/= venue-category-id categories-id)]))
+        source-query-2    (lib/join venues-query
+                                    (-> (lib/join-clause categories-table
+                                                         [(lib/= venue-category-id categories-id)])
+                                        (lib/with-join-fields [categories-name])))]
+    (mt/with-temp
+      [:model/Card {source-card-id :id} (mt/card-with-source-metadata-for-query source-query-1)
+       :model/Card {param-card-id :id
+                    param-card-params :parameters}  {:parameters [{:name                 "Category name"
+                                                                   :slug                 "category_name"
+                                                                   :id                   "category_name_param"
+                                                                   :type                 :string/=
+                                                                   :values_query_type    :list
+                                                                   :values_source_type   :card
+                                                                   :values_source_config {:card_id     source-card-id
+                                                                                          :value_field [:field "Categories__NAME" {:base-type "type/Text"}]}}]}]
+      (testing "saving the source card with different columns that still include the value_field keeps the parameter config"
+        (t2/update! :model/Card source-card-id (mt/card-with-source-metadata-for-query source-query-2))
+        (is (= param-card-params
+               (t2/select-one-fn :parameters :model/Card :id param-card-id))))
+      (testing "removing the join from the source card removes the parameter config"
+        (t2/update! :model/Card source-card-id (mt/card-with-source-metadata-for-query venues-query))
+        (is (= [{:name "Category name",
+                 :slug "category_name",
+                 :id "category_name_param",
+                 :type :string/=,
+                 :values_query_type :list,
+                 :values_source_type nil}]
+               (t2/select-one-fn :parameters :model/Card :id param-card-id)))))))
+
 (deftest ^:parallel descendants-test
   (testing "regular cards don't depend on anything"
     (mt/with-temp [:model/Card card {:name "some card"}]

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -21,6 +21,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util.unique-name-generator]
+   [metabase.parameters.custom-values :as custom-values]
    [metabase.permissions.core :as perms]
    [metabase.query-processor.api :as api.dataset]
    [metabase.query-processor.compile :as qp.compile]
@@ -923,6 +924,33 @@
                                                        :type                 :string/=,
                                                        :name                 "Text"
                                                        :id                   "abc"}})))))))))
+
+(deftest ^:parallel parameter-values-join-aliased-value-field-test
+  (testing "value_field referencing a joined column of the source model returns values instead of 400 (#75407)"
+    (let [mp                (mt/metadata-provider)
+          venues-table      (lib.metadata/table mp (mt/id :venues))
+          categories-table  (lib.metadata/table mp (mt/id :categories))
+          venue-category-id (lib.metadata/field mp (mt/id :venues :category_id))
+          categories-id     (lib.metadata/field mp (mt/id :categories :id))
+          source-query      (lib/join (lib/query mp venues-table)
+                                      (lib/join-clause categories-table
+                                                       [(lib/= venue-category-id categories-id)]))]
+      (mt/with-temp [:model/Card {card-id :id} (mt/card-with-source-metadata-for-query source-query)]
+        (binding [custom-values/*max-rows* 3]
+          (let [parameter {:name                 "Category name"
+                           :slug                 "category_name"
+                           :id                   (str (random-uuid))
+                           :type                 :string/=
+                           :values_query_type    :list
+                           :values_source_type   :card
+                           :values_source_config {:card_id     card-id
+                                                  :value_field [:field "Categories__NAME" {:base-type :type/Text}]}}
+                values    (->> (mt/user-http-request :crowberto :post 200 "dataset/parameter/values"
+                                                     {:parameter parameter :field_ids []})
+                               :values
+                               (map first)
+                               set)]
+            (is (= #{"American" "Artisan" "Asian"} values))))))))
 
 (deftest ^:parallel parameter-remapping-test
   (testing "field values"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75407

### Description

We were using a deprecated and incorrect method (`field->field-info`) to determine if we could get parameter values. Removes usage of that in favour of lib methods.

### How to verify

See repro steps from original issue. It should work now. 

### Demo

https://www.loom.com/share/d12326bf59c047d6b8728e4e4372ab3d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
