### PR TITLE
Log connection pool destruction at INFO for flaky-test diagnosis

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -211,7 +211,10 @@
      (select-keys details-with-auth [:password-expiry-timestamp]))))
 
 (defn- destroy-pool! [database-id pool-spec]
-  (log/debug (u/format-color :red "Closing old connection pool for database %s ..." database-id))
+  ;; INFO (not DEBUG) so pool destruction is visible in CI test-log artifacts: destroying a pool closes its
+  ;; checked-out connections, which kills in-flight queries with errors like SQL Server's "The result set is
+  ;; closed" (see DEV-2161). Pool destruction is rare and significant enough to warrant INFO in production too.
+  (log/info (u/format-color :red "Closing old connection pool for database %s ..." database-id))
   (driver-api/destroy-connection-pool! pool-spec)
   (ssh/close-tunnel! pool-spec))
 
@@ -298,8 +301,8 @@
         swapped-keys    (filter (fn [[cached-db-id _details-hash]]
                                   (= cached-db-id db-id))
                                 (keys (.asMap ^Cache swapped-connection-pools)))]
-    (log/debugf "Invalidating connection pools for database %d (canonical count: %d, swapped count: %d)"
-                db-id canonical-count (count swapped-keys))
+    (log/infof "Invalidating connection pools for database %d (canonical count: %d, swapped count: %d)"
+               db-id canonical-count (count swapped-keys))
     ;; Clear canonical pools for both connection types
     (doseq [cache-key canonical-keys
             :let      [[old-map] (swap-vals! pool-cache-key->connection-pool dissoc cache-key)


### PR DESCRIPTION
### Description

Improve logging for some flaky tests that fail with `"The result set is closed"`.

Destroying a c3p0 pool closes its checked-out connections, which kills any in-flight query on another thread with errors like SQL Server's "The result set is closed" (DEV-2161). These destroy/invalidate events were only logged at DEBUG, so CI test-log artifacts (which capture INFO+) could not show whether a pool destroy coincided with a flaky query failure.

Log destroy-pool! and invalidate-pool-for-db! at INFO so the next occurrence is diagnosable from the CI artifact alone. In tests these log lines automatically carry the running test's name via the logging context, attributing each pool destruction to its trigger.