### PR TITLE
fix: add optimistic updates for comments api in documents with many cards

### DIFF
--- a/frontend/src/metabase/api/api.ts
+++ b/frontend/src/metabase/api/api.ts
@@ -53,12 +53,6 @@ export const Api = createApi({
   tagTypes: TAG_TYPES,
   baseQuery,
   endpoints: () => ({}),
-  // RTK 2.x defaults to "delayed", which postpones tag invalidation until ALL
-  // in-flight queries of this instance settle. Long-running queries (e.g.
-  // document card data on a slow warehouse) would freeze every
-  // invalidation-driven refetch in the app, so mutations like posting a
-  // comment appeared to do nothing.
-  invalidationBehavior: "immediately",
 });
 
 export { skipToken };

--- a/frontend/src/metabase/api/api.ts
+++ b/frontend/src/metabase/api/api.ts
@@ -53,6 +53,12 @@ export const Api = createApi({
   tagTypes: TAG_TYPES,
   baseQuery,
   endpoints: () => ({}),
+  // RTK 2.x defaults to "delayed", which postpones tag invalidation until ALL
+  // in-flight queries of this instance settle. Long-running queries (e.g.
+  // document card data on a slow warehouse) would freeze every
+  // invalidation-driven refetch in the app, so mutations like posting a
+  // comment appeared to do nothing.
+  invalidationBehavior: "immediately",
 });
 
 export { skipToken };

--- a/frontend/src/metabase/api/comment.ts
+++ b/frontend/src/metabase/api/comment.ts
@@ -25,13 +25,8 @@ export type ToggleReactionRequest = CreateReactionRequest &
     currentUser: Pick<BaseUser, "id" | "common_name">;
   };
 
-// Comment mutations patch the cached list directly in `onQueryStarted` instead
-// of relying on the tag-driven refetch alone: with RTK's default "delayed"
-// invalidation behavior, that refetch is postponed until every in-flight query
-// on the shared Api instance settles, so on pages with long-running queries
-// (e.g. document card data on a slow warehouse) mutations would appear to do
-// nothing for minutes. The tags are kept so the list still reconciles with the
-// server once a refetch does run.
+// Update the cached comments manually, because RTK won't refetch it while
+// another query is still running
 export const commentApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     listComments: builder.query<

--- a/frontend/src/metabase/api/comment.ts
+++ b/frontend/src/metabase/api/comment.ts
@@ -7,6 +7,7 @@ import {
   provideUserListTags,
 } from "metabase/api/tags";
 import type {
+  BaseUser,
   Comment,
   CommentId,
   CreateCommentRequest,
@@ -17,6 +18,20 @@ import type {
   UpdateCommentRequest,
 } from "metabase-types/api";
 
+export type DeleteCommentRequest = { id: CommentId } & ListCommentsRequest;
+
+export type ToggleReactionRequest = CreateReactionRequest &
+  ListCommentsRequest & {
+    currentUser: Pick<BaseUser, "id" | "common_name">;
+  };
+
+// Comment mutations patch the cached list directly in `onQueryStarted` instead
+// of relying on the tag-driven refetch alone: with RTK's default "delayed"
+// invalidation behavior, that refetch is postponed until every in-flight query
+// on the shared Api instance settles, so on pages with long-running queries
+// (e.g. document card data on a slow warehouse) mutations would appear to do
+// nothing for minutes. The tags are kept so the list still reconciles with the
+// server once a refetch does run.
 export const commentApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     listComments: builder.query<
@@ -40,6 +55,25 @@ export const commentApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error) =>
         invalidateTags(error, [listTag("comment")]),
+      async onQueryStarted(_request, { dispatch, queryFulfilled }) {
+        try {
+          const { data: comment } = await queryFulfilled;
+          dispatch(
+            commentApi.util.updateQueryData(
+              "listComments",
+              {
+                target_type: comment.target_type,
+                target_id: comment.target_id,
+              },
+              (draft) => {
+                draft.comments.push(comment);
+              },
+            ),
+          );
+        } catch {
+          // the caller reports the error; there is nothing to patch
+        }
+      },
     }),
 
     updateComment: builder.mutation<Comment, UpdateCommentRequest>({
@@ -50,20 +84,72 @@ export const commentApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [idTag("comment", id), listTag("comment")]),
+      async onQueryStarted(_request, { dispatch, queryFulfilled }) {
+        try {
+          const { data: comment } = await queryFulfilled;
+          dispatch(
+            commentApi.util.updateQueryData(
+              "listComments",
+              {
+                target_type: comment.target_type,
+                target_id: comment.target_id,
+              },
+              (draft) => {
+                const index = draft.comments.findIndex(
+                  ({ id }) => id === comment.id,
+                );
+                if (index !== -1) {
+                  draft.comments[index] = comment;
+                }
+              },
+            ),
+          );
+        } catch {
+          console.error("Failed to update cached comment:", _request);
+        }
+      },
     }),
 
-    deleteComment: builder.mutation<void, CommentId>({
-      query: (id) => ({
+    deleteComment: builder.mutation<void, DeleteCommentRequest>({
+      query: ({ id }) => ({
         method: "DELETE",
         url: `/api/comment/${id}`,
       }),
-      invalidatesTags: (_, error, id) =>
+      invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [idTag("comment", id), listTag("comment")]),
+      async onQueryStarted(
+        { id, target_type, target_id },
+        { dispatch, queryFulfilled },
+      ) {
+        try {
+          await queryFulfilled;
+          dispatch(
+            commentApi.util.updateQueryData(
+              "listComments",
+              { target_type, target_id },
+              (draft) => {
+                const comment = draft.comments.find(
+                  (comment) => comment.id === id,
+                );
+                if (comment) {
+                  comment.deleted_at = new Date().toISOString();
+                }
+              },
+            ),
+          );
+        } catch {
+          console.error("Failed to delete cached comment:", {
+            id,
+            target_type,
+            target_id,
+          });
+        }
+      },
     }),
 
     toggleReaction: builder.mutation<
       { reacted: boolean },
-      CreateReactionRequest
+      ToggleReactionRequest
     >({
       query: ({ id, emoji }) => ({
         method: "POST",
@@ -72,6 +158,73 @@ export const commentApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [idTag("comment", id), listTag("comment")]),
+      async onQueryStarted(
+        { id, emoji, target_type, target_id, currentUser },
+        { dispatch, queryFulfilled },
+      ) {
+        // unlike the pessimistic patches above, reactions toggle optimistically
+        // (before the response) and roll back on error
+        const patch = dispatch(
+          commentApi.util.updateQueryData(
+            "listComments",
+            { target_type, target_id },
+            (draft) => {
+              const comment = draft.comments.find(
+                (comment) => comment.id === id,
+              );
+              if (!comment) {
+                return;
+              }
+
+              const reaction = comment.reactions.find(
+                (reaction) => reaction.emoji === emoji,
+              );
+              const hasReacted = reaction?.users.some(
+                (user) => user.id === currentUser.id,
+              );
+
+              if (reaction && hasReacted) {
+                reaction.users = reaction.users.filter(
+                  (user) => user.id !== currentUser.id,
+                );
+                reaction.count -= 1;
+                if (reaction.count <= 0) {
+                  comment.reactions = comment.reactions.filter(
+                    ({ emoji }) => emoji !== reaction.emoji,
+                  );
+                }
+              } else if (reaction) {
+                reaction.users.push({
+                  id: currentUser.id,
+                  name: currentUser.common_name,
+                });
+                reaction.count += 1;
+              } else {
+                comment.reactions.push({
+                  emoji,
+                  count: 1,
+                  users: [
+                    { id: currentUser.id, name: currentUser.common_name },
+                  ],
+                });
+              }
+            },
+          ),
+        );
+
+        try {
+          await queryFulfilled;
+        } catch {
+          patch.undo();
+          console.error("Failed to toggle reaction on cached comment:", {
+            id,
+            emoji,
+            target_type,
+            target_id,
+            currentUser,
+          });
+        }
+      },
     }),
 
     listMentions: builder.query<

--- a/frontend/src/metabase/api/comment.unit.spec.ts
+++ b/frontend/src/metabase/api/comment.unit.spec.ts
@@ -1,0 +1,69 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { createMockComment } from "metabase-types/api/mocks/comment";
+import { createMockDocumentContent } from "metabase-types/api/mocks/document";
+
+import { Api } from "./api";
+import { cardApi } from "./card";
+import { commentApi } from "./comment";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  fetchMock.get("path:/api/comment", { comments: [createMockComment()] });
+  fetchMock.post("path:/api/comment", createMockComment());
+  // A query that never settles, standing in for a long-running card query on
+  // a document page.
+  fetchMock.get("path:/api/card/1", new Promise(() => {}));
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  const listCommentsCalls = () =>
+    fetchMock.callHistory.calls("path:/api/comment", { method: "GET" }).length;
+
+  return { store, listCommentsCalls };
+}
+
+describe("commentApi invalidation", () => {
+  afterEach(() => {
+    // Drop the store's RTK Query subscriptions before pulling the fetch routes,
+    // otherwise orphaned subscriptions refetch against removed routes.
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("refetches the comment list right after a mutation, even while an unrelated query is still in flight", async () => {
+    const { store, listCommentsCalls } = setup();
+
+    store.dispatch(
+      commentApi.endpoints.listComments.initiate({
+        target_type: "document",
+        target_id: 1,
+      }),
+    );
+    await waitFor(() => expect(listCommentsCalls()).toBe(1));
+
+    // Keep a never-settling query in flight. With RTK's default "delayed"
+    // invalidation behavior it would block all tag invalidation, so comment
+    // mutations on documents with slow cards appeared to do nothing.
+    store.dispatch(cardApi.endpoints.getCard.initiate({ id: 1 }));
+
+    await store.dispatch(
+      commentApi.endpoints.createComment.initiate({
+        target_type: "document",
+        target_id: 1,
+        child_target_id: "node-1",
+        parent_comment_id: null,
+        content: createMockDocumentContent(),
+      }),
+    );
+
+    await waitFor(() => expect(listCommentsCalls()).toBe(2));
+  });
+});

--- a/frontend/src/metabase/api/comment.unit.spec.ts
+++ b/frontend/src/metabase/api/comment.unit.spec.ts
@@ -2,6 +2,7 @@ import { waitFor } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 
 import { getStore } from "__support__/entities-store";
+import { setupCommentEndpoints } from "__support__/server-mocks";
 import { createMockComment } from "metabase-types/api/mocks/comment";
 import { createMockDocumentContent } from "metabase-types/api/mocks/document";
 
@@ -12,11 +13,11 @@ import { commentApi } from "./comment";
 let activeStore: ReturnType<typeof getStore> | undefined;
 
 function setup() {
-  fetchMock.get("path:/api/comment", { comments: [createMockComment()] });
+  setupCommentEndpoints([createMockComment()], {
+    target_type: "document",
+    target_id: 1,
+  });
   fetchMock.post("path:/api/comment", createMockComment());
-  // A query that never settles, standing in for a long-running card query on
-  // a document page.
-  fetchMock.get("path:/api/card/1", new Promise(() => {}));
 
   const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
     Api.middleware,
@@ -49,9 +50,9 @@ describe("commentApi invalidation", () => {
     );
     await waitFor(() => expect(listCommentsCalls()).toBe(1));
 
-    // Keep a never-settling query in flight. With RTK's default "delayed"
-    // invalidation behavior it would block all tag invalidation, so comment
-    // mutations on documents with slow cards appeared to do nothing.
+    // Park a never-settling query in flight — RTK's default "delayed"
+    // invalidation behavior would postpone all refetches until it settles.
+    fetchMock.get("path:/api/card/1", new Promise(() => {}));
     store.dispatch(cardApi.endpoints.getCard.initiate({ id: 1 }));
 
     await store.dispatch(

--- a/frontend/src/metabase/api/comment.unit.spec.ts
+++ b/frontend/src/metabase/api/comment.unit.spec.ts
@@ -38,9 +38,7 @@ async function setup({ comments }: { comments: Comment[] }) {
 
 describe("commentApi cache updates", () => {
   afterEach(() => {
-    // Drop the store's RTK Query subscriptions before pulling the fetch routes:
-    // this aborts in-flight queries so the global afterEach `flush()` settles,
-    // and stops orphaned subscriptions refetching against removed routes.
+    // Abort in-flight queries before removing the fetch routes.
     activeStore?.dispatch(Api.util.resetApiState());
     activeStore = undefined;
     fetchMock.removeRoutes().clearHistory();
@@ -53,9 +51,7 @@ describe("commentApi cache updates", () => {
     const newComment = createMockComment({ id: 2, ...LIST_REQUEST });
     fetchMock.post("path:/api/comment", newComment);
 
-    // Park a never-settling query in flight — RTK's default "delayed"
-    // invalidation behavior postpones all tag-driven refetches until it
-    // settles, so the cache patch is the only way the new comment can appear.
+    // simulate never-resolving query
     fetchMock.get("path:/api/card/1", new Promise(() => {}));
     store.dispatch(cardApi.endpoints.getCard.initiate({ id: 1 }));
 

--- a/frontend/src/metabase/api/comment.unit.spec.ts
+++ b/frontend/src/metabase/api/comment.unit.spec.ts
@@ -3,6 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { getStore } from "__support__/entities-store";
 import { setupCommentEndpoints } from "__support__/server-mocks";
+import type { Comment } from "metabase-types/api";
 import { createMockComment } from "metabase-types/api/mocks/comment";
 import { createMockDocumentContent } from "metabase-types/api/mocks/document";
 
@@ -10,61 +11,138 @@ import { Api } from "./api";
 import { cardApi } from "./card";
 import { commentApi } from "./comment";
 
+const LIST_REQUEST = { target_type: "document" as const, target_id: 1 };
+const CURRENT_USER = { id: 7, common_name: "Current User" };
+
 let activeStore: ReturnType<typeof getStore> | undefined;
 
-function setup() {
-  setupCommentEndpoints([createMockComment()], {
-    target_type: "document",
-    target_id: 1,
-  });
-  fetchMock.post("path:/api/comment", createMockComment());
+async function setup({ comments }: { comments: Comment[] }) {
+  setupCommentEndpoints(comments, LIST_REQUEST);
 
   const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
     Api.middleware,
   ]);
   activeStore = store;
 
-  const listCommentsCalls = () =>
-    fetchMock.callHistory.calls("path:/api/comment", { method: "GET" }).length;
+  const getCachedComments = () =>
+    commentApi.endpoints.listComments.select(LIST_REQUEST)(store.getState())
+      .data?.comments;
 
-  return { store, listCommentsCalls };
+  store.dispatch(commentApi.endpoints.listComments.initiate(LIST_REQUEST));
+  await waitFor(() =>
+    expect(getCachedComments()).toHaveLength(comments.length),
+  );
+
+  return { store, getCachedComments };
 }
 
-describe("commentApi invalidation", () => {
+describe("commentApi cache updates", () => {
   afterEach(() => {
-    // Drop the store's RTK Query subscriptions before pulling the fetch routes,
-    // otherwise orphaned subscriptions refetch against removed routes.
+    // Drop the store's RTK Query subscriptions before pulling the fetch routes:
+    // this aborts in-flight queries so the global afterEach `flush()` settles,
+    // and stops orphaned subscriptions refetching against removed routes.
     activeStore?.dispatch(Api.util.resetApiState());
     activeStore = undefined;
     fetchMock.removeRoutes().clearHistory();
   });
 
-  it("refetches the comment list right after a mutation, even while an unrelated query is still in flight", async () => {
-    const { store, listCommentsCalls } = setup();
-
-    store.dispatch(
-      commentApi.endpoints.listComments.initiate({
-        target_type: "document",
-        target_id: 1,
-      }),
-    );
-    await waitFor(() => expect(listCommentsCalls()).toBe(1));
+  it("shows a created comment even while invalidation is starved by an in-flight query", async () => {
+    const { store, getCachedComments } = await setup({
+      comments: [createMockComment({ id: 1, ...LIST_REQUEST })],
+    });
+    const newComment = createMockComment({ id: 2, ...LIST_REQUEST });
+    fetchMock.post("path:/api/comment", newComment);
 
     // Park a never-settling query in flight — RTK's default "delayed"
-    // invalidation behavior would postpone all refetches until it settles.
+    // invalidation behavior postpones all tag-driven refetches until it
+    // settles, so the cache patch is the only way the new comment can appear.
     fetchMock.get("path:/api/card/1", new Promise(() => {}));
     store.dispatch(cardApi.endpoints.getCard.initiate({ id: 1 }));
 
     await store.dispatch(
       commentApi.endpoints.createComment.initiate({
-        target_type: "document",
-        target_id: 1,
+        ...LIST_REQUEST,
         child_target_id: "node-1",
         parent_comment_id: null,
         content: createMockDocumentContent(),
       }),
     );
 
-    await waitFor(() => expect(listCommentsCalls()).toBe(2));
+    expect(getCachedComments()?.map(({ id }) => id)).toEqual([1, 2]);
+    expect(
+      fetchMock.callHistory.calls("path:/api/comment", { method: "GET" }),
+    ).toHaveLength(1);
+  });
+
+  it("patches the cached comment when it is updated", async () => {
+    const comment = createMockComment({ id: 1, ...LIST_REQUEST });
+    const { store, getCachedComments } = await setup({ comments: [comment] });
+    fetchMock.put("path:/api/comment/1", { ...comment, is_resolved: true });
+
+    await store.dispatch(
+      commentApi.endpoints.updateComment.initiate({ id: 1, is_resolved: true }),
+    );
+
+    expect(getCachedComments()?.[0]?.is_resolved).toBe(true);
+  });
+
+  it("marks the cached comment as deleted when it is deleted", async () => {
+    const { store, getCachedComments } = await setup({
+      comments: [createMockComment({ id: 1, ...LIST_REQUEST })],
+    });
+    fetchMock.delete("path:/api/comment/1", 204);
+
+    await store.dispatch(
+      commentApi.endpoints.deleteComment.initiate({ id: 1, ...LIST_REQUEST }),
+    );
+
+    expect(getCachedComments()?.[0]?.deleted_at).toEqual(expect.any(String));
+  });
+
+  it("toggles the current user's reaction on the cached comment", async () => {
+    const { store, getCachedComments } = await setup({
+      comments: [createMockComment({ id: 1, ...LIST_REQUEST, reactions: [] })],
+    });
+    fetchMock.post("path:/api/comment/1/reaction", { reacted: true });
+
+    const toggle = () =>
+      store.dispatch(
+        commentApi.endpoints.toggleReaction.initiate({
+          id: 1,
+          emoji: "🤣",
+          ...LIST_REQUEST,
+          currentUser: CURRENT_USER,
+        }),
+      );
+
+    await toggle();
+    expect(getCachedComments()?.[0]?.reactions).toEqual([
+      {
+        emoji: "🤣",
+        count: 1,
+        users: [{ id: CURRENT_USER.id, name: CURRENT_USER.common_name }],
+      },
+    ]);
+
+    await toggle();
+    expect(getCachedComments()?.[0]?.reactions).toEqual([]);
+  });
+
+  it("reverts the reaction patch when the request fails", async () => {
+    const { store, getCachedComments } = await setup({
+      comments: [createMockComment({ id: 1, ...LIST_REQUEST, reactions: [] })],
+    });
+    fetchMock.post("path:/api/comment/1/reaction", 500);
+
+    await store.dispatch(
+      commentApi.endpoints.toggleReaction.initiate({
+        id: 1,
+        emoji: "🤣",
+        ...LIST_REQUEST,
+        currentUser: CURRENT_USER,
+      }),
+    );
+
+    expect(getCachedComments()?.[0]?.reactions).toEqual([]);
   });
 });

--- a/frontend/src/metabase/comments/components/Discussion/Discussion.tsx
+++ b/frontend/src/metabase/comments/components/Discussion/Discussion.tsx
@@ -71,7 +71,11 @@ export const Discussion = ({
   };
 
   const handleDeleteComment = async (comment: Comment) => {
-    const { error } = await deleteComment(comment.id);
+    const { error } = await deleteComment({
+      id: comment.id,
+      target_type: comment.target_type,
+      target_id: comment.target_id,
+    });
 
     if (error) {
       sendToast({
@@ -142,29 +146,37 @@ export const Discussion = ({
     sendToast({ icon: "check", message: t`Copied link` });
   };
 
-  const handleReaction = async (comment: Comment, emoji: string) => {
-    const { error } = await toggleReaction({ id: comment.id, emoji });
+  const handleToggleReaction = async (
+    comment: Comment,
+    emoji: string,
+    errorMessage: string,
+  ) => {
+    if (!currentUser) {
+      return;
+    }
+
+    const { error } = await toggleReaction({
+      id: comment.id,
+      emoji,
+      target_type: comment.target_type,
+      target_id: comment.target_id,
+      currentUser,
+    });
 
     if (error) {
       sendToast({
         icon: "warning_triangle_filled",
         iconColor: "warning",
-        message: t`Failed to add reaction`,
+        message: errorMessage,
       });
     }
   };
 
-  const handleReactionRemove = async (comment: Comment, emoji: string) => {
-    const { error } = await toggleReaction({ id: comment.id, emoji });
+  const handleReaction = (comment: Comment, emoji: string) =>
+    handleToggleReaction(comment, emoji, t`Failed to add reaction`);
 
-    if (error) {
-      sendToast({
-        icon: "warning_triangle_filled",
-        iconColor: "warning",
-        message: t`Failed to remove reaction`,
-      });
-    }
-  };
+  const handleReactionRemove = (comment: Comment, emoji: string) =>
+    handleToggleReaction(comment, emoji, t`Failed to remove reaction`);
 
   const handleMouseEnter = () => {
     if (enableHoverHighlight && effectiveChildTargetId) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70538 closes #70536
For big documents with many cards (same applies to dashboards with many cards) if we make any RTK mutation request, it has no effect as there are other queries in progress. It is a default RTK behavior https://redux-toolkit.js.org/rtk-query/api/createApi#invalidationbehavior

But it leads to the cases when you want to leave a comment or add a reaction to comment while data is still fetching for cards displaying in big documents, so you have to wait 5s+ to start your interaction with the page. 

To address this issue we add optimistic updates as changing default RTK behavior can lead to race conditions and requires additional verification as it can affect all API requests ([discussion](https://metaboat.slack.com/archives/C505ZNNH4/p1781250250278049))

actually closes [GDGT-1896: Can't resolve a comment, or add a subcomment, or add an emoji to a comment for a document](https://linear.app/metabase/issue/GDGT-1896/cant-resolve-a-comment-or-add-a-subcomment-or-add-an-emoji-to-a)

### Before


https://github.com/user-attachments/assets/a70ac95d-360b-42b0-bbb3-6641cbbe525d



### After


https://github.com/user-attachments/assets/b36ef906-ad29-4f61-aaf0-3d9f47493d67




