### PR TITLE
Fix restoring items from a remote-synced collection

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1445,7 +1445,8 @@
     (let [{collection-after-update :collection_id :as model-after-update} <>]
       (when (remote-synced-collection? collection-after-update)
         (check-non-remote-synced-dependencies model-after-update)
-        (when (api/column-will-change? :archived model-before-update model-after-update)
+        (when (and (api/column-will-change? :archived model-before-update model-after-update)
+                   (:archived model-after-update))
           (check-remote-synced-dependents model-after-update)))
       (when (and (api/column-will-change? :collection_id model-before-update model-after-update)
                  (moving-from-remote-synced? collection-before-update collection-after-update))

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -2509,6 +2509,41 @@
                             (collection/check-remote-synced-dependents (t2/instance :model/Collection {:id source-coll-id})))
           "Should throw exception when collection contains cards with remote-synced dependents"))))
 
+(deftest check-for-remote-sync-update-restore-test
+  (testing "restoring an item that lives in a remote-synced collection does not throw (GHY-3821)"
+    ;; The item's own containing remote-synced collection is reported as a dependent, so the
+    ;; dependents check must only fire when archiving (false->true), not when restoring (true->false).
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Card {card-id :id} {:name "Archived Card"
+                                              :collection_id remote-synced-id
+                                              :archived true
+                                              :database_id (mt/id)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (let [card-before-update (t2/select-one :model/Card :id card-id)]
+        ;; mirror the DB state after a restore has been applied within the update transaction
+        (t2/update! :model/Card card-id {:archived false})
+        (is (some? (collection/check-for-remote-sync-update card-before-update))
+            "Restoring an item in a remote-synced collection should not throw")))))
+
+(deftest check-for-remote-sync-update-archive-with-dependent-test
+  (testing "archiving an item that an active remote-synced item depends on still throws"
+    (mt/with-temp [:model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Card {base-card-id :id} {:name "Base Card"
+                                                   :collection_id remote-synced-id
+                                                   :database_id (mt/id)
+                                                   :dataset_query (mt/mbql-query venues)}
+                   :model/Card _ {:name "Dependent Card"
+                                  :collection_id remote-synced-id
+                                  :database_id (mt/id)
+                                  :dataset_query (mt/mbql-query nil {:source-table (str "card__" base-card-id)})}]
+      (let [card-before-update (t2/select-one :model/Card :id base-card-id)]
+        ;; mirror the DB state after an archive has been applied within the update transaction
+        (t2/update! :model/Card base-card-id {:archived true})
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Used by remote synced content."
+                              (collection/check-for-remote-sync-update card-before-update))
+            "Archiving an item with active remote-synced dependents should throw")))))
+
 (deftest ^:parallel remote-synced-dependents-with-dashboard-test
   (testing "remote-synced-dependents should return dashboards in remote-synced collections that contain the card"
     (mt/with-temp [:model/Collection {remote-synced-coll-id :id} {:is_remote_synced true}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73449
## Summary

Items in a remote-synced collection couldn't be restored from the trash — `Restore` failed with HTTP 400 `"Used by remote synced content."` (GHY-3821).

`check-for-remote-sync-update` ran the remote-synced *dependents* check whenever the `:archived` column changed. That check is meant to block **archiving** an item that other remote-synced content depends on. But `column-will-change? :archived` is undirected, so it also fired on **restore** (`true → false`). For an item sitting inside a remote-synced collection, `remote-synced-dependents` reports the item's own containing collection as a dependent, so restore always threw.

The fix adds a directionality guard: only run the dependents check when the item is being archived (`:archived` is true after the update). Restore skips it entirely; archiving with real dependents still throws as before.

The sibling checks are already correct and unchanged:
- `check-non-remote-synced-dependencies` still runs on both archive and restore.
- The move-out branch is already guarded by `moving-from-remote-synced?`.

## How to verify

```
1. Create a question in a remote-synced collection
2. Trash it
3. Try to restore → previously errored, now succeeds
```

## Tests

Two regression tests added to `collection_test.clj`:
- `check-for-remote-sync-update-restore-test` — restoring an item in a remote-synced collection does not throw (fails on master, passes with this fix).
- `check-for-remote-sync-update-archive-with-dependent-test` — archiving an item with an active remote-synced dependent still throws.

All 64 remote-sync tests in the namespace pass; kondo clean.

Fixes GHY-3821
