### PR TITLE
Fix quick filter on binned columns

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -41,6 +41,7 @@
   (:refer-clojure :exclude [select-keys mapv #?(:clj for)])
   (:require
    [medley.core :as m]
+   [metabase.lib.binning :as lib.binning]
    [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.expression :as lib.expression]
@@ -138,8 +139,10 @@
     (when-let [drill-details (lib.drill-thru.column-filter/prepare-query-for-drill-addition
                               query stage-number column column-ref :filter)]
       (let [temporal-unit (lib.temporal-bucket/temporal-bucket column-ref)
+            binning (lib.binning/binning column-ref)
             column (cond-> (:column drill-details)
-                     temporal-unit (assoc :temporal-unit temporal-unit))]
+                     temporal-unit (assoc :temporal-unit temporal-unit)
+                     binning       (assoc :lib/binning binning))]
         (merge drill-details
                {:lib/type   :metabase.lib.drill-thru/drill-thru
                 :type       :drill-thru/quick-filter

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -342,3 +342,31 @@
                                     [:field {:temporal-unit :month} (meta/id :orders :created-at)]
                                     "2023-03-01T00:00:00Z"]]}]}
               (lib/drill-thru base-query -1 nil drill "="))))))
+
+(deftest ^:parallel quick-filter-on-binned-column-keeps-binning-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/count))
+                  (lib/breakout (-> (meta/field-metadata :orders :total)
+                                    (lib/with-binning {:strategy :default}))))
+        count-col (m/find-first #(= (:name %) "count")
+                                (lib/returned-columns query))
+        total-col (m/find-first #(= (:name %) "TOTAL")
+                                (lib/returned-columns query))
+        context {:column total-col
+                 :column-ref (lib/ref total-col)
+                 :value 40
+                 :row [{:column total-col
+                        :column-ref (lib/ref total-col)
+                        :value 40}
+                       {:column count-col
+                        :column-ref (lib/ref count-col)
+                        :value 4107}]}
+        drill (m/find-first #(= (:type %) :drill-thru/quick-filter)
+                            (lib/available-drill-thrus query context))
+        drilled (lib/drill-thru query -1 nil drill "=")]
+    (is (=? [[:= {}
+              [:field {:binning {:strategy :default, :lib/type :metabase.lib.binning/binning}} (:id total-col)]
+              40]]
+            (lib/filters drilled)))
+    (is (= #{(:id count-col) (:id total-col)}
+           (set (map :id (lib/returned-columns drilled)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15334

### Description

When you try to use a quick filter on a binned column, we were checking against the unbinned column. Fix is to apply the binning from the column ref to the column. Similar to what we do for temporal bucketing. As a separate task we may want to let people use the underyling records drill thru ("See these orders") from the binned column (right now it's only a drill option on the count column). 

### How to verify

See repro steps in original issue. It should filter to the selected row with the column binning still applied. 

### Demo

https://github.com/user-attachments/assets/95b39116-bbfe-4c87-beed-f4e4aba6e35d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
