### PR TITLE
Move `AutoApi` to RTK hooks and update callers

### DIFF
--- a/frontend/src/metabase-types/api/automagic-dashboards.ts
+++ b/frontend/src/metabase-types/api/automagic-dashboards.ts
@@ -16,6 +16,13 @@ export interface GetXrayDashboardQueryMetadataRequest {
   dashboard_load_id?: string;
 }
 
+export interface GetXrayDashboardRequest {
+  // Multi-segment path after `/api/automagic-dashboards/`, e.g. `table/3` or
+  // `transient/table/3/cell/4`. Slashes are preserved (not URL-encoded).
+  subPath: string;
+  dashboard_load_id?: string;
+}
+
 export interface DatabaseXray {
   id: string;
   schema: string;

--- a/frontend/src/metabase/api/automagic-dashboards.ts
+++ b/frontend/src/metabase/api/automagic-dashboards.ts
@@ -16,15 +16,39 @@ import {
 } from "./tags";
 import { handleQueryFulfilled } from "./utils/lifecycle";
 
+// `subPath` is embedded raw into the request URL (its slashes are real path
+// separators) and originates from the `/auto/dashboard/*` route — i.e. it is
+// user-controlled. Reject `.`/`..` path segments so a crafted URL can't walk
+// out of the automagic-dashboards route into another same-origin endpoint.
+export function hasUnsafeXraySubPath(subPath: string): boolean {
+  const [path] = subPath.split("?");
+  return path.split("/").some((segment) => segment === "." || segment === "..");
+}
+
 export const automagicDashboardsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     getXrayDashboard: builder.query<Dashboard, GetXrayDashboardRequest>({
-      query: ({ subPath, ...params }) => ({
-        method: "GET",
-        // `subPath` is embedded raw so its slashes stay as path separators.
-        url: `/api/automagic-dashboards/${subPath}`,
-        params,
-      }),
+      queryFn: async (
+        { subPath, ...params },
+        _api,
+        _extraOptions,
+        baseQuery,
+      ) => {
+        if (hasUnsafeXraySubPath(subPath)) {
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              error: `Refusing to fetch x-ray dashboard for unsafe path: ${subPath}`,
+            },
+          };
+        }
+        const { data, error } = await baseQuery({
+          method: "GET",
+          url: `/api/automagic-dashboards/${subPath}`,
+          params,
+        });
+        return error ? { error } : { data: data as Dashboard };
+      },
     }),
     getXrayDashboardQueryMetadata: builder.query<
       DashboardQueryMetadata,

--- a/frontend/src/metabase/api/automagic-dashboards.ts
+++ b/frontend/src/metabase/api/automagic-dashboards.ts
@@ -6,6 +6,7 @@ import type {
   DatabaseId,
   DatabaseXray,
   GetXrayDashboardQueryMetadataRequest,
+  GetXrayDashboardRequest,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -17,6 +18,14 @@ import { handleQueryFulfilled } from "./utils/lifecycle";
 
 export const automagicDashboardsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
+    getXrayDashboard: builder.query<Dashboard, GetXrayDashboardRequest>({
+      query: ({ subPath, ...params }) => ({
+        method: "GET",
+        // `subPath` is embedded raw so its slashes stay as path separators.
+        url: `/api/automagic-dashboards/${subPath}`,
+        params,
+      }),
+    }),
     getXrayDashboardQueryMetadata: builder.query<
       DashboardQueryMetadata,
       GetXrayDashboardQueryMetadataRequest
@@ -62,4 +71,5 @@ export const {
   useGetXrayDashboardQueryMetadataQuery,
   useListDatabaseXraysQuery,
   useLazyGetXrayDashboardForModelQuery,
+  useLazyGetXrayDashboardQuery,
 } = automagicDashboardsApi;

--- a/frontend/src/metabase/api/automagic-dashboards.unit.spec.ts
+++ b/frontend/src/metabase/api/automagic-dashboards.unit.spec.ts
@@ -1,0 +1,84 @@
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { createMockDashboard } from "metabase-types/api/mocks";
+
+import { Api } from "./api";
+import {
+  automagicDashboardsApi,
+  hasUnsafeXraySubPath,
+} from "./automagic-dashboards";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  const xrayCalls = () =>
+    fetchMock.callHistory.calls(XRAY_URL_REGEX, { method: "GET" });
+
+  return { store, xrayCalls };
+}
+
+const XRAY_URL_REGEX = /\/api\/automagic-dashboards\//;
+
+describe("hasUnsafeXraySubPath", () => {
+  it.each([
+    "table/3",
+    "adhoc/eyJxdWVyeSI6e30/cell/eyJmaWx0ZXIiOltdfQ",
+    "question/1/cell/abc/compare/table/2",
+    "table/3?dashboard_load_id=x",
+    // a `..` in the query string is not path traversal
+    "table/3?next=../../secret",
+  ])("treats legitimate subPath %p as safe", (subPath) => {
+    expect(hasUnsafeXraySubPath(subPath)).toBe(false);
+  });
+
+  it.each([
+    "table/3/../../../api/user/current",
+    "../../foo",
+    "..",
+    "table/./3",
+  ])("flags traversal subPath %p as unsafe", (subPath) => {
+    expect(hasUnsafeXraySubPath(subPath)).toBe(true);
+  });
+});
+
+describe("getXrayDashboard endpoint", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("issues the request for a safe subPath", async () => {
+    fetchMock.get(XRAY_URL_REGEX, createMockDashboard());
+    const { store, xrayCalls } = setup();
+
+    const result = await store.dispatch(
+      automagicDashboardsApi.endpoints.getXrayDashboard.initiate({
+        subPath: "table/3",
+      }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(xrayCalls()).toHaveLength(1);
+  });
+
+  it("rejects a traversal subPath without issuing a request", async () => {
+    fetchMock.get(XRAY_URL_REGEX, createMockDashboard());
+    const { store, xrayCalls } = setup();
+
+    const result = await store.dispatch(
+      automagicDashboardsApi.endpoints.getXrayDashboard.initiate({
+        subPath: "table/3/../../../api/user/current",
+      }),
+    );
+
+    expect(result.error).toBeDefined();
+    expect(xrayCalls()).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/api/client/client.unit.spec.ts
+++ b/frontend/src/metabase/api/client/client.unit.spec.ts
@@ -14,25 +14,6 @@ describe("api", () => {
       fetchMock.removeRoutes().clearHistory();
     });
 
-    it("`:tag*` substitutes a multi-segment value without URL-encoding the slashes", async () => {
-      fetchMock.get("path:/api/automagic-dashboards/table/3/cell/4", {
-        items: [],
-      });
-
-      await apiInstance.request({
-        method: "GET",
-        url: "/api/automagic-dashboards/:subPath*",
-        params: { subPath: "table/3/cell/4" },
-      });
-
-      const call = fetchMock.callHistory.lastCall();
-      expect(call?.url).toMatch(
-        /\/api\/automagic-dashboards\/table\/3\/cell\/4$/,
-      );
-      // sanity-check: slashes were NOT %2F-encoded
-      expect(call?.url).not.toContain("%2F");
-    });
-
     it("substitutes :tag URL placeholders from `params`", async () => {
       fetchMock.get("path:/api/card/123/params/abc-def/values", { values: [] });
 

--- a/frontend/src/metabase/api/client/utils.ts
+++ b/frontend/src/metabase/api/client/utils.ts
@@ -183,16 +183,13 @@ async function readBody(response: Response): Promise<ResponseResult> {
   return { ok, status, body };
 }
 
-// URL template tags:
-// - `:tag`  — value is URL-encoded (default; slashes become %2F).
-// - `:tag*` — value is substituted raw (slashes preserved), for endpoints
-//             whose route includes a multi-segment path parameter.
-const URL_TAG_REGEX = /:\w+\*?/g;
+// `:tag` placeholders are URL-encoded (slashes become %2F).
+const URL_TAG_REGEX = /:\w+/g;
 
 /**
- * Replace `:tag` / `:tag*` placeholders in a URL template with values pulled
- * from `data` (params) first, then falling back to `body` fields — this is how
- * an embed `:token` gets filled from the request body. The key is consumed from
+ * Replace `:tag` placeholders in a URL template with values pulled from `data`
+ * (params) first, then falling back to `body` fields — this is how an embed
+ * `:token` gets filled from the request body. The key is consumed from
  * whichever bag held it, so the caller can use any leftovers as querystring
  * params (from `data`) or as the JSON body (from `body`).
  */
@@ -202,8 +199,7 @@ export function substituteUrlTags(
   body?: Record<string, unknown>,
 ): string {
   return url.replace(URL_TAG_REGEX, (tag) => {
-    const isRaw = tag.endsWith("*");
-    const paramName = tag.slice(1, isRaw ? -1 : undefined);
+    const paramName = tag.slice(1);
     let value: unknown;
     for (const bag of [data, body]) {
       if (bag && paramName in bag) {
@@ -220,6 +216,6 @@ export function substituteUrlTags(
       console.warn("Warning: calling", url, "without", tag);
       return "";
     }
-    return isRaw ? String(value) : encodeURIComponent(String(value));
+    return encodeURIComponent(String(value));
   });
 }

--- a/frontend/src/metabase/api/client/utils.unit.spec.ts
+++ b/frontend/src/metabase/api/client/utils.unit.spec.ts
@@ -31,19 +31,6 @@ describe("substituteUrlTags", () => {
     expect(url).toBe("/api/foo/a%2Fb%20c");
   });
 
-  it("substitutes :tag* values raw (preserves slashes)", () => {
-    const data = { subPath: "table/3/cell/4" };
-    const url = substituteUrlTags("/api/automagic-dashboards/:subPath*", data);
-    expect(url).toBe("/api/automagic-dashboards/table/3/cell/4");
-    expect(data).toEqual({});
-  });
-
-  it("mixes :tag (encoded) and :tag* (raw) in the same URL", () => {
-    const data = { id: "x/y", path: "a/b/c" };
-    const url = substituteUrlTags("/api/:id/sub/:path*", data);
-    expect(url).toBe("/api/x%2Fy/sub/a/b/c");
-  });
-
   it("substitutes empty string and warns when a tag has no value in data", () => {
     const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     const data = {};

--- a/frontend/src/metabase/api/utils/run-rtk-endpoint.ts
+++ b/frontend/src/metabase/api/utils/run-rtk-endpoint.ts
@@ -7,6 +7,17 @@ type RTKEndpoint = { initiate: (request: any, options: any) => any };
 
 type AnyDispatch = (action: any) => any;
 
+type RunRtkEndpointOptions = {
+  forceRefetch?: boolean;
+  /**
+   * Abort the in-flight request when this signal fires. Lets callers tie an
+   * imperative dispatch into an external `AbortController` (e.g. cancelling a
+   * stale fetch when the user navigates away), mirroring the `signal` option
+   * the legacy API clients accept.
+   */
+  signal?: AbortSignal;
+};
+
 /**
  * Imperatively dispatch an RTK Query endpoint, await its result, and clean up
  * the subscription. Use this when you need an endpoint's data inside a thunk
@@ -17,13 +28,20 @@ export async function runRtkEndpoint(
   request: unknown,
   dispatch: AnyDispatch,
   endpoint: RTKEndpoint,
-  { forceRefetch = true } = {},
+  { forceRefetch = true, signal }: RunRtkEndpointOptions = {},
 ): Promise<any> {
   const action = dispatch(endpoint.initiate(request, { forceRefetch }));
+
+  const abort = () => action.abort?.();
+  if (signal?.aborted) {
+    abort();
+  }
+  signal?.addEventListener("abort", abort);
 
   try {
     return await action.unwrap();
   } finally {
+    signal?.removeEventListener("abort", abort);
     action.unsubscribe?.();
   }
 }

--- a/frontend/src/metabase/api/utils/run-rtk-endpoint.unit.spec.ts
+++ b/frontend/src/metabase/api/utils/run-rtk-endpoint.unit.spec.ts
@@ -1,0 +1,81 @@
+import { runRtkEndpoint } from "./run-rtk-endpoint";
+
+type FakeAction = {
+  unwrap: jest.Mock;
+  unsubscribe: jest.Mock;
+  abort: jest.Mock;
+};
+
+const setup = (unwrapImpl: () => Promise<unknown>) => {
+  const action: FakeAction = {
+    unwrap: jest.fn(unwrapImpl),
+    unsubscribe: jest.fn(),
+    abort: jest.fn(),
+  };
+  const initiate = jest.fn(() => action);
+  const dispatch = jest.fn((thunk) => thunk);
+  const endpoint = { initiate };
+
+  return { action, initiate, dispatch, endpoint };
+};
+
+describe("runRtkEndpoint", () => {
+  it("returns the unwrapped result and cleans up the subscription", async () => {
+    const { action, dispatch, endpoint } = setup(() =>
+      Promise.resolve({ id: 1 }),
+    );
+
+    const result = await runRtkEndpoint({ id: 1 }, dispatch, endpoint);
+
+    expect(result).toEqual({ id: 1 });
+    expect(action.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the in-flight request when the signal fires", async () => {
+    const controller = new AbortController();
+    const { action, dispatch, endpoint } = setup(
+      () =>
+        new Promise((resolve) => {
+          controller.signal.addEventListener("abort", () =>
+            resolve({ aborted: true }),
+          );
+        }),
+    );
+
+    const promise = runRtkEndpoint({ id: 1 }, dispatch, endpoint, {
+      signal: controller.signal,
+    });
+    controller.abort();
+    await promise;
+
+    expect(action.abort).toHaveBeenCalledTimes(1);
+    expect(action.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts immediately when given an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { action, dispatch, endpoint } = setup(() =>
+      Promise.resolve({ id: 1 }),
+    );
+
+    await runRtkEndpoint({ id: 1 }, dispatch, endpoint, {
+      signal: controller.signal,
+    });
+
+    expect(action.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not abort when no signal fires", async () => {
+    const controller = new AbortController();
+    const { action, dispatch, endpoint } = setup(() =>
+      Promise.resolve({ id: 1 }),
+    );
+
+    await runRtkEndpoint({ id: 1 }, dispatch, endpoint, {
+      signal: controller.signal,
+    });
+
+    expect(action.abort).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -41,7 +41,7 @@ import type { Dispatch, GetState } from "metabase/redux/store";
 import { createAsyncThunk, createThunkAction } from "metabase/redux/utils";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { AutoApi, DashboardApi, EmbedApi, PublicApi } from "metabase/services";
+import { DashboardApi, EmbedApi, PublicApi } from "metabase/services";
 import {
   getDashboardType,
   isQuestionDashCard,
@@ -736,9 +736,10 @@ export const fetchDashboard = createAsyncThunk(
         const subPath = String(dashId).split("/").slice(3).join("/");
         const [entity, entityId] = subPath.split(/[/?]/);
         const [response] = await Promise.all([
-          AutoApi.dashboard(
+          runRtkEndpoint(
             { subPath, dashboard_load_id: dashboardLoadId },
-            { signal: fetchDashboardCancellation.signal },
+            dispatch,
+            automagicDashboardsApi.endpoints.getXrayDashboard,
           ),
           runRtkEndpoint(
             {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -740,6 +740,7 @@ export const fetchDashboard = createAsyncThunk(
             { subPath, dashboard_load_id: dashboardLoadId },
             dispatch,
             automagicDashboardsApi.endpoints.getXrayDashboard,
+            { signal: fetchDashboardCancellation.signal },
           ),
           runRtkEndpoint(
             {
@@ -749,6 +750,7 @@ export const fetchDashboard = createAsyncThunk(
             },
             dispatch,
             automagicDashboardsApi.endpoints.getXrayDashboardQueryMetadata,
+            { signal: fetchDashboardCancellation.signal },
           ),
         ]);
         result = {

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubXrayPickerModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubXrayPickerModal.tsx
@@ -2,16 +2,15 @@ import cx from "classnames";
 import { dissoc } from "icepick";
 import { t } from "ttag";
 
-import { Api, dashboardApi } from "metabase/api";
+import { Api, dashboardApi, useLazyGetXrayDashboardQuery } from "metabase/api";
 import { invalidateTags, listTag } from "metabase/api/tags";
 import { Link } from "metabase/common/components/Link";
 import { DataPickerModal } from "metabase/common/components/Pickers/DataPicker";
 import { useToast } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/redux";
-import { AutoApi } from "metabase/services";
 import * as Urls from "metabase/urls";
-import type { Dashboard, TableId } from "metabase-types/api";
+import type { TableId } from "metabase-types/api";
 
 interface EmbeddingHubXrayPickerModalProps {
   opened: boolean;
@@ -24,14 +23,15 @@ export const EmbeddingHubXrayPickerModal = ({
 }: EmbeddingHubXrayPickerModalProps) => {
   const dispatch = useDispatch();
   const [sendToast] = useToast();
+  const [fetchXrayDashboard] = useLazyGetXrayDashboardQuery();
 
   async function handleTableSelect(tableId: TableId) {
     onClose();
 
     try {
-      const xrayDashboard: Dashboard = await AutoApi.dashboard({
+      const xrayDashboard = await fetchXrayDashboard({
         subPath: `table/${tableId}`,
-      });
+      }).unwrap();
 
       const { data: savedDashboard } = await dispatch(
         dashboardApi.endpoints.saveDashboard.initiate(

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -57,11 +57,6 @@ export const EmbedApi = {
   dashboard: GET(getEmbedBase() + "/dashboard/:token"),
 };
 
-export const AutoApi = {
-  // `:subPath*` keeps slashes in subPath unencoded (multi-segment path).
-  dashboard: GET("/api/automagic-dashboards/:subPath*"),
-};
-
 export const ParameterApi = {
   parameterValues: POST("/api/dataset/parameter/values"),
   parameterSearch: POST("/api/dataset/parameter/search/:query"),


### PR DESCRIPTION
Removes `AutoApi` from `metabase/services`

Also removes the special syntax for url tags (ie. `:subPath*`) since it's no longer in use anywhere.