### PR TITLE
Make all API client request middleware declared statically

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -28,8 +28,11 @@ import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
 import type { SdkAuthState } from "embedding-sdk-shared/types/auth-state";
 import { SDK_AUTH_STATE_KEY } from "embedding-sdk-shared/types/auth-state";
-import { api } from "metabase/api/client";
 import { requestSessionTokenFromEmbedJs } from "metabase/embedding/embedding-iframe-sdk/utils";
+import {
+  setApiKeyHeader,
+  setSessionTokenHeader,
+} from "metabase/embedding/lib/embedding-request-auth";
 import {
   EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG,
   isEmbeddingEajs,
@@ -37,7 +40,7 @@ import {
 } from "metabase/embedding-sdk/config";
 import { samlTokenStorage } from "metabase/embedding-sdk/lib/saml-token-storage";
 import type { MetabaseEmbeddingSessionToken } from "metabase/embedding-sdk/types/refresh-token";
-import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import { loadSettings, refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { createAsyncThunk } from "metabase/redux/utils";
@@ -84,7 +87,8 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
       authState.user &&
       authState.siteSettings
     ) {
-      api.sessionToken = authState.session.id;
+      PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+        setSessionTokenHeader(authState.session.id);
       // Store the session token in Redux so getOrRefreshSession finds it
       // and doesn't trigger a redundant token refresh on the first API call.
       dispatch(
@@ -103,7 +107,8 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
             getOrRefreshSession(authConfig),
           ).unwrap();
           if (session?.id) {
-            api.sessionToken = session.id;
+            PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+              setSessionTokenHeader(session.id);
           }
         };
 
@@ -126,18 +131,21 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
 
   if (isValidApiKeyConfig) {
     // API key setup
-    api.apiKey = apiKey;
+    PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+      setApiKeyHeader(apiKey);
   } else if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.useExistingUserSession) {
     // Use existing user session. Do nothing.
   } else if (isValidInstanceUrl) {
-    // SSO setup
+    // SSO setup. The session-token strategy is installed by the refresh handler
+    // below once it has a token, and re-installed with each refreshed token.
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler =
       async () => {
         const session = await dispatch(
           getOrRefreshSession(authConfig),
         ).unwrap();
         if (session?.id) {
-          api.sessionToken = session.id;
+          PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+            setSessionTokenHeader(session.id);
         }
       };
     try {

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -136,21 +136,22 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
   } else if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.useExistingUserSession) {
     // Use existing user session. Do nothing.
   } else if (isValidInstanceUrl) {
-    // SSO setup. The session-token strategy is installed by the refresh handler
-    // below once it has a token, and re-installed with each refreshed token.
+    // SSO setup. Refresh the session and install the session-token strategy with
+    // the resulting token, re-installing it on every later refresh. Running it
+    // eagerly below means the initial user/settings requests already carry the
+    // header.
+    const refreshAndInstallSessionToken = async () => {
+      const session = await dispatch(getOrRefreshSession(authConfig)).unwrap();
+      if (session?.id) {
+        PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+          setSessionTokenHeader(session.id);
+      }
+    };
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler =
-      async () => {
-        const session = await dispatch(
-          getOrRefreshSession(authConfig),
-        ).unwrap();
-        if (session?.id) {
-          PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
-            setSessionTokenHeader(session.id);
-        }
-      };
+      refreshAndInstallSessionToken;
     try {
       // verify that the session is actually valid before proceeding
-      await dispatch(getOrRefreshSession(authConfig)).unwrap();
+      await refreshAndInstallSessionToken();
     } catch (e) {
       // TODO (Oisin 2025-05-27): Fix this. For some reason the instanceof check keeps returning `false`. I'd rather not do this
       // but due to time constraints this is what we have to do to make sure tests pass.

--- a/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
@@ -30,8 +30,8 @@ import type { SdkAuthState } from "embedding-sdk-shared/types/auth-state";
 import { SDK_AUTH_STATE_KEY } from "embedding-sdk-shared/types/auth-state";
 import { requestSessionTokenFromEmbedJs } from "metabase/embedding/embedding-iframe-sdk/utils";
 import {
+  sessionTokenHeaders,
   setApiKeyHeader,
-  setSessionTokenHeader,
 } from "metabase/embedding/lib/embedding-request-auth";
 import {
   EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG,
@@ -68,6 +68,15 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
   // remove any stale tokens that might be there from a previous session
   samlTokenStorage.remove();
 
+  // Resolve the SSO session token (refreshing it when expired) and emit it as
+  // the X-Metabase-Session header. This runs on the refresh-handler slot, which
+  // is ordered after the static auth-header slot, so a freshly refreshed token
+  // applies to the very request that triggered the refresh.
+  const sessionTokenHandler = async () => {
+    const session = await dispatch(getOrRefreshSession(authConfig)).unwrap();
+    return session?.id ? sessionTokenHeaders(session.id) : undefined;
+  };
+
   // Check if we can use the auth pre-fetched by the bootstrap chunk
   const earlyAuthStatus = getAuthState()?.status;
   if (earlyAuthStatus && earlyAuthStatus !== "skipped") {
@@ -87,8 +96,6 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
       authState.user &&
       authState.siteSettings
     ) {
-      PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
-        setSessionTokenHeader(authState.session.id);
       // Store the session token in Redux so getOrRefreshSession finds it
       // and doesn't trigger a redundant token refresh on the first API call.
       dispatch(
@@ -100,17 +107,10 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
       dispatch(loadSettings(authState.siteSettings as Settings));
       MetabaseSettings.setAll(authState.siteSettings as Settings);
 
-      // Set up the refresh handler so API calls can renew the token later.
+      // The session handler emits the X-Metabase-Session header on every API
+      // call, renewing the token when it expires.
       PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler =
-        async () => {
-          const session = await dispatch(
-            getOrRefreshSession(authConfig),
-          ).unwrap();
-          if (session?.id) {
-            PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
-              setSessionTokenHeader(session.id);
-          }
-        };
+        sessionTokenHandler;
 
       return;
     }
@@ -136,22 +136,15 @@ PLUGIN_EMBEDDING_SDK_AUTH.initAuth = async (
   } else if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.useExistingUserSession) {
     // Use existing user session. Do nothing.
   } else if (isValidInstanceUrl) {
-    // SSO setup. Refresh the session and install the session-token strategy with
-    // the resulting token, re-installing it on every later refresh. Running it
-    // eagerly below means the initial user/settings requests already carry the
-    // header.
-    const refreshAndInstallSessionToken = async () => {
-      const session = await dispatch(getOrRefreshSession(authConfig)).unwrap();
-      if (session?.id) {
-        PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
-          setSessionTokenHeader(session.id);
-      }
-    };
+    // SSO setup. The session handler sets the X-Metabase-Session header on every
+    // request and refreshes the token when it expires; later API calls pick it
+    // up because the handler runs in the request pipeline. Call it once eagerly
+    // to verify the session is valid before the app renders.
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler =
-      refreshAndInstallSessionToken;
+      sessionTokenHandler;
     try {
       // verify that the session is actually valid before proceeding
-      await refreshAndInstallSessionToken();
+      await sessionTokenHandler();
     } catch (e) {
       // TODO (Oisin 2025-05-27): Fix this. For some reason the instanceof check keeps returning `false`. I'd rather not do this
       // but due to time constraints this is what we have to do to make sure tests pass.

--- a/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/tests/auth-flow/jwt.unit.spec.tsx
@@ -208,11 +208,15 @@ describe("Auth Flow - JWT", () => {
       fetchRequestToken: customFetchFunction,
     });
 
-    setup({ authConfig });
+    const { getLastUserApiCall } = setup({ authConfig });
 
     expect(
       screen.queryByTestId("sdk-usage-problem-indicator"),
     ).not.toBeInTheDocument();
+
+    // Let the auth flow settle so its in-flight requests don't leak into the
+    // next test (the strict afterEach fails on unmocked routes).
+    await waitForRequest(() => getLastUserApiCall());
   });
 
   it("should include the subpath when requesting the SSO endpoint", async () => {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -22,7 +22,10 @@ import {
   api,
 } from "metabase/api/client";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
-import { setRequestClientHeaders } from "metabase/embedding/lib/embedding-request-auth";
+import {
+  setEmbedPreviewHeader,
+  setRequestClientHeaders,
+} from "metabase/embedding/lib/embedding-request-auth";
 import {
   EMBEDDING_SDK_CONFIG,
   isEmbeddingEajs,
@@ -68,6 +71,8 @@ const setSdkRequestClientHeadersOnce = _.once(
   (requestClient: RequestClientInfo) => {
     PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
       setRequestClientHeaders(requestClient);
+    PLUGIN_API.onBeforeRequestHandlers.setEmbedPreviewHeader =
+      setEmbedPreviewHeader;
   },
 );
 

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -16,13 +16,12 @@ import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
-import { api } from "metabase/api/client";
+import { type OnBeforeRequestHandlerConfig, api } from "metabase/api/client";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
 import {
   EMBEDDING_SDK_CONFIG,
   isEmbeddingEajs,
 } from "metabase/embedding-sdk/config";
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler = async (

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -22,6 +22,7 @@ import {
   EMBEDDING_SDK_CONFIG,
   isEmbeddingEajs,
 } from "metabase/embedding-sdk/config";
+import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler = async (
@@ -115,18 +116,15 @@ export const useInitDataInternal = ({
   }
 
   // For the React SDK, send the host page URL as the embed referrer in a
-  // header on every request. The EAJS iframe registers its own handler in
+  // header on every request. The EAJS iframe installs its own handler in
   // SdkIframeEmbedRoute.tsx using the value received via postMessage.
-  if (
-    !isEmbeddingEajs() &&
-    !api.beforeRequestHandlers.includes(reactSdkEmbedReferrerHandler)
-  ) {
-    api.beforeRequestHandlers.push(reactSdkEmbedReferrerHandler);
+  if (!isEmbeddingEajs()) {
+    PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.reactSdkEmbedReferrer =
+      reactSdkEmbedReferrerHandler;
   }
 
-  // Dedupe by handler identity (matches the `beforeRequestHandlers` pattern
-  // above) rather than total listener count — other code can register its own
-  // `responseError` listeners without disabling ours.
+  // Dedupe by handler identity rather than total listener count — other code
+  // can register its own `responseError` listeners without disabling ours.
   if (!api.listeners("responseError").includes(sdkResponseErrorHandler)) {
     api.on("responseError", sdkResponseErrorHandler);
   }

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -17,7 +17,7 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import {
-  type OnBeforeRequestHandlerConfig,
+  type OnBeforeRequestHandler,
   type RequestClientInfo,
   api,
 } from "metabase/api/client";
@@ -33,9 +33,9 @@ import {
 import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import registerVisualizations from "metabase/visualizations/register";
 
-const reactSdkEmbedReferrerHandler = async (
-  config: OnBeforeRequestHandlerConfig,
-): Promise<OnBeforeRequestHandlerConfig | void> => ({
+const reactSdkEmbedReferrerHandler: OnBeforeRequestHandler = async (
+  config,
+) => ({
   ...config,
   headers: {
     ...config.headers,

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -16,13 +16,18 @@ import { useLazySelector } from "embedding-sdk-shared/hooks/use-lazy-selector";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
-import { type OnBeforeRequestHandlerConfig, api } from "metabase/api/client";
+import {
+  type OnBeforeRequestHandlerConfig,
+  type RequestClientInfo,
+  api,
+} from "metabase/api/client";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
+import { setRequestClientHeaders } from "metabase/embedding/lib/embedding-request-auth";
 import {
   EMBEDDING_SDK_CONFIG,
   isEmbeddingEajs,
 } from "metabase/embedding-sdk/config";
-import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler = async (
@@ -55,6 +60,15 @@ const sdkResponseErrorHandler = ({
 const registerVisualizationsOnce = _.once(registerVisualizations);
 const registerDashboardVisualizationsOnce = _.once(
   registerDashboardVisualizations,
+);
+
+// Install the SDK's request-client header strategy once; re-renders keep the
+// first-set client (matching the previous set-once-if-unset behaviour).
+const setSdkRequestClientHeadersOnce = _.once(
+  (requestClient: RequestClientInfo) => {
+    PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
+      setRequestClientHeaders(requestClient);
+  },
 );
 
 interface InitDataLoaderParameters {
@@ -107,13 +121,11 @@ export const useInitDataInternal = ({
     api.basename = authConfig.metabaseInstanceUrl;
   }
 
-  if (!api.requestClient) {
-    api.requestClient = {
-      name: EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader,
-      // Note: this is *package* version, it's undefined in EAJS
-      version: sdkPackageVersion,
-    };
-  }
+  setSdkRequestClientHeadersOnce({
+    name: EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader,
+    // Note: this is *package* version, it's undefined in EAJS
+    version: sdkPackageVersion,
+  });
 
   // For the React SDK, send the host page URL as the embed referrer in a
   // header on every request. The EAJS iframe installs its own handler in

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
@@ -1,9 +1,9 @@
 import { merge } from "icepick";
 
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 import { overrideRequestsForGuestEmbeds } from "metabase/embedding/lib/override-requests-for-embeds";
 import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { createAsyncThunk } from "metabase/redux/utils";
 import { isJWT } from "metabase/utils/jwt";

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -510,7 +510,7 @@ export type GetEmbeddableCard = Pick<Card, "id" | "name">;
 
 export type GetRemappedCardParameterValueRequest = {
   card_id?: CardId | EntityToken;
-  entityIdentifier?: EntityUuid | EntityToken;
+  entityIdentifier?: EntityUuid | EntityToken | null;
   parameter_id: ParameterId;
   value: ParameterValueOrArray;
 };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -509,9 +509,9 @@ export type GetPublicCard = Pick<Card, "id" | "name" | "public_uuid">;
 export type GetEmbeddableCard = Pick<Card, "id" | "name">;
 
 export type GetRemappedCardParameterValueRequest = {
-  card_id?: CardId | EntityToken;
+  cardId?: CardId | EntityToken;
   entityIdentifier?: EntityUuid | EntityToken | null;
-  parameter_id: ParameterId;
+  paramId: ParameterId;
   value: ParameterValueOrArray;
 };
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -387,7 +387,7 @@ export type GetEmbeddableDashboard = Pick<Dashboard, "id" | "name">;
 
 export type GetRemappedDashboardParameterValueRequest = {
   dashboard_id?: DashboardId;
-  entityIdentifier?: EntityUuid | EntityToken;
+  entityIdentifier?: EntityUuid | EntityToken | null;
   parameter_id: ParameterId;
   value: ParameterValueOrArray;
 };

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -386,9 +386,9 @@ export type GetPublicDashboard = Pick<Dashboard, "id" | "name" | "public_uuid">;
 export type GetEmbeddableDashboard = Pick<Dashboard, "id" | "name">;
 
 export type GetRemappedDashboardParameterValueRequest = {
-  dashboard_id?: DashboardId;
+  dashId?: DashboardId;
   entityIdentifier?: EntityUuid | EntityToken | null;
-  parameter_id: ParameterId;
+  paramId: ParameterId;
   value: ParameterValueOrArray;
 };
 

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -155,14 +155,15 @@ export const cardApi = Api.injectEndpoints({
         query: ({ card_id, entityIdentifier, parameter_id, ...params }) => ({
           method: "GET",
           url: "/api/card/:cardId/params/:paramId/remapping",
-          // Embed requests carry an entity identifier (uuid/token) instead of
-          // the real card id; the embed override rewrites `:cardId` →
-          // `:entityIdentifier` (see override-requests-for-embeds). Mirrors the
-          // `cardId`/`entityIdentifier` switch in `parameters/actions`.
+          // Pass both ids; in an embed the override rewrites `:cardId` →
+          // `:entityIdentifier` and drops the real `cardId` from the params
+          // (see override-requests-for-embeds), and a null `entityIdentifier`
+          // never reaches the querystring.
           params: {
             ...params,
             paramId: parameter_id,
-            ...(entityIdentifier ? { entityIdentifier } : { cardId: card_id }),
+            cardId: card_id,
+            entityIdentifier,
           },
         }),
         providesTags: (_response, _error, { parameter_id }) =>

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -163,7 +163,7 @@ export const cardApi = Api.injectEndpoints({
             ...params,
             paramId: parameter_id,
             cardId: card_id,
-            entityIdentifier,
+            ...(entityIdentifier && { entityIdentifier }),
           },
         }),
         providesTags: (_response, _error, { parameter_id }) =>

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -1,4 +1,3 @@
-import { PLUGIN_API } from "metabase/plugins";
 import { QueryMetadataSchema, QuestionSchema } from "metabase/schema";
 import type {
   Card,
@@ -153,13 +152,18 @@ export const cardApi = Api.injectEndpoints({
         FieldValue,
         GetRemappedCardParameterValueRequest
       >({
-        query: ({ card_id, parameter_id, ...params }) => ({
+        query: ({ card_id, entityIdentifier, parameter_id, ...params }) => ({
           method: "GET",
-          url: PLUGIN_API.getRemappedCardParameterValueUrl(
-            card_id,
-            parameter_id,
-          ),
-          params,
+          url: "/api/card/:cardId/params/:paramId/remapping",
+          // Embed requests carry an entity identifier (uuid/token) instead of
+          // the real card id; the embed override rewrites `:cardId` →
+          // `:entityIdentifier` (see override-requests-for-embeds). Mirrors the
+          // `cardId`/`entityIdentifier` switch in `parameters/actions`.
+          params: {
+            ...params,
+            paramId: parameter_id,
+            ...(entityIdentifier ? { entityIdentifier } : { cardId: card_id }),
+          },
         }),
         providesTags: (_response, _error, { parameter_id }) =>
           provideParameterValuesTags(parameter_id),

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -152,22 +152,17 @@ export const cardApi = Api.injectEndpoints({
         FieldValue,
         GetRemappedCardParameterValueRequest
       >({
-        query: ({ card_id, entityIdentifier, parameter_id, ...params }) => ({
+        query: ({ entityIdentifier, ...params }) => ({
           method: "GET",
           url: "/api/card/:cardId/params/:paramId/remapping",
-          // Pass both ids; in an embed the override rewrites `:cardId` →
-          // `:entityIdentifier` and drops the real `cardId` from the params
-          // (see override-requests-for-embeds), and a null `entityIdentifier`
-          // never reaches the querystring.
-          params: {
-            ...params,
-            paramId: parameter_id,
-            cardId: card_id,
-            ...(entityIdentifier && { entityIdentifier }),
-          },
+          // In an embed the override rewrites `:cardId` → `:entityIdentifier` and
+          // drops the real `cardId` from the params (see
+          // override-requests-for-embeds); a null `entityIdentifier` is omitted
+          // so it never reaches the querystring.
+          params: { ...params, ...(entityIdentifier && { entityIdentifier }) },
         }),
-        providesTags: (_response, _error, { parameter_id }) =>
-          provideParameterValuesTags(parameter_id),
+        providesTags: (_response, _error, { paramId }) =>
+          provideParameterValuesTags(paramId),
       }),
       createCard: builder.mutation<Card, CreateCardRequest>({
         query: (body) => ({

--- a/frontend/src/metabase/api/client/client.ts
+++ b/frontend/src/metabase/api/client/client.ts
@@ -1,7 +1,6 @@
 /* eslint-disable metabase/no-literal-metabase-strings */
 import EventEmitter from "events";
 
-import { IFRAMED_IN_SELF } from "metabase/utils/iframe";
 import { getTraceparentHeader } from "metabase/utils/otel";
 import { retry } from "metabase/utils/retry";
 
@@ -15,7 +14,6 @@ import {
 } from "./middleware";
 import type {
   EventMap,
-  RequestClientInfo,
   RequestInit,
   RequestOptions,
   ResponseFor,
@@ -31,9 +29,6 @@ const MAX_RETRIES = 10;
 
 export class ApiClient extends EventEmitter<EventMap> {
   basename = "";
-  apiKey = "";
-  sessionToken: string | undefined;
-  requestClient: RequestClientInfo | undefined;
 
   private buildUrl(
     template: string,
@@ -51,28 +46,6 @@ export class ApiClient extends EventEmitter<EventMap> {
       Accept: "application/json",
       "Content-Type": "application/json",
     };
-
-    if (this.apiKey) {
-      headers["X-Api-Key"] = this.apiKey;
-    }
-
-    if (this.sessionToken) {
-      headers["X-Metabase-Session"] = this.sessionToken;
-    }
-
-    if (this.requestClient) {
-      if (IFRAMED_IN_SELF) {
-        headers["X-Metabase-Embedded-Preview"] = "true";
-      }
-      if (typeof this.requestClient === "object") {
-        headers["X-Metabase-Client"] = this.requestClient.name;
-        if (this.requestClient.version) {
-          headers["X-Metabase-Client-Version"] = this.requestClient.version;
-        }
-      } else {
-        headers["X-Metabase-Client"] = this.requestClient;
-      }
-    }
 
     const locale = getLocaleHeader();
     if (locale) {

--- a/frontend/src/metabase/api/client/client.ts
+++ b/frontend/src/metabase/api/client/client.ts
@@ -1,8 +1,7 @@
 /* eslint-disable metabase/no-literal-metabase-strings */
 import EventEmitter from "events";
 
-import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { IFRAMED_IN_SELF, isWithinIframe } from "metabase/utils/iframe";
+import { IFRAMED_IN_SELF } from "metabase/utils/iframe";
 import { getTraceparentHeader } from "metabase/utils/otel";
 import { retry } from "metabase/utils/retry";
 
@@ -59,10 +58,6 @@ export class ApiClient extends EventEmitter<EventMap> {
 
     if (this.sessionToken) {
       headers["X-Metabase-Session"] = this.sessionToken;
-    }
-
-    if (isWithinIframe() && !isEmbeddingSdk()) {
-      headers["X-Metabase-Embedded"] = "true";
     }
 
     if (this.requestClient) {

--- a/frontend/src/metabase/api/client/client.ts
+++ b/frontend/src/metabase/api/client/client.ts
@@ -2,10 +2,6 @@
 import EventEmitter from "events";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import type {
-  OnBeforeRequestHandler,
-  OnBeforeRequestHandlerConfig,
-} from "metabase/plugins/oss/api";
 import { IFRAMED_IN_SELF, isWithinIframe } from "metabase/utils/iframe";
 import { getTraceparentHeader } from "metabase/utils/otel";
 import { retry } from "metabase/utils/retry";
@@ -14,7 +10,11 @@ import { addAntiCsrfToken, updateAntiCsrfToken } from "./csrf";
 import { NetworkError, isRetriableError } from "./errors";
 import { getLocaleHeader } from "./locale";
 import { type RequestMethod, isRequestMethod } from "./method";
-import { apiRequestManipulationMiddleware } from "./middleware";
+import {
+  type OnBeforeRequestHandler,
+  type OnBeforeRequestHandlerConfig,
+  apiRequestManipulationMiddleware,
+} from "./middleware";
 import type {
   EventMap,
   RequestClientInfo,

--- a/frontend/src/metabase/api/client/client.ts
+++ b/frontend/src/metabase/api/client/client.ts
@@ -11,7 +11,6 @@ import { NetworkError, isRetriableError } from "./errors";
 import { getLocaleHeader } from "./locale";
 import { type RequestMethod, isRequestMethod } from "./method";
 import {
-  type OnBeforeRequestHandler,
   type OnBeforeRequestHandlerConfig,
   apiRequestManipulationMiddleware,
 } from "./middleware";
@@ -36,8 +35,6 @@ export class ApiClient extends EventEmitter<EventMap> {
   apiKey = "";
   sessionToken: string | undefined;
   requestClient: RequestClientInfo | undefined;
-
-  beforeRequestHandlers: OnBeforeRequestHandler[] = [];
 
   private buildUrl(
     template: string,
@@ -99,20 +96,17 @@ export class ApiClient extends EventEmitter<EventMap> {
   }
 
   private async _resolveOptions(options: OnBeforeRequestHandlerConfig) {
-    const middlewareResult = await apiRequestManipulationMiddleware(
-      this.beforeRequestHandlers,
-      {
-        ...options,
-        // `headers` is optional on the public API, but handlers may merge into
-        // it, so always hand the pipeline a real object to spread into.
-        headers: options.headers ?? {},
-        // This will transform arrays to objects with numeric keys
-        // we shouldn't be using top level-arrays in the API.
-        // Both bags are defensively copied so middleware can safely mutate them.
-        data: { ...options.data },
-        body: options.body ? { ...options.body } : undefined,
-      },
-    );
+    const middlewareResult = await apiRequestManipulationMiddleware({
+      ...options,
+      // `headers` is optional on the public API, but handlers may merge into
+      // it, so always hand the pipeline a real object to spread into.
+      headers: options.headers ?? {},
+      // This will transform arrays to objects with numeric keys
+      // we shouldn't be using top level-arrays in the API.
+      // Both bags are defensively copied so middleware can safely mutate them.
+      data: { ...options.data },
+      body: options.body ? { ...options.body } : undefined,
+    });
 
     return {
       ...middlewareResult,

--- a/frontend/src/metabase/api/client/client.unit.spec.ts
+++ b/frontend/src/metabase/api/client/client.unit.spec.ts
@@ -176,19 +176,20 @@ describe("api", () => {
       expect(call?.options?.body).toBeFalsy();
     });
 
-    it("omits params with undefined values from the querystring", async () => {
+    it("omits params with null/undefined values from the querystring", async () => {
       fetchMock.get("path:/api/search", { items: [] });
 
       await apiInstance.request({
         method: "GET",
         url: "/api/search",
-        params: { q: "foo", limit: undefined, offset: 0 },
+        params: { q: "foo", limit: undefined, cursor: null, offset: 0 },
       });
 
       const call = fetchMock.callHistory.lastCall();
       expect(call?.url).toContain("q=foo");
       expect(call?.url).toContain("offset=0");
       expect(call?.url).not.toContain("limit");
+      expect(call?.url).not.toContain("cursor");
     });
   });
 

--- a/frontend/src/metabase/api/client/client.unit.spec.ts
+++ b/frontend/src/metabase/api/client/client.unit.spec.ts
@@ -1,5 +1,7 @@
 import fetchMock from "fetch-mock";
 
+import { PLUGIN_API, reinitialize } from "metabase/plugins";
+
 import { ApiClient } from "./client";
 
 describe("api", () => {
@@ -12,6 +14,8 @@ describe("api", () => {
 
     afterEach(() => {
       fetchMock.removeRoutes().clearHistory();
+      // Reset any plugin request handlers installed by a test.
+      reinitialize();
     });
 
     it("substitutes :tag URL placeholders from `params`", async () => {
@@ -145,16 +149,17 @@ describe("api", () => {
       // from the body field — not just from URL params.
       fetchMock.get("path:/api/embed/card/SOME_JWT/query", { rows: [] });
 
-      apiInstance.beforeRequestHandlers.push(async (config) => {
-        if (config.url === "/api/card/:cardId/query") {
-          return {
-            ...config,
-            method: "GET" as const,
-            url: "/api/embed/card/:token/query",
-          };
-        }
-        return config;
-      });
+      PLUGIN_API.onBeforeRequestHandlers.overrideRequestsForPublicEmbeds =
+        async (config) => {
+          if (config.url === "/api/card/:cardId/query") {
+            return {
+              ...config,
+              method: "GET" as const,
+              url: "/api/embed/card/:token/query",
+            };
+          }
+          return config;
+        };
 
       await apiInstance.request({
         method: "POST",

--- a/frontend/src/metabase/api/client/index.ts
+++ b/frontend/src/metabase/api/client/index.ts
@@ -5,5 +5,5 @@ export type {
   OnBeforeRequestHandler,
   OnBeforeRequestHandlerConfig,
 } from "./middleware";
-export type { RequestOptions } from "./types";
+export type { RequestClientInfo, RequestOptions } from "./types";
 export { setLocaleHeader } from "./locale";

--- a/frontend/src/metabase/api/client/index.ts
+++ b/frontend/src/metabase/api/client/index.ts
@@ -1,5 +1,9 @@
 export * from "./client";
 export * from "./method";
 export * from "./errors";
+export type {
+  OnBeforeRequestHandler,
+  OnBeforeRequestHandlerConfig,
+} from "./middleware";
 export type { RequestOptions } from "./types";
 export { setLocaleHeader } from "./locale";

--- a/frontend/src/metabase/api/client/middleware.ts
+++ b/frontend/src/metabase/api/client/middleware.ts
@@ -1,4 +1,8 @@
-import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import {
+  PLUGIN_API,
+  PLUGIN_EMBEDDING_IFRAME_SDK,
+  PLUGIN_EMBEDDING_SDK,
+} from "metabase/plugins";
 
 import type { RequestMethod } from "./method";
 
@@ -21,22 +25,47 @@ export type OnBeforeRequestHandler = (
   data: OnBeforeRequestHandlerConfig,
 ) => Promise<void | Partial<OnBeforeRequestHandlerConfig>>;
 
-export async function apiRequestManipulationMiddleware(
-  beforeRequestHandlers: OnBeforeRequestHandler[],
-  requestConfig: OnBeforeRequestHandlerConfig,
-): Promise<OnBeforeRequestHandlerConfig> {
-  // Handlers order is important.
-  // Handlers are executed in order and each handler uses the data returned by a previous handler.
-  const handlers = [
+/**
+ * The complete, ordered request-manipulation pipeline.
+ *
+ * Every handler is a plugin slot — a no-op by default, populated by the owning
+ * feature's init flow (SDK auth, guest/public/static embeds, the embed-referrer
+ * handlers). Listing them here, rather than letting features push handlers onto
+ * a dynamic array, keeps the full set of things that can rewrite an outgoing
+ * request — and the order they run in — visible in one place.
+ *
+ * Order matters: handlers run in sequence and each one sees the result of the
+ * previous one. In particular the embed-preview rewrite must run after the
+ * embed overrides, which produce the `/api/embed/...` urls it rewrites.
+ */
+function getOnBeforeRequestHandlers(): OnBeforeRequestHandler[] {
+  return [
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers
       .getOrRefreshGuestSessionHandler,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.overrideRequestsForGuestEmbeds,
     PLUGIN_API.onBeforeRequestHandlers.overrideRequestsForPublicEmbeds,
-    PLUGIN_API.onBeforeRequestHandlers.overrideRequestsForStaticEmbeds,
-    ...beforeRequestHandlers,
+    PLUGIN_API.onBeforeRequestHandlers.rewriteEmbedPreviewUrl,
+    PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.reactSdkEmbedReferrer,
+    PLUGIN_EMBEDDING_IFRAME_SDK.onBeforeRequestHandlers.embedReferrer,
   ];
+}
 
+export async function apiRequestManipulationMiddleware(
+  requestConfig: OnBeforeRequestHandlerConfig,
+): Promise<OnBeforeRequestHandlerConfig> {
+  return runBeforeRequestHandlers(getOnBeforeRequestHandlers(), requestConfig);
+}
+
+/**
+ * Run a list of handlers over the request config, in order, merging each
+ * handler's partial result into the running config. Exported so the
+ * merge/ordering semantics can be unit-tested with an explicit handler list.
+ */
+export async function runBeforeRequestHandlers(
+  handlers: OnBeforeRequestHandler[],
+  requestConfig: OnBeforeRequestHandlerConfig,
+): Promise<OnBeforeRequestHandlerConfig> {
   let result = requestConfig;
   for (const handler of handlers) {
     const next = await handler(result);

--- a/frontend/src/metabase/api/client/middleware.ts
+++ b/frontend/src/metabase/api/client/middleware.ts
@@ -40,6 +40,7 @@ export type OnBeforeRequestHandler = (
  */
 function getOnBeforeRequestHandlers(): OnBeforeRequestHandler[] {
   return [
+    PLUGIN_API.onBeforeRequestHandlers.setEmbeddedHeader,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers
       .getOrRefreshGuestSessionHandler,

--- a/frontend/src/metabase/api/client/middleware.ts
+++ b/frontend/src/metabase/api/client/middleware.ts
@@ -40,6 +40,8 @@ export type OnBeforeRequestHandler = (
  */
 function getOnBeforeRequestHandlers(): OnBeforeRequestHandler[] {
   return [
+    PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders,
+    PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders,
     PLUGIN_API.onBeforeRequestHandlers.setEmbeddedHeader,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers

--- a/frontend/src/metabase/api/client/middleware.ts
+++ b/frontend/src/metabase/api/client/middleware.ts
@@ -41,6 +41,7 @@ export type OnBeforeRequestHandler = (
 function getOnBeforeRequestHandlers(): OnBeforeRequestHandler[] {
   return [
     PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders,
+    PLUGIN_API.onBeforeRequestHandlers.setEmbedPreviewHeader,
     PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders,
     PLUGIN_API.onBeforeRequestHandlers.setEmbeddedHeader,
     PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler,

--- a/frontend/src/metabase/api/client/middleware.ts
+++ b/frontend/src/metabase/api/client/middleware.ts
@@ -1,8 +1,25 @@
 import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
-import type {
-  OnBeforeRequestHandler,
-  OnBeforeRequestHandlerConfig,
-} from "metabase/plugins/oss/api";
+
+import type { RequestMethod } from "./method";
+
+export type OnBeforeRequestHandlerConfig = {
+  method: RequestMethod;
+  url: string;
+  headers?: Record<string, string>;
+  // URL `:tag` params (and querystring leftovers). For the legacy GET/POST
+  // helpers this holds the whole request bag.
+  data: Record<string, unknown>;
+  // The JSON-body bag, kept as a separate channel from `data`. Exposed to
+  // handlers so embed URL `:tag`s — notably the guest-embed `:token` — can be
+  // filled from body fields, and so the refresh handler can swap a stale body
+  // token. `undefined` for GETs, raw (FormData/URLSearchParams) bodies, and the
+  // legacy helpers (which pack everything into `data`).
+  body?: Record<string, unknown>;
+};
+
+export type OnBeforeRequestHandler = (
+  data: OnBeforeRequestHandlerConfig,
+) => Promise<void | Partial<OnBeforeRequestHandlerConfig>>;
 
 export async function apiRequestManipulationMiddleware(
   beforeRequestHandlers: OnBeforeRequestHandler[],

--- a/frontend/src/metabase/api/client/middleware.unit.spec.ts
+++ b/frontend/src/metabase/api/client/middleware.unit.spec.ts
@@ -1,8 +1,8 @@
 import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 
-import { apiRequestManipulationMiddleware } from "./middleware";
+import { runBeforeRequestHandlers } from "./middleware";
 
-describe("apiRequestManipulationMiddleware", () => {
+describe("runBeforeRequestHandlers", () => {
   it("should return the original data when there are no handlers", async () => {
     const inputData = {
       method: "GET" as const,
@@ -11,7 +11,7 @@ describe("apiRequestManipulationMiddleware", () => {
       data: {},
     };
 
-    const result = await apiRequestManipulationMiddleware([], inputData);
+    const result = await runBeforeRequestHandlers([], inputData);
     expect(result).toEqual(inputData);
   });
 
@@ -28,7 +28,7 @@ describe("apiRequestManipulationMiddleware", () => {
       return;
     });
 
-    const result = await apiRequestManipulationMiddleware([handler], inputData);
+    const result = await runBeforeRequestHandlers([handler], inputData);
 
     expect(result).toEqual(inputData);
     expect(handler).toHaveBeenCalledWith(inputData);
@@ -51,7 +51,7 @@ describe("apiRequestManipulationMiddleware", () => {
       };
     });
 
-    const result = await apiRequestManipulationMiddleware([handler], inputData);
+    const result = await runBeforeRequestHandlers([handler], inputData);
 
     expect(result).toEqual({
       ...inputData,
@@ -77,7 +77,7 @@ describe("apiRequestManipulationMiddleware", () => {
       return modifications;
     });
 
-    const result = await apiRequestManipulationMiddleware([handler], inputData);
+    const result = await runBeforeRequestHandlers([handler], inputData);
 
     expect(result).toEqual({ ...inputData, ...modifications });
   });
@@ -103,7 +103,7 @@ describe("apiRequestManipulationMiddleware", () => {
       };
     });
 
-    const result = await apiRequestManipulationMiddleware([handler], inputData);
+    const result = await runBeforeRequestHandlers([handler], inputData);
 
     expect(result.headers).toEqual({
       "X-Original": "value",
@@ -148,7 +148,7 @@ describe("apiRequestManipulationMiddleware", () => {
       };
     });
 
-    const result = await apiRequestManipulationMiddleware(
+    const result = await runBeforeRequestHandlers(
       [handler1, handler2, handler3],
       inputData,
     );
@@ -181,7 +181,7 @@ describe("apiRequestManipulationMiddleware", () => {
       };
     });
 
-    const result = await apiRequestManipulationMiddleware([handler], inputData);
+    const result = await runBeforeRequestHandlers([handler], inputData);
 
     expect(result.url).toBe("/api/modified-url");
     expect(result.headers).toEqual(inputData.headers);

--- a/frontend/src/metabase/api/client/middleware.unit.spec.ts
+++ b/frontend/src/metabase/api/client/middleware.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 
 import { apiRequestManipulationMiddleware } from "./middleware";
 

--- a/frontend/src/metabase/api/client/types.ts
+++ b/frontend/src/metabase/api/client/types.ts
@@ -22,9 +22,7 @@ export type ResponseFor<Raw extends boolean> = Raw extends true
   ? Response
   : unknown;
 
-export type RequestClientInfo =
-  | string
-  | { name: string; version: string | null };
+export type RequestClientInfo = { name: string; version?: string | null };
 
 export type ResponseErrorInfo = {
   metabaseVersion: string | null;

--- a/frontend/src/metabase/api/client/utils.ts
+++ b/frontend/src/metabase/api/client/utils.ts
@@ -42,7 +42,9 @@ export function appendQueryParameters(
 ) {
   for (const key in params) {
     const value = params[key];
-    if (value === undefined) {
+    // Skip nullish values so an absent param never becomes the literal string
+    // `"null"`/`"undefined"` in the querystring.
+    if (value == null) {
       continue;
     }
     if (Array.isArray(value)) {

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -1,4 +1,3 @@
-import { PLUGIN_API } from "metabase/plugins";
 import { DashboardSchema, QueryMetadataSchema } from "metabase/schema";
 import type {
   CopyDashboardRequest,
@@ -144,13 +143,25 @@ export const dashboardApi = Api.injectEndpoints({
         FieldValue,
         GetRemappedDashboardParameterValueRequest
       >({
-        query: ({ dashboard_id, parameter_id, ...params }) => ({
+        query: ({
+          dashboard_id,
+          entityIdentifier,
+          parameter_id,
+          ...params
+        }) => ({
           method: "GET",
-          url: PLUGIN_API.getRemappedDashboardParameterValueUrl(
-            dashboard_id,
-            parameter_id,
-          ),
-          params,
+          url: "/api/dashboard/:dashId/params/:paramId/remapping",
+          // Embed requests carry an entity identifier (uuid/token) instead of
+          // the real dashboard id; the embed override rewrites `:dashId` →
+          // `:entityIdentifier` (see override-requests-for-embeds). Mirrors the
+          // `dashId`/`entityIdentifier` switch in `parameters/actions`.
+          params: {
+            ...params,
+            paramId: parameter_id,
+            ...(entityIdentifier
+              ? { entityIdentifier }
+              : { dashId: dashboard_id }),
+          },
         }),
         providesTags: (_response, _error, { parameter_id }) =>
           provideParameterValuesTags(parameter_id),

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -159,7 +159,7 @@ export const dashboardApi = Api.injectEndpoints({
             ...params,
             paramId: parameter_id,
             dashId: dashboard_id,
-            entityIdentifier,
+            ...(entityIdentifier && { entityIdentifier }),
           },
         }),
         providesTags: (_response, _error, { parameter_id }) =>

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -151,16 +151,15 @@ export const dashboardApi = Api.injectEndpoints({
         }) => ({
           method: "GET",
           url: "/api/dashboard/:dashId/params/:paramId/remapping",
-          // Embed requests carry an entity identifier (uuid/token) instead of
-          // the real dashboard id; the embed override rewrites `:dashId` →
-          // `:entityIdentifier` (see override-requests-for-embeds). Mirrors the
-          // `dashId`/`entityIdentifier` switch in `parameters/actions`.
+          // Pass both ids; in an embed the override rewrites `:dashId` →
+          // `:entityIdentifier` and drops the real `dashId` from the params
+          // (see override-requests-for-embeds), and a null `entityIdentifier`
+          // never reaches the querystring.
           params: {
             ...params,
             paramId: parameter_id,
-            ...(entityIdentifier
-              ? { entityIdentifier }
-              : { dashId: dashboard_id }),
+            dashId: dashboard_id,
+            entityIdentifier,
           },
         }),
         providesTags: (_response, _error, { parameter_id }) =>

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -143,27 +143,17 @@ export const dashboardApi = Api.injectEndpoints({
         FieldValue,
         GetRemappedDashboardParameterValueRequest
       >({
-        query: ({
-          dashboard_id,
-          entityIdentifier,
-          parameter_id,
-          ...params
-        }) => ({
+        query: ({ entityIdentifier, ...params }) => ({
           method: "GET",
           url: "/api/dashboard/:dashId/params/:paramId/remapping",
-          // Pass both ids; in an embed the override rewrites `:dashId` →
-          // `:entityIdentifier` and drops the real `dashId` from the params
-          // (see override-requests-for-embeds), and a null `entityIdentifier`
-          // never reaches the querystring.
-          params: {
-            ...params,
-            paramId: parameter_id,
-            dashId: dashboard_id,
-            ...(entityIdentifier && { entityIdentifier }),
-          },
+          // In an embed the override rewrites `:dashId` → `:entityIdentifier` and
+          // drops the real `dashId` from the params (see
+          // override-requests-for-embeds); a null `entityIdentifier` is omitted
+          // so it never reaches the querystring.
+          params: { ...params, ...(entityIdentifier && { entityIdentifier }) },
         }),
-        providesTags: (_response, _error, { parameter_id }) =>
-          provideParameterValuesTags(parameter_id),
+        providesTags: (_response, _error, { paramId }) =>
+          provideParameterValuesTags(paramId),
       }),
       getDashboardParameterValues: builder.query<
         ParameterValues,

--- a/frontend/src/metabase/app-embed-mcp.tsx
+++ b/frontend/src/metabase/app-embed-mcp.tsx
@@ -4,8 +4,10 @@ import { createRoot } from "react-dom/client";
 import "metabase/embedding-sdk/vendors-side-effects";
 
 import { api } from "metabase/api/client";
+import { setSessionTokenHeader } from "metabase/embedding/lib/embedding-request-auth";
 import { McpUiAppRoute } from "metabase/embedding/mcp/McpUiAppRoute";
 import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
+import { PLUGIN_API } from "metabase/plugins";
 
 // Load EE plugins (whitelabeling, etc.) - no-op in OSS
 import "sdk-iframe-embedding-ee-plugins";
@@ -24,7 +26,8 @@ if (instanceUrl) {
 }
 
 if (sessionToken) {
-  api.sessionToken = sessionToken;
+  PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =
+    setSessionTokenHeader(sessionToken);
 }
 
 function init() {

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -30,7 +30,7 @@ const NOT_AUTHORIZED_TRIGGERS = [
  */
 if (isWithinIframe() && !IFRAMED_IN_SELF) {
   PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
-    setRequestClientHeaders("embedding-iframe-full-app");
+    setRequestClientHeaders({ name: "embedding-iframe-full-app" });
 }
 
 init(mainReducers, getRoutes, (store) => {

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -7,6 +7,8 @@ import _ from "underscore";
 
 import { api } from "metabase/api/client";
 import { init } from "metabase/app";
+import { setRequestClientHeaders } from "metabase/embedding/lib/embedding-request-auth";
+import { PLUGIN_API } from "metabase/plugins";
 import { mainReducers } from "metabase/reducers-main";
 import { setErrorPage } from "metabase/redux/app";
 import { clearCurrentUser } from "metabase/redux/user";
@@ -27,7 +29,8 @@ const NOT_AUTHORIZED_TRIGGERS = [
  * might want to use a flag too instead of just checking for being in an iframe.
  */
 if (isWithinIframe() && !IFRAMED_IN_SELF) {
-  api.requestClient = "embedding-iframe-full-app";
+  PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
+    setRequestClientHeaders("embedding-iframe-full-app");
 }
 
 init(mainReducers, getRoutes, (store) => {

--- a/frontend/src/metabase/embedding/config.ts
+++ b/frontend/src/metabase/embedding/config.ts
@@ -1,4 +1,7 @@
-import { setRequestClientHeaders } from "metabase/embedding/lib/embedding-request-auth";
+import {
+  setEmbedPreviewHeader,
+  setRequestClientHeaders,
+} from "metabase/embedding/lib/embedding-request-auth";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { PLUGIN_API } from "metabase/plugins";
 import { IFRAMED_IN_SELF, isWithinIframe } from "metabase/utils/iframe";
@@ -16,6 +19,8 @@ const EMBEDDING_CONFIG: InternalEmbeddingConfig = {
 export function setIsPublicEmbedding() {
   PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
     setRequestClientHeaders({ name: "embedding-public" });
+  PLUGIN_API.onBeforeRequestHandlers.setEmbedPreviewHeader =
+    setEmbedPreviewHeader;
 
   EMBEDDING_CONFIG.isPublicEmbedding = true;
 }

--- a/frontend/src/metabase/embedding/config.ts
+++ b/frontend/src/metabase/embedding/config.ts
@@ -1,5 +1,6 @@
-import { api } from "metabase/api/client";
+import { setRequestClientHeaders } from "metabase/embedding/lib/embedding-request-auth";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { PLUGIN_API } from "metabase/plugins";
 import { IFRAMED_IN_SELF, isWithinIframe } from "metabase/utils/iframe";
 
 type InternalEmbeddingConfig = {
@@ -13,7 +14,8 @@ const EMBEDDING_CONFIG: InternalEmbeddingConfig = {
 };
 
 export function setIsPublicEmbedding() {
-  api.requestClient = "embedding-public";
+  PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
+    setRequestClientHeaders("embedding-public");
 
   EMBEDDING_CONFIG.isPublicEmbedding = true;
 }
@@ -25,7 +27,8 @@ export function setIsStaticEmbedding() {
    * embedding iframe (only for Documents at the time of this comment)
    */
   if (!isEmbedPreview()) {
-    api.requestClient = "embedding-iframe-static";
+    PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
+      setRequestClientHeaders("embedding-iframe-static");
   }
   EMBEDDING_CONFIG.isStaticEmbedding = true;
 }

--- a/frontend/src/metabase/embedding/config.ts
+++ b/frontend/src/metabase/embedding/config.ts
@@ -15,7 +15,7 @@ const EMBEDDING_CONFIG: InternalEmbeddingConfig = {
 
 export function setIsPublicEmbedding() {
   PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
-    setRequestClientHeaders("embedding-public");
+    setRequestClientHeaders({ name: "embedding-public" });
 
   EMBEDDING_CONFIG.isPublicEmbedding = true;
 }
@@ -28,7 +28,7 @@ export function setIsStaticEmbedding() {
    */
   if (!isEmbedPreview()) {
     PLUGIN_API.onBeforeRequestHandlers.setRequestClientHeaders =
-      setRequestClientHeaders("embedding-iframe-static");
+      setRequestClientHeaders({ name: "embedding-iframe-static" });
   }
   EMBEDDING_CONFIG.isStaticEmbedding = true;
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -20,7 +20,7 @@ import type { SdkDashboardEntityPublicProps } from "embedding-sdk-bundle/types/d
 import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
 import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
 import { createSnowplowTracker } from "metabase/analytics";
-import { type OnBeforeRequestHandlerConfig, api } from "metabase/api/client";
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 import { EmbeddingFooter } from "metabase/embedding/components/EmbeddingFooter/EmbeddingFooter";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
@@ -61,10 +61,9 @@ const embedReferrerHandler = async (
   }
 };
 
-// Register once — uses a named function ref so it can't be pushed twice
-if (!api.beforeRequestHandlers.includes(embedReferrerHandler)) {
-  api.beforeRequestHandlers.push(embedReferrerHandler);
-}
+// Install the iframe embed-referrer handler into its plugin slot.
+PLUGIN_EMBEDDING_IFRAME_SDK.onBeforeRequestHandlers.embedReferrer =
+  embedReferrerHandler;
 
 const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
   // Tell the SDK whether to use the existing user session or not.

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -20,7 +20,7 @@ import type { SdkDashboardEntityPublicProps } from "embedding-sdk-bundle/types/d
 import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
 import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
 import { createSnowplowTracker } from "metabase/analytics";
-import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+import type { OnBeforeRequestHandler } from "metabase/api/client";
 import { EmbeddingFooter } from "metabase/embedding/components/EmbeddingFooter/EmbeddingFooter";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
@@ -46,9 +46,7 @@ import {
 
 let _embedReferrer: string | undefined;
 
-const embedReferrerHandler = async (
-  config: OnBeforeRequestHandlerConfig,
-): Promise<OnBeforeRequestHandlerConfig | void> => {
+const embedReferrerHandler: OnBeforeRequestHandler = async (config) => {
   if (_embedReferrer) {
     return {
       ...config,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -20,11 +20,10 @@ import type { SdkDashboardEntityPublicProps } from "embedding-sdk-bundle/types/d
 import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
 import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
 import { createSnowplowTracker } from "metabase/analytics";
-import { api } from "metabase/api/client";
+import { type OnBeforeRequestHandlerConfig, api } from "metabase/api/client";
 import { EmbeddingFooter } from "metabase/embedding/components/EmbeddingFooter/EmbeddingFooter";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/selectors/settings";
 import { getUserId } from "metabase/selectors/user";

--- a/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
+++ b/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
@@ -1,0 +1,50 @@
+/* eslint-disable metabase/no-literal-metabase-strings -- request header names */
+import type {
+  OnBeforeRequestHandlerConfig,
+  RequestClientInfo,
+} from "metabase/api/client";
+import { IFRAMED_IN_SELF } from "metabase/utils/iframe";
+
+type EmbeddingRequestHandler =
+  () => Promise<Partial<OnBeforeRequestHandlerConfig> | void>;
+
+/**
+ * Factories for the embedding-only request-header plugin handlers. Each closes
+ * over its value, so there's no shared mutable state — the embedding setup flow
+ * installs the handlers it needs onto the plugin slots:
+ *
+ *  - `setApiKeyHeader` / `setSessionTokenHeader` onto `setEmbeddingRequestAuthHeaders`
+ *    (whichever auth method is in use; the session strategy is re-installed on
+ *    refresh with the new token)
+ *  - `setRequestClientHeaders` onto its own slot
+ *
+ * In the normal app none are installed, so no embedding headers are emitted —
+ * keeping these embedding concerns out of the generic api client.
+ */
+export const setApiKeyHeader =
+  (apiKey: string): EmbeddingRequestHandler =>
+  async () => ({ headers: { "X-Api-Key": apiKey } });
+
+export const setSessionTokenHeader =
+  (sessionToken: string): EmbeddingRequestHandler =>
+  async () => ({ headers: { "X-Metabase-Session": sessionToken } });
+
+export const setRequestClientHeaders =
+  (requestClient: RequestClientInfo): EmbeddingRequestHandler =>
+  async () => {
+    const headers: Record<string, string> = {};
+
+    if (IFRAMED_IN_SELF) {
+      headers["X-Metabase-Embedded-Preview"] = "true";
+    }
+    if (typeof requestClient === "object") {
+      headers["X-Metabase-Client"] = requestClient.name;
+      if (requestClient.version) {
+        headers["X-Metabase-Client-Version"] = requestClient.version;
+      }
+    } else {
+      headers["X-Metabase-Client"] = requestClient;
+    }
+
+    return { headers };
+  };

--- a/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
+++ b/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
@@ -1,12 +1,10 @@
 /* eslint-disable metabase/no-literal-metabase-strings -- request header names */
 import type {
+  OnBeforeRequestHandler,
   OnBeforeRequestHandlerConfig,
   RequestClientInfo,
 } from "metabase/api/client";
 import { IFRAMED_IN_SELF } from "metabase/utils/iframe";
-
-type EmbeddingRequestHandler =
-  () => Promise<Partial<OnBeforeRequestHandlerConfig> | void>;
 
 /**
  * Factories for the embedding-only request-header plugin handlers. Each closes
@@ -25,7 +23,7 @@ type EmbeddingRequestHandler =
  * keeping these embedding concerns out of the generic api client.
  */
 export const setApiKeyHeader =
-  (apiKey: string): EmbeddingRequestHandler =>
+  (apiKey: string): OnBeforeRequestHandler =>
   async () => ({ headers: { "X-Api-Key": apiKey } });
 
 export const sessionTokenHeaders = (
@@ -35,12 +33,12 @@ export const sessionTokenHeaders = (
 });
 
 export const setSessionTokenHeader =
-  (sessionToken: string): EmbeddingRequestHandler =>
+  (sessionToken: string): OnBeforeRequestHandler =>
   async () =>
     sessionTokenHeaders(sessionToken);
 
 export const setRequestClientHeaders =
-  (requestClient: RequestClientInfo): EmbeddingRequestHandler =>
+  (requestClient: RequestClientInfo): OnBeforeRequestHandler =>
   async () => {
     const headers: Record<string, string> = {};
 
@@ -61,7 +59,7 @@ export const setRequestClientHeaders =
  * embed flows — static and full-app deliberately don't tag preview requests
  * (see EMB-930 in `metabase/embedding/config`).
  */
-export const setEmbedPreviewHeader: EmbeddingRequestHandler = async () => {
+export const setEmbedPreviewHeader: OnBeforeRequestHandler = async () => {
   if (IFRAMED_IN_SELF) {
     return { headers: { "X-Metabase-Embedded-Preview": "true" } };
   }

--- a/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
+++ b/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
@@ -14,8 +14,10 @@ type EmbeddingRequestHandler =
  * installs the handlers it needs onto the plugin slots:
  *
  *  - `setApiKeyHeader` / `setSessionTokenHeader` onto `setEmbeddingRequestAuthHeaders`
- *    (whichever auth method is in use; the session strategy is re-installed on
- *    refresh with the new token)
+ *    for static auth (an API key, or a session token that never refreshes — e.g.
+ *    MCP). A refreshing SSO session instead emits its header from
+ *    `getOrRefreshSessionHandler` via `sessionTokenHeaders`, so the refreshed
+ *    token applies to the request that triggered the refresh.
  *  - `setRequestClientHeaders` onto its own slot
  *  - `setEmbedPreviewHeader` onto its own slot (public + SDK flows only)
  *
@@ -26,9 +28,16 @@ export const setApiKeyHeader =
   (apiKey: string): EmbeddingRequestHandler =>
   async () => ({ headers: { "X-Api-Key": apiKey } });
 
+export const sessionTokenHeaders = (
+  sessionToken: string,
+): Partial<OnBeforeRequestHandlerConfig> => ({
+  headers: { "X-Metabase-Session": sessionToken },
+});
+
 export const setSessionTokenHeader =
   (sessionToken: string): EmbeddingRequestHandler =>
-  async () => ({ headers: { "X-Metabase-Session": sessionToken } });
+  async () =>
+    sessionTokenHeaders(sessionToken);
 
 export const setRequestClientHeaders =
   (requestClient: RequestClientInfo): EmbeddingRequestHandler =>

--- a/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
+++ b/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
@@ -37,13 +37,11 @@ export const setRequestClientHeaders =
     if (IFRAMED_IN_SELF) {
       headers["X-Metabase-Embedded-Preview"] = "true";
     }
-    if (typeof requestClient === "object") {
+    if (requestClient.name) {
       headers["X-Metabase-Client"] = requestClient.name;
-      if (requestClient.version) {
-        headers["X-Metabase-Client-Version"] = requestClient.version;
-      }
-    } else {
-      headers["X-Metabase-Client"] = requestClient;
+    }
+    if (requestClient.version) {
+      headers["X-Metabase-Client-Version"] = requestClient.version;
     }
 
     return { headers };

--- a/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
+++ b/frontend/src/metabase/embedding/lib/embedding-request-auth.ts
@@ -17,6 +17,7 @@ type EmbeddingRequestHandler =
  *    (whichever auth method is in use; the session strategy is re-installed on
  *    refresh with the new token)
  *  - `setRequestClientHeaders` onto its own slot
+ *  - `setEmbedPreviewHeader` onto its own slot (public + SDK flows only)
  *
  * In the normal app none are installed, so no embedding headers are emitted —
  * keeping these embedding concerns out of the generic api client.
@@ -34,9 +35,6 @@ export const setRequestClientHeaders =
   async () => {
     const headers: Record<string, string> = {};
 
-    if (IFRAMED_IN_SELF) {
-      headers["X-Metabase-Embedded-Preview"] = "true";
-    }
     if (requestClient.name) {
       headers["X-Metabase-Client"] = requestClient.name;
     }
@@ -46,3 +44,16 @@ export const setRequestClientHeaders =
 
     return { headers };
   };
+
+/**
+ * Tag requests coming from an embed preview (the page is iframed into itself).
+ * Kept separate from `setRequestClientHeaders` because preview mode is
+ * orthogonal to which client is embedding. Installed only by the public and SDK
+ * embed flows — static and full-app deliberately don't tag preview requests
+ * (see EMB-930 in `metabase/embedding/config`).
+ */
+export const setEmbedPreviewHeader: EmbeddingRequestHandler = async () => {
+  if (IFRAMED_IN_SELF) {
+    return { headers: { "X-Metabase-Embedded-Preview": "true" } };
+  }
+};

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -1,8 +1,7 @@
 import { sessionPropertiesPath } from "metabase/api";
-import {
-  type OnBeforeRequestHandlerConfig,
-  type RequestMethod,
-  api,
+import type {
+  OnBeforeRequestHandlerConfig,
+  RequestMethod,
 } from "metabase/api/client";
 import { isEmbedPreview } from "metabase/embedding/config";
 import {
@@ -245,20 +244,18 @@ export const rewriteEmbedPreviewUrl = async ({
 };
 
 /**
- * Registers the embed-preview rewrite on the shared client. It runs after the
- * embed override handlers, so it covers both the override-produced
- * `/api/embed/...` urls and the embed endpoints called directly.
+ * Installs the embed-preview rewrite into its plugin slot. It runs after the
+ * embed override handlers (see the pipeline in `middleware.ts`), so it covers
+ * both the override-produced `/api/embed/...` urls and the embed endpoints
+ * called directly (e.g. `EmbedApi`, `embedApi`).
  *
- * Idempotent, so call sites can register it at the earliest safe moment without
- * worrying about duplicates. For public/static embeds it must run *before* the
- * dashboard fetcher's effect (see `usePublicEndpoints`): React runs child
- * effects before parent effects, so registering from a parent `useMount` would
- * miss the very first embed request (the dashboard load).
+ * The slot's position in the pipeline is fixed, so this only needs to run before
+ * the first embed request — assigning the same handler again is a harmless
+ * no-op.
  */
 export const setupEmbedPreviewRewrite = () => {
-  if (!api.beforeRequestHandlers.includes(rewriteEmbedPreviewUrl)) {
-    api.beforeRequestHandlers.push(rewriteEmbedPreviewUrl);
-  }
+  PLUGIN_API.onBeforeRequestHandlers.rewriteEmbedPreviewUrl =
+    rewriteEmbedPreviewUrl;
 };
 
 /**

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -201,6 +201,17 @@ export const overrideRequests = async ({
     return { method, url, headers, data };
   }
 
+  // The matched embed endpoints address the entity by token/uuid
+  // (`:entityIdentifier`), never the real numeric id. Drop the id keys so they
+  // don't trail along as `?cardId=`/`?dashId=` querystring params now that the
+  // url has no `:cardId`/`:dashId` tag to consume them. The pipeline's merge
+  // can't delete keys, so mutate the bag in place — the client defensively
+  // copies it for exactly this.
+  if (findMatchingPattern(url)) {
+    delete data.cardId;
+    delete data.dashId;
+  }
+
   return {
     method: transformation.method,
     url: replaceWithEmbedBase({ embedType, url: transformation.url }),

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -1,12 +1,15 @@
 import { sessionPropertiesPath } from "metabase/api";
-import { type RequestMethod, api } from "metabase/api/client";
+import {
+  type OnBeforeRequestHandlerConfig,
+  type RequestMethod,
+  api,
+} from "metabase/api/client";
 import { isEmbedPreview } from "metabase/embedding/config";
 import {
   PLUGIN_API,
   PLUGIN_CONTENT_TRANSLATION,
   PLUGIN_EMBEDDING_SDK,
 } from "metabase/plugins";
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
 type EmbedType = "guest" | "static" | "public";

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -9,7 +9,6 @@ import {
   PLUGIN_CONTENT_TRANSLATION,
   PLUGIN_EMBEDDING_SDK,
 } from "metabase/plugins";
-import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
 type EmbedType = "guest" | "static" | "public";
 
@@ -210,22 +209,6 @@ export const overrideRequests = async ({
   };
 };
 
-const setupRemappingUrls = (embedType: EmbedType) => {
-  const baseUrl = getBaseUrlByEmbedType(embedType);
-
-  PLUGIN_API.getRemappedDashboardParameterValueUrl = (
-    _dashboardId: DashboardId | undefined,
-    parameterId: ParameterId,
-  ) =>
-    `${baseUrl}/dashboard/:entityIdentifier/params/${encodeURIComponent(parameterId)}/remapping`;
-
-  PLUGIN_API.getRemappedCardParameterValueUrl = (
-    _cardId: CardId | string | undefined,
-    parameterId: ParameterId,
-  ) =>
-    `${baseUrl}/card/:entityIdentifier/params/${encodeURIComponent(parameterId)}/remapping`;
-};
-
 const EMBED_API_BASE_PATTERN = /^\/api\/embed(?=\/|$)/;
 const EMBED_PREVIEW_API_BASE = "/api/preview_embed";
 
@@ -263,7 +246,6 @@ export const setupEmbedPreviewRewrite = () => {
  * into guest embeds API requests.
  */
 export const overrideRequestsForGuestEmbeds = () => {
-  setupRemappingUrls("guest");
   setupEmbedPreviewRewrite();
 
   PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.overrideRequestsForGuestEmbeds =
@@ -281,8 +263,6 @@ export const overrideRequestsForGuestEmbeds = () => {
 export const overrideRequestsForPublicOrStaticEmbeds = (
   embedType: "static" | "public",
 ) => {
-  setupRemappingUrls(embedType);
-
   PLUGIN_API.onBeforeRequestHandlers.overrideRequestsForPublicEmbeds = (data) =>
     overrideRequests({
       ...data,

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
@@ -1,5 +1,5 @@
-import { api } from "metabase/api/client";
 import { isEmbedPreview } from "metabase/embedding/config";
+import { PLUGIN_API, reinitialize } from "metabase/plugins";
 
 import {
   matchUrlPattern,
@@ -16,6 +16,8 @@ const mockIsEmbedPreview = jest.mocked(isEmbedPreview);
 
 afterEach(() => {
   mockIsEmbedPreview.mockReset();
+  // Reset any plugin request handlers installed by a test.
+  reinitialize();
 });
 
 describe("matchUrlPattern", () => {
@@ -151,24 +153,16 @@ describe("overrideRequests", () => {
 });
 
 describe("setupEmbedPreviewRewrite", () => {
-  // The embed route registers `usePublicEndpoints` on a parent of the dashboard
-  // fetcher, and React runs child effects before parent effects, so this must be
-  // called synchronously (not from an effect) to catch the first embed request.
-  it("registers rewriteEmbedPreviewUrl on the shared client, idempotently", () => {
-    const before = api.beforeRequestHandlers.filter(
-      (handler) => handler === rewriteEmbedPreviewUrl,
-    ).length;
-
-    expect(before).toBe(0);
+  it("installs rewriteEmbedPreviewUrl into the PLUGIN_API slot", () => {
+    expect(PLUGIN_API.onBeforeRequestHandlers.rewriteEmbedPreviewUrl).not.toBe(
+      rewriteEmbedPreviewUrl,
+    );
 
     setupEmbedPreviewRewrite();
-    setupEmbedPreviewRewrite();
 
-    const after = api.beforeRequestHandlers.filter(
-      (handler) => handler === rewriteEmbedPreviewUrl,
-    ).length;
-
-    expect(after).toBe(1);
+    expect(PLUGIN_API.onBeforeRequestHandlers.rewriteEmbedPreviewUrl).toBe(
+      rewriteEmbedPreviewUrl,
+    );
   });
 });
 

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.unit.spec.ts
@@ -150,6 +150,36 @@ describe("overrideRequests", () => {
     expect(result.url).toBe("/api/embed/card/:token/query");
     expect(result.method).toBe("GET");
   });
+
+  it("drops the real cardId so it isn't leaked as a querystring param", async () => {
+    const result = await overrideRequests({
+      embedType: "public",
+      method: "GET",
+      url: "/api/card/:cardId/params/:paramId/remapping",
+      data: { cardId: 123, paramId: "p1", entityIdentifier: "uuid-1" },
+    });
+
+    expect(result.url).toBe(
+      "/api/public/card/:entityIdentifier/params/:paramId/remapping",
+    );
+    expect(result.data).not.toHaveProperty("cardId");
+    expect(result.data.entityIdentifier).toBe("uuid-1");
+  });
+
+  it("drops the real dashId for dashboard parameter endpoints", async () => {
+    const result = await overrideRequests({
+      embedType: "guest",
+      method: "GET",
+      url: "/api/dashboard/:dashId/params/:paramId/values",
+      data: { dashId: 7, paramId: "p1", entityIdentifier: "uuid-2" },
+    });
+
+    expect(result.url).toBe(
+      "/api/embed/dashboard/:entityIdentifier/params/:paramId/values",
+    );
+    expect(result.data).not.toHaveProperty("dashId");
+    expect(result.data.entityIdentifier).toBe("uuid-2");
+  });
 });
 
 describe("setupEmbedPreviewRewrite", () => {

--- a/frontend/src/metabase/parameters/actions.ts
+++ b/frontend/src/metabase/parameters/actions.ts
@@ -71,7 +71,8 @@ export const fetchCardParameterValues =
   }: FetchCardParameterValuesOpts) =>
   (dispatch: DispatchFn, getState: GetState) => {
     const baseRequest: CardParameterValuesRequest = {
-      ...(entityIdentifier ? { entityIdentifier } : { cardId }),
+      cardId,
+      entityIdentifier,
       paramId: parameter.id,
     };
     const request:
@@ -106,7 +107,8 @@ export const fetchDashboardParameterValues =
   }: FetchDashboardParameterValuesOpts) =>
   (dispatch: DispatchFn, getState: GetState) => {
     const baseRequest: DashboardParameterValuesRequest = {
-      ...(entityIdentifier ? { entityIdentifier } : { dashId: dashboardId }),
+      dashId: dashboardId,
+      entityIdentifier,
       paramId: parameter.id,
       ...getFilteringParameterValuesMap(parameter, parameters),
     };

--- a/frontend/src/metabase/parameters/actions.ts
+++ b/frontend/src/metabase/parameters/actions.ts
@@ -72,7 +72,7 @@ export const fetchCardParameterValues =
   (dispatch: DispatchFn, getState: GetState) => {
     const baseRequest: CardParameterValuesRequest = {
       cardId,
-      entityIdentifier,
+      ...(entityIdentifier && { entityIdentifier }),
       paramId: parameter.id,
     };
     const request:
@@ -108,7 +108,7 @@ export const fetchDashboardParameterValues =
   (dispatch: DispatchFn, getState: GetState) => {
     const baseRequest: DashboardParameterValuesRequest = {
       dashId: dashboardId,
-      entityIdentifier,
+      ...(entityIdentifier && { entityIdentifier }),
       paramId: parameter.id,
       ...getFilteringParameterValuesMap(parameter, parameters),
     };

--- a/frontend/src/metabase/parameters/actions.unit.spec.ts
+++ b/frontend/src/metabase/parameters/actions.unit.spec.ts
@@ -1,0 +1,111 @@
+import fetchMock from "fetch-mock";
+
+import type { DispatchFn } from "metabase/redux";
+import type { GetState } from "metabase/redux/store";
+import { stableStringify } from "metabase/utils/objects";
+import type { ParameterValues } from "metabase-types/api";
+import { createMockParameter } from "metabase-types/api/mocks";
+
+import {
+  fetchCardParameterValues,
+  fetchDashboardParameterValues,
+} from "./actions";
+
+const PARAMETER = createMockParameter({ id: "param-1", name: "Category" });
+
+const CACHED: ParameterValues = {
+  values: [["Doohickey"], ["Gadget"]],
+  has_more_values: false,
+};
+
+const createGetState = (cache: Record<string, ParameterValues>): GetState =>
+  (() => ({
+    parameters: { parameterValuesCache: cache },
+  })) as unknown as GetState;
+
+const dispatch = jest.fn() as unknown as DispatchFn;
+
+describe("parameters > actions", () => {
+  // Regression guard for the parameter-value dropdowns: the request used as the
+  // cache key (and sent to the overridden embed endpoints) must not carry a null
+  // `entityIdentifier`, otherwise it pollutes the key and every lookup misses.
+  describe("fetchDashboardParameterValues", () => {
+    const DASHBOARD_ID = 42;
+
+    it("hits the cache keyed by dashId/paramId when not embedding", async () => {
+      const getState = createGetState({
+        [stableStringify({ dashId: DASHBOARD_ID, paramId: PARAMETER.id })]:
+          CACHED,
+      });
+
+      const result = await fetchDashboardParameterValues({
+        dashboardId: DASHBOARD_ID,
+        entityIdentifier: null,
+        parameter: PARAMETER,
+        parameters: [],
+      })(dispatch, getState);
+
+      expect(result).toEqual(CACHED);
+      // A cache hit must not fall through to the network.
+      expect(fetchMock.callHistory.calls()).toHaveLength(0);
+    });
+
+    it("includes entityIdentifier in the cache key when embedding", async () => {
+      const getState = createGetState({
+        [stableStringify({
+          dashId: DASHBOARD_ID,
+          entityIdentifier: "uuid-1",
+          paramId: PARAMETER.id,
+        })]: CACHED,
+      });
+
+      const result = await fetchDashboardParameterValues({
+        dashboardId: DASHBOARD_ID,
+        entityIdentifier: "uuid-1",
+        parameter: PARAMETER,
+        parameters: [],
+      })(dispatch, getState);
+
+      expect(result).toEqual(CACHED);
+      expect(fetchMock.callHistory.calls()).toHaveLength(0);
+    });
+  });
+
+  describe("fetchCardParameterValues", () => {
+    const CARD_ID = 7;
+
+    it("hits the cache keyed by cardId/paramId when not embedding", async () => {
+      const getState = createGetState({
+        [stableStringify({ cardId: CARD_ID, paramId: PARAMETER.id })]: CACHED,
+      });
+
+      const result = await fetchCardParameterValues({
+        cardId: CARD_ID,
+        entityIdentifier: null,
+        parameter: PARAMETER,
+      })(dispatch, getState);
+
+      expect(result).toEqual(CACHED);
+      expect(fetchMock.callHistory.calls()).toHaveLength(0);
+    });
+
+    it("includes entityIdentifier in the cache key when embedding", async () => {
+      const getState = createGetState({
+        [stableStringify({
+          cardId: CARD_ID,
+          entityIdentifier: "uuid-1",
+          paramId: PARAMETER.id,
+        })]: CACHED,
+      });
+
+      const result = await fetchCardParameterValues({
+        cardId: CARD_ID,
+        entityIdentifier: "uuid-1",
+        parameter: PARAMETER,
+      })(dispatch, getState);
+
+      expect(result).toEqual(CACHED);
+      expect(fetchMock.callHistory.calls()).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -739,9 +739,9 @@ function RemappedValue({
   const { data: dashboardData } = useGetRemappedDashboardParameterValueQuery(
     dashboardId != null && value != null && isRemapped
       ? {
-          dashboard_id: dashboardId,
+          dashId: dashboardId,
           ...(entityIdentifier && { entityIdentifier }),
-          parameter_id: parameter.id,
+          paramId: parameter.id,
           value,
         }
       : skipToken,
@@ -750,9 +750,9 @@ function RemappedValue({
   const { data: cardData } = useGetRemappedCardParameterValueQuery(
     cardId != null && value != null && isRemapped
       ? {
-          card_id: cardId,
+          cardId,
           ...(entityIdentifier && { entityIdentifier }),
-          parameter_id: parameter.id,
+          paramId: parameter.id,
           value,
         }
       : skipToken,

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -740,7 +740,7 @@ function RemappedValue({
     dashboardId != null && value != null && isRemapped
       ? {
           dashboard_id: dashboardId,
-          entityIdentifier,
+          ...(entityIdentifier && { entityIdentifier }),
           parameter_id: parameter.id,
           value,
         }
@@ -751,7 +751,7 @@ function RemappedValue({
     cardId != null && value != null && isRemapped
       ? {
           card_id: cardId,
-          entityIdentifier,
+          ...(entityIdentifier && { entityIdentifier }),
           parameter_id: parameter.id,
           value,
         }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -739,9 +739,8 @@ function RemappedValue({
   const { data: dashboardData } = useGetRemappedDashboardParameterValueQuery(
     dashboardId != null && value != null && isRemapped
       ? {
-          ...(entityIdentifier
-            ? { entityIdentifier }
-            : { dashboard_id: dashboardId }),
+          dashboard_id: dashboardId,
+          entityIdentifier,
           parameter_id: parameter.id,
           value,
         }
@@ -751,7 +750,8 @@ function RemappedValue({
   const { data: cardData } = useGetRemappedCardParameterValueQuery(
     cardId != null && value != null && isRemapped
       ? {
-          ...(entityIdentifier ? { entityIdentifier } : { card_id: cardId }),
+          card_id: cardId,
+          entityIdentifier,
           parameter_id: parameter.id,
           value,
         }

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,24 +1,5 @@
-import type { RequestMethod } from "metabase/api/client";
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
-
-export type OnBeforeRequestHandlerConfig = {
-  method: RequestMethod;
-  url: string;
-  headers?: Record<string, string>;
-  // URL `:tag` params (and querystring leftovers). For the legacy GET/POST
-  // helpers this holds the whole request bag.
-  data: Record<string, unknown>;
-  // The JSON-body bag, kept as a separate channel from `data`. Exposed to
-  // handlers so embed URL `:tag`s — notably the guest-embed `:token` — can be
-  // filled from body fields, and so the refresh handler can swap a stale body
-  // token. `undefined` for GETs, raw (FormData/URLSearchParams) bodies, and the
-  // legacy helpers (which pack everything into `data`).
-  body?: Record<string, unknown>;
-};
-
-export type OnBeforeRequestHandler = (
-  data: OnBeforeRequestHandlerConfig,
-) => Promise<void | Partial<OnBeforeRequestHandlerConfig>>;
 
 const getDefaultPluginApi = () => ({
   onBeforeRequestHandlers: {

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,4 +1,6 @@
 import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import { isWithinIframe } from "metabase/utils/iframe";
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
 const getDefaultPluginApi = () => ({
@@ -9,6 +11,18 @@ const getDefaultPluginApi = () => ({
     rewriteEmbedPreviewUrl: async (
       _data: OnBeforeRequestHandlerConfig,
     ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    // Tag requests from a non-SDK app running inside an iframe (interactive /
+    // static / public embedding) so the backend knows it's embedded. Lives here
+    // rather than in `metabase/api` so the client stays free of SDK imports.
+    setEmbeddedHeader:
+      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {
+        if (isWithinIframe() && !isEmbeddingSdk()) {
+          return {
+            // eslint-disable-next-line metabase/no-literal-metabase-strings -- header name
+            headers: { "X-Metabase-Embedded": "true" },
+          };
+        }
+      },
   },
   getRemappedCardParameterValueUrl: (
     cardId: CardId | string | undefined,

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,44 +1,40 @@
 /* eslint-disable metabase/no-literal-metabase-strings -- request header names */
-import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+import type { OnBeforeRequestHandler } from "metabase/api/client";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isWithinIframe } from "metabase/utils/iframe";
 
+const noop: OnBeforeRequestHandler = async () => {};
+
+// Tag requests from a non-SDK app running inside an iframe (interactive /
+// static / public embedding) so the backend knows it's embedded. Lives here
+// rather than in `metabase/api` so the client stays free of SDK imports.
+const setEmbeddedHeader: OnBeforeRequestHandler = async () => {
+  if (isWithinIframe() && !isEmbeddingSdk()) {
+    return { headers: { "X-Metabase-Embedded": "true" } };
+  }
+};
+
 const getDefaultPluginApi = () => ({
   onBeforeRequestHandlers: {
-    overrideRequestsForPublicEmbeds: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
-    rewriteEmbedPreviewUrl: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
-    // Tag requests from a non-SDK app running inside an iframe (interactive /
-    // static / public embedding) so the backend knows it's embedded. Lives here
-    // rather than in `metabase/api` so the client stays free of SDK imports.
-    setEmbeddedHeader:
-      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {
-        if (isWithinIframe() && !isEmbeddingSdk()) {
-          return { headers: { "X-Metabase-Embedded": "true" } };
-        }
-      },
-    // Emit the embedding client headers (`X-Metabase-Client` / `-Version` /
-    // `-Embedded-Preview`). A no-op slot: the embedding setup flow installs
-    // `setRequestClientHeaders` here, closing over the active client (see
-    // `embedding-request-auth`). Untouched in the normal app — keeping these
-    // embedding-only headers out of the generic api client.
-    setRequestClientHeaders:
-      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    overrideRequestsForPublicEmbeds: noop,
+    rewriteEmbedPreviewUrl: noop,
+    setEmbeddedHeader,
+    // Emit the embedding client headers (`X-Metabase-Client` / `-Version`). A
+    // no-op slot: the embedding setup flow installs `setRequestClientHeaders`
+    // here, closing over the active client (see `embedding-request-auth`).
+    // Untouched in the normal app — keeping these embedding-only headers out of
+    // the generic api client.
+    setRequestClientHeaders: noop,
     // Emit the embed-preview header (`X-Metabase-Embedded-Preview`). A no-op
     // slot: the public and SDK embed flows install `setEmbedPreviewHeader` here,
     // which tags requests when running inside an embed preview (see
     // `embedding-request-auth`).
-    setEmbedPreviewHeader:
-      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    setEmbedPreviewHeader: noop,
     // Emit the embedding auth header (`X-Api-Key` or `X-Metabase-Session`). A
     // no-op slot: the embedding auth flow installs exactly one strategy here —
     // `setApiKeyHeader` or `setSessionTokenHeader` — based on the auth method in
     // use (see `embedding-request-auth`).
-    setEmbeddingRequestAuthHeaders:
-      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    setEmbeddingRequestAuthHeaders: noop,
   },
 });
 

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable metabase/no-literal-metabase-strings -- request header names */
 import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isWithinIframe } from "metabase/utils/iframe";
@@ -16,12 +17,22 @@ const getDefaultPluginApi = () => ({
     setEmbeddedHeader:
       async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {
         if (isWithinIframe() && !isEmbeddingSdk()) {
-          return {
-            // eslint-disable-next-line metabase/no-literal-metabase-strings -- header name
-            headers: { "X-Metabase-Embedded": "true" },
-          };
+          return { headers: { "X-Metabase-Embedded": "true" } };
         }
       },
+    // Emit the embedding client headers (`X-Metabase-Client` / `-Version` /
+    // `-Embedded-Preview`). A no-op slot: the embedding setup flow installs
+    // `setRequestClientHeaders` here, closing over the active client (see
+    // `embedding-request-auth`). Untouched in the normal app — keeping these
+    // embedding-only headers out of the generic api client.
+    setRequestClientHeaders:
+      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    // Emit the embedding auth header (`X-Api-Key` or `X-Metabase-Session`). A
+    // no-op slot: the embedding auth flow installs exactly one strategy here —
+    // `setApiKeyHeader` or `setSessionTokenHeader` — based on the auth method in
+    // use (see `embedding-request-auth`).
+    setEmbeddingRequestAuthHeaders:
+      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
   },
 });
 

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -6,9 +6,9 @@ const getDefaultPluginApi = () => ({
     overrideRequestsForPublicEmbeds: async (
       _data: OnBeforeRequestHandlerConfig,
     ): Promise<OnBeforeRequestHandlerConfig | void> => {},
-    overrideRequestsForStaticEmbeds: async (
+    rewriteEmbedPreviewUrl: async (
       _data: OnBeforeRequestHandlerConfig,
-    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
+    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
   },
   getRemappedCardParameterValueUrl: (
     cardId: CardId | string | undefined,

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -27,6 +27,12 @@ const getDefaultPluginApi = () => ({
     // embedding-only headers out of the generic api client.
     setRequestClientHeaders:
       async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    // Emit the embed-preview header (`X-Metabase-Embedded-Preview`). A no-op
+    // slot: the public and SDK embed flows install `setEmbedPreviewHeader` here,
+    // which tags requests when running inside an embed preview (see
+    // `embedding-request-auth`).
+    setEmbedPreviewHeader:
+      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
     // Emit the embedding auth header (`X-Api-Key` or `X-Metabase-Session`). A
     // no-op slot: the embedding auth flow installs exactly one strategy here —
     // `setApiKeyHeader` or `setSessionTokenHeader` — based on the auth method in

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,7 +1,6 @@
 import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isWithinIframe } from "metabase/utils/iframe";
-import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
 const getDefaultPluginApi = () => ({
   onBeforeRequestHandlers: {
@@ -24,16 +23,6 @@ const getDefaultPluginApi = () => ({
         }
       },
   },
-  getRemappedCardParameterValueUrl: (
-    cardId: CardId | string | undefined,
-    parameterId: ParameterId,
-  ) =>
-    `/api/card/${cardId}/params/${encodeURIComponent(parameterId)}/remapping`,
-  getRemappedDashboardParameterValueUrl: (
-    dashboardId: DashboardId | undefined,
-    parameterId: ParameterId,
-  ) =>
-    `/api/dashboard/${dashboardId}/params/${encodeURIComponent(parameterId)}/remapping`,
 });
 
 export const PLUGIN_API = getDefaultPluginApi();

--- a/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
@@ -1,5 +1,12 @@
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+
 const getDefaultPluginEmbeddingIframeSdk = () => ({
   isEnabled: () => false,
+  onBeforeRequestHandlers: {
+    embedReferrer: async (
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+  },
 });
 
 export const PLUGIN_EMBEDDING_IFRAME_SDK = getDefaultPluginEmbeddingIframeSdk();

--- a/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-iframe-sdk.ts
@@ -1,11 +1,11 @@
-import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+import type { OnBeforeRequestHandler } from "metabase/api/client";
+
+const noop: OnBeforeRequestHandler = async () => {};
 
 const getDefaultPluginEmbeddingIframeSdk = () => ({
   isEnabled: () => false,
   onBeforeRequestHandlers: {
-    embedReferrer: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    embedReferrer: noop,
   },
 });
 

--- a/frontend/src/metabase/plugins/oss/embedding-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-sdk.ts
@@ -10,6 +10,9 @@ const getDefaultPluginEmbeddingSdk = () => ({
     overrideRequestsForGuestEmbeds: async (
       _data: OnBeforeRequestHandlerConfig,
     ): Promise<OnBeforeRequestHandlerConfig | void> => {},
+    reactSdkEmbedReferrer: async (
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
   },
 });
 

--- a/frontend/src/metabase/plugins/oss/embedding-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-sdk.ts
@@ -1,19 +1,14 @@
-import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
+import type { OnBeforeRequestHandler } from "metabase/api/client";
+
+const noop: OnBeforeRequestHandler = async () => {};
 
 const getDefaultPluginEmbeddingSdk = () => ({
   isEnabled: () => false,
   onBeforeRequestHandlers: {
-    getOrRefreshSessionHandler:
-      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
-    getOrRefreshGuestSessionHandler: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
-    overrideRequestsForGuestEmbeds: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
-    reactSdkEmbedReferrer: async (
-      _data: OnBeforeRequestHandlerConfig,
-    ): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
+    getOrRefreshSessionHandler: noop,
+    getOrRefreshGuestSessionHandler: noop,
+    overrideRequestsForGuestEmbeds: noop,
+    reactSdkEmbedReferrer: noop,
   },
 });
 

--- a/frontend/src/metabase/plugins/oss/embedding-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-sdk.ts
@@ -3,7 +3,8 @@ import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 const getDefaultPluginEmbeddingSdk = () => ({
   isEnabled: () => false,
   onBeforeRequestHandlers: {
-    getOrRefreshSessionHandler: async () => {},
+    getOrRefreshSessionHandler:
+      async (): Promise<Partial<OnBeforeRequestHandlerConfig> | void> => {},
     getOrRefreshGuestSessionHandler: async (
       _data: OnBeforeRequestHandlerConfig,
     ): Promise<OnBeforeRequestHandlerConfig | void> => {},

--- a/frontend/src/metabase/plugins/oss/embedding-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-sdk.ts
@@ -1,4 +1,4 @@
-import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
+import type { OnBeforeRequestHandlerConfig } from "metabase/api/client";
 
 const getDefaultPluginEmbeddingSdk = () => ({
   isEnabled: () => false,

--- a/frontend/src/metabase/redux/remappings.ts
+++ b/frontend/src/metabase/redux/remappings.ts
@@ -77,8 +77,8 @@ export const fetchRemapping = createThunkAction(
           {
             ...(entityIdentifier
               ? { entityIdentifier }
-              : { dashboard_id: dashboardId }),
-            parameter_id: parameter.id,
+              : { dashId: dashboardId }),
+            paramId: parameter.id,
             value,
           },
           dispatch,
@@ -88,8 +88,8 @@ export const fetchRemapping = createThunkAction(
       } else if (cardId != null) {
         remapping = await runRtkEndpoint(
           {
-            ...(entityIdentifier ? { entityIdentifier } : { card_id: cardId }),
-            parameter_id: parameter.id,
+            ...(entityIdentifier ? { entityIdentifier } : { cardId }),
+            paramId: parameter.id,
             value,
           },
           dispatch,


### PR DESCRIPTION
No linear issue, just a quality of life improvement.

This PR removes `metabase/embedding-sdk` imports from `metabase/api` completely.

On master, there are three ways we can override the default behavior of the `APIClient`.
I'll list them here from "more static" to "less static". This is also the order for most-easily debuggable to least-easily debuggable.

#### 1. Hardcode the behvior in the client's code itself and gate it behind a switch
[For example](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/api/client/client.ts#L67-L69):
```tsx
class APIClient {
  getClientHeaders() {
    // ...
  
    if (isWithinIframe() && !isEmbeddingSdk()) {
      headers["X-Metabase-Embedded"] = "true";
    }
  
    // ...
  }
}
```
The problem with this is that the `APIClient` now has to know about all modifications.

#### 2. As an `OnBeforeRequestHandler` middleware, hardcoded in `middleware.ts`
[Ie. as a statically-declared middleware](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/api/client/middleware.ts#L13-L21), that runs before each request. These handlers are updated by plugins:

```tsx
export async function apiRequestManipulationMiddleware() {
  const handlers = [
    PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshSessionHandler,
    // ...
  ]
  
  // ...
}
```

#### 3. As an `OnBeforeRequestHandler` middleware, dynamically registered
[For example](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts#L257-L259):
```tsx
export const setupEmbedPreviewRewrite = () => {
  if (!api.beforeRequestHandlers.includes(rewriteEmbedPreviewUrl)) {
    api.beforeRequestHandlers.push(rewriteEmbedPreviewUrl);
  }
};
```
This is super hard to trace, discover and debug.

### Solution

This PR replaces all the extension methods with 2., wiring all the overrides statically-declared middleware.

The PR also removes all the embedding-only state on the `ApiClient`: `sessionToken`, `apiKey`, `requestClient`.