### PR TITLE
Avoid reloading the database when describing sync fields

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -244,14 +244,20 @@
                 :preview-display false})))))))
 
 (defn describe-table-fields-xf
-  "Returns a transducer for computing metadata about the fields in a table"
-  [driver table]
-  (let [table-info (merge {:table-name (:name table)}
-                          (when (:schema table)
-                            {:table-schema (:schema table)}))]
-    (comp
-     (describe-fields-xf driver (driver-api/table->database table) table-info)
-     (map-indexed (fn [i col] (dissoc (assoc col :database-position i) :table-schema))))))
+  "Returns a transducer for computing metadata about the fields in a table.
+
+  Accepts `database` explicitly so sync code that already has the Database instance does not
+  need to repeatedly resolve it from `table`."
+  ([driver table]
+   (describe-table-fields-xf driver (driver-api/table->database table) table))
+
+  ([driver database table]
+   (let [table-info (merge {:table-name (:name table)}
+                           (when (:schema table)
+                             {:table-schema (:schema table)}))]
+     (comp
+      (describe-fields-xf driver database table-info)
+      (map-indexed (fn [i col] (dissoc (assoc col :database-position i) :table-schema)))))))
 
 (defmulti describe-table-fields
   "Returns a set of column metadata for `table` using JDBC Connection `conn`."
@@ -264,7 +270,7 @@
   [driver conn table db-name-or-nil]
   (into
    #{}
-   (describe-table-fields-xf driver table)
+   (describe-table-fields-xf driver (driver-api/table->database table) table)
    (fields-metadata driver conn table db-name-or-nil)))
 
 ;;; TODO -- it seems like in practice we usually call this without passing in a DB name, so `db-name-or-nil` is almost
@@ -738,7 +744,7 @@
           (comp
            (filter #(isa? (:base-type %) :type/JSON))
            (remove #(contains? @fields-with-json-unfolding-disabled (:name %)))
-           (describe-table-fields-xf driver table))
+           (describe-table-fields-xf driver (driver-api/table->database table) table))
           (describe-table-fields driver conn table nil))))
 
 (defn- sample-json-row-honey-sql

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -273,6 +273,15 @@
    (describe-table-fields-xf driver (driver-api/table->database table) table)
    (fields-metadata driver conn table db-name-or-nil)))
 
+(defn- describe-table-field-set
+  "Return the described field set for `table`, reusing the already-loaded `database`
+  when the caller has it instead of resolving it again from `table`."
+  [driver database conn table db-name-or-nil]
+  (into
+   #{}
+   (describe-table-fields-xf driver database table)
+   (fields-metadata driver conn table db-name-or-nil)))
+
 ;;; TODO -- it seems like in practice we usually call this without passing in a DB name, so `db-name-or-nil` is almost
 ;;; always just `nil`. There's currently not a great driver-agnostic way to determine the actual physical Database name
 ;;; anyway... Database `:name` is wrong, because it's a display name rather than a physical name. We might want to
@@ -333,10 +342,10 @@
                                       (assoc field :pk? true)))))))))
 
 (defn- describe-table*
-  [driver ^Connection conn table]
+  [driver database ^Connection conn table]
   {:pre [(instance? Connection conn)]}
   (->> (assoc (select-keys table [:name :schema])
-              :fields (describe-table-fields driver conn table nil))
+              :fields (describe-table-field-set driver database conn table nil))
        ;; find PKs and mark them
        (add-table-pks driver conn)))
 
@@ -348,7 +357,7 @@
    db
    nil
    (fn [^Connection conn]
-     (describe-table* driver conn table))))
+     (describe-table* driver db conn table))))
 
 (defmulti describe-fields-sql
   "Returns a SQL query ([sql & params]) for use in the default JDBC implementation of [[metabase.driver/describe-fields]],
@@ -732,7 +741,7 @@
 
 (defn- table->unfold-json-fields
   "Given a table return a list of json fields that need to unfold."
-  [driver conn table]
+  [driver database conn table]
   (let [fields-with-json-unfolding-disabled
         (->> (t2/select-fn-set :name [:model/Field :name]
                                :table_id (u/the-id table)
@@ -744,7 +753,7 @@
           (comp
            (filter #(isa? (:base-type %) :type/JSON))
            (remove #(contains? @fields-with-json-unfolding-disabled (:name %)))
-           (describe-table-fields-xf driver (driver-api/table->database table) table))
+           (describe-table-fields-xf driver database table))
           (describe-table-fields driver conn table nil))))
 
 (defn- sample-json-row-honey-sql
@@ -824,7 +833,7 @@
                                   jdbc-spec
                                   nil
                                   (fn [^Connection conn]
-                                    (let [unfold-json-fields (table->unfold-json-fields driver conn table)
+                                    (let [unfold-json-fields (table->unfold-json-fields driver database conn table)
                                           ;; Just pass in `nil` here, that's what we do in the normal sync process and it seems to work correctly.
                                           ;; We don't currently have a driver-agnostic way to get the physical database name. `(:name database)` is
                                           ;; wrong, because it's a human-friendly name rather than a physical name. `(get-in

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -231,6 +231,20 @@
                     (into [] (sql-jdbc.describe-table/describe-table-fields-xf :h2 db table))
                     (map :name))))))))
 
+(deftest describe-table-field-set-uses-explicit-database-test
+  (testing "the current sync path can reuse an already-loaded Database"
+    (let [table {:name "venues"}
+          db    {:engine :h2}
+          cols  [{:name "ID" :type_name "BIGINT"}
+                 {:name "NAME" :type_name "CHARACTER VARYING"}]]
+      (with-redefs [driver-api/table->database (fn [_]
+                                                 (throw (ex-info "table->database should not be called" {})))
+                    sql-jdbc.describe-table/fields-metadata (fn [_ _ _ _] cols)]
+        (is (= ["ID" "NAME"]
+               (->> (#'sql-jdbc.describe-table/describe-table-field-set :h2 db nil table nil)
+                    (sort-by :database-position)
+                    (map :name))))))))
+
 (deftest database-types-fallback-test
   (mt/test-drivers (apply disj (sql-jdbc-drivers-using-default-describe-table-or-fields-impl)
                           (tqpt/timeseries-drivers))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -7,6 +7,7 @@
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.common.table-rows-sample :as table-rows-sample]
+   [metabase.driver-api.core :as driver-api]
    [metabase.driver.mysql :as mysql]
    [metabase.driver.mysql-test :as mysql-test]
    [metabase.driver.sql :as driver.sql]
@@ -216,6 +217,19 @@
             :first
             (map (juxt :database-position (comp boolean :pk?))
                  (describe-fields-for-table (mt/db) (t2/select-one :model/Table :id (mt/id :venues))))))))))
+
+(deftest describe-table-fields-xf-uses-explicit-database-test
+  (testing "callers that already have a Database can avoid reloading it from the Table"
+    (let [table {:name "venues"}
+          db    {:engine :h2}
+          cols  [{:name "ID" :type_name "BIGINT"}
+                 {:name "NAME" :type_name "CHARACTER VARYING"}]]
+      (with-redefs [driver-api/table->database (fn [_]
+                                                 (throw (ex-info "table->database should not be called" {})))]
+        (is (= ["ID" "NAME"]
+               (->> cols
+                    (into [] (sql-jdbc.describe-table/describe-table-fields-xf :h2 db table))
+                    (map :name))))))))
 
 (deftest database-types-fallback-test
   (mt/test-drivers (apply disj (sql-jdbc-drivers-using-default-describe-table-or-fields-impl)


### PR DESCRIPTION
## Summary
- thread the already-loaded `Database` through the SQL-JDBC field-description sync paths instead of reloading it from each `Table`
- keep the existing two-arg `describe-table-fields-xf` arity as a compatibility fallback for callers that do not already have the `Database`
- add targeted regression coverage to make sure the explicit-database path does not fall back to `table->database`

## What changed in practice
The original issue reports repeated app-db lookups of the same `metabase_database` row during sync.

This patch now applies the explicit-`Database` path in the active SQL-JDBC sync flows touched here:
- `describe-table`
- `describe-nested-field-columns` when building JSON-unfold candidates

That means these paths now reuse the already-loaded `database` instead of resolving it again from `table` while describing fields.

## Expected outcome
- fewer redundant `table->database` / app-db lookups in these sync paths
- less unnecessary app-db work during metadata sync, especially on tables with many fields
- no user-visible behavior change in sync output; this is a performance/efficiency fix

## Who benefits
Admins and operators benefit indirectly because sync should do less avoidable work against the application database. End users should see the same synced schema/field results.

## Testing
- `clojure -X:dev:test :only metabase.driver.sql-jdbc.sync.describe-table-test/describe-table-fields-xf-uses-explicit-database-test`
- `clojure -X:dev:test :only metabase.driver.sql-jdbc.sync.describe-table-test/describe-table-field-set-uses-explicit-database-test`

Closes #38941
