### PR TITLE
Fix Guest embed options staying disabled until SSO terms are accepted

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -9,6 +9,11 @@ const { H } = cy;
 
 const suiteTitle = "scenarios > sharing > embed flow pre-selection";
 
+// The Behavior/Parameters/Appearance cards share a wrapper whose inline
+// `opacity` style is dimmed (0.5) while the selected auth type isn't ready.
+const optionCardsWrapper = () =>
+  getEmbedSidebar().findByText("Behavior").closest("[style*='opacity']");
+
 describe(suiteTitle, () => {
   beforeEach(() => {
     H.restore();
@@ -48,6 +53,29 @@ describe(suiteTitle, () => {
       event: "embed_wizard_options_completed",
       event_detail: "settings=default",
     });
+  });
+
+  it("lets Guest embedding proceed after accepting only the Guest terms, without requiring the SSO terms (EMB-1884)", () => {
+    // Reproduce a fresh Pro instance where neither auth type's terms have
+    // been accepted yet, so the option cards start dimmed.
+    H.updateSetting("show-simple-embed-terms", true);
+    H.updateSetting("show-static-embed-terms", true);
+    H.updateSetting("enable-embedding-static", false);
+
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.openSharingMenu("Embed");
+
+    cy.log("switch to Guest authentication");
+    getEmbedSidebar().findByLabelText("Guest").click();
+
+    cy.log("option cards stay dimmed until the Guest terms are accepted");
+    optionCardsWrapper().should("have.css", "opacity", "0.5");
+
+    cy.log("accept the Guest terms only — never the SSO terms");
+    H.embedModalEnableEmbedding();
+
+    cy.log("option cards become available without accepting the SSO terms");
+    optionCardsWrapper().should("have.css", "opacity", "1");
   });
 
   it("pre-selects question in embed flow when opened from question sharing modal", () => {

--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -9,8 +9,10 @@ const { H } = cy;
 
 const suiteTitle = "scenarios > sharing > embed flow pre-selection";
 
-// The Behavior/Parameters/Appearance cards share a wrapper whose inline
-// `opacity` style is dimmed (0.5) while the selected auth type isn't ready.
+// The Behavior/Parameters/Appearance cards share a wrapper that is dimmed and
+// made non-interactive (`pointer-events: none`) while the selected auth type
+// isn't ready. The wrapper always carries an inline `opacity` style, so it can
+// be selected in either state.
 const optionCardsWrapper = () =>
   getEmbedSidebar().findByText("Behavior").closest("[style*='opacity']");
 
@@ -68,14 +70,26 @@ describe(suiteTitle, () => {
     cy.log("switch to Guest authentication");
     getEmbedSidebar().findByLabelText("Guest").click();
 
-    cy.log("option cards stay dimmed until the Guest terms are accepted");
-    optionCardsWrapper().should("have.css", "opacity", "0.5");
+    cy.log(
+      "the Behavior options aren't interactive until the Guest terms are accepted",
+    );
+    optionCardsWrapper().should("have.css", "pointer-events", "none");
 
     cy.log("accept the Guest terms only — never the SSO terms");
     H.embedModalEnableEmbedding();
 
-    cy.log("option cards become available without accepting the SSO terms");
-    optionCardsWrapper().should("have.css", "opacity", "1");
+    cy.log(
+      "the Behavior options become interactive without accepting the SSO terms",
+    );
+    optionCardsWrapper().should("have.css", "pointer-events", "all");
+    getEmbedSidebar()
+      .findByLabelText("Allow downloads")
+      .click()
+      .should("be.checked");
+
+    getEmbedSidebar().findByText("Get code").click();
+    getEmbedSidebar().findByText("publish this dashboard").click();
+    H.codeMirrorValue().should("contain", 'with-downloads="true"');
   });
 
   it("pre-selects question in embed flow when opened from question sharing modal", () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/AppearanceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/AppearanceStep.tsx
@@ -17,16 +17,17 @@ export const AppearanceStep = () => {
   const {
     isFirstStep,
     isSimpleEmbedFeatureAvailable,
-    isSimpleEmbeddingTermsAccepted,
+    allowPreviewAndNavigation,
   } = useSdkIframeEmbedSetupContext();
 
   // When the wizard lands directly on this step (initialState) on a Pro
   // instance, the user needs to configure auth first — dim the option cards
-  // so the AuthenticationCard above takes focus.
+  // so the AuthenticationCard above takes focus. `allowPreviewAndNavigation`
+  // tracks the terms/enablement state of whichever auth type (SSO or Guest) is
+  // currently selected, so accepting the Guest terms un-dims the cards without
+  // forcing the user through the SSO flow.
   const isDimmed =
-    isFirstStep &&
-    isSimpleEmbedFeatureAvailable &&
-    !isSimpleEmbeddingTermsAccepted;
+    isFirstStep && isSimpleEmbedFeatureAvailable && !allowPreviewAndNavigation;
   const dimmedProps = {
     opacity: isDimmed ? 0.5 : 1,
     className: cx(isDimmed && CS.pointerEventsNone),

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/AppearanceStep.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/AppearanceStep/AppearanceStep.unit.spec.tsx
@@ -73,5 +73,45 @@ describe("AppearanceStep > option cards dim state when landing on this step dire
 
       expect(getOptionCardsWrapper()).toHaveStyle({ opacity: "1" });
     });
+
+    it("dims the option cards when Guest is selected but the guest-embed terms have not been accepted", async () => {
+      landOnAppearanceStep({
+        initialState: {
+          resourceId: 1,
+          resourceType: "dashboard",
+          isGuest: true,
+        },
+        simpleEmbeddingEnabled: true,
+        showSimpleEmbedTerms: true,
+        guestEmbeddingEnabled: false,
+        showStaticEmbedTerms: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Behavior")).toBeVisible();
+      });
+
+      expect(getOptionCardsWrapper()).toHaveStyle({ opacity: "0.5" });
+    });
+
+    it("does not dim the option cards when Guest is selected and the guest-embed terms are accepted, even if the simple-embedding terms are not", async () => {
+      landOnAppearanceStep({
+        initialState: {
+          resourceId: 1,
+          resourceType: "dashboard",
+          isGuest: true,
+        },
+        simpleEmbeddingEnabled: true,
+        showSimpleEmbedTerms: true,
+        guestEmbeddingEnabled: true,
+        showStaticEmbedTerms: false,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Behavior")).toBeVisible();
+      });
+
+      expect(getOptionCardsWrapper()).toHaveStyle({ opacity: "1" });
+    });
   });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/test-setup.tsx
@@ -32,6 +32,8 @@ export const setup = (options?: {
   enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
   simpleEmbeddingEnabled?: boolean;
   showSimpleEmbedTerms?: boolean;
+  guestEmbeddingEnabled?: boolean;
+  showStaticEmbedTerms?: boolean;
   jwtReady?: boolean;
   initialState?: SdkIframeEmbedSetupModalInitialState;
   hasEmailSetup?: boolean;
@@ -58,6 +60,8 @@ export const setup = (options?: {
     "token-features": tokenFeatures,
     "show-simple-embed-terms": options?.showSimpleEmbedTerms ?? false,
     "enable-embedding-simple": options?.simpleEmbeddingEnabled ?? false,
+    "show-static-embed-terms": options?.showStaticEmbedTerms ?? false,
+    "enable-embedding-static": options?.guestEmbeddingEnabled ?? false,
     "jwt-enabled": options?.jwtReady ?? false,
     "jwt-configured": options?.jwtReady ?? false,
     "jwt-enabled-and-configured": options?.jwtReady ?? false,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75793
Closes [EMB-1884: Guest embed option stays disabled until SSO terms are accepted](https://linear.app/metabase/issue/EMB-1884/guest-embed-option-stays-disabled-until-sso-terms-are-accepted)

### Description

In the Dashboard → Embed wizard, when a user landed directly on the embed-options step (opened from the sharing menu, so it's the first step) and selected **Guest** authentication, the option cards (Behavior, Parameters, Appearance) stayed dimmed/non-interactive until the terms were accepted through the **Metabase account (SSO)** option instead.

The dimming logic in `AppearanceStep` keyed off the SSO-only `isSimpleEmbeddingTermsAccepted` flag, whereas the rest of the wizard (navigation, preview, and the sibling `SelectEmbedExperienceStep`) already used `allowPreviewAndNavigation`, which correctly tracks whichever auth type is selected (Guest vs SSO). This change makes `AppearanceStep` use that same signal, so accepting the Guest terms un-dims the cards without forcing the user through the SSO flow.

### How to verify

1. On a Pro instance, ensure neither embedding terms have been accepted yet.
2. Open a dashboard → **Embed**.
3. Under Authentication, select **Guest**.
4. The Behavior/Parameters/Appearance cards are dimmed and show an "Agree and enable" control under the Guest option.
5. Click **Agree and enable** on the Guest option (do *not* touch the SSO option).
6. The option cards become available — no longer requiring the SSO terms.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
