### PR TITLE
Check custom aggregations don't contain unaggregated refs

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -567,7 +567,7 @@
          (assoc opts :name new-name :display-name new-name))))))
 
 (def ^:private aggregation-explainer
-  (mr/explainer ::lib.schema.aggregation/aggregation))
+  (mr/explainer ::lib.schema.aggregation/aggregation-with-no-unnaggregated-refs))
 
 (def ^:private filter-explainer
   (mr/explainer ::lib.schema.expression/boolean))

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -567,7 +567,7 @@
          (assoc opts :name new-name :display-name new-name))))))
 
 (def ^:private aggregation-explainer
-  (mr/explainer ::lib.schema.aggregation/aggregation-with-no-unnaggregated-refs))
+  (mr/explainer ::lib.schema.aggregation/aggregation-with-no-unaggregated-refs))
 
 (def ^:private filter-explainer
   (mr/explainer ::lib.schema.expression/boolean))

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -152,6 +152,39 @@
 (mr/def ::aggregations
   [:sequential {:min 1} [:ref ::aggregation]])
 
+(defn- has-unaggregated-ref?
+  "Checks if `x` contains a column reference that is not wrapped in an aggregation
+  function, e.g. the `[:field 2]` in `[:+ [:sum [:field 1]] [:field 2]]`."
+  [x]
+  (when (vector? x)
+    (let [[tag _opts & args] x]
+      (cond
+        (#{:field :expression} tag)
+        true
+
+        (lib.hierarchy/isa? tag ::aggregation-clause-tag)
+        false
+
+        ;; case/if conditions can reference unaggregated refs, we
+        ;; only need to check the result branches are aggregated
+        (#{:case :if} tag)
+        (let [[pairs default] args]
+          (boolean (or (some (fn [[_cond expr]] (has-unaggregated-ref? expr)) pairs)
+                       (has-unaggregated-ref? default))))
+
+        :else
+        (boolean (some has-unaggregated-ref? args))))))
+
+(mr/def ::aggregation-with-no-unnaggregated-refs
+  "Stricter variant of ::aggregation used for query builder verification. Not enforced
+  on whole queries, so saved questions with unaggregated fields keep working."
+  [:and
+   [:ref ::aggregation]
+   [:fn
+    {:error/message #(i18n/tru "Fields in custom aggregations must be wrapped with a function like Sum.")
+     :error/friendly true}
+    (complement has-unaggregated-ref?)]])
+
 (def aggregation-operators
   "The list of available aggregation operator.
   The order of operators is relevant for the front end."

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -175,7 +175,7 @@
         :else
         (boolean (some has-unaggregated-ref? args))))))
 
-(mr/def ::aggregation-with-no-unnaggregated-refs
+(mr/def ::aggregation-with-no-unaggregated-refs
   "Stricter variant of ::aggregation used for query builder verification. Not enforced
   on whole queries, so saved questions with unaggregated fields keep working."
   [:and

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -659,6 +659,33 @@
       [:+ 1 [:- 1 [:* 1 [:/ 1 true]]]] "Types are incompatible: / expects a number as the 2nd parameter."
       [:+ 1 [:- 1 [:* true [:/ 1 1]]]] "Types are incompatible: * expects a number as the 1st parameter.")))
 
+(deftest ^:parallel diagnose-expression-unaggregated-fields-test
+  (let [query         (lib/query meta/metadata-provider (meta/table-metadata :orders))
+        created-at    [:field (meta/id :orders :created-at)]
+        total         [:field (meta/id :orders :total)]
+        subtotal      [:field (meta/id :orders :subtotal)]
+        diagnose-expr (fn [expr]
+                        (lib.expression/diagnose-expression query 0 :aggregation (lib/->mbql5 expr) nil))]
+    (testing "aggregations without an aggregation function are rejected with an understandable error message"
+      (are [expr] (= {:message  "Aggregations should contain at least one aggregation function."
+                      :friendly true}
+                     (diagnose-expr expr))
+        [:datetime-diff created-at created-at :hour]
+        total
+        [:+ total subtotal]))
+    (testing "aggregations that contain an aggregation function are accepted"
+      (are [expr] (nil? (diagnose-expr expr))
+        [:sum total]
+        [:+ [:sum total] [:sum subtotal]]
+        [:+ [:sum total] 4]
+        [:+ [:sum total] [:floor [:sum subtotal]]]
+        [:+ [:sum total] [:count]]
+        ;; This is allowed by the BE but rejected by the FE
+        [:+ [:sum total] subtotal]
+        ;; TODO(rileythomp, 2026-06-12): This is allowed by the BE and FE
+        ;; but it should be rejected as it results in an error.
+        [:+ [:sum total] [:floor subtotal]]))))
+
 (deftest ^:parallel date-and-time-string-literals-test-1-dates
   (are [types input] (= types (lib.schema.expression/type-of input))
     #{:type/Date :type/Text} "2024-07-02"))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -543,7 +543,8 @@
                (nil? (lib.expression/diagnose-expression query 0 mode expr c-pos))
             :expression  (get exprs "non-circular-c")
             :aggregation (-> (get exprs "circular-c")
-                             (assoc 3 (lib/count)))
+                             (update 2 lib/sum)
+                             (assoc 4 (lib/count)))
             :filter      (assoc (get exprs "circular-c") 0 :=)))
         (testing "circular definition"
           (is (=? {:message "Cycle detected: c → x → b → c"}

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -673,18 +673,19 @@
         [:datetime-diff created-at created-at :hour]
         total
         [:+ total subtotal]))
+    (testing "aggregations with unaggregated refs are rejected with an understandable error message"
+      (are [expr] (= {:message  "Fields in custom aggregations must be wrapped with a function like Sum."
+                      :friendly true}
+                     (diagnose-expr expr))
+        [:+ [:sum total] subtotal]
+        [:+ [:sum total] [:floor subtotal]]))
     (testing "aggregations that contain an aggregation function are accepted"
       (are [expr] (nil? (diagnose-expr expr))
         [:sum total]
         [:+ [:sum total] [:sum subtotal]]
         [:+ [:sum total] 4]
         [:+ [:sum total] [:floor [:sum subtotal]]]
-        [:+ [:sum total] [:count]]
-        ;; This is allowed by the BE but rejected by the FE
-        [:+ [:sum total] subtotal]
-        ;; TODO(rileythomp, 2026-06-12): This is allowed by the BE and FE
-        ;; but it should be rejected as it results in an error.
-        [:+ [:sum total] [:floor subtotal]]))))
+        [:+ [:sum total] [:count]]))))
 
 (deftest ^:parallel date-and-time-string-literals-test-1-dates
   (are [types input] (= types (lib.schema.expression/type-of input))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/65218

### Description

Adds test to show that we show understandable error messages now when using invalid custom aggregations. 

Also adds schema validation that unaggregated refs can't be used in a custom aggregation expression (e.g. `Sum([Total]) + Floor([Subtotal])`. This should only get used by the frontend, the validation used throughout the QP is still the looser `::aggregation` schema. 

### How to verify

1. Create an invalid custom aggregation like `datetimeDiff([Birth Date],[Birth Date], "hour")`
2. See an error message like `Aggregations should contain at least one aggregation function.`


1. Create an invalid custom aggregation like `Sum([Total]) + Floor([Subtotal])`
2. See an error message like `Fields in custom aggregations must be wrapped with a function like Sum.`

### Demo

<details>

<summary>screen shots</summary>

<img width="750" height="510" alt="Screenshot 2026-06-12 at 11 26 02 AM" src="https://github.com/user-attachments/assets/6896f97a-96fc-44ff-957c-821237ad8ec9" />

<img width="755" height="501" alt="Screenshot 2026-06-12 at 11 25 25 AM" src="https://github.com/user-attachments/assets/10ce20b4-f128-46a3-8542-729ee6b99c88" />

<img width="766" height="505" alt="Screenshot 2026-06-12 at 12 20 11 PM" src="https://github.com/user-attachments/assets/f0fe478f-8b2d-45f9-9f10-d3f3a427bd9d" />

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
