### PR TITLE
PoC for 1D array field values and filter

### DIFF
--- a/frontend/src/metabase-lib/query/column_types.ts
+++ b/frontend/src/metabase-lib/query/column_types.ts
@@ -1,4 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
+import * as ARRAY_TYPES from "cljs/metabase.lib.types.array";
 import * as TYPES from "cljs/metabase.lib.types.isa";
 
 import type { ColumnMetadata, ColumnTypeInfo, JsColumnTypeInfo } from "./types";
@@ -15,7 +16,11 @@ export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
 export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
 export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
+export const isArray: TypeFn = TYPES.array_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
+
+export const columnForFilterWidget: TypeFn =
+  ARRAY_TYPES.column_for_filter_widget;
 
 // Semantic type checks. A semantic type can be assigned to a column with an
 // unrelated effective type. Do not imply any effective type when checking for a

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -33,6 +33,7 @@ export type DatabaseFeature =
   | "expressions/float"
   | "expressions/text"
   | "expressions/today"
+  | "filter/array-elements"
   | "native-parameters"
   | "nested-queries"
   | "standard-deviation-aggregations"

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import { useMemo } from "react";
 
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -41,7 +42,11 @@ export function FilterPickerBody({
   onBack,
   readOnly,
 }: FilterPickerBodyProps) {
-  const FilterWidget = getFilterWidget(column);
+  const filterColumn = useMemo(
+    () => Lib.columnForFilterWidget(column),
+    [column],
+  );
+  const FilterWidget = getFilterWidget(filterColumn);
   if (!FilterWidget) {
     return null;
   }
@@ -52,7 +57,7 @@ export function FilterPickerBody({
         autoFocus={autoFocus}
         query={query}
         stageIndex={stageIndex}
-        column={column}
+        column={filterColumn}
         filter={filter}
         isNew={isNew}
         withAddButton={withAddButton}

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -897,12 +897,30 @@
     ;; Does this driver provide :database-is-generated on (describe-fields) or (describe-table)
     :describe-is-generated
     ;;
+    ;; Does this driver support filtering 1-dimensional array columns (e.g. `value = ANY(array_col)`)?
+    ;; When supported, equality filters on array columns are rewritten to `:array-contains` (e.g. `value = ANY(col)` in
+    ;; Postgres). Also enables UNNEST-based distinct value fetching for FieldValues.
+    :filter/array-elements
+    ;;
     ;; Does this driver support the workspace feature
     :workspace
     ;;
     ;; Does this driver support table references in native queries -- for example, "select * from {{table}}" where
     ;; `{{table}}` gets replaced by a reference to a table.
     :parameters/table-reference})
+
+(defmulti array-element-base-type
+  "Given a raw `database-type` string (e.g. `_text` in Postgres), returns the Metabase base type of the individual
+  elements (e.g. `:type/Text`). Used at sync time to populate `:array-element-type` on column metadata and at query time
+  for value decoding. Returns `nil` for non-array database types."
+  {:arglists '([driver database-type])}
+  (fn [driver _database-type]
+    (dispatch-on-initialized-driver driver))
+  :hierarchy #'hierarchy)
+
+(defmethod array-element-base-type :default
+  [_driver _database-type]
+  nil)
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -81,6 +81,7 @@
                               :expressions/float              true
                               :expressions/integer            true
                               :expressions/text               true
+                              :filter/array-elements             true
                               :identifiers-with-spaces        true
                               :metadata/table-existence-check true
                               :now                            true
@@ -727,6 +728,34 @@
   [driver [_ _opts text divider position]]
   ((get-method sql.qp/->honeysql [:postgres :split-part]) driver [:split-part text divider position]))
 
+(defmethod sql.qp/array-unnest-from :postgres
+  [_driver table-honeysql col-identifier]
+  (let [[col-sql] (sql/format-expr col-identifier {:nested true})]
+    ;; Double-wrap `table-honeysql` so HoneySQL treats it as a single expression
+    ;; rather than a `[table alias ...]` pair (the identifier vector would otherwise
+    ;; be destructured as `[:h2x/identifier :table extras…]` → illegal syntax).
+    [[table-honeysql] [[:raw (format "UNNEST(%s) AS _elem" col-sql)]]]))
+
+(defn- array-contains->honeysql
+  [driver field values]
+  (let [field-honeysql (sql.qp/->honeysql driver field)
+        [col-sql & col-args] (sql/format-expr field-honeysql {:nested true})
+        any-expr (into [:raw (format "ANY(%s)" col-sql)] col-args)]
+    (if (= 1 (count values))
+      [:= (sql.qp/->honeysql driver (first values)) any-expr]
+      (into [:or]
+            (map (fn [value]
+                   [:= (sql.qp/->honeysql driver value) any-expr]))
+            values))))
+
+(defmethod sql.qp/->honeysql [:postgres :array-contains]
+  [driver [_tag field & values]]
+  (array-contains->honeysql driver field values))
+
+(defmethod sql.qp/->honeysql [:postgres-mbql5 :array-contains]
+  [driver [_tag _opts field & values]]
+  (array-contains->honeysql driver field values))
+
 (defmethod sql.qp/->honeysql [:postgres :text]
   [driver [_ value]]
   (h2x/maybe-cast "TEXT" (sql.qp/->honeysql driver value)))
@@ -1006,9 +1035,27 @@
               (map #(vector % :type/PostgresEnum)))
              database-types)))))
 
+(defn- array-element-base-type
+  "Given a Postgres array `database-type` like `_text` or `_int4`, return the base type of the array elements."
+  [database-type]
+  (when database-type
+    (let [db-type-name (cond
+                         (keyword? database-type) (name database-type)
+                         (string? database-type)  database-type
+                         :else                    (str database-type))]
+      (when (str/starts-with? db-type-name "_")
+        (let [element-db-type (keyword (subs db-type-name 1))]
+          (or (default-base-types element-db-type) :type/Text))))))
+
 (defmethod sql-jdbc.sync/database-type->base-type :postgres
   [_driver database-type]
-  (default-base-types database-type))
+  (or (default-base-types database-type)
+      (when (str/starts-with? (name database-type) "_")
+        :type/Array)))
+
+(defmethod driver/array-element-base-type :postgres
+  [_driver database-type]
+  (array-element-base-type database-type))
 
 (defmethod sql-jdbc.sync/column->semantic-type :postgres
   [_driver database-type _column-name]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -289,6 +289,18 @@
     [(driver/dispatch-on-initialized-driver driver) (driver-api/dispatch-by-clause-name-or-class x)])
   :hierarchy #'driver/hierarchy)
 
+(defmulti array-unnest-from
+  "Return a HoneySQL `:from` clause vector for unnesting a 1D array column into rows. Used by the batch
+  distinct-values fetcher to produce `SELECT DISTINCT unnested_element FROM table, UNNEST(col)`. Drivers override this
+  to provide their array-to-rows expansion (e.g. Postgres uses `UNNEST(col) AS _elem`)."
+  {:arglists '([driver table-honeysql col-identifier])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod array-unnest-from :default
+  [_driver _table-honeysql _col-identifier]
+  (throw (ex-info "array-unnest-from is not supported by this driver" {})))
+
 (defn compiled
   "Wraps a `honeysql-expr` in an psudeo-MBQL clause that prevents double-compilation if [[->honeysql]] is called on it
   again."
@@ -1901,6 +1913,10 @@
                                                      (parent-honeysql-col-effective-type-map field)
                                                      (parent-honeysql-col-base-type-map field))]
       [:= field-honeysql (->honeysql driver value)])))
+
+(defmethod ->honeysql [:sql :array-contains]
+  [_driver _clause]
+  (throw (ex-info "array-contains is not supported by this driver" {})))
 
 (defn- correct-null-behaviour
   [driver [op & args :as _clause]]

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -239,6 +239,9 @@
                {:database-position database-position})
              (when semantic-type
                {:semantic-type semantic-type})
+             (when (isa? base-type :type/Array)
+               (when-let [element-type (driver/array-element-base-type driver (:database-type col))]
+                 {:array-element-type element-type}))
              (when (and json? (driver/database-supports? driver :nested-field-columns db))
                {:visibility-type :details-only
                 :preview-display false})))))))

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -508,7 +508,8 @@
 (def boolean-functions
   "Functions that return boolean values. Should match `::BooleanExpression`."
   #{:and :or :not :< :<= :> :>= := :!= :in :not-in :between :starts-with :ends-with :contains
-    :does-not-contain :inside :is-empty :not-empty :is-null :not-null :relative-time-interval :time-interval :during})
+    :does-not-contain :inside :is-empty :not-empty :is-null :not-null :relative-time-interval :time-interval :during
+    :array-contains})
 
 ;; TODO (Tamas 2026-01-05): Remove :measure from this set once FE tests switch to using MBQL5
 (def ^:private aggregations
@@ -944,6 +945,11 @@
   value-or-field        [:ref ::EqualityComparable]
   more-values-or-fields (rest [:ref ::EqualityComparable]))
 
+(defclause array-contains
+  field                 [:ref ::EqualityFilterFieldArg]
+  value-or-field        [:ref ::EqualityComparable]
+  more-values-or-fields (rest [:ref ::EqualityComparable]))
+
 (defn- replace-exclude-date-filters
   "Replaces legacy exclude date filter clauses that rely on temporal bucketing with `:temporal-extract` function calls."
   [filter-clause]
@@ -1161,7 +1167,9 @@
    ;; filters drivers must implement
    and or not = != < > <= >= between starts-with ends-with contains
    ;; SUGAR filters drivers do not need to implement
-   in not-in does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval during))
+   in not-in does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval during
+   ;; array filters
+   array-contains))
 
 (mr/def ::Filter
   "Schema for a valid MBQL `:filter` clause."

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -725,6 +725,7 @@
   is-empty not-empty
   starts-with ends-with
   contains does-not-contain
+  array-contains
   relative-time-interval
   time-interval
   segment]) ; TODO: Move segment to sit with the `lib.segment` functions.

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -24,6 +24,7 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
+   [metabase.lib.types.array :as lib.types.array]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
@@ -282,6 +283,15 @@
   (and (lib.util/ref-clause? maybe-ref)
        (some #(lib.util/original-isa? maybe-ref %) types)))
 
+(defn- ref-matches-filter-widget-types?
+  "Whether the column referenced by `maybe-ref` should use filter widgets for `types`, including array columns whose
+  elements match `types`."
+  [query stage-number maybe-ref types]
+  (if-let [col (column-metadata-from-ref query stage-number maybe-ref)]
+    (let [filter-col (lib.types.array/column-for-filter-widget col)]
+      (some #(clojure.core/isa? (:effective-type filter-col) %) types))
+    (ref-clause-with-type? maybe-ref types)))
+
 (def ^:private StringFilterParts
   [:map
    [:operator ::lib.schema.filter/string-filter-operator]
@@ -310,7 +320,7 @@
    stage-number  :- :int
    filter-clause :- ::lib.schema.expression/expression]
   (let [ref->col    #(column-metadata-from-ref query stage-number %)
-        string-col? #(ref-clause-with-type? % [:type/Text :type/TextLike])
+        string-col? #(ref-matches-filter-widget-types? query stage-number % [:type/Text :type/TextLike])
         result (fn [op col-ref args options]
                  {:operator op, :column (ref->col col-ref), :values (vec args), :options options})]
     (match/match-one filter-clause
@@ -324,6 +334,13 @@
 
       ;; multiple arguments, `:!=`
       [(op :guard #{:!= :not-in}) _ (col-ref :guard string-col?) & (args :guard (every? string? args))]
+      (result :!= col-ref args {})
+
+      ;; array contains
+      [:array-contains _ (col-ref :guard string-col?) & (args :guard (every? string? args))]
+      (result := col-ref args {})
+
+      [:not _ [:array-contains _ (col-ref :guard string-col?) & (args :guard (every? string? args))]]
       (result :!= col-ref args {})
 
       ;; multiple arguments with options
@@ -374,7 +391,7 @@
    stage-number  :- :int
    filter-clause :- ::lib.schema.expression/expression]
   (let [ref->col    #(column-metadata-from-ref query stage-number %)
-        number-col? #(ref-clause-with-type? % [:type/Number])
+        number-col? #(ref-matches-filter-widget-types? query stage-number % [:type/Number])
         number-arg? #(some? (expression-arg->number %))]
     (match/match-one filter-clause
       (:or
@@ -389,6 +406,16 @@
        ;; exactly 2 arguments
        [(op :guard #{:between})           _ (col-ref :guard number-col?) & (args :len 2 :guard (every? number-arg? args))])
       {:operator ({:in :=, :not-in :!=} op op)
+       :column   (ref->col col-ref)
+       :values   (mapv expression-arg->number args)}
+
+      [:array-contains _ (col-ref :guard number-col?) & (args :guard (every? number-arg? args))]
+      {:operator :=
+       :column   (ref->col col-ref)
+       :values   (mapv expression-arg->number args)}
+
+      [:not _ [:array-contains _ (col-ref :guard number-col?) & (args :guard (every? number-arg? args))]]
+      {:operator :!=
        :column   (ref->col col-ref)
        :values   (mapv expression-arg->number args)}
 

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -392,6 +392,7 @@
 (lib.common/defop ends-with [whole & parts])
 (lib.common/defop contains [whole & parts])
 (lib.common/defop does-not-contain [whole & parts])
+(lib.common/defop array-contains [x y & more])
 (lib.common/defop relative-time-interval [x value bucket offset-value offset-bucket])
 (lib.common/defop time-interval [x amount unit])
 (lib.common/defop during [t v unit])

--- a/src/metabase/lib/js/metadata.cljc
+++ b/src/metabase/lib/js/metadata.cljc
@@ -297,6 +297,7 @@
       :base-type                        (keyword v)
       :coercion-strategy                (keyword v)
       :effective-type                   (keyword v)
+      :array-element-type               (keyword v)
       :fingerprint                      (if (map? v)
                                           (perf/keywordize-keys v)
                                           #?(:cljs (js->clj v :keywordize-keys true)

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -31,7 +31,7 @@
 
 (def predicate-operators
   "Set of predicate operators that can be user in filter clauses."
-  #{:and :or :not := :!= :> :>= :< :<= :is-null :not-null :is-empty :not-empty :starts-with :ends-with :contains :does-not-contain :between :inside})
+  #{:and :or :not := :!= :> :>= :< :<= :is-null :not-null :is-empty :not-empty :starts-with :ends-with :contains :does-not-contain :between :inside :array-contains})
 
 (mr/def ::default-filter-operator
   "Filter operators that should be supported by any column type. Note that the FE allows only `:is-empty` and
@@ -91,6 +91,9 @@
 (doseq [op [:= :!= :in :not-in]]
   (mbql-clause/define-catn-mbql-clause op :- :type/Boolean
     [:args [:repeat {:min 2} [:schema [:ref ::expression/equality-comparable]]]]))
+
+(mbql-clause/define-catn-mbql-clause :array-contains :- :type/Boolean
+  [:args [:repeat {:min 2} [:schema [:ref ::expression/equality-comparable]]]])
 
 (doseq [op [:< :<= :> :>=]]
   (mbql-clause/define-mbql-clause-with-schema-fn (tuple-clause-of-comparables-schema #{[0 1]})

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -345,6 +345,8 @@
     [:semantic-type  {:optional true} [:maybe ::lib.schema.common/semantic-or-relation-type]]
     ;; type of this column in the data warehouse, e.g. `TEXT` or `INTEGER`
     [:database-type  {:optional true} [:maybe :string]]
+    ;; for 1D array columns, the base type of individual elements (e.g. `:type/Text` for Postgres `_text`)
+    [:array-element-type {:optional true} [:maybe ::lib.schema.common/base-type]]
     [:active         {:optional true} :boolean]
     [:visibility-type {:optional true} [:maybe ::column.visibility-type]]
     ;; if this is a field from another table (implicit join), this is the field in the current table that should be

--- a/src/metabase/lib/types/array.cljc
+++ b/src/metabase/lib/types/array.cljc
@@ -1,0 +1,55 @@
+(ns metabase.lib.types.array
+  "Helpers for working with array column types."
+  (:require
+   [clojure.string :as str]
+   [metabase.lib.types.isa :as lib.types.isa]))
+
+(def ^:private element-type-from-database-type
+  "Map of common Postgres array element type names (the part after `_`) to Metabase base types.
+  Used as a fallback when `:array-element-type` is not pre-populated on column metadata (e.g. on the FE)."
+  {"bigint"   :type/BigInteger
+   "bool"     :type/Boolean
+   "boolean"  :type/Boolean
+   "float4"   :type/Float
+   "float8"   :type/Float
+   "int2"     :type/Integer
+   "int4"     :type/Integer
+   "int8"     :type/BigInteger
+   "integer"  :type/Integer
+   "numeric"  :type/Decimal
+   "real"     :type/Float
+   "smallint" :type/Integer
+   "text"     :type/Text
+   "uuid"     :type/UUID
+   "varchar"  :type/Text})
+
+(defn- infer-element-type-from-database-type
+  "Parse element type from a Postgres-style array database-type like `_text` or `_int4`."
+  [database-type]
+  (when database-type
+    (let [s (cond (keyword? database-type) (name database-type)
+                  (string? database-type)  database-type
+                  :else                    (str database-type))]
+      (when (str/starts-with? s "_")
+        (get element-type-from-database-type (subs s 1) :type/Text)))))
+
+(defn ^:export array-element-effective-type
+  "For array columns, returns the effective type of the array elements (e.g. `:type/Text` for `_text`).
+  Returns `nil` for non-array columns.
+
+  Prefers `:array-element-type` from column metadata (populated at sync time on the BE), falling back to
+  parsing `database-type` (needed on the FE where only the raw database type string is available)."
+  [column]
+  (when (lib.types.isa/array? column)
+    (or (:array-element-type column)
+        (infer-element-type-from-database-type (:database-type column)))))
+
+(defn ^:export column-for-filter-widget
+  "The FE filter pickers (StringFilterPicker, NumberFilterPicker, etc.) select themselves based on the column's
+  `effective-type`. Array columns have `effective-type` `:type/Array`, which matches no picker. This swaps in the
+  element type so the correct picker renders. Only picker selection uses this transformed metadata — query construction
+  still uses the original column."
+  [column]
+  (if-let [element-type (array-element-effective-type column)]
+    (assoc column :effective-type element-type)
+    column))

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -16,6 +16,7 @@
      (def ^:export key-string "JS-friendly access for the string type" ::string)
      (def ^:export key-string-like "JS-friendly access for the string-like type" ::string-like)
      (def ^:export key-boolean "JS-friendly access for the boolean type" ::boolean)
+     (def ^:export key-array "JS-friendly access for the array type" ::array)
      (def ^:export key-temporal "JS-friendly access for the temporal type" ::temporal)
      (def ^:export key-location "JS-friendly access for the location type" ::location)
      (def ^:export key-coordinate "JS-friendly access for the coordinate type" ::coordinate)
@@ -40,6 +41,7 @@
    ::string      {:effective-type [:type/Text]}
    ::string_like {:effective-type [:type/TextLike]}
    ::boolean     {:effective-type [:type/Boolean]}
+   ::array       {:effective-type [:type/Array]}
    ::coordinate  {:semantic-type [:type/Coordinate]}
    ::location    {:semantic-type [:type/Address]}
    ::entity      {:semantic-type [:type/FK :type/PK :type/Name]}

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -79,6 +79,11 @@
   [column]
   (or (string? column) (string-like? column)))
 
+(defn ^:export array?
+  "Is `column` of an array type?"
+  [column]
+  (field-type? ::lib.types.constants/array column))
+
 (defn ^:export summable?
   "Is `column` of a summable type?"
   [column]

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -7,6 +7,7 @@
    [clojure.core.cache.wrapped :as cache.wrapped]
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.driver :as driver]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
    [metabase.lib.metadata.invocation-tracker :as lib.metadata.invocation-tracker]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -168,6 +169,7 @@
                 :field/settings
                 :field/table_id
                 :field/visibility_type
+                :database/engine
                 :dimension/human_readable_field_id
                 :dimension/id
                 :dimension/name
@@ -177,6 +179,8 @@
     :from      [[(t2/table-name :model/Field) :field]]
     :left-join [[(t2/table-name :model/Table) :table]
                 [:= :field/table_id :table/id]
+                [(t2/table-name :model/Database) :database]
+                [:= :database/id :table/db_id]
                 [(t2/table-name :model/Dimension) :dimension]
                 [:and
                  [:= :dimension/field_id :field/id]
@@ -188,13 +192,19 @@
 
 (t2/define-after-select :metadata/column
   [field]
-  (let [field          (instance->metadata field :metadata/column)
-        dimension-type (some-> (:dimension/type field) keyword)]
+  (let [driver         (:database/engine field)
+        field          (instance->metadata field :metadata/column)
+        dimension-type (some-> (:dimension/type field) keyword)
+        array-element-type (when (and driver (isa? (:base-type field) :type/Array))
+                             (driver/array-element-base-type driver (:database-type field)))]
     (merge
      (dissoc field
              :table
+             :database/engine
              :dimension/human-readable-field-id :dimension/id :dimension/name :dimension/type
              :values/human-readable-values :values/values)
+     (when array-element-type
+       {:array-element-type array-element-type})
      (when (and (= dimension-type :external)
                 (:dimension/human-readable-field-id field))
        {:lib/external-remap {:lib/type :metadata.column.remapping/external

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -31,6 +31,8 @@
      (fn [_query _path-type _stage-or-join-path clause]
        (when (lib/clause-of-type? clause :stddev)
          (vswap! required-features conj! :standard-deviation-aggregations))
+       (when (lib/clause-of-type? clause :array-contains)
+         (vswap! required-features conj! :filter/array-elements))
        nil))
     (lib.walk/walk
      query

--- a/src/metabase/query_processor/middleware/rewrite_array_filters.clj
+++ b/src/metabase/query_processor/middleware/rewrite_array_filters.clj
@@ -1,0 +1,46 @@
+(ns metabase.query-processor.middleware.rewrite-array-filters
+  "Rewrite equality filters on array columns to `:array-contains` clauses before SQL compilation."
+  (:require
+   [metabase.driver.util :as driver.u]
+   [metabase.lib.field.resolution :as lib.field.resolution]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.walk :as lib.walk]
+   [metabase.util.malli :as mu]))
+
+(defn- array-field-ref?
+  [query stage-number column-ref]
+  (when (and (vector? column-ref) (= :field (first column-ref)))
+    (let [opts (second column-ref)]
+      (or (when-let [base-type (or (:base-type opts) (:effective-type opts))]
+            (isa? base-type :type/Array))
+          (when-let [column (lib.field.resolution/resolve-field-ref query stage-number column-ref)]
+            (isa? (or (:effective-type column) (:base-type column)) :type/Array))))))
+
+(defn- rewrite-array-filter-clause
+  "Matches `:=` / `:!=` / `:in` / `:not-in` clauses where the column ref resolves to `:type/Array`. Rewrites to
+  `:array-contains` (positive) or `[:not :array-contains]` (negative). Only activates when the driver advertises
+  `:filter/array-elements`."
+  [query path-type path clause]
+  (when (and (= path-type :lib.walk/stage)
+             (vector? clause))
+    (let [[tag opts column & values] clause]
+      (when (and (#{:= :in :!= :not-in} tag)
+                 (seq values)
+                 (let [{:keys [query stage-number]} (lib.walk/query-for-path query path)]
+                   (array-field-ref? query stage-number column)))
+        (let [{:keys [query stage-number]} (lib.walk/query-for-path query path)
+              database (lib.metadata/database query)
+              driver   (:engine database)]
+          (when (driver.u/supports? driver :filter/array-elements database)
+            (case tag
+              (:= :in) (into [:array-contains opts column] values)
+              (:!= :not-in)
+              (lib.options/ensure-uuid
+               [:not {} (into [:array-contains opts column] values)]))))))))
+
+(mu/defn rewrite-array-filters :- ::lib.schema/query
+  "Rewrite `:=` / `:in` filters on array columns to `:array-contains`, and negated variants to `[:not ...]`."
+  [query :- ::lib.schema/query]
+  (lib.walk/walk-clauses query rewrite-array-filter-clause))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -38,6 +38,7 @@
    [metabase.query-processor.middleware.resolve-joins :as resolve-joins]
    [metabase.query-processor.middleware.resolve-referenced :as qp.resolve-referenced]
    [metabase.query-processor.middleware.resolve-source-table :as qp.resolve-source-table]
+   [metabase.query-processor.middleware.rewrite-array-filters :as qp.rewrite-array-filters]
    [metabase.query-processor.middleware.validate :as validate]
    [metabase.query-processor.middleware.validate-temporal-bucketing :as validate-temporal-bucketing]
    [metabase.query-processor.middleware.wrap-value-literals :as qp.wrap-value-literals]
@@ -104,6 +105,7 @@
    #'auto-parse-filter-values/auto-parse-filter-values
    #'validate-temporal-bucketing/validate-temporal-bucketing
    #'optimize-temporal-clauses/optimize-temporal-clauses
+   #'qp.rewrite-array-filters/rewrite-array-filters
    #'limit/add-default-limit
    #'qp.middleware.enterprise/apply-download-limit
    #'qp.middleware.enterprise/apply-workspace-remapping

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -173,8 +173,9 @@
     [:not (app-db/isa :semantic_type :type/PK)]
     [:= :semantic_type nil]]
    [:not-in :visibility_type ["retired" "sensitive"]]
-   [:not-in :base_type (conj (app-db/type-keyword->descendants :type/fingerprint-unsupported)
-                             (u/qualified-name :type/*))]])
+   [:not-in :base_type (disj (into #{(u/qualified-name :type/*)}
+                                   (app-db/type-keyword->descendants :type/fingerprint-unsupported))
+                             (u/qualified-name :type/Array))]])
 
 (def ^:dynamic *refingerprint?*
   "Whether we are refingerprinting or doing the normal fingerprinting. Refingerprinting should get fields that already

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -3,8 +3,6 @@
   (:require
    [java-time.api :as t]
    [metabase.app-db.core :as mdb]
-   [metabase.driver :as driver]
-   [metabase.driver.util :as driver.u]
    [metabase.sync.interface :as i]
    [metabase.sync.util :as sync-util]
    [metabase.tracing.core :as tracing]
@@ -36,22 +34,8 @@
   (t2/select :model/Field :table_id (u/the-id table), :active true, :visibility_type "normal"))
 
 (defn- can-batch-distinct?
-  "Can this `table`'s database support the UNION ALL distinct-batch query? Requires:
-
-  - A SQL-derived driver (so HoneySQL compilation works).
-  - The `:nested-queries` feature (each UNION arm is wrapped as a subquery in `FROM`).
-  - The table does not require a partition filter. Partitioned BigQuery tables fail without a
-    `WHERE` on the partition column; `metadata-from-qp/table-query` (used by the per-field path)
-    injects one via [[metabase.warehouse-schema.metadata-queries/add-required-filters-if-needed]],
-    but `run-distinct-batch` runs as a native query that bypasses that middleware.
-
-  Tables that fail any check fall back to the per-field path."
   [table]
-  (let [database (t2/select-one :model/Database :id (:db_id table))
-        engine   (:engine database)]
-    (and (isa? driver/hierarchy engine :sql)
-         (driver.u/supports? engine :nested-queries database)
-         (not (:database_require_filter table)))))
+  (distinct-batch/can-batch-distinct? table))
 
 (def ^:private empty-counts
   "Initial counter map for a sync run.

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -58,7 +58,8 @@
    ;; nullable for databases that don't support field partition
    [:database-partitioned       {:optional true} [:maybe :boolean]]
    [:database-required          {:optional true} :boolean]
-   [:visibility-type            {:optional true} [:maybe :keyword]]])
+   [:visibility-type            {:optional true} [:maybe :keyword]]
+   [:array-element-type         {:optional true} [:maybe ::lib.schema.common/base-type]]])
 
 (def TableMetadataField
   "Schema for a given Field as provided in [[metabase.driver/describe-table]]."

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -742,7 +742,8 @@
   [base-type semantic-type]
   (not
    (or (isa? base-type :type/Temporal)
-       (isa? base-type :type/Collection)
+       (and (isa? base-type :type/Collection)
+            (not (isa? base-type :type/Array)))
        (isa? base-type :type/Float)
        ;; Don't let IDs become list Fields (they already can't become categories, because they already have a semantic
        ;; type). It just doesn't make sense to cache a sequence of numbers since they aren't inherently meaningful

--- a/src/metabase/warehouse_schema/field_values/distinct_batch.clj
+++ b/src/metabase/warehouse_schema/field_values/distinct_batch.clj
@@ -27,7 +27,9 @@
   chain-filter → params.field-values → field → field-values) would form a cycle if these
   requires lived in `metabase.warehouse-schema.models.field-values`."
   (:require
+   [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.query-processor :as qp]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -65,6 +67,24 @@
                                         (catch NumberFormatException _ s))
     :else                          s))
 
+(defn can-batch-distinct?
+  "Can `table`'s database use the UNION ALL distinct-batch query? Requires a SQL-derived driver, the `:nested-queries`
+  feature, and a table that does not require a partition filter. Partitioned BigQuery tables fail without a `WHERE` on
+  the partition column; the per-field MBQL path injects one via middleware, but `run-distinct-batch` runs as native SQL
+  that bypasses it."
+  [table]
+  (let [database (t2/select-one :model/Database :id (:db_id table))
+        engine   (:engine database)]
+    (and (isa? driver/hierarchy engine :sql)
+         (driver.u/supports? engine :nested-queries database)
+         (not (:database_require_filter table)))))
+
+(defn- field-value-base-type
+  [driver field]
+  (if (isa? (:base_type field) :type/Array)
+    (or (driver/array-element-base-type driver (:database_type field)) :type/Text)
+    (:base_type field)))
+
 (defn- table-honeysql
   "Driver-aware HoneySQL identifier for `table`. Routes through `sql.qp/->honeysql` so drivers
   that need to qualify table identifiers further (e.g. BigQuery's project-id prefix) get their
@@ -82,8 +102,13 @@
                      (sql.qp/mbql-clause driver ::sql.qp/cast-to-text
                                          (h2x/identifier :field col-name))))
 
-(defn- build-arm
-  "HoneySQL for one UNION arm."
+(defn- array-field?
+  [driver database field]
+  (and (isa? (:base_type field) :type/Array)
+       (driver.u/supports? driver :filter/array-elements database)))
+
+(defn- build-arm-scalar
+  "HoneySQL for one UNION arm over a scalar column."
   [driver table field]
   (let [cast-expr (cast-to-text-honeysql driver (:name field))
         inner     {:select   [[[:inline (:name field)] :field_name]
@@ -103,10 +128,35 @@
     {:select [:*]
      :from   [[limited :_arm]]}))
 
+(defn- build-arm-array
+  "HoneySQL for one UNION arm over a 1D array column. Generates
+  `SELECT DISTINCT CAST(elem AS text) FROM table, UNNEST(array_col) AS elem LIMIT N`, producing the individual values
+  stored inside array cells for FieldValues filter pickers."
+  [driver table field]
+  (let [elem-id   (h2x/identifier :field "_elem")
+        cast-expr (sql.qp/->honeysql driver
+                                     (sql.qp/mbql-clause driver ::sql.qp/cast-to-text elem-id))
+        inner     {:select   [[[:inline (:name field)] :field_name]
+                              [cast-expr :value_out]]
+                   :from     (sql.qp/array-unnest-from driver
+                                                       (table-honeysql driver table)
+                                                       (h2x/identifier :field (:name field)))
+                   :group-by [cast-expr]}
+        limited   (sql.qp/apply-top-level-clause driver :limit inner {:limit field-values/*distinct-limit*})]
+    {:select [:*]
+     :from   [[limited :_arm]]}))
+
+(defn- build-arm
+  "HoneySQL for one UNION arm."
+  [driver database table field]
+  (if (array-field? driver database field)
+    (build-arm-array driver table field)
+    (build-arm-scalar driver table field)))
+
 (defn- build-union
   "Build the full HoneySQL form for one batch of fields. Single field → no UNION wrapper."
-  [driver table fields]
-  (let [arms (mapv #(build-arm driver table %) fields)]
+  [driver database table fields]
+  (let [arms (mapv #(build-arm driver database table %) fields)]
     (if (= 1 (count arms))
       (first arms)
       {:union-all arms})))
@@ -124,8 +174,9 @@
   (or equivalent) to decide log-and-continue vs abort semantics."
   [table fields]
   (let [db-id          (:db_id table)
-        driver         (:engine (t2/select-one :model/Database :id db-id))
-        hsql           (build-union driver table fields)
+        database       (t2/select-one :model/Database :id db-id)
+        driver         (:engine database)
+        hsql           (build-union driver database table fields)
         [sql & params] (sql.qp/format-honeysql driver hsql)
         result         (qp/process-query
                         {:database db-id
@@ -135,7 +186,7 @@
         by-name        (into {} (map (juxt :name identity)) fields)]
     (reduce (fn [acc [field-name value-str]]
               (let [field (get by-name field-name)
-                    v     (decode-value (:base_type field) value-str)]
+                    v     (decode-value (field-value-base-type driver field) value-str)]
                 (-> acc
                     (update-in [(:id field) :values] (fnil conj []) v)
                     (update-in [(:id field) :raw-count] (fnil inc 0)))))

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -263,7 +263,8 @@
         ;; preview_display is set to false by sync for fields that shouldn't have FieldValues
         ;; (e.g. long text fields, JSON columns, auto-cruft columns). Defaults to true if not provided.
         (not (false? preview-display))
-        (not (isa? (keyword base-type) :type/field-values-unsupported))
+        (or (not (isa? (keyword base-type) :type/field-values-unsupported))
+            (isa? (keyword base-type) :type/Array))
         (not (= (keyword base-type) :type/*))
         (#{:list :auto-list} (keyword has-field-values)))))))
 
@@ -378,6 +379,32 @@
           (recur new-str-length (conj acc (first values)) (rest values)))))))
 
 ;;; TODO -- move into [[metabase.warehouse-schema.metadata-from-qp]] ??
+(defn- field->model
+  [field]
+  (cond
+    (t2/model field) field
+    (:id field)      (t2/select-one :model/Field :id (:id field))
+    :else            nil))
+
+(defn- distinct-scalar-values
+  [field]
+  (let [column (cond-> field
+                 (t2/model field) (lib-be/instance->metadata :metadata/column))
+        result ((requiring-resolve 'metabase.warehouse-schema.metadata-from-qp/table-query)
+                (:table-id column)
+                (fn [query]
+                  (-> query
+                      (lib/breakout column)
+                      (lib/limit *distinct-limit*)))
+                qp.reducible/default-rff)]
+    {:values (-> result :data :rows)}))
+
+(defn- distinct-values-via-batch
+  [field table]
+  (let [run-distinct-batch (requiring-resolve 'metabase.warehouse-schema.field-values.distinct-batch/run-distinct-batch)]
+    {:values (mapv vector (get-in (run-distinct-batch table [field])
+                                  [(:id field) :values]))}))
+
 (mu/defn distinct-values
   "Fetch raw distinct values for `field` from the warehouse, row-capped at
   `*distinct-limit*`. Returns `{:values rows-as-1-tuples}`.
@@ -390,16 +417,14 @@
              (ms/InstanceOf :model/Field)
              ::lib.schema.metadata/column]]
   (try
-    (let [field  (cond-> field
-                   (t2/model field) (lib-be/instance->metadata :metadata/column))
-          result ((requiring-resolve 'metabase.warehouse-schema.metadata-from-qp/table-query)
-                  (:table-id field)
-                  (fn [query]
-                    (-> query
-                        (lib/breakout field)
-                        (lib/limit *distinct-limit*)))
-                  qp.reducible/default-rff)]
-      {:values (-> result :data :rows)})
+    (let [field-model (or (field->model field) field)
+          table-id    (or (:table_id field-model) (:table-id field-model))
+          table       (when table-id (t2/select-one :model/Table :id table-id))]
+      (if (and field-model table
+               ((requiring-resolve 'metabase.warehouse-schema.field-values.distinct-batch/can-batch-distinct?)
+                table))
+        (distinct-values-via-batch field-model table)
+        (distinct-scalar-values field)))
     (catch Throwable e
       (log/error e "Error fetching field values")
       nil)))

--- a/test/metabase/driver/postgres_array_test.clj
+++ b/test/metabase/driver/postgres_array_test.clj
@@ -1,0 +1,38 @@
+(ns metabase.driver.postgres-array-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.driver-api.core :as driver-api]
+   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
+   [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.util.honey-sql-2 :as h2x]))
+
+(deftest ^:parallel database-type->base-type-test
+  (is (= :type/Array
+         (sql-jdbc.sync.interface/database-type->base-type :postgres :_text)))
+  (is (= :type/Array
+         (sql-jdbc.sync.interface/database-type->base-type :postgres :_int4)))
+  (is (= :type/Text
+         (sql-jdbc.sync.interface/database-type->base-type :postgres :text))))
+
+(deftest ^:parallel array-element-base-type-test
+  (is (= :type/Text (driver/array-element-base-type :postgres "_text")))
+  (is (= :type/Integer (driver/array-element-base-type :postgres "_int4"))))
+
+(deftest ^:parallel array-unnest-from-test
+  (let [table-hsql (h2x/identifier :table "venues")
+        col-hsql   (h2x/identifier :field "tags")
+        [table-entry unnest-from] (sql.qp/array-unnest-from :postgres table-hsql col-hsql)]
+    (is (= [table-hsql] table-entry))
+    (is (= [[:raw "UNNEST(tags) AS _elem"]] unnest-from))))
+
+(deftest ^:parallel array-contains->honeysql-test
+  (let [[sql & params]
+        (sql.qp/format-honeysql :postgres
+                                (sql.qp/->honeysql :postgres
+                                                   [:array-contains
+                                                    [:field "tags" {:base-type :type/Array
+                                                                    driver-api/qp.add.source-table "venues"}]
+                                                    "foo"]))]
+    (is (re-find #"ANY\(venues\.tags\)" sql))
+    (is (= ["foo"] params))))

--- a/test/metabase/lib/types/array_test.cljc
+++ b/test/metabase/lib/types/array_test.cljc
@@ -1,0 +1,33 @@
+(ns metabase.lib.types.array-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.types.array :as lib.types.array]))
+
+(deftest ^:parallel array-element-effective-type-test
+  (testing "reads :array-element-type when present (BE path)"
+    (is (= :type/Text
+           (lib.types.array/array-element-effective-type
+            {:base-type :type/Array, :array-element-type :type/Text}))))
+  (testing "falls back to parsing database-type (FE path)"
+    (is (= :type/Text
+           (lib.types.array/array-element-effective-type
+            {:base-type :type/Array, :database-type "_text"})))
+    (is (= :type/Integer
+           (lib.types.array/array-element-effective-type
+            {:base-type :type/Array, :database-type "_int4"})))
+    (is (= :type/Text
+           (lib.types.array/array-element-effective-type
+            {:base-type :type/Array, :database-type :_text}))))
+  (testing "returns nil for non-array columns"
+    (is (nil? (lib.types.array/array-element-effective-type
+               {:base-type :type/Text, :database-type "text"})))))
+
+(deftest ^:parallel column-for-filter-widget-test
+  (let [array-col {:base-type :type/Array, :array-element-type :type/Integer, :effective-type :type/Array}]
+    (is (= :type/Integer
+           (:effective-type (lib.types.array/column-for-filter-widget array-col)))))
+  (let [array-col-fe {:base-type :type/Array, :database-type "_int4", :effective-type :type/Array}]
+    (is (= :type/Integer
+           (:effective-type (lib.types.array/column-for-filter-widget array-col-fe)))))
+  (let [text-col {:base-type :type/Text, :effective-type :type/Text}]
+    (is (= text-col (lib.types.array/column-for-filter-widget text-col)))))

--- a/test/metabase/query_processor/middleware/check_features_test.clj
+++ b/test/metabase/query_processor/middleware/check_features_test.clj
@@ -45,3 +45,12 @@
            clojure.lang.ExceptionInfo
            #"\Qstandard-deviation-aggregations is not supported by mock-driver driver.\E"
            (check-features/check-features query))))))
+
+(deftest ^:parallel check-array-contains-test
+  (driver/with-driver ::mock-driver
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/filter (lib/array-contains (meta/field-metadata :venues :name) "foo")))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"\Qarray-elements is not supported by mock-driver driver.\E"
+           (check-features/check-features query))))))

--- a/test/metabase/query_processor/middleware/rewrite_array_filters_test.clj
+++ b/test/metabase/query_processor/middleware/rewrite_array_filters_test.clj
@@ -1,0 +1,37 @@
+(ns metabase.query-processor.middleware.rewrite-array-filters-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.query-processor.middleware.rewrite-array-filters :as rewrite-array-filters]))
+
+(def ^:private postgres-metadata-provider
+  (meta/updated-metadata-provider assoc :engine :postgres))
+
+(defn- array-field-metadata []
+  (assoc (meta/field-metadata :venues :name)
+         :base-type :type/Array
+         :effective-type :type/Array
+         :database-type "_text"
+         :array-element-type :type/Text))
+
+(deftest ^:parallel rewrite-equality-array-filters-test
+  (let [query (-> (lib/query postgres-metadata-provider (meta/table-metadata :venues))
+                  (lib/filter (lib/= (array-field-metadata) "foo")))
+        rewritten (rewrite-array-filters/rewrite-array-filters query)
+        filter-clause (first (lib/filters rewritten))]
+    (is (= :array-contains (first filter-clause)))
+    (is (= "foo" (nth filter-clause 3)))))
+
+(deftest ^:parallel rewrite-negated-array-filters-test
+  (let [query (-> (lib/query postgres-metadata-provider (meta/table-metadata :venues))
+                  (lib/filter (lib/!= (array-field-metadata) "foo")))
+        rewritten (rewrite-array-filters/rewrite-array-filters query)
+        filter-clause (first (lib/filters rewritten))]
+    (is (= :not (first filter-clause)))
+    (is (= :array-contains (first (nth filter-clause 2))))))
+
+(deftest ^:parallel rewrite-scalar-filters-test
+  (let [query (-> (lib/query postgres-metadata-provider (meta/table-metadata :venues))
+                  (lib/filter (lib/= (meta/field-metadata :venues :name) "foo")))]
+    (is (= query (rewrite-array-filters/rewrite-array-filters query)))))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -28,21 +28,22 @@
          (#'sync.fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))))
 
 (def ^:private skip-fingerprint-base-types
-  (into #{"type/*"
-          "type/Structured"
-          "type/SerializedJSON"
-          "type/JSON"
-          "type/Dictionary"
-          "type/Array"
-          "type/Collection"
-          "type/XML"
-          "type/fingerprint-unsupported"}
-        (comp (mapcat descendants)
-              (map u/qualified-name))
-        [:type/Collection
-         :type/Structured
-         :type/Large
-         :type/fingerprint-unsupported]))
+  (disj
+   (into #{"type/*"
+           "type/Structured"
+           "type/SerializedJSON"
+           "type/JSON"
+           "type/Dictionary"
+           "type/Collection"
+           "type/XML"
+           "type/fingerprint-unsupported"}
+         (comp (mapcat descendants)
+               (map u/qualified-name))
+         [:type/Collection
+          :type/Structured
+          :type/Large
+          :type/fingerprint-unsupported])
+   "type/Array"))
 
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test
   (testing (str "Make sure we generate the correct HoneySQL WHERE clause based on whatever is in "

--- a/test/metabase/warehouse_schema/models/field_values_test.clj
+++ b/test/metabase/warehouse_schema/models/field_values_test.clj
@@ -6,10 +6,12 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.models.serialization :as serdes]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -25,7 +27,6 @@
 (def ^:private base-types-without-field-values
   #{:type/*
     :type/JSON
-    :type/Array
     :type/DruidJSON
     :type/Dictionary
     :type/Structured
@@ -708,4 +709,32 @@
             (let [{:keys [values raw-count]} (get results (:id source-field))]
               (is (< raw-count field-values/*distinct-limit*)
                   "source has few enough distinct values to not hit the LIMIT")
-              (is (every? string? values)))))))))
+              (is (every? string? values))))))))
+  (deftest ^:mb/driver-tests distinct-values-array-field-test
+    (mt/test-driver :postgres
+      (tx/drop-if-exists-and-create-db! driver/*driver* "array_field_values_test")
+      (let [details (mt/dbdef->connection-details :postgres :db {:database-name "array_field_values_test"})
+            spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
+        (jdbc/execute! spec ["CREATE TABLE array_tags (
+                             id SERIAL PRIMARY KEY,
+                             tags TEXT[]);"
+                             "INSERT INTO array_tags (tags) VALUES
+                             (ARRAY['alpha','beta','gamma']),
+                             (ARRAY['gamma','delta']);"])
+        (mt/with-temp [:model/Database database {:engine :postgres, :details details}]
+          (mt/with-db database
+            (sync/sync-database! database)
+            (let [table-id   (t2/select-one-pk :model/Table :db_id (u/the-id database) :name "array_tags")
+                  tags-field (t2/select-one :model/Field :table_id table-id :name "tags")]
+              (is (= :type/Array (:base_type tags-field)))
+              (is (= "_text" (:database_type tags-field)))
+              (testing "distinct-values returns individual array elements"
+                (let [{:keys [values]} (field-values/distinct-values tags-field)]
+                  (is (= #{"alpha" "beta" "gamma" "delta"}
+                         (set (map first values))))))
+              (testing "create-or-update-full-field-values! persists unnested values"
+                (field-values/clear-field-values-for-field! tags-field)
+                (field-values/create-or-update-full-field-values! tags-field)
+                (let [fv (field-values/get-latest-full-field-values (:id tags-field))]
+                  (is (= #{"alpha" "beta" "gamma" "delta"}
+                         (set (:values fv)))))))))))))


### PR DESCRIPTION
Vibe coded test to see how much is it to support array get-filter-values, metadata, sync and querying on arrays (https://github.com/metabase/metabase/issues/2974)

This PR got extremely convoluted at some point, but the entire point is:
- adding a feature on the database to understand that a field is a 1 dimensional array (more than this is simply a weird scenario I haven't seen in data analytics ever)
- adding to the driver (postgres for the sake of this PoC) how to get the unique filter values (e.g. unnest) and the base type of those filter values
- if we get a type/Array, now we can offer in the FE the unique filter values that we got from the get-filter-values operation
- if a user selects a field value, we can now do value = ANY(<field>) (or the negative)

BTW: this PR breaks https://github.com/metabase/metabase/issues/38778 (casting the array to a varchar and then doing contains over that. We should keep doing the exact same thing or just copy the operation we do with "IS"
Also, this PR does not cover Actions and I haven't tested field filters on it, but working fully with MBQL works fine

*How do the same operation in other databases?*
- Snowflake: ARRAY_CONTAINS(col, value). https://docs.snowflake.com/en/sql-reference/functions/array_contains
- BigQuery: value IN UNNEST(col). https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/operators#in_operators
- ClickHouse: has(col, value). https://clickhouse.com/docs/sql-reference/functions/array-functions#has
- Athena/Presto/Starburst: https://docs.aws.amazon.com/athena/latest/ug/filtering-with-unnest.html (Athena). - - Starburst/Trino has https://trino.io/docs/current/functions/array.html#contains
- Hive/SparkSQL/Databricks: ARRAY_CONTAINS(col, value). https://docs.databricks.com/gcp/en/sql/language-manual/functions/array_contains
- MySQL: Seems like it's not supported https://dev.mysql.com/worklog/task/?id=2081
-Mongo: {col: {$in: [values]}}

*How to get the unique values in other databases?*
- BigQuery: SELECT DISTINCT elem FROM table, UNNEST(col) AS elem LIMIT 1000.  https://docs.cloud.google.com/bigquery/docs/arrays#flattening_arrays
- Snowflake: https://docs.snowflake.com/en/sql-reference/functions/flatten
- ClickHouse: SELECT DISTINCT arrayJoin(col) FROM table WHERE col IS NOT NULL LIMIT 1000. https://clickhouse.com/docs/guides/working-with-arrays#arrayJoin
- Athena/Presto/Starburst: SELECT DISTINCT elem FROM table CROSS JOIN UNNEST(col) AS t(elem) LIMIT 1000. https://docs.aws.amazon.com/athena/latest/ug/flattening-arrays.html#flattening-arrays-cross-join-and-unnest
- Hive/SparkSQL/Databricks: SELECT DISTINCT explode(col) FROM table WHERE col IS NOT NULL LIMIT 1000. https://docs.databricks.com/aws/en/sql/language-manual/functions/explode
- MongoDB: https://www.mongodb.com/docs/manual/reference/method/db.collection.distinct/