### PR TITLE
Move `GTAPApi` from `metabase/services` to `metabase/api`

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -9,6 +9,7 @@ import {
   useGetCardQuery,
   useGetPermissionsGroupQuery,
   useGetTableQuery,
+  useValidateGroupTableAccessPolicyMutation,
 } from "metabase/api";
 import { ActionButton } from "metabase/common/components/ActionButton";
 import {
@@ -21,7 +22,6 @@ import { Radio } from "metabase/common/components/Radio";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import { GTAPApi } from "metabase/services";
 import { Button, Center, Icon, Loader } from "metabase/ui";
 import { getName } from "metabase/utils/name";
 import type {
@@ -111,13 +111,15 @@ const EditSandboxingModal = ({
   const [showPickerModal, { turnOn: showModal, turnOff: hideModal }] =
     useToggle(false);
 
+  const [validatePolicy] = useValidateGroupTableAccessPolicyMutation();
+
   const [{ error }, savePolicy] = useAsyncFn(async () => {
     const shouldValidate = normalizedPolicy.card_id != null;
     if (shouldValidate) {
-      await GTAPApi.validate(normalizedPolicy);
+      await validatePolicy(normalizedPolicy).unwrap();
     }
     onSave(normalizedPolicy);
-  }, [normalizedPolicy]);
+  }, [normalizedPolicy, validatePolicy]);
 
   const remainingAttributesOptions = attributes.filter(
     (attribute) => !(attribute in policy.attribute_remappings),

--- a/enterprise/frontend/src/metabase-enterprise/shared/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/shared/reducer.ts
@@ -1,12 +1,13 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+import { userApi } from "metabase/api";
 import { createAsyncThunk } from "metabase/redux/utils";
-import { GTAPApi } from "metabase/services";
 import type { UserAttributeKey } from "metabase-types/api";
 
 export const fetchUserAttributes = createAsyncThunk(
   "metabase-enterprise/shared/FETCH_USER_ATTRIBUTES",
-  async () => GTAPApi.attributes(),
+  async (_, { dispatch }) =>
+    dispatch(userApi.endpoints.listUserAttributes.initiate()).unwrap(),
 );
 
 export interface EnterpriseSharedState {

--- a/frontend/src/metabase/api/group-table-access-policy.ts
+++ b/frontend/src/metabase/api/group-table-access-policy.ts
@@ -31,10 +31,23 @@ export const groupTableAccessPolicyApi = Api.injectEndpoints({
       }),
       providesTags: () => [listTag("group-table-access-policy")],
     }),
+    // Validate a sandbox without saving it. This runs the same validation that
+    // happens on save, so it does not mutate any cached data.
+    validateGroupTableAccessPolicy: builder.mutation<
+      void,
+      GroupTableAccessPolicy
+    >({
+      query: (policy) => ({
+        method: "POST",
+        url: "/api/mt/gtap/validate",
+        body: policy,
+      }),
+    }),
   }),
 });
 
 export const {
   useListGroupTableAccessPoliciesQuery,
   useGetGroupTableAccessPolicyQuery,
+  useValidateGroupTableAccessPolicyMutation,
 } = groupTableAccessPolicyApi;

--- a/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
+++ b/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
+import { skipToken, useListUserAttributesQuery } from "metabase/api";
 import { getDashcardData, getParameters } from "metabase/dashboard/selectors";
 import {
   getTargetsForDashboard,
@@ -8,7 +9,6 @@ import {
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
-import { GTAPApi } from "metabase/services";
 import { isQuestionDashCard } from "metabase/utils/dashboard";
 import MetabaseSettings from "metabase/utils/settings";
 import Question from "metabase-lib/v1/Question";
@@ -108,26 +108,9 @@ export function useLoadQuestionMetadata(question: Question | null | undefined) {
 }
 
 export function useUserAttributes(): string[] {
-  const [userAttributes, setUserAttributes] = useState<string[]>([]);
+  const { data: userAttributes } = useListUserAttributesQuery(
+    MetabaseSettings.sandboxingEnabled() ? undefined : skipToken,
+  );
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const loadUserAttributes = async () => {
-      if (MetabaseSettings.sandboxingEnabled()) {
-        const attributes = await GTAPApi.attributes();
-        if (isMounted) {
-          setUserAttributes(attributes);
-        }
-      }
-    };
-
-    loadUserAttributes();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return userAttributes;
+  return userAttributes ?? [];
 }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -1,12 +1,5 @@
 import { DELETE, GET, POST, PUT } from "metabase/api/legacy-client";
 
-// only available with token loaded
-export const GTAPApi = {
-  list: GET("/api/mt/gtap"),
-  attributes: GET("/api/mt/user/attributes"),
-  validate: POST("/api/mt/gtap/validate"),
-};
-
 export const StoreApi = {
   tokenStatus: GET("/api/premium-features/token/status"),
 };


### PR DESCRIPTION
Removes another caller for the legacy client.