### PR TITLE
Allow to run current query in native query editor

### DIFF
--- a/docs/questions/native-editor/writing-sql.md
+++ b/docs/questions/native-editor/writing-sql.md
@@ -43,6 +43,8 @@ You'll notice that the table that comes back is the same as if you had used the 
 
 You can run your SQL query by pressing **ctrl + enter** on Windows and Linux, or **⌘ + return** on a Mac. You can also run only part of a query by highlighting the part you'd like to run before clicking the run button or using the run shortcut key.
 
+If you're editing a large query and have multiple queries in the editor separated by semicolons, you don't need to highlight the same query over and over each time you make a change. Instead, just leave your cursor inside the query you want to rerun and hit the run shortcut. Metabase will figure out which query you mean based on the cursor position — and it's smart enough to ignore semicolons hiding inside strings, identifiers, and comments.
+
 Questions asked using SQL can be saved, downloaded, converted to models, and added to dashboards just like questions asked using the query builder.
 
 You can also [refer to models and saved questions][ref-models] in your SQL queries.

--- a/docs/questions/native-editor/writing-sql.md
+++ b/docs/questions/native-editor/writing-sql.md
@@ -41,10 +41,9 @@ You'll notice that the table that comes back is the same as if you had used the 
 
 ### Running query selections
 
-You can run your SQL query by pressing **ctrl + enter** on Windows and Linux, or **⌘ + return** on a Mac. You can also run only part of a query by highlighting the part you'd like to run before clicking the run button or using the run shortcut key.
+You can run your SQL query by pressing **ctrl + enter** on Windows and Linux, or **⌘ + return** on a Mac. If you have multiple queries separated by a semicolon, this shortcut will only run the query under the cursor.
 
-If you're editing a large query and have multiple queries in the editor separated by semicolons, you don't need to highlight the same query over and over each time you make a change. Instead, just leave your cursor inside the query you want to rerun and hit the run shortcut. Metabase will figure out which query you mean based on the cursor position — and it's smart enough to ignore semicolons hiding inside strings, identifiers, and comments.
-
+You can also run only part of a query by highlighting the part you'd like to run before clicking the run button or using the run shortcut key.
 Questions asked using SQL can be saved, downloaded, converted to models, and added to dashboards just like questions asked using the query builder.
 
 You can also [refer to models and saved questions][ref-models] in your SQL queries.

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -22,12 +22,15 @@ import type Question from "metabase-lib/v1/Question";
 import { isAdHocModelOrMetricQuestion } from "metabase-lib/v1/metadata/utils/models";
 import type { Dataset } from "metabase-types/api";
 
+import { getCurrentQuery } from "metabase/querying/components/NativeQueryEditor/utils";
+
 import {
   getAllNativeEditorSelectedText,
   getCard,
   getFirstQueryResult,
   getIsResultDirty,
   getIsRunning,
+  getNativeEditorCursorOffset,
   getOriginalQuestion,
   getOriginalQuestionWithParameterValues,
   getQueryResults,
@@ -298,7 +301,25 @@ export const runOrCancelQuestionOrSelectedQuery =
           shouldUpdateUrl: false,
         }),
       );
-    } else {
-      dispatch(runQuestionQuery());
+      return;
+    } else if (queryInfo.isNative) {
+      // No text selected - try to determine current query from cursor position
+      // when the query contains multiple semicolon-delimited statements
+      const cursorOffset = getNativeEditorCursorOffset(getState());
+      if (cursorOffset != null) {
+        const queryText = Lib.rawNativeQuery(query);
+        const currentQuery = getCurrentQuery(queryText, cursorOffset);
+        if (currentQuery) {
+          const currentQueryObj = Lib.withNativeQuery(query, currentQuery);
+          dispatch(
+            runQuestionQuery({
+              overrideWithQuestion: question.setQuery(currentQueryObj),
+              shouldUpdateUrl: false,
+            }),
+          );
+          return;
+        }
+      }
     }
+    dispatch(runQuestionQuery());
   };

--- a/frontend/src/metabase/querying/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/querying/components/NativeQueryEditor/utils.ts
@@ -93,6 +93,140 @@ export function canFormatForEngine(engine: string) {
   return getFormatterDialect(engine) != null;
 }
 
+export function getCurrentQuery(
+  queryText: string,
+  cursorOffset: number,
+): string | null {
+  const realSemicolons = findRealSemicolonPositions(queryText);
+
+  if (realSemicolons.length === 0) {
+    return null;
+  }
+
+  let lastBefore = -1;
+  let nextAtOrAfter = -1;
+
+  for (const pos of realSemicolons) {
+    if (pos < cursorOffset) {
+      lastBefore = pos;
+    }
+    if (pos >= cursorOffset && nextAtOrAfter === -1) {
+      nextAtOrAfter = pos;
+    }
+  }
+
+  const start = lastBefore + 1;
+  const end =
+    nextAtOrAfter === -1 ? queryText.length : nextAtOrAfter;
+
+  let result = queryText.slice(start, end).trim();
+
+  // Handle cursor positioned between two consecutive semicolons (empty statement)
+  if (result === "" && lastBefore >= 0) {
+    const idx = realSemicolons.indexOf(lastBefore);
+    const prevReal = idx > 0 ? realSemicolons[idx - 1] : -1;
+    result = queryText.slice(prevReal + 1, lastBefore).trim();
+  }
+
+  if (
+    result === "" ||
+    result === queryText.trim() ||
+    result + ";" === queryText.trim()
+  ) {
+    return null;
+  }
+
+  return result;
+}
+
+/**
+ * Scans through query text and returns positions of semicolons that act as
+ * real statement separators, excluding semicolons inside:
+ * - Single-quoted string literals ('...') with '' escaping
+ * - Double-quoted identifiers ("...") with "" escaping
+ * - Single-line comments (-- ...)
+ * - Multi-line comments (/* ... *​/)
+ */
+function findRealSemicolonPositions(queryText: string): number[] {
+  const positions: number[] = [];
+  let i = 0;
+
+  while (i < queryText.length) {
+    switch (queryText[i]) {
+      case "'":
+        i++;
+        while (i < queryText.length) {
+          if (queryText[i] === "'") {
+            if (i + 1 < queryText.length && queryText[i + 1] === "'") {
+              i += 2;
+              continue;
+            }
+            break;
+          }
+          i++;
+        }
+        i++;
+        break;
+
+      case '"':
+        i++;
+        while (i < queryText.length) {
+          if (queryText[i] === '"') {
+            if (i + 1 < queryText.length && queryText[i + 1] === '"') {
+              i += 2;
+              continue;
+            }
+            break;
+          }
+          i++;
+        }
+        i++;
+        break;
+
+      case "-":
+        if (i + 1 < queryText.length && queryText[i + 1] === "-") {
+          i += 2;
+          while (i < queryText.length && queryText[i] !== "\n") {
+            i++;
+          }
+        } else {
+          i++;
+        }
+        break;
+
+      case "/":
+        if (i + 1 < queryText.length && queryText[i + 1] === "*") {
+          i += 2;
+          while (i < queryText.length) {
+            if (
+              queryText[i] === "*" &&
+              i + 1 < queryText.length &&
+              queryText[i + 1] === "/"
+            ) {
+              i += 2;
+              break;
+            }
+            i++;
+          }
+        } else {
+          i++;
+        }
+        break;
+
+      case ";":
+        positions.push(i);
+        i++;
+        break;
+
+      default:
+        i++;
+        break;
+    }
+  }
+
+  return positions;
+}
+
 export function formatQuery(queryText: string, engine: string) {
   const dialect = getFormatterDialect(engine);
   if (!dialect) {

--- a/frontend/src/metabase/querying/components/NativeQueryEditor/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/components/NativeQueryEditor/utils.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   canFormatForEngine,
   formatQuery,
+  getCurrentQuery,
 } from "metabase/querying/components/NativeQueryEditor/utils";
 
 const formattingTestCases = [
@@ -197,6 +198,117 @@ describe("utils", () => {
       expect(canFormatForEngine("druid")).toBe(false);
       expect(canFormatForEngine("sqlite")).toBe(false);
       expect(canFormatForEngine("sqlserver")).toBe(false);
+    });
+  });
+
+  describe("getCurrentQuery", () => {
+    it("should return null when there are no semicolons", () => {
+      expect(getCurrentQuery("SELECT 1", 0)).toBeNull();
+      expect(getCurrentQuery("SELECT 1", 4)).toBeNull();
+      expect(getCurrentQuery("SELECT 1", 8)).toBeNull();
+    });
+
+    it("should return null for single statement ending with semicolon", () => {
+      expect(getCurrentQuery("SELECT 1;", 0)).toBeNull();
+      expect(getCurrentQuery("SELECT 1;", 4)).toBeNull();
+      expect(getCurrentQuery("SELECT 1;", 8)).toBeNull();
+    });
+
+    it("should return the first statement when cursor is in the first statement", () => {
+      const query = "SELECT 1; SELECT 2;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 1");
+      expect(getCurrentQuery(query, 4)).toBe("SELECT 1");
+      expect(getCurrentQuery(query, 8)).toBe("SELECT 1");
+    });
+
+    it("should return the second statement when cursor is in the second statement", () => {
+      const query = "SELECT 1; SELECT 2;";
+      expect(getCurrentQuery(query, 9)).toBe("SELECT 2");
+      expect(getCurrentQuery(query, 13)).toBe("SELECT 2");
+      expect(getCurrentQuery(query, 17)).toBe("SELECT 2");
+    });
+
+    it("should handle cursor at the very end of the query", () => {
+      const query = "SELECT 1; SELECT 2;";
+      expect(getCurrentQuery(query, query.length)).toBe("SELECT 2");
+    });
+
+    it("should handle cursor on the semicolon itself", () => {
+      const query = "SELECT 1; SELECT 2";
+      // Cursor at position 8 (the semicolon)
+      expect(getCurrentQuery(query, 8)).toBe("SELECT 1");
+    });
+
+    it("should handle multiple semicolons correctly", () => {
+      const query = "SELECT 1; SELECT 2; SELECT 3;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 1");
+      expect(getCurrentQuery(query, 10)).toBe("SELECT 2");
+      expect(getCurrentQuery(query, 20)).toBe("SELECT 3");
+    });
+
+    it("should handle queries with newlines", () => {
+      const query = "SELECT 1\nFROM t1;\nSELECT 2\nFROM t2;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 1\nFROM t1");
+      expect(getCurrentQuery(query, 15)).toBe("SELECT 2\nFROM t2");
+    });
+
+    it("should trim whitespace from extracted queries", () => {
+      const query = "  SELECT 1  ;  SELECT 2  ;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 1");
+      expect(getCurrentQuery(query, 15)).toBe("SELECT 2");
+    });
+
+    it("should not split on semicolons inside single-quoted strings", () => {
+      const query = "SELECT ';' as punct; SELECT 2;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT ';' as punct");
+      expect(getCurrentQuery(query, 5)).toBe("SELECT ';' as punct");
+      expect(getCurrentQuery(query, 22)).toBe("SELECT 2");
+    });
+
+    it("should not split on semicolons inside double-quoted identifiers", () => {
+      const query = 'SELECT "a;b" AS x; SELECT 2;';
+      expect(getCurrentQuery(query, 0)).toBe('SELECT "a;b" AS x');
+      expect(getCurrentQuery(query, 19)).toBe("SELECT 2");
+    });
+
+    it("should not split on semicolons inside single-line comments", () => {
+      const query = "SELECT 1 -- this; is a comment;\nSELECT 2;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 1 -- this; is a comment");
+      expect(getCurrentQuery(query, 35)).toBe("SELECT 2");
+    });
+
+    it("should not split on semicolons inside multi-line comments", () => {
+      const query = "SELECT 1 /* this; is; a comment */; SELECT 2;";
+      expect(getCurrentQuery(query, 0)).toBe(
+        "SELECT 1 /* this; is; a comment */",
+      );
+      expect(getCurrentQuery(query, 38)).toBe("SELECT 2");
+    });
+
+    it("should handle escaped single quotes '' inside string literals", () => {
+      const query = "SELECT 'it''s; here' AS msg; SELECT 2;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT 'it''s; here' AS msg");
+      expect(getCurrentQuery(query, 30)).toBe("SELECT 2");
+    });
+
+    it("should handle escaped double quotes inside identifiers", () => {
+      const query = 'SELECT "a""b;c" AS x; SELECT 2;';
+      expect(getCurrentQuery(query, 0)).toBe('SELECT "a""b;c" AS x');
+      expect(getCurrentQuery(query, 24)).toBe("SELECT 2");
+    });
+
+    it("should handle mixed strings, comments, and real statement separators", () => {
+      const query =
+        "SELECT ';' as a; -- comment;\nSELECT 'x;y' as b /* block; */; SELECT 3;";
+      expect(getCurrentQuery(query, 0)).toBe("SELECT ';' as a");
+      expect(getCurrentQuery(query, 20)).toBe("-- comment;\nSELECT 'x;y' as b /* block; */");
+      expect(getCurrentQuery(query, 65)).toBe("SELECT 3");
+    });
+
+    it("should return null when the only semicolons are inside strings", () => {
+      const query = "SELECT 'hello; world' AS msg";
+      expect(getCurrentQuery(query, 0)).toBeNull();
+      expect(getCurrentQuery(query, 15)).toBeNull();
     });
   });
 


### PR DESCRIPTION
Closes #75849

### Description

When editing large native/SQL queries with multiple statements separated by semicolons, users previously had to manually highlight the query they wanted to run each time they made a change. This PR eliminates that friction by detecting which statement the cursor is currently in and running that statement automatically.

The core logic lives in a new `getCurrentQuery()` utility in NativeQueryEditor/utils.ts. It uses a state machine (`findRealSemicolonPositions()`) to find real statement-separator semicolons while correctly skipping:

- Single-quoted string literals ('...') with '' escaping
- Double-quoted identifiers ("...") with "" escaping
- Single-line comments (-- ...)
- Multi-line comments (/* ... */)

The detection is integrated into `runOrCancelQuestionOrSelectedQuery` with this priority order:

1. Selected text - if the user has highlighted text, that takes priority (existing behavior)
2. Cursor position - if no text is selected and the query is native, figure out which semicolon-delimited statement the cursor is in and run only that
3. Full query - fall through to run everything as before

### How to verify

1. New question → SQL query → Sample Dataset
2. Write a multi-statement query like:
SELECT * FROM orders LIMIT 5;
SELECT * FROM people LIMIT 5;
SELECT * FROM products LIMIT 5;
3. Place your cursor in the second line and press ⌘ + return — only the second query should execute
4. Verify comments, strings, and identifiers containing semicolons don't confuse the detection:
SELECT 'test;value' AS a; -- this comment has a '
SELECT 2; /* another; comment */ SELECT 3;
5. Verify that selecting text still works (takes priority over cursor detection)
6. Verify that a single-statement query with no semicolons runs the full query as before

Checklist

- Tests have been added to cover changes in this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/75850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

