### PR TITLE
Remove simple services API's

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
@@ -1,7 +1,9 @@
 import { c, t } from "ttag";
 import _ from "underscore";
 
-import { ModerationReviewApi } from "metabase/services";
+import { contentVerificationApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import type { Dispatch } from "metabase/redux/store";
 import type { ColorName } from "metabase/ui/colors/types";
 import type Question from "metabase-lib/v1/Question";
 import type {
@@ -15,35 +17,49 @@ import { MODERATION_STATUS_ICONS } from "./constants";
 
 export { MODERATION_STATUS } from "./constants";
 
-export function verifyItem({
-  text,
-  itemId,
-  itemType,
-}: {
-  text: string;
-  itemId: number;
-  itemType: string;
-}) {
-  return ModerationReviewApi.create({
-    status: "verified",
-    moderated_item_id: itemId,
-    moderated_item_type: itemType,
+export function verifyItem(
+  {
     text,
-  });
+    itemId,
+    itemType,
+  }: {
+    text: string;
+    itemId: number;
+    itemType: string;
+  },
+  dispatch: Dispatch,
+) {
+  return runRtkEndpoint(
+    {
+      status: "verified",
+      moderated_item_id: itemId,
+      moderated_item_type: itemType,
+      text,
+    },
+    dispatch,
+    contentVerificationApi.endpoints.editItemVerification,
+  );
 }
 
-export function removeReview({
-  itemId,
-  itemType,
-}: {
-  itemId: number;
-  itemType: string;
-}) {
-  return ModerationReviewApi.create({
-    status: null,
-    moderated_item_id: itemId,
-    moderated_item_type: itemType,
-  });
+export function removeReview(
+  {
+    itemId,
+    itemType,
+  }: {
+    itemId: number;
+    itemType: string;
+  },
+  dispatch: Dispatch,
+) {
+  return runRtkEndpoint(
+    {
+      status: null,
+      moderated_item_id: itemId,
+      moderated_item_type: itemType,
+    },
+    dispatch,
+    contentVerificationApi.endpoints.editItemVerification,
+  );
 }
 
 type NoIcon = Record<string, never>;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
@@ -1,9 +1,6 @@
 import { c, t } from "ttag";
 import _ from "underscore";
 
-import { contentVerificationApi } from "metabase/api";
-import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import type { Dispatch } from "metabase/redux/store";
 import type { ColorName } from "metabase/ui/colors/types";
 import type Question from "metabase-lib/v1/Question";
 import type {
@@ -16,51 +13,6 @@ import type {
 import { MODERATION_STATUS_ICONS } from "./constants";
 
 export { MODERATION_STATUS } from "./constants";
-
-export function verifyItem(
-  {
-    text,
-    itemId,
-    itemType,
-  }: {
-    text: string;
-    itemId: number;
-    itemType: string;
-  },
-  dispatch: Dispatch,
-) {
-  return runRtkEndpoint(
-    {
-      status: "verified",
-      moderated_item_id: itemId,
-      moderated_item_type: itemType,
-      text,
-    },
-    dispatch,
-    contentVerificationApi.endpoints.editItemVerification,
-  );
-}
-
-export function removeReview(
-  {
-    itemId,
-    itemType,
-  }: {
-    itemId: number;
-    itemType: string;
-  },
-  dispatch: Dispatch,
-) {
-  return runRtkEndpoint(
-    {
-      status: null,
-      moderated_item_id: itemId,
-      moderated_item_type: itemType,
-    },
-    dispatch,
-    contentVerificationApi.endpoints.editItemVerification,
-  );
-}
 
 type NoIcon = Record<string, never>;
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
@@ -1,4 +1,8 @@
-import { ModerationReviewApi } from "metabase/services";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+import { Api } from "metabase/api";
 import type Question from "metabase-lib/v1/Question";
 import type { ModerationReview } from "metabase-types/api";
 import {
@@ -19,50 +23,49 @@ import {
   verifyItem,
 } from "./service";
 
-jest.mock("metabase/services", () => ({
-  ModerationReviewApi: {
-    create: jest.fn(() => Promise.resolve({ id: 123 })),
-  },
-}));
+const setupStore = () =>
+  getStore({ [Api.reducerPath]: Api.reducer }, {}, [Api.middleware]);
 
 describe("moderation/service", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  afterEach(() => {
+    fetchMock.removeRoutes().clearHistory();
   });
 
   describe("verifyItem", () => {
     it("should create a new moderation review", async () => {
-      const review = await verifyItem({
-        itemId: 123,
-        itemType: "card",
-        text: "bar",
-      });
+      fetchMock.post("path:/api/moderation-review", { id: 123 });
+      const store = setupStore();
 
-      expect(ModerationReviewApi.create).toHaveBeenCalledWith({
+      await verifyItem(
+        { itemId: 123, itemType: "card", text: "bar" },
+        store.dispatch,
+      );
+
+      const [request] = await findRequests("POST");
+      expect(request.url).toContain("/api/moderation-review");
+      expect(request.body).toEqual({
         status: "verified",
         moderated_item_id: 123,
         moderated_item_type: "card",
         text: "bar",
       });
-
-      expect(review).toEqual({ id: 123 });
     });
   });
 
   describe("removeReview", () => {
     it("should create a new moderation review with a null status", async () => {
-      const review = await removeReview({
-        itemId: 123,
-        itemType: "card",
-      });
+      fetchMock.post("path:/api/moderation-review", { id: 123 });
+      const store = setupStore();
 
-      expect(ModerationReviewApi.create).toHaveBeenCalledWith({
+      await removeReview({ itemId: 123, itemType: "card" }, store.dispatch);
+
+      const [request] = await findRequests("POST");
+      expect(request.url).toContain("/api/moderation-review");
+      expect(request.body).toEqual({
         status: null,
         moderated_item_id: 123,
         moderated_item_type: "card",
       });
-
-      expect(review).toEqual({ id: 123 });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
@@ -1,8 +1,5 @@
 import fetchMock from "fetch-mock";
 
-import { getStore } from "__support__/entities-store";
-import { findRequests } from "__support__/server-mocks";
-import { Api } from "metabase/api";
 import type Question from "metabase-lib/v1/Question";
 import type { ModerationReview } from "metabase-types/api";
 import {
@@ -19,54 +16,11 @@ import {
   getStatusIconForQuestion,
   getTextForReviewBanner,
   isItemVerified,
-  removeReview,
-  verifyItem,
 } from "./service";
-
-const setupStore = () =>
-  getStore({ [Api.reducerPath]: Api.reducer }, {}, [Api.middleware]);
 
 describe("moderation/service", () => {
   afterEach(() => {
     fetchMock.removeRoutes().clearHistory();
-  });
-
-  describe("verifyItem", () => {
-    it("should create a new moderation review", async () => {
-      fetchMock.post("path:/api/moderation-review", { id: 123 });
-      const store = setupStore();
-
-      await verifyItem(
-        { itemId: 123, itemType: "card", text: "bar" },
-        store.dispatch,
-      );
-
-      const [request] = await findRequests("POST");
-      expect(request.url).toContain("/api/moderation-review");
-      expect(request.body).toEqual({
-        status: "verified",
-        moderated_item_id: 123,
-        moderated_item_type: "card",
-        text: "bar",
-      });
-    });
-  });
-
-  describe("removeReview", () => {
-    it("should create a new moderation review with a null status", async () => {
-      fetchMock.post("path:/api/moderation-review", { id: 123 });
-      const store = setupStore();
-
-      await removeReview({ itemId: 123, itemType: "card" }, store.dispatch);
-
-      const [request] = await findRequests("POST");
-      expect(request.url).toContain("/api/moderation-review");
-      expect(request.body).toEqual({
-        status: null,
-        moderated_item_id: 123,
-        moderated_item_type: "card",
-      });
-    });
   });
 
   describe("getStatusIcon", () => {

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -9,6 +9,7 @@ import {
   useGetCardQuery,
   useGetPermissionsGroupQuery,
   useGetTableQuery,
+  useValidateGroupTableAccessPolicyMutation,
 } from "metabase/api";
 import { ActionButton } from "metabase/common/components/ActionButton";
 import {
@@ -21,7 +22,6 @@ import { Radio } from "metabase/common/components/Radio";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import { GTAPApi } from "metabase/services";
 import { Button, Center, Icon, Loader } from "metabase/ui";
 import { getName } from "metabase/utils/name";
 import type {
@@ -111,13 +111,15 @@ const EditSandboxingModal = ({
   const [showPickerModal, { turnOn: showModal, turnOff: hideModal }] =
     useToggle(false);
 
+  const [validatePolicy] = useValidateGroupTableAccessPolicyMutation();
+
   const [{ error }, savePolicy] = useAsyncFn(async () => {
     const shouldValidate = normalizedPolicy.card_id != null;
     if (shouldValidate) {
-      await GTAPApi.validate(normalizedPolicy);
+      await validatePolicy(normalizedPolicy).unwrap();
     }
     onSave(normalizedPolicy);
-  }, [normalizedPolicy]);
+  }, [normalizedPolicy, validatePolicy]);
 
   const remainingAttributesOptions = attributes.filter(
     (attribute) => !(attribute in policy.attribute_remappings),

--- a/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { t } from "ttag";
 
-import { SettingsApi, StoreApi } from "metabase/services";
+import { premiumFeaturesApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
+import { useDispatch } from "metabase/redux";
+import { SettingsApi } from "metabase/services";
 import { reload } from "metabase/utils/dom";
 import type { TokenStatus } from "metabase-types/api";
 
@@ -13,6 +16,7 @@ const INVALID_TOKEN_ERROR = t`This token doesn't seem to be valid. Double-check 
 const UNABLE_TO_VALIDATE_TOKEN = t`We're having trouble validating your token. Please double-check that your instance can connect to Metabase's servers.`;
 
 export const useLicense = (onActivated?: () => void) => {
+  const dispatch = useDispatch();
   const [tokenStatus, setTokenStatus] = useState<TokenStatus>();
   const [loading, setLoading] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -54,7 +58,13 @@ export const useLicense = (onActivated?: () => void) => {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        setTokenStatus(await StoreApi.tokenStatus());
+        setTokenStatus(
+          await runRtkEndpoint(
+            undefined,
+            dispatch,
+            premiumFeaturesApi.endpoints.getTokenStatus,
+          ),
+        );
       } catch (e) {
         if ((e as any).status !== 404) {
           setError(UNABLE_TO_VALIDATE_TOKEN);
@@ -65,7 +75,7 @@ export const useLicense = (onActivated?: () => void) => {
     };
 
     fetchStatus();
-  }, []);
+  }, [dispatch]);
 
   return {
     isUpdating,

--- a/enterprise/frontend/src/metabase-enterprise/shared/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/shared/reducer.ts
@@ -1,12 +1,14 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+import { userApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { createAsyncThunk } from "metabase/redux/utils";
-import { GTAPApi } from "metabase/services";
 import type { UserAttributeKey } from "metabase-types/api";
 
 export const fetchUserAttributes = createAsyncThunk(
   "metabase-enterprise/shared/FETCH_USER_ATTRIBUTES",
-  async () => GTAPApi.attributes(),
+  async (_, { dispatch }) =>
+    runRtkEndpoint(undefined, dispatch, userApi.endpoints.listUserAttributes),
 );
 
 export interface EnterpriseSharedState {

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -239,3 +239,18 @@ export type BulkNotificationPayload = {
   action: BulkNotificationAction;
   creator_id?: UserId;
 };
+
+// Unauthenticated, hash-based email unsubscribe (pulse subscriptions and
+// notifications). The two endpoints accept mutually-exclusive id keys, so both
+// are optional here.
+export type UnsubscribeRequest = {
+  hash: string;
+  email: string;
+  "pulse-id"?: string;
+  "notification-handler-id"?: string;
+};
+
+export type UnsubscribeResponse = {
+  status?: string;
+  title: string;
+};

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -147,6 +147,12 @@ export type FieldsPermissions =
   | DataPermissionValue.SANDBOXED
   | DataPermissionValue.BLOCKED;
 
+export type UpdateCollectionPermissionsGraphRequest = {
+  namespace?: string | null;
+  revision: number;
+  groups: CollectionPermissions;
+};
+
 export type CollectionPermissionsGraph = {
   groups: CollectionPermissions;
   revision: number;

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -48,6 +48,15 @@ export type PermissionsGraph = {
   revision: number;
 };
 
+// The `groups`/`revision` pair is always present; advanced-permissions plugins
+// (sandboxing, impersonation, …) append their own top-level keys, hence the
+// open index signature.
+export type UpdatePermissionsGraphRequest = {
+  groups: GroupsPermissions;
+  revision: number;
+  [key: string]: unknown;
+};
+
 export type GroupsPermissions = {
   [key: GroupId | string]: GroupPermissions;
 };

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -76,7 +76,7 @@ export default forwardRef<HTMLDivElement, ErrorBoundaryProps>(
       <ErrorBoundaryInner
         {...props}
         forwardedRef={ref}
-        onReportError={() => reportFrontendError({ type: "component-crash" })}
+        onReportError={() => void reportFrontendError({ type: "component-crash" })}
       />
     );
   },

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -6,18 +6,22 @@ import type {
 } from "react";
 import { Component, forwardRef } from "react";
 
+import { useReportFrontendErrorMutation } from "metabase/api";
 import { SmallGenericError } from "metabase/common/components/ErrorPages";
-import { FrontendErrorsApi } from "metabase/services";
 
 interface ErrorBoundaryProps extends PropsWithChildren {
   onError?: (errorInfo: ErrorInfo) => void;
   errorComponent?: ComponentType;
   message?: string;
+}
+
+interface ErrorBoundaryInnerProps extends ErrorBoundaryProps {
   forwardedRef?: ForwardedRef<HTMLDivElement>;
+  onReportError: () => void;
 }
 
 class ErrorBoundaryInner extends Component<
-  ErrorBoundaryProps,
+  ErrorBoundaryInnerProps,
   {
     hasError: boolean;
   }
@@ -36,7 +40,7 @@ class ErrorBoundaryInner extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error(error, errorInfo);
-    FrontendErrorsApi.report({ type: "component-crash" }).catch(() => {});
+    this.props.onReportError();
     // if we don't provide a specific onError action, the component will display a generic error message
     if (this.props.onError) {
       this.props.onError(errorInfo);
@@ -67,6 +71,13 @@ class ErrorBoundaryInner extends Component<
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default forwardRef<HTMLDivElement, ErrorBoundaryProps>(
   function ErrorBoundary(props, ref) {
-    return <ErrorBoundaryInner {...props} forwardedRef={ref} />;
+    const [reportFrontendError] = useReportFrontendErrorMutation();
+    return (
+      <ErrorBoundaryInner
+        {...props}
+        forwardedRef={ref}
+        onReportError={() => reportFrontendError({ type: "component-crash" })}
+      />
+    );
   },
 );

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -76,7 +76,9 @@ export default forwardRef<HTMLDivElement, ErrorBoundaryProps>(
       <ErrorBoundaryInner
         {...props}
         forwardedRef={ref}
-        onReportError={() => void reportFrontendError({ type: "component-crash" })}
+        onReportError={() =>
+          void reportFrontendError({ type: "component-crash" })
+        }
       />
     );
   },

--- a/frontend/src/metabase/admin/datamodel/datamodel.ts
+++ b/frontend/src/metabase/admin/datamodel/datamodel.ts
@@ -1,17 +1,22 @@
+import { revisionApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import {
   combineReducers,
   createThunkAction,
   handleActions,
 } from "metabase/redux";
-import { RevisionsApi } from "metabase/services";
 import type { Revision, RevisionId } from "metabase-types/api";
 
 export const FETCH_REVISIONS = "metabase/admin/datamodel/FETCH_REVISIONS";
 
 export const fetchSegmentRevisions = createThunkAction(
   FETCH_REVISIONS,
-  (id: RevisionId | string) => async () =>
-    RevisionsApi.get({ entity: "segment", id: Number(id) }),
+  (id: RevisionId | string) => async (dispatch) =>
+    runRtkEndpoint(
+      { entity: "segment", id: Number(id) },
+      dispatch,
+      revisionApi.endpoints.listRevisions,
+    ),
 );
 
 const revisions = handleActions<Revision[] | null>(

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -8,6 +8,11 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { ModelCachingScheduleWidget } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget";
+import {
+  useDisablePersistMutation,
+  useEnablePersistMutation,
+  useSetRefreshScheduleMutation,
+} from "metabase/api";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { useDocsUrl, useSetting, useToast } from "metabase/common/hooks";
@@ -17,7 +22,6 @@ import {
   getApplicationName,
   getShowMetabaseLinks,
 } from "metabase/selectors/whitelabel";
-import { PersistedModelsApi } from "metabase/services";
 import { Switch, Text } from "metabase/ui";
 
 import ModelPersistenceConfigurationS from "./ModelPersistenceConfiguration.module.css";
@@ -71,6 +75,9 @@ export const ModelPersistenceConfiguration = () => {
 
   const dispatch = useDispatch();
   const [sendToast, removeToast] = useToast();
+  const [enablePersist] = useEnablePersistMutation();
+  const [disablePersist] = useDisablePersistMutation();
+  const [setRefreshSchedule] = useSetRefreshScheduleMutation();
 
   const showLoadingToast = async () => {
     const result = await sendToast({
@@ -105,8 +112,8 @@ export const ModelPersistenceConfiguration = () => {
     const shouldEnable = e.target.checked;
     setModelPersistenceEnabled(shouldEnable);
     const promise = shouldEnable
-      ? PersistedModelsApi.enablePersistence()
-      : PersistedModelsApi.disablePersistence();
+      ? enablePersist().unwrap()
+      : disablePersist().unwrap();
     await resolveWithToasts([promise]);
     dispatch(refreshSiteSettings());
   };
@@ -158,9 +165,9 @@ export const ModelPersistenceConfiguration = () => {
             <ModelCachingScheduleWidget
               value={modelCachingSchedule}
               options={modelCachingOptions}
-              onChange={async (value: unknown) => {
+              onChange={async (value: string) => {
                 await resolveWithToasts([
-                  PersistedModelsApi.setRefreshSchedule({ cron: value }),
+                  setRefreshSchedule({ cron: value }).unwrap(),
                   dispatch(refreshSiteSettings()),
                 ]);
               }}

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -31,7 +31,7 @@ import {
   createThunkAction,
 } from "metabase/redux";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
-import { CollectionsApi, PermissionsApi } from "metabase/services";
+import { CollectionsApi } from "metabase/services";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Collection,
@@ -69,7 +69,12 @@ export const LOAD_DATA_PERMISSIONS =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS";
 export const loadDataPermissions = createThunkAction(
   LOAD_DATA_PERMISSIONS,
-  () => async () => PermissionsApi.graph(),
+  () => async (dispatch) =>
+    runRtkEndpoint(
+      undefined,
+      dispatch,
+      permissionApi.endpoints.getPermissionsGraph,
+    ),
 );
 function isLoadDataPermissionsAction(
   action: UnknownAction,
@@ -94,8 +99,12 @@ const LOAD_DATA_PERMISSIONS_FOR_GROUP =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
 export const loadDataPermissionsForGroup = createThunkAction(
   LOAD_DATA_PERMISSIONS_FOR_GROUP,
-  (groupId: number | undefined) => async () =>
-    PermissionsApi.graphForGroup({ groupId }),
+  (groupId: number | undefined) => async (dispatch) =>
+    runRtkEndpoint(
+      groupId,
+      dispatch,
+      permissionApi.endpoints.getGroupPermissionsGraph,
+    ),
 );
 function isLoadDataPermissionsForGroupAction(
   action: UnknownAction,
@@ -109,8 +118,12 @@ const LOAD_DATA_PERMISSIONS_FOR_DB =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_DB";
 export const loadDataPermissionsForDb = createThunkAction(
   LOAD_DATA_PERMISSIONS_FOR_DB,
-  (databaseId: number | undefined) => async () =>
-    PermissionsApi.graphForDB({ databaseId }),
+  (databaseId: number | undefined) => async (dispatch) =>
+    runRtkEndpoint(
+      databaseId,
+      dispatch,
+      permissionApi.endpoints.getDatabasePermissionsGraph,
+    ),
 );
 function isLoadDataPermissionsForDbAction(
   action: UnknownAction,
@@ -261,7 +274,7 @@ export const SAVE_DATA_PERMISSIONS =
   "metabase/admin/permissions/data/SAVE_DATA_PERMISSIONS";
 export const saveDataPermissions = createThunkAction(
   SAVE_DATA_PERMISSIONS,
-  () => async (_dispatch, getState) => {
+  () => async (dispatch, getState) => {
     const state = getState();
     const allGroupIds = selectGroupList(state).map((group) => String(group.id));
     const {
@@ -293,11 +306,15 @@ export const saveDataPermissions = createThunkAction(
     );
     const modifiedGroupIds = Object.keys(modifiedGroups);
 
-    const response = await PermissionsApi.updateGraph({
-      groups: modifiedGroups,
-      revision: dataPermissionsRevision,
-      ...advancedPermissions.permissions,
-    });
+    const response = await runRtkEndpoint(
+      {
+        groups: modifiedGroups,
+        revision: dataPermissionsRevision,
+        ...advancedPermissions.permissions,
+      },
+      dispatch,
+      permissionApi.endpoints.updatePermissionsGraph,
+    );
 
     return {
       ...response,

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -18,7 +18,7 @@ import {
   updateTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
-import { databaseApi, permissionApi } from "metabase/api";
+import { collectionApi, databaseApi, permissionApi } from "metabase/api";
 import { type ErrorPayload, getErrorMessage } from "metabase/api/utils/errors";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import {
@@ -31,7 +31,6 @@ import {
   createThunkAction,
 } from "metabase/redux";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
-import { CollectionsApi } from "metabase/services";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Collection,
@@ -147,9 +146,13 @@ const LOAD_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/LOAD_COLLECTION_PERMISSIONS";
 export const loadCollectionPermissions = createThunkAction(
   LOAD_COLLECTION_PERMISSIONS,
-  (namespace) => async () => {
+  (namespace) => async (dispatch) => {
     const params = namespace != null ? { namespace } : {};
-    return CollectionsApi.graph(params);
+    return runRtkEndpoint(
+      params,
+      dispatch,
+      collectionApi.endpoints.getCollectionPermissionsGraph,
+    );
   },
 );
 function isLoadCollectionPermissionsAction(
@@ -349,7 +352,7 @@ const SAVE_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/data/SAVE_COLLECTION_PERMISSIONS";
 export const saveCollectionPermissions = createThunkAction(
   SAVE_COLLECTION_PERMISSIONS,
-  (namespace) => async (_dispatch, getState) => {
+  (namespace) => async (dispatch, getState) => {
     const {
       originalCollectionPermissions,
       collectionPermissions,
@@ -361,11 +364,15 @@ export const saveCollectionPermissions = createThunkAction(
       collectionPermissions,
     );
 
-    const result = await CollectionsApi.updateGraph({
-      namespace,
-      revision: collectionPermissionsRevision,
-      groups: modifiedPermissions,
-    });
+    const result = await runRtkEndpoint(
+      {
+        namespace,
+        revision: collectionPermissionsRevision,
+        groups: modifiedPermissions,
+      },
+      dispatch,
+      collectionApi.endpoints.updateCollectionPermissionsGraph,
+    );
 
     return {
       ...result,
@@ -401,8 +408,12 @@ const LOAD_TENANT_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/LOAD_TENANT_COLLECTION_PERMISSIONS";
 export const loadTenantCollectionPermissions = createThunkAction(
   LOAD_TENANT_COLLECTION_PERMISSIONS,
-  () => async () => {
-    return CollectionsApi.graph({ namespace: TENANT_NAMESPACE });
+  () => async (dispatch) => {
+    return runRtkEndpoint(
+      { namespace: TENANT_NAMESPACE },
+      dispatch,
+      collectionApi.endpoints.getCollectionPermissionsGraph,
+    );
   },
 );
 function isLoadTenantCollectionPermissionsAction(
@@ -438,7 +449,7 @@ const SAVE_TENANT_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/data/SAVE_TENANT_COLLECTION_PERMISSIONS";
 export const saveTenantCollectionPermissions = createThunkAction(
   SAVE_TENANT_COLLECTION_PERMISSIONS,
-  () => async (_dispatch, getState) => {
+  () => async (dispatch, getState) => {
     const {
       originalTenantCollectionPermissions,
       tenantCollectionPermissions,
@@ -450,11 +461,15 @@ export const saveTenantCollectionPermissions = createThunkAction(
       tenantCollectionPermissions,
     );
 
-    const result = await CollectionsApi.updateGraph({
-      namespace: TENANT_NAMESPACE,
-      revision: tenantCollectionPermissionsRevision,
-      groups: modifiedPermissions,
-    });
+    const result = await runRtkEndpoint(
+      {
+        namespace: TENANT_NAMESPACE,
+        revision: tenantCollectionPermissionsRevision,
+        groups: modifiedPermissions,
+      },
+      dispatch,
+      collectionApi.endpoints.updateCollectionPermissionsGraph,
+    );
 
     return {
       ...result,
@@ -487,8 +502,12 @@ const LOAD_TENANT_SPECIFIC_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/LOAD_TENANT_SPECIFIC_COLLECTION_PERMISSIONS";
 export const loadTenantSpecificCollectionPermissions = createThunkAction(
   LOAD_TENANT_SPECIFIC_COLLECTION_PERMISSIONS,
-  () => async () => {
-    return CollectionsApi.graph({ namespace: TENANT_SPECIFIC_NAMESPACE });
+  () => async (dispatch) => {
+    return runRtkEndpoint(
+      { namespace: TENANT_SPECIFIC_NAMESPACE },
+      dispatch,
+      collectionApi.endpoints.getCollectionPermissionsGraph,
+    );
   },
 );
 function isLoadTenantSpecificCollectionPermissionsAction(
@@ -519,7 +538,7 @@ const SAVE_TENANT_SPECIFIC_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/data/SAVE_TENANT_SPECIFIC_COLLECTION_PERMISSIONS";
 export const saveTenantSpecificCollectionPermissions = createThunkAction(
   SAVE_TENANT_SPECIFIC_COLLECTION_PERMISSIONS,
-  () => async (_dispatch, getState) => {
+  () => async (dispatch, getState) => {
     const {
       originalTenantSpecificCollectionPermissions,
       tenantSpecificCollectionPermissions,
@@ -531,11 +550,15 @@ export const saveTenantSpecificCollectionPermissions = createThunkAction(
       tenantSpecificCollectionPermissions,
     );
 
-    const result = await CollectionsApi.updateGraph({
-      namespace: TENANT_SPECIFIC_NAMESPACE,
-      revision: tenantSpecificCollectionPermissionsRevision,
-      groups: modifiedPermissions,
-    });
+    const result = await runRtkEndpoint(
+      {
+        namespace: TENANT_SPECIFIC_NAMESPACE,
+        revision: tenantSpecificCollectionPermissionsRevision,
+        groups: modifiedPermissions,
+      },
+      dispatch,
+      collectionApi.endpoints.updateCollectionPermissionsGraph,
+    );
 
     return {
       ...result,

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -5,6 +5,7 @@ import {
 } from "metabase/schema";
 import type {
   Collection,
+  CollectionPermissionsGraph,
   CreateCollectionRequest,
   DeleteCollectionRequest,
   GetCollectionDashboardQuestionCandidatesRequest,
@@ -15,6 +16,7 @@ import type {
   ListCollectionsTreeRequest,
   MoveCollectionDashboardCandidatesRequest,
   MoveCollectionDashboardCandidatesResult,
+  UpdateCollectionPermissionsGraphRequest,
   UpdateCollectionRequest,
   getCollectionRequest,
 } from "metabase-types/api";
@@ -122,6 +124,26 @@ export const collectionApi = Api.injectEndpoints({
           lifecycle,
         ),
     }),
+    getCollectionPermissionsGraph: builder.query<
+      CollectionPermissionsGraph,
+      { namespace?: string } | void
+    >({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/collection/graph",
+        params: params ?? undefined,
+      }),
+    }),
+    updateCollectionPermissionsGraph: builder.mutation<
+      CollectionPermissionsGraph,
+      UpdateCollectionPermissionsGraphRequest
+    >({
+      query: (body) => ({
+        method: "PUT",
+        url: "/api/collection/graph?skip-graph=true",
+        body,
+      }),
+    }),
     createCollection: builder.mutation<Collection, CreateCollectionRequest>({
       query: (body) => ({
         method: "POST",
@@ -220,6 +242,8 @@ export const {
   useListCollectionsTreeQuery,
   useListCollectionItemsQuery,
   useGetCollectionQuery,
+  useGetCollectionPermissionsGraphQuery,
+  useUpdateCollectionPermissionsGraphMutation,
   useCreateCollectionMutation,
   useUpdateCollectionMutation,
   useDeleteCollectionMutation,

--- a/frontend/src/metabase/api/embed.ts
+++ b/frontend/src/metabase/api/embed.ts
@@ -1,6 +1,21 @@
-import type { CardId, DashCardId, Dataset } from "metabase-types/api";
+import type {
+  Card,
+  CardId,
+  DashCardId,
+  Dashboard,
+  Dataset,
+} from "metabase-types/api";
 
 import { Api } from "./api";
+
+export type GetEmbedCardRequest = {
+  token: string;
+};
+
+export type GetEmbedDashboardRequest = {
+  token: string;
+  dashboard_load_id?: number;
+};
 
 export type EmbedCardQueryRequest = {
   token: string;
@@ -20,6 +35,21 @@ export type EmbedDashcardQueryRequest = {
 
 export const embedApi = Api.injectEndpoints({
   endpoints: (builder) => ({
+    getEmbedCard: builder.query<Card, GetEmbedCardRequest>({
+      query: ({ token }) => ({
+        method: "GET",
+        url: `/api/embed/card/${token}`,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+    getEmbedDashboard: builder.query<Dashboard, GetEmbedDashboardRequest>({
+      query: ({ token, ...params }) => ({
+        method: "GET",
+        url: `/api/embed/dashboard/${token}`,
+        params,
+      }),
+      keepUnusedDataFor: 0,
+    }),
     getEmbedCardQuery: builder.query<Dataset, EmbedCardQueryRequest>({
       // `/api/embed` is rewritten to `/api/preview_embed` by the request
       // middleware when running inside an embed preview.
@@ -61,6 +91,8 @@ export const embedApi = Api.injectEndpoints({
 });
 
 export const {
+  useGetEmbedCardQuery,
+  useGetEmbedDashboardQuery,
   useGetEmbedCardQueryQuery,
   useGetEmbedCardQueryPivotQuery,
   useGetEmbedDashcardQueryQuery,

--- a/frontend/src/metabase/api/frontend-errors.ts
+++ b/frontend/src/metabase/api/frontend-errors.ts
@@ -1,0 +1,21 @@
+import { Api } from "./api";
+
+export type FrontendErrorType = "component-crash" | "chart-render-error";
+
+interface ReportFrontendErrorRequest {
+  type: FrontendErrorType;
+}
+
+export const frontendErrorsApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    reportFrontendError: builder.mutation<void, ReportFrontendErrorRequest>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/frontend-errors",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useReportFrontendErrorMutation } = frontendErrorsApi;

--- a/frontend/src/metabase/api/frontend-errors.unit.spec.ts
+++ b/frontend/src/metabase/api/frontend-errors.unit.spec.ts
@@ -1,0 +1,48 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+
+import { Api } from "./api";
+import { frontendErrorsApi } from "./frontend-errors";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  fetchMock.post("path:/api/frontend-errors", 204);
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  return { store };
+}
+
+describe("frontendErrorsApi", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("reports a frontend error type to the backend", async () => {
+    const { store } = setup();
+
+    await store.dispatch(
+      frontendErrorsApi.endpoints.reportFrontendError.initiate({
+        type: "component-crash",
+      }),
+    );
+
+    await waitFor(async () => {
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+    });
+
+    const [{ url, body }] = await findRequests("POST");
+    expect(url).toContain("/api/frontend-errors");
+    expect(body).toEqual({ type: "component-crash" });
+  });
+});

--- a/frontend/src/metabase/api/group-table-access-policy.ts
+++ b/frontend/src/metabase/api/group-table-access-policy.ts
@@ -31,10 +31,21 @@ export const groupTableAccessPolicyApi = Api.injectEndpoints({
       }),
       providesTags: () => [listTag("group-table-access-policy")],
     }),
+    validateGroupTableAccessPolicy: builder.mutation<
+      void,
+      GroupTableAccessPolicy
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/mt/gtap/validate",
+        body,
+      }),
+    }),
   }),
 });
 
 export const {
   useListGroupTableAccessPoliciesQuery,
   useGetGroupTableAccessPolicyQuery,
+  useValidateGroupTableAccessPolicyMutation,
 } = groupTableAccessPolicyApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -20,6 +20,7 @@ export * from "./document";
 export * from "./embed";
 export * from "./entity-id";
 export * from "./field";
+export * from "./frontend-errors";
 export * from "./glossary";
 export * from "./google";
 export * from "./group-table-access-policy";

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -46,6 +46,7 @@ export * from "./security-center";
 export * from "./segment";
 export * from "./session";
 export * from "./settings";
+export * from "./setup";
 export * from "./slack";
 export * from "./snippet";
 export * from "./subscription";

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -39,6 +39,7 @@ export * from "./permission";
 export * from "./persist";
 export * from "./premium-features";
 export * from "./public";
+export * from "./pulse";
 export * from "./query-endpoints";
 export * from "./revision";
 export * from "./search";

--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -7,6 +7,8 @@ import type {
   ListNotificationsRequest,
   Notification,
   NotificationId,
+  UnsubscribeRequest,
+  UnsubscribeResponse,
   UpdateNotificationRequest,
 } from "metabase-types/api/notification";
 
@@ -140,6 +142,26 @@ export const notificationApi = Api.injectEndpoints({
       providesTags: (result) =>
         result ? provideAdminNotificationTags(result) : [],
     }),
+    unsubscribeFromNotificationByEmail: builder.mutation<
+      UnsubscribeResponse,
+      UnsubscribeRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/notification/unsubscribe",
+        body,
+      }),
+    }),
+    undoUnsubscribeFromNotificationByEmail: builder.mutation<
+      UnsubscribeResponse,
+      UnsubscribeRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/notification/unsubscribe/undo",
+        body,
+      }),
+    }),
   }),
 });
 
@@ -157,4 +179,6 @@ export const {
   useAdminListNotificationsQuery,
   useBulkNotificationActionMutation,
   useAdminNotificationDetailQuery,
+  useUnsubscribeFromNotificationByEmailMutation,
+  useUndoUnsubscribeFromNotificationByEmailMutation,
 } = notificationApi;

--- a/frontend/src/metabase/api/parameters.ts
+++ b/frontend/src/metabase/api/parameters.ts
@@ -13,10 +13,10 @@ export const parametersApi = Api.injectEndpoints({
       ParameterValues,
       GetParameterValuesRequest
     >({
-      query: (params) => ({
+      query: (body) => ({
         method: "POST",
         url: `/api/dataset/parameter/values`,
-        params,
+        body,
       }),
       providesTags: (_values, _error, params) => [
         idTag("parameter-values", params.parameter.id),
@@ -26,11 +26,15 @@ export const parametersApi = Api.injectEndpoints({
       ParameterValues,
       SearchParameterValuesRequest
     >({
-      query: (params) => ({
+      query: ({ query, ...body }) => ({
         method: "POST",
-        url: `/api/dataset/parameter/search/${params.query}`,
-        params,
+        url: `/api/dataset/parameter/search/${encodeURIComponent(query)}`,
+        body,
       }),
+      // Each distinct search term is its own cache entry and RTK Query has no
+      // entry-count cap, so retaining type-ahead results would let the cache
+      // grow unbounded. Drop them as soon as the request is no longer in use.
+      keepUnusedDataFor: 0,
     }),
   }),
 });

--- a/frontend/src/metabase/api/parameters.unit.spec.ts
+++ b/frontend/src/metabase/api/parameters.unit.spec.ts
@@ -1,0 +1,81 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+import {
+  createMockParameter,
+  createMockParameterValues,
+} from "metabase-types/api/mocks";
+
+import { Api } from "./api";
+import { parametersApi } from "./parameters";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  fetchMock.post(
+    "path:/api/dataset/parameter/values",
+    createMockParameterValues(),
+  );
+  fetchMock.post(
+    "express:/api/dataset/parameter/search/:query",
+    createMockParameterValues(),
+  );
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  return { store };
+}
+
+describe("parametersApi", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("sends the parameter and fields as a POST body when fetching values", async () => {
+    const { store } = setup();
+    const parameter = createMockParameter({ id: "abc" });
+
+    await store.dispatch(
+      parametersApi.endpoints.getParameterValues.initiate({
+        parameter,
+        field_ids: [1, 2],
+      }),
+    );
+
+    await waitFor(async () => {
+      expect(await findRequests("POST")).toHaveLength(1);
+    });
+
+    const [{ url, body }] = await findRequests("POST");
+    expect(url).toContain("/api/dataset/parameter/values");
+    expect(body).toEqual({ parameter, field_ids: [1, 2] });
+  });
+
+  it("puts the query in the URL and the rest in the body when searching values", async () => {
+    const { store } = setup();
+    const parameter = createMockParameter({ id: "abc" });
+
+    await store.dispatch(
+      parametersApi.endpoints.searchParameterValues.initiate({
+        parameter,
+        field_ids: [1, 2],
+        query: "foo bar",
+      }),
+    );
+
+    await waitFor(async () => {
+      expect(await findRequests("POST")).toHaveLength(1);
+    });
+
+    const [{ url, body }] = await findRequests("POST");
+    expect(url).toContain("/api/dataset/parameter/search/foo%20bar");
+    expect(body).toEqual({ parameter, field_ids: [1, 2] });
+  });
+});

--- a/frontend/src/metabase/api/permission.ts
+++ b/frontend/src/metabase/api/permission.ts
@@ -1,11 +1,14 @@
 import type {
   BaseGroupInfo,
   CreateMembershipRequest,
+  DatabaseId,
   Group,
   GroupId,
   GroupListQuery,
   ListUserMembershipsResponse,
   Membership,
+  PermissionsGraph,
+  UpdatePermissionsGraphRequest,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -19,6 +22,34 @@ import {
 
 export const permissionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
+    getPermissionsGraph: builder.query<PermissionsGraph, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/permissions/graph",
+      }),
+    }),
+    getGroupPermissionsGraph: builder.query<PermissionsGraph, GroupId>({
+      query: (groupId) => ({
+        method: "GET",
+        url: `/api/permissions/graph/group/${groupId}`,
+      }),
+    }),
+    getDatabasePermissionsGraph: builder.query<PermissionsGraph, DatabaseId>({
+      query: (databaseId) => ({
+        method: "GET",
+        url: `/api/permissions/graph/db/${databaseId}`,
+      }),
+    }),
+    updatePermissionsGraph: builder.mutation<
+      PermissionsGraph,
+      UpdatePermissionsGraphRequest
+    >({
+      query: (body) => ({
+        method: "PUT",
+        url: "/api/permissions/graph",
+        body,
+      }),
+    }),
     listPermissionsGroups: builder.query<
       GroupListQuery[],
       { tenancy?: "external" | "internal" } | undefined
@@ -136,6 +167,10 @@ export const permissionApi = Api.injectEndpoints({
 });
 
 export const {
+  useGetPermissionsGraphQuery,
+  useGetGroupPermissionsGraphQuery,
+  useGetDatabasePermissionsGraphQuery,
+  useUpdatePermissionsGraphMutation,
   useListPermissionsGroupsQuery,
   useGetPermissionsGroupQuery,
   useCreatePermissionsGroupMutation,

--- a/frontend/src/metabase/api/permission.unit.spec.ts
+++ b/frontend/src/metabase/api/permission.unit.spec.ts
@@ -1,0 +1,84 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+import { createMockPermissionsGraph } from "metabase-types/api/mocks";
+
+import { Api } from "./api";
+import { permissionApi } from "./permission";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+  return { store };
+}
+
+const GRAPH = createMockPermissionsGraph({ groups: [], databases: [] });
+
+describe("permissionApi data-permissions graph", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("fetches the full graph", async () => {
+    fetchMock.get("path:/api/permissions/graph", GRAPH);
+    const { store } = setup();
+
+    const { data } = await store.dispatch(
+      permissionApi.endpoints.getPermissionsGraph.initiate(),
+    );
+
+    expect(data?.revision).toBe(1);
+    const [request] = await findRequests("GET");
+    expect(request.url).toContain("/api/permissions/graph");
+  });
+
+  it("fetches the graph for a single group", async () => {
+    fetchMock.get("path:/api/permissions/graph/group/5", GRAPH);
+    const { store } = setup();
+
+    await store.dispatch(
+      permissionApi.endpoints.getGroupPermissionsGraph.initiate(5),
+    );
+
+    const [request] = await findRequests("GET");
+    expect(request.url).toContain("/api/permissions/graph/group/5");
+  });
+
+  it("fetches the graph for a single database", async () => {
+    fetchMock.get("path:/api/permissions/graph/db/9", GRAPH);
+    const { store } = setup();
+
+    await store.dispatch(
+      permissionApi.endpoints.getDatabasePermissionsGraph.initiate(9),
+    );
+
+    const [request] = await findRequests("GET");
+    expect(request.url).toContain("/api/permissions/graph/db/9");
+  });
+
+  it("updates the graph", async () => {
+    fetchMock.put("path:/api/permissions/graph", GRAPH);
+    const { store } = setup();
+
+    const body = { groups: {}, revision: 1 };
+    await store.dispatch(
+      permissionApi.endpoints.updatePermissionsGraph.initiate(body),
+    );
+
+    await waitFor(async () => {
+      const puts = await findRequests("PUT");
+      expect(puts).toHaveLength(1);
+    });
+    const [request] = await findRequests("PUT");
+    expect(request.url).toContain("/api/permissions/graph");
+    expect(request.body).toEqual(body);
+  });
+});

--- a/frontend/src/metabase/api/persist.ts
+++ b/frontend/src/metabase/api/persist.ts
@@ -63,7 +63,7 @@ export const persistApi = Api.injectEndpoints({
     setRefreshSchedule: builder.mutation<void, PersistedInfoRefreshSchedule>({
       query: (body) => ({
         method: "POST",
-        url: "/api/persist/set-refresh/schedule",
+        url: "/api/persist/set-refresh-schedule",
         body,
       }),
       invalidatesTags: (_, error) =>

--- a/frontend/src/metabase/api/persist.unit.spec.ts
+++ b/frontend/src/metabase/api/persist.unit.spec.ts
@@ -1,0 +1,75 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+
+import { Api } from "./api";
+import { persistApi } from "./persist";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  fetchMock.post("path:/api/persist/enable", 204);
+  fetchMock.post("path:/api/persist/disable", 204);
+  fetchMock.post("path:/api/persist/set-refresh-schedule", 204);
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  return { store };
+}
+
+describe("persistApi", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("enables persistence", async () => {
+    const { store } = setup();
+
+    await store.dispatch(persistApi.endpoints.enablePersist.initiate());
+
+    await waitFor(async () => {
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+    });
+    const [request] = await findRequests("POST");
+    expect(request.url).toContain("/api/persist/enable");
+  });
+
+  it("disables persistence", async () => {
+    const { store } = setup();
+
+    await store.dispatch(persistApi.endpoints.disablePersist.initiate());
+
+    await waitFor(async () => {
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+    });
+    const [request] = await findRequests("POST");
+    expect(request.url).toContain("/api/persist/disable");
+  });
+
+  it("sets the refresh schedule", async () => {
+    const { store } = setup();
+
+    await store.dispatch(
+      persistApi.endpoints.setRefreshSchedule.initiate({
+        cron: "0 0 0/6 * * ? *",
+      }),
+    );
+
+    await waitFor(async () => {
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+    });
+    const [request] = await findRequests("POST");
+    expect(request.url).toContain("/api/persist/set-refresh-schedule");
+    expect(request.body).toEqual({ cron: "0 0 0/6 * * ? *" });
+  });
+});

--- a/frontend/src/metabase/api/premium-features.ts
+++ b/frontend/src/metabase/api/premium-features.ts
@@ -5,6 +5,12 @@ import { invalidateTags, tag } from "./tags";
 
 export const premiumFeaturesApi = Api.injectEndpoints({
   endpoints: (builder) => ({
+    getTokenStatus: builder.query<TokenStatus, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/premium-features/token/status",
+      }),
+    }),
     refreshTokenStatus: builder.mutation<TokenStatus, void>({
       query: () => ({
         method: "POST",
@@ -16,4 +22,5 @@ export const premiumFeaturesApi = Api.injectEndpoints({
   }),
 });
 
-export const { useRefreshTokenStatusMutation } = premiumFeaturesApi;
+export const { useGetTokenStatusQuery, useRefreshTokenStatusMutation } =
+  premiumFeaturesApi;

--- a/frontend/src/metabase/api/public.ts
+++ b/frontend/src/metabase/api/public.ts
@@ -1,6 +1,53 @@
-import type { CardId, DashCardId, Dataset } from "metabase-types/api";
+import type {
+  ActionExecutionResult,
+  Card,
+  CardId,
+  DashCardId,
+  Dashboard,
+  DashboardId,
+  Dataset,
+  Document,
+  ParametersForActionExecution,
+  WritebackAction,
+} from "metabase-types/api";
 
 import { Api } from "./api";
+
+export type GetPublicActionRequest = {
+  uuid: string;
+};
+
+export type GetPublicCardRequest = {
+  uuid: string;
+};
+
+export type GetPublicDashboardRequest = {
+  uuid: string;
+  dashboard_load_id?: number;
+};
+
+export type GetPublicDocumentRequest = {
+  uuid: string;
+};
+
+export type ExecutePublicActionRequest = {
+  uuid: string;
+  parameters: ParametersForActionExecution;
+};
+
+export type ExecutePublicDashcardActionRequest = {
+  dashboardId: DashboardId;
+  dashcardId: DashCardId;
+  modelId: CardId | null;
+  parameters: ParametersForActionExecution;
+};
+
+export type PrefetchPublicDashcardValuesRequest = {
+  dashboardId: DashboardId;
+  dashcardId: DashCardId;
+  // Already JSON-stringified by the caller and passed through the query string.
+  parameters?: string;
+};
 
 export type PublicCardQueryRequest = {
   uuid: string;
@@ -27,6 +74,66 @@ const PIVOT_PREFIX = "/api/public/pivot";
 
 export const publicApi = Api.injectEndpoints({
   endpoints: (builder) => ({
+    getPublicAction: builder.query<WritebackAction, GetPublicActionRequest>({
+      query: ({ uuid }) => ({
+        method: "GET",
+        url: `/api/public/action/${uuid}`,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+    getPublicCard: builder.query<Card, GetPublicCardRequest>({
+      query: ({ uuid }) => ({
+        method: "GET",
+        url: `/api/public/card/${uuid}`,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+    getPublicDashboard: builder.query<Dashboard, GetPublicDashboardRequest>({
+      query: ({ uuid, ...params }) => ({
+        method: "GET",
+        url: `/api/public/dashboard/${uuid}`,
+        params,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+    getPublicDocument: builder.query<Document, GetPublicDocumentRequest>({
+      query: ({ uuid }) => ({
+        method: "GET",
+        url: `/api/public/document/${uuid}`,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+    executePublicAction: builder.mutation<
+      ActionExecutionResult,
+      ExecutePublicActionRequest
+    >({
+      query: ({ uuid, parameters }) => ({
+        method: "POST",
+        url: `/api/public/action/${uuid}/execute`,
+        body: { parameters },
+      }),
+    }),
+    executePublicDashcardAction: builder.mutation<
+      ActionExecutionResult,
+      ExecutePublicDashcardActionRequest
+    >({
+      query: ({ dashboardId, dashcardId, modelId, parameters }) => ({
+        method: "POST",
+        url: `/api/public/dashboard/${dashboardId}/dashcard/${dashcardId}/execute`,
+        body: { modelId, parameters },
+      }),
+    }),
+    prefetchPublicDashcardValues: builder.query<
+      ParametersForActionExecution,
+      PrefetchPublicDashcardValuesRequest
+    >({
+      query: ({ dashboardId, dashcardId, ...params }) => ({
+        method: "GET",
+        url: `/api/public/dashboard/${dashboardId}/dashcard/${dashcardId}/execute`,
+        params,
+      }),
+      keepUnusedDataFor: 0,
+    }),
     getPublicCardQuery: builder.query<Dataset, PublicCardQueryRequest>({
       query: ({ uuid, ...params }) => ({
         method: "GET",
@@ -78,6 +185,13 @@ export const publicApi = Api.injectEndpoints({
 });
 
 export const {
+  useGetPublicActionQuery,
+  useGetPublicCardQuery,
+  useGetPublicDashboardQuery,
+  useGetPublicDocumentQuery,
+  useExecutePublicActionMutation,
+  useExecutePublicDashcardActionMutation,
+  usePrefetchPublicDashcardValuesQuery,
   useGetPublicCardQueryQuery,
   useGetPublicCardQueryPivotQuery,
   useGetPublicDashcardQueryQuery,

--- a/frontend/src/metabase/api/pulse.ts
+++ b/frontend/src/metabase/api/pulse.ts
@@ -1,0 +1,36 @@
+import type {
+  UnsubscribeRequest,
+  UnsubscribeResponse,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+
+export const pulseApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    unsubscribeFromPulse: builder.mutation<
+      UnsubscribeResponse,
+      UnsubscribeRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/pulse/unsubscribe",
+        body,
+      }),
+    }),
+    undoUnsubscribeFromPulse: builder.mutation<
+      UnsubscribeResponse,
+      UnsubscribeRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/pulse/unsubscribe/undo",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const {
+  useUnsubscribeFromPulseMutation,
+  useUndoUnsubscribeFromPulseMutation,
+} = pulseApi;

--- a/frontend/src/metabase/api/setup.ts
+++ b/frontend/src/metabase/api/setup.ts
@@ -1,0 +1,29 @@
+import { Api } from "./api";
+
+interface CreateSetupRequest {
+  token: string;
+  user: {
+    email: string;
+    password: string;
+    first_name?: string | null;
+    last_name?: string | null;
+  };
+  prefs: {
+    site_name: string;
+    site_locale?: string | null;
+  };
+}
+
+export const setupApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    createSetup: builder.mutation<void, CreateSetupRequest>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/setup",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useCreateSetupMutation } = setupApi;

--- a/frontend/src/metabase/api/setup.unit.spec.ts
+++ b/frontend/src/metabase/api/setup.unit.spec.ts
@@ -1,0 +1,58 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+
+import { Api } from "./api";
+import { setupApi } from "./setup";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  fetchMock.post("path:/api/setup", 200);
+
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+
+  return { store };
+}
+
+describe("setupApi", () => {
+  afterEach(() => {
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  it("creates the first user during setup", async () => {
+    const { store } = setup();
+
+    const body = {
+      token: "123456",
+      user: {
+        email: "first@metabase.test",
+        password: "metasample123",
+        first_name: "First",
+        last_name: "User",
+      },
+      prefs: {
+        site_name: "Metabase",
+        site_locale: "en",
+      },
+    };
+
+    await store.dispatch(setupApi.endpoints.createSetup.initiate(body));
+
+    await waitFor(async () => {
+      const posts = await findRequests("POST");
+      expect(posts).toHaveLength(1);
+    });
+
+    const [request] = await findRequests("POST");
+    expect(request.url).toContain("/api/setup");
+    expect(request.body).toEqual(body);
+  });
+});

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -1,4 +1,3 @@
-import { userUpdated } from "metabase/redux/user";
 import type {
   CreateUserRequest,
   ListUsersRequest,
@@ -17,7 +16,6 @@ import {
   provideUserListTags,
   provideUserTags,
 } from "./tags";
-import { handleQueryFulfilled } from "./utils/lifecycle";
 
 export const userApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -42,6 +40,13 @@ export const userApi = Api.injectEndpoints({
       query: (id) => ({
         method: "GET",
         url: `/api/user/${id}`,
+      }),
+      providesTags: (user) => (user ? provideUserTags(user) : []),
+    }),
+    getCurrentUser: builder.query<User, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/user/current",
       }),
       providesTags: (user) => (user ? provideUserTags(user) : []),
     }),
@@ -99,11 +104,6 @@ export const userApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("user"), idTag("user", id)]),
-      onQueryStarted: (_request, { dispatch, queryFulfilled }) =>
-        handleQueryFulfilled(queryFulfilled, (user) => {
-          // used to keep current user state in sync
-          dispatch(userUpdated(user));
-        }),
     }),
     getPasswordResetUrl: builder.mutation<
       { password_reset_url: string },
@@ -118,6 +118,14 @@ export const userApi = Api.injectEndpoints({
       query: () => "/api/mt/user/attributes",
       providesTags: (response) => (response ? [listTag("user")] : []),
     }),
+    updateUserModalQbnewb: builder.mutation<void, UserId>({
+      query: (id) => ({
+        method: "PUT",
+        url: `/api/user/${id}/modal/qbnewb`,
+      }),
+      invalidatesTags: (_, error, id) =>
+        invalidateTags(error, [idTag("user", id)]),
+    }),
   }),
 });
 
@@ -125,6 +133,7 @@ export const {
   useListUsersQuery,
   useListUserRecipientsQuery,
   useGetUserQuery,
+  useGetCurrentUserQuery,
   useCreateUserMutation,
   useUpdatePasswordMutation,
   useDeactivateUserMutation,
@@ -132,4 +141,5 @@ export const {
   useUpdateUserMutation,
   useGetPasswordResetUrlMutation,
   useListUserAttributesQuery,
+  useUpdateUserModalQbnewbMutation,
 } = userApi;

--- a/frontend/src/metabase/api/user.unit.spec.ts
+++ b/frontend/src/metabase/api/user.unit.spec.ts
@@ -1,0 +1,65 @@
+import { waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
+
+import { getStore } from "__support__/entities-store";
+import { findRequests } from "__support__/server-mocks";
+import { createMockUser } from "metabase-types/api/mocks";
+
+import { Api } from "./api";
+import { userApi } from "./user";
+
+let activeStore: ReturnType<typeof getStore> | undefined;
+
+function setup() {
+  const store = getStore({ [Api.reducerPath]: Api.reducer }, {}, [
+    Api.middleware,
+  ]);
+  activeStore = store;
+  return { store };
+}
+
+describe("userApi", () => {
+  afterEach(() => {
+    // Drop the store's RTK Query subscriptions before pulling the fetch routes,
+    // otherwise orphaned subscriptions refetch against removed routes.
+    activeStore?.dispatch(Api.util.resetApiState());
+    activeStore = undefined;
+    fetchMock.removeRoutes().clearHistory();
+  });
+
+  describe("getCurrentUser", () => {
+    it("fetches the current user", async () => {
+      const user = createMockUser({ id: 7 });
+      fetchMock.get("path:/api/user/current", user);
+
+      const { store } = setup();
+
+      const { data } = await store.dispatch(
+        userApi.endpoints.getCurrentUser.initiate(),
+      );
+
+      expect(data?.id).toBe(7);
+
+      const [request] = await findRequests("GET");
+      expect(request.url).toContain("/api/user/current");
+    });
+  });
+
+  describe("updateUserModalQbnewb", () => {
+    it("marks the qbnewb modal as seen for the given user", async () => {
+      fetchMock.put("path:/api/user/7/modal/qbnewb", 204);
+
+      const { store } = setup();
+
+      await store.dispatch(userApi.endpoints.updateUserModalQbnewb.initiate(7));
+
+      await waitFor(async () => {
+        const puts = await findRequests("PUT");
+        expect(puts).toHaveLength(1);
+      });
+
+      const [request] = await findRequests("PUT");
+      expect(request.url).toContain("/api/user/7/modal/qbnewb");
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/ErrorPages/utils.ts
+++ b/frontend/src/metabase/common/components/ErrorPages/utils.ts
@@ -1,9 +1,8 @@
 import Bowser from "bowser";
 
-import { cardApi, dashboardApi } from "metabase/api";
+import { cardApi, collectionApi, dashboardApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import type { DispatchFn } from "metabase/redux";
-import { CollectionsApi } from "metabase/services";
 import { b64url_to_utf8 } from "metabase/utils/encoding";
 
 import type { ReportableEntityName } from "./types";
@@ -45,7 +44,11 @@ export const getEntityDetails = ({
         dashboardApi.endpoints.getDashboard,
       ).catch(nullOnCatch);
     case "collection":
-      return CollectionsApi.get({ id }).catch(nullOnCatch);
+      return runRtkEndpoint(
+        { id },
+        dispatch,
+        collectionApi.endpoints.getCollection,
+      ).catch(nullOnCatch);
     default:
       return Promise.resolve(null);
   }

--- a/frontend/src/metabase/common/components/Unsubscribe.tsx
+++ b/frontend/src/metabase/common/components/Unsubscribe.tsx
@@ -4,7 +4,9 @@ import { useAsync } from "react-use";
 import { jt, t } from "ttag";
 
 import {
+  useUndoUnsubscribeFromNotificationByEmailMutation,
   useUndoUnsubscribeFromPulseMutation,
+  useUnsubscribeFromNotificationByEmailMutation,
   useUnsubscribeFromPulseMutation,
 } from "metabase/api";
 import { NotFound } from "metabase/common/components/ErrorPages";
@@ -14,7 +16,6 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { LogoIcon } from "metabase/common/components/LogoIcon";
 import { useSelector } from "metabase/redux";
 import { getLoginPageIllustration } from "metabase/selectors/whitelabel";
-import { NotificationUnsubscribeApi } from "metabase/services";
 import { Button, Center, Stack, Text } from "metabase/ui";
 
 import {
@@ -183,6 +184,10 @@ function useUnsubscribeRequest({
 
   const [unsubscribeFromPulse] = useUnsubscribeFromPulseMutation();
   const [undoUnsubscribeFromPulse] = useUndoUnsubscribeFromPulseMutation();
+  const [unsubscribeFromNotification] =
+    useUnsubscribeFromNotificationByEmailMutation();
+  const [undoUnsubscribeFromNotification] =
+    useUndoUnsubscribeFromNotificationByEmailMutation();
 
   const {
     value: data,
@@ -195,16 +200,15 @@ function useUnsubscribeRequest({
 
     const isUnsubscribe = subscriptionChange === SUBSCRIPTION.UNSUBSCRIBE;
 
-    if (notificationHandlerId) {
-      const method = isUnsubscribe
-        ? NotificationUnsubscribeApi.unsubscribe
-        : NotificationUnsubscribeApi.undo_unsubscribe;
-      return await method(params);
-    }
+    const triggers = notificationHandlerId
+      ? {
+          unsubscribe: unsubscribeFromNotification,
+          undo: undoUnsubscribeFromNotification,
+        }
+      : { unsubscribe: unsubscribeFromPulse, undo: undoUnsubscribeFromPulse };
 
-    const unsubscribe = isUnsubscribe
-      ? unsubscribeFromPulse
-      : undoUnsubscribeFromPulse;
+    const unsubscribe = isUnsubscribe ? triggers.unsubscribe : triggers.undo;
+
     return await unsubscribe(params).unwrap();
   }, [
     params,
@@ -212,6 +216,8 @@ function useUnsubscribeRequest({
     notificationHandlerId,
     unsubscribeFromPulse,
     undoUnsubscribeFromPulse,
+    unsubscribeFromNotification,
+    undoUnsubscribeFromNotification,
   ]);
 
   return { data, isLoading, error };

--- a/frontend/src/metabase/common/components/Unsubscribe.tsx
+++ b/frontend/src/metabase/common/components/Unsubscribe.tsx
@@ -3,6 +3,10 @@ import { useMemo, useState } from "react";
 import { useAsync } from "react-use";
 import { jt, t } from "ttag";
 
+import {
+  useUndoUnsubscribeFromPulseMutation,
+  useUnsubscribeFromPulseMutation,
+} from "metabase/api";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { LighthouseIllustration } from "metabase/common/components/LighthouseIllustration";
@@ -10,10 +14,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { LogoIcon } from "metabase/common/components/LogoIcon";
 import { useSelector } from "metabase/redux";
 import { getLoginPageIllustration } from "metabase/selectors/whitelabel";
-import {
-  NotificationUnsubscribeApi,
-  PulseUnsubscribeApi,
-} from "metabase/services";
+import { NotificationUnsubscribeApi } from "metabase/services";
 import { Button, Center, Stack, Text } from "metabase/ui";
 
 import {
@@ -180,6 +181,9 @@ function useUnsubscribeRequest({
     return undefined;
   }, [hash, email, pulseId, notificationHandlerId]);
 
+  const [unsubscribeFromPulse] = useUnsubscribeFromPulseMutation();
+  const [undoUnsubscribeFromPulse] = useUndoUnsubscribeFromPulseMutation();
+
   const {
     value: data,
     loading: isLoading,
@@ -189,17 +193,26 @@ function useUnsubscribeRequest({
       throw new Error(ERRORS.MISSING_REQUIRED_PARAMETERS);
     }
 
-    const api = notificationHandlerId
-      ? NotificationUnsubscribeApi
-      : PulseUnsubscribeApi;
+    const isUnsubscribe = subscriptionChange === SUBSCRIPTION.UNSUBSCRIBE;
 
-    const method =
-      subscriptionChange === SUBSCRIPTION.UNSUBSCRIBE
-        ? api.unsubscribe
-        : api.undo_unsubscribe;
+    if (notificationHandlerId) {
+      const method = isUnsubscribe
+        ? NotificationUnsubscribeApi.unsubscribe
+        : NotificationUnsubscribeApi.undo_unsubscribe;
+      return await method(params);
+    }
 
-    return await method(params);
-  }, [params, subscriptionChange]);
+    const unsubscribe = isUnsubscribe
+      ? unsubscribeFromPulse
+      : undoUnsubscribeFromPulse;
+    return await unsubscribe(params).unwrap();
+  }, [
+    params,
+    subscriptionChange,
+    notificationHandlerId,
+    unsubscribeFromPulse,
+    undoUnsubscribeFromPulse,
+  ]);
 
   return { data, isLoading, error };
 }

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -2,12 +2,11 @@ import {
   getActionErrorMessage,
   getActionExecutionMessage,
 } from "metabase/actions/utils";
-import { actionApi } from "metabase/api";
+import { actionApi, publicApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import type { Dispatch } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
-import { PublicApi } from "metabase/services";
 import { getDashboardType } from "metabase/utils/dashboard";
 import type {
   ActionDashboardCard,
@@ -44,7 +43,11 @@ export const executeRowAction = async ({
   try {
     const result =
       getDashboardType(dashboard.id) === "public"
-        ? await PublicApi.executeDashcardAction(executeActionRequest)
+        ? await runRtkEndpoint(
+            executeActionRequest,
+            dispatch,
+            publicApi.endpoints.executePublicDashcardAction,
+          )
         : await runRtkEndpoint(
             executeActionRequest,
             dispatch,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -41,7 +41,6 @@ import type { Dispatch, GetState } from "metabase/redux/store";
 import { createAsyncThunk, createThunkAction } from "metabase/redux/utils";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { PublicApi } from "metabase/services";
 import {
   getDashboardType,
   isQuestionDashCard,
@@ -707,8 +706,10 @@ export const fetchDashboard = createAsyncThunk(
         };
         result = denormalize(dashId, dashboardSchema, entities);
       } else if (dashboardType === "public") {
-        result = await PublicApi.dashboard(
+        result = await runRtkEndpoint(
           { uuid: dashId, dashboard_load_id: dashboardLoadId },
+          dispatch,
+          publicApi.endpoints.getPublicDashboard,
           { signal: fetchDashboardCancellation.signal },
         );
         result = {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -41,7 +41,7 @@ import type { Dispatch, GetState } from "metabase/redux/store";
 import { createAsyncThunk, createThunkAction } from "metabase/redux/utils";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
-import { EmbedApi, PublicApi } from "metabase/services";
+import { PublicApi } from "metabase/services";
 import {
   getDashboardType,
   isQuestionDashCard,
@@ -720,8 +720,10 @@ export const fetchDashboard = createAsyncThunk(
           })),
         };
       } else if (dashboardType === "embed") {
-        result = await EmbedApi.dashboard(
+        result = await runRtkEndpoint(
           { token: dashId, dashboard_load_id: dashboardLoadId },
+          dispatch,
+          embedApi.endpoints.getEmbedDashboard,
           { signal: fetchDashboardCancellation.signal },
         );
         result = {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -15,13 +15,15 @@ import {
   createMockStoreDashboard,
 } from "metabase/redux/store/mocks";
 import { isQuestionDashCard } from "metabase/utils/dashboard";
-import type { Dashboard } from "metabase-types/api";
+import type { Dashboard, DashboardId } from "metabase-types/api";
 import {
   createMockCard,
   createMockDashboard,
   createMockDashboardCard,
   createMockDashboardQueryMetadata,
   createMockDashboardTab,
+  createMockVirtualCard,
+  createMockVirtualDashCard,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -269,6 +271,39 @@ describe("fetchDashboard", () => {
     expect(firstResult.payload).toMatchObject({ result: null });
     // Second fetch completes with the API response
     expect(secondResult.payload).toMatchObject({ result: { foo: true } });
+  });
+
+  it("loads an embedded dashboard with virtual cards without mutating the frozen RTK response", async () => {
+    // RTK Query freezes its cached responses, so the virtual-card merge must
+    // not mutate the returned dashcards in place (metabase public/embed/x-ray
+    // dashboards otherwise fail to load).
+    const token = "header.payload.signature";
+    const dashboard = createMockDashboard({
+      id: token as unknown as number,
+      dashcards: [
+        createMockVirtualDashCard({
+          id: 1,
+          visualization_settings: {
+            virtual_card: createMockVirtualCard({ display: "heading" }),
+            text: "A heading",
+          },
+        }),
+      ],
+    });
+
+    fetchMock.get(`path:/api/embed/dashboard/${token}`, dashboard);
+
+    const store = setup();
+
+    const result = await store.dispatch(
+      fetchDashboard({
+        dashId: token as unknown as DashboardId,
+        queryParams: {},
+        options: {},
+      }),
+    );
+
+    expect(result.type).toBe("metabase/dashboard/FETCH_DASHBOARD/fulfilled");
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/ActionVizForm.tsx
@@ -7,11 +7,10 @@ import ActionParametersInputForm, {
 } from "metabase/actions/containers/ActionParametersInputForm";
 import { useActionInitialValues } from "metabase/actions/hooks/use-action-initial-values";
 import { getFormTitle, isImplicitUpdateAction } from "metabase/actions/utils";
-import { actionApi } from "metabase/api";
+import { actionApi, publicApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { Modal } from "metabase/common/components/Modal";
 import { useDispatch } from "metabase/redux";
-import { PublicApi } from "metabase/services";
 import { getDashboardType } from "metabase/utils/dashboard";
 import type {
   ActionDashboardCard,
@@ -97,11 +96,15 @@ function ActionVizForm({
     }
 
     if (getDashboardType(dashboard.id) === "public") {
-      return PublicApi.prefetchDashcardValues({
-        dashboardId: dashboard.id,
-        dashcardId: dashcard.id,
-        parameters: JSON.stringify(dashcardParamValues),
-      });
+      return runRtkEndpoint(
+        {
+          dashboardId: dashboard.id,
+          dashcardId: dashcard.id,
+          parameters: JSON.stringify(dashcardParamValues),
+        },
+        dispatch,
+        publicApi.endpoints.prefetchPublicDashcardValues,
+      );
     }
 
     return runRtkEndpoint(

--- a/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
+++ b/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
+import { skipToken, useListUserAttributesQuery } from "metabase/api";
 import { getDashcardData, getParameters } from "metabase/dashboard/selectors";
 import {
   getTargetsForDashboard,
@@ -8,7 +9,6 @@ import {
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
-import { GTAPApi } from "metabase/services";
 import { isQuestionDashCard } from "metabase/utils/dashboard";
 import MetabaseSettings from "metabase/utils/settings";
 import Question from "metabase-lib/v1/Question";
@@ -108,26 +108,9 @@ export function useLoadQuestionMetadata(question: Question | null | undefined) {
 }
 
 export function useUserAttributes(): string[] {
-  const [userAttributes, setUserAttributes] = useState<string[]>([]);
+  const { data: userAttributes } = useListUserAttributesQuery(
+    MetabaseSettings.sandboxingEnabled() ? undefined : skipToken,
+  );
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const loadUserAttributes = async () => {
-      if (MetabaseSettings.sandboxingEnabled()) {
-        const attributes = await GTAPApi.attributes();
-        if (isMounted) {
-          setUserAttributes(attributes);
-        }
-      }
-    };
-
-    loadUserAttributes();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return userAttributes;
+  return userAttributes ?? [];
 }

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/DashboardSubscriptionsSidebar.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import _ from "underscore";
 
-import { skipToken, useListSubscriptionsQuery } from "metabase/api";
+import { skipToken, useListSubscriptionsQuery, userApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { useSetArchive } from "metabase/archive/hooks";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import type { ScheduleChangeProp } from "metabase/common/components/SchedulePicker";
@@ -19,10 +20,9 @@ import {
   getPulseFormInput,
 } from "metabase/notifications/pulse/selectors";
 import { NEW_PULSE_TEMPLATE, cleanPulse, createChannel } from "metabase/pulse";
-import { connect } from "metabase/redux";
+import { connect, useDispatch } from "metabase/redux";
 import type { DraftDashboardSubscription, State } from "metabase/redux/store";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { UserApi } from "metabase/services";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Channel,
@@ -177,6 +177,7 @@ function DashboardSubscriptionsSidebarInner({
   onCancel,
   loading: isSubscriptionListLoading,
 }: DashboardSubscriptionsSidebarInnerProps) {
+  const dispatch = useDispatch();
   const archive = useSetArchive();
   const [editingMode, setEditingMode] = useState<EditingMode>(
     EDITING_MODES.LIST_PULSES_OR_NEW_PULSE,
@@ -224,7 +225,12 @@ function DashboardSubscriptionsSidebarInner({
         // We don't need the the list of users in modular embedding/SDK context because we will hard code the recipient to the logged in user.
         setUsers([]);
       } else {
-        setUsers((await UserApi.list()).data);
+        const { data } = await runRtkEndpoint(
+          undefined,
+          dispatch,
+          userApi.endpoints.listUserRecipients,
+        );
+        setUsers(data);
       }
     }
     fetchUsers();

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-update-all-tenant-users-group-permissions.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-update-all-tenant-users-group-permissions.ts
@@ -1,11 +1,16 @@
 import { useCallback, useMemo } from "react";
 
-import { Api, databaseApi, useListPermissionsGroupsQuery } from "metabase/api";
+import {
+  Api,
+  databaseApi,
+  permissionApi,
+  useListPermissionsGroupsQuery,
+} from "metabase/api";
 import { tableApi } from "metabase/api/table";
 import { listTag } from "metabase/api/tags";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { useDispatch } from "metabase/redux";
-import { PermissionsApi } from "metabase/services";
 import type { DatabaseId, TableId } from "metabase-types/api";
 
 import {
@@ -99,9 +104,11 @@ export function useUpdateAllTenantUsersGroupPermissions(): UseUpdateAllTenantUse
         .catch(() => [] as DatabaseId[]);
 
       // get the revision number of the graph
-      const graph = await PermissionsApi.graphForGroup({
-        groupId: allTenantUsersGroupId,
-      });
+      const graph = await runRtkEndpoint(
+        allTenantUsersGroupId,
+        dispatch,
+        permissionApi.endpoints.getGroupPermissionsGraph,
+      );
 
       const groups = buildPermissionsGraph(
         allTenantUsersGroupId,
@@ -120,12 +127,16 @@ export function useUpdateAllTenantUsersGroupPermissions(): UseUpdateAllTenantUse
         attribute: "database_role",
       }));
 
-      await PermissionsApi.updateGraph({
-        groups,
-        revision: graph?.revision,
-        ...(sandboxes.length > 0 && { sandboxes }),
-        ...(impersonations.length > 0 && { impersonations }),
-      });
+      await runRtkEndpoint(
+        {
+          groups,
+          revision: graph?.revision,
+          ...(sandboxes.length > 0 && { sandboxes }),
+          ...(impersonations.length > 0 && { impersonations }),
+        },
+        dispatch,
+        permissionApi.endpoints.updatePermissionsGraph,
+      );
 
       // invalidate the onboarding checklist and group table access policies
       // so subsequent updates can find the newly created sandbox IDs

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -244,8 +244,7 @@ export const rewriteEmbedPreviewUrl = async ({
 /**
  * Registers the embed-preview rewrite on the shared client. It runs after the
  * embed override handlers, so it covers both the override-produced
- * `/api/embed/...` urls and the embed endpoints called directly (e.g.
- * `EmbedApi`, `embedApi`).
+ * `/api/embed/...` urls and the embed endpoints called directly.
  *
  * Idempotent, so call sites can register it at the earliest safe moment without
  * worrying about duplicates. For public/static embeds it must run *before* the

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpUserAndSettingsFetch.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpUserAndSettingsFetch.ts
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
+import { userApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { userUpdated } from "metabase/redux/user";
-import { UserApi } from "metabase/services";
 
 import {
   type McpAppsUserAndSettingsFetchErrorType,
@@ -56,7 +57,11 @@ export function useMcpUserAndSettingsFetch({
         }
 
         const [currentUser] = await Promise.all([
-          UserApi.current(),
+          runRtkEndpoint(
+            undefined,
+            store.dispatch,
+            userApi.endpoints.getCurrentUser,
+          ),
           store.dispatch(refreshSiteSettings()),
         ]);
 

--- a/frontend/src/metabase/parameters/actions.ts
+++ b/frontend/src/metabase/parameters/actions.ts
@@ -1,11 +1,11 @@
-import { cardApi, dashboardApi } from "metabase/api";
+import { cardApi, dashboardApi, parametersApi } from "metabase/api";
 import type {
   CardParameterValuesRequest,
   SearchCardParameterValuesRequest,
 } from "metabase/api/card";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import type { DispatchFn } from "metabase/redux";
 import type { GetState } from "metabase/redux/store";
-import { ParameterApi } from "metabase/services";
 import { stableStringify } from "metabase/utils/objects";
 import { getNonVirtualFields } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import { normalizeParameter } from "metabase-lib/v1/parameters/utils/parameter-values";
@@ -130,10 +130,17 @@ interface ParameterValuesRequest {
   query?: string;
 }
 
-const loadParameterValues = async (request: ParameterValuesRequest) => {
-  const { values, has_more_values } = request.query
-    ? await ParameterApi.parameterSearch(request)
-    : await ParameterApi.parameterValues(request);
+const loadParameterValues = async (
+  request: ParameterValuesRequest,
+  dispatch: DispatchFn,
+) => {
+  const { values, has_more_values } = await runRtkEndpoint(
+    request,
+    dispatch,
+    request.query
+      ? parametersApi.endpoints.searchParameterValues
+      : parametersApi.endpoints.getParameterValues,
+  );
 
   return {
     values: values,

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -2,9 +2,11 @@ import { useCallback, useState } from "react";
 
 import ActionForm from "metabase/actions/components/ActionForm";
 import { getSuccessMessage } from "metabase/actions/utils";
+import { publicApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { usePageTitle } from "metabase/hooks/use-page-title";
+import { useDispatch } from "metabase/redux";
 import type { AppErrorDescriptor } from "metabase/redux/store";
-import { PublicApi } from "metabase/services";
 import type {
   ParametersForActionExecution,
   WritebackAction,
@@ -23,6 +25,7 @@ interface Props {
 }
 
 function PublicAction({ action, publicId, onError }: Props) {
+  const dispatch = useDispatch();
   const [isSubmitted, setSubmitted] = useState(false);
   const successMessage = getSuccessMessage(action);
 
@@ -31,13 +34,17 @@ function PublicAction({ action, publicId, onError }: Props) {
   const handleSubmit = useCallback(
     async (parameters: ParametersForActionExecution) => {
       try {
-        await PublicApi.executeAction({ uuid: publicId, parameters });
+        await runRtkEndpoint(
+          { uuid: publicId, parameters },
+          dispatch,
+          publicApi.endpoints.executePublicAction,
+        );
         setSubmitted(true);
       } catch (error) {
         onError(error as AppErrorDescriptor);
       }
     },
-    [publicId, onError],
+    [publicId, onError, dispatch],
   );
 
   if (isSubmitted) {

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect } from "react";
 import { useAsyncFn, useMount } from "react-use";
 
+import { publicApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { SyncedEmbedFrame } from "metabase/public/components/EmbedFrame";
-import { connect } from "metabase/redux";
+import { connect, useDispatch } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
-import { PublicApi } from "metabase/services";
 
 import PublicAction from "./PublicAction";
 import {
@@ -27,9 +28,15 @@ const mapDispatchToProps = {
 };
 
 function PublicActionLoader({ params, setErrorPage }: Props) {
+  const dispatch = useDispatch();
   const [{ value: action, error }, fetchAction] = useAsyncFn(
-    () => PublicApi.action({ uuid: params.uuid }),
-    [params.uuid],
+    () =>
+      runRtkEndpoint(
+        { uuid: params.uuid },
+        dispatch,
+        publicApi.endpoints.getPublicAction,
+      ),
+    [params.uuid, dispatch],
   );
 
   useMount(() => {

--- a/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
+++ b/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
@@ -6,6 +6,8 @@ import type { Location } from "history";
 import { useEffect, useMemo } from "react";
 import { useAsync, useMount } from "react-use";
 
+import { publicApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { ExternalCardDataProvider } from "metabase/documents/contexts/ExternalCardDataContext";
@@ -23,7 +25,6 @@ import { SmartLink } from "metabase/rich_text_editing/tiptap/extensions/SmartLin
 import { SupportingText } from "metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
 import { DROP_ZONE_COLOR } from "metabase/rich_text_editing/tiptap/extensions/shared/constants";
 import { getSetting } from "metabase/selectors/settings";
-import { PublicApi } from "metabase/services";
 import { Box } from "metabase/ui";
 import { initializeIframeResizer } from "metabase/utils/dom";
 import type { Document } from "metabase-types/api";
@@ -52,9 +53,13 @@ export const PublicDocument = ({ location, params }: PublicDocumentProps) => {
     loading,
     error,
   } = useAsync(async () => {
-    const doc = await PublicApi.document({ uuid });
+    const doc = await runRtkEndpoint(
+      { uuid },
+      dispatch,
+      publicApi.endpoints.getPublicDocument,
+    );
     return doc as Document;
-  }, [uuid]);
+  }, [uuid, dispatch]);
 
   useEffect(() => {
     if (error) {

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useLatest, useMount } from "react-use";
 
 import { embedApi, makePivotAwareQueryRunner, publicApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { applyParameters } from "metabase/common/utils/card";
 import { fetchDataOrError } from "metabase/dashboard/utils";
 import { LocaleProvider } from "metabase/embedding/LocaleProvider";
@@ -17,7 +18,7 @@ import { updateMetadata } from "metabase/redux/metadata";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
-import { EmbedApi, PublicApi } from "metabase/services";
+import { PublicApi } from "metabase/services";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import { getParameterValuesBySlug } from "metabase-lib/v1/parameters/utils/parameter-values";
 import { getParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
@@ -64,7 +65,11 @@ export const PublicOrEmbeddedQuestion = ({
     try {
       let card;
       if (token) {
-        card = await EmbedApi.card({ token });
+        card = await runRtkEndpoint(
+          { token },
+          dispatch,
+          embedApi.endpoints.getEmbedCard,
+        );
       } else if (uuid) {
         card = await PublicApi.card({ uuid });
       } else {

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -18,7 +18,6 @@ import { updateMetadata } from "metabase/redux/metadata";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
-import { PublicApi } from "metabase/services";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import { getParameterValuesBySlug } from "metabase-lib/v1/parameters/utils/parameter-values";
 import { getParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
@@ -71,7 +70,11 @@ export const PublicOrEmbeddedQuestion = ({
           embedApi.endpoints.getEmbedCard,
         );
       } else if (uuid) {
-        card = await PublicApi.card({ uuid });
+        card = await runRtkEndpoint(
+          { uuid },
+          dispatch,
+          publicApi.endpoints.getPublicCard,
+        );
       } else {
         throw { status: 404 };
       }

--- a/frontend/src/metabase/query_builder/actions/modal.ts
+++ b/frontend/src/metabase/query_builder/actions/modal.ts
@@ -1,12 +1,17 @@
+import { userApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { createThunkAction } from "metabase/redux";
-import { UserApi } from "metabase/services";
 import { checkNotNull } from "metabase/utils/types";
 
 export const CLOSE_QB_NEWB_MODAL = "metabase/qb/CLOSE_QB_NEWB_MODAL";
 export const closeQbNewbModal = createThunkAction(CLOSE_QB_NEWB_MODAL, () => {
-  return async (_dispatch, getState) => {
+  return async (dispatch, getState) => {
     // persist the fact that this user has seen the NewbModal
     const { currentUser } = getState();
-    await UserApi.update_qbnewb({ id: checkNotNull(currentUser).id });
+    await runRtkEndpoint(
+      checkNotNull(currentUser).id,
+      dispatch,
+      userApi.endpoints.updateUserModalQbnewb,
+    );
   };
 });

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -7,6 +7,7 @@ import {
   databaseApi,
   datasetApi,
   fieldApi,
+  revisionApi,
   segmentApi,
   tableApi,
 } from "metabase/api";
@@ -15,7 +16,6 @@ import { isProduction } from "metabase/env";
 import { createThunkAction } from "metabase/redux";
 import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
 import { DatabaseSchema, FieldSchema, TableSchema } from "metabase/schema";
-import { RevisionsApi } from "metabase/services";
 import { hasRemappedParameterValues } from "metabase-lib/v1/parameters/utils/parameter-source";
 import { normalizeParameter } from "metabase-lib/v1/parameters/utils/parameter-values";
 
@@ -148,11 +148,12 @@ export const updateFieldDimension =
 
 export const FETCH_REVISIONS = "metabase/metadata/FETCH_REVISIONS";
 export const fetchRevisions = createThunkAction(FETCH_REVISIONS, (type, id) => {
-  return async () => {
-    const revisions = await RevisionsApi.get({
-      id,
-      entity: type === "metric" ? "legacy-metric" : type,
-    });
+  return async (dispatch) => {
+    const revisions = await runRtkEndpoint(
+      { id, entity: type === "metric" ? "legacy-metric" : type },
+      dispatch,
+      revisionApi.endpoints.listRevisions,
+    );
     return { type, id, revisions };
   };
 });

--- a/frontend/src/metabase/redux/query-builder.ts
+++ b/frontend/src/metabase/redux/query-builder.ts
@@ -1,7 +1,8 @@
 import { createAction } from "redux-actions";
 
+import { userApi } from "metabase/api";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { createThunkAction } from "metabase/redux";
-import { UserApi } from "metabase/services";
 import { checkNotNull } from "metabase/utils/types";
 import type { ParameterId, ParameterValueOrArray } from "metabase-types/api";
 
@@ -144,8 +145,12 @@ export const RESET_ROW_ZOOM = "metabase/qb/RESET_ROW_ZOOM";
 
 export const CLOSE_QB_NEWB_MODAL = "metabase/qb/CLOSE_QB_NEWB_MODAL";
 export const closeQbNewbModal = createThunkAction(CLOSE_QB_NEWB_MODAL, () => {
-  return async (_dispatch, getState) => {
+  return async (dispatch, getState) => {
     const { currentUser } = getState();
-    await UserApi.update_qbnewb({ id: checkNotNull(currentUser).id });
+    await runRtkEndpoint(
+      checkNotNull(currentUser).id,
+      dispatch,
+      userApi.endpoints.updateUserModalQbnewb,
+    );
   };
 });

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -1,20 +1,20 @@
 import { createAction, createReducer } from "@reduxjs/toolkit";
 
+import { userApi } from "metabase/api";
 import { updateDashboard } from "metabase/api/dashboard";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { CLOSE_QB_NEWB_MODAL } from "metabase/redux/query-builder";
 import { createAsyncThunk } from "metabase/redux/utils";
-import { UserApi } from "metabase/services";
 import type { User } from "metabase-types/api";
 
 export const refreshCurrentUser = createAsyncThunk(
   "metabase/user/REFRESH_CURRENT_USER",
-  async (_, { fulfillWithValue }) => {
-    try {
-      return UserApi.current();
-    } catch (e) {
-      return fulfillWithValue(null);
-    }
-  },
+  // Let a failed request reject the thunk rather than fulfilling it with
+  // `null`. A fulfilled `null` (e.g. from the 401 the bootstrap fetch gets on
+  // the login page) makes the admin `paths` reducer permanently drop every
+  // admin path, which it never restores once a real superuser logs in.
+  (_, { dispatch }) =>
+    runRtkEndpoint(undefined, dispatch, userApi.endpoints.getCurrentUser),
 );
 
 export const loadCurrentUser = createAsyncThunk(
@@ -49,6 +49,17 @@ export const currentUser = createReducer<User | null>(null, (builder) => {
       }
       return state;
     })
+    .addMatcher(
+      userApi.endpoints.updateUser.matchFulfilled,
+      (state, { payload: user }) => {
+        // keep current user state in sync when the user updates themselves
+        const isCurrentUserUpdated = user && state?.id === user.id;
+        if (isCurrentUserUpdated) {
+          return { ...state, ...user };
+        }
+        return state;
+      },
+    )
     .addMatcher(updateDashboard.matchFulfilled, (state, { payload }) => {
       if (
         state != null &&

--- a/frontend/src/metabase/search/components/UserNameDisplay/UserNameDisplay.tsx
+++ b/frontend/src/metabase/search/components/UserNameDisplay/UserNameDisplay.tsx
@@ -1,9 +1,8 @@
-import { useAsync } from "react-use";
 import { t } from "ttag";
 
-import { UserApi } from "metabase/services";
+import { useListUserRecipientsQuery } from "metabase/api";
 import { Text } from "metabase/ui";
-import type { UserId, UserListResult } from "metabase-types/api";
+import type { UserId } from "metabase-types/api";
 
 export type UserNameDisplayProps = {
   userIdList: UserId[];
@@ -14,10 +13,8 @@ export const UserNameDisplay = ({
   userIdList,
   label,
 }: UserNameDisplayProps) => {
-  const { loading: isLoading, value } = useAsync<
-    () => Promise<{ data: UserListResult[] }>
-  >(UserApi.list);
-  const users = value?.data ?? [];
+  const { isLoading, data } = useListUserRecipientsQuery();
+  const users = data?.data ?? [];
 
   const selectedUserList = users.filter((user) => userIdList.includes(user.id));
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -7,12 +7,6 @@ export const GTAPApi = {
   validate: POST("/api/mt/gtap/validate"),
 };
 
-export const CollectionsApi = {
-  get: GET("/api/collection/:id"),
-  graph: GET("/api/collection/graph"),
-  updateGraph: PUT("/api/collection/graph?skip-graph=true"),
-};
-
 export const PublicApi = {
   action: GET(`/api/public/action/:uuid`),
   executeDashcardAction: POST(

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -78,10 +78,3 @@ export const SettingsApi = {
   put: PUT("/api/setting/:key"),
   putAll: PUT("/api/setting"),
 };
-
-export const PermissionsApi = {
-  graph: GET("/api/permissions/graph"),
-  graphForGroup: GET("/api/permissions/graph/group/:groupId"),
-  graphForDB: GET("/api/permissions/graph/db/:databaseId"),
-  updateGraph: PUT("/api/permissions/graph"),
-};

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -21,12 +21,6 @@ export const EmbedApi = {
   dashboard: GET("/api/embed/dashboard/:token"),
 };
 
-// also unauthenticated
-export const NotificationUnsubscribeApi = {
-  unsubscribe: POST("/api/notification/unsubscribe"),
-  undo_unsubscribe: POST("/api/notification/unsubscribe/undo"),
-};
-
 export const SessionApi = {
   create: POST("/api/session"),
   createWithGoogleAuth: POST("/api/session/google_auth"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -14,13 +14,6 @@ export const PublicApi = {
   document: GET(`/api/public/document/:uuid`),
 };
 
-// `/api/embed` is rewritten to `/api/preview_embed` by the request middleware
-// when running inside an embed preview.
-export const EmbedApi = {
-  card: GET("/api/embed/card/:token"),
-  dashboard: GET("/api/embed/dashboard/:token"),
-};
-
 export const SessionApi = {
   create: POST("/api/session"),
   createWithGoogleAuth: POST("/api/session/google_auth"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -21,12 +21,6 @@ export const EmbedApi = {
   dashboard: GET("/api/embed/dashboard/:token"),
 };
 
-/// this in unauthenticated, for letting people who are not logged in unsubscribe from Alerts/DashboardSubscriptions
-export const PulseUnsubscribeApi = {
-  unsubscribe: POST("/api/pulse/unsubscribe"),
-  undo_unsubscribe: POST("/api/pulse/unsubscribe/undo"),
-};
-
 // also unauthenticated
 export const NotificationUnsubscribeApi = {
   unsubscribe: POST("/api/notification/unsubscribe"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -7,10 +7,6 @@ export const GTAPApi = {
   validate: POST("/api/mt/gtap/validate"),
 };
 
-export const StoreApi = {
-  tokenStatus: GET("/api/premium-features/token/status"),
-};
-
 export const CollectionsApi = {
   get: GET("/api/collection/:id"),
   graph: GET("/api/collection/graph"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -95,9 +95,3 @@ export const PersistedModelsApi = {
 export const SetupApi = {
   create: POST("/api/setup"),
 };
-
-export const UserApi = {
-  list: GET("/api/user/recipients"),
-  current: GET("/api/user/current"),
-  update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
-};

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -91,7 +91,3 @@ export const PersistedModelsApi = {
   disablePersistence: POST("/api/persist/disable"),
   setRefreshSchedule: POST("/api/persist/set-refresh-schedule"),
 };
-
-export const SetupApi = {
-  create: POST("/api/setup"),
-};

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -34,11 +34,6 @@ export const EmbedApi = {
   dashboard: GET("/api/embed/dashboard/:token"),
 };
 
-export const ModerationReviewApi = {
-  create: POST("/api/moderation-review"),
-  update: PUT("/api/moderation-review/:id"),
-};
-
 /// this in unauthenticated, for letting people who are not logged in unsubscribe from Alerts/DashboardSubscriptions
 export const PulseUnsubscribeApi = {
   unsubscribe: POST("/api/pulse/unsubscribe"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -1,19 +1,5 @@
 import { DELETE, GET, POST, PUT } from "metabase/api/legacy-client";
 
-export const PublicApi = {
-  action: GET(`/api/public/action/:uuid`),
-  executeDashcardAction: POST(
-    `/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute`,
-  ),
-  executeAction: POST(`/api/public/action/:uuid/execute`),
-  card: GET(`/api/public/card/:uuid`),
-  dashboard: GET(`/api/public/dashboard/:uuid`),
-  prefetchDashcardValues: GET(
-    `/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute`,
-  ),
-  document: GET(`/api/public/document/:uuid`),
-};
-
 export const SessionApi = {
   create: POST("/api/session"),
   createWithGoogleAuth: POST("/api/session/google_auth"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -85,9 +85,3 @@ export const PermissionsApi = {
   graphForDB: GET("/api/permissions/graph/db/:databaseId"),
   updateGraph: PUT("/api/permissions/graph"),
 };
-
-export const PersistedModelsApi = {
-  enablePersistence: POST("/api/persist/enable"),
-  disablePersistence: POST("/api/persist/disable"),
-  setRefreshSchedule: POST("/api/persist/set-refresh-schedule"),
-};

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -51,10 +51,6 @@ export const NotificationUnsubscribeApi = {
   undo_unsubscribe: POST("/api/notification/unsubscribe/undo"),
 };
 
-export const RevisionsApi = {
-  get: GET("/api/revision/:entity/:id"),
-};
-
 export const SessionApi = {
   create: POST("/api/session"),
   createWithGoogleAuth: POST("/api/session/google_auth"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -38,11 +38,6 @@ export const EmbedApi = {
   dashboard: GET("/api/embed/dashboard/:token"),
 };
 
-export const ParameterApi = {
-  parameterValues: POST("/api/dataset/parameter/values"),
-  parameterSearch: POST("/api/dataset/parameter/search/:query"),
-};
-
 export const ModerationReviewApi = {
   create: POST("/api/moderation-review"),
   update: PUT("/api/moderation-review/:id"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -1,12 +1,5 @@
 import { DELETE, GET, POST, PUT } from "metabase/api/legacy-client";
 
-// only available with token loaded
-export const GTAPApi = {
-  list: GET("/api/mt/gtap"),
-  attributes: GET("/api/mt/user/attributes"),
-  validate: POST("/api/mt/gtap/validate"),
-};
-
 export const PublicApi = {
   action: GET(`/api/public/action/:uuid`),
   executeDashcardAction: POST(

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -101,7 +101,3 @@ export const UserApi = {
   current: GET("/api/user/current"),
   update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
 };
-
-export const FrontendErrorsApi = {
-  report: POST("/api/frontend-errors"),
-};

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -1,8 +1,9 @@
 import { createAction } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
-import { userApi } from "metabase/api";
+import { setupApi, userApi } from "metabase/api";
 import { loadLocalization } from "metabase/api/localization";
+import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { createDatabase } from "metabase/redux/databases";
 import {
   initializeSettings,
@@ -18,7 +19,6 @@ import type {
 } from "metabase/redux/store";
 import { createAsyncThunk } from "metabase/redux/utils";
 import { getSetting } from "metabase/selectors/settings";
-import { SetupApi } from "metabase/services";
 import MetabaseSettings from "metabase/utils/settings";
 import type { DatabaseData, Settings, UsageReason } from "metabase-types/api";
 
@@ -95,14 +95,18 @@ export const submitUser = createAsyncThunk<void, UserInfo, ThunkConfig>(
     const locale = getLocale(getState());
 
     try {
-      await SetupApi.create({
-        token,
-        user,
-        prefs: {
-          site_name: user.site_name,
-          site_locale: locale?.code,
+      await runRtkEndpoint(
+        {
+          token,
+          user,
+          prefs: {
+            site_name: user.site_name,
+            site_locale: locale?.code,
+          },
         },
-      });
+        dispatch,
+        setupApi.endpoints.createSetup,
+      );
     } catch (error) {
       return rejectWithValue(error);
     }

--- a/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
@@ -29,7 +29,9 @@ export function ChartRenderingErrorBoundary(
   return (
     <ChartRenderingErrorBoundaryInner
       {...props}
-      onReportError={() => void reportFrontendError({ type: "chart-render-error" })}
+      onReportError={() =>
+        void reportFrontendError({ type: "chart-render-error" })
+      }
     />
   );
 }

--- a/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
@@ -1,23 +1,35 @@
 import { Component } from "react";
 
-import { FrontendErrorsApi } from "metabase/services";
+import { useReportFrontendErrorMutation } from "metabase/api";
 
 interface ChartRenderingErrorBoundaryProps {
   onRenderError: (errorMessage: string) => void;
   children: React.ReactNode;
 }
 
-export class ChartRenderingErrorBoundary extends Component<ChartRenderingErrorBoundaryProps> {
-  constructor(props: ChartRenderingErrorBoundaryProps) {
-    super(props);
-  }
+interface ChartRenderingErrorBoundaryInnerProps extends ChartRenderingErrorBoundaryProps {
+  onReportError: () => void;
+}
 
+class ChartRenderingErrorBoundaryInner extends Component<ChartRenderingErrorBoundaryInnerProps> {
   componentDidCatch(error: any) {
-    FrontendErrorsApi.report({ type: "chart-render-error" }).catch(() => {});
+    this.props.onReportError();
     this.props.onRenderError(error.message || error);
   }
 
   render() {
     return this.props.children;
   }
+}
+
+export function ChartRenderingErrorBoundary(
+  props: ChartRenderingErrorBoundaryProps,
+) {
+  const [reportFrontendError] = useReportFrontendErrorMutation();
+  return (
+    <ChartRenderingErrorBoundaryInner
+      {...props}
+      onReportError={() => reportFrontendError({ type: "chart-render-error" })}
+    />
+  );
 }

--- a/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
@@ -29,7 +29,7 @@ export function ChartRenderingErrorBoundary(
   return (
     <ChartRenderingErrorBoundaryInner
       {...props}
-      onReportError={() => reportFrontendError({ type: "chart-render-error" })}
+      onReportError={() => void reportFrontendError({ type: "chart-render-error" })}
     />
   );
 }


### PR DESCRIPTION
Removes all the straightforward Api's from `metabase/services` and implements them in RTK query hooks instead.

Updates the caller code to use the new implementations.

Api's that have been removed from `services.js`:
- `CollectionsApi`
- `EmbedApi`
- `FrontendErrorsApi`
- `GTAPApi`
- `ModerationReviewApi`
- `NotificationUnsubscribeApi`
- `ParameterApi`
- `PermissionsApi`
- `PersistedModelsApi`
- `PublicApi`
- `PulseUnsubscribeApi`
- `RevisionsApi`
- `SetupApi`
- `StoreApi`
- `UserApi`

Deferred removals (this are a bit trickier so I'll follow up with separate PR's):
- `SessionApi`
- `SettingsApi`