### PR TITLE
Fix "Showing x rows" indicator disappearing after running selected SQ…

### DIFF
--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -166,7 +166,14 @@ export const runQuestionQuery = ({
       ignoreCache: ignoreCache,
       isDirty: isQueryDirty,
     })
-      .then((queryResults) => dispatch(queryCompleted(question, queryResults)))
+      .then((queryResults) => {
+        const lastRunCardQuestion = overrideWithQuestion
+          ? getQuestion(getState())
+          : null;
+        dispatch(
+          queryCompleted(question, queryResults, lastRunCardQuestion),
+        );
+      })
       .catch((error) => dispatch(queryErrored(startTime, error)));
 
     dispatch({ type: RUN_QUERY_TYPE, payload: { cancelQueryController } });
@@ -196,7 +203,11 @@ const loadStartUIControls = createThunkAction(
   },
 );
 
-export const queryCompleted = (question: Question, queryResults: Dataset[]) => {
+export const queryCompleted = (
+  question: Question,
+  queryResults: Dataset[],
+  lastRunCardQuestion?: Question | null,
+) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const [{ data, error }] = queryResults;
     const prevCard = getCard(getState());
@@ -234,11 +245,13 @@ export const queryCompleted = (question: Question, queryResults: Dataset[]) => {
     }
 
     const card = question.card();
+    const lastRunCard = lastRunCardQuestion?.card() ?? card;
 
     dispatch({
       type: QUERY_COMPLETED_TYPE,
       payload: {
         card,
+        lastRunCard,
         queryResults,
       },
     });

--- a/frontend/src/metabase/query_builder/reducers.ts
+++ b/frontend/src/metabase/query_builder/reducers.ts
@@ -443,9 +443,12 @@ export const tableForeignKeyReferences = createReducer<Record<
 export const lastRunCard = createReducer<Card | null>(null, (builder) => {
   builder
     .addCase(RESET_QB, () => null)
-    .addCase<string, { type: string; payload: { card: Card } }>(
+    .addCase<
+      string,
+      { type: string; payload: { card: Card; lastRunCard?: Card } }
+    >(
       QUERY_COMPLETED,
-      (_state, action) => action.payload.card,
+      (_state, action) => action.payload.lastRunCard ?? action.payload.card,
     )
     .addCase(QUERY_ERRORED, () => null);
 });

--- a/frontend/src/metabase/query_builder/reducers.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/reducers.unit.spec.ts
@@ -1,0 +1,60 @@
+import {
+  QUERY_COMPLETED,
+  QUERY_ERRORED,
+  RESET_QB,
+} from "metabase/redux/query-builder";
+import { createMockCard } from "metabase-types/api/mocks";
+
+import { lastRunCard } from "./reducers";
+
+describe("lastRunCard reducer", () => {
+  it("starts as null", () => {
+    const state = lastRunCard(undefined, { type: "__INIT__" });
+    expect(state).toBeNull();
+  });
+
+  it("stores lastRunCard on QUERY_COMPLETED when lastRunCard is provided", () => {
+    const card = createMockCard({ id: 1, name: "Original" });
+    const vizCard = createMockCard({ id: 2, name: "Override" });
+
+    const state = lastRunCard(null, {
+      type: QUERY_COMPLETED,
+      payload: { card: vizCard, lastRunCard: card, queryResults: [] },
+    });
+
+    expect(state).toEqual(card);
+    expect(state?.id).toBe(1);
+    expect(state?.name).toBe("Original");
+  });
+
+  it("falls back to card when lastRunCard is not provided (backward compatibility)", () => {
+    const card = createMockCard({ id: 3, name: "Legacy" });
+
+    const state = lastRunCard(null, {
+      type: QUERY_COMPLETED,
+      payload: { card, queryResults: [] },
+    });
+
+    expect(state).toEqual(card);
+    expect(state?.id).toBe(3);
+  });
+
+  it("resets to null on RESET_QB", () => {
+    const card = createMockCard({ id: 5 });
+
+    const state = lastRunCard(card, { type: RESET_QB });
+
+    expect(state).toBeNull();
+  });
+
+  it("resets to null on QUERY_ERRORED", () => {
+    const card = createMockCard({ id: 5 });
+
+    const state = lastRunCard(card, {
+      type: QUERY_ERRORED,
+      payload: null,
+    });
+
+    expect(state).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #75869

### Description

When a user selects a portion of a multi-statement native SQL query and executes it, the "Showing x rows" row count indicator disappears from the results footer.

**Root cause:** selecting a query text range creates an override question. runQuestionQuery passes this override question to queryCompleted, which stores its card as lastRunCard. The dirtiness comparison in `getIsResultDirty` then compares this override (single-statement) card against the full multi-query datasetQuery — a mismatch that produces isResultDirty = true, hiding the row count.

**Fix:** `queryCompleted` now accepts an optional `lastRunCardQuestion` parameter. When provided, the original question's card is stored as `lastRunCard` instead of the override card. The reducer falls back to action.payload.card when `lastRunCard` is absent, preserving backward compatibility with all existing callers.

### How to verify

1. Open a native SQL question with two or more statements separated by ; (e.g., SELECT * FROM orders; SELECT * FROM products)
2. Select only the first statement with the cursor
3. Press Cmd+Enter (or click Run)
4. Before fix: the "Showing first 2000 rows" footer indicator disappears after execution
5. After fix: the indicator correctly shows "Showing first 2000 rows"

### Checklist
- The reducer test directly validates the core logic (`lastRunCard ?? card` fallback)
- The existing QuestionRowCount.unit.spec.ts integration test already covers the end-to-end behavior


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/75872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

