### PR TITLE
Use desired column alias when merging model metadata

### DIFF
--- a/e2e/test/scenarios/models/reproductions-2.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions-2.cy.spec.ts
@@ -555,7 +555,7 @@ describe("Issue 30712", () => {
   });
 });
 
-describe("issue 60930", { tags: "@skip" }, () => {
+describe("issue 60930", () => {
   const modelDetails: StructuredQuestionDetails = {
     name: "Model",
     type: "model",

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -86,16 +86,22 @@
 
   Ensure that saved metadata from datasets or source queries can remain in the results metadata. We always recompute
   metadata in general, so need to blend the saved metadata on top of the computed metadata. First argument should be
-  the metadata from a run from the query, and `pre-existing` should be the metadata from the database we wish to
+  the metadata from a run from the query, and `old-metadata` should be the metadata from the database we wish to
   ensure survives."
   {:deprecated "0.57.0"}
-  [fresh pre-existing]
+  [new-metadata old-metadata]
   #_{:clj-kondo/ignore [:deprecated-var]}
-  (let [by-name (m/index-by :name pre-existing)]
-    (for [col fresh]
-      (if-let [existing (get by-name (:name col))]
-        (merge col (select-keys existing preserved-keys))
-        col))))
+  (let [old-cols-by-desired-col-alias (m/index-by :lib/desired-column-alias (filter :lib/desired-column-alias old-metadata))
+        old-cols-by-name (m/index-by :name old-metadata)]
+    (for [new-col new-metadata]
+      (if-let [old-col (or (get old-cols-by-desired-col-alias (:lib/desired-column-alias new-col))
+                           ;; Only match by name if a desired column alias is missing,
+                           ;; otherwise we could match different columns with the same name
+                           (let [old-col (get old-cols-by-name (:name new-col))]
+                             (when (not-every? :lib/desired-column-alias [new-col old-col])
+                               old-col)))]
+        (merge new-col (select-keys old-col preserved-keys))
+        new-col))))
 
 (def ^:dynamic *execute-async?*
   "Used to control `with-execute-async` to whether or not execute its body asynchronously."

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1220,8 +1220,7 @@
                            (lib/join (-> (lib/join-clause reviews-table
                                                           [(lib/= orders-product-id reviews-product-id)])
                                          (lib/with-join-alias "Reviews")
-                                         (lib/with-join-fields [reviews-id reviews-product-id reviews-created-at])))
-                           lib/->legacy-MBQL))
+                                         (lib/with-join-fields [reviews-id reviews-product-id reviews-created-at])))))
           with-products (mt/user-http-request :crowberto :post 200 "card"
                                               {:name                   "model 60930"
                                                :type                   :model

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1195,6 +1195,56 @@
               (is (= expected-names
                      (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))))))))
 
+(deftest updating-model-query-does-not-shift-metadata-overrides-test
+  (testing "Metadata should not shift to another column with the same name when the query changes (#60930)"
+    (let [mp                 (mt/metadata-provider)
+          orders-table       (lib.metadata/table mp (mt/id :orders))
+          products-table     (lib.metadata/table mp (mt/id :products))
+          reviews-table      (lib.metadata/table mp (mt/id :reviews))
+          orders-id          (lib.metadata/field mp (mt/id :orders :id))
+          orders-user-id     (lib.metadata/field mp (mt/id :orders :user_id))
+          orders-product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+          orders-created-at  (lib.metadata/field mp (mt/id :orders :created_at))
+          products-id        (lib.metadata/field mp (mt/id :products :id))
+          products-created   (lib.metadata/field mp (mt/id :products :created_at))
+          reviews-id         (lib.metadata/field mp (mt/id :reviews :id))
+          reviews-product-id (lib.metadata/field mp (mt/id :reviews :product_id))
+          reviews-created-at (lib.metadata/field mp (mt/id :reviews :created_at))
+          join-query (fn [products-fields]
+                       (-> (lib/query mp orders-table)
+                           (lib/with-fields [orders-id orders-user-id orders-product-id orders-created-at])
+                           (lib/join (-> (lib/join-clause products-table
+                                                          [(lib/= orders-product-id products-id)])
+                                         (lib/with-join-alias "Products")
+                                         (lib/with-join-fields products-fields)))
+                           (lib/join (-> (lib/join-clause reviews-table
+                                                          [(lib/= orders-product-id reviews-product-id)])
+                                         (lib/with-join-alias "Reviews")
+                                         (lib/with-join-fields [reviews-id reviews-product-id reviews-created-at])))
+                           lib/->legacy-MBQL))
+          with-products (mt/user-http-request :crowberto :post 200 "card"
+                                              {:name                   "model 60930"
+                                               :type                   :model
+                                               :display                :table
+                                               :dataset_query          (join-query [products-id products-created])
+                                               :visualization_settings {}})
+          card-id (:id with-products)
+          without-products (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                                                 {:dataset_query   (join-query :none)})]
+      (testing "columns get the correct display name after columns with the same name are removed"
+        (is (= ["ID" "User ID" "Product ID" "Created At"
+                "Reviews → ID" "Reviews → Product ID" "Reviews → Created At"]
+               (map :display_name (:result_metadata without-products))
+               (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))
+      (let [with-products-again (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                                                      {:dataset_query   (join-query [products-id products-created])})]
+        (testing "columns get the correct display name after columns with the same name are added"
+          (is (= ["ID" "User ID" "Product ID" "Created At"
+                  "Products → ID" "Products → Created At"
+                  "Reviews → ID" "Reviews → Product ID" "Reviews → Created At"]
+                 (map :display_name (:result_metadata with-products-again))
+                 (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))))))
+
 (deftest ^:parallel updating-native-card-preserves-metadata
   (testing "A trivial change in a native question should not remove result_metadata (#37009)"
     (let [query (to-native (updating-card-updates-metadata-query))

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -121,6 +121,7 @@
               ((get-method driver/query-result-metadata :default) :h2 query))))))
 
 (deftest ^:parallel combine-metadata-test
+  #_{:clj-kondo/ignore [:deprecated-var]}
   (are [old-metadata new-metadata expected] (= expected (qp.util/combine-metadata new-metadata old-metadata))
     ;; columns get the correct display name after columns with the same name are removed
     [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.query-processor.metadata :as qp.metadata]
+   [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]))
 
 (deftest ^:parallel mbql-query-metadata-test
@@ -118,3 +119,24 @@
                 :base_type     :type/Integer
                 :database_type "INTEGER"}]
               ((get-method driver/query-result-metadata :default) :h2 query))))))
+
+(deftest ^:parallel combine-metadata-test
+  (are [old-metadata new-metadata expected] (= expected (qp.util/combine-metadata new-metadata old-metadata))
+    ;; columns get the correct display name after columns with the same name are removed
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Products → ID", :lib/desired-column-alias "Products__id"}
+     {:name "id_3", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]
+
+    ;; columns get the correct display name after columns with the same name are added
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Products → ID", :lib/desired-column-alias "Products__id"}
+     {:name "id_3", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]
+    [{:name "id",   :display_name "ID",            :lib/desired-column-alias "id"}
+     {:name "id_2", :display_name "Products → ID", :lib/desired-column-alias "Products__id"}
+     {:name "id_3", :display_name "Reviews → ID",  :lib/desired-column-alias "Reviews__id"}]))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60930

### Description

When merging old metadata with existing metadata, we should be matching columns by `:lib/desired-column-alias` instead of `:name` to avoid collisions when adding/removing columns with the same name. 

**NB**: I believe there's a similar bug in `lib.card/merge-model-metadata`, but I'm leaving that as a separate follow up where we can fix that and also deprecate all usage of `combine-metadata`


### How to verify

See repro steps in original issue. The columns should keep the correct display names now. 

### Demo

[loom](https://www.loom.com/share/4159340ee91d43f3873a0ad251d46fff)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
