### PR TITLE
fix(test): fix flaky embedded dashboard tab view_count assertions

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -534,15 +534,6 @@ describe("scenarios > dashboard > tabs", () => {
       cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
     });
 
-    const firstQuestion = () => {
-      return cy.request("GET", `/api/card/${ORDERS_QUESTION_ID}`).its("body");
-    };
-    const secondQuestion = () => {
-      return cy
-        .request("GET", `/api/card/${ORDERS_COUNT_QUESTION_ID}`)
-        .its("body");
-    };
-
     cy.intercept(
       "GET",
       `/api/embed/dashboard/*/dashcard/*/card/${ORDERS_QUESTION_ID}*`,
@@ -562,34 +553,20 @@ describe("scenarios > dashboard > tabs", () => {
 
     // publish the embedded dashboard so that we can directly navigate to its url
     H.publishChanges("dashboard", () => {});
+
     // directly navigate to the embedded dashboard, starting on Tab 1
     H.visitIframe();
     // wait for results
     cy.findAllByTestId("dashcard").contains("37.65");
-    cy.signInAsAdmin();
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
     cy.get("@secondTabQuerySpy").should("not.have.been.called");
 
-    cy.wait("@firstTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 1 (previously) + 1 (firstQuestion) + 1 (first tab query)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(1); // 1 (previously)
-      });
-    });
+    cy.wait("@firstTabQuery");
 
     H.goToTab("Tab 2");
     cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.wait("@secondTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 3 (previously)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 1 (previously) + 1 (second tab query)
-      });
-    });
+    cy.wait("@secondTabQuery");
 
     H.goToTab("Tab 1");
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");


### PR DESCRIPTION
Fixes EMB-1826

### Description

The test "should only fetch cards on the current tab of an embedded dashboard" was flaky in stress runs.

**Root cause: view_count assertions against an async batch queue**

The test was introduced in May 2024 (#43102) when `view_count` increments were synchronous. In Jul 2024, `2767fce7adff` (#45007) moved increments to a 20-second async batch queue:

https://github.com/metabase/metabase/blob/f3d2ef76b20fae8c597773eb7342be0a350d5064/src/metabase/view_log/events/view_log.clj#L66-L80

The `synchronous-batch-updates: true` e2e setting was supposed to handle this, but empirically the assertions are still racy in stress runs — increments from setup, previous burns, and the action under test can coalesce or arrive out of order, causing the asserted value to be skipped or wrong.

**Fix: drop the view_count assertions**

Backend tests covering the increment mechanism have existed since 2024 (pre-batch-queue):

https://github.com/metabase/metabase/blob/f3d2ef76b20fae8c597773eb7342be0a350d5064/test/metabase/view_log/events/view_log_test.clj#L157-L168

https://github.com/metabase/metabase/blob/f3d2ef76b20fae8c597773eb7342be0a350d5064/test/metabase/view_log/events/view_log_test.clj#L314-L325

https://github.com/metabase/metabase/blob/f3d2ef76b20fae8c597773eb7342be0a350d5064/test/metabase/view_log/events/view_log_test.clj#L203-L226

The intercept spy assertions (`calledOnce` / `not.have.been.called`) fully cover the test's stated behavior: only cards on the active tab are queried.

### How to verify

- Branch (30 runs): ✅ 30/30 — [run](https://github.com/metabase/metabase/actions/runs/27681751140)
- Master (30 runs): ❌ 24/30 — [run](https://github.com/metabase/metabase/actions/runs/27565056271)