### PR TITLE
Fix a very foolish mistake around percentages for health inspector.

### DIFF
--- a/src/metabase/health_inspector/core.clj
+++ b/src/metabase/health_inspector/core.clj
@@ -24,9 +24,11 @@
               (inc valid)
               valid)}))
 
-(defn- percent [n] (* 100 (int n)))
+(defn- percent [n] (int (* 100 n)))
 
-(defn- validate-queries []
+(defn ^:internal validate-queries
+  "Determine how many saved queries are valid according to the malli schema."
+  []
   (let [queries (t2/reducible-select :report_card {:where [:= :archived false]})
         {:keys [total valid]} (reduce validate-query {:total 0 :valid 0} queries)
         ratio (if (zero? total)

--- a/test/metabase/health_inspector/core_test.clj
+++ b/test/metabase/health_inspector/core_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.health-inspector.core :as hi]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (defn- test-check []
@@ -17,6 +18,21 @@
              (:test-check report))))
     (testing "validate-queries works"
       (is (= 100 (-> report :validate-queries :health))))))
+
+(deftest validate-queries*-works
+  (let [bad-query {"database" 1
+                   "query" {"expressions" "extremely invalid"
+                            "source-table" 2}
+                   "type" "query"}
+        bad-card (assoc (dissoc (t2/select-one :report_card) :id :entity_id)
+                        :dataset_query (json/encode bad-query)
+                        :description "bad query")
+        bad (t2/insert! :report_card bad-card)]
+    (try
+      (let [{:keys [health message]} (hi/validate-queries)]
+        (is (< 0 health 100))
+        (is (= "Some queries are invalid." message)))
+      (finally (t2/delete! :report_card bad)))))
 
 (deftest report-db-test
   (t2/delete! :health_inspector_runs)


### PR DESCRIPTION
You have to multiply your ratio by 100 *before* you convert it to an integer. `>_<`

Add a test that catches this.