### PR TITLE
add documents to search on link dashcards

### DIFF
--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
@@ -43,6 +43,7 @@ const MODELS_TO_SEARCH: SearchModel[] = [
   "collection",
   "database",
   "table",
+  "document",
 ];
 
 export interface LinkVizProps {

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -366,6 +366,47 @@ describe("LinkViz", () => {
       });
     });
 
+    it("should find Documents when searching (UXW-4440)", async () => {
+      const documentSearchDashcard = createMockLinkDashboardCard({
+        url: "Quarterly",
+      });
+      const searchDocumentItem = createMockCollectionItem({
+        id: 2,
+        model: "document",
+        name: "Quarterly Plan Doc",
+        collection: searchCardCollection,
+      });
+      setupSearchEndpoints([searchDocumentItem]);
+      setupUserRecipientsEndpoint({ users: [createMockUser()] });
+      setupCollectionByIdEndpoint({
+        collections: [searchCardCollection],
+      });
+
+      const { changeSpy } = setup({
+        isEditing: true,
+        dashcard: documentSearchDashcard,
+        settings:
+          documentSearchDashcard.visualization_settings as LinkCardVizSettings,
+      });
+
+      const searchInput = screen.getByPlaceholderText("https://example.com");
+
+      await userEvent.click(searchInput);
+      await waitForLoaderToBeRemoved();
+
+      await userEvent.click(await screen.findByText("Quarterly Plan Doc"));
+
+      expect(changeSpy).toHaveBeenCalledWith({
+        link: {
+          entity: expect.objectContaining({
+            id: 2,
+            name: "Quarterly Plan Doc",
+            model: "document",
+          }),
+        },
+      });
+    });
+
     it("clicking a recent item should update the entity", async () => {
       const recentTableItem = createMockRecentTableItem({
         model: "table",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75485
### Description

1 line change to add documents to the entity search on Entity Link Dash Cards

### How to verify
1. Go to a dashboard -> edit
2. Search for a document
3. Add the document


### Demo

<img width="1364" height="937" alt="image" src="https://github.com/user-attachments/assets/c56a88ed-59f5-42ad-a764-54c91d995937" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
