### PR TITLE
Surface YAML parse reason in remote-sync ingestion errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -154,6 +154,15 @@
     (some-> e ex-cause ex-message (str/includes? "database not found"))
     (format "Import failed: A referenced database does not exist on this instance. %s" (ex-message (ex-cause e)))
 
+    (seq (:ingest-errors (ex-data e)))
+    (let [ingest-errors (:ingest-errors (ex-data e))]
+      (format "Failed to read %d file(s) from the repository:\n%s"
+              (count ingest-errors)
+              (str/join "\n" (for [ie ingest-errors
+                                   :let [{:keys [file reason]} (ex-data ie)]]
+                               (cond-> (str "  • " file)
+                                 reason (str ": " reason))))))
+
     :else
     (format "Failed to reload from git repository: %s" (ex-message e))))
 

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -156,11 +156,11 @@
 
     (seq (:ingest-errors (ex-data e)))
     (let [ingest-errors (:ingest-errors (ex-data e))]
-      (format "Failed to read %d file(s) from the repository:\n%s"
+      (format "Failed to read %d file(s) from the repository: %s"
               (count ingest-errors)
-              (str/join "\n" (for [ie ingest-errors
+              (str/join "; " (for [ie ingest-errors
                                    :let [{:keys [file reason]} (ex-data ie)]]
-                               (cond-> (str "  • " file)
+                               (cond-> file
                                  reason (str ": " reason))))))
 
     :else

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
@@ -10,7 +10,25 @@
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
    [toucan2.core :as t2])
-  (:import (metabase_enterprise.remote_sync.source.protocol SourceSnapshot)))
+  (:import
+   (metabase_enterprise.remote_sync.source.protocol SourceSnapshot)
+   (org.yaml.snakeyaml.error MarkedYAMLException)))
+
+(set! *warn-on-reflection* true)
+
+(defn- error-reason
+  "A concise, single-line reason for an ingestion failure, suitable for display and machine-readable
+  storage. For YAML errors, SnakeYAML's first message line is a generic context (e.g. \"while scanning
+  for the next token\"); the useful diagnostic is the problem plus its mark, so those are extracted.
+  Otherwise falls back to the first line of the message."
+  [e]
+  (if (instance? MarkedYAMLException e)
+    (let [^MarkedYAMLException e e
+          mark (.getProblemMark e)]
+      (cond-> (.getProblem e)
+        ;; marks are 0-based; report them 1-based to match editors
+        mark (str (format " (line %d, column %d)" (inc (.getLine mark)) (inc (.getColumn mark))))))
+    (some-> (ex-message e) str/split-lines first str/trim)))
 
 (defn- ingest-content
   [file-content]
@@ -31,14 +49,16 @@
                                               (source.p/read-file snapshot path)
                                               (catch Exception e
                                                 (log/warn (u/strip-error e "Error reading file during ingestion"))
-                                                (swap! errors conj (ex-info (format "Failed to read file: %s" path) {:file path} e))
+                                                (swap! errors conj (ex-info (format "Failed to read file: %s" path)
+                                                                            {:file path :reason (error-reason e)} e))
                                                 nil))
                                     loaded (try
                                              (when content
                                                (serdes/path (ingest-content content)))
                                              (catch Exception e
                                                (log/warn (u/strip-error e "Error parsing file during ingestion"))
-                                               (swap! errors conj (ex-info (format "Failed to parse file: %s" path) {:file path} e))
+                                               (swap! errors conj (ex-info (format "Failed to parse file: %s" path)
+                                                                           {:file path :reason (error-reason e)} e))
                                                nil))]
                               :when loaded]
                           [(serialization/strip-labels loaded) {:content content :path path}]))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -92,7 +92,10 @@
                              bad-yaml}}
           result    (impl/import! (source.p/snapshot (test-helpers/create-mock-source :initial-files files)) task-id)]
       (is (= :error (:status result))
-          "Import should fail when a YAML file cannot be parsed, not silently skip it"))))
+          "Import should fail when a YAML file cannot be parsed, not silently skip it")
+      (testing "the error message names the offending file and the parse reason"
+        (is (str/includes? (:message result) "collections/main/test/bad_card.yaml"))
+        (is (str/includes? (:message result) "expected ',' or ']'"))))))
 
 (deftest import!-handles-generic-errors-test
   (testing "import! handles generic errors"
@@ -116,7 +119,19 @@
           e     (ex-info "Failed to load into database for Card abc123"
                          {:path "Card abc123"}
                          cause)]
-      (is (str/includes? (impl/source-error-message e) "A referenced database does not exist on this instance")))))
+      (is (str/includes? (impl/source-error-message e) "A referenced database does not exist on this instance"))))
+  (testing "source-error-message lists each unreadable file with its parse reason (GHY-3887)"
+    (let [ingest-err (ex-info "Failed to parse file: collections/transforms/a.yaml"
+                              {:file "collections/transforms/a.yaml"
+                               :reason "found character '@' that cannot start any token. (Do not use @ for indentation) (line 1, column 1)"})
+          e          (ex-info "Failed to read 1 file(s) during ingestion: collections/transforms/a.yaml"
+                              {:ingest-errors [ingest-err]
+                               :files         ["collections/transforms/a.yaml"]}
+                              ingest-err)
+          msg        (impl/source-error-message e)]
+      (is (str/includes? msg "Failed to read 1 file(s)"))
+      (is (str/includes? msg "collections/transforms/a.yaml"))
+      (is (str/includes? msg "found character '@'")))))
 
 ;; We need to make sure the task-id we use to track the Remote Sync is not bound to a transactions because of the behavior of
 ;; update-sync-progress. So the follow two tests cannot use with-temp to create models


### PR DESCRIPTION
## Summary

Fixes the unhelpful error surfaced in [GHY-3887](https://linear.app/metabase/issue/GHY-3887). When a remote-sync **pull** hit an unreadable or unparseable file, the error only named the file:

> Failed to read 1 file(s) during ingestion: collections/transforms/.../stg_gh_workflow_step.yaml

…with no indication of *why*. (In the reported case the file had a stray git-diff hunk header `@@ -1,37 +0,0 @@` as its first line — a copy-paste artifact from restoring the file via GitHub's diff view — and `@` is a YAML reserved indicator, so SnakeYAML refused to parse it.) The underlying cause was preserved in the exception chain but never rendered into any message.

## Changes

- **`ingestable.clj`** — read- and parse-failure `ex-info`s now carry a concise, **machine-readable** `:reason` in ex-data. For YAML errors the reason is SnakeYAML's `getProblem` plus its 1-based line/column. (SnakeYAML's message *first line* is a generic context wrapper — `"while scanning for the next token"` — so first-line-only would be unhelpful; we extract the actual problem instead.) Non-YAML errors fall back to the first line of the message.
- **`impl.clj` `source-error-message`** — new branch that detects `:ingest-errors` in ex-data and renders one line per failed file with its `:reason`:

  ```
  Failed to read 1 file(s) from the repository:
    • collections/transforms/.../stg_gh_workflow_step.yaml: found character '@' that cannot start any token. (Do not use @ for indentation) (line 1, column 1)
  ```

The raw exception structure is untouched; the `{:file :reason}` pairs in ex-data stay available for callers to reconstruct the message differently (e.g. a modal-friendly layout — tracked as a follow-up, since these reason lines can be long).

<img width="471" height="317" alt="Screenshot 2026-06-15 at 4 48 32 PM" src="https://github.com/user-attachments/assets/033a9715-b23f-4828-9b63-b65b8b167838" />


## Testing

- Strengthened `import!-unparseable-yaml-should-not-silently-succeed-test` to assert the message names the file and includes the parse reason.
- Added a `source-error-message` unit test for the ingest-errors branch.
- All targeted `remote_sync.impl-test` tests pass; kondo clean (0 errors, 0 warnings).