### PR TITLE
Allow single non-select statements for admins on impersonated DBs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.impersonation.middleware
   (:require
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
+   [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
@@ -26,7 +27,9 @@
         impersonation-enabled?
         (as-> q
               (do (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
-                  (driver/validate-impersonated-query driver/*driver* q)))
+                  (driver/validate-impersonated-query
+                   driver/*driver*
+                   (cond-> q api/*is-superuser?* (assoc :impersonation/admin? true)))))
         ;; Only assign the role for non-admin impersonated users
         role
         (assoc :impersonation/role role)))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1085,6 +1085,39 @@
                             (format "INSERT INTO %s (name) VALUES ('x'); SELECT 1;" venues-table)
                             (format "SET ROLE NONE; DELETE FROM %s WHERE id = -1;" venues-table)))))))))))))))
 
+(deftest admins-can-run-show-timezone-statement-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :postgres})
+    (mt/with-premium-features #{:advanced-permissions}
+      (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+            role-a (u/lower-case-en (mt/random-name))]
+        (tx/with-temp-roles! driver/*driver*
+          (impersonation-granting-details driver/*driver* (mt/db))
+          {role-a {venues-table {}}}
+          (impersonation-default-user driver/*driver*)
+          (impersonation-default-role driver/*driver*)
+          (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                   :details (impersonation-details driver/*driver* (mt/db))}]
+            (mt/with-db database
+              (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+              (sync/sync-database! database {:scan :schema})
+              (let [impersonation-setup {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                         :attributes     {"impersonation_attr" role-a}}]
+                (testing "A SHOW TIMEZONE statement works for admin"
+                  (impersonation.util-test/with-impersonations-for-user! :crowberto impersonation-setup
+                    (is (= [["UTC"]]
+                           (-> (lib/native-query (mt/metadata-provider) "SHOW TIMEZONE")
+                               (qp/process-query)
+                               (mt/rows))))))
+                (testing "A SHOW TIMEZONE statement errors for non-admin"
+                  (impersonation.util-test/with-impersonations! impersonation-setup
+                    (is (thrown-with-msg?
+                         java.lang.Exception
+                         #"Invalid impersonated native query. Must be a single select statement."
+                         (-> (lib/native-query (mt/metadata-provider) "SHOW TIMEZONE")
+                             (qp/process-query)
+                             (mt/rows))))))))))))))
+
 (deftest ^:parallel impersonated-query-parse-error-message-test
   (testing "When a native query fails to parse, the validator reports a parse error -- not a misleading 'must be a single select' message (#73593)"
     (let [validate (fn [sql]

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1634,13 +1634,15 @@ def is_single_stmt_of_type(sql: str, stmt_type: str = "read", dialect: str = Non
     """Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
     and returns the query reconstructed from the parsed AST.
     """
-    result = {"is_single_stmt?": False}
+    result = {"is_single_stmt?": False, "allowed_stmt_type?": False}
     try:
         stmts = sqlglot.parse(sql, read=dialect)
         allowed_types = (exp.Select, exp.SetOperation)
         if stmt_type != "read": allowed_types = (exp.Update, exp.Insert, exp.Delete)
-        if len(stmts) == 1 and isinstance(stmts[0], allowed_types):
+        if len(stmts) == 1:
             result["is_single_stmt?"] = True
+            if isinstance(stmts[0], allowed_types):
+                result["allowed_stmt_type?"] = True
             result["sql"] = stmts[0].sql(dialect=dialect) if dialect else stmts[0].sql()
     except Exception as e:
         result["error"] = str(e)

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -290,7 +290,11 @@
   "Validates a native query by parsing it and ensuring that it is a single statement.
    Reads `:impersonation/allow-write?` on the query to decide what to require: when truthy (set by
    [[metabase.query-processor.writeback/execute-write-query!]] for custom write actions) require a single
-   write statement (insert, update, delete); otherwise require a single select statement."
+   write statement (insert, update, delete); otherwise require a single select statement.
+
+   Queries that cannot be parsed are always rejected. Admins are allowed to run parseable queries that
+   aren't a single select/write statement (e.g. `SHOW TIMEZONE`); non-admins are restricted to a single
+   statement of the required type."
   [driver query]
   (update query :stages
           (fn [stages]
@@ -299,7 +303,7 @@
                       (let [[stmt-type allowed-stmts] (if (:impersonation/allow-write? query)
                                                         ["write" (tru "insert, update, or delete")]
                                                         ["read" (tru "select")])
-                            {:keys [is-single-stmt? sql error]}
+                            {:keys [is-single-stmt? allowed-stmt-type? sql error]}
                             (sql-tools/is-single-stmt-of-type? driver (:native stage) stmt-type)]
                         (cond error
                               (do
@@ -307,11 +311,15 @@
                                 (throw (ex-info (tru "Unable to parse native query. There might be something wrong with your query.")
                                                 {:type qp.error-type/invalid-query
                                                  :sql  (:native stage)})))
-                              (not is-single-stmt?)
+
+                              (and is-single-stmt?
+                                   (or allowed-stmt-type? (:impersonation/admin? query)))
+                              (assoc stage :native sql)
+
+                              :else
                               (throw (ex-info (tru "Invalid impersonated native query. Must be a single {0} statement." allowed-stmts)
                                               {:type qp.error-type/invalid-query
-                                               :sql  (:native stage)}))
-                              :else (assoc stage :native sql)))
+                                               :sql  (:native stage)}))))
                       stage))
                   stages))))
 

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -200,7 +200,7 @@
         "DROP TABLE table" true
         "SET ROLE NONE; DROP TABLE table" false
         "SELECT set_config('role', 'none', false); DROP TABLE table" false
-        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;" (= driver/*driver* :postgres)))
+        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;" (isa? driver/hierarchy driver/*driver* :postgres)))
     (testing "A single insert, update or delete statement returns true and the reconstructed SQL"
       (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?}
                      (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -200,7 +200,7 @@
         "DROP TABLE table" true
         "SET ROLE NONE; DROP TABLE table" false
         "SELECT set_config('role', 'none', false); DROP TABLE table" false
-        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;" true))
+        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;" (= driver/*driver* :postgres)))
     (testing "A single insert, update or delete statement returns true and the reconstructed SQL"
       (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?}
                      (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -184,7 +184,7 @@
                     (lib/filter (lib/= product-category "Widget")))
           native-query (:query (qp.compile/compile-with-inline-parameters query))]
       (testing "A single SELECT statement returns true and the reconstructed SQL"
-        (are [sql] (=? {:is-single-stmt? true, :sql string?}
+        (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?}
                        (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
           native-query
           "SELECT 1"
@@ -192,37 +192,37 @@
           "WITH x AS (SELECT * FROM foo) SELECT * from x"
           "WITH x AS (SELECT a FROM foo), y AS (SELECT b FROM bar), z AS (SELECT c FROM baz) SELECT x.a, y.b, z.c FROM x, y, z")))
     (testing "All other read queries are rejected"
-      (are [sql] (=? {:is-single-stmt? false}
-                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
-        "SELECT ("
-        "SELECT 1; SELECT 2"
-        "SET ROLE NONE"
-        "DROP TABLE table"
-        "SET ROLE NONE; DROP TABLE table"
-        "SELECT set_config('role', 'none', false); DROP TABLE table"
-        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;"))
+      (are [sql is-single-stmt?] (=? {:is-single-stmt? is-single-stmt? :allowed-stmt-type? false}
+                                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
+        "SELECT (" false
+        "SELECT 1; SELECT 2" false
+        "SET ROLE NONE" true
+        "DROP TABLE table" true
+        "SET ROLE NONE; DROP TABLE table" false
+        "SELECT set_config('role', 'none', false); DROP TABLE table" false
+        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;" true))
     (testing "A single insert, update or delete statement returns true and the reconstructed SQL"
-      (are [sql] (=? {:is-single-stmt? true, :sql string?}
+      (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?}
                      (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))
         "INSERT INTO table VALUES (1)"
         "UPDATE table SET column = 1"
         "DELETE FROM table WHERE id = 1"))
     (testing "All other write queries are rejected"
-      (are [sql] (=? {:is-single-stmt? false}
-                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))
-        "SELECT 1"
-        "INSERT INTO table VALUES (1); SELECT 1"
-        "UPDATE table SET column = 1; SELECT 1"
-        "DELETE FROM table WHERE id = 1; SELECT 1"
-        "SET ROLE NONE; INSERT INTO table VALUES (1)"
-        "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1"))
+      (are [sql is-single-stmt?] (=? {:is-single-stmt? is-single-stmt? :allowed-stmt-type? false}
+                                     (sql-tools/is-single-stmt-of-type? driver/*driver* sql "write"))
+        "SELECT 1" true
+        "INSERT INTO table VALUES (1); SELECT 1" false
+        "UPDATE table SET column = 1; SELECT 1" false
+        "DELETE FROM table WHERE id = 1; SELECT 1" false
+        "SET ROLE NONE; INSERT INTO table VALUES (1)" false
+        "SELECT set_config('role', 'none', false); DELETE FROM table WHERE id = 1" false))
     (testing "A single set operation statement returns true and the reconstructed SQL"
       (doseq [op ["UNION ALL" "INTERSECT ALL" "EXCEPT ALL"]
               ts [["foo" "bar"] ["foo" "bar" "baz"]]
               :let [sql (str/join (str " " op " ") (map #(str "SELECT * FROM " %) ts))]]
         (is (=? {:is-single-stmt? true, :sql string?}
                 (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))))
-      (are [sql] (=? {:is-single-stmt? true, :sql string?}
+      (are [sql] (=? {:is-single-stmt? true, :allowed-stmt-type? true :sql string?}
                      (sql-tools/is-single-stmt-of-type? driver/*driver* sql "read"))
         "SELECT * FROM foo UNION ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"
         "SELECT * FROM foo UNION ALL SELECT * FROM bar EXCEPT ALL SELECT * FROM baz"
@@ -234,10 +234,11 @@
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"
     (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]
-      (are [sql is-single-stmt?] (= {:is-single-stmt? is-single-stmt? :sql sql}
-                                    (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
-        values-query true
-        (str "SELECT 1; " values-query) false
-        (str "SET ROLE none; " values-query) false
-        (str values-query "; SELECT 1") false
-        (str values-query "; SET ROLE none") false))))
+      (are [sql is-single-stmt? allowed-stmt-type?]
+           (= {:is-single-stmt? is-single-stmt? :allowed-stmt-type? allowed-stmt-type? :sql sql}
+              (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+        values-query true true
+        (str "SELECT 1; " values-query) false false
+        (str "SET ROLE none; " values-query) false false
+        (str values-query "; SELECT 1") false false
+        (str values-query "; SET ROLE none") false false))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/74538

### Description

We were rejecting any impersonated non-select statements, including for admins. This was initially to ensure we had the same behaviour for admins and non-admins when we couldn't parse the query. But this means that admins can't run queries such as `show timezone` from the native query editor. The change in this PR is to require all impersonated queries to be single statements, but allow admin queries to not be select queries. Non-admins are still required to be single select statements. 

### How to verify

See repro steps in original issue. You should be able to run `show timzone` as an admin, but not as a non-admin now. 

### Demo


<details>

<summary>screen recording</summary>

https://github.com/user-attachments/assets/79026225-3c38-41a9-aa08-ef87a033304a

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
