### PR TITLE
Manual backport of health inspector to 62.

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1017,6 +1017,17 @@
    :api  #{metabase.graph.core}
    :uses #{util}}
 
+  health-inspector
+  {:team "Querying Platform"
+   :api #{metabase.health-inspector.api
+          metabase.health-inspector.init}
+   :uses #{api
+           lib
+           lib-be
+           settings
+           task
+           util}}
+
   indexed-entities
   {:team "UX West"
    :api  #{metabase.indexed-entities.api

--- a/resources/migrations/063/20260521_health_inspector_runs.yaml
+++ b/resources/migrations/063/20260521_health_inspector_runs.yaml
@@ -1,0 +1,42 @@
+## Create a table for health inspector runs
+
+databaseChangeLog:
+  - changeSet:
+      id: v63.2026-05-21T10:47:00
+      author: technomancy
+      comment: Create health_inspector_runs table.
+      changes:
+        - createTable:
+            tableName: health_inspector_runs
+            remarks: Records status of health inspector runs over time
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: message
+                  type: ${text.type}
+                  remarks: A message to show to the instance admin.
+              - column:
+                  name: check_name
+                  type: varchar(254)
+                  remarks: The name of the check
+                  constraints:
+                    nullable: false
+              - column:
+                  name: run_at
+                  type: ${timestamp_type}
+                  remarks: When it was run
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: health
+                  type: int
+                  remarks: Health as a percentage out of 100
+                  constraints:
+                    nullable: false

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -28,6 +28,7 @@
    [metabase.frontend-errors.api]
    [metabase.geojson.api]
    [metabase.glossary.api]
+   [metabase.health-inspector.api]
    [metabase.indexed-entities.api]
    [metabase.llm.api]
    [metabase.logger.api]
@@ -190,6 +191,7 @@
    "/geojson"              'metabase.geojson.api
    "/glossary"             (+auth 'metabase.glossary.api)
    "/google"               (+auth metabase.sso.api/google-auth-routes)
+   "/health-inspector"     (+auth 'metabase.health-inspector.api)
    "/ldap"                 (+auth metabase.sso.api/ldap-routes)
    "/llm"                  (+auth metabase.llm.api/routes)
    "/logger"               (+auth 'metabase.logger.api)

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -33,6 +33,7 @@
    [metabase.embedding.init]
    [metabase.events.init]
    [metabase.geojson.init]
+   [metabase.health-inspector.init]
    [metabase.indexed-entities.init]
    [metabase.lib-be.init]
    [metabase.lib.init]

--- a/src/metabase/health_inspector/api.clj
+++ b/src/metabase/health_inspector/api.clj
@@ -1,0 +1,19 @@
+(ns metabase.health-inspector.api
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.health-inspector.core :as health]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]))
+
+(mr/def ::result [:map
+                  [:check_name string?]
+                  [:health number?]
+                  [:message string?]
+                  [:run_at ms/TemporalInstant]])
+
+(api.macros/defendpoint :get "/" :- [:sequential ::result]
+  "Get a list of recent health check runs."
+  [_route-params {:keys [limit] :as _query-params} _body]
+  (api/check-superuser)
+  (health/list-runs (min (or limit 32) 512)))

--- a/src/metabase/health_inspector/api_test.clj
+++ b/src/metabase/health_inspector/api_test.clj
@@ -1,0 +1,15 @@
+(ns metabase.health-inspector.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.health-inspector.core :as hi]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest api-test
+  (t2/delete! :health_inspector_runs)
+  (hi/save-report)
+  (hi/save-report)
+  (let [response (mt/user-http-request :crowberto :get 200 "/health-inspector")]
+    (is (= [100 100 100 100] (map :health response)))
+    (is (= ["test-check" "test-check" "validate-queries" "validate-queries"]
+           (sort (map :check_name response))))))

--- a/src/metabase/health_inspector/core.clj
+++ b/src/metabase/health_inspector/core.clj
@@ -1,0 +1,94 @@
+(ns metabase.health-inspector.core
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.health-inspector.settings :as setting]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.schema :as schema]
+   [metabase.task.core :as task]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- validate-query [{:keys [total valid]} {:keys [dataset_query]}]
+  (let [timer (u/start-timer)
+        query (lib-be/normalize-query (json/decode dataset_query keyword))
+        valid? (mr/validate ::schema/query query)]
+    (Thread/sleep ^Long (u/since-ms timer))
+    {:total (inc total)
+     :valid (if valid?
+              (inc valid)
+              valid)}))
+
+(defn- percent [n] (int (* 100 n)))
+
+(defn ^:internal validate-queries
+  "Determine how many saved queries are valid according to the malli schema."
+  []
+  (let [queries (t2/reducible-select :report_card {:where [:= :archived false]})
+        {:keys [total valid]} (reduce validate-query {:total 0 :valid 0} queries)
+        ratio (if (zero? total)
+                1
+                (/ valid total))]
+    {:health (percent ratio)
+     :message (if (= 1 ratio)
+                "All queries valid."
+                "Some queries are invalid.")}))
+
+(defonce ^:private checks (atom {:validate-queries validate-queries}))
+
+(defn register-check!
+  "Register a new check function with a given name.
+  Check functions take no args and return a map with a :health ratio and :description string."
+  [name check-fn]
+  (swap! checks assoc name check-fn))
+
+(defn report
+  "Run all registered checks and produce a report describing potential problems."
+  []
+  (into {} (for [[name f] @checks]
+             [name (f)])))
+
+(defn save-report
+  "Run a health inspector report and save it to the DB."
+  []
+  (doseq [[check-name result] (report)]
+    (t2/insert! :health_inspector_runs (-> result
+                                           (select-keys [:health :message])
+                                           (assoc :check_name (name check-name))))))
+
+(defn list-runs
+  "Return the most recent health inspector runs from the DB."
+  [limit]
+  (t2/select :health_inspector_runs {:limit limit :order-by [[:run_at :desc]]}))
+
+(task/defjob ^:private ^{org.quartz.DisallowConcurrentExecution true} SaveReport [_]
+  (when (setting/health-inspector-enabled)
+    ;; background job should always be the lowest priority
+    (.setPriority (Thread/currentThread) 1)
+    ;; quartz doesn't have support for jitter, so we fake it with a sleep
+    (Thread/sleep ^Long (rand-int 60000))
+    (save-report)))
+
+(defmethod task/init! ::SaveReport [_]
+  (let [job-key (jobs/key "metabase.health-inspector.job")
+        trigger-key (triggers/key "metabase.health-inspector.trigger")
+        job (jobs/build
+             (jobs/of-type SaveReport)
+             (jobs/with-identity job-key)
+             (jobs/with-description "Gather health checks.")
+             (jobs/store-durably))
+        trigger (triggers/build
+                 (triggers/with-identity trigger-key)
+                 (triggers/for-job job-key)
+                 (triggers/start-now)
+                 ;; 2:28AM every day
+                 (triggers/with-schedule
+                  (cron/schedule
+                   (cron/cron-schedule "0 28 2 * * ? *")
+                   (cron/with-misfire-handling-instruction-do-nothing))))]
+    (task/schedule-task! job trigger)))

--- a/src/metabase/health_inspector/core_test.clj
+++ b/src/metabase/health_inspector/core_test.clj
@@ -1,0 +1,44 @@
+(ns metabase.health-inspector.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.health-inspector.core :as hi]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+(defn- test-check []
+  {:health 100
+   :message "test check"})
+
+(hi/register-check! :test-check test-check)
+
+(deftest report-test
+  (let [report (hi/report)]
+    (testing "test check works"
+      (is (= {:health 100 :message "test check"}
+             (:test-check report))))
+    (testing "validate-queries works"
+      (is (= 100 (-> report :validate-queries :health))))))
+
+(deftest validate-queries*-works
+  (let [bad-query {"database" 1
+                   "query" {"expressions" "extremely invalid"
+                            "source-table" 2}
+                   "type" "query"}
+        bad-card (assoc (dissoc (t2/select-one :report_card) :id :entity_id)
+                        :dataset_query (json/encode bad-query)
+                        :description "bad query")
+        bad (t2/insert! :report_card bad-card)]
+    (try
+      (let [{:keys [health message]} (hi/validate-queries)]
+        (is (< 0 health 100))
+        (is (= "Some queries are invalid." message)))
+      (finally (t2/delete! :report_card bad)))))
+
+(deftest report-db-test
+  (t2/delete! :health_inspector_runs)
+  (hi/save-report)
+  (hi/save-report)
+  (let [runs (group-by :check_name (hi/list-runs 32))]
+    (is (= [100 100] (map :health (runs "test-check"))))
+    (is (= ["test check" "test check"] (map :message (runs "test-check"))))
+    (is (= [100 100] (map :health (runs "validate-queries"))))))

--- a/src/metabase/health_inspector/init.clj
+++ b/src/metabase/health_inspector/init.clj
@@ -1,0 +1,3 @@
+(ns metabase.health-inspector.init
+  (:require
+   [metabase.health-inspector.settings]))

--- a/src/metabase/health_inspector/settings.clj
+++ b/src/metabase/health_inspector/settings.clj
@@ -1,0 +1,13 @@
+(ns metabase.health-inspector.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting health-inspector-enabled
+  (deferred-tru "Enable or disable all health inspector checks.")
+  :type       :boolean
+  :default    false
+  :doc        false
+  :visibility :admin
+  :export?    false
+  :audit      :getter)


### PR DESCRIPTION
Rationale: the health inspector feature is largely motivated by wanting to learn more about the health of databases across our cloud instances, and we don't want to wait to gather this data until version 63 goes live to cloud.

Mostly just https://github.com/metabase/metabase/pull/74681 but also the fix from https://github.com/metabase/metabase/pull/75890.

This is a fairly straightforward backport; the only hiccup is that the migration that adds its table is marked as a version 63 migration. I don't know if this will cause any problems, but it will certainly *look* wrong.