### PR TITLE
Take the metric's name into account when replacing references

### DIFF
--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -139,7 +139,7 @@
       (assoc-in query [:stages stage-number :aggregation]
                 (match/replace aggregations
                   [:metric _ metric-id]
-                  (if-let [{replacement :aggregation} (get lookup metric-id)]
+                  (if-let [{replacement :aggregation, metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
                     (let [replacement (match/replace replacement
@@ -154,6 +154,9 @@
                                 %
                                 {:name (lib/column-name query stage-number replacement)}
                                 (select-keys % [:name :display-name])
+                                ;; The metric card's name is the column's display-name externally,
+                                ;; overriding the inner aggregation's display-name (#58307).
+                                (when metric-name {:display-name metric-name})
                                 (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
                     (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -622,17 +622,29 @@
 (deftest ^:parallel default-metric-names-test
   (let [[source-metric mp] (mock-metric)]
     (is (=?
-         {:stages [{:aggregation [[:avg {:display-name (symbol "nil #_\"key is not present.\""), :name "avg"} some?]]}]}
+         {:stages [{:aggregation [[:avg {:display-name "Mock Metric", :name "avg"} some?]]}]}
          (adjust (-> (lib/query mp (meta/table-metadata :products))
                      (lib/aggregate (lib.metadata/metric mp (:id source-metric)))))))))
 
-(deftest ^:parallel include-source-names-test
-  (let [[source-metric mp] (mock-metric (-> (basic-metric-query)
-                                            (add-aggregation-options {:display-name "My cool metric" :name "Named Metric"})))]
-    (is (=?
-         {:stages [{:aggregation [[:avg {:display-name "My cool metric" :name "Named Metric"} some?]]}]}
-         (adjust (-> (lib/query mp (meta/table-metadata :products))
-                     (lib/aggregate (lib.metadata/metric mp (:id source-metric)))))))))
+(deftest ^:parallel metric-name-overrides-inner-display-name-test
+  (testing "Result column should use the metric card's name, not the inner aggregation's display-name (#58307)"
+    (let [[source-metric mp] (mock-metric (-> (basic-metric-query)
+                                              (add-aggregation-options {:display-name "My cool metric" :name "Named Metric"})))]
+      (is (=?
+           {:stages [{:aggregation [[:avg {:display-name "Mock Metric" :name "Named Metric"} some?]]}]}
+           (adjust (-> (lib/query mp (meta/table-metadata :products))
+                       (lib/aggregate (lib.metadata/metric mp (:id source-metric))))))))))
+
+(deftest ^:parallel metric-name-in-returned-columns-test
+  (testing "Returned column display-name should match the metric card name (#58307)"
+    (let [[source-metric mp] (mock-metric meta/metadata-provider
+                                          (-> (basic-metric-query)
+                                              (add-aggregation-options {:display-name "total_price_no_tax_no_discount"}))
+                                          {:name "total_price_no_tax_no_discount_metric"})
+          query (-> (lib/query mp (meta/table-metadata :products))
+                    (lib/aggregate (lib.metadata/metric mp (:id source-metric))))]
+      (is (= "total_price_no_tax_no_discount_metric"
+             (-> query adjust lib/returned-columns last :display-name))))))
 
 (deftest ^:parallel override-source-names-test
   (let [[source-metric mp] (mock-metric (-> (basic-metric-query)
@@ -684,7 +696,7 @@
                  :aggregation  [[:aggregation-options
                                  [:sum [:case [[[:= [:field (meta/id :venues :name) {}] [:value "abc" {}]]
                                                 [:field (meta/id :venues :price) {}]]]]]
-                                 {:display-name "My Cool Aggregation"}]]}
+                                 {:display-name "Mock Metric"}]]}
           expand-macros (fn [mbql-query]
                           (lib.convert/->legacy-MBQL (adjust (lib/query mp (lib.convert/->mbql5 mbql-query)))))]
       (comment


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58307
Closes QUE2-159

### Description

Use the metric's name when resolving metric references.

### How to verify

No manual changing should be necessary to get the metric's name. Also see the tests.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
