### PR TITLE
Prefer adding field to join with same join alias

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.field.resolution :as lib.field.resolution]
    [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.join :as lib.join]
+   [metabase.lib.join.util :as lib.join.util]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
@@ -612,8 +613,14 @@
         (lib.util/update-query-stage populated stage-number update :fields conj column-ref)))))
 
 (defn- add-field-to-join [query stage-number column]
-  (let [column-ref   (lib.ref/ref column)
-        [join field] (first (for [join  (lib.join/joins query stage-number)
+  (let [column-ref (lib.ref/ref column)
+        join-alias (lib.join.util/current-join-alias column)
+        joins (lib.join/joins query stage-number)
+        joins (if-let [join-with-alias (and join-alias
+                                            (m/find-first #(= (:alias %) join-alias) joins))]
+                [join-with-alias]
+                joins)
+        [join field] (first (for [join  joins
                                   :let [joinables (lib.join/joinable-columns query stage-number join)
                                         field     (lib.equality/find-matching-column
                                                    query stage-number column-ref joinables)]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -2580,3 +2580,52 @@
            (#'lib.field/find-stage-index-and-clause-by-uuid query -1 "a1898aa6-4928-4e97-837d-e440ce21085e")))
     (is (nil? (#'lib.field/find-stage-index-and-clause-by-uuid query -1 "00000000-0000-0000-0000-000000000002")))
     (is (nil? (#'lib.field/find-stage-index-and-clause-by-uuid query 0  "a1898aa6-4928-4e97-837d-e440ce21085e")))))
+
+(deftest ^:parallel add-field-to-join-disambiguated-by-join-alias-test
+  (testing "adding a column back to a join that matches a column from a joined native model works (#64779)"
+    (let [id-col (-> (lib.metadata/field meta/metadata-provider (meta/id :products :id))
+                     (dissoc :table-id :id :fk-target-field-id))
+          mp (lib.tu/metadata-provider-with-mock-card {:lib/type        :metadata/card
+                                                       :id              1
+                                                       :database-id     (meta/id)
+                                                       :name            "Products ID model"
+                                                       :type            :model
+                                                       :dataset-query   {:database (meta/id)
+                                                                         :type     :native
+                                                                         :native   {:query "SELECT ID FROM PRODUCTS"}}
+                                                       :result-metadata [id-col]})
+          native-model       (lib.metadata/card mp 1)
+          model-id           (-> (lib/query mp native-model) lib/returned-columns first)
+          products-table     (lib.metadata/table mp (meta/id :products))
+          products-id        (lib.metadata/field mp (meta/id :products :id))
+          reviews-table      (lib.metadata/table mp (meta/id :reviews))
+          reviews-product-id (lib.metadata/field mp (meta/id :reviews :product-id))
+          query (-> (lib/query mp products-table)
+                    (lib/join (lib/join-clause native-model [(lib/= products-id model-id)]))
+                    (lib/join (lib/join-clause reviews-table [(lib/= products-id reviews-product-id)])))
+          reviews? #(= (:lib/original-join-alias %) "Reviews")
+          query-without-reviews-cols (reduce #(lib/remove-field %1 -1 %2)
+                                             query
+                                             (filter reviews? (lib/visible-columns query)))
+          reviews-id (m/find-first #(and (= (:name %) "ID") (reviews? %))
+                                   (lib/visible-columns query-without-reviews-cols))]
+      (testing "check every reviews column has been unselected"
+        (is (= :none
+               (->> (lib/joins query-without-reviews-cols)
+                    (m/find-first #(= (:alias %) "Reviews"))
+                    (lib/join-fields)))))
+      (let [query-with-reviews-id (lib/add-field query-without-reviews-cols -1 reviews-id)
+            query-joins (lib/joins query-with-reviews-id)]
+        (testing "reviews.ID is added to the Reviews join, not the ID column in the native model join"
+          (is (=? [[:field {:join-alias "Reviews"} (meta/id :reviews :id)]]
+                  (->> query-joins
+                       (m/find-first #(= (:alias %) "Reviews"))
+                       (lib/join-fields)))))
+        (testing "the native model join remains the same"
+          (is (= :all
+                 (->> query-joins
+                      (m/find-first #(= (:alias %) "Products ID model"))
+                      (lib/join-fields)))))
+        (testing "Reviews.ID is now returned by the query"
+          (is (some #(= (:id %) (meta/id :reviews :id))
+                    (lib/returned-columns query-with-reviews-id))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64779

### Description

When adding a field to a join, we were looking across all joins and picking the first one that matched. This would erroneously match a native model from another join that had the same column name. The fix in this PR is to first try matching against a join that has the same join alias as the field we are adding.

### How to verify

See repro steps in original issue. You should be able to select the invoices ID column now and it should appear in the query results correctly. 

### Demo

https://www.loom.com/share/52332e3a80014a3caebd434a74bd8854

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
