### PR TITLE
GDGT-2631 Fix name input border cut off on hover

### DIFF
--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -1,4 +1,5 @@
 .name {
+  &:hover,
   &:focus-within {
     position: relative;
     z-index: 1; /* prevent focus state from being cut off after imitating collapsed borders */


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75922
Closes [GDGT-2631](https://linear.app/metabase/issue/GDGT-2631/name-input-border-cut-off-on-hover)

### How to verify

1. Go to Admin > Table Metadata
2. Open a table or a field
3. Hover the table/field name input

### Demo

[Before](https://github.com/user-attachments/assets/3fdf509c-9ccb-4995-bf77-60f603169b32) vs [after](https://github.com/user-attachments/assets/0e762c98-8443-472d-bcb8-4f4966a997ea)