### PR TITLE
Show empty state in Admin Table Metadata Table Picker

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/Results.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/Results.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { Box, Flex, Icon, Skeleton, rem } from "metabase/ui";
@@ -103,16 +104,16 @@ export function Results({
           const item = items[index];
           const {
             value,
-            label,
             type,
             isExpanded,
-            isLoading,
+            isEmpty,
             key,
             level,
             parent,
             disabled,
           } = item;
           const isActive = type === "table" && value?.tableId === activeTableId;
+          const interactive = !disabled && !isEmpty;
           const parentIndex = items.findIndex((item) => item.key === parent);
           const children = items.filter((item) => item.parent === key);
           const hasTableChildren = children.some(
@@ -120,7 +121,7 @@ export function Results({
           );
 
           const handleItemSelect = (open?: boolean) => {
-            if (disabled) {
+            if (!interactive) {
               return;
             }
 
@@ -183,7 +184,7 @@ export function Results({
             }
 
             if (
-              !disabled &&
+              interactive &&
               (event.code === "Space" || event.code === "Enter")
             ) {
               // toggle the current item
@@ -206,11 +207,11 @@ export function Results({
               })}
               data-index={index}
               data-open={isExpanded}
-              tabIndex={disabled ? -1 : 0}
+              tabIndex={interactive ? 0 : -1}
               style={{
                 top: start,
                 marginLeft: level * INDENT_OFFSET,
-                pointerEvents: disabled ? "none" : undefined,
+                pointerEvents: interactive ? undefined : "none",
               }}
               to={Urls.dataModel({
                 databaseId: value?.databaseId,
@@ -234,7 +235,7 @@ export function Results({
               <Flex align="center" mih={ITEM_MIN_HEIGHT} py="xs" w="100%">
                 <Flex align="flex-start" gap="xs" w="100%">
                   <Flex align="center" gap="xs">
-                    {hasChildren(type) && (
+                    {hasChildren(type) && !isEmpty && (
                       <Icon
                         name="chevronright"
                         size={10}
@@ -245,28 +246,12 @@ export function Results({
                       />
                     )}
 
-                    <Icon name={TYPE_ICONS[type]} className={S.icon} />
+                    {!isEmpty && (
+                      <Icon name={TYPE_ICONS[type]} className={S.icon} />
+                    )}
                   </Flex>
 
-                  {isLoading ? (
-                    <Loading />
-                  ) : (
-                    <Box
-                      className={S.label}
-                      c={
-                        type === "table" &&
-                        item.table &&
-                        item.table.visibility_type != null &&
-                        !isActive
-                          ? "text-secondary"
-                          : undefined
-                      }
-                      data-testid="tree-item-label"
-                      pl="sm"
-                    >
-                      {label}
-                    </Box>
-                  )}
+                  <ItemLabel item={item} isActive={isActive} />
                 </Flex>
               </Flex>
 
@@ -318,6 +303,42 @@ export function Results({
           );
         })}
       </Box>
+    </Box>
+  );
+}
+
+function ItemLabel({ item, isActive }: { item: FlatItem; isActive: boolean }) {
+  if (item.isLoading) {
+    return <Loading />;
+  }
+
+  if (item.isEmpty) {
+    return (
+      <Box
+        className={S.label}
+        c="text-disabled"
+        data-testid="empty-placeholder"
+        pl="1.25rem"
+      >
+        {t`Empty`}
+      </Box>
+    );
+  }
+
+  const isMutedTable =
+    item.type === "table" &&
+    item.table != null &&
+    item.table.visibility_type != null &&
+    !isActive;
+
+  return (
+    <Box
+      className={S.label}
+      c={isMutedTable ? "text-secondary" : undefined}
+      data-testid="tree-item-label"
+      pl="sm"
+    >
+      {item.label}
     </Box>
   );
 }

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/TablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/TablePicker.unit.spec.tsx
@@ -129,6 +129,12 @@ const DATABASE_WITH_UNNAMED_SCHEMA = createMockDatabase({
   tables: [CORGE, GRAULT, GLORP],
 });
 
+const DATABASE_WITH_NO_TABLES = createMockDatabase({
+  id: nextId(),
+  name: "DATABASE_WITH_NO_TABLES",
+  tables: [],
+});
+
 const MOCK_DATABASES = [
   DATABASE_WITH_MULTIPLE_SCHEMAS,
   DATABASE_WITH_SINGLE_SCHEMA,
@@ -253,6 +259,38 @@ describe("TablePicker", () => {
       // the schema is flattened into the parent
       expect(item(QUU)).toBeInTheDocument();
       expect(item(QUX)).toBeInTheDocument();
+    });
+
+    it("does not show a loading skeleton forever when an expanded database has no tables (metabase#74508)", async () => {
+      const { onChange } = setup({
+        path: {},
+        databases: [DATABASE_WITH_MULTIPLE_SCHEMAS, DATABASE_WITH_NO_TABLES],
+      });
+
+      await waitLoading();
+
+      expect(item(DATABASE_WITH_NO_TABLES)).toBeInTheDocument();
+      await clickItem(DATABASE_WITH_NO_TABLES);
+      await waitLoading();
+
+      expect(onChange).toHaveBeenCalledWith({
+        databaseId: DATABASE_WITH_NO_TABLES.id,
+      });
+
+      // Once the (empty) schema list has loaded, no skeleton should remain
+      expect(
+        screen.queryByTestId("loading-placeholder"),
+      ).not.toBeInTheDocument();
+      // The empty database is still rendered, just with nothing nested under it
+      expect(item(DATABASE_WITH_NO_TABLES)).toBeInTheDocument();
+
+      // Instead of a skeleton or a blank gap, an inert "Empty" row is shown
+      expect(screen.getByText("Empty")).toBeInTheDocument();
+
+      // The "Empty" row is display-only: not focusable and not clickable
+      const emptyRow = item("Empty");
+      expect(emptyRow).toHaveAttribute("tabindex", "-1");
+      expect(emptyRow).toHaveStyle({ pointerEvents: "none" });
     });
 
     it("should be possible to navigate with the keyboard", async () => {

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useTableLoader.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useTableLoader.ts
@@ -137,6 +137,7 @@ export function useTableLoader(path: TreePath) {
           // fetch the tables immediately so we can render a flattened tree.
           if (schemaName === UNNAMED_SCHEMA_NAME || schemas.length === 1) {
             schema.children = await getTables(databaseId, schemaName);
+            schema.loaded = true;
           }
           return schema;
         }) ?? [],
@@ -155,19 +156,24 @@ export function useTableLoader(path: TreePath) {
       ]);
 
       const newTree: TreeNode = rootNode(
-        databases.map((database) => ({
-          ...database,
-          children:
-            database.value.databaseId !== databaseId
-              ? database.children
-              : schemas.map((schema) => ({
-                  ...schema,
-                  children:
-                    schema.value.schemaName !== schemaName
-                      ? schema.children
-                      : tables,
-                })),
-        })),
+        databases.map((database) => {
+          if (database.value.databaseId !== databaseId) {
+            return database;
+          }
+          // We just fetched this database's schemas, so its children are
+          // complete even when the result is empty.
+          return {
+            ...database,
+            loaded: true,
+            children: schemas.map((schema) => {
+              if (schema.value.schemaName !== schemaName) {
+                return schema;
+              }
+              // We just fetched this schema's tables, so mark it loaded too.
+              return { ...schema, loaded: true, children: tables };
+            }),
+          };
+        }),
       );
       setTree((current) => {
         const merged = merge(current, newTree);

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/types.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/types.ts
@@ -29,6 +29,7 @@ export type DatabaseNode = {
   key: NodeKey;
   value: { databaseId: DatabaseId };
   children: SchemaNode[];
+  loaded?: boolean;
 };
 
 export type SchemaNode = {
@@ -37,6 +38,7 @@ export type SchemaNode = {
   key: string;
   value: { databaseId: DatabaseId; schemaName: SchemaName };
   children: TableNode[];
+  loaded?: boolean;
 };
 
 export type TableNode = {
@@ -57,11 +59,12 @@ export type Item = DatabaseItem | SchemaItem | TableItem;
 
 export type ItemType = Item["type"];
 
-export type FlatItem = LoadingItem | ExpandedItem;
+export type FlatItem = LoadingItem | EmptyItem | ExpandedItem;
 
 type ExpandedItem = Item & {
   isExpanded?: boolean;
   isLoading?: false;
+  isEmpty?: false;
   parent?: NodeKey;
   level: number;
   disabled?: boolean;
@@ -69,6 +72,23 @@ type ExpandedItem = Item & {
 
 type LoadingItem = {
   isLoading: true;
+  isEmpty?: false;
+  type: ItemType;
+  key: string;
+  level: number;
+  isExpanded?: boolean;
+  value?: TreePath;
+  label?: string;
+  parent?: NodeKey;
+  table?: undefined;
+  disabled?: never;
+};
+
+// Shown when a database or schema has finished loading but has no children, so
+// we communicate "empty" instead of leaving a blank gap or a forever skeleton.
+type EmptyItem = {
+  isEmpty: true;
+  isLoading?: false;
   type: ItemType;
   key: string;
   level: number;

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/utils.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/utils.ts
@@ -14,6 +14,14 @@ export function hasChildren(type: ItemType): boolean {
   return type !== "table";
 }
 
+// Whether a node's children have finished fetching. Only database and schema
+// nodes load their children lazily, so only they carry the `loaded` flag.
+function isLoaded(node: TreeNode): boolean {
+  return (
+    (node.type === "database" || node.type === "schema") && node.loaded === true
+  );
+}
+
 // Returns a new state object with all the nodes along the path expanded.
 export function expandPath(
   state: ExpandedState,
@@ -102,6 +110,14 @@ export function flatten(
     const childType = CHILD_TYPES[node.type];
     if (!childType) {
       return [{ ...node, level, parent }];
+    }
+    if (isLoaded(node)) {
+      // Children have been fetched and there genuinely are none (e.g. an empty
+      // database). Show an "Empty" placeholder rather than a forever skeleton.
+      return [
+        { ...node, isExpanded: true, level, parent },
+        emptyItem(childType, level + 1, node),
+      ];
     }
     return [
       { ...node, isExpanded: true, level, parent },
@@ -203,5 +219,21 @@ export function loadingItem(
     parent: parent?.type === "root" ? undefined : parent?.key,
     isLoading: true,
     key: Math.random().toString(),
+  };
+}
+
+export function emptyItem(
+  type: ItemType,
+  level: number,
+  parent?: TreeNode,
+): FlatItem {
+  return {
+    type,
+    level,
+    value: parent?.type === "root" ? undefined : parent?.value,
+    parent: parent?.type === "root" ? undefined : parent?.key,
+    isEmpty: true,
+    // Stable key (one empty placeholder per parent) so it isn't remounted.
+    key: `${parent?.key ?? "root"}:empty`,
   };
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74508
### Description

Adds an empty state for the table picker in Admin Table Metadata. When a user expands a database with no schemas, after the loading state we will display an unclickable `Empty` item. 

### How to verify

1. Set up an environment where you have added a DB with no schemas
2. Go to Admin -> Table Metadata
3. Try to expand your empty table, you should see an "Empty" item

### Demo

<img width="420" height="350" alt="image" src="https://github.com/user-attachments/assets/9b0659dc-0db8-423b-9db4-ba86de0d7152" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
