### PR TITLE
Do not show the `sdk-disabled` usage problem on localhost

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { screen, within } from "__support__/ui";
+import * as IsLocalhostModule from "embedding-sdk-bundle/lib/get-is-localhost";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import {
@@ -118,7 +119,26 @@ describe("SdkUsageProblemDisplay (simple embedding)", () => {
     );
   });
 
-  it("shows an error when simple embedding is disabled", async () => {
+  // We allow simple embedding to be used locally even when it's disabled for the
+  // instance — same as the SDK; on localhost there is no usage problem.
+  it("does not show an error when simple embedding is disabled on localhost", async () => {
+    expect(window.location.origin).toBe("http://localhost");
+
+    await setup({
+      hasSimpleEmbeddingFeature: true,
+      isSimpleEmbeddingEnabled: false,
+    });
+
+    expect(
+      screen.queryByTestId(PROBLEM_INDICATOR_TEST_ID),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error when simple embedding is disabled in production", async () => {
+    const mock = jest
+      .spyOn(IsLocalhostModule, "getIsLocalhost")
+      .mockImplementation(() => false);
+
     await setup({
       hasSimpleEmbeddingFeature: true,
       isSimpleEmbeddingEnabled: false,
@@ -131,5 +151,7 @@ describe("SdkUsageProblemDisplay (simple embedding)", () => {
     expect(
       within(card).getByText(/not enabled for this instance/),
     ).toBeInTheDocument();
+
+    mock.mockRestore();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -184,6 +184,37 @@ describe("SdkUsageProblemDisplay", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the API key warning when the SDK is disabled on localhost but an API key is used", async () => {
+    expect(window.location.origin).toBe("http://localhost");
+
+    setup({
+      authConfig: createMockApiKeyConfig(),
+      hasEmbeddingFeature: true,
+      isEmbeddingSdkEnabled: false,
+    });
+
+    await userEvent.click(screen.getByTestId(PROBLEM_INDICATOR_TEST_ID));
+
+    const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
+
+    // API keys are always allowed on localhost regardless of the
+    // `enable-embedding-sdk` setting, so the eval-only warning still shows —
+    // not the "not enabled" error.
+    expect(
+      within(card).getByText("This embed is powered by the Metabase SDK."),
+    ).toBeInTheDocument();
+
+    expect(
+      within(card).getByText(
+        /This is intended for evaluation purposes and works only on localhost. To use on other sites, implement SSO./,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      within(card).queryByText(/Embedding is not enabled for this instance/),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an error when Embedding SDK is disabled in production", async () => {
     const mock = jest
       .spyOn(IsLocalhostModule, "getIsLocalhost")

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -167,9 +167,28 @@ describe("SdkUsageProblemDisplay", () => {
     mock.mockRestore();
   });
 
-  // Caveat: we cannot detect this on non-localhost environments, as
-  // CORS is disabled on /api/session/properties.
-  it("shows an error when Embedding SDK is disabled on localhost", async () => {
+  // We allow the SDK to be used locally even when embedding isn't enabled for
+  // the instance: showing an error was confusing — clicking "hide" cleared it
+  // and the SDK rendered anyway — so on localhost there is no usage problem.
+  it("does not show an error when Embedding SDK is disabled on localhost", () => {
+    expect(window.location.origin).toBe("http://localhost");
+
+    setup({
+      authConfig: createMockSdkConfig(),
+      hasEmbeddingFeature: true,
+      isEmbeddingSdkEnabled: false,
+    });
+
+    expect(
+      screen.queryByTestId(PROBLEM_INDICATOR_TEST_ID),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error when Embedding SDK is disabled in production", async () => {
+    const mock = jest
+      .spyOn(IsLocalhostModule, "getIsLocalhost")
+      .mockImplementation(() => false);
+
     setup({
       authConfig: createMockSdkConfig(),
       hasEmbeddingFeature: true,
@@ -194,6 +213,8 @@ describe("SdkUsageProblemDisplay", () => {
       "href",
       "https://www.metabase.com/docs/latest/embedding/sdk/introduction#in-metabase",
     );
+
+    mock.mockRestore();
   });
 
   it("shows a warning when development mode is enabled", async () => {

--- a/frontend/src/embedding-sdk-bundle/lib/usage-problem.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/usage-problem.ts
@@ -126,6 +126,7 @@ export function getSdkUsageProblem(
         {
           hasTokenFeature: true,
           isEnabled: false,
+          isLocalhost: false,
         },
         () => toError("EMBEDDING_SDK_NOT_ENABLED"),
       )


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1781620366708619


Initially we decided to show SDK components locally even if SDK is disabled in Admin UI, but only after we click `hide  error`.
Maybe in pure SDK it works (but it very strange, as until the error is hidden, we don't show anything), but for Data Apps it introduces some frustration.

The solution - we don't show this usage problem for localhost at all.