### PR TITLE
Allow including everything in data and metric library in schema endpoint

### DIFF
--- a/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -27,14 +27,16 @@ Keep the semantic layer and presentation layer separate.
 
 If the schema file already exists, use it. If it is missing or stale, treat schema generation as semantic-layer curation for this data app, not a mechanical export.
 
-Before generating, make sure the user has explicitly chosen both scopes the app needs:
+Before generating, make sure the user has explicitly chosen the scopes the app needs:
 
-- `includeDataLibrary=true` for everything under the top-level `Library / Data` collection.
-- `includeMetricLibrary=true` for everything under the top-level `Library / Metrics` collection.
-- `libraryCollections` for specific Data/Metrics library subcollections by numeric ID or representation `entity_id`. These provide tables, fields, segments, measures, and metrics.
-- `questionCollections` for saved questions from normal collections.
+- Library scope:
+  - `includeDataLibrary=true` for the whole `Library / Data` tree
+  - `includeMetricLibrary=true` for the whole `Library / Metrics` tree
+  - `libraryCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data/Metrics library subcollections.
+- Saved question scope:
+  - `questionCollections=<collection-id>[,<collection-id>]` for saved questions from normal collections.
 
-If the user did not already specify a library scope (`includeDataLibrary`, `includeMetricLibrary`, or `libraryCollections`) and/or `questionCollections`, stop and ask what they want:
+If the user did not already choose a library scope and/or saved question scope, stop and ask what they want:
 
 - Include the entire semantic layer/library in the generated schema file. Only offer this when the app is intentionally using the semantic layer and the library looks small enough to be useful.
 - Include only part of it: the whole Data library, the whole Metrics library, selected library subcollections, selected question collections, or a mix. For example, `includeMetricLibrary=true&libraryCollections=g-jLnamuHKdezZMthJ-z7` includes the entire Metrics library and one Data subcollection.
@@ -46,7 +48,11 @@ If the current working tree looks like a Metabase remote-sync repository, inspec
 - Table YAML under `databases/**/tables/**/<table>.yaml` can show `collection_id: librarylibrarydatadat` for tables directly in Data, or another collection `entity_id` for subcollections.
 - Card YAML under `collections/main/**` with `type: question`, `type: model`, or `type: metric` shows normal saved-question/model/metric placement.
 
-Correlate those representation files with the user's request and offer concrete choices. Prefer `includeDataLibrary=true` / `includeMetricLibrary=true` for whole top-level libraries, and representation `entity_id` values for specific library subcollections. If you cannot tell from representations, say you do not know and ask for collection IDs or entity IDs.
+Correlate those representation files with the user's request and offer concrete choices.
+
+- Prefer representation `entity_id` values for specific library subcollections.
+- Only use `includeDataLibrary=true` / `includeMetricLibrary=true` if the user agrees to include the whole data or metric library.
+- If you cannot tell from representations, say you do not know and ask for collection IDs or entity IDs.
 
 Warn the user before exporting the whole instance. Including everything is noisy: it bloats context, makes agents more likely to pick irrelevant entities, and weakens the intended boundary between the curated semantic layer and the presentation layer.
 

--- a/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -27,12 +27,26 @@ Keep the semantic layer and presentation layer separate.
 
 If the schema file already exists, use it. If it is missing or stale, treat schema generation as semantic-layer curation for this data app, not a mechanical export.
 
-Before generating, ask which collections should be available to the app:
+Before generating, make sure the user has explicitly chosen both scopes the app needs:
 
-- `libraryCollections` for curated Data/Metrics library subcollections. These provide tables, fields, segments, measures, and metrics.
+- `includeDataLibrary=true` for everything under the top-level `Library / Data` collection.
+- `includeMetricLibrary=true` for everything under the top-level `Library / Metrics` collection.
+- `libraryCollections` for specific Data/Metrics library subcollections by numeric ID or representation `entity_id`. These provide tables, fields, segments, measures, and metrics.
 - `questionCollections` for saved questions from normal collections.
 
-If the repository contains Metabase representation YAML, such as `collections/` or `databases/` folders, inspect those files enough to offer concrete collection choices by name. Otherwise ask the user for collection IDs or names.
+If the user did not already specify a library scope (`includeDataLibrary`, `includeMetricLibrary`, or `libraryCollections`) and/or `questionCollections`, stop and ask what they want:
+
+- Include the entire semantic layer/library in the generated schema file. Only offer this when the app is intentionally using the semantic layer and the library looks small enough to be useful.
+- Include only part of it: the whole Data library, the whole Metrics library, selected library subcollections, selected question collections, or a mix. For example, `includeMetricLibrary=true&libraryCollections=g-jLnamuHKdezZMthJ-z7` includes the entire Metrics library and one Data subcollection.
+
+If the current working tree looks like a Metabase remote-sync repository, inspect representation YAML before asking. Useful signals:
+
+- `collections/main/library/data.yaml` and `collections/main/library/metrics.yaml` are the top-level Data and Metrics library collections.
+- Child collection YAML under `collections/main/library/data/` or `collections/main/library/metrics/` exposes a stable `entity_id`; use that value in `libraryCollections` when a subcollection name could be ambiguous.
+- Table YAML under `databases/**/tables/**/<table>.yaml` can show `collection_id: librarylibrarydatadat` for tables directly in Data, or another collection `entity_id` for subcollections.
+- Card YAML under `collections/main/**` with `type: question`, `type: model`, or `type: metric` shows normal saved-question/model/metric placement.
+
+Correlate those representation files with the user's request and offer concrete choices. Prefer `includeDataLibrary=true` / `includeMetricLibrary=true` for whole top-level libraries, and representation `entity_id` values for specific library subcollections. If you cannot tell from representations, say you do not know and ask for collection IDs or entity IDs.
 
 Warn the user before exporting the whole instance. Including everything is noisy: it bloats context, makes agents more likely to pick irrelevant entities, and weakens the intended boundary between the curated semantic layer and the presentation layer.
 
@@ -43,12 +57,16 @@ curl \
   -o src/metabase.data.ts \
   -H "x-api-key: <YOUR_API_KEY>" \
   -H "Accept: text/typescript" \
-  "http://localhost:3000/api/typed-schemas/v1/typescript?libraryCollections=24,25&questionCollections=10,11"
+  "http://localhost:3000/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true&questionCollections=10,11"
 ```
 
 Other useful filters:
 
 - `?database=Production` or `?database=1` for one database.
+- `?includeDataLibrary=true` for every published table in the top-level Data library and its subcollections.
+- `?includeMetricLibrary=true` for every metric in the top-level Metrics library and its subcollections, plus mapped source tables needed by those metrics.
+- `?includeDataLibrary=true&includeMetricLibrary=true` for everything in both top-level semantic libraries.
+- `?includeDataLibrary=true&libraryCollections=g-jLnamuHKdezZMthJ-z7` for the whole Data library plus one specific library subcollection.
 - No query parameters only when the user explicitly wants the whole instance.
 
 ## Standard Pattern

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -160,6 +160,12 @@
   [v]
   (contains? #{true "true" "1"} v))
 
+(def ^:private library-data-entity-id
+  "librarylibrarydatadat")
+
+(def ^:private library-metrics-entity-id
+  "librarylibrarymetrics")
+
 (defn- query-database-value
   [query-params]
   (some-> (or (query-param query-params :database)
@@ -223,6 +229,16 @@
                                               :libraryCollections
                                               :collections]))
 
+(defn- query-include-data-library?
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-data-library)
+                           (query-param query-params :includeDataLibrary))))
+
+(defn- query-include-metric-library?
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-metric-library)
+                           (query-param query-params :includeMetricLibrary))))
+
 (defn- query-question-collection-values
   [query-params]
   (query-comma-separated-values query-params [:question-collections
@@ -244,9 +260,19 @@
            (filter mi/can-read?)
            first))))
 
-(defn- library-collection-for-id
-  [collection-id]
-  (->> (t2/select :model/Collection :id collection-id)
+(defn- library-collection-for-ref
+  [collection-value]
+  (let [collection-id (parse-id collection-value)]
+    (->> (if collection-id
+           (t2/select :model/Collection :id collection-id)
+           (t2/select :model/Collection :entity_id collection-value))
+         (filter #(contains? collection/library-collection-types (:type %)))
+         (filter mi/can-read?)
+         first)))
+
+(defn- library-collection-for-entity-id
+  [entity-id]
+  (->> (t2/select :model/Collection :entity_id entity-id)
        (filter #(contains? collection/library-collection-types (:type %)))
        (filter mi/can-read?)
        first))
@@ -296,9 +322,39 @@
   [collection-values]
   (when (seq collection-values)
     (let [collections (for [collection-value collection-values]
-                        (or (library-collection-for-id (parse-collection-id collection-value))
+                        (or (library-collection-for-ref collection-value)
                             (api/check-404 false)))]
       (library-collection-scope* collections))))
+
+(defn- included-library-root-collections
+  [query-params]
+  (keep (fn [[include? entity-id]]
+          (when include?
+            (or (library-collection-for-entity-id entity-id)
+                (api/check-404 false))))
+        [[(query-include-data-library? query-params) library-data-entity-id]
+         [(query-include-metric-library? query-params) library-metrics-entity-id]]))
+
+(defn- library-scope
+  [query-params]
+  (let [library-value             (query-library-value query-params)
+        library-collection-values (query-library-collection-values query-params)
+        included-roots            (included-library-root-collections query-params)
+        collection-scope          (cond
+                                    library-value
+                                    (library-collection-scope library-value)
+
+                                    library-collection-values
+                                    (library-collections-scope library-collection-values))]
+    (cond
+      (and collection-scope (seq included-roots))
+      (library-collection-scope* (concat (:library-collections collection-scope) included-roots))
+
+      (seq included-roots)
+      (library-collection-scope* included-roots)
+
+      :else
+      collection-scope)))
 
 (defn- select-cards
   ([card-type database-ids]
@@ -757,12 +813,17 @@
   (let [library-value              (query-library-value query-params)
         library-collection-values  (query-library-collection-values query-params)
         question-collection-values (query-question-collection-values query-params)
-        collection-scoped?         (or library-value library-collection-values question-collection-values)
+        include-library-root?      (or (query-include-data-library? query-params)
+                                       (query-include-metric-library? query-params))
+        collection-scoped?         (or library-value
+                                       library-collection-values
+                                       question-collection-values
+                                       include-library-root?)
         database-value             (query-database-value query-params)
         questions-only             (truthy-query-param? (query-param query-params :questions))]
     (api/check-400
-     (not (and library-value library-collection-values))
-     "The library and library-collections query parameters are mutually exclusive.")
+     (not (and library-value (or library-collection-values include-library-root?)))
+     "The library query parameter is mutually exclusive with library-collections, includeDataLibrary, and includeMetricLibrary.")
     (api/check-400
      (not (and collection-scoped? database-value))
      "Collection-scoped query parameters and database query parameters are mutually exclusive.")
@@ -789,6 +850,7 @@
   (let [library-value              (query-library-value query-params)
         library-collection-values  (query-library-collection-values query-params)
         question-collection-values (query-question-collection-values query-params)
+        library-scope              (library-scope query-params)
         database-ids               (database-ids-for-value (query-database-value query-params))
         question-collection-ids    (collection-scope question-collection-values)
         models                     (cond
@@ -802,14 +864,8 @@
                                      [])
         questions-only             (truthy-query-param? (query-param query-params :questions))]
     (cond
-      (or library-value library-collection-values question-collection-values)
-      (let [library-scope       (cond
-                                  library-value
-                                  (library-collection-scope library-value)
-
-                                  library-collection-values
-                                  (library-collections-scope library-collection-values))
-            questions           (if question-collection-values
+      (or library-value library-collection-values library-scope question-collection-values)
+      (let [questions           (if question-collection-values
                                   (question-schemas nil question-collection-ids)
                                   [])
             library-schema      (some-> library-scope

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -380,6 +380,56 @@
                                                           (:id metric-child))}))
                           [:collection-ids :data-collection-ids :metric-collection-ids]))))))
 
+(deftest library-collections-scope-accepts-representation-entity-ids-test
+  (mt/with-temp [:model/Collection root         {:name "Library"
+                                                 :type "library"
+                                                 :location "/"}
+                 :model/Collection data         {:name "Data"
+                                                 :type "library-data"
+                                                 :location (collection/children-location root)}
+                 :model/Collection website      {:name      "Website"
+                                                 :type      "library-data"
+                                                 :entity_id "g-jLnamuHKdezZMthJ-z7"
+                                                 :location  (collection/children-location data)}
+                 :model/Collection website-page {:name "Website Page"
+                                                 :type "library-data"
+                                                 :location (collection/children-location website)}]
+    (mt/with-test-user :crowberto
+      (is (= {:collection-ids        #{(:id website) (:id website-page)}
+              :data-collection-ids   #{(:id website) (:id website-page)}
+              :metric-collection-ids #{}}
+             (select-keys (#'typed-schemas.api/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
+                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
+
+(deftest library-scope-includes-canonical-data-and-metrics-libraries-test
+  (with-redefs [typed-schemas.api/library-data-entity-id    "test-library-data"
+                typed-schemas.api/library-metrics-entity-id "test-library-metrics"]
+    (mt/with-temp [:model/Collection root         {:name "Library"
+                                                   :type "library"
+                                                   :location "/"}
+                   :model/Collection data         {:name      "Data"
+                                                   :type      "library-data"
+                                                   :entity_id "test-library-data"
+                                                   :location  (collection/children-location root)}
+                   :model/Collection metrics      {:name      "Metrics"
+                                                   :type      "library-metrics"
+                                                   :entity_id "test-library-metrics"
+                                                   :location  (collection/children-location root)}
+                   :model/Collection data-child   {:name "Boba Data"
+                                                   :type "library-data"
+                                                   :location (collection/children-location data)}
+                   :model/Collection metric-child {:name "Boba Metrics"
+                                                   :type "library-metrics"
+                                                   :location (collection/children-location metrics)}]
+      (mt/with-test-user :crowberto
+        (is (= {:collection-ids        #{(:id data) (:id data-child) (:id metrics) (:id metric-child)}
+                :data-collection-ids   #{(:id data) (:id data-child)}
+                :metric-collection-ids #{(:id metrics) (:id metric-child)}}
+               (select-keys (#'typed-schemas.api/library-scope
+                             {:includeDataLibrary   "true"
+                              :includeMetricLibrary "true"})
+                            [:collection-ids :data-collection-ids :metric-collection-ids])))))))
+
 (deftest query-collection-values-accept-camel-case-aliases-test
   (is (= ["1" "2"]
          (#'typed-schemas.api/query-library-collection-values {:libraryCollections "1, 2"})))


### PR DESCRIPTION
Closes [EMB-1902](https://linear.app/metabase/issue/EMB-1902/allow-including-everything-in-data-and-metric-library-in-schema)

### Description

Adds explicit schema endpoint query params for including the whole top-level semantic libraries:

- `includeDataLibrary=true` includes everything under `Library / Data`.
- `includeMetricLibrary=true` includes everything under `Library / Metrics`.
- `libraryCollections` continues to include specific library subcollections, now by numeric ID or representation `entity_id`.

Also updates the `metabase-data-app-semantic-layer` skill so agents inspect remote-sync representation YAML, use the new whole-library params for small libraries, and use representation `entity_id` values for selected subcollections.

### How to verify

1. Generate a schema with `includeDataLibrary=true` and confirm it includes published tables from the top-level Data library.
2. Generate a schema with `includeMetricLibrary=true` and confirm it includes metrics from the top-level Metrics library and their mapped source tables.
3. Generate a schema with `libraryCollections=<representation-entity-id>` and confirm it includes only that selected library subcollection subtree.
4. Run `./bin/test-agent :only '[metabase.typed-schemas.api-test]'`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
