### PR TITLE
Oauth client event mark ran v63

### DIFF
--- a/resources/migrations/062/20260601_oauth_client_event.yaml
+++ b/resources/migrations/062/20260601_oauth_client_event.yaml
@@ -1,0 +1,135 @@
+## Append-only audit trail for the OAuth dynamic client registration (DCR) lifecycle.
+## One row is recorded when a client registers, and one row per approve/deny decision.
+##
+## Backport from v63 (migrations/063/20260601_oauth_client_event.yaml). Each changeset is
+## guarded with a MARK_RAN precondition against its v63 counterpart so a v63 -> v62 downgrade
+## (where the v63 changeset already created the object) skips instead of failing.
+
+databaseChangeLog:
+  - changeSet:
+      id: v62.k7m2qd
+      author: bshepherdson
+      comment: Create oauth_client_event table to audit DCR registration and decision events
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v63.k7m2qd
+              author: bshepherdson
+              changeLogFile: migrations/063/20260601_oauth_client_event.yaml
+      changes:
+        - createTable:
+            tableName: oauth_client_event
+            remarks: Append-only audit log of dynamic client registration and authorization events
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  remarks: Auto-incrementing primary key
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: oauth_client_id
+                  type: int
+                  remarks: FK to oauth_client.id; nulled out if the client is deleted
+                  constraints:
+                    nullable: true
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: FK to core_user.id of the user who made the decision; null for registration events
+                  constraints:
+                    nullable: true
+              - column:
+                  name: event_type
+                  type: varchar(20)
+                  remarks: "Event type: registered, approved, or denied"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the event occurred
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v62.r9w4xb
+      author: bshepherdson
+      comment: Add index on oauth_client_event.oauth_client_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v63.r9w4xb
+              author: bshepherdson
+              changeLogFile: migrations/063/20260601_oauth_client_event.yaml
+      changes:
+        - createIndex:
+            tableName: oauth_client_event
+            indexName: idx_oauth_client_event_oauth_client_id
+            columns:
+              - column:
+                  name: oauth_client_id
+
+  - changeSet:
+      id: v62.x2d7kq
+      author: bshepherdson
+      comment: Add index on oauth_client_event.user_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v63.x2d7kq
+              author: bshepherdson
+              changeLogFile: migrations/063/20260601_oauth_client_event.yaml
+      changes:
+        - createIndex:
+            tableName: oauth_client_event
+            indexName: idx_oauth_client_event_user_id
+            columns:
+              - column:
+                  name: user_id
+
+  - changeSet:
+      id: v62.t3z8np
+      author: bshepherdson
+      comment: Add FK on oauth_client_event.oauth_client_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v63.t3z8np
+              author: bshepherdson
+              changeLogFile: migrations/063/20260601_oauth_client_event.yaml
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: oauth_client_event
+            baseColumnNames: oauth_client_id
+            referencedTableName: oauth_client
+            referencedColumnNames: id
+            constraintName: fk_oauth_client_event_oauth_client_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v62.h5c1vj
+      author: bshepherdson
+      comment: Add FK on oauth_client_event.user_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v63.h5c1vj
+              author: bshepherdson
+              changeLogFile: migrations/063/20260601_oauth_client_event.yaml
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: oauth_client_event
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_oauth_client_event_user_id
+            onDelete: SET NULL

--- a/resources/migrations/063/20260601_oauth_client_event.yaml
+++ b/resources/migrations/063/20260601_oauth_client_event.yaml
@@ -57,7 +57,7 @@ databaseChangeLog:
                   defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
-      rollback: ""
+      rollback: "" # rolling back in 62. See comment at the top of the file
 
   - changeSet:
       id: v63.r9w4xb
@@ -77,7 +77,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: oauth_client_id
-      rollback: ""
+      rollback: "" # rolling back in 62. See comment at the top of the file
 
   - changeSet:
       id: v63.x2d7kq
@@ -97,7 +97,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: user_id
-      rollback: ""
+      rollback: "" # rolling back in 62. See comment at the top of the file
 
   - changeSet:
       id: v63.t3z8np
@@ -118,7 +118,7 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_oauth_client_event_oauth_client_id
             onDelete: SET NULL
-      rollback: ""
+      rollback: "" # rolling back in 62. See comment at the top of the file
 
   - changeSet:
       id: v63.h5c1vj
@@ -139,4 +139,4 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_oauth_client_event_user_id
             onDelete: SET NULL
-      rollback: ""
+      rollback: "" # rolling back in 62. See comment at the top of the file

--- a/resources/migrations/063/20260601_oauth_client_event.yaml
+++ b/resources/migrations/063/20260601_oauth_client_event.yaml
@@ -1,11 +1,24 @@
 ## Append-only audit trail for the OAuth dynamic client registration (DCR) lifecycle.
 ## One row is recorded when a client registers, and one row per approve/deny decision.
+##
+## This migration was also backported to v62 (migrations/062/20260601_oauth_client_event.yaml).
+## Each changeset is guarded with a MARK_RAN precondition against its v62 counterpart so a
+## v62 -> v63 upgrade (where the v62 changeset already created the object) skips instead of
+## failing. The empty rollbacks keep a v63 -> v62 downgrade from dropping objects the still-
+## recorded v62 changesets own.
 
 databaseChangeLog:
   - changeSet:
       id: v63.k7m2qd
       author: bshepherdson
       comment: Create oauth_client_event table to audit DCR registration and decision events
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v62.k7m2qd
+              author: bshepherdson
+              changeLogFile: migrations/062/20260601_oauth_client_event.yaml
       changes:
         - createTable:
             tableName: oauth_client_event
@@ -44,11 +57,19 @@ databaseChangeLog:
                   defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
+      rollback: ""
 
   - changeSet:
       id: v63.r9w4xb
       author: bshepherdson
       comment: Add index on oauth_client_event.oauth_client_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v62.r9w4xb
+              author: bshepherdson
+              changeLogFile: migrations/062/20260601_oauth_client_event.yaml
       changes:
         - createIndex:
             tableName: oauth_client_event
@@ -56,11 +77,19 @@ databaseChangeLog:
             columns:
               - column:
                   name: oauth_client_id
+      rollback: ""
 
   - changeSet:
       id: v63.x2d7kq
       author: bshepherdson
       comment: Add index on oauth_client_event.user_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v62.x2d7kq
+              author: bshepherdson
+              changeLogFile: migrations/062/20260601_oauth_client_event.yaml
       changes:
         - createIndex:
             tableName: oauth_client_event
@@ -68,11 +97,19 @@ databaseChangeLog:
             columns:
               - column:
                   name: user_id
+      rollback: ""
 
   - changeSet:
       id: v63.t3z8np
       author: bshepherdson
       comment: Add FK on oauth_client_event.oauth_client_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v62.t3z8np
+              author: bshepherdson
+              changeLogFile: migrations/062/20260601_oauth_client_event.yaml
       changes:
         - addForeignKeyConstraint:
             baseTableName: oauth_client_event
@@ -81,11 +118,19 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_oauth_client_event_oauth_client_id
             onDelete: SET NULL
+      rollback: ""
 
   - changeSet:
       id: v63.h5c1vj
       author: bshepherdson
       comment: Add FK on oauth_client_event.user_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v62.h5c1vj
+              author: bshepherdson
+              changeLogFile: migrations/062/20260601_oauth_client_event.yaml
       changes:
         - addForeignKeyConstraint:
             baseTableName: oauth_client_event
@@ -94,3 +139,4 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_oauth_client_event_user_id
             onDelete: SET NULL
+      rollback: ""


### PR DESCRIPTION
### Description

When https://github.com/metabase/metabase/pull/75886 was merged, it created a situation where users upgrading from 62 to 63 could effectively hit the same migration twice, which would cause a failure (can't create a table that already exsits, etc). This PR adds the 62 migration to the 63, does a couple things:

- if we are migrating from 62 -> 63, then the 63 migration will do nothing
- if we are mgrating from 63 -> 62, the the 63 migration will do nothing
- If for whatever reason, the 63 migration has already run, the 62 migration will not run
