### PR TITLE
Re-enable test and clean up fixmes

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -162,7 +162,7 @@
 ;; MariaDB doesn't have the JSON type at all, though `JSON` was introduced as an alias for LONGTEXT in 10.2.7.
 (defmethod driver/database-supports? [:mysql :nested-field-columns]
   [_driver _feat db]
-  (and (driver.common/json-unfolding-default db) (mysql? db)))
+  (and (driver.common/json-unfolding-default db) (not (mariadb? db))))
 
 (defmethod driver/database-supports? [:mysql :table-privileges]
   [_driver _feat _db]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -121,13 +121,6 @@
   [_driver database]
   (:db (:details database)))
 
-;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.
-;; And MariaDB doesn't have the JSON type at all, though `JSON` was introduced as an alias for LONGTEXT in 10.2.7.
-;; But since JSON unfolding will only apply columns with JSON types, this won't cause any problems during sync.
-(defmethod driver/database-supports? [:mysql :nested-field-columns]
-  [_driver _feat db]
-  (driver.common/json-unfolding-default db))
-
 (doseq [feature [:actions :actions/custom :actions/data-editing]]
   (defmethod driver/database-supports? [:mysql feature]
     [driver _feat _db]
@@ -165,6 +158,11 @@
   "Returns true if the database is MariaDB."
   [conn :- (lib.schema.common/instance-of-class Connection)]
   (= (connection-flavor conn) "MariaDB"))
+
+;; MariaDB doesn't have the JSON type at all, though `JSON` was introduced as an alias for LONGTEXT in 10.2.7.
+(defmethod driver/database-supports? [:mysql :nested-field-columns]
+  [_driver _feat db]
+  (and (driver.common/json-unfolding-default db) (mysql? db)))
 
 (defmethod driver/database-supports? [:mysql :table-privileges]
   [_driver _feat _db]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1560,7 +1560,7 @@
   ->query
   can-preview
   can-run
-  can-save
+  can-save?
   check-card-overwrite
   native?
   preview-query

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2676,7 +2676,7 @@
    (lib.cache/side-channel-cache
     (keyword "can-save" card-type) a-query
     (fn [_]
-      (lib.core/can-save a-query (keyword card-type))))))
+      (lib.core/can-save? a-query (keyword card-type))))))
 
 (defn ^:export ensure-filter-stage
   "Adds an empty stage to `query` if its last stage contains both breakouts and aggregations.

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -96,24 +96,23 @@
        (:database query)
        (boolean (can-run-method query card-type))))
 
-(defmulti can-save-method
+(defmulti can-save?-method
   "Returns whether the query can be saved based on first stage :lib/type."
   {:arglists '([query card-type])}
   (fn [query _card-type]
     (:lib/type (lib.util/query-stage query 0))))
 
-(defmethod can-save-method :default
+(defmethod can-save?-method :default
   [_query _card-type]
   true)
 
-;;; TODO FIXME -- boolean functions should end in `?`
-(mu/defn can-save :- :boolean
+(mu/defn can-save? :- :boolean
   "Returns whether `query` for a card of `card-type` can be saved."
   [query :- ::lib.schema/query
    card-type :- ::lib.schema.metadata/card.type]
   (and (lib.metadata/editable? query)
        (can-run query card-type)
-       (boolean (can-save-method query card-type))))
+       (boolean (can-save?-method query card-type))))
 
 (mu/defn can-preview :- :boolean
   "Returns whether the query can be previewed.

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -484,7 +484,7 @@
   [dataset-query :- [:maybe ::queries.schema/query]
    card-type     :- [:maybe ::queries.schema/card-type]]
   (when (and (seq dataset-query) (= card-type :metric))
-    (when-not (lib/can-save dataset-query card-type)
+    (when-not (lib/can-save? dataset-query card-type)
       (throw (ex-info (tru "Card of type {0} is invalid, cannot be saved." (name card-type))
                       {:type        card-type
                        :status-code 400})))))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -433,19 +433,18 @@
 ;;; End tests for `describe-*` methods used in sync
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: Uncomment when https://github.com/metabase/metabase/pull/60263 is merged
-#_(deftest ^:parallel data-editing-requires-describe-features-test
-    (testing "Drivers supporting :actions/data-editing must support relevant describe-X features"
-      (mt/test-drivers (mt/normal-drivers-with-feature :actions/data-editing)
-        (testing "describe-default-expr feature"
-          (is (driver/database-supports? driver/*driver* :describe-default-expr (mt/db))
-              (str driver/*driver* " must support :describe-default-expr to support :actions/data-editing")))
-        (testing "describe-is-generated feature"
-          (is (driver/database-supports? driver/*driver* :describe-is-generated (mt/db))
-              (str driver/*driver* " must support :describe-is-generated to support :actions/data-editing")))
-        (testing "describe-is-nullable feature"
-          (is (driver/database-supports? driver/*driver* :describe-is-nullable (mt/db))
-              (str driver/*driver* " must support :describe-is-nullable to support :actions/data-editing"))))))
+(deftest ^:parallel data-editing-requires-describe-features-test
+  (testing "Drivers supporting :actions/data-editing must support relevant describe-X features"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions/data-editing)
+      (testing "describe-default-expr feature"
+        (is (driver/database-supports? driver/*driver* :describe-default-expr (mt/db))
+            (str driver/*driver* " must support :describe-default-expr to support :actions/data-editing")))
+      (testing "describe-is-generated feature"
+        (is (driver/database-supports? driver/*driver* :describe-is-generated (mt/db))
+            (str driver/*driver* " must support :describe-is-generated to support :actions/data-editing")))
+      (testing "describe-is-nullable feature"
+        (is (driver/database-supports? driver/*driver* :describe-is-nullable (mt/db))
+            (str driver/*driver* " must support :describe-is-nullable to support :actions/data-editing"))))))
 
 (deftest query-driver-success-metrics-test
   (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -1198,7 +1198,7 @@
                {:lib/source-column-alias "BODY",       :display-name "Body",       :selected? true}
                {:lib/source-column-alias "CREATED_AT", :display-name "Created At", :selected? true}
                ;; the following two Card 1 → ID should have :selected? true
-               {:lib/source-column-alias "ID",    :display-name "Card 1 → ID", :selected? true} ; FIXME - these should be true
+               {:lib/source-column-alias "ID",    :display-name "Card 1 → ID", :selected? true}
                {:lib/source-column-alias "o__ID", :display-name "Card 1 → ID", :selected? true}
                ;; these are implicitly joinable fields, :selected? false is right
                {:lib/source-column-alias "ID",         :display-name "ID",         :selected? false}

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1379,9 +1379,7 @@
                                                            :name-selected? false}]]
       (testing (str "fields = " (pr-str fields))
         (let [join  (lib/with-join-fields original-join fields)
-              ;; FIXME -- joins replacement broken -- #32026
-              ;; query (lib/replace-clause query original-join join)
-              query (assoc-in query [:stages 0 :joins] [join])
+              query (lib/replace-clause query original-join join)
               cols  (lib/join-fieldable-columns query -1 join)]
           (is (=? [{:name                         "ID"
                     :lib/join-alias "Cat"

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -234,11 +234,11 @@
                           (lib/append-stage)
                           (lib/aggregate (lib/count))))))
 
-(deftest ^:parallel can-save-test
+(deftest ^:parallel can-save?-test
   (mu/disable-enforcement
     #_{:clj-kondo/ignore [:equals-true]}
     (are [can-save? card-type query]
-         (= can-save? (lib.query/can-save query card-type))
+         (= can-save? (lib.query/can-save? query card-type))
       true  :question (lib.tu/venues-query)
       false :question (assoc (lib.tu/venues-query) :database nil)           ; database unknown - no permissions
       true  :question (lib/native-query meta/metadata-provider "SELECT")

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -1663,12 +1663,9 @@
                     [str int]
                     (qp/process-query query))))))))))
 
-;;; TODO -- not clear why this test is hardcoded to only run against Postgres, and not to run against our other DBs that
-;;; support JSON unfolding e.g. MySQL. FIXME
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel unfolded-json-with-custom-expression-test
   (testing "Should keep roots of unfolded JSON fields in the nested query (#29184)"
-    (mt/test-driver :postgres
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-field-columns)
       (mt/dataset json
         (let [field-id (mt/id :json "json_bit → title")]
           (is (=? {:status :completed}

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -760,7 +760,7 @@
                                 [:cum-sum
                                  [:field "TOTAL" {::add/source-table ::add/source
                                                   ::add/source-alias "TOTAL"}]]
-                                {::add/source-alias "sum" ; FIXME This key shouldn't be here, this doesn't come from the source query.
+                                {::add/source-alias "sum"
                                  ::add/desired-alias "sum"}]]
                  :breakout [[:field "CREATED_AT" {::add/source-alias "CREATED_AT"
                                                   ::add/desired-alias "CREATED_AT"}]


### PR DESCRIPTION
There was a todo to re-enable this `data-editing-requires-describe-features-test` once https://github.com/metabase/metabase/pull/60263 was merged which it has been now. 

Removes some trivial fixmes

Sets the `:nested-field-columns` driver feature to false for mariadb so that `unfolded-json-with-custom-expression-test` doesn't need to hard code postgres

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
