### PR TITLE
fix(mysql): don't pass getCatalog() as the sync catalog filter (#75929)

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -695,7 +695,17 @@
    ;; removing that overhead. See also
    ;; https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_useLocalSessionState
    ;; and #44507
-   :useLocalSessionState true})
+   :useLocalSessionState true
+   ;; A `nil` catalog passed to `DatabaseMetaData.getTables` must mean "the current (bound) database",
+   ;; NOT "every database the user has privileges on". `active-tables` (and `describe-database` generally)
+   ;; relies on this: it passes `nil` for the catalog and trusts the driver to scope results to the
+   ;; connected DB. This is the MariaDB 2.x default, but pin it explicitly so that (a) the contract is
+   ;; documented where the next person bumping the driver will see it, and (b) a future driver upgrade
+   ;; can't silently flip the default to `false` and widen sync to sibling databases — Connector/J 8.x,
+   ;; for instance, defaults this to `false`. Pinning `true` is also why we must pass `nil` rather than
+   ;; `(.getCatalog conn)`: on Vitess/PlanetScale replica connections getCatalog returns the routing-
+   ;; qualified `<db>@replica`, which never matches the bare `TABLE_SCHEMA`. See #75929.
+   :nullCatalogMeansCurrent true})
 
 (defn- maybe-add-program-name-option [jdbc-spec additional-options-map]
   ;; connectionAttributes (if multiple) are separated by commas, so values that contain spaces are OK, so long as they
@@ -751,18 +761,22 @@
            (sql-jdbc.common/handle-additional-options details))))))
 
 (defmethod sql-jdbc.sync/active-tables :mysql
-  [driver ^java.sql.Connection conn schema-inclusion-filters schema-exclusion-filters]
-  ;; Scope describe-database to the connection's current catalog (= bound DB).
-  ;; By default `post-filtered-active-tables` passes `nil` for the catalog filter,
-  ;; which makes JDBC enumerate every DB the user has privileges on. That's wrong
-  ;; for workspace MySQL users — they own the iso DB and have GRANT SELECT on the
-  ;; canonical DB, so the iso DB's tables would leak into sync. Constraining to
-  ;; `conn.getCatalog()` means only the canonical (bound) DB's tables show up,
-  ;; regardless of what else the user can read. Also strictly more correct for
-  ;; plain MySQL: a user with GRANT on multiple DBs only configured one as the
-  ;; Metabase Database; sync should never have surfaced the others.
-  (sql-jdbc.sync/post-filtered-active-tables
-   driver conn (.getCatalog conn) schema-inclusion-filters schema-exclusion-filters))
+  [& args]
+  ;; Pass `nil` for the catalog filter (the default). Our MySQL/MariaDB JDBC driver defaults to
+  ;; `nullCatalogMeansCurrent=true`, so a `nil` catalog already scopes `getTables()` to the connection's
+  ;; current (bound) database — it does NOT enumerate every DB the user can read.
+  ;;
+  ;; Do NOT pass `(.getCatalog conn)` here. On PlanetScale/Vitess connections made with *replica*
+  ;; credentials (or any `<db>@replica`-targeted connection), `SELECT DATABASE()` — which backs
+  ;; `getCatalog()` — returns the routing-qualified name `<db>@replica`. The driver compiles a non-nil
+  ;; catalog into `WHERE TABLE_SCHEMA = '<db>@replica'`, but `information_schema` stores the bare
+  ;; `TABLE_SCHEMA = '<db>'`, so the filter matches nothing and sync sees an empty database. The `@replica`
+  ;; suffix is a Vitess routing directive, not part of the schema name, so it can never equal a real
+  ;; `TABLE_SCHEMA`. See #75929. (Verified against live PlanetScale: nil → 3 tables, getCatalog → 0.)
+  ;;
+  ;; (If no database is bound, current-DB scoping resolves to nothing and `getTables` returns zero tables;
+  ;; this fails safe and is unreachable in practice since a MySQL Database always has `:dbname`.)
+  (apply sql-jdbc.sync/post-filtered-active-tables args))
 
 (defmethod sql-jdbc.sync/excluded-schemas :mysql
   [_]


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/75929

Table enumeration broke for PlanetScale databases configured with replica (or any `<db>@replica`-targeted) credentials starting in 0.62.

Root cause
----------
`active-tables :mysql` was changed to pass `(.getCatalog conn)` as the catalog filter to `DatabaseMetaData.getTables`. `getCatalog()` is backed by `SELECT DATABASE()`, which on a Vitess/PlanetScale replica connection returns the routing-qualified name `<db>@replica`. The driver compiles a non-nil catalog into `WHERE TABLE_SCHEMA = '<db>@replica'`, but `information_schema` stores the bare `TABLE_SCHEMA = '<db>'`, so the filter matches nothing and sync sees an empty database. Primary credentials return the bare name, which is why the same sync worked on primary but not replica creds.

The `@replica` suffix is a Vitess routing directive, not part of the schema name, so it can never equal a real `TABLE_SCHEMA`. There is no clean catalog to recover at runtime: getCatalog/DATABASE()/SCHEMA() are all contaminated, and setCatalog is a no-op on Vitess.

Fix
---
1. Revert `active-tables :mysql` to pass `nil` for the catalog. The MariaDB driver's `nullCatalogMeansCurrent=true` default already scopes a nil catalog to the connection's current (bound) database — it does NOT enumerate every DB the user can read. This delegates "current database" resolution to the driver instead of reconstructing a filter string, and correctly returns the bound DB's tables on both primary and replica PlanetScale connections.

2. Pin `nullCatalogMeansCurrent=true` explicitly in `default-connection-args` so the contract is documented and a future driver bump (Connector/J 8.x defaults it to `false`) can't silently widen sync to sibling databases.

The original change aimed to stop workspace MySQL users (GRANT SELECT on the canonical DB + ownership of an iso DB) from leaking the iso DB into sync. That leak does not occur with the shipped driver: `nullCatalogMeansCurrent=true` already scopes `nil` to the bound DB. This is corroborated by the test suite running many databases on one MySQL server with exact-set table assertions — a true over-enumeration would have failed those deterministically. Verified directly against live PlanetScale (replica: nil -> 3 tables, getCatalog -> 0; primary: 3) and a local multi-DB MySQL server (scoped to the bound DB, no leak).

Why no test
-----------
This regression is not reproducible without Vitess, so no local test has teeth. The bug only manifests when `getCatalog()` returns a value that differs from the `information_schema` TABLE_SCHEMA — i.e. PlanetScale's `<db>@replica`. On stock MySQL `getCatalog()` returns the bare bound-DB name, so any local test would scope correctly and stay green even if `(.getCatalog conn)` were reintroduced. A behavioral cross-DB test passes whether or not the bug is present; a unit test asserting the `nullCatalogMeansCurrent` pin is orthogonal to the catalog argument and likewise passes with the bug reintroduced. Both would give false confidence. A faithful test requires a live Vitess/PlanetScale instance, which isn't available in CI. The inline code comments document the trap, the mechanism, and the verified reproduction as the durable regression guard.

Here's a repro with the following containers:

```
docker run -d --name mysql-local -e MYSQL_ROOT_PASSWORD=mysecretpassword -e MYSQL_ROOT_HOST='%' -p 3306:3306 mysql:8

docker run -d --name vitess-local \
    -p 33574:33574 \
    -p 33575:33575 \
    -p 33577:33577 \
    -e PORT=33574 \
    -e KEYSPACES=stuff,unsharded \
    -e NUM_SHARDS=2,1 \
    -e MYSQL_BIND_HOST=0.0.0.0 \
    -e VTCOMBO_BIND_HOST=0.0.0.0 \
    vitess/vttestserver:mysql80
```

```clojure
(letfn [(probe [label uri]
          (with-open [conn (jdbc/get-connection {:connection-uri uri})]
            (let [cnt (fn [cat] (with-open [rs (.getTables (.getMetaData conn) cat nil "%"
                                                           (into-array String ["TABLE"]))]
                                  (count (jdbc/result-set-seq rs))))]
              {:label label
               :getCatalog (.getCatalog conn)
               :nil-filter (cnt nil)
               :getCatalog-filter (cnt (.getCatalog conn))})))]
  (mapv (fn [[db conn-s]] (probe db conn-s))
        [["MySQL"           "jdbc:mysql://127.0.0.1:3306/stuff?user=root&password=mysecretpassword"]
         ["Vitess"          "jdbc:mysql://127.0.0.1:33577/stuff?user=root&password="]
         ["Vitess @replica" "jdbc:mysql://127.0.0.1:33577/stuff@replica?user=root&password="]]))
[{:label "MySQL",
  :getCatalog "stuff",
  :nil-filter 3,
  :getCatalog-filter 3}
 {:label "Vitess",
  :getCatalog "stuff",
  :nil-filter 3,
  :getCatalog-filter 3}
 {:label "Vitess @replica",
  :getCatalog "stuff@replica",
  :nil-filter 3,
  :getCatalog-filter 0}]
```
