### PR TITLE
Fix dependencies cycles handling

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/events.clj
@@ -216,7 +216,7 @@
 (methodical/defmethod events/publish-event! ::check-card-dependents
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (deps.findings/mark-entity-stale! :card (:id object))
+    (deps.findings/mark-entity-and-transitive-dependents-stale! :card (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
 (derive ::check-card-dependents-on-delete :metabase/event)
@@ -225,7 +225,7 @@
 (methodical/defmethod events/publish-event! ::check-card-dependents-on-delete
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :card (:id object))
+    (when (deps.findings/mark-transitive-dependents-stale! {:card [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
 (derive ::check-transform :metabase/event)
@@ -235,7 +235,7 @@
 (methodical/defmethod events/publish-event! ::check-transform
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (deps.findings/mark-entity-stale! :transform (:id object))
+    (deps.findings/mark-entity-and-transitive-dependents-stale! :transform (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
 (derive ::check-transform-on-delete :metabase/event)
@@ -244,7 +244,7 @@
 (methodical/defmethod events/publish-event! ::check-transform-on-delete
   [_ {:keys [id]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :transform id)
+    (when (deps.findings/mark-transitive-dependents-stale! {:transform [id]})
       (task.entity-check/trigger-entity-check-job!))))
 
 (derive ::check-segment-dependents :metabase/event)
@@ -254,7 +254,7 @@
 (methodical/defmethod events/publish-event! ::check-segment-dependents
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (deps.findings/mark-entity-stale! :segment (:id object))
+    (deps.findings/mark-entity-and-transitive-dependents-stale! :segment (:id object))
     (task.entity-check/trigger-entity-check-job!)))
 
 (derive ::check-segment-dependents-on-delete :metabase/event)
@@ -263,7 +263,7 @@
 (methodical/defmethod events/publish-event! ::check-segment-dependents-on-delete
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :segment (:id object))
+    (when (deps.findings/mark-transitive-dependents-stale! {:segment [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
 (derive ::check-transform-dependents :metabase/event)
@@ -272,7 +272,7 @@
 (methodical/defmethod events/publish-event! ::check-transform-dependents
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :transform (:transform-id object))
+    (when (deps.findings/mark-transitive-dependents-stale! {:transform [(:transform-id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
 (defn- synced-db->direct-dependents-of-changed-tables
@@ -318,7 +318,7 @@
   (when (premium-features/has-feature? :dependencies)
     (let [changes (synced-db->direct-dependents-of-changed-tables db-id)]
       (when (and (seq changes)
-                 (deps.findings/mark-all-immediate-dependents-stale! {:table changes}))
+                 (deps.findings/mark-transitive-dependents-stale! {:table changes}))
         (task.entity-check/trigger-entity-check-job!)))))
 
 ;; ### Admin UI Table/Field Metadata Updates
@@ -329,7 +329,7 @@
 (methodical/defmethod events/publish-event! ::check-table-metadata-update
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :table (:id object))
+    (when (deps.findings/mark-transitive-dependents-stale! {:table [(:id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
 (derive ::check-field-metadata-update :metabase/event)
@@ -338,7 +338,7 @@
 (methodical/defmethod events/publish-event! ::check-field-metadata-update
   [_ {:keys [object]}]
   (when (premium-features/has-feature? :dependencies)
-    (when (deps.findings/mark-immediate-dependents-stale! :table (:table_id object))
+    (when (deps.findings/mark-transitive-dependents-stale! {:table [(:table_id object)]})
       (task.entity-check/trigger-entity-check-job!))))
 
 ;; ### Database Deletion (orphans transforms)
@@ -352,4 +352,5 @@
   [db-id]
   (when-let [transform-ids (not-empty (t2/select-pks-set :model/Transform :source_database_id db-id))]
     (deps.analysis-finding/mark-stale! :transform transform-ids)
+    (deps.findings/mark-transitive-dependents-stale! {:transform transform-ids})
     (task.entity-check/trigger-entity-check-job!)))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -86,18 +86,14 @@
 (def dependable-entities
   "Entities which can be depended on by other entities, even if they cannot themselves be analyzed.
 
-  For example, `:table`s can be passed to [[mark-dependents-stale!]] as the upstream entity whose dependents are now
+  For example, `:table`s can be passed to [[mark-transitive-dependents-stale!]] as an upstream entity whose dependents are now
   stale, but we cannot analyze tables themselves."
   (conj analyzable-entities :table))
 
-(def ^:private DependableEntityType
-  "Schema for entity types supported by analysis findings."
-  (into [:enum] dependable-entities))
-
 (defn- mark-supported-dependents-stale!
   "Given a map of {entity-type [entity-ids]}, mark all supported (analyzable) types as stale.
-  For non-analyzable entities (e.g., tables), looks through to their dependents so the wave
-  can reach analyzable entities beyond them.
+  For non-analyzable entities (e.g., tables), looks through to their dependents so we still
+  reach analyzable entities beyond them.
   Returns true if any supported dependents were found."
   [dependents]
   (let [{analyzable true non-analyzable false}
@@ -121,31 +117,18 @@
       (deps.analysis-finding/mark-stale! dep-type dep-ids))
     (boolean (seq all-supported))))
 
-(mu/defn mark-dependents-stale! :- :boolean
-  "Mark all transitive dependents of an entity as stale for re-analysis.
-  Returns true if any supported dependents were found, false otherwise.
+(defn mark-transitive-dependents-stale!
+  "Mark all transitive dependents of the given upstream entities stale for re-analysis. Takes `{entity-type [entity-ids]}`
+  — entity types may be non-analyzable (e.g. `:table`), since they can still have analyzable dependents, and each id
+  collection may be any seqable (vector, set, ...). Returns true if any supported (analyzable) dependents were found.
 
   Uses `transitive-dependents` (not `transitive-mbql-dependents`) because:
   1. It's faster - doesn't need to fetch entities to check for native-ness
   2. Native dependents marked stale will just be quickly re-validated as valid"
-  [entity-type :- DependableEntityType
-   entity-id   :- pos-int?]
-  (let [dependents (models.dependency/transitive-dependents {entity-type [{:id entity-id}]})]
-    (mark-supported-dependents-stale! dependents)))
-
-(defn mark-all-immediate-dependents-stale!
-  "Mark the immediate dependents of multiple entities as stale.
-  Takes a map of {entity-type entity-ids} where entity-ids is a set of IDs.
-  Does NOT traverse transitively — the entity-check job loop propagates in waves.
-  Returns true if any supported dependents were found."
   [type->entity-ids]
-  (let [key-seq (for [[entity-type ids] type->entity-ids
-                      id ids]
-                  [entity-type id])
-        deps-map (models.dependency/direct-dependents key-seq)
-        dependents (models.dependency/group-nodes
-                    (into #{} cat (vals deps-map)))]
-    (mark-supported-dependents-stale! dependents)))
+  (-> (models.dependency/transitive-dependents
+       (update-vals type->entity-ids (fn [ids] (map (fn [id] {:id id}) ids))))
+      mark-supported-dependents-stale!))
 
 (mu/defn mark-entity-stale!
   "Mark a single entity as stale for re-analysis by the background job."
@@ -153,41 +136,32 @@
    entity-id   :- pos-int?]
   (deps.analysis-finding/mark-stale! entity-type [entity-id]))
 
-(mu/defn mark-immediate-dependents-stale! :- :boolean
-  "Mark the immediate dependents of an entity as stale.
-  Unlike [[mark-dependents-stale!]], this does NOT traverse transitively."
-  [entity-type :- DependableEntityType
+(mu/defn mark-entity-and-transitive-dependents-stale!
+  "Mark `entity-id` and all of its transitive dependents stale for re-analysis. Use this when an entity changes: it
+  queues the whole affected subtree up front so the entity-check job drains a fixed set of stale entities (see
+  [[metabase-enterprise.dependencies.task.entity-check/check-entities!]]) without re-propagating staleness during the
+  drain — which can never terminate when the dependency graph has a cycle."
+  [entity-type :- AnalyzableEntityType
    entity-id   :- pos-int?]
-  (let [key-seq [[entity-type entity-id]]
-        deps-map (models.dependency/direct-dependents key-seq)
-        dependents (models.dependency/group-nodes
-                    (into #{} cat (vals deps-map)))]
-    (mark-supported-dependents-stale! dependents)))
-
-(defn- analyze-and-propagate!
-  "Analyze an entity and mark its immediate dependents as stale.
-  Wrapped in a transaction so that if marking dependents fails, the analysis
-  is rolled back and the entity stays stale for retry on the next pass.
-  The newly-stale dependents are picked up by the job's loop in
-  `task.entity-check/check-entities!`, which drains all stale entities
-  before returning — no need to re-trigger the job."
-  [instance]
-  (let [entity-type (deps.dependency-types/model->dependency-type (t2/model instance))]
-    (t2/with-transaction [_conn]
-      (upsert-analysis! instance)
-      (mark-immediate-dependents-stale! entity-type (:id instance)))))
+  (mark-entity-stale! entity-type entity-id)
+  (mark-transitive-dependents-stale! {entity-type [entity-id]}))
 
 (mu/defn analyze-batch! :- nat-int?
   "Add or update analyses for a batch of entities.
 
   Takes in an entity type and batch size, and looks for a batch of entities with missing or out of date
-  AnalysisFindings and then upsert new analyses for them."
+  AnalysisFindings and then upsert new analyses for them.
+
+  This only *analyzes* (each [[upsert-analysis!]] clears that entity's stale flag); it does NOT propagate staleness to
+  dependents. Propagation happens up front when an entity changes (see [[mark-entity-and-transitive-dependents-stale!]] and the
+  event handlers), so the entity-check job drains a fixed set of stale entities that only shrinks — guaranteeing
+  termination even when the dependency graph has cycles."
   [type :- AnalyzableEntityType
    batch-size :- pos-int?]
   (let [instances (deps.analysis-finding/instances-for-analysis type batch-size)]
     (lib-be/with-metadata-provider-cache
       (doseq [instance instances]
-        (try (analyze-and-propagate! instance)
+        (try (upsert-analysis! instance)
              (catch Exception e
                (log/errorf e "Analyzing entity %s %s failed"
                            (t2/model instance) (:id instance))))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -82,6 +82,12 @@
   []
   (t2/exists? :model/AnalysisFinding :stale true))
 
+(defn stale-entity-count
+  "Number of analysis findings currently marked stale, across all entity types. Used by the entity-check drain loop to
+  detect whether it is still making progress."
+  []
+  (t2/count :model/AnalysisFinding :stale true))
+
 (defn instances-for-analysis
   "Find a batch of instances of type `entity-type` and maximum size `batch-size` with missing, outdated,
   or stale AnalysisFindings.

--- a/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/task/entity_check.clj
@@ -28,16 +28,24 @@
       (< 1)))
 
 (defn- check-entities!
-  "Process entities, draining all stale entities before returning.
-  Continues looping as long as there are stale entities — this is important because
-  [[deps.findings/analyze-and-propagate!]] marks immediate dependents stale during processing,
-  which need to be picked up in subsequent waves."
+  "Drain the currently-stale entities, analyzing each one.
+
+  Staleness is propagated up front, at the moment an entity changes (see the dependencies event handlers, which mark the
+  whole affected subtree via [[deps.findings/mark-entity-and-transitive-dependents-stale!]]). The drain therefore works through a
+  fixed set that only shrinks — it never re-marks anything stale during draining — so it always terminates, even when the
+  dependency graph has cycles.
+
+  As a safety net, the loop also stops as soon as a pass fails to reduce the stale count (e.g. an entity whose analysis
+  can't be persisted). That keeps a single unprocessable entity from spinning the loop forever; the next scheduled run
+  retries it."
   []
   (when (premium-features/has-feature? :dependencies)
-    (loop []
+    (loop [prev-stale nil]
       (process-one-batch!)
-      (when (deps.analysis-finding/has-stale-entities?)
-        (recur)))))
+      (let [stale (deps.analysis-finding/stale-entity-count)]
+        (when (and (pos? stale)
+                   (or (nil? prev-stale) (< stale prev-stale)))
+          (recur stale))))))
 
 (declare schedule-run!)
 

--- a/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/events_test.clj
@@ -727,34 +727,10 @@
 
 ;;; ------------------------------------------------ Analysis propagation tests ------------------------------------------------
 
-(deftest ^:sequential card-update-transaction-rollback-test
-  (run-with-dependencies-setup!
-   (fn [mp]
-     (testing "If marking immediate dependents stale fails, analysis upsert is rolled back"
-       (let [products (lib.metadata/table mp (mt/id :products))
-             old-version models.analysis-finding/*current-analysis-finding-version*
-             new-version (inc old-version)]
-         (mt/with-temp [:model/Card {card-id :id :as card} {:dataset_query (lib/query mp products)}]
-           (deps.findings/upsert-analysis! card)
-           (testing "Initial analysis exists"
-             (is (= old-version (t2/select-one-fn :analysis_version :model/AnalysisFinding
-                                                  :analyzed_entity_type :card
-                                                  :analyzed_entity_id card-id))))
-           (binding [models.analysis-finding/*current-analysis-finding-version* new-version]
-             (mt/with-dynamic-fn-redefs [deps.findings/mark-immediate-dependents-stale!
-                                         (fn [_ _] (throw (ex-info "Simulated failure" {})))]
-               ;; analyze-and-propagate! wraps in a transaction, so the upsert should be rolled back
-               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Simulated failure"
-                                     (#'deps.findings/analyze-and-propagate! card)))))
-           (testing "Analysis should be unchanged after rolled-back transaction"
-             (is (= old-version (t2/select-one-fn :analysis_version :model/AnalysisFinding
-                                                  :analyzed_entity_type :card
-                                                  :analyzed_entity_id card-id))))))))))
-
 (deftest ^:sequential card-update-triggers-native-cards-test
   (run-with-dependencies-setup!
    (fn [mp]
-     (testing "Card update marks entity stale, and the entity-check job re-analyzes it and marks dependents stale"
+     (testing "Card update marks the card and its transitive dependents stale, and the entity-check job re-analyzes them"
        (mt/with-temp [:model/Card {parent-id :id :as parent} {:dataset_query (lib/native-query mp "select * from products")}
                       :model/Card {child-id :id :as child} {:dataset_query (lib/query mp (lib.metadata/card mp parent-id))}
                       :model/Dependency _ {:from_entity_type :card :from_entity_id child-id
@@ -773,7 +749,7 @@
            (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
                                          :analyzed_entity_type :card
                                          :analyzed_entity_id parent-id))))
-         (testing "Child should have been re-analyzed via wave propagation"
+         (testing "Child should have been re-analyzed (it was marked stale up front as a transitive dependent)"
            (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
                                          :analyzed_entity_type :card
                                          :analyzed_entity_id child-id)))))))))
@@ -781,7 +757,7 @@
 (deftest ^:sequential card-update-stops-on-transforms-test
   (run-with-dependencies-setup!
    (fn [mp]
-     (testing "Card update marks immediate dependents stale including transforms, wave propagates through"
+     (testing "Card update marks the card and its transitive dependents (including transforms) stale up front"
        (let [products (lib.metadata/table mp (mt/id :products))
              orders (lib.metadata/table mp (mt/id :orders))
              old-version models.analysis-finding/*current-analysis-finding-version*]
@@ -805,9 +781,9 @@
              :transform {transform-id old-version}})
            ;; Event marks parent stale in analysis_finding, which triggers entity-check
            (events/publish-event! :event/card-update {:object parent-card :previous-object parent-card :user-id api/*current-user-id*})
-           ;; Run entity-check job — should propagate through transform to child via waves
+           ;; Run entity-check job to drain the stale entities
            (#'task.entity-check/check-entities!)
-           (testing "All entities should be re-analyzed after wave propagation"
+           (testing "All entities should be re-analyzed after the drain"
              (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
                                            :analyzed_entity_type :card :analyzed_entity_id parent-card-id)))
              (is (false? (t2/select-one-fn :stale :model/AnalysisFinding

--- a/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
@@ -157,7 +157,7 @@
                               :analyzed_entity_id card-id)))))))))
 
 (deftest mark-dependents-stale-test
-  (testing "mark-dependents-stale! marks direct dependents as stale"
+  (testing "mark-transitive-dependents-stale! marks direct dependents as stale"
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))]
       (mt/with-premium-features #{:dependencies}
@@ -175,13 +175,13 @@
                      (stale-map [parent-card-id child-card-id]))
                   "neither should be stale before marking")
               (t2/with-transaction [_conn]
-                (deps.findings/mark-dependents-stale! :card parent-card-id)
+                (deps.findings/mark-transitive-dependents-stale! {:card [parent-card-id]})
                 (is (= {parent-card-id false, child-card-id true}
                        (stale-map [parent-card-id child-card-id]))
                     "parent should NOT be stale, child should be stale")))))))))
 
 (deftest mark-dependents-stale-transitive-test
-  (testing "mark-dependents-stale! marks transitive dependents as stale"
+  (testing "mark-transitive-dependents-stale! marks transitive dependents as stale"
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))]
       (mt/with-premium-features #{:dependencies}
@@ -201,13 +201,13 @@
               (run! deps.findings/upsert-analysis!
                     (t2/select :model/Card :id [:in [grandparent-id parent-id child-id]]))
               (t2/with-transaction [_conn]
-                (deps.findings/mark-dependents-stale! :card grandparent-id)
+                (deps.findings/mark-transitive-dependents-stale! {:card [grandparent-id]})
                 (is (= {grandparent-id false, parent-id true, child-id true}
                        (stale-map [grandparent-id parent-id child-id]))
                     "grandparent should NOT be stale, parent and child should be stale (transitive)")))))))))
 
-(deftest ^:sequential wave-propagation-via-entity-check-test
-  (testing "analyze-and-propagate! marks immediate dependents stale, and the job loop drains them in waves"
+(deftest ^:sequential mark-subtree-stale-then-drain-test
+  (testing "marking an entity stale also marks its whole transitive subtree up front, and check-entities! drains it"
     (backfill-all-entity-analyses!)
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))]
@@ -226,20 +226,19 @@
               (is (= {gp-id false, p-id false, c-id false}
                      (stale-map [gp-id p-id c-id]))
                   "all should start as not stale")
-              ;; Mark only the immediate dependents of grandparent (just parent, not child)
-              (deps.findings/mark-immediate-dependents-stale! :card gp-id)
-              (is (= {gp-id false, p-id true, c-id false}
+              ;; A change to the grandparent marks it AND its whole transitive subtree (parent and child) stale up front
+              (deps.findings/mark-entity-and-transitive-dependents-stale! :card gp-id)
+              (is (= {gp-id true, p-id true, c-id true}
                      (stale-map [gp-id p-id c-id]))
-                  "only parent should be stale (immediate), child should NOT be stale yet")
-              ;; Run the entity-check job loop — it should analyze parent, which marks child stale,
-              ;; then analyze child in the next wave
+                  "the grandparent and its whole subtree should be stale")
+              ;; The drain analyzes each once, without re-marking anything stale during draining
               (#'task.entity-check/check-entities!)
               (is (= {gp-id false, p-id false, c-id false}
                      (stale-map [gp-id p-id c-id]))
-                  "after check-entities!, all should be re-analyzed (not stale) — wave propagation worked"))))))))
+                  "after check-entities!, the whole subtree should be re-analyzed (not stale)"))))))))
 
-(deftest ^:sequential wave-propagation-through-non-analyzable-entity-test
-  (testing "Wave propagation skips non-analyzable intermediaries (e.g., tables) and reaches cards beyond them"
+(deftest ^:sequential transitive-marking-through-non-analyzable-entity-test
+  (testing "marking dependents stale reaches analyzable entities beyond non-analyzable intermediaries (e.g., tables)"
     (backfill-all-entity-analyses!)
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))
@@ -247,12 +246,12 @@
       (mt/with-premium-features #{:dependencies}
         (lib-be/with-metadata-provider-cache
           (mt/with-model-cleanup [:model/AnalysisFinding]
-            ;; Chain: transform → (depends on) table ← (depends on) card
-            ;; Table is not analyzable, but card should still be reached by the wave
+            ;; Chain: card → (depends on) table → (depends on) transform.
+            ;; The table is not analyzable, but the card beyond it should still be reached.
             (mt/with-temp [:model/Transform {transform-id :id :as transform}
                            {:source {:type :query :query (lib/query mp products)}
-                            :name "test_wave_transform"
-                            :target {:schema "public" :name "wave_test_table" :type :table}}
+                            :name "test_transitive_transform"
+                            :target {:schema "public" :name "transitive_test_table" :type :table}}
                            :model/Card {card-id :id :as card}
                            {:dataset_query (lib/query mp products)}
                            ;; table depends on transform (downstream of transform)
@@ -266,14 +265,40 @@
               (deps.findings/upsert-analysis! card)
               (is (false? (finding-stale? :card card-id))
                   "card should start as not stale")
-              ;; Mark only immediate dependents of transform stale
-              ;; The immediate dependent is the table, which is NOT analyzable
-              ;; The card is two hops away: transform → table → card
-              (deps.findings/mark-immediate-dependents-stale! :transform transform-id)
-              ;; The look-through should have reached the card through the non-analyzable table
+              ;; The card is two hops downstream of the transform: transform → table → card
+              (deps.findings/mark-transitive-dependents-stale! {:transform [transform-id]})
               (is (true? (finding-stale? :card card-id))
-                  "card should be stale — look-through reached it via non-analyzable table")
+                  "card should be stale — transitive marking reached it via the non-analyzable table")
               ;; Run entity-check to drain stale entities
               (#'task.entity-check/check-entities!)
               (is (false? (finding-stale? :card card-id))
                   "card should be re-analyzed after entity-check"))))))))
+
+(deftest ^:sequential cyclic-dependency-drain-terminates-test
+  (testing "check-entities! terminates on a cyclic dependency graph — staleness is fixed up front and never re-marked
+            during the drain"
+    (backfill-all-entity-analyses!)
+    (let [mp (mt/metadata-provider)
+          products (lib.metadata/table mp (mt/id :products))]
+      (mt/with-premium-features #{:dependencies}
+        (lib-be/with-metadata-provider-cache
+          (mt/with-model-cleanup [:model/AnalysisFinding]
+            (mt/with-temp [:model/Card {a-id :id :as a-card} {:dataset_query (lib/query mp products)}
+                           :model/Card {b-id :id :as b-card} {:dataset_query (lib/query mp products)}
+                           ;; cycle: a depends on b, and b depends on a
+                           :model/Dependency _ {:from_entity_type :card :from_entity_id a-id
+                                                :to_entity_type :card :to_entity_id b-id}
+                           :model/Dependency _ {:from_entity_type :card :from_entity_id b-id
+                                                :to_entity_type :card :to_entity_id a-id}]
+              (run! deps.findings/upsert-analysis! [a-card b-card])
+              (deps.findings/mark-entity-and-transitive-dependents-stale! :card a-id)
+              (is (= {a-id true, b-id true}
+                     (stale-map [a-id b-id]))
+                  "both cycle members should be marked stale")
+              ;; Under the old wave-propagation design this drain would loop forever; bound it so a regression fails fast.
+              (let [done (future (#'task.entity-check/check-entities!))]
+                (is (not= ::timeout (deref done 30000 ::timeout))
+                    "check-entities! must terminate on a cyclic graph")
+                (is (= {a-id false, b-id false}
+                       (stale-map [a-id b-id]))
+                    "both cycle members should be drained (re-analyzed, not stale)")))))))))


### PR DESCRIPTION
Based on our logs, we have dependency graph cycles that make the backfill job work non-stop. This PR fixes the issue using the original approach - on a change, mark all **transitive** dependents as stale, and then drain, without "waves". 