### PR TITLE
ci(drivers): Don't let cancelled or timed-out info drivers block PRs

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1636,6 +1636,11 @@ jobs:
 
   drivers-tests-result:
     needs:
+      # Supplies each driver's configured status (info/skip/required) so this gate can ignore
+      # "info" drivers regardless of their result -- including cancelled or timed-out runs, which
+      # the per-job continue-on-error cannot force green because the controlling step never
+      # completes. Not a driver job; it is filtered out of the pass/fail check below.
+      - determine-driver-skips
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
       - be-tests-athena-ee
@@ -1670,15 +1675,44 @@ jobs:
         uses: actions/github-script@v9
         env:
           needs: ${{ toJson(needs) }}
+          # Job name -> configured driver status, from determine-driver-skips. An "info" driver is
+          # data-collection only and must never gate; a cancelled/timed-out info job lands here as
+          # cancelled/failure (its own continue-on-error can't force it green), so we drop info jobs
+          # from the gate entirely. Empty/unknown status falls back to "required" (gates as before).
+          statuses: |
+            {
+              "be-tests-athena-ee": "${{ needs.determine-driver-skips.outputs.athena-status }}",
+              "be-tests-bigquery-cloud-sdk-ee": "${{ needs.determine-driver-skips.outputs.bigquery-status }}",
+              "be-tests-clickhouse-ee": "${{ needs.determine-driver-skips.outputs.clickhouse-status }}",
+              "be-tests-databricks-ee": "${{ needs.determine-driver-skips.outputs.databricks-status }}",
+              "be-tests-druid-jdbc-ee": "${{ needs.determine-driver-skips.outputs.druid-jdbc-status }}",
+              "be-tests-mongo": "${{ needs.determine-driver-skips.outputs.mongo-status }}",
+              "be-tests-mongo-ssl": "${{ needs.determine-driver-skips.outputs.mongo-ssl-status }}",
+              "be-tests-mongo-sharded-cluster-ee": "${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-status }}",
+              "be-tests-mysql-mariadb": "${{ needs.determine-driver-skips.outputs.mysql-mariadb-status }}",
+              "be-tests-oracle": "${{ needs.determine-driver-skips.outputs.oracle-status }}",
+              "be-tests-presto-jdbc-ee": "${{ needs.determine-driver-skips.outputs.presto-jdbc-status }}",
+              "be-tests-redshift-ee": "${{ needs.determine-driver-skips.outputs.redshift-status }}",
+              "be-tests-snowflake-ee": "${{ needs.determine-driver-skips.outputs.snowflake-status }}",
+              "be-tests-sparksql-ee": "${{ needs.determine-driver-skips.outputs.sparksql-status }}",
+              "be-tests-sqlite-ee": "${{ needs.determine-driver-skips.outputs.sqlite-status }}",
+              "be-tests-sqlserver": "${{ needs.determine-driver-skips.outputs.sqlserver-status }}"
+            }
         with:
           script: | # js
             const needs = JSON.parse(process.env.needs);
+            const statuses = JSON.parse(process.env.statuses);
 
-            const jobs = Object.entries(needs).map(
-              ([jobName, jobValues]) => ({
+            // Drop the determine-driver-skips bookkeeping job, then drop "info" drivers: they are
+            // non-gating, so their result (including cancelled/timed-out) must not fail this check.
+            const jobs = Object.entries(needs)
+              .filter(([jobName]) => jobName !== 'determine-driver-skips')
+              .map(([jobName, jobValues]) => ({
                 name: jobName,
-                result: jobValues.result
-              }));
+                result: jobValues.result,
+                status: statuses[jobName] || 'required'
+              }))
+              .filter(job => job.status !== 'info');
 
             // are all jobs skipped or successful?
             if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {


### PR DESCRIPTION
Resolves DEV-2185

## Summary

The drivers-tests-result gate passes only when every needed job is success or skipped. An info driver's job is forced green by the upload step's continue-on-error, but that only neutralizes a step that runs and fails normally. When an info job is cancelled (fail-fast, manual cancel) or times out, the controlling step never completes, so the job's result is cancelled/failure and the gate fails the required check, blocking PRs.

Feed each driver's configured status into the result job and drop info drivers from the pass/fail check entirely, so their result never gates regardless of cancelled/timed-out/failure. Empty or unknown status falls back to required, so the gate can only stop gating an explicitly-info driver, never weaken a required one.

> [!NOTE]
> This is most likely only a temporary patch. We ideally want to work on a more holistic approach that involves ci-conductor.