### PR TITLE
feat(data-apps): allow passing down a card with viz settings

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-card-prop.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-card-prop.cy.spec.tsx
@@ -1,0 +1,75 @@
+import {
+  InteractiveQuestion,
+  type MetabaseCard,
+  StaticQuestion,
+} from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+// What a data app actually passes: a `card` object built from a query (e.g. the
+// output of `createMetabaseQuery` / `useMetabaseQueryObject`) plus the chosen
+// `visualization` and its `visualizationSettings`. The serialized-string form is
+// an edge case covered by the unit tests; here we verify the data-app path
+// renders the chosen chart end-to-end.
+const card: MetabaseCard = {
+  query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+      breakout: [["field", ORDERS.PRODUCT_ID, null]],
+      limit: 2,
+    },
+  },
+  visualization: "bar",
+  visualizationSettings: {
+    "graph.y_axis.title_text": "Max quantity",
+  },
+};
+
+describe("scenarios > embedding-sdk > sdk-question card prop", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("InteractiveQuestion should render the chosen visualization from the `card` prop", () => {
+    mountSdkContent(<InteractiveQuestion card={card} />);
+
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response?.statusCode).to.equal(202);
+    });
+
+    getSdkRoot().within(() => {
+      cy.log("renders the chart, honoring the chosen `bar` visualization");
+      cy.findByTestId("visualization-root").should("be.visible");
+      cy.findByTestId("table-root").should("not.exist");
+    });
+  });
+
+  it("StaticQuestion should render the chosen visualization from the `card` prop", () => {
+    mountSdkContent(<StaticQuestion card={card} />);
+
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response?.statusCode).to.equal(202);
+    });
+
+    getSdkRoot().within(() => {
+      cy.log("renders the chart, honoring the chosen `bar` visualization");
+      cy.findByTestId("visualization-root").should("be.visible");
+      cy.findByTestId("table-root").should("not.exist");
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -151,6 +151,7 @@ export type {
   MetabaseFontFamily,
   MetabaseGlobalPluginsConfig,
   ProtectedColorKey,
+  MetabaseCard,
   MetabasePluginsConfig,
   MetabaseQuestion,
   MetabaseTheme,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -36,13 +36,14 @@ const propsSchema: Yup.SchemaOf<InteractiveQuestionInternalProps> = Yup.object({
   })
     .optional()
     .noUnknown(),
-  questionId: Yup.mixed().when(["token", "query"], {
-    is: (token: unknown, query: unknown) =>
-      token !== undefined || query !== undefined,
+  questionId: Yup.mixed().when(["token", "query", "card"], {
+    is: (token: unknown, query: unknown, card: unknown) =>
+      token !== undefined || query !== undefined || card !== undefined,
     then: (schema) => schema.optional(),
     otherwise: (schema) => schema.required(),
   }),
   token: Yup.mixed().optional(),
+  card: Yup.mixed().optional(),
   query: Yup.mixed().optional(),
   style: Yup.mixed().optional(),
   targetCollection: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -32,7 +32,7 @@ import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
-import { getCardFromSdkQuestionQuery } from "embedding-sdk-bundle/lib/sdk-question-query";
+import { resolveDeserializedCard } from "embedding-sdk-bundle/lib/sdk-question/resolve-deserialized-card";
 import type {
   SdkQuestionEntityInternalProps,
   SdkQuestionEntityPublicProps,
@@ -107,6 +107,7 @@ export type InteractiveQuestionComponents = {
 function InteractiveQuestionInner(props: InteractiveQuestionInternalProps) {
   const {
     query,
+    card,
     questionId,
     title,
     withDownloads,
@@ -139,8 +140,8 @@ function InteractiveQuestionInner(props: InteractiveQuestionInternalProps) {
   );
 
   const deserializedCard = useMemo(
-    () => getCardFromSdkQuestionQuery(query),
-    [query],
+    () => resolveDeserializedCard({ card, query }),
+    [card, query],
   );
 
   return (

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -34,6 +34,7 @@ import {
 } from "__support__/ui";
 import { addAlertModalTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec";
 import { addAlertsButtonTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec";
+import { addCardPropTests } from "embedding-sdk-bundle/components/public/question/shared-tests/card-prop.spec";
 import type { SetupOpts } from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
 import {
   TEST_COLUMN,
@@ -182,6 +183,7 @@ const setup = async ({
 };
 
 addQueryPropTests({ Component: InteractiveQuestionInternal });
+addCardPropTests({ Component: InteractiveQuestion });
 
 describe("InteractiveQuestion", () => {
   addAlertsButtonTests(setup, {

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -15,13 +15,14 @@ const propsSchema: Yup.SchemaOf<StaticQuestionInternalProps> = Yup.object({
   sqlParameters: Yup.mixed().optional(),
   onSqlParametersChange: Yup.mixed().optional(),
   hiddenParameters: Yup.mixed().optional(),
-  questionId: Yup.mixed().when(["token", "query"], {
-    is: (token: unknown, query: unknown) =>
-      token !== undefined || query !== undefined,
+  questionId: Yup.mixed().when(["token", "query", "card"], {
+    is: (token: unknown, query: unknown, card: unknown) =>
+      token !== undefined || query !== undefined || card !== undefined,
     then: (schema) => schema.optional(),
     otherwise: (schema) => schema.required(),
   }),
   token: Yup.mixed().optional(),
+  card: Yup.mixed().optional(),
   query: Yup.mixed().optional(),
   style: Yup.mixed().optional(),
   title: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -32,7 +32,7 @@ import {
 import { QuestionAlertsButton } from "embedding-sdk-bundle/components/public/notifications/QuestionAlertsButton";
 import { useMobileLayout } from "embedding-sdk-bundle/hooks/private/use-mobile-layout";
 import { useNormalizeGuestEmbedQuestionOrDashboardComponentProps } from "embedding-sdk-bundle/hooks/private/use-normalize-guest-embed-question-or-dashboard-component-props";
-import { getCardFromSdkQuestionQuery } from "embedding-sdk-bundle/lib/sdk-question-query";
+import { resolveDeserializedCard } from "embedding-sdk-bundle/lib/sdk-question/resolve-deserialized-card";
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import type {
@@ -109,6 +109,7 @@ const StaticQuestionInner = (
   props: StaticQuestionInternalProps,
 ): JSX.Element | null => {
   const query = props.query;
+  const card = props.card;
 
   // Normalize props for Guest Embed usage (e.g. enforce withDownloads in OSS).
   const normalizedProps =
@@ -156,8 +157,8 @@ const StaticQuestionInner = (
   );
 
   const deserializedCard = useMemo(
-    () => getCardFromSdkQuestionQuery(query),
-    [query],
+    () => resolveDeserializedCard({ card, query }),
+    [card, query],
   );
 
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -23,6 +23,7 @@ import {
 } from "__support__/ui";
 import { addAlertModalTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec";
 import { addAlertsButtonTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec";
+import { addCardPropTests } from "embedding-sdk-bundle/components/public/question/shared-tests/card-prop.spec";
 import type { SetupOpts } from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
 import {
   TEST_COLUMN,
@@ -154,6 +155,7 @@ const setup = async ({
 };
 
 addQueryPropTests({ Component: StaticQuestionInternal });
+addCardPropTests({ Component: StaticQuestion });
 
 describe("StaticQuestion", () => {
   addAlertsButtonTests(setup, { customComponent: StaticQuestion.AlertsButton });

--- a/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/card-prop.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/card-prop.spec.tsx
@@ -1,0 +1,143 @@
+import {
+  setupAdhocQueryMetadataEndpoint,
+  setupCardDataset,
+  setupCollectionByIdEndpoint,
+  setupNotificationChannelsEndpoints,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  screen,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
+import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
+import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
+import type { MetabaseCard } from "embedding-sdk-bundle/types/question";
+import { utf8_to_b64url } from "metabase/utils/encoding";
+import {
+  createMockCardQueryMetadata,
+  createMockCollection,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { TEST_COLUMN, TEST_DB, TEST_TABLE } from "./constants.spec";
+
+export function addCardPropTests({
+  Component,
+}: {
+  Component: (props: { card: string | MetabaseCard }) => React.ReactNode;
+}) {
+  describe("card prop", () => {
+    const DATASET_QUERY = {
+      database: TEST_DB.id,
+      type: "query" as const,
+      query: { "source-table": TEST_TABLE.id },
+    };
+
+    const CARD_STRING = utf8_to_b64url(
+      JSON.stringify({ dataset_query: DATASET_QUERY }),
+    );
+
+    const CARD_OBJECT: MetabaseCard = {
+      query: DATASET_QUERY,
+      visualization: "table",
+      visualizationSettings: {},
+    };
+
+    // A category + numeric dataset so a bar chart has something to render.
+    const BAR_CATEGORY_COLUMN = createMockColumn({
+      name: "CATEGORY",
+      display_name: "Category",
+      base_type: "type/Text",
+    });
+    const BAR_VALUE_COLUMN = createMockColumn({
+      name: "COUNT",
+      display_name: "Count",
+      base_type: "type/Integer",
+    });
+    const BAR_DATASET = createMockDataset({
+      data: createMockDatasetData({
+        cols: [BAR_CATEGORY_COLUMN, BAR_VALUE_COLUMN],
+        rows: [
+          ["a", 10],
+          ["b", 20],
+          ["c", 30],
+        ],
+      }),
+    });
+
+    const BAR_CARD: MetabaseCard = {
+      query: DATASET_QUERY,
+      visualization: "bar",
+      visualizationSettings: {
+        "graph.dimensions": ["CATEGORY"],
+        "graph.metrics": ["COUNT"],
+      },
+    };
+
+    const TABLE_DATASET = createMockDataset({
+      data: createMockDatasetData({
+        cols: [TEST_COLUMN],
+        rows: [["Test Row"], ["Test Row 2"]],
+      }),
+    });
+
+    async function setup(card: string | MetabaseCard, dataset = TABLE_DATASET) {
+      const { state } = setupSdkState();
+
+      setupNotificationChannelsEndpoints({ email: { configured: false } });
+      setupAdhocQueryMetadataEndpoint(
+        createMockCardQueryMetadata({ databases: [TEST_DB] }),
+      );
+      setupCardDataset({ dataset });
+      setupCollectionByIdEndpoint({
+        collections: [createMockCollection({ id: 1 })],
+      });
+
+      renderWithSDKProviders(<Component card={card} />, {
+        componentProviderProps: { authConfig: createMockSdkConfig() },
+        storeInitialState: state,
+      });
+
+      await waitForLoaderToBeRemoved();
+    }
+
+    beforeAll(() => {
+      mockGetBoundingClientRect();
+    });
+
+    it("should render a visualization when given a serialized card string", async () => {
+      await setup(CARD_STRING);
+
+      expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+      expect(
+        within(screen.getByTestId("table-root")).getByText(
+          TEST_COLUMN.display_name,
+        ),
+      ).toBeVisible();
+    });
+
+    it("should render a visualization when given a card object", async () => {
+      await setup(CARD_OBJECT);
+
+      expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+      expect(
+        within(screen.getByTestId("table-root")).getByText(
+          TEST_COLUMN.display_name,
+        ),
+      ).toBeVisible();
+    });
+
+    it("should honor the chosen `visualization` instead of defaulting to a table", async () => {
+      await setup(BAR_CARD, BAR_DATASET);
+
+      expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+      // The `bar` visualization is honored (and locked), so a chart renders...
+      expect(screen.getByTestId("chart-container")).toBeInTheDocument();
+      expect(screen.queryByTestId("table-root")).not.toBeInTheDocument();
+    });
+  });
+}

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
@@ -1,10 +1,10 @@
 import type { SdkQuestionEntityInternalProps } from "embedding-sdk-bundle/types/question";
 import { deserializeCardFromQuery } from "metabase/common/utils/card";
-import type { Card } from "metabase-types/api";
+import type { UnsavedCard } from "metabase-types/api";
 
 export function getCardFromSdkQuestionQuery(
   query: SdkQuestionEntityInternalProps["query"] | undefined,
-): Card | undefined {
+): UnsavedCard | undefined {
   if (!query) {
     return undefined;
   }
@@ -17,5 +17,5 @@ export function getCardFromSdkQuestionQuery(
     dataset_query: query,
     display: "table",
     visualization_settings: {},
-  } as Card;
+  };
 }

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
@@ -1,0 +1,30 @@
+import type { MetabaseCard } from "embedding-sdk-bundle/types/question";
+import { deserializeCardFromQuery } from "metabase/common/utils/card";
+import type { UnsavedCard } from "metabase-types/api";
+
+export function resolveCardProp(
+  input: string | MetabaseCard,
+): UnsavedCard | null {
+  if (typeof input === "string") {
+    // A card copied from a question URL hash (`/question#<base64>` or bare base64).
+    try {
+      return deserializeCardFromQuery(input);
+    } catch {
+      console.warn(
+        // eslint-disable-next-line metabase/no-literal-metabase-strings
+        "InteractiveQuestion/StaticQuestion: the `card` string could not be parsed as a serialized question. Pass a value copied from a question URL hash, or a MetabaseCard object.",
+      );
+      return null;
+    }
+  }
+
+  return {
+    dataset_query: input.query,
+    // Public-facing `visualization` maps to the internal card `display`.
+    display: input.visualization,
+    // Default to locking the chosen display so the query builder doesn't
+    // reset it to a "sensible default" after results load..
+    displayIsLocked: input.displayIsLocked ?? true,
+    visualization_settings: input.visualizationSettings ?? {},
+  };
+}

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.unit.spec.ts
@@ -1,0 +1,68 @@
+import type { MetabaseCard } from "embedding-sdk-bundle/types/question";
+import { utf8_to_b64url } from "metabase/utils/encoding";
+import type { DatasetQuery } from "metabase-types/api";
+
+import { resolveCardProp } from "./resolve-card-prop";
+
+const DATASET_QUERY: DatasetQuery = {
+  database: 1,
+  type: "query",
+  query: { "source-table": 2 },
+};
+
+const serialize = (card: object) => utf8_to_b64url(JSON.stringify(card));
+
+describe("resolveCardProp", () => {
+  it("parses a bare base64 string", () => {
+    const card = resolveCardProp(serialize({ dataset_query: DATASET_QUERY }));
+
+    expect(card?.dataset_query).toEqual(DATASET_QUERY);
+  });
+
+  it("parses a `/question#<base64>` prefixed string", () => {
+    const card = resolveCardProp(
+      "/question#" + serialize({ dataset_query: DATASET_QUERY }),
+    );
+
+    expect(card?.dataset_query).toEqual(DATASET_QUERY);
+  });
+
+  it("returns null and warns for an unparseable string", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(resolveCardProp("not-a-real-card")).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("could not be parsed"),
+    );
+
+    warn.mockRestore();
+  });
+
+  it("maps a camelCase MetabaseCard object to a snake_case Card", () => {
+    const input: MetabaseCard = {
+      query: DATASET_QUERY,
+      visualization: "bar",
+      visualizationSettings: { "graph.dimensions": ["x"] },
+    };
+
+    const card = resolveCardProp(input);
+
+    expect(card).toEqual({
+      dataset_query: DATASET_QUERY,
+      display: "bar",
+      displayIsLocked: true,
+      visualization_settings: { "graph.dimensions": ["x"] },
+    });
+  });
+
+  it("respects an explicit `displayIsLocked: false`", () => {
+    const card = resolveCardProp({
+      query: DATASET_QUERY,
+      visualization: "bar",
+      visualizationSettings: {},
+      displayIsLocked: false,
+    });
+
+    expect(card?.displayIsLocked).toBe(false);
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-deserialized-card.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-deserialized-card.ts
@@ -1,0 +1,16 @@
+import { resolveCardProp } from "embedding-sdk-bundle/lib/sdk-question/resolve-card-prop";
+import { getCardFromSdkQuestionQuery } from "embedding-sdk-bundle/lib/sdk-question-query";
+import type { UnsavedCard } from "metabase-types/api";
+
+export function resolveDeserializedCard({
+  card,
+  query,
+}: {
+  card?: Parameters<typeof resolveCardProp>[0];
+  query?: Parameters<typeof getCardFromSdkQuestionQuery>[0];
+}): UnsavedCard | undefined {
+  if (card != null) {
+    return resolveCardProp(card) ?? undefined;
+  }
+  return getCardFromSdkQuestionQuery(query);
+}

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -48,10 +48,13 @@ export type MetabotMessage = MetabotUserTextMessage | MetabotAgentMessage;
 
 /** @category useMetabot */
 export type MetabotChartProps =
-  | (Omit<StaticQuestionProps, "questionId" | "token" | "query"> & {
+  | (Omit<StaticQuestionProps, "questionId" | "token" | "query" | "card"> & {
       drills?: false;
     })
-  | (Omit<InteractiveQuestionProps, "questionId" | "token" | "query"> & {
+  | (Omit<
+      InteractiveQuestionProps,
+      "questionId" | "token" | "query" | "card"
+    > & {
       drills: true;
     });
 

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
+import type { MetabaseCard } from "metabase/embedding-sdk/types/question";
 import type { QueryParams } from "metabase/query_builder/actions";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import type InternalQuestion from "metabase-lib/v1/Question";
@@ -8,12 +9,16 @@ import type {
   Card,
   ParameterValuesMap,
   StructuredDatasetQuery,
+  UnsavedCard,
 } from "metabase-types/api";
 
 import type { SdkDashboardId } from "./dashboard";
 import type { SdkEntityId, SdkEntityToken } from "./entity";
 
-export type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
+export type {
+  MetabaseCard,
+  MetabaseQuestion,
+} from "metabase/embedding-sdk/types/question";
 
 /**
  * Represents the identifier for a question in the Metabase SDK.
@@ -67,6 +72,7 @@ export type SdkQuestionEntityPublicProps =
        */
       questionId: SdkQuestionId | null;
       token?: never;
+      card?: never;
       query?: never;
     }
   | {
@@ -75,11 +81,24 @@ export type SdkQuestionEntityPublicProps =
        * A valid JWT token for the guest embed.
        */
       token: SdkEntityToken | null;
+      card?: never;
       query?: never;
     }
   | {
       questionId?: never;
       token?: never;
+      /**
+       * An ad-hoc question to render without saving it first. Either a
+       * {@link MetabaseCard} object, or a serialized card string copied from a
+       * question URL hash (`/question#<base64>` or the bare base64).
+       */
+      card: string | MetabaseCard;
+      query?: never;
+    }
+  | {
+      questionId?: never;
+      token?: never;
+      card?: never;
       /**
        * A table-backed ad hoc query created with `createMetabaseQuery`.
        */
@@ -95,6 +114,7 @@ export type SdkQuestionEntityInternalProps =
   | {
       questionId?: never;
       token?: never;
+      card?: never;
       query: string;
     };
 
@@ -120,7 +140,7 @@ export type LoadSdkQuestionParams = {
   /**
    * @internal
    */
-  deserializedCard?: Card;
+  deserializedCard?: UnsavedCard;
 
   /**
    * @internal

--- a/frontend/src/metabase/embedding-sdk/types/question.ts
+++ b/frontend/src/metabase/embedding-sdk/types/question.ts
@@ -1,3 +1,7 @@
+import type { VisualizationSettings } from "metabase-types/api/card";
+import type { DatasetQuery } from "metabase-types/api/query";
+import type { CustomVizDisplayType } from "metabase-types/api/visualization";
+
 export interface MetabaseQuestion {
   id: number;
   name: string;
@@ -6,3 +10,176 @@ export interface MetabaseQuestion {
 
   isSavedQuestion: boolean;
 }
+
+/**
+ * Each visualization below exposes a curated subset of {@link VisualizationSettings}
+ * via `Pick`. Only these keys are allowed, so `visualizationSettings` autocompletes
+ * and typechecks against the chosen `visualization`. To surface another setting,
+ * add its key to the relevant family. Custom visualizations (`custom:...`) are the
+ * exception and accept any settings.
+ */
+
+/** Bar, line, area, combo, row. */
+export type CartesianVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "graph.dimensions"
+  | "graph.metrics"
+  | "graph.series_order"
+  | "graph.show_values"
+  | "graph.show_trendline"
+  | "graph.show_goal"
+  | "graph.goal_value"
+  | "graph.goal_label"
+  | "graph.x_axis.title_text"
+  | "graph.x_axis.scale"
+  | "graph.x_axis.axis_enabled"
+  | "graph.y_axis.title_text"
+  | "graph.y_axis.scale"
+  | "graph.y_axis.auto_range"
+  | "graph.y_axis.min"
+  | "graph.y_axis.max"
+  | "stackable.stack_type"
+  | "series_settings"
+  | "column_settings"
+>;
+
+/** Scatter plot: cartesian axes plus a bubble-size column. */
+export type ScatterVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "graph.dimensions"
+  | "graph.metrics"
+  | "graph.x_axis.scale"
+  | "graph.y_axis.scale"
+  | "scatter.bubble"
+  | "series_settings"
+  | "column_settings"
+>;
+
+/** Waterfall chart. */
+export type WaterfallVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "graph.dimensions"
+  | "graph.metrics"
+  | "graph.show_values"
+  | "waterfall.increase_color"
+  | "waterfall.decrease_color"
+  | "waterfall.total_color"
+  | "waterfall.show_total"
+  | "column_settings"
+>;
+
+/** Table, pivot, object detail, list. */
+export type TableVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "table.columns"
+  | "table.column_formatting"
+  | "pivot_table.column_split"
+  | "pivot_table.collapsed_rows"
+  | "column_settings"
+>;
+
+/** Pie / donut. */
+export type PieVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "pie.dimension"
+  | "pie.metric"
+  | "pie.sort_rows"
+  | "pie.show_legend"
+  | "pie.show_total"
+  | "pie.show_labels"
+  | "pie.percent_visibility"
+  | "pie.decimal_places"
+  | "pie.slice_threshold"
+  | "pie.colors"
+  | "column_settings"
+>;
+
+/** Scalar, smart scalar (trend), gauge, progress. */
+export type ScalarVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "scalar.field"
+  | "scalar.switch_positive_negative"
+  | "scalar.compact_primary_number"
+  | "scalar.comparisons"
+  | "column_settings"
+>;
+
+/** Funnel. */
+export type FunnelVisualizationSettings = Pick<
+  VisualizationSettings,
+  "funnel.rows" | "column_settings"
+>;
+
+/** Sankey. */
+export type SankeyVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "sankey.source"
+  | "sankey.target"
+  | "sankey.value"
+  | "sankey.node_align"
+  | "sankey.show_edge_labels"
+  | "column_settings"
+>;
+
+/** Box plot. */
+export type BoxplotVisualizationSettings = Pick<
+  VisualizationSettings,
+  | "boxplot.whisker_type"
+  | "boxplot.points_mode"
+  | "boxplot.show_mean"
+  | "boxplot.show_values_mode"
+  | "column_settings"
+>;
+
+/** Map (pin/region). No map-specific keys are surfaced yet. */
+export type MapVisualizationSettings = Pick<
+  VisualizationSettings,
+  "column_settings"
+>;
+
+interface MetabaseCardBase {
+  query: DatasetQuery;
+  displayIsLocked?: boolean;
+}
+
+export type MetabaseCard = MetabaseCardBase &
+  (
+    | {
+        visualization: "table" | "pivot" | "object" | "list";
+        visualizationSettings?: TableVisualizationSettings;
+      }
+    | {
+        visualization: "bar" | "line" | "area" | "combo" | "row";
+        visualizationSettings?: CartesianVisualizationSettings;
+      }
+    | {
+        visualization: "scatter";
+        visualizationSettings?: ScatterVisualizationSettings;
+      }
+    | {
+        visualization: "waterfall";
+        visualizationSettings?: WaterfallVisualizationSettings;
+      }
+    | { visualization: "pie"; visualizationSettings?: PieVisualizationSettings }
+    | {
+        visualization: "scalar" | "smartscalar" | "gauge" | "progress";
+        visualizationSettings?: ScalarVisualizationSettings;
+      }
+    | {
+        visualization: "funnel";
+        visualizationSettings?: FunnelVisualizationSettings;
+      }
+    | { visualization: "map"; visualizationSettings?: MapVisualizationSettings }
+    | {
+        visualization: "sankey";
+        visualizationSettings?: SankeyVisualizationSettings;
+      }
+    | {
+        visualization: "boxplot";
+        visualizationSettings?: BoxplotVisualizationSettings;
+      }
+    | {
+        visualization: CustomVizDisplayType;
+        visualizationSettings?: Record<string, unknown>;
+      }
+  );

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -33,7 +33,7 @@ import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import { updateCardTemplateTagNames } from "metabase-lib/v1/queries/NativeQuery";
-import type { Card, SegmentId } from "metabase-types/api";
+import type { Card, SegmentId, UnsavedCard } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 import { isSavedCard } from "metabase-types/guards";
 
@@ -197,7 +197,7 @@ export async function resolveCards({
 }: {
   cardId?: string | number;
   token?: EntityToken | null;
-  deserializedCard?: Card;
+  deserializedCard?: UnsavedCard;
   options: BlankQueryOptions;
   dispatch: Dispatch;
   getState: GetState;


### PR DESCRIPTION
Closes [EMB-1878: Expose visualization settings prop on SDK question components](https://linear.app/metabase/issue/EMB-1878/expose-visualization-settings-prop-on-sdk-question-components) by fixing the root need we had, which was to allow data apps to customize the visualization rendered and the visualization settings.

This does it by adding a new `card` prop that has the shape
```
{
query, // the query, as returned by `useMetabaseQuery`
visualization: "pie",
visualizationSettings: {} // typed based on visualization
}
```
`visualizationSettings` should allow a subset of the types, but we can iterate on what to expose based on what the the data app prototypes need
When `display` starts with "custom:` we currently allow any visualizationSetting as we can't know the type of viz settings for custom viz at the moment

## Demo
data app code:
```tsx
/* eslint-disable import/no-default-export */
import type { CSSProperties } from "react";

import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
import {
  breakout,
  filter,
  useMetabaseQueryObject,
} from "@metabase/embedding-sdk-react/data-app";

import schema from "./metabase.data";

const revenue = schema.metrics.revenue;
const numberOfOrders = schema.metrics.numberOfOrders;
const ordersCreatedAt = schema.tables.orders.fields.createdAt;
const RANGE = ["2025-01-01", "2027-01-01"] as const;

export default function App() {
  const query = useMetabaseQueryObject({
    metric: revenue,
    filters: [filter(ordersCreatedAt, "between", [...RANGE])],
    breakouts: [
      breakout(revenue.dimensions.orders.createdAt, { bucket: "month" }),
    ],
  });

  const ordersQuery = useMetabaseQueryObject({
    metric: numberOfOrders,
    filters: [filter(ordersCreatedAt, "between", [...RANGE])],
    breakouts: [
      breakout(numberOfOrders.dimensions.orders.createdAt, { bucket: "month" }),
    ],
  });

  return (
    <div style={{ display: "grid", gap: 24, padding: 24 }}>
      <div style={GRID}>
        <InteractiveQuestion
          card={{ query, visualization: "bar" }}
          height={300}
        />

        <InteractiveQuestion
          height={300}
          card={{
            query,
            visualization: "line",
            visualizationSettings: {
              "graph.show_values": true,
              "graph.y_axis.title_text": "Revenue (USD)",
            },
          }}
        />
      </div>

      {/* Bottom: same custom visualization, two different settings. */}
      <div style={GRID}>
        <InteractiveQuestion
          height={300}
          card={{
            query: ordersQuery,
            visualization: "custom:IdealRange",
            visualizationSettings: { min: 400, max: 600 },
          }}
        />
        <InteractiveQuestion
          height={300}
          card={{
            query: ordersQuery,
            visualization: "custom:IdealRange",
            visualizationSettings: { min: 200, max: 350 },
          }}
        />
      </div>
    </div>
  );
}

const GRID = {
  display: "grid",
  gridTemplateColumns: "repeat(auto-fill, minmax(360px, 1fr))",
  gap: 16,
} satisfies CSSProperties;

```

Result:
<img width="955" height="748" alt="image" src="https://github.com/user-attachments/assets/d2b02e83-69ee-4581-9267-c934f4509b1b" />
