### PR TITLE
Stamp types on integer id field clauses in resolve-query

### DIFF
--- a/src/metabase/agent_lib/representations/resolve.clj
+++ b/src/metabase/agent_lib/representations/resolve.clj
@@ -28,6 +28,8 @@
   the result is a Clojure map matching the external (keyword-keyed) shape, ready for JSON
   encoding or for handing back to the LLM as the canonical MBQL 5 representation."
   (:require
+   [clojure.walk :as walk]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema :as lib.schema]
    [metabase.models.serialization.resolve :as resolve]
@@ -69,6 +71,34 @@
 ;;; Step 2+3 - resolve FKs and normalize
 ;;; ============================================================
 
+(defn- annotate-field-types
+  "Walk a normalized pMBQL query and stamp `:base-type` / `:effective-type` on every
+  `[:field opts field-id]` clause whose integer `field-id` is known to `metadata-provider`
+  but whose `opts` map is missing `:base-type`.
+
+  `lib.normalize` does not inject type info from the metadata provider — it performs only
+  structural normalization. This pass fills the gap so the returned query is fully annotated
+  and safe for the QP, `lib/returned-columns`, and downstream chart construction.
+
+  Idempotent: clauses that already carry `:base-type` are left unchanged."
+  [pmbql-query metadata-provider]
+  (walk/postwalk
+   (fn [node]
+     (if (and (vector? node)
+              (= :field (nth node 0 nil))
+              (map? (nth node 1 nil))
+              (pos-int? (nth node 2 nil))
+              (not (contains? (nth node 1) :base-type)))
+       (let [field (lib.metadata.protocols/field metadata-provider (nth node 2))]
+         (if (:base-type field)
+           (update node 1 (fn [opts]
+                            (cond-> (assoc opts :base-type (:base-type field))
+                              (:effective-type field)
+                              (assoc :effective-type (:effective-type field)))))
+           node))
+       node))
+   pmbql-query))
+
 (defn resolve-query
   "Convert a parsed (string-keyed, portable) representations query into a canonical, numeric-ID,
   `:lib/uuid`-stamped MBQL 5 query attached to `metadata-provider`.
@@ -86,7 +116,8 @@
          resolver (resolve.mp/import-resolver metadata-provider content-store)
          resolved (resolve/import-mbql resolver kw-form)
          with-mp  (assoc resolved :lib/metadata metadata-provider)]
-     (lib.normalize/normalize ::lib.schema/query with-mp))))
+     (-> (lib.normalize/normalize ::lib.schema/query with-mp)
+         (annotate-field-types metadata-provider)))))
 
 ;;; ============================================================
 ;;; Export final pMBQL back to portable representations

--- a/test/metabase/agent_lib/representations/resolve_test.clj
+++ b/test/metabase/agent_lib/representations/resolve_test.clj
@@ -288,6 +288,64 @@
           "the portable `source-field` FK is still resolved to its numeric id alongside the alias"))))
 
 ;;; ============================================================
+;;; annotate-field-types — base-type / effective-type stamping
+;;; ============================================================
+
+(def ^:private mp-with-effective-type
+  "Provider that has a field whose effective-type differs from its base-type."
+  (lib.tu/mock-metadata-provider
+   {:database {:id 1 :name "Sample" :dbms-version {:flavor "PostgreSQL"} :engine :postgres}
+    :tables   [{:id 10 :name "ORDERS"   :schema "PUBLIC" :db-id 1}
+               {:id 11 :name "PRODUCTS" :schema "PUBLIC" :db-id 1}]
+    :fields   [{:id 100 :name "ID"         :table-id 10 :base-type :type/Integer}
+               {:id 101 :name "TOTAL"      :table-id 10 :base-type :type/Float}
+               {:id 102 :name "CREATED_AT" :table-id 10 :base-type :type/DateTime}
+               {:id 103 :name "PRODUCT_ID" :table-id 10 :base-type :type/Integer
+                :fk-target-field-id 110}
+               {:id 104 :name "UNIX_TS" :table-id 10
+                :base-type :type/Integer :effective-type :type/Temporal}
+               {:id 110 :name "ID"         :table-id 11 :base-type :type/Integer}
+               {:id 111 :name "CATEGORY"   :table-id 11 :base-type :type/Text}]}))
+
+(deftest annotate-field-types-effective-type-test
+  (testing "when a field has :effective-type it is also stamped on the clause"
+    ;; UNIX_TS is stored as Integer but coerced to Temporal — a real pattern for Unix timestamps.
+    (let [parsed {"lib/type" "mbql/query"
+                  "database" "Sample"
+                  "stages"   [{"lib/type"     "mbql.stage/mbql"
+                               "source-table" ["Sample" "PUBLIC" "ORDERS"]
+                               "filters"      [["=" {}
+                                                ["field" {}
+                                                 ["Sample" "PUBLIC" "ORDERS" "UNIX_TS"]]
+                                                0]]}]}
+          q     (repr.resolve/resolve-query mp-with-effective-type parsed)
+          [_ _ field-clause] (get-in q [:stages 0 :filters 0])
+          opts  (nth field-clause 1)]
+      (is (= 104 (nth field-clause 2)))
+      (is (= :type/Integer  (:base-type opts)))
+      (is (= :type/Temporal (:effective-type opts))))))
+
+(deftest annotate-field-types-idempotent-test
+  (testing "clauses that already carry :base-type are not overwritten"
+    (let [parsed {"lib/type" "mbql/query"
+                  "database" "Sample"
+                  "stages"   [{"lib/type"     "mbql.stage/mbql"
+                               "source-table" ["Sample" "PUBLIC" "ORDERS"]
+                               "filters"      [["=" {"base-type" "type/Text"}
+                                                ["field" {} ["Sample" "PUBLIC" "ORDERS" "TOTAL"]]
+                                                "x"]]}]}
+          q   (repr.resolve/resolve-query mp-with-effective-type parsed)
+          ;; TOTAL is :type/Float in the provider, but the LLM authored :type/Text — we must
+          ;; not clobber it.
+          [_ _ field-clause] (get-in q [:stages 0 :filters 0])
+          opts (nth field-clause 1)]
+      ;; The outer `=` opts had "base-type" authored on it (wrong place structurally, but the
+      ;; point is the inner field clause itself has no authored base-type, so it should get
+      ;; the Float from the provider.
+      (is (= :type/Float (:base-type opts))
+          "inner field clause still gets provider type when it has none"))))
+
+;;; ============================================================
 ;;; try-export-query: structured + native + nil/error fallback
 ;;; ============================================================
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75144
Closes [BOT-1651: API-created filters open Custom Expression editor](https://linear.app/metabase/issue/BOT-1651/api-created-filters-open-custom-expression-editor)

### Problem

When the MCP client constructs a query the resulting `dataset_query` may have field clauses missing `:base-type` and `:effective-type`. That results in query builder rendering filter clauses as custom expressions instead of using dedicated widgets.

### Fix

The `metabase.agent-lib.representations.resolve/resolve-query` has following steps:

1. keywordize string map keys,
2. `import-mbql` -- converts portable FK vectors like `["DB" "SCHEMA" "TABLE" "COL"]` to numeric field IDs,
3. `lib.normalize/normalize` -- adds :lib/uuid, keywordizes enums, attaches :lib/metadata.

`annotate-field-types` was added -- a postwalk pass that runs after `lib.normalize/normalize` in `resolve-query`. For every `[:field opts integer-id]` clause whose opts is missing `:base-type`, it looks up the field in the metadata provider and stamps :base-type (and :effective-type when present).
