### PR TITLE
Allow `unsafe-eval` for data app iframe

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -179,7 +179,7 @@
 
 (defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
-  [nonce data-app-inline-styles?]
+  [nonce data-app-iframe?]
   {"Content-Security-Policy"
    (str/join
     (for [[k vs] {:default-src  ["'none'"]
@@ -205,18 +205,25 @@
                                  (when config/is-dev?
                                    ["'unsafe-eval'"
                                     (str "http://localhost:" cljs-dev-port)])
+                                 ;; Custom data apps run their uploaded bundle inside a Near-Membrane
+                                 ;; sandbox, which executes the bundle source via `eval` (its sandbox
+                                 ;; lives in a same-origin child iframe that inherits this document's
+                                 ;; CSP). So the data-app entrypoint must allow 'unsafe-eval' — scoped
+                                 ;; to this route only; the main app CSP stays strict.
+                                 (when data-app-iframe?
+                                   ["'unsafe-eval'"])
                                  (when-not config/is-dev?
                                    (map (partial format "'sha256-%s'") inline-js-hashes)))
                   :child-src    ["'self'"
                                  "https://accounts.google.com"]
                   :style-src    ["'self'"
                                  ;; See [[generate-nonce]].
-                                 (when (and nonce (not data-app-inline-styles?))
+                                 (when (and nonce (not data-app-iframe?))
                                    (format "'nonce-%s'" nonce))
                                  ;; Custom data apps render into an isolated iframe whose outer document only owns
                                  ;; the iframe boundary. Allowing inline styles here lets single-file uploaded apps
-                                 ;; style their own sandboxed document without relaxing script-src or the main app CSP.
-                                 (when data-app-inline-styles?
+                                 ;; style their own sandboxed document without relaxing the main app CSP.
+                                 (when data-app-iframe?
                                    "'unsafe-inline'")
                                  ;; for webpack hot reloading
                                  (when config/is-dev?
@@ -272,8 +279,8 @@
     (or (interactive-embedding-origins) "'none'")))
 
 (defn- content-security-policy-header-with-frame-ancestors
-  [frame-ancestors-mode nonce data-app-inline-styles?]
-  (update (content-security-policy-header nonce data-app-inline-styles?)
+  [frame-ancestors-mode nonce data-app-iframe?]
+  (update (content-security-policy-header nonce data-app-iframe?)
           "Content-Security-Policy"
           #(format "%s frame-ancestors %s;" % (frame-ancestors-value frame-ancestors-mode))))
 
@@ -376,12 +383,12 @@
    `:frame-ancestors` controls clickjacking protection: `:any` (open embedding),
    `:self` (same-origin only), or `:none` (default — no framing unless interactive
    embedding is configured)."
-  [& {:keys [origin nonce frame-ancestors allow-cache? data-app-inline-styles?]
-      :or   {frame-ancestors :none, allow-cache? false, data-app-inline-styles? false}}]
+  [& {:keys [origin nonce frame-ancestors allow-cache? data-app-iframe?]
+      :or   {frame-ancestors :none, allow-cache? false, data-app-iframe? false}}]
   (merge
    (if allow-cache? cache-far-future-headers (cache-prevention-headers))
    strict-transport-security-header
-   (content-security-policy-header-with-frame-ancestors frame-ancestors nonce data-app-inline-styles?)
+   (content-security-policy-header-with-frame-ancestors frame-ancestors nonce data-app-iframe?)
    (access-control-headers origin (embedding.settings/embedding-app-origins-sdk))
    ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
    (x-frame-options-header frame-ancestors)
@@ -421,7 +428,7 @@
                                                 ((some-fn request/public? request/embed?) request) :any
                                                 :else                                              :none)
                  :allow-cache?                (request/cacheable? request)
-                 :data-app-inline-styles?     (data-app-iframe-request? request))
+                 :data-app-iframe?     (data-app-iframe-request? request))
         cors-headers (when (always-allow-cors? request response)
                        {"Access-Control-Allow-Origin" "*"
                         "Access-Control-Allow-Headers" "*"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -162,6 +162,24 @@
         (is (str/includes? data-script-src "'nonce-"))
         (is (not (str/includes? data-script-src "'unsafe-inline'")))))))
 
+(deftest data-app-unsafe-eval-csp-test
+  (testing "Only data-app iframe responses allow 'unsafe-eval' in script-src"
+    ;; Data apps run their uploaded bundle through a Near-Membrane sandbox whose
+    ;; same-origin child iframe inherits this document's CSP and evaluates the
+    ;; bundle source via `eval`, so the data-app entrypoint must permit
+    ;; 'unsafe-eval' while the main app CSP stays strict.
+    (with-redefs [config/is-dev? false]
+      (let [wrapped-handler (mw.security/add-security-headers
+                             (fn [_request respond _raise]
+                               (respond {:status 200 :headers {} :body "ok"})))
+            script-src-for  (fn [uri]
+                              (-> (wrapped-handler {:uri uri :headers {}} identity identity)
+                                  (csp-directive-from-response "script-src")))]
+        (is (not (str/includes? (script-src-for "/") "'unsafe-eval'")))
+        (is (str/includes? (script-src-for "/embed/data-app/boba") "'unsafe-eval'"))
+        ;; sub-routes under the data-app entrypoint are the same SPA shell
+        (is (str/includes? (script-src-for "/embed/data-app/boba/sub/route") "'unsafe-eval'"))))))
+
 (deftest ^:parallel test-parse-url
   (testing "Should parse valid urls"
     (are [url expected] (= expected


### PR DESCRIPTION
Allow `unsafe-eval` for data app iframe.

Context:
- near membrane uses evals, and we don't allow it currently except when it's a dev mode.