### PR TITLE
Add ci-conductor (dry run) quarantine gate for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -209,6 +209,21 @@ jobs:
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ inputs.specs && steps.tagged-e2e.outcome || steps.split-e2e.outcome }}
 
+      # Quarantine gate (DEV-2082). Compare this job's ultimate test failures
+      # (recorded by after:spec into ./target/quarantine-failures.jsonl) against
+      # ci-conductor's quarantine list and decide whether the job should pass:
+      # pass if every failure is quarantined, fail if any isn't. This mirrors
+      # what Trunk's analytics-uploader does for us today. Runs in dry-run mode
+      # for now (QUARANTINE_DRY_RUN defaults to true) — it only prints the
+      # verdict and never fails the job. `continue-on-error` is belt-and-braces
+      # while it's observational; drop both it and the dry run to enforce.
+      - name: Quarantine gate (dry run)
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 2
+        shell: bash
+        run: bun e2e/support/check-quarantine.ts
+
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
         if: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -59,6 +59,11 @@ jobs:
     name: e2e-tests-${{ inputs.name }}-${{ inputs.edition }}
     env:
       MB_EDITION: ${{ inputs.edition }}
+      # Absolute path for the quarantine failures file (DEV-2082). The after:spec
+      # recorder runs in Cypress' plugins process, whose cwd differs from the
+      # workspace where the gate step runs; an absolute path anchored to the
+      # workspace makes both agree regardless of cwd.
+      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -20,6 +20,12 @@
 
 import { readFileSync } from "node:fs";
 
+import {
+  type FailedTest,
+  type QuarantineEntry,
+  compareFailedToQuarantine,
+} from "./quarantine-compare";
+
 const {
   CI_CONDUCTOR_BASE_URL,
   CI_CONDUCTOR_WEBHOOK_SECRET,
@@ -36,37 +42,6 @@ const TEST_SUITE = "e2e";
 
 const failuresFile =
   QUARANTINE_FAILURES_FILE ?? "./target/quarantine-failures.jsonl";
-
-/** One quarantined test as served by ci-conductor's `/api/quarantine`. */
-type QuarantineEntry = {
-  test_name: string;
-  test_suite: string;
-  test_path: string;
-  file_path: string;
-};
-
-/** A test that ultimately failed in this run, as recorded by after:spec. */
-type FailedTest = {
-  test_name: string;
-  test_path: string | null;
-  file_path: string | null;
-};
-
-/**
- * Identity key for a test: the spec file path, describe path, and leaf test
- * name as a JSON tuple. ci-conductor's quarantine list and our after:spec
- * recorder both derive these three fields from the same Cypress title array
- * (file_path = `spec.relative`, test_path = the joined `describe` titles), so
- * they match exactly. JSON-encoding keeps the parts distinct, so tuples that
- * differ only in where a boundary falls can't collide.
- */
-function matchKey(
-  filePath: string | null | undefined,
-  testPath: string | null | undefined,
-  testName: string,
-): string {
-  return JSON.stringify([filePath ?? "", testPath ?? "", testName]);
-}
 
 /** Read the run's failed tests from the JSONL file. */
 function readFailedTests(file: string): FailedTest[] {
@@ -161,28 +136,22 @@ async function main(): Promise<void> {
     return;
   }
 
-  const quarantined = new Set(
-    quarantine.map((q) => matchKey(q.file_path, q.test_path, q.test_name)),
-  );
-
-  const unquarantined = failed.filter(
-    (test) =>
-      !quarantined.has(
-        matchKey(test.file_path, test.test_path, test.test_name),
-      ),
+  const { quarantined, unquarantined } = compareFailedToQuarantine(
+    failed,
+    quarantine,
   );
 
   console.log(
     `[quarantine] ${failed.length} failed test(s); ${quarantine.length} test(s) in the ${TEST_SUITE} quarantine list.`,
   );
-  failed.forEach((test) => {
-    const isQuarantined = quarantined.has(
-      matchKey(test.file_path, test.test_path, test.test_name),
-    );
-    console.log(
-      `  ${isQuarantined ? "✓ quarantined" : "✗ NOT quarantined"}: ${test.test_name}  (${test.file_path ?? "unknown file"})`,
-    );
-  });
+  const describe = (test: FailedTest) =>
+    `${test.test_name}  (${test.file_path ?? "unknown file"})`;
+  quarantined.forEach((test) =>
+    console.log(`  ✓ quarantined: ${describe(test)}`),
+  );
+  unquarantined.forEach((test) =>
+    console.log(`  ✗ NOT quarantined: ${describe(test)}`),
+  );
 
   finish(
     unquarantined.length > 0,

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -147,10 +147,10 @@ async function main(): Promise<void> {
   const describe = (test: FailedTest) =>
     `${test.test_name}  (${test.file_path ?? "unknown file"})`;
   quarantined.forEach((test) =>
-    console.log(`  ✓ quarantined: ${describe(test)}`),
+    console.log(`  🔒 quarantined: ${describe(test)}`),
   );
   unquarantined.forEach((test) =>
-    console.log(`  ✗ NOT quarantined: ${describe(test)}`),
+    console.log(`  🚨 NOT quarantined: ${describe(test)}`),
   );
 
   finish(

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -35,9 +35,7 @@ const isDryRun = QUARANTINE_DRY_RUN !== "false";
 const TEST_SUITE = "e2e";
 
 const failuresFile =
-  process.argv[2] ??
-  QUARANTINE_FAILURES_FILE ??
-  "./target/quarantine-failures.jsonl";
+  QUARANTINE_FAILURES_FILE ?? "./target/quarantine-failures.jsonl";
 
 /** One quarantined test as served by ci-conductor's `/api/quarantine`. */
 type QuarantineEntry = {
@@ -54,31 +52,23 @@ type FailedTest = {
   file_path: string | null;
 };
 
-/** Basename of a path, tolerant of both POSIX and Windows separators. */
-function baseName(p: string): string {
-  return p.split(/[\\/]/).pop() ?? "";
-}
-
 /**
- * Identity key for a test. ci-conductor's quarantine list and our after:spec
- * recorder both derive these fields from the same Cypress title array, so an
- * exact comparison is sound. We key on the spec basename (robust to any
- * path-prefix difference), the describe path, and the leaf test name.
+ * Identity key for a test: the spec file path, describe path, and leaf test
+ * name as a JSON tuple. ci-conductor's quarantine list and our after:spec
+ * recorder both derive these three fields from the same Cypress title array
+ * (file_path = `spec.relative`, test_path = the joined `describe` titles), so
+ * they match exactly. JSON-encoding keeps the parts distinct, so tuples that
+ * differ only in where a boundary falls can't collide.
  */
 function matchKey(
   filePath: string | null | undefined,
   testPath: string | null | undefined,
   testName: string,
 ): string {
-  return [
-    filePath ? baseName(filePath) : "",
-    (testPath ?? "").trim(),
-    testName.trim(),
-    // NUL separator: can't appear in any of the parts, so no collisions.
-  ].join("\u0000");
+  return JSON.stringify([filePath ?? "", testPath ?? "", testName]);
 }
 
-/** Read and de-dupe the run's failed tests from the JSONL file. */
+/** Read the run's failed tests from the JSONL file. */
 function readFailedTests(file: string): FailedTest[] {
   let raw: string;
   try {
@@ -88,7 +78,7 @@ function readFailedTests(file: string): FailedTest[] {
     return [];
   }
 
-  const parsed = raw
+  return raw
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line !== "")
@@ -101,16 +91,6 @@ function readFailedTests(file: string): FailedTest[] {
       }
     })
     .filter((test): test is FailedTest => test !== null);
-
-  const seen = new Set<string>();
-  return parsed.filter((test) => {
-    const key = matchKey(test.file_path, test.test_path, test.test_name);
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
 }
 
 /**

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -19,7 +19,6 @@
 // the same Cypress title array, so the comparison here is exact.
 
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
 const {
   CI_CONDUCTOR_WEBHOOK_URL,
@@ -85,11 +84,7 @@ function readFailedTests(file: string): FailedTest[] {
   try {
     raw = readFileSync(file, "utf8");
   } catch {
-    // Log cwd too: if the recorder and this step disagree on where the file
-    // lives, the mismatch is then obvious side by side. DEV-2082.
-    console.log(
-      `[quarantine] no failures file at ${resolve(file)} (cwd=${process.cwd()}); nothing to gate.`,
-    );
+    console.log(`[quarantine] no failures file at ${file}; nothing to gate.`);
     return [];
   }
 

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env bun
+
+// Quarantine gate (DEV-2082). After an e2e job runs, compare the tests that
+// *ultimately failed* against the quarantine list served by ci-conductor and
+// decide whether the job should pass or fail:
+//
+//   - No failures                    -> pass (nothing to gate)
+//   - Every failure is quarantined   -> pass (exit cleanly)
+//   - Any failure is NOT quarantined -> fail
+//
+// This mirrors what Trunk's analytics-uploader currently does for us; the goal
+// is to eventually replace that. For now the gate runs in DRY-RUN mode: it
+// computes and prints the verdict but always exits 0, so it can be observed in
+// CI without affecting job outcomes. Flip QUARANTINE_DRY_RUN=false to enforce.
+//
+// The failures come from the file written by after:spec
+// (`recordFailedTestsForQuarantine` in ci_conductor.ts). Both that file and
+// ci-conductor's quarantine list derive {test_name, test_path, file_path} from
+// the same Cypress title array, so the comparison here is exact.
+
+import { readFileSync } from "node:fs";
+
+const {
+  CI_CONDUCTOR_WEBHOOK_URL,
+  CI_CONDUCTOR_WEBHOOK_SECRET,
+  // Default to a dry run: compute and print the verdict, but never fail the
+  // job. Set to "false" to actually gate the build on the verdict.
+  QUARANTINE_DRY_RUN,
+  QUARANTINE_FAILURES_FILE,
+} = process.env;
+
+const isDryRun = QUARANTINE_DRY_RUN !== "false";
+
+// The test suite to gate. ci-conductor keys its quarantine list by suite.
+const TEST_SUITE = "e2e";
+
+const failuresFile =
+  process.argv[2] ??
+  QUARANTINE_FAILURES_FILE ??
+  "./target/quarantine-failures.jsonl";
+
+/** One quarantined test as served by ci-conductor's `/api/quarantine`. */
+type QuarantineEntry = {
+  test_name: string;
+  test_suite: string;
+  test_path: string;
+  file_path: string;
+};
+
+/** A test that ultimately failed in this run, as recorded by after:spec. */
+type FailedTest = {
+  test_name: string;
+  test_path: string | null;
+  file_path: string | null;
+};
+
+/** Basename of a path, tolerant of both POSIX and Windows separators. */
+function baseName(p: string): string {
+  return p.split(/[\\/]/).pop() ?? "";
+}
+
+/**
+ * Identity key for a test. ci-conductor's quarantine list and our after:spec
+ * recorder both derive these fields from the same Cypress title array, so an
+ * exact comparison is sound. We key on the spec basename (robust to any
+ * path-prefix difference), the describe path, and the leaf test name.
+ */
+function matchKey(
+  filePath: string | null | undefined,
+  testPath: string | null | undefined,
+  testName: string,
+): string {
+  return [
+    filePath ? baseName(filePath) : "",
+    (testPath ?? "").trim(),
+    testName.trim(),
+    // NUL separator: can't appear in any of the parts, so no collisions.
+  ].join("\u0000");
+}
+
+/** Read and de-dupe the run's failed tests from the JSONL file. */
+function readFailedTests(file: string): FailedTest[] {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    console.log(`[quarantine] no failures file at ${file}; nothing to gate.`);
+    return [];
+  }
+
+  const parsed = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line): FailedTest | null => {
+      try {
+        return JSON.parse(line) as FailedTest;
+      } catch {
+        console.error(`[quarantine] skipping unparseable line: ${line}`);
+        return null;
+      }
+    })
+    .filter((test): test is FailedTest => test !== null);
+
+  const seen = new Set<string>();
+  return parsed.filter((test) => {
+    const key = matchKey(test.file_path, test.test_path, test.test_name);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Resolve the ci-conductor API base from the webhook URL secret. That secret
+ * holds the webhooks base (".../webhooks"); the quarantine list lives at
+ * ".../api/quarantine" on the same host, so we drop the "/webhooks" suffix.
+ */
+function quarantineUrl(): string | null {
+  if (!CI_CONDUCTOR_WEBHOOK_URL) {
+    return null;
+  }
+  const base = CI_CONDUCTOR_WEBHOOK_URL.replace(/\/+$/, "").replace(
+    /\/webhooks$/,
+    "",
+  );
+  return `${base}/api/quarantine?suite=${TEST_SUITE}`;
+}
+
+/** Fetch the quarantine list, or null if it can't be retrieved. */
+async function fetchQuarantine(): Promise<QuarantineEntry[] | null> {
+  const url = quarantineUrl();
+  if (!url) {
+    console.log(
+      "[quarantine] CI_CONDUCTOR_WEBHOOK_URL is unset; cannot fetch the quarantine list.",
+    );
+    return null;
+  }
+  try {
+    const headers: Record<string, string> = {};
+    if (CI_CONDUCTOR_WEBHOOK_SECRET) {
+      headers["x-internal-secret"] = CI_CONDUCTOR_WEBHOOK_SECRET;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      console.error(
+        `[quarantine] GET ${url} returned ${response.status} ${response.statusText}`,
+      );
+      return null;
+    }
+    const body = (await response.json()) as { tests?: QuarantineEntry[] };
+    return body.tests ?? [];
+  } catch (error) {
+    console.error(`[quarantine] failed to fetch ${url}`, error);
+    return null;
+  }
+}
+
+/** Print the verdict and, outside dry run, set the exit code accordingly. */
+function finish(shouldFail: boolean, reason: string): void {
+  const verdict = shouldFail ? "FAIL" : "PASS";
+  const mode = isDryRun ? " (dry run — not enforced)" : "";
+  console.log(`[quarantine] verdict: ${verdict}${mode} — ${reason}.`);
+  if (shouldFail && !isDryRun) {
+    process.exitCode = 1;
+  }
+}
+
+async function main(): Promise<void> {
+  const failed = readFailedTests(failuresFile);
+
+  if (failed.length === 0) {
+    console.log("[quarantine] no failed tests; passing.");
+    return;
+  }
+
+  const quarantine = await fetchQuarantine();
+  if (quarantine === null) {
+    // We couldn't read the list, so we can't confirm everything is
+    // quarantined — that's a failing verdict (enforced only outside dry run).
+    finish(true, "could not fetch the quarantine list");
+    return;
+  }
+
+  const quarantined = new Set(
+    quarantine.map((q) => matchKey(q.file_path, q.test_path, q.test_name)),
+  );
+
+  const unquarantined = failed.filter(
+    (test) =>
+      !quarantined.has(
+        matchKey(test.file_path, test.test_path, test.test_name),
+      ),
+  );
+
+  console.log(
+    `[quarantine] ${failed.length} failed test(s); ${quarantine.length} test(s) in the ${TEST_SUITE} quarantine list.`,
+  );
+  failed.forEach((test) => {
+    const isQuarantined = quarantined.has(
+      matchKey(test.file_path, test.test_path, test.test_name),
+    );
+    console.log(
+      `  ${isQuarantined ? "✓ quarantined" : "✗ NOT quarantined"}: ${test.test_name}  (${test.file_path ?? "unknown file"})`,
+    );
+  });
+
+  finish(
+    unquarantined.length > 0,
+    unquarantined.length > 0
+      ? `${unquarantined.length} failed test(s) are not quarantined`
+      : "every failed test is quarantined",
+  );
+}
+
+// Only run when invoked directly (`bun check-quarantine.ts`), not on import.
+if (import.meta.main) {
+  await main();
+}

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -21,7 +21,7 @@
 import { readFileSync } from "node:fs";
 
 const {
-  CI_CONDUCTOR_WEBHOOK_URL,
+  CI_CONDUCTOR_BASE_URL,
   CI_CONDUCTOR_WEBHOOK_SECRET,
   // Default to a dry run: compute and print the verdict, but never fail the
   // job. Set to "false" to actually gate the build on the verdict.
@@ -94,18 +94,15 @@ function readFailedTests(file: string): FailedTest[] {
 }
 
 /**
- * Resolve the ci-conductor API base from the webhook URL secret. That secret
- * holds the webhooks base (".../webhooks"); the quarantine list lives at
- * ".../api/quarantine" on the same host, so we drop the "/webhooks" suffix.
+ * Build the quarantine list URL from the ci-conductor base origin secret. The
+ * reporter posts to ".../webhooks/failed-tests"; the quarantine list lives at
+ * ".../api/quarantine" on the same host.
  */
 function quarantineUrl(): string | null {
-  if (!CI_CONDUCTOR_WEBHOOK_URL) {
+  if (!CI_CONDUCTOR_BASE_URL) {
     return null;
   }
-  const base = CI_CONDUCTOR_WEBHOOK_URL.replace(/\/+$/, "").replace(
-    /\/webhooks$/,
-    "",
-  );
+  const base = CI_CONDUCTOR_BASE_URL.replace(/\/+$/, "");
   return `${base}/api/quarantine?suite=${TEST_SUITE}`;
 }
 
@@ -114,7 +111,7 @@ async function fetchQuarantine(): Promise<QuarantineEntry[] | null> {
   const url = quarantineUrl();
   if (!url) {
     console.log(
-      "[quarantine] CI_CONDUCTOR_WEBHOOK_URL is unset; cannot fetch the quarantine list.",
+      "[quarantine] CI_CONDUCTOR_BASE_URL is unset; cannot fetch the quarantine list.",
     );
     return null;
   }

--- a/e2e/support/check-quarantine.ts
+++ b/e2e/support/check-quarantine.ts
@@ -19,6 +19,7 @@
 // the same Cypress title array, so the comparison here is exact.
 
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const {
   CI_CONDUCTOR_WEBHOOK_URL,
@@ -84,7 +85,11 @@ function readFailedTests(file: string): FailedTest[] {
   try {
     raw = readFileSync(file, "utf8");
   } catch {
-    console.log(`[quarantine] no failures file at ${file}; nothing to gate.`);
+    // Log cwd too: if the recorder and this step disagree on where the file
+    // lives, the mismatch is then obvious side by side. DEV-2082.
+    console.log(
+      `[quarantine] no failures file at ${resolve(file)} (cwd=${process.cwd()}); nothing to gate.`,
+    );
     return [];
   }
 

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,4 +1,5 @@
-import { readFileSync, statSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { dirname } from "node:path";
 
 import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
@@ -270,6 +271,47 @@ export function extractFailedTests(
   }
 
   return tests;
+}
+
+/**
+ * Where after:spec records this run's ultimate test failures for the post-run
+ * quarantine gate (DEV-2082). One JSON object per line
+ * (`{test_name, test_path, file_path}`), appended per spec, so the gate step
+ * can read the whole job's failures from a single file. Override with
+ * QUARANTINE_FAILURES_FILE. Note these are the SAME fields ci-conductor stores
+ * in its quarantine list (both derived from the same Cypress title array), so
+ * the gate can compare them exactly. See `check-quarantine.ts`.
+ */
+const QUARANTINE_FAILURES_FILE =
+  process.env.QUARANTINE_FAILURES_FILE ?? "./target/quarantine-failures.jsonl";
+
+/**
+ * Persist the tests that ultimately failed (status "failure") so the post-run
+ * quarantine gate can decide whether the job passes. Flaky tests that recovered
+ * on retry and passing tests don't gate the build, so they're filtered out.
+ * Best-effort and never throws — recording must not break the test run.
+ */
+export function recordFailedTestsForQuarantine(tests: ConductorTest[]): void {
+  try {
+    const broken = tests.filter((test) => test.status === "failure");
+    if (broken.length === 0) {
+      return;
+    }
+    const lines =
+      broken
+        .map((test) =>
+          JSON.stringify({
+            test_name: test.name,
+            test_path: test.path ?? null,
+            file_path: test.file ?? null,
+          }),
+        )
+        .join("\n") + "\n";
+    mkdirSync(dirname(QUARANTINE_FAILURES_FILE), { recursive: true });
+    appendFileSync(QUARANTINE_FAILURES_FILE, lines);
+  } catch (error) {
+    console.error("[quarantine] failed to record failures", error);
+  }
 }
 
 /**

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 
 import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
@@ -319,12 +319,6 @@ export function recordFailedTestsForQuarantine(tests: ConductorTest[]): void {
         .join("\n") + "\n";
     mkdirSync(dirname(QUARANTINE_FAILURES_FILE), { recursive: true });
     appendFileSync(QUARANTINE_FAILURES_FILE, lines);
-    // Log where we wrote so the gate's input is auditable — and so a cwd/path
-    // mismatch between this (Cypress plugins) process and the gate step is
-    // obvious in CI. resolve() makes the absolute target explicit. DEV-2082.
-    console.log(
-      `[quarantine] recorded ${broken.length} failure(s) to ${resolve(QUARANTINE_FAILURES_FILE)} (cwd=${process.cwd()})`,
-    );
   } catch (error) {
     console.error("[quarantine] failed to record failures", error);
   }

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -76,26 +76,19 @@ type ConductorTest = {
 };
 
 /**
- * Classify a test. The test's *final* state is authoritative: it's what
- * mocha/JUnit (and Trunk) count as a failure, and — unlike the per-attempt
- * `state` — it's reliable across Cypress' retry shapes. A retried failure can
- * arrive with an `attempts` array that isn't uniformly "failed", which used to
- * misclassify a hard failure as a "flake" (DEV-2082). So:
- *   - finalState "failed"                  -> "failure"
- *   - finalState "passed", ≥1 failed attempt -> "flake" (recovered on retry)
- *   - finalState "passed", no failed attempt -> "passed"
- * The attempts array is only consulted to tell a clean pass from a flake.
+ * Classify a test from its attempts: "passed" if every attempt passed,
+ * "failure" if every attempt failed, "flake" if it failed at least once but
+ * ultimately passed on retry. Callers only pass tests that ran (a non-empty
+ * attempts array of passes and/or fails), never pending/skipped.
  */
 function classifyStatus(
-  finalState: string | undefined,
   attempts: { state: string }[],
 ): "failure" | "flake" | "passed" {
-  if (finalState === "failed") {
-    return "failure";
+  if (attempts.every((attempt) => attempt.state === "passed")) {
+    return "passed";
   }
-  return attempts.some((attempt) => attempt.state === "failed")
-    ? "flake"
-    : "passed";
+  const allFailed = attempts.every((attempt) => attempt.state === "failed");
+  return allFailed ? "failure" : "flake";
 }
 
 /**
@@ -202,11 +195,11 @@ function encodeScreenshot(filePath: string): string | undefined {
 }
 
 /**
- * Pull the reportable tests out of a single spec's run results. Classification
- * keys off each test's authoritative final `state`: we include "broken" tests
- * (final state failed) and "flaky" ones (final state passed but ≥1 attempt
- * failed). On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include tests
- * that passed cleanly, so conductor can see a previously-failing test recover.
+ * Pull the reportable tests out of a single spec's run results. We always
+ * include any test that had at least one failed attempt — so both "broken"
+ * (every attempt failed) and "flaky" (failed at least once, passed on retry)
+ * are reported. On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include
+ * tests that passed, so conductor can see a previously-failing test recover.
  * Pending/skipped tests are never reported. Each row carries a derived `status`
  * ("failure" | "flake" | "passed"); see `classifyStatus`.
  *
@@ -232,16 +225,13 @@ export function extractFailedTests(
   const tests = (results?.tests ?? [])
     .filter((test) => {
       const attempts = test.attempts ?? [];
-      const everFailed = attempts.some((attempt) => attempt.state === "failed");
-      // The final state is authoritative (see classifyStatus). Report a test
-      // that ultimately failed, or flaked (passed on retry after a failed
-      // attempt). On a re-run we additionally report a clean pass so conductor
-      // can see a previously-failing test recover. Pending/skipped (any other
-      // final state) are never reported.
-      const isFailure = test.state === "failed";
-      const isFlake = test.state === "passed" && everFailed;
-      const isCleanPass = test.state === "passed" && !everFailed;
-      return isFailure || isFlake || (isRerun && isCleanPass);
+      const failed = attempts.some((attempt) => attempt.state === "failed");
+      // A test "passed" only if it ran and every attempt passed — this excludes
+      // pending/skipped tests, which we never report.
+      const passed =
+        attempts.length > 0 &&
+        attempts.every((attempt) => attempt.state === "passed");
+      return failed || (isRerun && passed);
     })
     .map((test) => {
       const titlePath = test.title ?? [];
@@ -262,7 +252,7 @@ export function extractFailedTests(
         file,
         duration: test.duration,
         attempts,
-        status: classifyStatus(test.state, attempts),
+        status: classifyStatus(attempts),
         message: test.displayError ?? null,
         ...(screenshotPath ? { screenshotPath } : {}),
       };

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 
 import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
@@ -319,6 +319,12 @@ export function recordFailedTestsForQuarantine(tests: ConductorTest[]): void {
         .join("\n") + "\n";
     mkdirSync(dirname(QUARANTINE_FAILURES_FILE), { recursive: true });
     appendFileSync(QUARANTINE_FAILURES_FILE, lines);
+    // Log where we wrote so the gate's input is auditable — and so a cwd/path
+    // mismatch between this (Cypress plugins) process and the gate step is
+    // obvious in CI. resolve() makes the absolute target explicit. DEV-2082.
+    console.log(
+      `[quarantine] recorded ${broken.length} failure(s) to ${resolve(QUARANTINE_FAILURES_FILE)} (cwd=${process.cwd()})`,
+    );
   } catch (error) {
     console.error("[quarantine] failed to record failures", error);
   }

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -76,19 +76,26 @@ type ConductorTest = {
 };
 
 /**
- * Classify a test from its attempts: "passed" if every attempt passed,
- * "failure" if every attempt failed, "flake" if it failed at least once but
- * ultimately passed on retry. Callers only pass tests that ran (a non-empty
- * attempts array of passes and/or fails), never pending/skipped.
+ * Classify a test. The test's *final* state is authoritative: it's what
+ * mocha/JUnit (and Trunk) count as a failure, and — unlike the per-attempt
+ * `state` — it's reliable across Cypress' retry shapes. A retried failure can
+ * arrive with an `attempts` array that isn't uniformly "failed", which used to
+ * misclassify a hard failure as a "flake" (DEV-2082). So:
+ *   - finalState "failed"                  -> "failure"
+ *   - finalState "passed", ≥1 failed attempt -> "flake" (recovered on retry)
+ *   - finalState "passed", no failed attempt -> "passed"
+ * The attempts array is only consulted to tell a clean pass from a flake.
  */
 function classifyStatus(
+  finalState: string | undefined,
   attempts: { state: string }[],
 ): "failure" | "flake" | "passed" {
-  if (attempts.every((attempt) => attempt.state === "passed")) {
-    return "passed";
+  if (finalState === "failed") {
+    return "failure";
   }
-  const allFailed = attempts.every((attempt) => attempt.state === "failed");
-  return allFailed ? "failure" : "flake";
+  return attempts.some((attempt) => attempt.state === "failed")
+    ? "flake"
+    : "passed";
 }
 
 /**
@@ -195,11 +202,11 @@ function encodeScreenshot(filePath: string): string | undefined {
 }
 
 /**
- * Pull the reportable tests out of a single spec's run results. We always
- * include any test that had at least one failed attempt — so both "broken"
- * (every attempt failed) and "flaky" (failed at least once, passed on retry)
- * are reported. On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include
- * tests that passed, so conductor can see a previously-failing test recover.
+ * Pull the reportable tests out of a single spec's run results. Classification
+ * keys off each test's authoritative final `state`: we include "broken" tests
+ * (final state failed) and "flaky" ones (final state passed but ≥1 attempt
+ * failed). On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include tests
+ * that passed cleanly, so conductor can see a previously-failing test recover.
  * Pending/skipped tests are never reported. Each row carries a derived `status`
  * ("failure" | "flake" | "passed"); see `classifyStatus`.
  *
@@ -225,13 +232,16 @@ export function extractFailedTests(
   const tests = (results?.tests ?? [])
     .filter((test) => {
       const attempts = test.attempts ?? [];
-      const failed = attempts.some((attempt) => attempt.state === "failed");
-      // A test "passed" only if it ran and every attempt passed — this excludes
-      // pending/skipped tests, which we never report.
-      const passed =
-        attempts.length > 0 &&
-        attempts.every((attempt) => attempt.state === "passed");
-      return failed || (isRerun && passed);
+      const everFailed = attempts.some((attempt) => attempt.state === "failed");
+      // The final state is authoritative (see classifyStatus). Report a test
+      // that ultimately failed, or flaked (passed on retry after a failed
+      // attempt). On a re-run we additionally report a clean pass so conductor
+      // can see a previously-failing test recover. Pending/skipped (any other
+      // final state) are never reported.
+      const isFailure = test.state === "failed";
+      const isFlake = test.state === "passed" && everFailed;
+      const isCleanPass = test.state === "passed" && !everFailed;
+      return isFailure || isFlake || (isRerun && isCleanPass);
     })
     .map((test) => {
       const titlePath = test.title ?? [];
@@ -252,7 +262,7 @@ export function extractFailedTests(
         file,
         duration: test.duration,
         attempts,
-        status: classifyStatus(attempts),
+        status: classifyStatus(test.state, attempts),
         message: test.displayError ?? null,
         ...(screenshotPath ? { screenshotPath } : {}),
       };

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -1,3 +1,7 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { extractFailedTests, resolveScreenshotPath } from "./ci_conductor";
 
 // jest.mock is hoisted; the mocked default must be referenced via a `mock`-
@@ -640,6 +644,107 @@ describe("reportFailedTestsToConductor", () => {
       reportFailedTestsToConductor(oneTest),
     ).resolves.toBeUndefined();
     expect(console.error).toHaveBeenCalled();
+    (console.error as jest.Mock).mockRestore();
+  });
+});
+
+describe("recordFailedTestsForQuarantine", () => {
+  const failuresFile = join(tmpdir(), `q-failures-${process.pid}.jsonl`);
+
+  afterEach(() => {
+    if (existsSync(failuresFile)) {
+      rmSync(failuresFile);
+    }
+  });
+
+  // The recorder reads QUARANTINE_FAILURES_FILE at import time, so point it at
+  // a temp file by re-importing the module with that env applied.
+  const load = () => loadConductor({ QUARANTINE_FAILURES_FILE: failuresFile });
+
+  const readLines = () =>
+    readFileSync(failuresFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+  it("records only ultimate failures (not flakes or passes), one per line", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    const results = makeResults({
+      tests: [
+        test(["scenarios > foo", "passes"], ["passed"]),
+        test(["scenarios > foo", "flakes then passes"], ["failed", "passed"]),
+        test(["scenarios > foo", "stays broken"], ["failed", "failed"], "boom"),
+      ],
+    });
+
+    recordFailedTestsForQuarantine(extractFailedTests(spec, results));
+
+    expect(readLines()).toEqual([
+      {
+        test_name: "stays broken",
+        test_path: "scenarios > foo",
+        file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+      },
+    ]);
+  });
+
+  it("appends across calls so the whole job's failures accumulate", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({ tests: [test(["A", "one"], ["failed", "failed"], "x")] }),
+      ),
+    );
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({ tests: [test(["B", "two"], ["failed", "failed"], "y")] }),
+      ),
+    );
+
+    expect(readLines().map((t) => t.test_name)).toEqual(["one", "two"]);
+  });
+
+  it("writes nothing when there are no ultimate failures", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({
+          tests: [
+            test(["A", "ok"], ["passed"]),
+            test(["A", "flaky"], ["failed", "passed"]),
+          ],
+        }),
+      ),
+    );
+
+    expect(existsSync(failuresFile)).toBe(false);
+  });
+
+  it("never throws when the file can't be written", async () => {
+    // A NUL byte in the path makes the fs calls throw; the recorder must swallow it.
+    const { recordFailedTestsForQuarantine } = await loadConductor({
+      QUARANTINE_FAILURES_FILE: "/tmp/\0/nope.jsonl",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      recordFailedTestsForQuarantine([
+        {
+          name: "n",
+          path: "p",
+          file: "f",
+          status: "failure",
+          attempts: [{ state: "failed" }],
+        },
+      ] as Parameters<typeof recordFailedTestsForQuarantine>[0]),
+    ).not.toThrow();
+
     (console.error as jest.Mock).mockRestore();
   });
 });

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -139,6 +139,47 @@ describe("extractFailedTests", () => {
     });
   });
 
+  it("classifies by the final state, not by every-attempt-failed (DEV-2082 regression)", () => {
+    // A retried failure can arrive with an attempts array that isn't uniformly
+    // "failed" (Cypress' shape). The final `state` is authoritative, so this is
+    // a "failure" — the old every-attempt-failed check misread it as a "flake".
+    const results = makeResults({
+      tests: [
+        {
+          title: ["a", "broken with odd attempts"],
+          state: "failed",
+          displayError: "boom",
+          duration: 100,
+          attempts: [{ state: "failed" }, { state: "unknown" }],
+        },
+      ] as unknown as CypressCommandLine.RunResult["tests"],
+    });
+
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
+      name: "broken with odd attempts",
+      status: "failure",
+    });
+  });
+
+  it("includes a broken test (final state failed) even with an empty attempts array", () => {
+    const results = makeResults({
+      tests: [
+        {
+          title: ["a", "broken no attempts"],
+          state: "failed",
+          displayError: "boom",
+          duration: 100,
+          attempts: [],
+        },
+      ] as unknown as CypressCommandLine.RunResult["tests"],
+    });
+
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
+      name: "broken no attempts",
+      status: "failure",
+    });
+  });
+
   it("excludes healthy, pending, and skipped tests", () => {
     const results = makeResults({
       tests: [
@@ -683,6 +724,32 @@ describe("recordFailedTestsForQuarantine", () => {
     expect(readLines()).toEqual([
       {
         test_name: "stays broken",
+        test_path: "scenarios > foo",
+        file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+      },
+    ]);
+  });
+
+  it("records a failure whose attempts array isn't uniformly failed (DEV-2082)", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    const results = makeResults({
+      tests: [
+        {
+          title: ["scenarios > foo", "stays broken on retry"],
+          state: "failed",
+          displayError: "boom",
+          duration: 100,
+          attempts: [{ state: "failed" }, { state: "unknown" }],
+        },
+      ] as unknown as CypressCommandLine.RunResult["tests"],
+    });
+
+    recordFailedTestsForQuarantine(extractFailedTests(spec, results));
+
+    expect(readLines()).toEqual([
+      {
+        test_name: "stays broken on retry",
         test_path: "scenarios > foo",
         file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
       },

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -139,47 +139,6 @@ describe("extractFailedTests", () => {
     });
   });
 
-  it("classifies by the final state, not by every-attempt-failed (DEV-2082 regression)", () => {
-    // A retried failure can arrive with an attempts array that isn't uniformly
-    // "failed" (Cypress' shape). The final `state` is authoritative, so this is
-    // a "failure" — the old every-attempt-failed check misread it as a "flake".
-    const results = makeResults({
-      tests: [
-        {
-          title: ["a", "broken with odd attempts"],
-          state: "failed",
-          displayError: "boom",
-          duration: 100,
-          attempts: [{ state: "failed" }, { state: "unknown" }],
-        },
-      ] as unknown as CypressCommandLine.RunResult["tests"],
-    });
-
-    expect(extractFailedTests(spec, results)[0]).toMatchObject({
-      name: "broken with odd attempts",
-      status: "failure",
-    });
-  });
-
-  it("includes a broken test (final state failed) even with an empty attempts array", () => {
-    const results = makeResults({
-      tests: [
-        {
-          title: ["a", "broken no attempts"],
-          state: "failed",
-          displayError: "boom",
-          duration: 100,
-          attempts: [],
-        },
-      ] as unknown as CypressCommandLine.RunResult["tests"],
-    });
-
-    expect(extractFailedTests(spec, results)[0]).toMatchObject({
-      name: "broken no attempts",
-      status: "failure",
-    });
-  });
-
   it("excludes healthy, pending, and skipped tests", () => {
     const results = makeResults({
       tests: [
@@ -724,32 +683,6 @@ describe("recordFailedTestsForQuarantine", () => {
     expect(readLines()).toEqual([
       {
         test_name: "stays broken",
-        test_path: "scenarios > foo",
-        file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
-      },
-    ]);
-  });
-
-  it("records a failure whose attempts array isn't uniformly failed (DEV-2082)", async () => {
-    const { recordFailedTestsForQuarantine } = await load();
-
-    const results = makeResults({
-      tests: [
-        {
-          title: ["scenarios > foo", "stays broken on retry"],
-          state: "failed",
-          displayError: "boom",
-          duration: 100,
-          attempts: [{ state: "failed" }, { state: "unknown" }],
-        },
-      ] as unknown as CypressCommandLine.RunResult["tests"],
-    });
-
-    recordFailedTestsForQuarantine(extractFailedTests(spec, results));
-
-    expect(readLines()).toEqual([
-      {
-        test_name: "stays broken on retry",
         test_path: "scenarios > foo",
         file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
       },

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -221,6 +221,7 @@ const defaultConfig = {
             console.log(
               "[quarantine-diag]",
               spec.relative,
+              `cwd=${process.cwd()}`,
               JSON.stringify(diag),
             );
           }

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -10,6 +10,7 @@ import { BACKEND_HOST, BACKEND_PORT } from "../runner/constants/backend-port";
 
 import {
   extractFailedTests,
+  recordFailedTestsForQuarantine,
   reportFailedTestsToConductor,
 } from "./ci_conductor";
 import * as ciTasks from "./ci_tasks";
@@ -200,7 +201,10 @@ const defaultConfig = {
         // a hard backstop around everything — extraction, payload build, and
         // the request. The reporter also handles its own errors internally.
         try {
-          await reportFailedTestsToConductor(extractFailedTests(spec, results));
+          const failedTests = extractFailedTests(spec, results);
+          // Persist ultimate failures for the post-run quarantine gate (DEV-2082).
+          recordFailedTestsForQuarantine(failedTests);
+          await reportFailedTestsToConductor(failedTests);
         } catch (error) {
           console.error("[ci-conductor] reporting failed (ignored)", error);
         }

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -201,6 +201,30 @@ const defaultConfig = {
         // a hard backstop around everything — extraction, payload build, and
         // the request. The reporter also handles its own errors internally.
         try {
+          // TEMP DIAGNOSTIC (DEV-2082): dump the raw Cypress per-test shape for
+          // any test that failed or had a failed attempt, so we can confirm
+          // Cypress 15's actual after:spec `state`/`attempts` structure for
+          // retried failures. Remove once the quarantine classification is
+          // verified against a real CI failure.
+          const diag = (results?.tests ?? [])
+            .filter(
+              (t) =>
+                t.state === "failed" ||
+                (t.attempts ?? []).some((a) => a.state === "failed"),
+            )
+            .map((t) => ({
+              title: t.title,
+              state: t.state,
+              attempts: (t.attempts ?? []).map((a) => a.state),
+            }));
+          if (diag.length > 0) {
+            console.log(
+              "[quarantine-diag]",
+              spec.relative,
+              JSON.stringify(diag),
+            );
+          }
+
           const failedTests = extractFailedTests(spec, results);
           // Persist ultimate failures for the post-run quarantine gate (DEV-2082).
           recordFailedTestsForQuarantine(failedTests);

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -201,31 +201,6 @@ const defaultConfig = {
         // a hard backstop around everything — extraction, payload build, and
         // the request. The reporter also handles its own errors internally.
         try {
-          // TEMP DIAGNOSTIC (DEV-2082): dump the raw Cypress per-test shape for
-          // any test that failed or had a failed attempt, so we can confirm
-          // Cypress 15's actual after:spec `state`/`attempts` structure for
-          // retried failures. Remove once the quarantine classification is
-          // verified against a real CI failure.
-          const diag = (results?.tests ?? [])
-            .filter(
-              (t) =>
-                t.state === "failed" ||
-                (t.attempts ?? []).some((a) => a.state === "failed"),
-            )
-            .map((t) => ({
-              title: t.title,
-              state: t.state,
-              attempts: (t.attempts ?? []).map((a) => a.state),
-            }));
-          if (diag.length > 0) {
-            console.log(
-              "[quarantine-diag]",
-              spec.relative,
-              `cwd=${process.cwd()}`,
-              JSON.stringify(diag),
-            );
-          }
-
           const failedTests = extractFailedTests(spec, results);
           // Persist ultimate failures for the post-run quarantine gate (DEV-2082).
           recordFailedTestsForQuarantine(failedTests);

--- a/e2e/support/quarantine-compare.ts
+++ b/e2e/support/quarantine-compare.ts
@@ -1,0 +1,59 @@
+// Pure comparison logic for the quarantine gate (DEV-2082), split out from the
+// `check-quarantine.ts` executable so it can be unit tested without the script's
+// CLI side effects (`import.meta.main`, env reads, `fetch`).
+
+import _ from "underscore";
+
+/** One quarantined test as served by ci-conductor's `/api/quarantine`. */
+export type QuarantineEntry = {
+  test_name: string;
+  test_suite: string;
+  test_path: string;
+  file_path: string;
+};
+
+/** A test that ultimately failed in this run, as recorded by after:spec. */
+export type FailedTest = {
+  test_name: string;
+  test_path: string | null;
+  file_path: string | null;
+};
+
+/**
+ * Identity key for a test: the spec file path, describe path, and leaf test
+ * name as a JSON tuple. ci-conductor's quarantine list and our after:spec
+ * recorder both derive these three fields from the same Cypress title array
+ * (file_path = `spec.relative`, test_path = the joined `describe` titles), so
+ * they match exactly. JSON-encoding keeps the parts distinct, so tuples that
+ * differ only in where a boundary falls can't collide.
+ */
+export function matchKey(
+  filePath: string | null | undefined,
+  testPath: string | null | undefined,
+  testName: string,
+): string {
+  return JSON.stringify([filePath ?? "", testPath ?? "", testName]);
+}
+
+/**
+ * Partition the run's failed tests into those that are quarantined and those
+ * that are not, matching on exact {file_path, test_path, test_name} identity.
+ * A single pass over the failures, so the gate doesn't repeat the (potentially
+ * large) comparison when it later logs or counts each bucket.
+ */
+export function compareFailedToQuarantine(
+  failedTests: FailedTest[],
+  quarantineEntries: QuarantineEntry[],
+): { quarantined: FailedTest[]; unquarantined: FailedTest[] } {
+  const quarantinedKeys = new Set(
+    quarantineEntries.map((q) =>
+      matchKey(q.file_path, q.test_path, q.test_name),
+    ),
+  );
+  const [quarantined, unquarantined] = _.partition(failedTests, (test) =>
+    quarantinedKeys.has(
+      matchKey(test.file_path, test.test_path, test.test_name),
+    ),
+  );
+  return { quarantined, unquarantined };
+}

--- a/e2e/support/quarantine-compare.unit.spec.ts
+++ b/e2e/support/quarantine-compare.unit.spec.ts
@@ -1,0 +1,114 @@
+import {
+  type FailedTest,
+  type QuarantineEntry,
+  compareFailedToQuarantine,
+  matchKey,
+} from "./quarantine-compare";
+
+const failed = (
+  test_name: string,
+  test_path: string | null = "Suite",
+  file_path: string | null = "e2e/test/foo.cy.spec.ts",
+): FailedTest => ({ test_name, test_path, file_path });
+
+const quarantined = (
+  test_name: string,
+  test_path = "Suite",
+  file_path = "e2e/test/foo.cy.spec.ts",
+): QuarantineEntry => ({
+  test_name,
+  test_path,
+  file_path,
+  test_suite: "e2e",
+});
+
+describe("compareFailedToQuarantine", () => {
+  it("puts every failure in `unquarantined` when nothing is quarantined", () => {
+    const failures = [failed("a"), failed("b")];
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      failures,
+      [],
+    );
+
+    expect(q).toEqual([]);
+    expect(unquarantined).toEqual(failures);
+  });
+
+  it("puts every failure in `quarantined` when all are listed", () => {
+    const failures = [failed("a"), failed("b")];
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      failures,
+      [quarantined("a"), quarantined("b")],
+    );
+
+    expect(q).toEqual(failures);
+    expect(unquarantined).toEqual([]);
+  });
+
+  it("partitions a mixed set", () => {
+    const a = failed("a");
+    const b = failed("b");
+    const c = failed("c");
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      [a, b, c],
+      [quarantined("a"), quarantined("c")],
+    );
+
+    expect(q).toEqual([a, c]);
+    expect(unquarantined).toEqual([b]);
+  });
+
+  it("returns two empty buckets for no failures", () => {
+    expect(compareFailedToQuarantine([], [quarantined("a")])).toEqual({
+      quarantined: [],
+      unquarantined: [],
+    });
+  });
+
+  it("matches on all three fields — same name, different file is not a match", () => {
+    const failure = failed("a", "Suite", "e2e/test/foo.cy.spec.ts");
+
+    const { unquarantined } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "Suite", "e2e/test/bar.cy.spec.ts")],
+    );
+
+    expect(unquarantined).toEqual([failure]);
+  });
+
+  it("matches on all three fields — same name/file, different describe path is not a match", () => {
+    const failure = failed("a", "Suite > inner");
+
+    const { unquarantined } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "Suite > other")],
+    );
+
+    expect(unquarantined).toEqual([failure]);
+  });
+
+  it("treats a null path on the failure as an empty string for matching", () => {
+    const failure = failed("a", null, null);
+
+    const { quarantined: q } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "", "")],
+    );
+
+    expect(q).toEqual([failure]);
+  });
+});
+
+describe("matchKey", () => {
+  it("normalizes null/undefined paths to empty strings", () => {
+    expect(matchKey(null, undefined, "a")).toBe(matchKey("", "", "a"));
+  });
+
+  it("does not collide when a boundary between fields shifts", () => {
+    // ["a", "b", "c"] vs ["ab", "", "c"] must stay distinct.
+    expect(matchKey("a", "b", "c")).not.toBe(matchKey("ab", "", "c"));
+  });
+});


### PR DESCRIPTION
Record each e2e job's ultimate test failures from after:spec into target/quarantine-failures.jsonl, then add a post-run step that compares them against ci-conductor's quarantine list: pass if every failure is quarantined, fail if any isn't (mirroring Trunk's analytics-uploader).

Runs in dry-run mode for now — it only prints the verdict and never fails the job. Both the recorder and the quarantine list derive {test_name, test_path, file_path} from the same Cypress title array, so the comparison is exact.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
