### PR TITLE
Propagate parent collection `:type` only for Library types

### DIFF
--- a/src/metabase/collections/create.clj
+++ b/src/metabase/collections/create.clj
@@ -62,8 +62,9 @@
 
 (mu/defn apply-defaults-to-collection :- NewCollectionArguments
   "Converts `CreateCollectionArguments` into `NewCollectionArguments` — i.e. translates what the API
-  gets into what toucan needs to create a collection. Inherits `:namespace`, `:type` (excluding
-  `\"trash\"`), and `:is_remote_synced` from the parent collection."
+  gets into what toucan needs to create a collection. Inherits `:namespace`, `:type` (only the
+  library family — see `collection/library-collection-types`), and `:is_remote_synced` from the
+  parent collection."
   [coll-data :- CreateCollectionArguments]
   (let [parent-coll (parent-or-root coll-data)]
     ;; `api/write-check` handles both branches - a real collection and the root sentinel
@@ -73,8 +74,12 @@
           (and (:namespace parent-coll)
                (nil? (:namespace coll-data))) (assoc :namespace (:namespace parent-coll))
           parent-coll (assoc :location (collection/children-location parent-coll))
-          (and (:type parent-coll)
-               (not= (:type parent-coll) "trash")) (assoc :type (:type parent-coll)))
+          ;; Only the library family of types propagates to children. Other special types
+          ;; (e.g. "trash", "tenant-specific-root-collection") are root-only sentinels and must
+          ;; NOT leak onto children — doing so fails the closed `NewCollectionArguments` schema and
+          ;; would mis-tag the child (UXW-4520).
+          (contains? collection/library-collection-types (:type parent-coll))
+          (assoc :type (:type parent-coll)))
         (assoc :is_remote_synced (boolean (:is_remote_synced parent-coll)))
         (select-keys (malli.util/keys NewCollectionArguments)))))
 

--- a/test/metabase/collections/create_test.clj
+++ b/test/metabase/collections/create_test.clj
@@ -44,6 +44,15 @@
                          {:name "Not-Trash Child" :parent_id (:id parent)})]
           (is (nil? (:type defaulted))
               "Trash type does not propagate to children")))))
+  (testing "Child does NOT inherit :type \"tenant-specific-root-collection\" from a tenant root parent (UXW-4520)"
+    (mt/with-temp [:model/Collection parent {:name "Tenant Root" :type "tenant-specific-root-collection"}]
+      (with-redefs [api/write-check (fn [& _])]
+        ;; The tenant root type is a root-only sentinel; propagating it would fail the closed
+        ;; output schema and break tenant sub-collection creation.
+        (let [defaulted (collections.create/apply-defaults-to-collection
+                         {:name "Tenant Sub" :parent_id (:id parent)})]
+          (is (nil? (:type defaulted))
+              "Tenant root type does not propagate to children")))))
   (testing "Child inherits :is_remote_synced from a remote-synced parent"
     (mt/with-temp [:model/Collection parent {:name "RS Parent" :is_remote_synced true}]
       (with-redefs [api/write-check (fn [& _])]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75968
Fixes UXW-4520.

### Description

Previously this propagated all `:type`s other than `"trash"`, which
accidentally copied the magic `"tenant-specific-root-collection"` and
broke creating subcollections for tenants.

This flips the logic from "block only trash" to "allow only library",
which fixes this issue and should be more future-proof.

### How to verify

1. Run an EE instance with multi-tenancy enabled.
2. Create a tenant
3. Try to create a subcollection in the tenant-specific root collection.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
