### PR TITLE
Fix public pivot table downloads

### DIFF
--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -307,6 +307,7 @@ const getPublicQuestionParams = (
   uuid: string,
   type: string,
   result: Dataset,
+  exportParams: ExportParams,
 ): DownloadQueryResultsParams => {
   const parameters = (result?.json_query?.parameters ?? []).map((param) => ({
     id: param.id,
@@ -318,6 +319,7 @@ const getPublicQuestionParams = (
     url: Urls.publicQuestion({ uuid, type, includeSiteUrl: false }),
     params: new URLSearchParams({
       parameters: JSON.stringify(parameters),
+      ..._.mapObject(exportParams, (value) => String(value)),
     }),
   };
 };
@@ -493,7 +495,7 @@ export const getDatasetParams = ({
       );
     }
     if (resourceType === "question" && uuid) {
-      return getPublicQuestionParams(uuid, type, result);
+      return getPublicQuestionParams(uuid, type, result, exportParams);
     }
   }
 

--- a/frontend/src/metabase/redux/downloads.unit.spec.ts
+++ b/frontend/src/metabase/redux/downloads.unit.spec.ts
@@ -129,6 +129,27 @@ describe("getDatasetParams - embed question (token-based)", () => {
   });
 });
 
+describe("getDatasetParams - public question (uuid-based)", () => {
+  const PUBLIC_UUID = "11111111-2222-3333-4444-555555555555";
+  const question = new Question(createMockCard({ id: 1 }), undefined);
+  const result = createMockDataset();
+
+  it("forwards format_rows and pivot_results to the public question endpoint (#75545)", () => {
+    const downloadParams = getDatasetParams({
+      type: "xlsx",
+      question,
+      result,
+      uuid: PUBLIC_UUID,
+      enableFormatting: true,
+      enablePivot: true,
+    });
+
+    const url = new URLSearchParams(downloadParams.params);
+    expect(url.get("format_rows")).toBe("true");
+    expect(url.get("pivot_results")).toBe("true");
+  });
+});
+
 describe("getChartFileName", () => {
   beforeEach(() => {
     jest.useFakeTimers();


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75545
Closes https://linear.app/metabase/issue/UXW-4445/public-links-for-pivot-tables-download-does-not-preserve-pivot

### Description

Public standalone question downloads were not forwarding `format_rows` or `pivot_results` to the public export endpoint, so public pivot table XLSX exports were returned flat even when `Keep the data pivoted` was enabled.

This forwards the existing export params for public question downloads, matching the other download paths.

### How to verify

1. Create a new question using Sample Database Orders data.
2. Build a pivot table, for example Sum of Total grouped by Product Category and Created At year. Visualize as pivot table.
3. Save the question.
4. Enable public sharing for the question.
5. Open the generated public question link, copy the link (do not enable XLSX from here)
6. Open the download menu from the public link page. Choose XLSX.
7. Enable Keep the data pivoted, and enable Formatted if available.
8. Download the file and open the XLSX.
9. Confirm the XLSX preserves the pivot table layout.

### Demo
https://www.loom.com/share/fd9de0c20a304e3b9d29ec5f90645e0e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
