### PR TITLE
Fix conditional formatting for mini bar cells

### DIFF
--- a/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
@@ -23,6 +23,7 @@ export const BaseCell = memo(function BaseCell({
   className,
   hasHover = true,
   children,
+  style,
   ...rest
 }: BaseCellProps) {
   const cellStyle = useMemo(() => {
@@ -64,7 +65,7 @@ export const BaseCell = memo(function BaseCell({
         },
         className,
       )}
-      style={cellStyle}
+      style={{ ...cellStyle, ...style }}
       {...rest}
     >
       {children}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/MiniBarCell.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/MiniBarCell.tsx
@@ -97,6 +97,7 @@ export const MiniBarCell = <TValue,>({
 
   return (
     <BaseCell
+      data-testid="mini-bar-cell"
       className={S.root}
       backgroundColor={backgroundColor}
       align={align}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/MiniBarCell.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/MiniBarCell.unit.spec.tsx
@@ -44,4 +44,26 @@ describe("MiniBarCell", () => {
     const miniBar = screen.getByTestId("mini-bar");
     expect(miniBar).toHaveStyle({ width: "100%" });
   });
+
+  it("should apply backgroundColor to the cell wrapper (#75095)", () => {
+    const columnSettings = {
+      show_mini_bar: true,
+      number_style: "decimal",
+    };
+    render(
+      <MiniBarCell
+        formatter={formatter}
+        value={0.5}
+        extent={[0.5, 0.8]}
+        columnSettings={columnSettings}
+        rowIndex={rowIndex}
+        columnId={columnId}
+        backgroundColor="rgb(237, 110, 110)"
+      />,
+    );
+
+    expect(screen.getByTestId("mini-bar-cell")).toHaveStyle({
+      "--cell-bg-color": "rgb(237, 110, 110)",
+    });
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75095
Closes https://linear.app/metabase/issue/UXW-4327/conditional-formatting-does-not-work-if-the-mini-bar-chart-is-enabled

### Description

Fixes mini bar table cells dropping conditional formatting backgrounds when `BaseCell` receives an external `style` prop.

### How to verify

1. Create a native SQL question with a numeric column. Example from Linear task:
  ```
    select 100 as a, 150 as b, 0.5 as c union all
    select 120 as a, 150 as b, 0.6 as c union all
    select 130 as a, 150 as b, 0.7 as c union all
    select 140 as a, 150 as b, 0.8 as c
  ```
2. Enable mini bar chart for that column.
3. Add conditional formatting for that same column.
4. Confirm the mini bar cells respect the conditional background color.

### Demo
Before:
<img width="1032" height="687" alt="image" src="https://github.com/user-attachments/assets/a28ca9e8-fe77-46b4-b676-81325b0721da" />

After:
<img width="1032" height="687" alt="image" src="https://github.com/user-attachments/assets/19140a48-b38b-4688-b8bf-45c3383044a2" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
