### PR TITLE
Avoid duplicate app db requests in public and embedded cards and dashboards

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1612,6 +1612,7 @@
    :uses #{actions
            analytics
            api
+           app-db
            dashboards
            dashboards-rest
            events

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -956,7 +956,7 @@
            request
            tiles
            util}
-   :model-imports #{:model/Card :model/Dashboard :model/EmbeddingTheme}}
+   :model-imports #{:model/Card :model/Dashboard :model/DashboardCard :model/EmbeddingTheme}}
 
   events
   {:team "DevEx"
@@ -1612,7 +1612,6 @@
    :uses #{actions
            analytics
            api
-           app-db
            dashboards
            dashboards-rest
            events

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1836,8 +1836,6 @@
            util
            workspaces}
    :model-imports #{:model/Card
-                    :model/Dashboard
-                    :model/DashboardCard
                     :model/DashboardCardSeries
                     :model/Database
                     :model/QueryCache
@@ -2285,7 +2283,8 @@
            parameters
            query-processor
            settings
-           util}}
+           util}
+   :model-imports #{:model/Card :model/Dashboard :model/DashboardCard}}
 
   timeline
   {:team "UX West"

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -967,7 +967,7 @@ describe("scenarios > admin > settings > map settings", () => {
     // Not GeoJSON
     cy.findByPlaceholderText(
       "Like https://my-mb-server.com/maps/my-map.json",
-    ).type("https://metabase.com");
+    ).type("https://www.metabase.com");
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage

--- a/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
+++ b/enterprise/backend/test/metabase/notification/payload/execute_ee_test.clj
@@ -14,12 +14,10 @@
                 "with caching enabled should returns the correct viz-settings #57793")
     (let [query (mt/mbql-query orders {:aggregation [[:count]
                                                      [:sum $total]]})
-          result-for-dashcard (fn [dashboard-id dashcard-id card-id]
+          result-for-dashcard (fn [dashcard]
                                 (-> (mt/as-admin
                                       (notification.payload.execute/execute-dashboard-subscription-card
-                                       {:dashboard_id dashboard-id
-                                        :card_id      card-id
-                                        :id           dashcard-id}
+                                       dashcard
                                        []))
                                     :result))
           result-for-card (fn [card-id]
@@ -39,9 +37,9 @@
                                                   :visualization_settings
                                                   {:table.cell_column "count", :table.columns [{:name "count", :enabled true} {:name "sum", :enabled false}]}}
            :model/Dashboard {dashboard-id :id}   {}
-           :model/DashboardCard {dashcard-1 :id} {:dashboard_id dashboard-id
+           :model/DashboardCard dashcard-1       {:dashboard_id dashboard-id
                                                   :card_id     card-1}
-           :model/DashboardCard {dashcard-2 :id} {:dashboard_id dashboard-id
+           :model/DashboardCard dashcard-2       {:dashboard_id dashboard-id
                                                   :card_id     card-2}
            :model/CacheConfig _                  {:model    "database"
                                                   :model_id (mt/id)
@@ -57,13 +55,13 @@
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
-                    (result-for-dashcard dashboard-id dashcard-1 card-1)))
+                    (result-for-dashcard dashcard-1)))
             (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled true
                                              :metabase.models.visualization-settings/table-column-name "count"}
                                             {:metabase.models.visualization-settings/table-column-enabled false
                                              :metabase.models.visualization-settings/table-column-name "sum"}]}}}
-                    (result-for-dashcard dashboard-id dashcard-2 card-2))))
+                    (result-for-dashcard dashcard-2))))
           (testing "Card 2 has count visible and sum hidden"
             (is (=? {:data {:viz-settings {:metabase.models.visualization-settings/table-columns
                                            [{:metabase.models.visualization-settings/table-column-enabled false
@@ -103,13 +101,12 @@
           [:model/Card          {card-id :id} {:dataset_query          query
                                                :visualization_settings initial-setting}
            :model/Dashboard     {dash-id :id} {}
-           :model/DashboardCard {dc-id :id}   {:dashboard_id dash-id :card_id card-id}
+           :model/DashboardCard dashcard      {:dashboard_id dash-id :card_id card-id}
            :model/CacheConfig   _             {:model    "database"
                                                :model_id (mt/id)
                                                :strategy :duration
                                                :config   {:unit :hours :duration 1}}]
-          (let [dashcard         {:dashboard_id dash-id :card_id card-id :id dc-id}
-                run-sub!         (fn [] (:result (mt/as-admin
+          (let [run-sub!         (fn [] (:result (mt/as-admin
                                                    (notification.payload.execute/execute-dashboard-subscription-card
                                                     dashcard []))))
                 cache-updated-at #(t2/select-one-fn :updated_at :model/QueryCache)]

--- a/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
@@ -32,7 +32,7 @@
   [card-id parameters]
   (mt/as-admin
     (qp.card/process-query-for-card
-     card-id :api
+     (t2/select-one :model/Card :id card-id) :api
      :parameters parameters
      :make-run (constantly
                 (fn [query info]
@@ -42,9 +42,9 @@
   [card-id dashboard-id dashcard-id parameters]
   (mt/as-admin
     (qp.card/process-query-for-card
-     card-id :api
+     (t2/select-one :model/Card :id card-id) :api
      :dashboard-id dashboard-id
-     :dashcard-id dashcard-id
+     :dashcard (t2/select-one :model/DashboardCard :id dashcard-id)
      :parameters parameters
      :make-run (constantly
                 (fn [query info]

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1398,9 +1398,9 @@
     (m/mapply qp.dashboard/process-query-for-dashcard
               (merge
                body
-               {:dashboard-id dashboard-id
-                :card-id      card-id
-                :dashcard-id  dashcard-id}))))
+               {:dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+                :card      (api/check-404 (t2/select-one :model/Card :id card-id))
+                :dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1430,9 +1430,10 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (m/mapply qp.dashboard/process-query-for-dashcard
-            {:dashboard-id  dashboard-id
-             :card-id       card-id
-             :dashcard-id   dashcard-id
+            ;; authenticated app path: fetch fresh entities (no caching/staleness)
+            {:dashboard     (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+             :card          (api/check-404 (t2/select-one :model/Card :id card-id))
+             :dashcard      (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
              :export-format export-format
              :parameters    (cond-> parameters
                               (string? parameters) json/decode+kw)
@@ -1464,7 +1465,8 @@
   (m/mapply qp.dashboard/process-query-for-dashcard
             (merge
              body
-             {:dashboard-id dashboard-id
-              :card-id      card-id
-              :dashcard-id  dashcard-id
-              :qp           qp.pivot/run-pivot-query})))
+             ;; authenticated app path: fetch fresh entities (no caching/staleness)
+             {:dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+              :card      (api/check-404 (t2/select-one :model/Card :id card-id))
+              :dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+              :qp        qp.pivot/run-pivot-query})))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1430,7 +1430,6 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (m/mapply qp.dashboard/process-query-for-dashcard
-            ;; authenticated app path: fetch fresh entities (no caching/staleness)
             {:dashboard     (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
              :card          (api/check-404 (t2/select-one :model/Card :id card-id))
              :dashcard      (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
@@ -1465,7 +1464,6 @@
   (m/mapply qp.dashboard/process-query-for-dashcard
             (merge
              body
-             ;; authenticated app path: fetch fresh entities (no caching/staleness)
              {:dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
               :card      (api/check-404 (t2/select-one :model/Card :id card-id))
               :dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1398,9 +1398,9 @@
     (m/mapply qp.dashboard/process-query-for-dashcard
               (merge
                body
-               {:dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-                :card      (api/check-404 (t2/select-one :model/Card :id card-id))
-                :dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))}))))
+               {:dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+                :card      (api/check-404 (t2/select-one :model/Card card-id))
+                :dashcard  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -1430,9 +1430,9 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (m/mapply qp.dashboard/process-query-for-dashcard
-            {:dashboard     (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-             :card          (api/check-404 (t2/select-one :model/Card :id card-id))
-             :dashcard      (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+            {:dashboard     (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+             :card          (api/check-404 (t2/select-one :model/Card card-id))
+             :dashcard      (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
              :export-format export-format
              :parameters    (cond-> parameters
                               (string? parameters) json/decode+kw)
@@ -1464,7 +1464,7 @@
   (m/mapply qp.dashboard/process-query-for-dashcard
             (merge
              body
-             {:dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-              :card      (api/check-404 (t2/select-one :model/Card :id card-id))
-              :dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+             {:dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+              :card      (api/check-404 (t2/select-one :model/Card card-id))
+              :dashcard  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
               :qp        qp.pivot/run-pivot-query})))

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -455,7 +455,7 @@
        [:pivot_results {:default false} ms/BooleanValue]]]
   (validate-card-in-document document-id card-id)
   (qp.card/process-query-for-card
-   (api/check-404 (t2/select-one :model/Card :id card-id)) export-format
+   (api/check-404 (t2/select-one :model/Card card-id)) export-format
    :parameters  (cond-> parameters
                   (string? parameters) json/decode+kw)
    :constraints nil

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -455,7 +455,7 @@
        [:pivot_results {:default false} ms/BooleanValue]]]
   (validate-card-in-document document-id card-id)
   (qp.card/process-query-for-card
-   card-id export-format
+   (api/check-404 (t2/select-one :model/Card :id card-id)) export-format
    :parameters  (cond-> parameters
                   (string? parameters) json/decode+kw)
    :constraints nil

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -17,6 +17,7 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.parameters.operators :as params.ops]
+   [metabase.tiles.api :as api.tiles]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -419,6 +420,15 @@
      :context       (get-embed-dashboard-context export-format)
      :constraints   constraints
      :middleware    middleware)))
+
+(defn process-tiles-query-for-dashcard
+  "Like [[metabase.tiles.api/process-tiles-query-for-dashcard]], but resolves the Dashboard/DashboardCard/Card entities
+  through the shared public/embed TTL-memoized cache. Used by the embed tiles endpoints. Returns a Ring response."
+  [dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field]
+  (api.tiles/process-tiles-query-for-dashcard (api/check-404 (api.public/fetch-cached-dashboard dashboard-id))
+                                              (api/check-404 (api.public/fetch-cached-dashcard dashcard-id))
+                                              (api/check-404 (api.public/fetch-cached-card card-id))
+                                              parameters zoom x y lat-field lon-field))
 
 (defn card-param-values
   "Search for card parameter values. Does security checks to ensure the parameter is on the card and then gets param

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -89,43 +89,40 @@
   (check-params-are-allowed object-embedding-params token-params user-params)
   (check-params-exist object-embedding-params (merge token-params user-params)))
 
-(defn- check-embedding-enabled-for-object
-  "Check that embedding is enabled, that `object` exists, and embedding for `object` is enabled."
-  ([entity id]
-   (api/check (pos-int? id)
-              [400 (tru "{0} id should be a positive integer." (name entity))])
-   (check-embedding-enabled-for-object (t2/select-one [entity :enable_embedding] :id id)))
+(defn check-embedding-enabled-for-object
+  "Check that embedding is enabled, that the pre-loaded `object` exists, and embedding for `object` is enabled. Callers
+  are responsible for selecting `object` (with at least `:enable_embedding` and `:archived`) exactly once per request
+  and threading it here."
+  [object]
+  (embedding.validation/check-embedding-enabled)
+  (api/check-404 object)
+  (api/check-not-archived object)
+  (api/check (:enable_embedding object)
+             [400 (tru "Embedding is not enabled for this object.")]))
 
-  ([object]
-   (embedding.validation/check-embedding-enabled)
-   (api/check-404 object)
-   (api/check-not-archived object)
-   (api/check (:enable_embedding object)
-              [400 (tru "Embedding is not enabled for this object.")])))
+(def ^{:arglists '([card])} check-embedding-enabled-for-card
+  "Runs check-embedding-enabled-for-object for a pre-loaded Card entity."
+  check-embedding-enabled-for-object)
 
-(def ^{:arglists '([card-id])} check-embedding-enabled-for-card
-  "Runs check-embedding-enabled-for-object for a given Card id"
-  (partial check-embedding-enabled-for-object :model/Card))
-
-(def ^{:arglists '([dashboard-id])} check-embedding-enabled-for-dashboard
-  "Runs check-embedding-enabled-for-object for a given Dashboard id"
-  (partial check-embedding-enabled-for-object :model/Dashboard))
+(def ^{:arglists '([dashboard])} check-embedding-enabled-for-dashboard
+  "Runs check-embedding-enabled-for-object for a pre-loaded Dashboard entity."
+  check-embedding-enabled-for-object)
 
 (defn- resolve-card-parameters
-  "Returns parameters for a card (HUH?)" ; TODO - better docstring
-  [card-or-id]
-  (-> (t2/select-one [:model/Card :dataset_query :parameters :card_schema], :id (u/the-id card-or-id))
+  "Returns the combined `:parameters` (including template-tag parameters) for a pre-loaded `card` entity."
+  [card]
+  (-> card
       api.public/combine-parameters-and-template-tags
       :parameters))
 
 (mu/defn- resolve-dashboard-parameters :- [:sequential [:map
                                                         [:id ms/NonBlankString]]]
-  "Given a `dashboard-id` and parameters map in the format `slug->value`, return a sequence of parameters with `:id`s
-  that can be passed to various functions in the [[metabase.dashboards-rest.api]] namespace such as
-  [[metabase.dashboards-rest.api/process-query-for-dashcard]]."
-  [dashboard-id :- ms/PositiveInt
-   slug->value  :- :map]
-  (let [parameters (t2/select-one-fn :parameters :model/Dashboard :id dashboard-id)
+  "Given a pre-loaded `dashboard` entity and parameters map in the format `slug->value`, return a sequence of
+  parameters with `:id`s that can be passed to various functions in the [[metabase.dashboards-rest.api]] namespace such
+  as [[metabase.dashboards-rest.api/process-query-for-dashcard]]."
+  [dashboard   :- :map
+   slug->value :- :map]
+  (let [parameters (:parameters dashboard)
         slug->id (into {} (map (juxt :slug :id)) parameters)
         slug->type (into {} (map (juxt :slug :type)) parameters)]
     (vec (for [[slug value] slug->value
@@ -297,13 +294,18 @@
 
 ;;; ---------------------------- Card Fns used by both /api/embed and /api/preview_embed -----------------------------
 
+(defn unsigned-token->card-id
+  "Get the Card ID from an unsigned token, translating an `entity_id` to a numeric id if necessary."
+  [unsigned-token]
+  (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
+       (eid-translation/->id :model/Card)))
+
 (defn card-for-unsigned-token
   "Return the info needed for embedding about Card specified in `token`. Additional `constraints` can be passed to the
   `public-card` function that fetches the Card."
   [unsigned-token & {:keys [embedding-params constraints]}]
   {:pre [((some-fn empty? sequential?) constraints) (even? (count constraints))]}
-  (let [pre-card-id  (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
-        card-id      (eid-translation/->id :model/Card pre-card-id)
+  (let [card-id      (unsigned-token->card-id unsigned-token)
         token-params (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
         resolved-embedding-params (or embedding-params
                                       (t2/select-one-fn :embedding_params :model/Card :id card-id))]
@@ -323,26 +325,21 @@
     :embedded-question))
 
 (defn process-query-for-card-with-params
-  "Run the query associated with Card with `card-id` using JWT `token-params`, user-supplied URL `query-params`,
-   an `embedding-params` whitelist, and additional query `options`. Returns `StreamingResponse` that should be
-  returned as the API endpoint result."
-  [& {:keys [export-format card-id embedding-params token-params query-params qp constraints options]
+  "Run the query associated with pre-loaded Card `card` using JWT `token-params`, user-supplied URL `query-params`,
+   an `embedding-params` whitelist, and additional query `options`. Callers are responsible for selecting `card`
+  exactly once per request and threading it here. Returns `StreamingResponse` that should be returned as the API
+  endpoint result."
+  [& {:keys [export-format card embedding-params token-params query-params qp constraints options]
       :or   {qp qp.card/process-query-for-card-default-qp}}]
-  {:pre [(integer? card-id) (u/maybe? map? embedding-params) (map? token-params) (map? query-params)]}
+  {:pre [(map? card) (pos-int? (:id card)) (u/maybe? map? embedding-params) (map? token-params) (map? query-params)]}
   (let [merged-slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
-        parameters         (apply-slug->value (resolve-card-parameters card-id) merged-slug->value)]
+        parameters         (apply-slug->value (resolve-card-parameters card) merged-slug->value)]
     (m/mapply api.public/process-query-for-card-with-id
-              card-id export-format parameters
+              card export-format parameters
               :context     (get-embed-card-context export-format)
               :constraints constraints
               :qp          qp
               options)))
-
-(defn unsigned-token->card-id
-  "Get the Card ID from an unsigned token."
-  [unsigned-token]
-  (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
-       (eid-translation/->id :model/Card)))
 
 ;;; -------------------------- Dashboard Fns used by both /api/embed and /api/preview_embed --------------------------
 
@@ -375,13 +372,18 @@
         ;; TODO cleanup
         (update :param_fields update-vals (fn [fields] (into [] (filter #(not (field-ids-to-remove (:id %)))) fields))))))
 
+(defn unsigned-token->dashboard-id
+  "Get the Dashboard ID from an unsigned token, translating an `entity_id` to a numeric id if necessary."
+  [unsigned-token]
+  (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+       (eid-translation/->id :model/Dashboard)))
+
 (mu/defn dashboard-for-unsigned-token :- ::dashboards.schema/dashboard
   "Return the info needed for embedding about Dashboard specified in `token`. Additional `constraints` can be passed to
   the `public-dashboard` function that fetches the Dashboard."
   [unsigned-token & {:keys [embedding-params constraints]}]
   {:pre [((some-fn empty? sequential?) constraints) (even? (count constraints))]}
-  (let [pre-dashboard-id (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        dashboard-id (eid-translation/->id :model/Dashboard pre-dashboard-id)
+  (let [dashboard-id (unsigned-token->dashboard-id unsigned-token)
         embedding-params (or embedding-params
                              (t2/select-one-fn :embedding_params :model/Dashboard, :id dashboard-id))
         token-params (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
@@ -401,19 +403,21 @@
     :embedded-dashboard))
 
 (defn process-query-for-dashcard
-  "Return results for running the query belonging to a DashboardCard. Returns a `StreamingResponse`."
-  [& {:keys [dashboard-id dashcard-id card-id export-format embedding-params token-params middleware
+  "Return results for running the query belonging to a DashboardCard. Callers are responsible for selecting the
+  `dashboard`, `dashcard`, and `card` entities exactly once per request and threading them here. Returns a
+  `StreamingResponse`."
+  [& {:keys [dashboard dashcard card export-format embedding-params token-params middleware
              query-params constraints qp]
       :or   {constraints (qp.constraints/default-query-constraints)
              qp          qp.card/process-query-for-card-default-qp}}]
-  {:pre [(integer? dashboard-id) (integer? dashcard-id) (integer? card-id) (u/maybe? map? embedding-params)
+  {:pre [(map? dashboard) (map? dashcard) (map? card) (u/maybe? map? embedding-params)
          (map? token-params) (map? query-params)]}
   (let [slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
-        parameters  (resolve-dashboard-parameters dashboard-id slug->value)]
+        parameters  (resolve-dashboard-parameters dashboard slug->value)]
     (api.public/process-query-for-dashcard
-     :dashboard-id  dashboard-id
-     :card-id       card-id
-     :dashcard-id   dashcard-id
+     :dashboard     dashboard
+     :card          card
+     :dashcard      dashcard
      :export-format export-format
      :parameters    parameters
      :qp            qp
@@ -422,12 +426,11 @@
      :middleware    middleware)))
 
 (defn process-tiles-query-for-dashcard
-  "Like [[metabase.tiles.api/process-tiles-query-for-dashcard]], but resolves the Dashboard/DashboardCard/Card entities
-  through the shared public/embed TTL-memoized cache. Used by the embed tiles endpoints. Returns a Ring response."
-  [dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field]
-  (api.tiles/process-tiles-query-for-dashcard (api/check-404 (api.public/fetch-cached-dashboard dashboard-id))
-                                              (api/check-404 (api.public/fetch-cached-dashcard dashcard-id))
-                                              (api/check-404 (api.public/fetch-cached-card card-id))
+  "Like [[metabase.tiles.api/process-tiles-query-for-dashcard]], but takes pre-loaded Dashboard/DashboardCard/Card
+  entities. Used by the embed tiles endpoints. Callers select each entity exactly once and thread it here. Returns
+   a Ring response."
+  [dashboard dashcard card parameters zoom x y lat-field lon-field]
+  (api.tiles/process-tiles-query-for-dashcard dashboard dashcard card
                                               parameters zoom x y lat-field lon-field))
 
 (defn card-param-values
@@ -519,12 +522,6 @@
                       (u/pprint-to-str (u/all-ex-data e)))
           (throw e))))))
 
-(defn unsigned-token->dashboard-id
-  "Get the Dashboard ID from an unsigned token."
-  [unsigned-token]
-  (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-       (eid-translation/->id :model/Dashboard)))
-
 (defn dashboard-param-values
   "Common implementation for fetching parameter values for embedding and preview-embedding.
   Optionally pass a map with `:preview` containing `true` (or some non-falsy value) to disable checking
@@ -534,9 +531,9 @@
    & {:keys [preview] :or {preview false}}]
   (let [unsigned-token                                 (embed/unsign token)
         dashboard-id                                   (unsigned-token->dashboard-id unsigned-token)
-        _                                              (when-not preview (check-embedding-enabled-for-dashboard dashboard-id))
-        slug-token-params                              (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
         dashboard                                      (t2/select-one :model/Dashboard :id dashboard-id)
+        _                                              (when-not preview (check-embedding-enabled-for-dashboard dashboard))
+        slug-token-params                              (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
         {parameters                 :parameters
          published-embedding-params :embedding_params} dashboard
         ;; when previewing an embed, embedding-params should come from the token,
@@ -589,8 +586,8 @@
   ([token param-key value {:keys [preview] :or {preview false}}]
    (let [unsigned-token             (embed/unsign token)
          dashboard-id               (unsigned-token->dashboard-id unsigned-token)
-         _                          (when-not preview (check-embedding-enabled-for-dashboard dashboard-id))
          dashboard                  (t2/select-one :model/Dashboard :id dashboard-id)
+         _                          (when-not preview (check-embedding-enabled-for-dashboard dashboard))
          slug-token-params          (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
          parameters                 (:parameters dashboard)
          id->slug                   (into {} (map (juxt :id :slug)) parameters)

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -91,7 +91,7 @@
                                                      qp qp.card/process-query-for-card-default-qp}
                                                 :as options}]
   (let [card-id (api.embed.common/unsigned-token->card-id unsigned-token)
-        card    (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card    (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/check-embedding-enabled-for-card card)
     (database-routing/with-database-routing-off
       (api.embed.common/process-query-for-card-with-params
@@ -311,7 +311,7 @@
                                  [:param-key ms/NonBlankString]]]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
-        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-values {:unsigned-token unsigned
                                          :card card
@@ -326,7 +326,7 @@
   [{:keys [token param-key prefix]} :- api.embed.common/SearchParams]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
-        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-values {:unsigned-token unsigned
                                          :card card
@@ -345,7 +345,7 @@
    {:keys [value]} :- [:map [:value :string]]]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
-        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-remapped-value {:unsigned-token unsigned
                                                  :card card
@@ -405,7 +405,7 @@
        [:lonField string?]]]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
-        card (api/check-404 (t2/select-one :model/Card :id card-id))
+        card (api/check-404 (t2/select-one :model/Card card-id))
         parameters (when parameters (json/decode+kw parameters))
         lat-field (json/decode+kw latField)
         lon-field (json/decode+kw lonField)]

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -78,8 +78,9 @@
      {:resource {:question <card-id>}}"
   [{:keys [token]} :- [:map
                        [:token api.embed.common/EncodedToken]]]
-  (let [unsigned (unsign-and-translate-ids token)]
-    (api.embed.common/check-embedding-enabled-for-card (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :question]))
+  (let [unsigned (unsign-and-translate-ids token)
+        card-id  (api.embed.common/unsigned-token->card-id unsigned)]
+    (api.embed.common/check-embedding-enabled-for-card (api/check-404 (t2/select-one [:model/Card :enable_embedding :archived] :id card-id)))
     (api.embed.common/card-for-unsigned-token unsigned, :constraints [:enable_embedding true])))
 
 (defn ^:private run-query-for-unsigned-token-async
@@ -89,14 +90,15 @@
                                                 :or {constraints (qp.constraints/default-query-constraints)
                                                      qp qp.card/process-query-for-card-default-qp}
                                                 :as options}]
-  (let [card-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:resource :question])]
-    (api.embed.common/check-embedding-enabled-for-card card-id)
+  (let [card-id (api.embed.common/unsigned-token->card-id unsigned-token)
+        card    (api/check-404 (t2/select-one :model/Card :id card-id))]
+    (api.embed.common/check-embedding-enabled-for-card card)
     (database-routing/with-database-routing-off
       (api.embed.common/process-query-for-card-with-params
        :export-format export-format
-       :card-id card-id
+       :card card
        :token-params (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:params])
-       :embedding-params (t2/select-one-fn :embedding_params :model/Card :id card-id)
+       :embedding-params (:embedding_params card)
        :query-params (api.embed.common/parse-query-params (dissoc query-params :format_rows :pivot_results))
        :qp qp
        :constraints constraints
@@ -160,8 +162,9 @@
      {:resource {:dashboard <dashboard-id>}}"
   [{:keys [token]} :- [:map
                        [:token api.embed.common/EncodedToken]]]
-  (let [unsigned (unsign-and-translate-ids token)]
-    (api.embed.common/check-embedding-enabled-for-dashboard (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :dashboard]))
+  (let [unsigned     (unsign-and-translate-ids token)
+        dashboard-id (api.embed.common/unsigned-token->dashboard-id unsigned)]
+    (api.embed.common/check-embedding-enabled-for-dashboard (api/check-404 (t2/select-one [:model/Dashboard :enable_embedding :archived] :id dashboard-id)))
     (u/prog1 (api.embed.common/dashboard-for-unsigned-token unsigned, :constraints [:enable_embedding true])
       (events/publish-event! :event/dashboard-read {:object-id (:id <>), :user-id api/*current-user-id*}))))
 
@@ -182,15 +185,18 @@
       :or {constraints (qp.constraints/default-query-constraints)
            qp qp.card/process-query-for-card-default-qp}}]
   (let [unsigned-token (unsign-and-translate-ids token)
-        dashboard-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])]
-    (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)
+        dashboard-id   (api.embed.common/unsigned-token->dashboard-id unsigned-token)
+        dashboard      (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+        dashcard       (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
+    (api.embed.common/check-embedding-enabled-for-dashboard dashboard)
     (database-routing/with-database-routing-off
       (api.embed.common/process-query-for-dashcard
        :export-format export-format
-       :dashboard-id dashboard-id
-       :dashcard-id dashcard-id
-       :card-id card-id
-       :embedding-params (t2/select-one-fn :embedding_params :model/Dashboard :id dashboard-id)
+       :dashboard dashboard
+       :dashcard dashcard
+       :card card
+       :embedding-params (:embedding_params dashboard)
        :token-params (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:params])
        :query-params (api.embed.common/parse-query-params (dissoc query-params :format_rows :pivot_results))
        :constraints constraints
@@ -304,9 +310,9 @@
                                  [:token api.embed.common/EncodedToken]
                                  [:param-key ms/NonBlankString]]]
   (let [unsigned (unsign-and-translate-ids token)
-        card-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :question])
-        card (t2/select-one :model/Card :id card-id)]
-    (api.embed.common/check-embedding-enabled-for-card card-id)
+        card-id (api.embed.common/unsigned-token->card-id unsigned)
+        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+    (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-values {:unsigned-token unsigned
                                          :card card
                                          :param-key param-key})))
@@ -319,9 +325,9 @@
   "Embedded version of chain filter search endpoint."
   [{:keys [token param-key prefix]} :- api.embed.common/SearchParams]
   (let [unsigned (unsign-and-translate-ids token)
-        card-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :question])
-        card (t2/select-one :model/Card :id card-id)]
-    (api.embed.common/check-embedding-enabled-for-card card-id)
+        card-id (api.embed.common/unsigned-token->card-id unsigned)
+        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+    (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-values {:unsigned-token unsigned
                                          :card card
                                          :param-key param-key
@@ -338,9 +344,9 @@
                                  [:param-key ms/NonBlankString]]
    {:keys [value]} :- [:map [:value :string]]]
   (let [unsigned (unsign-and-translate-ids token)
-        card-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :question])
-        card (t2/select-one :model/Card :id card-id)]
-    (api.embed.common/check-embedding-enabled-for-card card-id)
+        card-id (api.embed.common/unsigned-token->card-id unsigned)
+        card (api/check-404 (t2/select-one :model/Card :id card-id))]
+    (api.embed.common/check-embedding-enabled-for-card card)
     (api.embed.common/card-param-remapped-value {:unsigned-token unsigned
                                                  :card card
                                                  :param-key param-key
@@ -399,12 +405,13 @@
        [:lonField string?]]]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
+        card (api/check-404 (t2/select-one :model/Card :id card-id))
         parameters (when parameters (json/decode+kw parameters))
         lat-field (json/decode+kw latField)
         lon-field (json/decode+kw lonField)]
-    (api.embed.common/check-embedding-enabled-for-card card-id)
+    (api.embed.common/check-embedding-enabled-for-card card)
     (request/as-admin
-      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
+      (api.tiles/process-tiles-query-for-card card parameters zoom x y lat-field lon-field))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -427,9 +434,12 @@
        [:lonField string?]]]
   (let [unsigned (unsign-and-translate-ids token)
         dashboard-id (api.embed.common/unsigned-token->dashboard-id unsigned)
+        dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+        dashcard (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card (api/check-404 (t2/select-one :model/Card :id card-id))
         parameters (when parameters (json/decode+kw parameters))
         lat-field (json/decode+kw latField)
         lon-field (json/decode+kw lonField)]
-    (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)
+    (api.embed.common/check-embedding-enabled-for-dashboard dashboard)
     (request/as-admin
-      (api.embed.common/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
+      (api.embed.common/process-tiles-query-for-dashcard dashboard dashcard card parameters zoom x y lat-field lon-field))))

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -432,4 +432,4 @@
         lon-field (json/decode+kw lonField)]
     (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)
     (request/as-admin
-      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
+      (api.embed.common/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -186,9 +186,9 @@
            qp qp.card/process-query-for-card-default-qp}}]
   (let [unsigned-token (unsign-and-translate-ids token)
         dashboard-id   (api.embed.common/unsigned-token->dashboard-id unsigned-token)
-        dashboard      (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard       (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
+        dashboard      (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+        dashcard       (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card           (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/check-embedding-enabled-for-dashboard dashboard)
     (database-routing/with-database-routing-off
       (api.embed.common/process-query-for-dashcard
@@ -434,9 +434,9 @@
        [:lonField string?]]]
   (let [unsigned (unsign-and-translate-ids token)
         dashboard-id (api.embed.common/unsigned-token->dashboard-id unsigned)
-        dashboard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card (api/check-404 (t2/select-one :model/Card :id card-id))
+        dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+        dashcard (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card (api/check-404 (t2/select-one :model/Card card-id))
         parameters (when parameters (json/decode+kw parameters))
         lat-field (json/decode+kw latField)
         lon-field (json/decode+kw lonField)]

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -162,9 +162,9 @@
    query-params]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card             (api/check-404 (t2/select-one :model/Card :id card-id))
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card card-id))
         embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
         token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
     (api.embed.common/process-query-for-dashcard
@@ -209,9 +209,9 @@
    query-params]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card             (api/check-404 (t2/select-one :model/Card :id card-id))
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card card-id))
         embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
         token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
     (api.embed.common/process-query-for-dashcard
@@ -243,7 +243,7 @@
        [:lonField string?]]]
   (let [unsigned-token   (check-and-unsign token)
         card-id    (api.embed.common/unsigned-token->card-id unsigned-token)
-        card       (api/check-404 (t2/select-one :model/Card :id card-id))
+        card       (api/check-404 (t2/select-one :model/Card card-id))
         parameters (json/decode+kw parameters)
         lat-field  (json/decode+kw latField)
         lon-field  (json/decode+kw lonField)]
@@ -271,9 +271,9 @@
        [:lonField string?]]]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card             (api/check-404 (t2/select-one :model/Card :id card-id))
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card card-id))
         parameters       (json/decode+kw parameters)
         lat-field        (json/decode+kw latField)
         lon-field        (json/decode+kw lonField)]

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -19,7 +19,8 @@
    [metabase.tiles.api :as api.tiles]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
-   [ring.util.codec :as codec]))
+   [ring.util.codec :as codec]
+   [toucan2.core :as t2]))
 
 (defn- check-and-unsign [token]
   (api/check-superuser)
@@ -52,10 +53,11 @@
                        [:token api.embed.common/EncodedToken]]
    query-params]
   (let [unsigned-token (check-and-unsign token)
-        card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])]
+        card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
+        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
     (api.embed.common/process-query-for-card-with-params
      :export-format    :api
-     :card-id          card-id
+     :card             card
      :token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
      :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
      :constraints      {:max-results max-results}
@@ -160,13 +162,16 @@
    query-params]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card :id card-id))
         embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
         token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
     (api.embed.common/process-query-for-dashcard
      :export-format    :api
-     :dashboard-id     dashboard-id
-     :dashcard-id      dashcard-id
-     :card-id          card-id
+     :dashboard        dashboard
+     :dashcard         dashcard
+     :card             card
      :embedding-params embedding-params
      :token-params     token-params
      :query-params     (api.embed.common/parse-query-params query-params))))
@@ -181,10 +186,11 @@
                        [:token api.embed.common/EncodedToken]]
    query-params]
   (let [unsigned-token (check-and-unsign token)
-        card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])]
+        card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
+        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
     (api.embed.common/process-query-for-card-with-params
      :export-format    :api
-     :card-id          card-id
+     :card             card
      :token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
      :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
      :query-params     (api.embed.common/parse-query-params query-params)
@@ -203,13 +209,16 @@
    query-params]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card :id card-id))
         embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
         token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
     (api.embed.common/process-query-for-dashcard
      :export-format    :api
-     :dashboard-id     dashboard-id
-     :dashcard-id      dashcard-id
-     :card-id          card-id
+     :dashboard        dashboard
+     :dashcard         dashcard
+     :card             card
      :embedding-params embedding-params
      :token-params     token-params
      :query-params     (api.embed.common/parse-query-params query-params)
@@ -234,11 +243,12 @@
        [:lonField string?]]]
   (let [unsigned-token   (check-and-unsign token)
         card-id    (api.embed.common/unsigned-token->card-id unsigned-token)
+        card       (api/check-404 (t2/select-one :model/Card :id card-id))
         parameters (json/decode+kw parameters)
         lat-field  (json/decode+kw latField)
         lon-field  (json/decode+kw lonField)]
     (request/as-admin
-      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
+      (api.tiles/process-tiles-query-for-card card parameters zoom x y lat-field lon-field))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -261,8 +271,11 @@
        [:lonField string?]]]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        dashboard        (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+        dashcard         (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card             (api/check-404 (t2/select-one :model/Card :id card-id))
         parameters       (json/decode+kw parameters)
         lat-field        (json/decode+kw latField)
         lon-field        (json/decode+kw lonField)]
     (request/as-admin
-      (api.embed.common/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
+      (api.embed.common/process-tiles-query-for-dashcard dashboard dashcard card parameters zoom x y lat-field lon-field))))

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -265,4 +265,4 @@
         lat-field        (json/decode+kw latField)
         lon-field        (json/decode+kw lonField)]
     (request/as-admin
-      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
+      (api.embed.common/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -54,7 +54,7 @@
    query-params]
   (let [unsigned-token (check-and-unsign token)
         card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
-        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card           (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/process-query-for-card-with-params
      :export-format    :api
      :card             card
@@ -187,7 +187,7 @@
    query-params]
   (let [unsigned-token (check-and-unsign token)
         card-id        (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
-        card           (api/check-404 (t2/select-one :model/Card :id card-id))]
+        card           (api/check-404 (t2/select-one :model/Card card-id))]
     (api.embed.common/process-query-for-card-with-params
      :export-format    :api
      :card             card

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -49,7 +49,9 @@
                     (if (:link-local (ex-data e))
                       (throw (ex-info (ex-message e) (dissoc (ex-data e) :link-local) e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
-        success? (<= 200 (:status resp) 399)
+        ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`, for SSRF
+        ;; protection), so its (empty) body must be treated as a failed load rather than streamed as GeoJSON.
+        success? (<= 200 (:status resp) 299)
         allowed-content-types #{"application/geo+json"
                                 "application/vnd.geo+json"
                                 "application/json"

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -300,8 +300,9 @@
   "Returns the result for a card."
   [creator-id :- pos-int?
    card-id :- pos-int?]
-  (let [result (request/with-current-user creator-id
-                 (-> (qp.card/process-query-for-card card-id :api
+  (let [card   (t2/select-one :model/Card card-id)
+        result (request/with-current-user creator-id
+                 (-> (qp.card/process-query-for-card card :api
                                                      ;; TODO rename to :notification?
                                                      :context     :pulse
                                                      :constraints {}
@@ -320,6 +321,6 @@
                      fixup-viz-settings
                      format-qp-result))]
     (log/debugf "Result has %d rows" (:row_count result))
-    {:card   (t2/select-one :model/Card card-id)
+    {:card   card
      :result result
      :type   :card}))

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -167,37 +167,39 @@
   (log/with-context {:card_id card_id}
     (try
       (when-let [card (t2/select-one :model/Card :id card_id :archived false)]
-        (let [multi-cards    (dashboard-card/dashcard->multi-cards dashcard)
+        (let [dashboard      (t2/select-one :model/Dashboard :id dashboard_id)
+              multi-cards    (dashboard-card/dashcard->multi-cards dashcard)
               result-fn      (fn [card-id]
-                               {:card     (if (= card-id (:id card))
+                               (let [card (if (= card-id (:id card))
                                             card
-                                            (t2/select-one :model/Card :id card-id))
-                                :dashcard dashcard
-                                ;; TODO should this be dashcard?
-                                :type     :card
-                                :result   (-> (qp.dashboard/process-query-for-dashcard
-                                               :dashboard-id  dashboard_id
-                                               :card-id       card-id
-                                               :dashcard-id   (u/the-id dashcard)
-                                               :context       :dashboard-subscription
-                                               :export-format :api
-                                               :parameters    parameters
-                                               :constraints   {}
-                                               :middleware    {:process-viz-settings?             true
-                                                               :js-int-to-string?                 false
-                                                               :add-default-userland-constraints? false}
-                                               :make-run      (fn make-run [qp _export-format]
-                                                                (^:once fn* [query info]
-                                                                  (qp
-                                                                   (qp/userland-query query info)
-                                                                   ;; Pass streaming rff with 2000 row threshold
-                                                                   (notification.temp-storage/notification-rff
-                                                                    cells-to-disk-threshold
-                                                                    {:dashboard_id dashboard_id
-                                                                     :card_id card-id
-                                                                     :dashcard_id (u/the-id dashcard)})))))
-                                              fixup-viz-settings
-                                              format-qp-result)})
+                                            (t2/select-one :model/Card :id card-id))]
+                                 {:card     card
+                                  :dashcard dashcard
+                                  ;; TODO should this be dashcard?
+                                  :type     :card
+                                  :result   (-> (qp.dashboard/process-query-for-dashcard
+                                                 :dashboard     dashboard
+                                                 :card          card
+                                                 :dashcard      dashcard
+                                                 :context       :dashboard-subscription
+                                                 :export-format :api
+                                                 :parameters    parameters
+                                                 :constraints   {}
+                                                 :middleware    {:process-viz-settings?             true
+                                                                 :js-int-to-string?                 false
+                                                                 :add-default-userland-constraints? false}
+                                                 :make-run      (fn make-run [qp _export-format]
+                                                                  (^:once fn* [query info]
+                                                                    (qp
+                                                                     (qp/userland-query query info)
+                                                                     ;; Pass streaming rff with 2000 row threshold
+                                                                     (notification.temp-storage/notification-rff
+                                                                      cells-to-disk-threshold
+                                                                      {:dashboard_id dashboard_id
+                                                                       :card_id card-id
+                                                                       :dashcard_id (u/the-id dashcard)})))))
+                                                fixup-viz-settings
+                                                format-qp-result)}))
               result         (result-fn card_id)
               series-results (mapv (comp result-fn :id) multi-cards)]
           (log/debugf "Dashcard has %d series" (count multi-cards))

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -1,12 +1,14 @@
 (ns metabase.public-sharing-rest.api
   "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
   (:require
+   [clojure.core.memoize :as memoize]
    [hiccup.core :as hiccup]
    [medley.core :as m]
    [metabase.actions.core :as actions]
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.app-db.core :as mdb]
    [metabase.dashboards-rest.api :as api.dashboard]
    [metabase.dashboards.schema :as dashboards.schema]
    [metabase.events.core :as events]
@@ -283,6 +285,38 @@
   (u/prog1 (dashboard-with-uuid uuid)
     (events/publish-event! :event/dashboard-read {:object-id (:id <>), :user-id api/*current-user-id*})))
 
+(def ^:private cached-entity-ttl-ms
+  "How long the public/embed entity caches below hold onto a fetched Dashboard/DashboardCard/Card row.
+
+  These caches exist ONLY for the high-volume, unauthenticated public + embed read paths, where bounded staleness (up
+  to this TTL) is acceptable in exchange for cutting duplicate app-DB fetches within a single request. They must NEVER
+  be used on any path that requires read-your-writes freshness (i.e. the authenticated app)."
+  (u/minutes->ms 1))
+
+(def fetch-cached-dashboard
+  "TTL-memoized fetch of a full `:model/Dashboard` row by id. Public/embed read paths only; see
+  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/Dashboard :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
+(def fetch-cached-dashcard
+  "TTL-memoized fetch of a full `:model/DashboardCard` row by id. Public/embed read paths only; see
+  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/DashboardCard :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
+(def fetch-cached-card
+  "TTL-memoized fetch of a full `:model/Card` row by id. Public/embed read paths only; see [[cached-entity-ttl-ms]].
+  Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/Card :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
 (defn process-query-for-dashcard
   "Return the results of running a query for Card with `card-id` belonging to Dashboard with `dashboard-id` via
   `dashcard-id`. `card-id`, `dashboard-id`, and `dashcard-id` are all required; other parameters are optional:
@@ -291,17 +325,27 @@
   * `export-format` - `:api` (default format with metadata), `:json` (results only), `:csv`, or `:xslx`. Default: `:api`
   * `qp`            - QP function to run the query with. Default [[qp/process-query]] + [[qp/userland-context]]
 
+  This is the single bridge for all public + embed dashcard-query entry points. It resolves `dashboard-id`,
+  `dashcard-id`, and `card-id` to full entities via the shared TTL-memoized caches (acceptable here because these are
+  unauthenticated read paths) and hands the entities to [[qp.dashboard/process-query-for-dashcard]].
+
   Throws a 404 immediately if the Card isn't part of the Dashboard. Returns a `StreamingResponse`."
   {:arglists '([& {:keys [dashboard-id card-id dashcard-id export-format parameters] :as options}])}
-  [& {:keys [export-format parameters qp]
+  [& {:keys [dashboard-id card-id dashcard-id export-format parameters qp]
       :or   {qp            qp.card/process-query-for-card-default-qp
              export-format :api}
       :as   options}]
-  (let [options (merge
+  (let [dashboard (api/check-404 (fetch-cached-dashboard dashboard-id))
+        dashcard  (api/check-404 (fetch-cached-dashcard dashcard-id))
+        card      (api/check-404 (fetch-cached-card card-id))
+        options (merge
                  {:context     :public-dashboard
                   :constraints (qp.constraints/default-query-constraints)}
-                 options
-                 {:parameters    (cond-> parameters
+                 (dissoc options :dashboard-id :card-id :dashcard-id)
+                 {:dashboard     dashboard
+                  :dashcard      dashcard
+                  :card          card
+                  :parameters    (cond-> parameters
                                    (string? parameters) json/decode+kw)
                   :export-format export-format
                   :qp            qp
@@ -724,7 +768,10 @@
         lat-field    (json/decode+kw latField)
         lon-field    (json/decode+kw lonField)]
     (request/as-admin
-      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
+      (api.tiles/process-tiles-query-for-dashcard (api/check-404 (fetch-cached-dashboard dashboard-id))
+                                                  (api/check-404 (fetch-cached-dashcard dashcard-id))
+                                                  (api/check-404 (fetch-cached-card card-id))
+                                                  parameters zoom x y lat-field lon-field))))
 
 ;;; ------------------------------------------------ Public Documents -------------------------------------------------
 

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -727,8 +727,8 @@
        [:lonField string?]]]
   (public-sharing.validation/check-public-sharing-enabled)
   (let [dashboard  (api/check-404 (t2/select-one :model/Dashboard :public_uuid uuid, :archived false))
-        dashcard   (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-        card       (api/check-404 (t2/select-one :model/Card :id card-id))
+        dashcard   (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+        card       (api/check-404 (t2/select-one :model/Card card-id))
         parameters (when parameters (json/decode+kw parameters))
         lat-field  (json/decode+kw latField)
         lon-field  (json/decode+kw lonField)]

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -91,6 +91,38 @@
 
 (defn- card-with-uuid [uuid] (public-card :public_uuid uuid))
 
+(def ^:private cached-entity-ttl-ms
+  "How long the public/embed entity caches below hold onto a fetched Dashboard/DashboardCard/Card row.
+
+  These caches exist ONLY for the high-volume, unauthenticated public + embed read paths, where bounded staleness (up
+  to this TTL) is acceptable in exchange for cutting duplicate app-DB fetches within a single request. They must NEVER
+  be used on any path that requires read-your-writes freshness (i.e. the authenticated app)."
+  (u/minutes->ms 1))
+
+(def fetch-cached-dashboard
+  "TTL-memoized fetch of a full `:model/Dashboard` row by id. Public/embed read paths only; see
+  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/Dashboard :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
+(def fetch-cached-dashcard
+  "TTL-memoized fetch of a full `:model/DashboardCard` row by id. Public/embed read paths only; see
+  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/DashboardCard :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
+(def fetch-cached-card
+  "TTL-memoized fetch of a full `:model/Card` row by id. Public/embed read paths only; see [[cached-entity-ttl-ms]].
+  Do NOT use on authenticated app paths that require read-your-writes freshness."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
+   (fn [id] (t2/select-one :model/Card :id id))
+   :ttl/threshold cached-entity-ttl-ms))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -161,7 +193,8 @@
   ;; tries to do the `read-check`, and a second time for when the query is ran (async) so the QP middleware will have
   ;; the correct perms
   (request/as-admin
-    (m/mapply qp.card/process-query-for-card card-id export-format
+    ;; public/embed read path: hand qp.card the cached Card so it doesn't re-fetch it (it still read-checks it)
+    (m/mapply qp.card/process-query-for-card (api/check-404 (fetch-cached-card card-id)) export-format
               :parameters parameters
               :context    (export-format->context export-format)
               :qp         qp
@@ -284,38 +317,6 @@
   (public-sharing.validation/check-public-sharing-enabled)
   (u/prog1 (dashboard-with-uuid uuid)
     (events/publish-event! :event/dashboard-read {:object-id (:id <>), :user-id api/*current-user-id*})))
-
-(def ^:private cached-entity-ttl-ms
-  "How long the public/embed entity caches below hold onto a fetched Dashboard/DashboardCard/Card row.
-
-  These caches exist ONLY for the high-volume, unauthenticated public + embed read paths, where bounded staleness (up
-  to this TTL) is acceptable in exchange for cutting duplicate app-DB fetches within a single request. They must NEVER
-  be used on any path that requires read-your-writes freshness (i.e. the authenticated app)."
-  (u/minutes->ms 1))
-
-(def fetch-cached-dashboard
-  "TTL-memoized fetch of a full `:model/Dashboard` row by id. Public/embed read paths only; see
-  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/Dashboard :id id))
-   :ttl/threshold cached-entity-ttl-ms))
-
-(def fetch-cached-dashcard
-  "TTL-memoized fetch of a full `:model/DashboardCard` row by id. Public/embed read paths only; see
-  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/DashboardCard :id id))
-   :ttl/threshold cached-entity-ttl-ms))
-
-(def fetch-cached-card
-  "TTL-memoized fetch of a full `:model/Card` row by id. Public/embed read paths only; see [[cached-entity-ttl-ms]].
-  Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/Card :id id))
-   :ttl/threshold cached-entity-ttl-ms))
 
 (defn process-query-for-dashcard
   "Return the results of running a query for Card with `card-id` belonging to Dashboard with `dashboard-id` via

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -193,7 +193,6 @@
   ;; tries to do the `read-check`, and a second time for when the query is ran (async) so the QP middleware will have
   ;; the correct perms
   (request/as-admin
-    ;; public/embed read path: hand qp.card the cached Card so it doesn't re-fetch it (it still read-checks it)
     (m/mapply qp.card/process-query-for-card (api/check-404 (fetch-cached-card card-id)) export-format
               :parameters parameters
               :context    (export-format->context export-format)

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -1,18 +1,15 @@
 (ns metabase.public-sharing-rest.api
   "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
   (:require
-   [clojure.core.memoize :as memoize]
    [hiccup.core :as hiccup]
    [medley.core :as m]
    [metabase.actions.core :as actions]
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.app-db.core :as mdb]
    [metabase.dashboards-rest.api :as api.dashboard]
    [metabase.dashboards.schema :as dashboards.schema]
    [metabase.events.core :as events]
-   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.info :as lib.schema.info]
    [metabase.models.interface :as mi]
    [metabase.parameters.dashboard :as parameters.dashboard]
@@ -91,38 +88,6 @@
 
 (defn- card-with-uuid [uuid] (public-card :public_uuid uuid))
 
-(def ^:private cached-entity-ttl-ms
-  "How long the public/embed entity caches below hold onto a fetched Dashboard/DashboardCard/Card row.
-
-  These caches exist ONLY for the high-volume, unauthenticated public + embed read paths, where bounded staleness (up
-  to this TTL) is acceptable in exchange for cutting duplicate app-DB fetches within a single request. They must NEVER
-  be used on any path that requires read-your-writes freshness (i.e. the authenticated app)."
-  (u/minutes->ms 1))
-
-(def fetch-cached-dashboard
-  "TTL-memoized fetch of a full `:model/Dashboard` row by id. Public/embed read paths only; see
-  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/Dashboard :id id))
-   :ttl/threshold cached-entity-ttl-ms))
-
-(def fetch-cached-dashcard
-  "TTL-memoized fetch of a full `:model/DashboardCard` row by id. Public/embed read paths only; see
-  [[cached-entity-ttl-ms]]. Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/DashboardCard :id id))
-   :ttl/threshold cached-entity-ttl-ms))
-
-(def fetch-cached-card
-  "TTL-memoized fetch of a full `:model/Card` row by id. Public/embed read paths only; see [[cached-entity-ttl-ms]].
-  Do NOT use on authenticated app paths that require read-your-writes freshness."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[id]] [(mdb/unique-identifier) id])}
-   (fn [id] (t2/select-one :model/Card :id id))
-   :ttl/threshold cached-entity-ttl-ms))
-
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -179,9 +144,10 @@
     :public-question))
 
 (mu/defn process-query-for-card-with-id
-  "Run the query belonging to Card with `card-id` with `parameters` and other query options (e.g. `:constraints`).
-  Returns a `StreamingResponse` object that should be returned as the result of an API endpoint."
-  [card-id :- ::lib.schema.id/card
+  "Run the query for pre-loaded Card `card` with `parameters` and other query options (e.g. `:constraints`).
+  Callers are responsible for resolving `card` themselves with a fresh `t2/select-one` call (each endpoint should
+  select the Card exactly once and thread the loaded entity here). Returns a `StreamingResponse`."
+  [card
    export-format
    parameters
    & {:keys [qp]
@@ -193,7 +159,7 @@
   ;; tries to do the `read-check`, and a second time for when the query is ran (async) so the QP middleware will have
   ;; the correct perms
   (request/as-admin
-    (m/mapply qp.card/process-query-for-card (api/check-404 (fetch-cached-card card-id)) export-format
+    (m/mapply qp.card/process-query-for-card card export-format
               :parameters parameters
               :context    (export-format->context export-format)
               :qp         qp
@@ -205,8 +171,8 @@
   `StreamingResponse` object that should be returned as the result of an API endpoint."
   [uuid export-format parameters & options]
   (public-sharing.validation/check-public-sharing-enabled)
-  (let [card-id (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))]
-    (apply process-query-for-card-with-id card-id export-format parameters options)))
+  (let [card (api/check-404 (t2/select-one :model/Card :public_uuid uuid, :archived false))]
+    (apply process-query-for-card-with-id card export-format parameters options)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -318,30 +284,24 @@
     (events/publish-event! :event/dashboard-read {:object-id (:id <>), :user-id api/*current-user-id*})))
 
 (defn process-query-for-dashcard
-  "Return the results of running a query for Card with `card-id` belonging to Dashboard with `dashboard-id` via
-  `dashcard-id`. `card-id`, `dashboard-id`, and `dashcard-id` are all required; other parameters are optional:
+  "Return the results of running a query for pre-loaded Card `card` on pre-loaded DashboardCard `dashcard` belonging to
+  pre-loaded Dashboard `dashboard`.
 
+  Additional options:
   * `parameters`    - MBQL query parameters, either already parsed or as a serialized JSON string
   * `export-format` - `:api` (default format with metadata), `:json` (results only), `:csv`, or `:xslx`. Default: `:api`
   * `qp`            - QP function to run the query with. Default [[qp/process-query]] + [[qp/userland-context]]
 
-  This is the single bridge for all public + embed dashcard-query entry points. It resolves `dashboard-id`,
-  `dashcard-id`, and `card-id` to full entities via the shared TTL-memoized caches (acceptable here because these are
-  unauthenticated read paths) and hands the entities to [[qp.dashboard/process-query-for-dashcard]].
-
-  Throws a 404 immediately if the Card isn't part of the Dashboard. Returns a `StreamingResponse`."
-  {:arglists '([& {:keys [dashboard-id card-id dashcard-id export-format parameters] :as options}])}
-  [& {:keys [dashboard-id card-id dashcard-id export-format parameters qp]
+  Callers are responsible for 404-checking each entity before threading it here. Returns a `StreamingResponse`."
+  {:arglists '([& {:keys [dashboard dashcard card export-format parameters] :as options}])}
+  [& {:keys [export-format parameters qp dashboard dashcard card]
       :or   {qp            qp.card/process-query-for-card-default-qp
              export-format :api}
       :as   options}]
-  (let [dashboard (api/check-404 (fetch-cached-dashboard dashboard-id))
-        dashcard  (api/check-404 (fetch-cached-dashcard dashcard-id))
-        card      (api/check-404 (fetch-cached-card card-id))
-        options (merge
+  (let [options (merge
                  {:context     :public-dashboard
                   :constraints (qp.constraints/default-query-constraints)}
-                 (dissoc options :dashboard-id :card-id :dashcard-id)
+                 options
                  {:dashboard     dashboard
                   :dashcard      dashcard
                   :card          card
@@ -375,12 +335,13 @@
    {:keys [parameters]} :- [:map
                             [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
-  (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
+  (let [card      (api/check-404 (t2/select-one :model/Card :id card-id :archived false))
+        dashboard (api/check-404 (t2/select-one :model/Dashboard :public_uuid uuid, :archived false))
+        dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))]
     (process-query-for-dashcard
-     :dashboard-id  dashboard-id
-     :card-id       card-id
-     :dashcard-id   dashcard-id
+     :dashboard     dashboard
+     :card          card
+     :dashcard      dashcard
      :export-format :api
      :parameters    parameters)))
 
@@ -408,12 +369,13 @@
                                                       [:format_rows   {:default false} ms/BooleanValue]
                                                       [:pivot_results {:default false} ms/BooleanValue]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
-  (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
+  (let [card      (api/check-404 (t2/select-one :model/Card :id card-id :archived false))
+        dashboard (api/check-404 (t2/select-one :model/Dashboard :public_uuid uuid, :archived false))
+        dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))]
     (u/prog1 (process-query-for-dashcard
-              :dashboard-id  dashboard-id
-              :card-id       card-id
-              :dashcard-id   dashcard-id
+              :dashboard     dashboard
+              :card          card
+              :dashcard      dashcard
               :export-format export-format
               :parameters    parameters
               :constraints   nil
@@ -654,12 +616,13 @@
    {:keys [parameters]} :- [:map
                             [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
-  (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
+  (let [card      (api/check-404 (t2/select-one :model/Card :id card-id :archived false))
+        dashboard (api/check-404 (t2/select-one :model/Dashboard :public_uuid uuid, :archived false))
+        dashcard  (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))]
     (process-query-for-dashcard
-     :dashboard-id  dashboard-id
-     :card-id       card-id
-     :dashcard-id   dashcard-id
+     :dashboard     dashboard
+     :card          card
+     :dashcard      dashcard
      :export-format :api
      :parameters    parameters
      :qp            qp.pivot/run-pivot-query)))
@@ -735,12 +698,12 @@
        [:latField string?]
        [:lonField string?]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (let [card-id    (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))
+  (let [card       (api/check-404 (t2/select-one :model/Card :public_uuid uuid, :archived false))
         parameters (when parameters (json/decode+kw parameters))
         lat-field  (json/decode+kw latField)
         lon-field  (json/decode+kw lonField)]
     (request/as-admin
-      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
+      (api.tiles/process-tiles-query-for-card card parameters zoom x y lat-field lon-field))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -763,14 +726,14 @@
        [:latField string?]
        [:lonField string?]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))
-        parameters   (when parameters (json/decode+kw parameters))
-        lat-field    (json/decode+kw latField)
-        lon-field    (json/decode+kw lonField)]
+  (let [dashboard  (api/check-404 (t2/select-one :model/Dashboard :public_uuid uuid, :archived false))
+        dashcard   (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+        card       (api/check-404 (t2/select-one :model/Card :id card-id))
+        parameters (when parameters (json/decode+kw parameters))
+        lat-field  (json/decode+kw latField)
+        lon-field  (json/decode+kw lonField)]
     (request/as-admin
-      (api.tiles/process-tiles-query-for-dashcard (api/check-404 (fetch-cached-dashboard dashboard-id))
-                                                  (api/check-404 (fetch-cached-dashcard dashcard-id))
-                                                  (api/check-404 (fetch-cached-card card-id))
+      (api.tiles/process-tiles-query-for-dashcard dashboard dashcard card
                                                   parameters zoom x y lat-field lon-field))))
 
 ;;; ------------------------------------------------ Public Documents -------------------------------------------------
@@ -807,10 +770,12 @@
 
   We validate the document-card association to prevent users from querying arbitrary cards by guessing IDs. Only
   cards explicitly embedded in the public document (via document_id FK) are accessible through public document
-  endpoints. This prevents bypassing collection permissions by accessing cards through public document routes."
+  endpoints. This prevents bypassing collection permissions by accessing cards through public document routes.
+
+  Returns the loaded `:model/Card` entity so the caller can thread it downstream without re-selecting it."
   [uuid card-id]
   (let [document-id (api/check-404 (t2/select-one-pk :model/Document :public_uuid uuid :archived false))]
-    (api/check-404 (t2/select-one-pk :model/Card :id card-id :document_id document-id :archived false))))
+    (api/check-404 (t2/select-one :model/Card :id card-id :document_id document-id :archived false))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -842,14 +807,14 @@
    {:keys [parameters]} :- [:map
                             [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (validate-card-in-public-document uuid card-id)
-  ;; Run the query as admin since public documents are available to everyone anyway
-  (u/prog1 (process-query-for-card-with-id
-            card-id
-            :api
-            (json/decode+kw parameters)
-            :constraints (qp.constraints/default-query-constraints))
-    (events/publish-event! :event/card-read {:object-id card-id :user-id api/*current-user-id* :context :question})))
+  (let [card (validate-card-in-public-document uuid card-id)]
+    ;; Run the query as admin since public documents are available to everyone anyway
+    (u/prog1 (process-query-for-card-with-id
+              card
+              :api
+              (json/decode+kw parameters)
+              :constraints (qp.constraints/default-query-constraints))
+      (events/publish-event! :event/card-read {:object-id card-id :user-id api/*current-user-id* :context :question}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -870,17 +835,17 @@
                                                       [:format_rows   {:default false} ms/BooleanValue]
                                                       [:pivot_results {:default false} ms/BooleanValue]]]
   (public-sharing.validation/check-public-sharing-enabled)
-  (validate-card-in-public-document uuid card-id)
-  (process-query-for-card-with-id
-   card-id
-   export-format
-   (cond-> parameters
-     (string? parameters) json/decode+kw)
-   :constraints nil
-   :middleware {:process-viz-settings? true
-                :js-int-to-string?     false
-                :format-rows?          format_rows
-                :pivot?                pivot_results}))
+  (let [card (validate-card-in-public-document uuid card-id)]
+    (process-query-for-card-with-id
+     card
+     export-format
+     (cond-> parameters
+       (string? parameters) json/decode+kw)
+     :constraints nil
+     :middleware {:process-viz-settings? true
+                  :js-int-to-string?     false
+                  :format-rows?          format_rows
+                  :pivot?                pivot_results})))
 
 ;;; ----------------------------------------- Route Definitions & Complaints -----------------------------------------
 

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -904,7 +904,7 @@
   ;; endpoint instead. Or error in that situation? We're not even validating that you have access to this Dashboard.
   (let [resolved-card-id (eid-translation/->id-or-404 :card card-id)]
     (qp.card/process-query-for-card
-     (api/check-404 (t2/select-one :model/Card :id resolved-card-id)) :api
+     (api/check-404 (t2/select-one :model/Card resolved-card-id)) :api
      :parameters parameters
      :ignore-cache ignore_cache
      :dashboard-id dashboard_id
@@ -944,7 +944,7 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (qp.card/process-query-for-card
-   (api/check-404 (t2/select-one :model/Card :id card-id)) export-format
+   (api/check-404 (t2/select-one :model/Card card-id)) export-format
    :parameters  parameters
    :constraints nil
    :context     (api.dataset/export-format->context export-format)
@@ -1018,7 +1018,7 @@
    {:keys [parameters ignore_cache]
     :or   {ignore_cache false}} :- [:map
                                     [:ignore_cache {:optional true} [:maybe :boolean]]]]
-  (qp.card/process-query-for-card (api/check-404 (t2/select-one :model/Card :id card-id)) :api
+  (qp.card/process-query-for-card (api/check-404 (t2/select-one :model/Card card-id)) :api
                                   :parameters   parameters
                                   :qp           qp.pivot/run-pivot-query
                                   :ignore-cache ignore_cache))

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -904,7 +904,7 @@
   ;; endpoint instead. Or error in that situation? We're not even validating that you have access to this Dashboard.
   (let [resolved-card-id (eid-translation/->id-or-404 :card card-id)]
     (qp.card/process-query-for-card
-     resolved-card-id :api
+     (api/check-404 (t2/select-one :model/Card :id resolved-card-id)) :api
      :parameters parameters
      :ignore-cache ignore_cache
      :dashboard-id dashboard_id
@@ -944,7 +944,7 @@
        [:format_rows   {:default false} ms/BooleanValue]
        [:pivot_results {:default false} ms/BooleanValue]]]
   (qp.card/process-query-for-card
-   card-id export-format
+   (api/check-404 (t2/select-one :model/Card :id card-id)) export-format
    :parameters  parameters
    :constraints nil
    :context     (api.dataset/export-format->context export-format)
@@ -1018,7 +1018,7 @@
    {:keys [parameters ignore_cache]
     :or   {ignore_cache false}} :- [:map
                                     [:ignore_cache {:optional true} [:maybe :boolean]]]]
-  (qp.card/process-query-for-card card-id :api
+  (qp.card/process-query-for-card (api/check-404 (t2/select-one :model/Card :id card-id)) :api
                                   :parameters   parameters
                                   :qp           qp.pivot/run-pivot-query
                                   :ignore-cache ignore_cache))

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -33,9 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
-   [metabase.util.performance :refer [mapv select-keys not-empty]]
-   ^{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2]))
+   [metabase.util.performance :refer [mapv select-keys not-empty]]))
 
 (set! *warn-on-reflection* true)
 
@@ -143,8 +141,8 @@
   false)
 
 (mu/defn- card-template-tag-parameters
-  "Template tag parameters that have been specified for the query for Card with `card-id`, if any, returned as a map in
-  the format
+  "Template tag parameters that have been specified for the Card's `query` (`:dataset_query`), if any, returned as a map
+  in the format
 
     {\"template_tag_parameter_name\" :parameter-type, ...}
 
@@ -154,8 +152,8 @@
   Parameter type in this case is something like `:string` or `:number` or `:date/month-year`; parameters passed in as
   parameters to the API request must be allowed for this type (i.e. `:string/=` is allowed for a `:string` parameter,
   but `:number/=` is not)."
-  [card-id :- ::lib.schema.id/card]
-  (let [query (api/check-404 (t2/select-one-fn :dataset_query :model/Card :id card-id))]
+  [query :- [:maybe ::lib.schema/query]]
+  (let [query (api/check-404 query)]
     (into
      {}
      (keep (fn [[param-name {widget-type :widget-type, tag-type :type}]]
@@ -211,11 +209,12 @@
 
 (mu/defn- validate-card-parameters
   "Unless [[*allow-arbitrary-mbql-parameters*]] is truthy, check to make all supplied `parameters` actually match up
-  with template tags in the query for Card with `card-id`."
-  [card-id    :- ::lib.schema.id/card
-   parameters :- [:maybe [:ref ::lib.schema.parameter/parameters]]]
+  with template tags in `dataset-query` (the query for the Card with `card-id`)."
+  [card-id       :- ::lib.schema.id/card
+   dataset-query :- [:maybe ::lib.schema/query]
+   parameters    :- [:maybe [:ref ::lib.schema.parameter/parameters]]]
   (when-not *allow-arbitrary-mbql-parameters*
-    (let [template-tags (card-template-tag-parameters card-id)]
+    (let [template-tags (card-template-tag-parameters dataset-query)]
       (doseq [request-parameter parameters
               :let              [parameter-name (infer-parameter-name request-parameter)]]
         (let [matching-widget-type (or (get template-tags parameter-name)
@@ -318,50 +317,47 @@
   `context` is a keyword describing the situation in which this query is being ran, e.g. `:question` (from a Saved
   Question) or `:dashboard` (from a Saved Question in a Dashboard). See [[metabase.legacy-mbql.schema/Context]] for
   all valid options."
-  [card-id :- ::lib.schema.id/card
+  [card :- ::queries.schema/card
    export-format
-   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp make-run ignore-cache]
+   & {:keys [parameters constraints context dashboard-id dashcard middleware qp make-run ignore-cache]
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              ;; param `make-run` can be used to control how the query is ran, e.g. if you need to customize the `context`
              ;; passed to the QP
              make-run    process-query-for-card-default-run-fn}}]
-  {:pre [(pos-int? card-id) (u/maybe? sequential? parameters)]}
-  (let [card       (api/read-check (t2/select-one [:model/Card :id :name :dataset_query :database_id :collection_id
-                                                   :type :result_metadata :visualization_settings :display
-                                                   :cache_invalidated_at :entity_id :created_at :card_schema
-                                                   :parameters]
-                                                  :id card-id))
-        parameters (some-> parameters parameters.schema/normalize-parameters-without-adding-default-types)
-        parameters (enrich-parameters-from-card parameters (combined-parameters-and-template-tags card))
-        dash-viz   (when (and (not= context :question)
-                              dashcard-id)
-                     (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
-        card-viz   (:visualization_settings card)
-        merged-viz (m/deep-merge card-viz dash-viz)
+  {:pre [(map? card) (pos-int? (:id card)) (u/maybe? sequential? parameters)]}
+  (let [card        (api/read-check card)
+        card-id     (:id card)
+        dashcard-id (:id dashcard)
+        parameters  (some-> parameters parameters.schema/normalize-parameters-without-adding-default-types)
+        parameters  (enrich-parameters-from-card parameters (combined-parameters-and-template-tags card))
+        dash-viz    (when (and (not= context :question) dashcard)
+                      (:visualization_settings dashcard))
+        card-viz    (:visualization_settings card)
+        merged-viz  (m/deep-merge card-viz dash-viz)
         ;; We need to check this here because dashcards don't get selected until this point
-        qp         (if (= :pivot (:display card))
-                     qp.pivot/run-pivot-query
-                     (or qp process-query-for-card-default-qp))
-        runner     (make-run qp export-format)
-        query      (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
-                       (assoc :viz-settings merged-viz)
-                       (update :middleware (fn [middleware]
-                                             (merge
-                                              {:js-int-to-string? true, :ignore-cached-results? ignore-cache}
-                                              middleware))))
-        info       (cond-> {:executed-by            api/*current-user-id*
-                            :context                context
-                            :card-id                card-id
-                            :card-name              (:name card)
-                            :dashboard-id           dashboard-id
-                            :visualization-settings merged-viz}
-                     (and (= (:type card) :model) (seq (:result_metadata card)))
-                     (assoc :metadata/model-metadata (:result_metadata card)
-                            :metadata/own-model-query? true))]
+        qp          (if (= :pivot (:display card))
+                      qp.pivot/run-pivot-query
+                      (or qp process-query-for-card-default-qp))
+        runner      (make-run qp export-format)
+        query       (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
+                        (assoc :viz-settings merged-viz)
+                        (update :middleware (fn [middleware]
+                                              (merge
+                                               {:js-int-to-string? true, :ignore-cached-results? ignore-cache}
+                                               middleware))))
+        info        (cond-> {:executed-by            api/*current-user-id*
+                             :context                context
+                             :card-id                card-id
+                             :card-name              (:name card)
+                             :dashboard-id           dashboard-id
+                             :visualization-settings merged-viz}
+                      (and (= (:type card) :model) (seq (:result_metadata card)))
+                      (assoc :metadata/model-metadata (:result_metadata card)
+                             :metadata/own-model-query? true))]
     (when (seq parameters)
-      (validate-card-parameters card-id (lib/normalize ::lib.schema.parameter/parameters parameters)))
-    (log/tracef "Running query for Card %d:\n%s" card-id
+      (validate-card-parameters card-id (:dataset_query card) (lib/normalize ::lib.schema.parameter/parameters parameters)))
+    (log/tracef "Running query for Card %d (dashcard %s):\n%s" card-id dashcard-id
                 (u/pprint-to-str query))
     (binding [qp.perms/*card-id* card-id]
       (when-let [context (card-read-context info)]

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -198,10 +198,10 @@
                              (dissoc options :dashboard :dashcard :card)
                              {:parameters   resolved-params
                               :dashboard-id dashboard-id
-                              :dashcard-id  dashcard-id})]
+                              :dashcard     dashcard})]
         (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
                     dashboard-id card-id dashcard-id
                     (u/pprint-to-str options))
         ;; we've already validated our parameters, so we don't need the [[qp.card]] namespace to do it again
         (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
-          (m/mapply qp.card/process-query-for-card card-id export-format options))))))
+          (m/mapply qp.card/process-query-for-card card export-format options))))))

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -26,21 +26,16 @@
    [toucan2.core :as t2]))
 
 (defn- check-card-and-dashcard-are-in-dashboard
-  "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in the DashboardCard with
-  `dashcard-id` at the top level or as a series. If not such relationship exists this will throw a 404 Exception."
-  [dashboard-id card-id dashcard-id]
-  (api/check-404
-   (or (t2/exists? :model/DashboardCard
-                   :id           dashcard-id
-                   :dashboard_id dashboard-id
-                   :card_id      card-id)
-       (and
-        (t2/exists? :model/DashboardCard
-                    :id           dashcard-id
-                    :dashboard_id dashboard-id)
-        (t2/exists? :model/DashboardCardSeries
-                    :card_id          card-id
-                    :dashboardcard_id dashcard-id)))))
+  "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in the already-loaded `dashcard` at the
+  top level or as a series. If no such relationship exists this will throw a 404 Exception."
+  [dashboard-id card-id dashcard]
+  (let [dashcard-id (:id dashcard)]
+    (api/check-404
+     (and (= (:dashboard_id dashcard) dashboard-id)
+          (or (= (:card_id dashcard) card-id)
+              (t2/exists? :model/DashboardCardSeries
+                          :card_id          card-id
+                          :dashboardcard_id dashcard-id))))))
 
 (defn- resolve-param-for-card
   [card-id dashcard-id param-id->param {param-id :id, :as request-param}]
@@ -122,16 +117,14 @@
   "Given a sequence of parameters included in a query-processing request to run the query for a Dashboard/Card, validate
   that those parameters exist and have allowed types, and merge in default values and other info from the parameter
   mappings."
-  [dashboard-id   :- ::lib.schema.id/dashboard
+  [dashboard      :- ::dashboards.schema/dashboard
+   dashcard       :- ::dashboards.schema/dashcard
    card-id        :- ::lib.schema.id/card
-   dashcard-id    :- ::lib.schema.id/dashcard
    request-params :- [:maybe [:sequential :map]]]
-  (log/tracef "Resolving Dashboard %d Card %d query request parameters" dashboard-id card-id)
-  (let [request-params            (some-> request-params not-empty (->> (lib/normalize ::dashboards.schema/parameters)))
-        dashboard                 (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-        dashcard                  (api/check-404 (t2/select-one [:model/DashboardCard :id :card_id :dashboard_id :parameter_mappings]
-                                                                :id dashcard-id
-                                                                :dashboard_id dashboard-id))
+  (let [dashboard-id              (:id dashboard)
+        dashcard-id               (:id dashcard)
+        _                         (log/tracef "Resolving Dashboard %d Card %d query request parameters" dashboard-id card-id)
+        request-params            (some-> request-params not-empty (->> (lib/normalize ::dashboards.schema/parameters)))
         resolved-params           (dashboard/dashboard->resolved-params (assoc dashboard :dashcards [dashcard]))
         dashboard-param-id->param (into {}
                                         ;; remove the `:default` values from Dashboard params. We don't ACTUALLY want to
@@ -170,41 +163,45 @@
   Exception if preconditions such as proper permissions are not met *before* returning the `StreamingResponse`.
 
   See [[metabase.query-processor.card/process-query-for-card]] for more information about the various parameters."
-  {:arglists '([& {:keys [dashboard-id card-id dashcard-id export-format parameters ignore-cache constraints parameters middleware]}])}
-  [& {:keys [dashboard-id card-id dashcard-id parameters export-format]
+  {:arglists '([& {:keys [dashboard dashcard card export-format parameters ignore-cache constraints parameters middleware]}])}
+  [& {:keys [dashboard card dashcard parameters export-format]
       :or   {export-format :api}
       :as   options}]
-  (span/with-span! {:name       "run-query-for-dashcard-async"
-                    :attributes {:dashboard/id dashboard-id
-                                 :dashcard/id  dashcard-id
-                                 :card/id      card-id}}
-    (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id api/*current-user-id*})
-    ;; make sure we can read this Dashboard. Card will get read-checked later on inside
-    ;; [[qp.card/process-query-for-card]]
-    (api/read-check :model/Dashboard dashboard-id)
-    (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
-    ;; Early view-data permission check so that blocked users get a 403 *before* parameter
-    ;; resolution. Without this, a missing required parameter would produce a 400, and the
-    ;; frontend couldn't distinguish "no permission" (hide inline filters) from "missing
-    ;; params" (show inline filters). The QP middleware's check-block-permissions does a
-    ;; thorough check later on the resolved query; this is intentionally just the card's
-    ;; database_id since we don't have the resolved query yet.
-    (api/check-403
-     (not= :blocked
-           (perms/most-permissive-database-permission-for-user
-            api/*current-user-id* :perms/view-data
-            (t2/select-one-fn :database_id :model/Card card-id))))
-    (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
-          options         (merge
-                           {:ignore-cache false
-                            :constraints  (qp.constraints/default-query-constraints)
-                            :context      :dashboard}
-                           options
-                           {:parameters   resolved-params
-                            :dashboard-id dashboard-id})]
-      (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
-                  dashboard-id card-id dashcard-id
-                  (u/pprint-to-str options))
-      ;; we've already validated our parameters, so we don't need the [[qp.card]] namespace to do it again
-      (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
-        (m/mapply qp.card/process-query-for-card card-id export-format options)))))
+  (let [dashboard-id (:id dashboard)
+        card-id      (:id card)
+        dashcard-id  (:id dashcard)]
+    (span/with-span! {:name       "run-query-for-dashcard-async"
+                      :attributes {:dashboard/id dashboard-id
+                                   :dashcard/id  dashcard-id
+                                   :card/id      card-id}}
+      (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id api/*current-user-id*})
+      ;; make sure we can read this Dashboard. Card will get read-checked later on inside
+      ;; [[qp.card/process-query-for-card]]
+      (api/read-check dashboard)
+      (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard)
+      ;; Early view-data permission check so that blocked users get a 403 *before* parameter
+      ;; resolution. Without this, a missing required parameter would produce a 400, and the
+      ;; frontend couldn't distinguish "no permission" (hide inline filters) from "missing
+      ;; params" (show inline filters). The QP middleware's check-block-permissions does a
+      ;; thorough check later on the resolved query; this is intentionally just the card's
+      ;; database_id since we don't have the resolved query yet.
+      (api/check-403
+       (not= :blocked
+             (perms/most-permissive-database-permission-for-user
+              api/*current-user-id* :perms/view-data
+              (:database_id card))))
+      (let [resolved-params (resolve-params-for-query dashboard dashcard card-id parameters)
+            options         (merge
+                             {:ignore-cache false
+                              :constraints  (qp.constraints/default-query-constraints)
+                              :context      :dashboard}
+                             (dissoc options :dashboard :dashcard :card)
+                             {:parameters   resolved-params
+                              :dashboard-id dashboard-id
+                              :dashcard-id  dashcard-id})]
+        (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
+                    dashboard-id card-id dashcard-id
+                    (u/pprint-to-str options))
+        ;; we've already validated our parameters, so we don't need the [[qp.card]] namespace to do it again
+        (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
+          (m/mapply qp.card/process-query-for-card card-id export-format options))))))

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -195,10 +195,9 @@
                              {:ignore-cache false
                               :constraints  (qp.constraints/default-query-constraints)
                               :context      :dashboard}
-                             (dissoc options :dashboard :dashcard :card)
+                             (dissoc options :dashboard :card)
                              {:parameters   resolved-params
-                              :dashboard-id dashboard-id
-                              :dashcard     dashcard})]
+                              :dashboard-id dashboard-id})]
         (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
                     dashboard-id card-id dashcard-id
                     (u/pprint-to-str options))

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -242,7 +242,7 @@
         lon-field-ref (mbql.normalize/normalize lon-field-ref)
         result
         (qp.card/process-query-for-card
-         card-id
+         (api/check-404 (t2/select-one :model/Card :id card-id))
          :api
          {:parameters parameters
           :context    :map-tiles

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -21,7 +21,8 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.web-mercator :as mercator])
+   [metabase.util.web-mercator :as mercator]
+   [toucan2.core :as t2])
   (:import
    (java.awt Color)
    (java.awt.image BufferedImage)
@@ -256,15 +257,15 @@
     (tiles-response result zoom points)))
 
 (defn process-tiles-query-for-dashcard
-  "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
-  [dashboard-id dashcard-id card-id parameters zoom x y lat-field-ref lon-field-ref]
+  "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG."
+  [dashboard dashcard card parameters zoom x y lat-field-ref lon-field-ref]
   (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
         lon-field-ref (mbql.normalize/normalize lon-field-ref)
         result
         (qp.dashboard/process-query-for-dashcard
-         :dashboard-id  dashboard-id
-         :dashcard-id   dashcard-id
-         :card-id       card-id
+         :dashboard     dashboard
+         :dashcard      dashcard
+         :card          card
          :export-format :api
          :parameters    parameters
          :context       :map-tiles
@@ -324,4 +325,7 @@
        [:parameters {:optional true} ::parameters]
        [:latField ::legacy-ref]
        [:lonField ::legacy-ref]]]
-  (process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))
+  (process-tiles-query-for-dashcard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
+                                    (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
+                                    (api/check-404 (t2/select-one :model/Card :id card-id))
+                                    parameters zoom x y lat-field lon-field))

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -327,7 +327,7 @@
        [:parameters {:optional true} ::parameters]
        [:latField ::legacy-ref]
        [:lonField ::legacy-ref]]]
-  (process-tiles-query-for-dashcard (api/check-404 (t2/select-one :model/Dashboard :id dashboard-id))
-                                    (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id))
-                                    (api/check-404 (t2/select-one :model/Card :id card-id))
+  (process-tiles-query-for-dashcard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
+                                    (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
+                                    (api/check-404 (t2/select-one :model/Card card-id))
                                     parameters zoom x y lat-field lon-field))

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -236,13 +236,14 @@
     (tiles-response result zoom points)))
 
 (defn process-tiles-query-for-card
-  "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
-  [card-id parameters zoom x y lat-field-ref lon-field-ref]
+  "Generates a single tile image for a pre-loaded Card and returns a Ring response that contains the data as a PNG.
+  Callers are responsible for selecting the `card` entity exactly once per request and threading it here."
+  [card parameters zoom x y lat-field-ref lon-field-ref]
   (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
         lon-field-ref (mbql.normalize/normalize lon-field-ref)
         result
         (qp.card/process-query-for-card
-         (api/check-404 (t2/select-one :model/Card :id card-id))
+         card
          :api
          {:parameters parameters
           :context    :map-tiles
@@ -304,7 +305,8 @@
        [:parameters {:optional true} ::parameters]
        [:latField ::legacy-ref]
        [:lonField ::legacy-ref]]]
-  (process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))
+  (process-tiles-query-for-card (api/check-404 (t2/select-one :model/Card :id card-id))
+                                parameters zoom x y lat-field lon-field))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -305,7 +305,7 @@
        [:parameters {:optional true} ::parameters]
        [:latField ::legacy-ref]
        [:lonField ::legacy-ref]]]
-  (process-tiles-query-for-card (api/check-404 (t2/select-one :model/Card :id card-id))
+  (process-tiles-query-for-card (api/check-404 (t2/select-one :model/Card card-id))
                                 parameters zoom x y lat-field lon-field))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -2725,8 +2725,8 @@
                                                                 :userland-query?                   true}}}]
     (with-cards-in-readable-collection! card
       (let [orig (mt/original-fn #'qp.card/process-query-for-card)]
-        (mt/with-dynamic-fn-redefs [qp.card/process-query-for-card (fn [card-id export-format & options]
-                                                                     (apply orig card-id export-format
+        (mt/with-dynamic-fn-redefs [qp.card/process-query-for-card (fn [card export-format & options]
+                                                                     (apply orig card export-format
                                                                             :make-run (constantly (fn [{:keys [constraints]} _]
                                                                                                     {:constraints constraints}))
                                                                             options))]

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -24,7 +24,8 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
-   [metabase.util.json :as json]))
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -35,86 +36,71 @@
   ;; stuff doesn't belong in the Dashboard QP namespace
   (mt/as-admin
     (qp.card/process-query-for-card
-     card-id :api
+     (t2/select-one :model/Card :id card-id) :api
      :make-run (constantly
                 (fn [query info]
                   (qp/process-query (assoc query :info info)))))))
 
 (defn field-filter-query
-  "A query with a Field Filter parameter"
+  "An MBQL 5 native query with a Field Filter (`:dimension`) parameter."
   []
-  {:database (mt/id)
-   :type     :native
-   :native   {:template-tags {"date" {:id           "_DATE_"
-                                      :name         "date"
-                                      :display-name "Check-In Date"
-                                      :type         :dimension
-                                      :dimension    [:field (mt/id :checkins :date) nil]
-                                      :widget-type  :date/all-options}}
-              :query         "SELECT count(*)\nFROM CHECKINS\nWHERE {{date}}"}})
+  (-> (lib/native-query (mt/metadata-provider) "SELECT count(*)\nFROM CHECKINS\nWHERE {{date}}")
+      (lib/with-template-tags {"date" {:id           "_DATE_"
+                                       :name         "date"
+                                       :display-name "Check-In Date"
+                                       :type         :dimension
+                                       :dimension    (lib/ref (lib.metadata/field (mt/metadata-provider) (mt/id :checkins :date)))
+                                       :widget-type  :date/all-options}})))
 
 (defn field-filter-query-between
-  "A query with a Field Filter 'between' parameter"
+  "An MBQL 5 native query with a Field Filter 'between' parameter."
   []
-  {:database (mt/id)
-   :type     :native
-   :native   {:template-tags {"quantities" {:id           "_QUANTITIES_"
-                                            :name         "quantities"
-                                            :display-name "Quantity Range"
-                                            :type         :dimension
-                                            :dimension    [:field (mt/id :orders :quantity) nil]
-                                            :widget-type  :number/between}}
-              :query         "SELECT count(*)\nFROM ORDERS\n[[WHERE {{quantities}}]]"}})
+  (-> (lib/native-query (mt/metadata-provider) "SELECT count(*)\nFROM ORDERS\n[[WHERE {{quantities}}]]")
+      (lib/with-template-tags {"quantities" {:id           "_QUANTITIES_"
+                                             :name         "quantities"
+                                             :display-name "Quantity Range"
+                                             :type         :dimension
+                                             :dimension    (lib/ref (lib.metadata/field (mt/metadata-provider) (mt/id :orders :quantity)))
+                                             :widget-type  :number/between}})))
 
 (defn non-field-filter-query
-  "A query with a parameter that is not a Field Filter"
+  "An MBQL 5 native query with a parameter that is not a Field Filter."
   []
-  {:database (mt/id)
-   :type     :native
-   :native   {:template-tags {"id"
-                              {:id           "_ID_"
-                               :name         "id"
-                               :display-name "Order ID"
-                               :type         :number
-                               :required     true
-                               :default      "1"}}
-              :query         "SELECT *\nFROM ORDERS\nWHERE id = {{id}}"}})
+  (-> (lib/native-query (mt/metadata-provider) "SELECT *\nFROM ORDERS\nWHERE id = {{id}}")
+      (lib/with-template-tags {"id" {:id           "_ID_"
+                                     :name         "id"
+                                     :display-name "Order ID"
+                                     :type         :number
+                                     :required     true
+                                     :default      "1"}})))
 
 (defn non-parameter-template-tag-query
-  "A query with template tags that aren't parameters"
+  "An MBQL 5 native query whose template tags include a source-card reference and a snippet (neither of which is a
+  parameter)."
   []
-  (assoc (non-field-filter-query)
-         "abcdef"
-         {:id           "abcdef"
-          :name         "#1234"
-          :display-name "#1234"
-          :type         :card
-          :card-id      1234}
-         "xyz"
-         {:id           "xyz"
-          :name         "snippet: My Snippet"
-          :display-name "Snippet: My Snippet"
-          :type         :snippet
-          :snippet-name "My Snippet"
-          :snippet-id   1}))
+  (-> (lib/native-query (mt/metadata-provider)
+                        "SELECT *\nFROM ORDERS\nWHERE id = {{id}} AND {{#1234}} AND {{snippet: My Snippet}}")
+      (lib/with-template-tags {"id" {:id           "_ID_"
+                                     :name         "id"
+                                     :display-name "Order ID"
+                                     :type         :number
+                                     :required     true
+                                     :default      "1"}})))
 
 (deftest ^:parallel card-template-tag-parameters-test
   (testing "Card with a Field filter parameter"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query (field-filter-query)}]
-      (is (= {"date" :date/all-options}
-             (#'qp.card/card-template-tag-parameters card-id))))))
+    (is (= {"date" :date/all-options}
+           (#'qp.card/card-template-tag-parameters (field-filter-query))))))
 
 (deftest ^:parallel card-template-tag-parameters-test-2
   (testing "Card with a non-Field-filter parameter"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query (non-field-filter-query)}]
-      (is (= {"id" :number}
-             (#'qp.card/card-template-tag-parameters card-id))))))
+    (is (= {"id" :number}
+           (#'qp.card/card-template-tag-parameters (non-field-filter-query))))))
 
 (deftest ^:parallel card-template-tag-parameters-test-3
   (testing "Should ignore native query snippets and source card IDs"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query (non-parameter-template-tag-query)}]
-      (is (= {"id" :number}
-             (#'qp.card/card-template-tag-parameters card-id))))))
+    (is (= {"id" :number}
+           (#'qp.card/card-template-tag-parameters (non-parameter-template-tag-query))))))
 
 (deftest ^:parallel infer-parameter-name-test
   (is (= "my_param"
@@ -130,10 +116,10 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Invalid parameter: Card [\d,]+ does not have a template tag named \"fake\""
-           (#'qp.card/validate-card-parameters card-id [{:id    "_FAKE_"
-                                                         :name  "fake"
-                                                         :type  :date/single
-                                                         :value "2016-01-01"}]))))))
+           (#'qp.card/validate-card-parameters card-id (field-filter-query) [{:id    "_FAKE_"
+                                                                              :name  "fake"
+                                                                              :type  :date/single
+                                                                              :value "2016-01-01"}]))))))
 
 (deftest ^:parallel validate-card-parameters-test-2
   (mt/with-temp [:model/Card {card-id :id} {:dataset_query (field-filter-query)}]
@@ -152,10 +138,10 @@
   (mt/with-temp [:model/Card {card-id :id} {:dataset_query (field-filter-query)}]
     (testing "Should disallow parameters with types not allowed for the widget type"
       (letfn [(validate [param-type]
-                (#'qp.card/validate-card-parameters card-id [{:id    "_DATE_"
-                                                              :name  "date"
-                                                              :type  param-type
-                                                              :value "2016-01-01"}]))]
+                (#'qp.card/validate-card-parameters card-id (field-filter-query) [{:id    "_DATE_"
+                                                                                   :name  "date"
+                                                                                   :type  param-type
+                                                                                   :value "2016-01-01"}]))]
         (testing "allowed types"
           (doseq [allowed-type #{:date/all-options :date :date/single :date/range}]
             (testing allowed-type
@@ -268,7 +254,7 @@
           (mt/with-test-user :rasta
             (letfn [(process-query-for-card [card]
                       (qp.card/process-query-for-card
-                       (u/the-id card) :api
+                       card :api
                        :make-run (constantly
                                   (fn [query info]
                                     (let [info (assoc info :query-hash (byte-array 0))]

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -24,19 +24,18 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
-   [metabase.util.json :as json]
-   [toucan2.core :as t2]))
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
 (defn run-query-for-card
   "Run query for Card synchronously."
-  [card-id]
+  [card]
   ;; TODO -- we shouldn't do the perms checks if there is no current User context. It seems like API-level perms check
   ;; stuff doesn't belong in the Dashboard QP namespace
   (mt/as-admin
     (qp.card/process-query-for-card
-     (t2/select-one :model/Card :id card-id) :api
+     card :api
      :make-run (constantly
                 (fn [query info]
                   (qp/process-query (assoc query :info info)))))))
@@ -210,25 +209,25 @@
 
 (deftest ^:parallel bad-viz-settings-should-still-work-test
   (testing "We should still be able to run a query that has Card bad viz settings referencing a column not in the query (#34950)"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query
-                                              (mt/mbql-query venues
-                                                {:aggregation [[:count]]})
+    (mt/with-temp [:model/Card card {:dataset_query
+                                     (mt/mbql-query venues
+                                       {:aggregation [[:count]]})
 
-                                              :visualization_settings
-                                              {:column_settings {(json/encode
-                                                                  [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]])
-                                                                 {:date_abbreviate true
-                                                                  :some_other_key  [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]]}}}}]
+                                     :visualization_settings
+                                     {:column_settings {(json/encode
+                                                         [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]])
+                                                        {:date_abbreviate true
+                                                         :some_other_key  [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]]}}}}]
       (is (= [[100]]
-             (mt/rows (run-query-for-card card-id)))))))
+             (mt/rows (run-query-for-card card)))))))
 
 (deftest ^:parallel pivot-tables-should-not-override-the-run-function
   (testing "Pivot tables should not override the run function (#44160)"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query
-                                              (mt/mbql-query venues
-                                                {:aggregation [[:count]]})
-                                              :display :pivot}]
-      (let [result (run-query-for-card card-id)]
+    (mt/with-temp [:model/Card card {:dataset_query
+                                     (mt/mbql-query venues
+                                       {:aggregation [[:count]]})
+                                     :display :pivot}]
+      (let [result (run-query-for-card card)]
         (is (=? {:status :completed}
                 result))
         (is (= [[100]] (mt/rows result)))))))
@@ -282,7 +281,7 @@
                                                           :display_name "Name"
                                                           :base_type    :type/Text}]}]
         (mt/with-metadata-provider (mt/id)
-          (run-query-for-card (u/the-id card))
+          (run-query-for-card card)
           (is (= [{:name         "NAME"
                    :display_name "Name"
                    :base_type    :type/Text}]
@@ -325,8 +324,8 @@
                                                 mp     (mt/metadata-provider)]
                                             {:dataset_query (lib/query mp (lib.metadata/card mp (:id card-1)))
                                              :result_metadata (:result-metadata card-2)})]
-          (doseq [[card-type card-id] {"model"                     (:id card-1)
-                                       "card with model as source" (:id card-2)}]
+          (doseq [[card-type card] {"model"                     card-1
+                                    "card with model as source" card-2}]
             (testing card-type
               (is (=? [{:name "ID",          :description "user description", :display_name "user display name", :semantic_type :type/Quantity}
                        {:name "NAME",        :description "user description", :display_name "user display name", :semantic_type :type/Name}
@@ -334,7 +333,7 @@
                        {:name "LATITUDE",    :description "user description", :display_name "user display name", :semantic_type :type/Cost}
                        {:name "LONGITUDE",   :description "user description", :display_name "user display name", :semantic_type :type/Cost}
                        {:name "PRICE",       :description "user description", :display_name "user display name", :semantic_type :type/Quantity}]
-                      (mt/cols (run-query-for-card card-id)))))))))))
+                      (mt/cols (run-query-for-card card)))))))))))
 
 (def card-download-filename-cases
   [["My Public Report" "my_public_report"]

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -128,22 +128,23 @@
   (testing "If both Dashboard and Card have default values for a Field filter parameter, Card defaults should take precedence\n"
     (mt/dataset test-data
       (mt/with-temp
-        [:model/Card {card-id :id} {:dataset_query {:database (mt/id)
-                                                    :type     :native
-                                                    :native   {:query (str "SELECT distinct category "
-                                                                           "FROM products "
-                                                                           "WHERE {{filter}} "
-                                                                           "ORDER BY category ASC")
-                                                               :template-tags
-                                                               {"filter"
-                                                                {:id           "xyz456"
-                                                                 :name         "filter"
-                                                                 :display-name "Filter"
-                                                                 :type         :dimension
-                                                                 :dimension    [:field (mt/id :products :category) nil]
-                                                                 :widget-type  :category
-                                                                 :default      ["Gizmo" "Gadget"]
-                                                                 :required     false}}}}}
+        [:model/Card {card-id :id, :as card}
+         {:dataset_query {:database (mt/id)
+                          :type     :native
+                          :native   {:query (str "SELECT distinct category "
+                                                 "FROM products "
+                                                 "WHERE {{filter}} "
+                                                 "ORDER BY category ASC")
+                                     :template-tags
+                                     {"filter"
+                                      {:id           "xyz456"
+                                       :name         "filter"
+                                       :display-name "Filter"
+                                       :type         :dimension
+                                       :dimension    [:field (mt/id :products :category) nil]
+                                       :widget-type  :category
+                                       :default      ["Gizmo" "Gadget"]
+                                       :required     false}}}}}
          :model/Dashboard {dashboard-id :id} {:parameters [{:name    "category"
                                                             :slug    "category"
                                                             :id      "abc123"
@@ -156,7 +157,7 @@
                                                                        :target       [:dimension [:template-tag "filter"]]}]}]
         (testing "Sanity check: running Card query should use Card defaults"
           (is (= [["Gadget"] ["Gizmo"]]
-                 (mt/rows (qp.card-test/run-query-for-card card-id)))))
+                 (mt/rows (qp.card-test/run-query-for-card card)))))
         (testing "No value specified: should prefer Card defaults"
           (is (= [["Gadget"] ["Gizmo"]]
                  (mt/rows (run-query-for-dashcard dashboard-id card-id dashcard-id)))))
@@ -226,17 +227,18 @@
   (testing "If both Dashboard and Card have default values for a raw value parameter, Card defaults should take precedence\n"
     (mt/dataset test-data
       (mt/with-temp
-        [:model/Card {card-id :id} {:dataset_query {:database (mt/id)
-                                                    :type     :native
-                                                    :native   {:query "SELECT {{filter}}"
-                                                               :template-tags
-                                                               {"filter"
-                                                                {:id           "f0774ef5-a14a-e181-f557-2d4bb1fc94ae"
-                                                                 :name         "filter"
-                                                                 :display-name "Filter"
-                                                                 :type         "text"
-                                                                 :required     true
-                                                                 :default      "Foo"}}}}}
+        [:model/Card {card-id :id, :as card}
+         {:dataset_query {:database (mt/id)
+                          :type     :native
+                          :native   {:query "SELECT {{filter}}"
+                                     :template-tags
+                                     {"filter"
+                                      {:id           "f0774ef5-a14a-e181-f557-2d4bb1fc94ae"
+                                       :name         "filter"
+                                       :display-name "Filter"
+                                       :type         "text"
+                                       :required     true
+                                       :default      "Foo"}}}}}
          :model/Dashboard {dashboard-id :id} {:parameters [{:name    "Text"
                                                             :slug    "text"
                                                             :id      "5791ff38"
@@ -249,7 +251,7 @@
                                                                        :target       [:variable [:template-tag "filter"]]}]}]
         (testing "Sanity check: running Card query should use Card defaults"
           (is (= [["Foo"]]
-                 (mt/rows (qp.card-test/run-query-for-card card-id)))))
+                 (mt/rows (qp.card-test/run-query-for-card card)))))
         (testing "No value specified: should prefer Card defaults"
           (is (= [["Foo"]]
                  (mt/rows (run-query-for-dashcard dashboard-id card-id dashcard-id)))))

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -20,20 +20,26 @@
   ;; stuff doesn't belong in the Dashboard QP namespace
   (mt/as-admin
     (apply qp.dashboard/process-query-for-dashcard
-           :dashboard-id dashboard-id
-           :card-id      card-id
-           :dashcard-id  dashcard-id
+           :dashboard (t2/select-one :model/Dashboard :id dashboard-id)
+           :card      (t2/select-one :model/Card :id card-id)
+           :dashcard  (t2/select-one :model/DashboardCard :id dashcard-id)
            :make-run     (constantly
                           (fn run [query info]
                             (qp/process-query (assoc query :info info))))
            options)))
+
+(defn- resolve-params-for-query [dashboard-id card-id dashcard-id params]
+  (#'qp.dashboard/resolve-params-for-query (t2/select-one :model/Dashboard :id dashboard-id)
+                                           (t2/select-one :model/DashboardCard :id dashcard-id)
+                                           card-id
+                                           params))
 
 (deftest ^:parallel resolve-parameters-validation-test
   (api.dashboard-test/with-chain-filter-fixtures [{{dashboard-id :id} :dashboard
                                                    {card-id :id}      :card
                                                    {dashcard-id :id}  :dashcard}]
     (letfn [(resolve-params [params]
-              (#'qp.dashboard/resolve-params-for-query dashboard-id card-id dashcard-id params))]
+              (resolve-params-for-query dashboard-id card-id dashcard-id params))]
       (testing "Valid parameters"
         (is (= [{:type   :category
                  :id     "_PRICE_"
@@ -77,7 +83,7 @@
                      :type :number/=
                      :value [4]
                      :target [:variable [:template-tag "qty_locked"]]}]
-                   (#'qp.dashboard/resolve-params-for-query dashboard-id card-id dashcard-id params)))
+                   (resolve-params-for-query dashboard-id card-id dashcard-id params)))
             ;; test the full query with two different values to ensure it is actually used
             (is (= [[2391]]
                    (mt/rows

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -510,7 +510,7 @@
 
 (deftest different-filters-update-result-metadata-test
   ;; When the query itself changes (different filter baked in), result_metadata should update.
-  (mt/with-temp [:model/Card {card-id :id, :as card}
+  (mt/with-temp [:model/Card {card-id :id}
                  {:dataset_query   (mt/mbql-query orders
                                      {:aggregation [[:count] [:sum $total]]
                                       :breakout    [$product_id]})
@@ -524,7 +524,7 @@
                                            :filter      [:= $product_id product-id]})})
             (mt/as-admin
               (qp/process-query-for-card
-               card :api
+               (t2/select-one :model/Card card-id) :api
                :make-run (constantly
                           (fn [query info]
                             (qp/process-query (assoc query :info info))))))

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -510,7 +510,7 @@
 
 (deftest different-filters-update-result-metadata-test
   ;; When the query itself changes (different filter baked in), result_metadata should update.
-  (mt/with-temp [:model/Card {card-id :id}
+  (mt/with-temp [:model/Card {card-id :id, :as card}
                  {:dataset_query   (mt/mbql-query orders
                                      {:aggregation [[:count] [:sum $total]]
                                       :breakout    [$product_id]})
@@ -524,7 +524,7 @@
                                            :filter      [:= $product_id product-id]})})
             (mt/as-admin
               (qp/process-query-for-card
-               (t2/select-one :model/Card :id card-id) :api
+               card :api
                :make-run (constantly
                           (fn [query info]
                             (qp/process-query (assoc query :info info))))))
@@ -547,7 +547,7 @@
 (deftest parameterized-queries-do-not-thrash-result-metadata-test
   ;; When parameters are applied via :parameters, result_metadata should not be updated.
   ;; See QUE2-502 for details.
-  (mt/with-temp [:model/Card {card-id :id}
+  (mt/with-temp [:model/Card {card-id :id, :as card}
                  {:dataset_query   (mt/mbql-query orders
                                      {:aggregation [[:count] [:sum $total]]
                                       :breakout    [$product_id]})
@@ -558,7 +558,7 @@
             (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
               (mt/as-admin
                 (qp/process-query-for-card
-                 (t2/select-one :model/Card :id card-id) :api
+                 card :api
                  :parameters [{:id     "product-id-param"
                                :type   :id
                                :target [:dimension (mt/$ids orders $product_id)]

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -524,7 +524,7 @@
                                            :filter      [:= $product_id product-id]})})
             (mt/as-admin
               (qp/process-query-for-card
-               card-id :api
+               (t2/select-one :model/Card :id card-id) :api
                :make-run (constantly
                           (fn [query info]
                             (qp/process-query (assoc query :info info))))))
@@ -558,7 +558,7 @@
             (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
               (mt/as-admin
                 (qp/process-query-for-card
-                 card-id :api
+                 (t2/select-one :model/Card :id card-id) :api
                  :parameters [{:id     "product-id-param"
                                :type   :id
                                :target [:dimension (mt/$ids orders $product_id)]

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -824,12 +824,11 @@
   (testing "Dashcard parameter mappings have valid targets when X-raying models (#58214)"
     (mt/dataset test-data
       (mt/with-temp
-        [:model/Card {model-id :id} {:table_id      (mt/id :orders)
-                                     :dataset_query (mt/mbql-query orders)
-                                     :type          :model}]
-        (is (vector? (-> (qp.card-test/run-query-for-card model-id) :data :results_metadata :columns)))
-        (let [model-card (t2/select-one :model/Card model-id)
-              dashboard (magic/automagic-analysis model-card nil)
+        [:model/Card model-card {:table_id      (mt/id :orders)
+                                 :dataset_query (mt/mbql-query orders)
+                                 :type          :model}]
+        (is (vector? (-> (qp.card-test/run-query-for-card model-card) :data :results_metadata :columns)))
+        (let [dashboard (magic/automagic-analysis model-card nil)
               parameter-mappings (eduction (comp (keep :parameter_mappings) cat) (:dashcards dashboard))
               dimension? (mr/validator ::mbql.s/dimension)]
           (is (every? (comp dimension? :target) parameter-mappings)))))))


### PR DESCRIPTION
Changes:
- Makes `qp.card` and `qp.dashboard` accept already fetched cards, dashcards, and the dashboard. Removes `t2` dependency in certain namespaces.
- Updates call sites to pass already loaded entities or fetch them in place, avoiding duplicate `t2/select-one` calls.

Dashboard card query endpoint:
```
  ┌─────┬────────┬──────────────────────┬──────────────────────────────────────────────────────┬───────┐
  │  #  │   Op   │        Table         │                         Why                          │ Count │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 1   │ SELECT │ report_dashboard     │ endpoint loads the dashboard                         │ 1     │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 2   │ SELECT │ report_dashboardcard │ endpoint loads the dashcard                          │ 1     │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 3   │ SELECT │ report_card          │ endpoint loads the card                              │ 1     │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 4   │ SELECT │ metabase_field       │ QP metadata provider (card's fields, one batched IN) │ 1     │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 5   │ SELECT │ metabase_database    │ QP metadata provider (card's database)               │ 1     │
  ├─────┼────────┼──────────────────────┼──────────────────────────────────────────────────────┼───────┤
  │ 6   │ SELECT │ cache_config         │ cache-strategy lookup                                │ 1     │
  └─────┴────────┴──────────────────────┴──────────────────────────────────────────────────────┴───────┘
```