### PR TITLE
Add Kondo linter to check for empty `testing` forms

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -61,6 +61,7 @@
   :metabase/check-def-check-not-uppercase-name               {:level :warning}
   :metabase/check-def-no-underscores                         {:level :warning}
   :metabase/check-me-humanize                                {:level :warning}
+  :metabase/check-testing-not-empty                          {:level :warning}
   :metabase/defsetting-must-specify-export                   {:level :warning}
   :metabase/defsetting-namespace                             {:level :warning}
   :metabase/discourage-millis-duration                       {:level :warning}
@@ -538,6 +539,7 @@
  {:analyze-call
   {cljs.test/deftest                                                                                                         hooks.clojure.test/deftest
    cljs.test/is                                                                                                              hooks.clojure.test/is
+   cljs.test/testing                                                                                                         hooks.clojure.test/testing
    cljs.test/use-fixtures                                                                                                    hooks.clojure.test/use-fixtures
    clojure.core/def                                                                                                          hooks.clojure.core.def/lint-def
    clojure.core/definterface                                                                                                 hooks.clojure.core.def/lint-def
@@ -556,6 +558,7 @@
    clojure.core/-                                                                                                            hooks.metabase.util.timing/discourage-millis-duration
    clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
    clojure.test/is                                                                                                           hooks.clojure.test/is
+   clojure.test/testing                                                                                                      hooks.clojure.test/testing
    clojure.test/use-fixtures                                                                                                 hooks.clojure.test/use-fixtures
    malli.error/humanize                                                                                                      hooks.malli.error/humanize
    metabase-enterprise.advanced-permissions.models.permissions.application-permissions-test/with-new-group-and-current-graph hooks.common/with-two-top-level-bindings

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -224,26 +224,38 @@
 
               nil)))))))
 
-(defn is [{:keys [node lang]}]
+(defn is [{:keys [node lang], :as input}]
   (when (= lang :cljs)
     (warn-about-missing-test-expr-requires-in-cljs node))
-  {:node node})
+  input)
 
 (defn use-fixtures
   "Flag `:parallel/unsafe` forms inside fixtures. Skipped when the surrounding
-   namespace is marked `^:synchronous` -- the ns marker is the author's
-   explicit opt-in to a single-threaded test ns where destructive setup is
-   safe. Without that opt-in, kondo can't know whether sibling deftests will
-   be `^:parallel`, so the conservative default is to flag.
+  namespace is marked `^:synchronous` -- the ns marker is the author's
+  explicit opt-in to a single-threaded test ns where destructive setup is
+  safe. Without that opt-in, kondo can't know whether sibling deftests will
+  be `^:parallel`, so the conservative default is to flag.
 
-   Sister to [[deftest-check-parallel]]: the deftest hook rejects `^:parallel`
-   tests inside a `^:synchronous` ns, so the two checks together form a
-   coherent opt-in: either the whole ns is synchronous (fixtures can be
-   anything; no parallel tests allowed) or it isn't (fixtures must be
-   parallel-safe)."
-  [{:keys [node config], ns-sym :ns}]
+  Sister to [[deftest-check-parallel]]: the deftest hook rejects `^:parallel`
+  tests inside a `^:synchronous` ns, so the two checks together form a
+  coherent opt-in: either the whole ns is synchronous (fixtures can be
+  anything; no parallel tests allowed) or it isn't (fixtures must be
+  parallel-safe)."
+  [{:keys [node config], ns-sym :ns, :as input}]
   (when-not (:synchronous (meta ns-sym))
     (let [linter-config (get-in config [:linters :metabase/validate-deftest])]
       (doseq [form (rest (:children node))]
         (warn-about-disallowed-parallel-forms form linter-config))))
-  {:node node})
+  input)
+
+(defn testing
+  "Check that we don't have an empty `testing` form like
+
+    (testing \"message\")"
+  [{{[_testing _message & body] :children, :as node} :node, :as input}]
+  (when (empty? body)
+    (hooks/reg-finding!
+     (assoc (meta node)
+            :message "A `testing` form that doesn't wrap anything doesn't do anything"
+            :type    :metabase/check-testing-not-empty)))
+  input)

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -7,7 +7,7 @@
    [metabase-enterprise.action-v2.coerce :as coerce]
    [metabase.test :as mt]))
 
-(deftest coercion-conversions-test
+(deftest ^:parallel coercion-conversions-test
   (mt/with-clock #t "2000-01-01T00:00:00Z"
     (let [test-cases
           [{:strategy :Coercion/UNIXSeconds->DateTime
@@ -59,9 +59,12 @@
                   (format "Roundtrip conversion failed for %s: %s -> %s -> %s"
                           strategy input (in input) (out (in input)))))))))))
 
-(deftest coercion-fns-static-test
+(deftest ^:parallel coercion-fns-static-test
   (testing "all coercion pair have to have an in and out function"
-    (testing (every? #(and (fn? (:in %)) (fn? (:out %))) coerce/coercion-fns)))
+    (doseq [[k {:keys [in out]}] coerce/coercion-fns]
+      (testing k
+        (is (ifn? in) :in)
+        (is (ifn? out) :out))))
   ;; TODO: fix this test by implementing all strategies
   (let [implemented (set (keys coerce/coercion-fns))
         expected-fns (into #{} (filter (comp #{"Coercion"} namespace)) (descendants :Coercion/*))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -63,8 +63,8 @@
   (testing "all coercion pair have to have an in and out function"
     (doseq [[k {:keys [in out]}] coerce/coercion-fns]
       (testing k
-        (is (ifn? in) ":in")
-        (is (ifn? out) ":out"))))
+        (is (or (fn? in) (fn? @in)) ":in")
+        (is (or (fn? out) (fn? @in)) ":out"))))
   ;; TODO: fix this test by implementing all strategies
   (let [implemented (set (keys coerce/coercion-fns))
         expected-fns (into #{} (filter (comp #{"Coercion"} namespace)) (descendants :Coercion/*))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -63,8 +63,8 @@
   (testing "all coercion pair have to have an in and out function"
     (doseq [[k {:keys [in out]}] coerce/coercion-fns]
       (testing k
-        (is (ifn? in) :in)
-        (is (ifn? out) :out))))
+        (is (ifn? in) ":in")
+        (is (ifn? out) ":out"))))
   ;; TODO: fix this test by implementing all strategies
   (let [implemented (set (keys coerce/coercion-fns))
         expected-fns (into #{} (filter (comp #{"Coercion"} namespace)) (descendants :Coercion/*))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -39,10 +39,10 @@
 
                              "the API"
                              api-test-db-perms}]
-      (testing (str message "\n"))
-      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
-        (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
-        (is (nil? (perms group-id)))))))
+      (testing (str message "\n")
+        (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
+          (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
+          (is (nil? (perms group-id))))))))
 
 (defn- grant-block-perms! [group-id]
   (data-perms.graph/update-data-perms-graph!

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -1204,45 +1204,45 @@
               (is (true? (:is_remote_synced (t2/select-one :model/Collection :id coll-id)))))))))))
 
 (deftest create-branch
-  (testing "POST /api/ee/remote-sync/create-branch creates a new branch")
-  (let [mock-source (test-helpers/create-mock-source)]
-    (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
-                                       remote-sync-token "test-token"
-                                       remote-sync-branch "main"
-                                       remote-sync-type :read-write]
-      (mt/with-dynamic-fn-redefs [source/source-from-settings (constantly mock-source)]
-        (is (= {:status "success"
-                :message "Branch 'feature-branch' created from 'main'"}
-               (mt/user-http-request :crowberto :post 200 "ee/remote-sync/create-branch"
-                                     {:name "feature-branch"})))
-        (is (= #{["main" "main-ref"] ["develop" "develop-ref"] ["feature-branch" "feature-branch-ref"]}
-               (set (source.p/branches mock-source))))
-        (is (= "feature-branch" (settings/remote-sync-branch)))))))
-
-(deftest stash
-  (testing "POST /api/ee/remote-sync/stash")
-  (let [mock-source (test-helpers/create-mock-source)
-        export-calls (atom 0)]
-    (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
-                                       remote-sync-token "test-token"
-                                       remote-sync-branch "main"
-                                       remote-sync-type :read-write]
-      (mt/with-temp [:model/RemoteSyncObject remote-sync {:model_type "Card"
-                                                          :model_id 1
-                                                          :model_name "Test Card"
-                                                          :model_collection_id 1
-                                                          :status "updated"
-                                                          :status_changed_at (java.time.OffsetDateTime/now)}]
-        (mt/with-dynamic-fn-redefs [source/source-from-settings (constantly mock-source)
-                                    impl/async-export!          (fn [_ _ _ & _opts] (assoc remote-sync :calls (swap! export-calls inc)))]
-          (is (=? {:status "success"
-                   :message "Stashing to feature-branch"}
-                  (mt/user-http-request :crowberto :post 200 "ee/remote-sync/stash"
-                                        {:new_branch "feature-branch"
-                                         :message "Stash message"})))
+  (testing "POST /api/ee/remote-sync/create-branch creates a new branch"
+    (let [mock-source (test-helpers/create-mock-source)]
+      (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                         remote-sync-token "test-token"
+                                         remote-sync-branch "main"
+                                         remote-sync-type :read-write]
+        (mt/with-dynamic-fn-redefs [source/source-from-settings (constantly mock-source)]
+          (is (= {:status  "success"
+                  :message "Branch 'feature-branch' created from 'main'"}
+                 (mt/user-http-request :crowberto :post 200 "ee/remote-sync/create-branch"
+                                       {:name "feature-branch"})))
           (is (= #{["main" "main-ref"] ["develop" "develop-ref"] ["feature-branch" "feature-branch-ref"]}
                  (set (source.p/branches mock-source))))
-          (is (= 1 @export-calls)))))))
+          (is (= "feature-branch" (settings/remote-sync-branch))))))))
+
+(deftest stash
+  (testing "POST /api/ee/remote-sync/stash"
+    (let [mock-source  (test-helpers/create-mock-source)
+          export-calls (atom 0)]
+      (mt/with-temporary-setting-values [remote-sync-url "https://github.com/test/repo.git"
+                                         remote-sync-token "test-token"
+                                         remote-sync-branch "main"
+                                         remote-sync-type :read-write]
+        (mt/with-temp [:model/RemoteSyncObject remote-sync {:model_type          "Card"
+                                                            :model_id            1
+                                                            :model_name          "Test Card"
+                                                            :model_collection_id 1
+                                                            :status              "updated"
+                                                            :status_changed_at   (java.time.OffsetDateTime/now)}]
+          (mt/with-dynamic-fn-redefs [source/source-from-settings (constantly mock-source)
+                                      impl/async-export!          (fn [_ _ _ & _opts] (assoc remote-sync :calls (swap! export-calls inc)))]
+            (is (=? {:status  "success"
+                     :message "Stashing to feature-branch"}
+                    (mt/user-http-request :crowberto :post 200 "ee/remote-sync/stash"
+                                          {:new_branch "feature-branch"
+                                           :message    "Stash message"})))
+            (is (= #{["main" "main-ref"] ["develop" "develop-ref"] ["feature-branch" "feature-branch-ref"]}
+                   (set (source.p/branches mock-source))))
+            (is (= 1 @export-calls))))))))
 
 ;;; ------------------------------------------------- Has Remote Changes Endpoint -------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -810,12 +810,12 @@
               ;; ensuring field ids are stable by loading dataset in db first
               (mt/db)
               (mt/$ids nil
-                (testing "Column ids are different in different dbs")
-                (is (not= {:people.name       %people.name
-                           :orders.user_id    %orders.user_id
-                           :products.title    %products.title
-                           :orders.product_id %orders.product_id}
-                          @old-ids))
+                (testing "Column ids are different in different dbs"
+                  (is (not= {:people.name       %people.name
+                             :orders.user_id    %orders.user_id
+                             :products.title    %products.title
+                             :orders.product_id %orders.product_id}
+                            @old-ids)))
                 (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir))
                 (let [viz (t2/select-one-fn :visualization_settings :model/Card :entity_id (:entity_id @card1s))]
                   (testing "column names inside pivot table transferred"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -338,30 +338,30 @@
             (is (str/starts-with? result "SELECT"))))))))
 
 (deftest describe-table-works-without-get-table-metadata-permission-test
-  (testing "`describe-table` works if the AWS user's IAM policy doesn't include athena:GetTableMetadata permissions")
-  (mt/test-driver :athena
-    (mt/dataset airports
-      (let [catalog "AwsDataCatalog" ; The bug only happens when :catalog is not nil
-            details (assoc (:details (mt/db))
-                           ;; these credentials are for a user that doesn't have athena:GetTableMetadata permissions
-                           :access_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-access-key)
-                           :secret_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-secret-key)
-                           :catalog catalog)]
-        (mt/with-temp [:model/Database db {:engine :athena, :details details}]
-          (sync/sync-database! db {:scan :schema})
-          (let [table (t2/select-one :model/Table :db_id (:id db) :name "airport")]
-            (testing "Check that .getColumns returns no results, meaning the athena JDBC driver still has a bug"
-              ;; If this test fails and .getColumns returns results, the athena JDBC driver has been fixed and we can
-              ;; undo the changes in https://github.com/metabase/metabase/pull/44032
-              (is (empty? (sql-jdbc.execute/do-with-connection-with-options
-                           :athena
-                           db
-                           nil
-                           (fn [^java.sql.Connection conn]
-                             (let [metadata (.getMetaData conn)]
-                               (#'athena/get-columns metadata catalog (:schema table) (:name table))))))))
-            (testing "`describe-table` returns the fields anyway"
-              (is (not-empty (:fields (driver/describe-table :athena db table)))))))))))
+  (testing "`describe-table` works if the AWS user's IAM policy doesn't include athena:GetTableMetadata permissions"
+    (mt/test-driver :athena
+      (mt/dataset airports
+        (let [catalog "AwsDataCatalog" ; The bug only happens when :catalog is not nil
+              details (assoc (:details (mt/db))
+                             ;; these credentials are for a user that doesn't have athena:GetTableMetadata permissions
+                             :access_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-access-key)
+                             :secret_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-secret-key)
+                             :catalog catalog)]
+          (mt/with-temp [:model/Database db {:engine :athena, :details details}]
+            (sync/sync-database! db {:scan :schema})
+            (let [table (t2/select-one :model/Table :db_id (:id db) :name "airport")]
+              (testing "Check that .getColumns returns no results, meaning the athena JDBC driver still has a bug"
+                ;; If this test fails and .getColumns returns results, the athena JDBC driver has been fixed and we can
+                ;; undo the changes in https://github.com/metabase/metabase/pull/44032
+                (is (empty? (sql-jdbc.execute/do-with-connection-with-options
+                             :athena
+                             db
+                             nil
+                             (fn [^java.sql.Connection conn]
+                               (let [metadata (.getMetaData conn)]
+                                 (#'athena/get-columns metadata catalog (:schema table) (:name table))))))))
+              (testing "`describe-table` returns the fields anyway"
+                (is (not-empty (:fields (driver/describe-table :athena db table))))))))))))
 
 (deftest describe-table-falls-back-to-describe-on-duplicate-jdbc-columns-test
   (testing "`describe-table-fields` uses DESCRIBE if the JDBC driver returns duplicate column names (#58441, GHY-3273)"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -938,17 +938,17 @@
                                       "decimal_col"    (bigdec decimal-val)
                                       "bignumeric_col" (bigdec bignumeric-val)
                                       "bigdecimal_col" (bigdec bigdecimal-val)}]
-              (testing (format "filtering against %s" col-nm))
-              (is (= 1
-                     (-> (mt/first-row
-                          (mt/run-mbql-query nil
-                            {:source-table (mt/id tbl-nm)
-                             :aggregation  [[:count]]
-                             :parameters   [{:name   col-nm
-                                             :type   :number/=
-                                             :target [:field (mt/id tbl-nm col-nm)]
-                                             :value  [param-v]}]}))
-                         first))))))))))
+              (testing (format "filtering against %s" col-nm)
+                (is (= 1
+                       (-> (mt/first-row
+                            (mt/run-mbql-query nil
+                              {:source-table (mt/id tbl-nm)
+                               :aggregation  [[:count]]
+                               :parameters   [{:name   col-nm
+                                               :type   :number/=
+                                               :target [:field (mt/id tbl-nm col-nm)]
+                                               :value  [param-v]}]}))
+                           first)))))))))))
 
 (deftest sync-table-with-array-test
   (mt/test-driver

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -24,11 +24,11 @@
 
 (deftest ^:parallel query->collection-name-test
   (testing "query->collection-name"
-    (testing "should be able to extract :collection from :source-query")
-    (is (= "checkins"
-           (#'mongo.qp/query->collection-name {:query {:source-query
-                                                       {:collection "checkins"
-                                                        :native     []}}})))
+    (testing "should be able to extract :collection from :source-query"
+      (is (= "checkins"
+             (#'mongo.qp/query->collection-name {:query {:source-query
+                                                         {:collection "checkins"
+                                                          :native     []}}}))))
     (testing "should work for nested-nested queries"
       (is (= "checkins"
              (#'mongo.qp/query->collection-name {:query {:source-query {:source-query

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -183,34 +183,34 @@
 (deftest ^:parallel dont-add-top-clauses-for-top-level-test
   (mt/test-driver :sqlserver
     (testing (str "We don't need to add TOP clauses for top-level order by. Normally we always add one anyway because "
-                  "of the max-results stuff, but make sure our impl doesn't add one when it's not in the source MBQL"))
-    ;; in order to actually see how things would work without the implicit max-results limit added we'll preprocess
-    ;; the query, strip off the `:limit` that got added, and then feed it back to the QP where we left off
-    (let [preprocessed (-> (mt/mbql-query venues
-                             {:source-query {:source-table $$venues
-                                             :fields       [$name]
-                                             :order-by     [[:asc $id]]}
-                              :order-by     [[:asc $id]]})
-                           qp.preprocess/preprocess
-                           (lib/limit nil))]
-      (mt/with-metadata-provider (mt/id)
-        (is (= {:query  ["SELECT"
-                         "  \"__mb_source\".\"name\" AS \"name\""
-                         "FROM"
-                         "  ("
-                         "    SELECT"
-                         "      TOP(1048575) \"dbo\".\"venues\".\"name\" AS \"name\""
-                         "    FROM"
-                         "      \"dbo\".\"venues\""
-                         "    ORDER BY"
-                         "      \"dbo\".\"venues\".\"id\" ASC"
-                         "  ) AS \"__mb_source\""
-                         "ORDER BY"
-                         "  \"__mb_source\".\"id\" ASC"]
-                :params nil}
-               (-> (driver/mbql->native :sqlserver preprocessed)
-                   (update :query (fn [sql]
-                                    (str/split-lines (driver/prettify-native-form :sqlserver sql)))))))))))
+                  "of the max-results stuff, but make sure our impl doesn't add one when it's not in the source MBQL")
+      ;; in order to actually see how things would work without the implicit max-results limit added we'll preprocess
+      ;; the query, strip off the `:limit` that got added, and then feed it back to the QP where we left off
+      (let [preprocessed (-> (mt/mbql-query venues
+                               {:source-query {:source-table $$venues
+                                               :fields       [$name]
+                                               :order-by     [[:asc $id]]}
+                                :order-by     [[:asc $id]]})
+                             qp.preprocess/preprocess
+                             (lib/limit nil))]
+        (mt/with-metadata-provider (mt/id)
+          (is (= {:query  ["SELECT"
+                           "  \"__mb_source\".\"name\" AS \"name\""
+                           "FROM"
+                           "  ("
+                           "    SELECT"
+                           "      TOP(1048575) \"dbo\".\"venues\".\"name\" AS \"name\""
+                           "    FROM"
+                           "      \"dbo\".\"venues\""
+                           "    ORDER BY"
+                           "      \"dbo\".\"venues\".\"id\" ASC"
+                           "  ) AS \"__mb_source\""
+                           "ORDER BY"
+                           "  \"__mb_source\".\"id\" ASC"]
+                  :params nil}
+                 (-> (driver/mbql->native :sqlserver preprocessed)
+                     (update :query (fn [sql]
+                                      (str/split-lines (driver/prettify-native-form :sqlserver sql))))))))))))
 
 (deftest ^:parallel max-results-should-actually-work-test
   (mt/test-driver :sqlserver

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -580,11 +580,11 @@
   (testing "query_executions"
     (let [{:keys [query_executions query_executions_24h]} (#'stats/->snowplow-grouped-metric-info)]
       (doseq [k (keys query_executions)]
-        (testing (str "> key " k))
-        (is (contains? query_executions_24h k))
-        (is (not (< (get query_executions k)
-                    (get query_executions_24h k)))
-            "There are never more query executions in the 24h version than all-of-time.")))))
+        (testing (str "> key " k)
+          (is (contains? query_executions_24h k))
+          (is (not (< (get query_executions k)
+                      (get query_executions_24h k)))
+              "There are never more query executions in the 24h version than all-of-time."))))))
 
 (deftest snowplow-setting-tests
   (testing "snowplow formated settings"

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -1129,11 +1129,11 @@
                   (testing "the persist-models-enabled is assoced back to options"
                     (is (= {:options  "{\"persist-models-enabled\":true}"
                             :settings {:database-enable-actions true}}
-                           (t2/select-one [:model/Database :settings :options] success-id)))
+                           (t2/select-one [:model/Database :settings :options] success-id))))
+                  (testing "if settings doesn't have :persist-models-enabled, then options is empty map"
                     (is (= {:options  nil
                             :settings {:database-enable-actions true}}
-                           (t2/select-one [:model/Database :settings :options] empty-options-id))))
-                  (testing "if settings doesn't have :persist-models-enabled, then options is empty map"))))))]
+                           (t2/select-one [:model/Database :settings :options] empty-options-id)))))))))]
     (do-test false)
     (encryption-test/with-secret-key "dont-tell-anyone-about-this"
       (do-test true))))
@@ -1688,31 +1688,31 @@
           (is (not (contains? card-revision-object "type")))
           (is (not (contains? model-revision-object "type"))))))))
 
-(deftest ^:mb/old-migrations-test card-revision-add-type-null-character-test
-  (testing "CardRevisionAddType migration works even if there's a null character in revision.object (metabase#40835)")
-  (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
-    (let [user-id          (:id (new-instance-with-default :core_user))
-          db-id            (:id (new-instance-with-default :metabase_database))
-          card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
-          viz-settings     "{\"table.pivot_column\":\"\u0000..\\u0000\"}" ; note the escaped and unescaped null characters
-          card-revision-id (:id (new-instance-with-default :revision
-                                                           {:object    (json/encode
-                                                                        (assoc (dissoc card :type)
-                                                                               :visualization_settings viz-settings))
-                                                            :model     "Card"
-                                                            :model_id  (:id card)
-                                                            :user_id   user-id}))]
-      (testing "sanity check revision object"
-        (let [card-revision-object (t2/select-one-fn (comp json/decode :object) :revision card-revision-id)]
-          (testing "doesn't have type"
-            (is (not (contains? card-revision-object "type"))))))
-      (testing "after migration card revisions should have type"
-        (migrate!)
-        (let [card-revision-object  (t2/select-one-fn (comp json/decode :object) :revision card-revision-id)]
-          (is (= "question" (get card-revision-object "type")))
-          (testing "original visualization_settings should be preserved"
-            (is (= viz-settings
-                   (get card-revision-object "visualization_settings")))))))))
+(deftest ^:mb/old-migrations-test card-revision-add-type-null-character-
+  (testing "CardRevisionAddType migration works even if there's a null character in revision.object (metabase#40835)"
+    (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
+      (let [user-id          (:id (new-instance-with-default :core_user))
+            db-id            (:id (new-instance-with-default :metabase_database))
+            card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
+            viz-settings     "{\"table.pivot_column\":\"\u0000..\\u0000\"}" ; note the escaped and unescaped null characters
+            card-revision-id (:id (new-instance-with-default :revision
+                                                             {:object   (json/encode
+                                                                         (assoc (dissoc card :type)
+                                                                                :visualization_settings viz-settings))
+                                                              :model    "Card"
+                                                              :model_id (:id card)
+                                                              :user_id  user-id}))]
+        (testing "sanity check revision object"
+          (let [card-revision-object (t2/select-one-fn (comp json/decode :object) :revision card-revision-id)]
+            (testing "doesn't have type"
+              (is (not (contains? card-revision-object "type"))))))
+        (testing "after migration card revisions should have type"
+          (migrate!)
+          (let [card-revision-object (t2/select-one-fn (comp json/decode :object) :revision card-revision-id)]
+            (is (= "question" (get card-revision-object "type")))
+            (testing "original visualization_settings should be preserved"
+              (is (= viz-settings
+                     (get card-revision-object "visualization_settings"))))))))))
 
 (deftest ^:mb/old-migrations-test delete-scan-field-values-trigger-test
   (testing "We should delete the triggers for DBs that are configured not to scan their field values\n"

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -1688,7 +1688,7 @@
           (is (not (contains? card-revision-object "type")))
           (is (not (contains? model-revision-object "type"))))))))
 
-(deftest ^:mb/old-migrations-test card-revision-add-type-null-character-
+(deftest ^:mb/old-migrations-test card-revision-add-type-null-character-test
   (testing "CardRevisionAddType migration works even if there's a null character in revision.object (metabase#40835)"
     (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
       (let [user-id          (:id (new-instance-with-default :core_user))

--- a/test/metabase/dashboards/models/dashboard_test.clj
+++ b/test/metabase/dashboards/models/dashboard_test.clj
@@ -182,11 +182,11 @@
              (mi/can-read? dash)))))
     (testing (str "Check that if a Dashboard is in a Collection, someone who would otherwise be able to see it under "
                   "the old artifact-permissions regime will *NOT* be able to see it if they don't have permissions for "
-                  "that Collection"))
-    (mt/with-full-data-perms-for-all-users!
-      (binding [api/*current-user-permissions-set* (atom #{})]
-        (is (= false
-               (mi/can-read? dash)))))
+                  "that Collection")
+      (mt/with-full-data-perms-for-all-users!
+        (binding [api/*current-user-permissions-set* (atom #{})]
+          (is (= false
+                 (mi/can-read? dash))))))
     (testing "Do we have *write* Permissions for a Dashboard if we have *write* Permissions for the Collection its in?"
       (binding [api/*current-user-permissions-set* (atom #{(perms/collection-readwrite-path collection)})]
         (mi/can-write? dash)))))

--- a/test/metabase/internal_stats/query_executions_test.clj
+++ b/test/metabase/internal_stats/query_executions_test.clj
@@ -93,33 +93,33 @@
                       (-> before :query-executions-24h :interactive_embed)))))))))
 
 (deftest query-execution-last-utc-day-test
-  (testing "count query exeuections over the previous utc day")
-  (t/with-clock (t/mock-clock 1583351015000)
-    (let [yesterday-defaults (assoc query-execution-defaults
-                                    :started_at (-> (t/offset-date-time (t/zone-offset "+00"))
-                                                    (t/minus (t/days 1))))]
-      (mt/with-temp [:model/User           u {}
-                     :model/QueryExecution _ yesterday-defaults
-                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-sdk-react")
-                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-simple")
-                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
-                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
-                     :model/QueryExecution _ (assoc yesterday-defaults
-                                                    :embedding_client "embedding-iframe"
-                                                    :executor_id (u/the-id u))
-                     :model/QueryExecution _ (assoc yesterday-defaults :context :public-question)
-                     :model/QueryExecution _ (assoc yesterday-defaults :context :public-csv-download)
-                     :model/QueryExecution _ query-execution-defaults
-                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
-                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-simple")
-                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
-                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
-        (is (= {:query_executions_sdk_embed 1,
-                :query_executions_simple_embed 1,
-                :query_executions_interactive_embed 1,
-                :query_executions_static_embed 2,
-                :query_executions_public_link 2,
-                :query_executions_internal 1}
-               (sut/query-execution-last-utc-day)))))))
+  (testing "count query exeuections over the previous utc day"
+    (t/with-clock (t/mock-clock 1583351015000)
+      (let [yesterday-defaults (assoc query-execution-defaults
+                                      :started_at (-> (t/offset-date-time (t/zone-offset "+00"))
+                                                      (t/minus (t/days 1))))]
+        (mt/with-temp [:model/User           u {}
+                       :model/QueryExecution _ yesterday-defaults
+                       :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-sdk-react")
+                       :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-simple")
+                       :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                       :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                       :model/QueryExecution _ (assoc yesterday-defaults
+                                                      :embedding_client "embedding-iframe"
+                                                      :executor_id (u/the-id u))
+                       :model/QueryExecution _ (assoc yesterday-defaults :context :public-question)
+                       :model/QueryExecution _ (assoc yesterday-defaults :context :public-csv-download)
+                       :model/QueryExecution _ query-execution-defaults
+                       :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                       :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-simple")
+                       :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                       :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                       :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                       :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
+          (is (= {:query_executions_sdk_embed         1
+                  :query_executions_simple_embed      1
+                  :query_executions_interactive_embed 1
+                  :query_executions_static_embed      2
+                  :query_executions_public_link       2
+                  :query_executions_internal          1}
+                 (sut/query-execution-last-utc-day))))))))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -723,37 +723,37 @@
 (deftest ^:parallel available-drill-thrus-test-9
   (testing (str "fk-filter should not get returned for non-fk column (#34440) "
                 "fk-details should not get returned for non-fk column (#34441) "
-                "underlying-records should only get shown once for aggregated query (#34439)"))
-  (lib.drill-thru.tu/test-drill-variants-with-merged-args
-   lib.drill-thru.tu/test-available-drill-thrus
-   "aggregated cell click on count column"
-   {:click-type  :cell
-    :query-type  :aggregated
-    :column-name "count"
-    :expected    [{:type :drill-thru/automatic-insights
-                   :dimensions [{:column {:name "PRODUCT_ID"}}
-                                {:column {:name "CREATED_AT"}}]}
-                  {:type      :drill-thru/quick-filter
-                   :operators [{:name "<"}
-                               {:name ">"}
-                               {:name "="}
-                               {:name "≠"}]}
-                  {:type       :drill-thru/underlying-records
-                   :row-count  77
-                   :table-name "Orders"}
-                  {:display-name "See this month by week"
-                   :type         :drill-thru/zoom-in.timeseries}]
-    ;; Underlying records and automatic insights are not supported for native.
-    ;; zoom-in.timeseries can't be because we don't know what unit (if any) it's currently bucketed by.
-    :native-drills #{:drill-thru/quick-filter}}
+                "underlying-records should only get shown once for aggregated query (#34439)")
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-available-drill-thrus
+     "aggregated cell click on count column"
+     {:click-type    :cell
+      :query-type    :aggregated
+      :column-name   "count"
+      :expected      [{:type       :drill-thru/automatic-insights
+                       :dimensions [{:column {:name "PRODUCT_ID"}}
+                                    {:column {:name "CREATED_AT"}}]}
+                      {:type      :drill-thru/quick-filter
+                       :operators [{:name "<"}
+                                   {:name ">"}
+                                   {:name "="}
+                                   {:name "≠"}]}
+                      {:type       :drill-thru/underlying-records
+                       :row-count  77
+                       :table-name "Orders"}
+                      {:display-name "See this month by week"
+                       :type         :drill-thru/zoom-in.timeseries}]
+      ;; Underlying records and automatic insights are not supported for native.
+      ;; zoom-in.timeseries can't be because we don't know what unit (if any) it's currently bucketed by.
+      :native-drills #{:drill-thru/quick-filter}}
 
-   "drill thrus are disabled for native queries with template-tag variables"
-   {:custom-native #(lib/with-native-query %
-                      "SELECT COUNT(*) FROM orders GROUP BY product_id HAVING product_id > {{mytag}}")
-    :native-drills #{}}
+     "drill thrus are disabled for native queries with template-tag variables"
+     {:custom-native #(lib/with-native-query %
+                        "SELECT COUNT(*) FROM orders GROUP BY product_id HAVING product_id > {{mytag}}")
+      :native-drills #{}}
 
-   "snippets and card tags are allowed"
-   {:custom-native #(lib/with-native-query % "SELECT COUNT(*) FROM {{#123-mycard}} GROUP BY {{snippet:mysnip}}")}))
+     "snippets and card tags are allowed"
+     {:custom-native #(lib/with-native-query % "SELECT COUNT(*) FROM {{#123-mycard}} GROUP BY {{snippet:mysnip}}")})))
 
 (deftest ^:parallel available-drill-thrus-test-10
   (testing (str "fk-filter should not get returned for non-fk column (#34440) "

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -232,18 +232,18 @@
 (deftest ^:parallel arithmetic-expression-type-of-test
   (testing "Make sure we can calculate correct type information for arithmetic expression"
     (let [field [:field {:lib/uuid (str (random-uuid))} (meta/id :venues :id)]]
-      (testing "+, -, and * should return common ancestor type of all args")
-      (doseq [tag   [:+ :- :*]
-              arg-2 [1 1.0]
-              :let  [clause [tag {:lib/uuid (str (random-uuid))} field arg-2]]]
-        (testing (str \newline (pr-str clause))
-          (testing "assume :type/Number for refs with unknown types (#29946)"
-            (is (= :type/Number
-                   (lib.schema.expression/type-of clause))))
-          (is (= (condp = arg-2
-                   1   :type/Integer
-                   1.0 :type/Float)
-                 (lib/type-of (lib.tu/venues-query) clause)))))
+      (testing "+, -, and * should return common ancestor type of all args"
+        (doseq [tag   [:+ :- :*]
+                arg-2 [1 1.0]
+                :let  [clause [tag {:lib/uuid (str (random-uuid))} field arg-2]]]
+          (testing (str \newline (pr-str clause))
+            (testing "assume :type/Number for refs with unknown types (#29946)"
+              (is (= :type/Number
+                     (lib.schema.expression/type-of clause))))
+            (is (= (condp = arg-2
+                     1   :type/Integer
+                     1.0 :type/Float)
+                   (lib/type-of (lib.tu/venues-query) clause))))))
       (testing "/ should always return type/Float"
         (doseq [arg-2 [1 1.0]
                 :let  [clause [:/ {:lib/uuid (str (random-uuid))} field arg-2]]]

--- a/test/metabase/lib/schema/common_test.cljc
+++ b/test/metabase/lib/schema/common_test.cljc
@@ -15,13 +15,12 @@
 
 (deftest ^:parallel normalize-base-type-test
   (testing "Support normalizing really messed up base types like `:type/creationtime` => `:type/CreationTime` (#63397)"
-    (testing (str "Don't do this normalization in dev, because it's a major bug and we shouldn't encourage people to"
-                  " write messed up code that needs this to be done to fix it")
-      #?(:clj
-         (is (thrown-with-msg?
-              clojure.lang.ExceptionInfo
-              #"Invalid output: \[\"Not a valid base type: :type/creationtime, got: :type/creationtime\"\]"
-              (lib/normalize ::lib.schema.common/base-type "type/creationtime")))))
+    #?(:clj (testing (str "Don't do this normalization in dev, because it's a major bug and we shouldn't encourage people to"
+                          " write messed up code that needs this to be done to fix it")
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"Invalid output: \[\"Not a valid base type: :type/creationtime, got: :type/creationtime\"\]"
+                   (lib/normalize ::lib.schema.common/base-type "type/creationtime")))))
     (testing "in prod (when Malli enforcement is off) we should be able to fix it"
       (mu/disable-enforcement
         (is (= :type/CreationTime

--- a/test/metabase/lib/walk/util_test.cljc
+++ b/test/metabase/lib/walk/util_test.cljc
@@ -12,29 +12,29 @@
 
 (deftest ^:parallel all-source-table-ids-test
   (testing (str "make sure that `all-table-ids` can properly find all Tables in the query, even in cases where a map "
-                "has a `:source-table` and some of its children also have a `:source-table`"))
-  (is (= (lib.tu.macros/$ids nil
-           #{$$checkins $$venues $$users $$categories})
-         (lib.walk.util/all-source-table-ids
-          (lib/query
-           meta/metadata-provider
-           (lib.tu.macros/mbql-query nil
-             {:source-table $$checkins
-              :joins        [{:source-table $$venues
-                              :alias        "V"
-                              :condition    [:=
-                                             $checkins.venue-id
-                                             &V.venues.id]}
-                             {:source-query {:source-table $$users
-                                             :joins        [{:source-table $$categories
-                                                             :alias        "Cat"
-                                                             :condition    [:=
-                                                                            $users.id
-                                                                            &Cat.categories.id]}]}
-                              :alias        "U"
-                              :condition    [:=
-                                             $checkins.user-id
-                                             &U.users.id]}]}))))))
+                "has a `:source-table` and some of its children also have a `:source-table`")
+    (is (= (lib.tu.macros/$ids nil
+             #{$$checkins $$venues $$users $$categories})
+           (lib.walk.util/all-source-table-ids
+            (lib/query
+             meta/metadata-provider
+             (lib.tu.macros/mbql-query nil
+               {:source-table $$checkins
+                :joins        [{:source-table $$venues
+                                :alias        "V"
+                                :condition    [:=
+                                               $checkins.venue-id
+                                               &V.venues.id]}
+                               {:source-query {:source-table $$users
+                                               :joins        [{:source-table $$categories
+                                                               :alias        "Cat"
+                                                               :condition    [:=
+                                                                              $users.id
+                                                                              &Cat.categories.id]}]}
+                                :alias        "U"
+                                :condition    [:=
+                                               $checkins.user-id
+                                               &U.users.id]}]})))))))
 
 (deftest ^:parallel all-field-ids-test
   (mu/disable-enforcement

--- a/test/metabase/product_feedback/task/follow_up_emails_test.clj
+++ b/test/metabase/product_feedback/task/follow_up_emails_test.clj
@@ -10,14 +10,14 @@
 
 (deftest send-follow-up-email-test
   (testing (str "Make sure that `send-follow-up-email!` only sends a single email instead even when triggered multiple "
-                "times (#4253) follow-up emails get sent to the oldest admin"))
-  (mt/with-temporary-setting-values [anon-tracking-enabled true
-                                     follow-up-email-sent  false]
-    (with-fake-inbox
-      (#'follow-up-emails/send-follow-up-email!)
-      (#'follow-up-emails/send-follow-up-email!)
-      (is (= 1
-             (-> @inbox vals first count))))))
+                "times (#4253) follow-up emails get sent to the oldest admin")
+    (mt/with-temporary-setting-values [anon-tracking-enabled true
+                                       follow-up-email-sent  false]
+      (with-fake-inbox
+        (#'follow-up-emails/send-follow-up-email!)
+        (#'follow-up-emails/send-follow-up-email!)
+        (is (= 1
+               (-> @inbox vals first count)))))))
 
 (deftest send-follow-up-email-survey-not-enabled-test
   (testing "Make sure we don't send an email when surveys-enabled is false."

--- a/test/metabase/query_processor/cast_test.clj
+++ b/test/metabase/query_processor/cast_test.clj
@@ -146,25 +146,25 @@
       (doseq [[table fields]          [[:people [{:field :zip :db-type "TEXT"}]]
                                        [:orders [{:field :total :db-type "FLOAT"}]]]
               {:keys [field db-type]} fields]
-        (testing (str "Casting " db-type " to integer"))
-        (let [nested-query (lib/query mp (lib.metadata/table mp (mt/id table)))
-              mp           (lib.tu/mock-metadata-provider
-                            mp
-                            {:cards [{:id 1, :dataset-query nested-query}]})
-              field-md     (lib.metadata/field mp (mt/id table field))
-              query        (-> (lib/query mp (lib.metadata/card mp 1))
-                               (lib/with-fields [field-md])
-                               (as-> q
-                                     (lib/expression q "INTCAST" (lib/integer field-md)))
-                               (lib/limit 100))
-              result       (-> query qp/process-query)
-              cols         (mt/cols result)
-              rows         (mt/rows result)]
-          (is (types/field-is-type? :type/Number (last cols)))
-          (doseq [[uncasted-value casted-value] rows]
-            (is (= (biginteger (->integer uncasted-value))
-                   (biginteger casted-value))
-                (str "Casting " (pr-str uncasted-value)))))))))
+        (testing (str "Casting " db-type " to integer")
+          (let [nested-query (lib/query mp (lib.metadata/table mp (mt/id table)))
+                mp           (lib.tu/mock-metadata-provider
+                              mp
+                              {:cards [{:id 1, :dataset-query nested-query}]})
+                field-md     (lib.metadata/field mp (mt/id table field))
+                query        (-> (lib/query mp (lib.metadata/card mp 1))
+                                 (lib/with-fields [field-md])
+                                 (as-> q
+                                       (lib/expression q "INTCAST" (lib/integer field-md)))
+                                 (lib/limit 100))
+                result       (-> query qp/process-query)
+                cols         (mt/cols result)
+                rows         (mt/rows result)]
+            (is (types/field-is-type? :type/Number (last cols)))
+            (doseq [[uncasted-value casted-value] rows]
+              (is (= (biginteger (->integer uncasted-value))
+                     (biginteger casted-value))
+                  (str "Casting " (pr-str uncasted-value))))))))))
 
 (deftest ^:parallel integer-cast-nested-query-custom-expressions
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions/integer)

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -757,14 +757,14 @@
 
 (deftest ^:parallel card-perms-test-2
   (testing "perms for a Card with a SQL source query\n"
-    (testing "reading should require that you have read permissions for the Card's Collection")
-    (testing "should be able to save even if you don't have SQL write perms (#6845)"
-      (qp.store/with-metadata-provider (qp.test-util/metadata-provider-with-cards-for-queries
-                                        [(mt/native-query {:query "SELECT * FROM VENUES"})])
-        (is (= {:paths #{(perms/collection-read-path collection/root-collection)}}
-               (query-perms/required-perms-for-query (query-with-source-card 1
-                                                                             lib.schema.id/saved-questions-virtual-database-id
-                                                                             :aggregation [:count]))))))))
+    (testing "reading should require that you have read permissions for the Card's Collection"
+      (testing "should be able to save even if you don't have SQL write perms (#6845)"
+        (qp.store/with-metadata-provider (qp.test-util/metadata-provider-with-cards-for-queries
+                                          [(mt/native-query {:query "SELECT * FROM VENUES"})])
+          (is (= {:paths #{(perms/collection-read-path collection/root-collection)}}
+                 (query-perms/required-perms-for-query (query-with-source-card 1
+                                                                               lib.schema.id/saved-questions-virtual-database-id
+                                                                               :aggregation [:count])))))))))
 
 (deftest card-perms-test-3
   (testing "perms for Card -> Card -> MBQL Source query\n"
@@ -782,10 +782,10 @@
                            :model/Card       card-2 {:collection_id (u/the-id collection)
                                                      :dataset_query (mt/mbql-query nil
                                                                       {:source-table (format "card__%d" (u/the-id card-1))})}]
-              (testing "read perms for both Cards should be the same as reading the parent collection")
-              (is (= (mi/perms-objects-set collection :read)
-                     (mi/perms-objects-set card-1 :read)
-                     (mi/perms-objects-set card-2 :read)))
+              (testing "read perms for both Cards should be the same as reading the parent collection"
+                (is (= (mi/perms-objects-set collection :read)
+                       (mi/perms-objects-set card-1 :read)
+                       (mi/perms-objects-set card-2 :read))))
               (testing "\nSanity check: shouldn't be able to read before we grant permissions\n"
                 (doseq [[object-name object] {"Collection" collection
                                               "Card 1"     card-1

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -581,8 +581,8 @@
           (testing "We continue using our cached references for some time"
             (is (= active-before (active-table-after 100)))
             (is (= active-before (active-table-after (/ period 2)))))
-          (testing "But eventually we refresh")
-          (is (= active-after (active-table-after period))))
+          (testing "But eventually we refresh"
+            (is (= active-after (active-table-after period)))))
         (finally
           (t2/delete! :model/SearchIndexMetadata :version "auto-refresh-test")
           (#'search.index/delete-obsolete-tables!))))))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -39,17 +39,17 @@
 
 (deftest comment-should-not-overwrite-custom-description-test
   (testing (str "test changing the description in metabase db so we can check it is not overwritten by comment in "
-                "source db when resyncing"))
-  (mt/test-drivers #{:h2 :postgres}
-    (mt/dataset update-desc
-      (mt/with-temp-copy-of-db
-        ;; change the description in metabase while the source table comment remains the same
-        (t2/update! :model/Field {:id (mt/id "update_desc" "updated_desc")}, {:description "updated description"})
-        ;; now sync the DB again, this should NOT overwrite the manually updated description
-        (sync/sync-table! (t2/select-one :model/Table :id (mt/id "update_desc")))
-        (is (= #{{:name (mt/format-name "id"), :description nil}
-                 {:name (mt/format-name "updated_desc"), :description "updated description"}}
-               (db->fields (mt/db))))))))
+                "source db when resyncing")
+    (mt/test-drivers #{:h2 :postgres}
+      (mt/dataset update-desc
+        (mt/with-temp-copy-of-db
+          ;; change the description in metabase while the source table comment remains the same
+          (t2/update! :model/Field {:id (mt/id "update_desc" "updated_desc")}, {:description "updated description"})
+          ;; now sync the DB again, this should NOT overwrite the manually updated description
+          (sync/sync-table! (t2/select-one :model/Table :id (mt/id "update_desc")))
+          (is (= #{{:name (mt/format-name "id"), :description nil}
+                   {:name (mt/format-name "updated_desc"), :description "updated description"}}
+                 (db->fields (mt/db)))))))))
 
 (tx/defdataset ^:private comment-after-sync
   [["comment_after_sync"

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -47,8 +47,8 @@
            (vec (encryption/secret-key->hash "Toucans"))))))
 
 (deftest ^:parallel unique-hashes-test
-  (testing (is (not= (vec secret)
-                     (vec secret-2)))))
+  (is (not= (vec secret)
+            (vec secret-2))))
 
 (deftest ^:parallel hash-pattern-test
   (is (re= #"^[0-9A-Za-z/+]+=*$"

--- a/test/metabase/util/files_test.clj
+++ b/test/metabase/util/files_test.clj
@@ -17,11 +17,11 @@
       (spit file "abc")
       (is (u.files/regular-file? (u.files/get-path file)))))
   (mt/with-temp-dir [dir "temp-dir"]
-    (testing (format "dir = %s" (pr-str dir)))
-    (let [file-in-dir (str (u.files/get-path dir "file"))]
-      (testing (format "file = %s" (pr-str file-in-dir))
-        (spit file-in-dir "abc")        ; create a file in the dir to make sure it exists
-        (is (u.files/regular-file? (u.files/get-path file-in-dir)))))
+    (testing (format "dir = %s" (pr-str dir))
+      (let [file-in-dir (str (u.files/get-path dir "file"))]
+        (testing (format "file = %s" (pr-str file-in-dir))
+          (spit file-in-dir "abc")        ; create a file in the dir to make sure it exists
+          (is (u.files/regular-file? (u.files/get-path file-in-dir))))))
     (is (not (u.files/regular-file? (u.files/get-path dir))))))
 
 (defn- write-test-zip!


### PR DESCRIPTION
They don't do anything.

Fix existing places breaking the rules.

Probably best to review this with whitespace-only changes hidden