### PR TITLE
Fix capitalization of "View schema" table action label

### DIFF
--- a/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
+++ b/e2e/test/scenarios/schema-viewer/schema-viewer.cy.spec.ts
@@ -518,10 +518,10 @@ describe("scenarios > schema-viewer (entry points + loader/error states)", () =>
     cy.findAllByTestId("tree-item").contains("Orders").click();
 
     cy.log(
-      "Click the 'View Schema' action in the Orders table section — opens with Orders as focal",
+      "Click the 'View schema' action in the Orders table section — opens with Orders as focal",
     );
     H.DataModel.TableSection.getActionsMenuButton().click();
-    H.menu().findByText("View Schema").click();
+    H.menu().findByText("View schema").click();
     cy.wait("@erd");
     cy.url()
       .should("include", "/data-studio/schema-viewer")

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.tsx
@@ -73,7 +73,7 @@ export function TableActionsMenu({ table }: Props) {
   };
 
   // Without sync actions and find-and-replace, the menu would hold only
-  // "View Schema", so render it directly as a button instead of a single-item menu.
+  // "View schema", so render it directly as a button instead of a single-item menu.
   if (!showSyncItems && !showReplaceItem) {
     return (
       <Button
@@ -82,7 +82,7 @@ export function TableActionsMenu({ table }: Props) {
         size="md"
         leftSection={<Icon name="network" size={16} />}
       >
-        {t`View Schema`}
+        {t`View schema`}
       </Button>
     );
   }
@@ -103,7 +103,7 @@ export function TableActionsMenu({ table }: Props) {
             to={schemaViewerUrl}
             leftSection={<Icon name="network" />}
           >
-            {t`View Schema`}
+            {t`View schema`}
           </Menu.Item>
 
           {showSyncItems && (

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableActionsMenu/TableActionsMenu.unit.spec.tsx
@@ -47,13 +47,13 @@ describe("TableActionsMenu", () => {
 
     // it's a menu, not a standalone link
     expect(
-      screen.queryByRole("link", { name: /View Schema/ }),
+      screen.queryByRole("link", { name: /View schema/ }),
     ).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "More actions" }));
 
     expect(
-      await screen.findByRole("menuitem", { name: /View Schema/ }),
+      await screen.findByRole("menuitem", { name: /View schema/ }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("menuitem", { name: /Re-sync schema/ }),
@@ -66,7 +66,7 @@ describe("TableActionsMenu", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a standalone View Schema button when there are no other actions", () => {
+  it("renders a standalone View schema button when there are no other actions", () => {
     // attached DWH => no sync items, and a non-admin can't replace sources
     setup({
       table: createMockTable({
@@ -75,7 +75,7 @@ describe("TableActionsMenu", () => {
     });
 
     expect(
-      screen.getByRole("link", { name: /View Schema/ }),
+      screen.getByRole("link", { name: /View schema/ }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "More actions" }),
@@ -93,13 +93,13 @@ describe("TableActionsMenu", () => {
 
     // the selector keeps it a menu rather than collapsing to a button
     expect(
-      screen.queryByRole("link", { name: /View Schema/ }),
+      screen.queryByRole("link", { name: /View schema/ }),
     ).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "More actions" }));
 
     expect(
-      await screen.findByRole("menuitem", { name: /View Schema/ }),
+      await screen.findByRole("menuitem", { name: /View schema/ }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("menuitem", { name: /Find and replace/ }),

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/common.unit.spec.tsx
@@ -71,7 +71,7 @@ describe("TableSection", () => {
       );
 
       expect(
-        await screen.findByRole("menuitem", { name: /View Schema/ }),
+        await screen.findByRole("menuitem", { name: /View schema/ }),
       ).toBeInTheDocument();
     });
 
@@ -83,7 +83,7 @@ describe("TableSection", () => {
       // With no sync actions and no source replacement, the menu collapses to a
       // standalone schema viewer link rather than a "More actions" menu.
       expect(
-        screen.getByRole("link", { name: /View Schema/ }),
+        screen.getByRole("link", { name: /View schema/ }),
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "More actions" }),


### PR DESCRIPTION
### Description

Sentence-case the data model table actions menu label so it reads "View schema" instead of "View Schema", matching Metabase's sentence-case capitalization convention for UI labels. Updates the menu item, the standalone-button variant, and the affected unit and e2e tests.

### How to verify

1. Open a database in the data model (Data Studio) and select a table.
2. Open the table's actions menu (or, for a data-warehouse-attached database with no sync/replace actions, view the standalone link).
3. Confirm the label reads "View schema".

### Demo

<img width="256" height="289" alt="image" src="https://github.com/user-attachments/assets/6a4c443b-6987-4c19-a8ab-f8ea4fe421b8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Made with [Cursor](https://cursor.com)