### PR TITLE
Use table of LHS join column in query builder

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.tsx
@@ -47,6 +47,11 @@ export const JoinColumnButton = forwardRef(function JoinColumnTarget(
     () => getButtonLabel(query, stageIndex, expression, tc, locale),
     [query, stageIndex, expression, tc, locale],
   );
+  const columnTableName = useMemo(
+    () =>
+      getColumnTableName(query, stageIndex, expression, isLhsPicker, tableName),
+    [query, stageIndex, expression, isLhsPicker, tableName],
+  );
   const isEmpty = expression == null;
   const isLiteral =
     expression != null && Lib.isJoinConditionLHSorRHSLiteral(expression);
@@ -79,7 +84,7 @@ export const JoinColumnButton = forwardRef(function JoinColumnTarget(
       onClick={onClick}
       aria-label={isLhsPicker ? t`Left column` : t`Right column`}
     >
-      {tableName != null && !isLiteral && (
+      {columnTableName != null && !isLiteral && (
         <Text
           display="block"
           fz={11}
@@ -88,7 +93,7 @@ export const JoinColumnButton = forwardRef(function JoinColumnTarget(
           ta="left"
           fw={400}
         >
-          {tc(tableName)}
+          {tc(columnTableName)}
         </Text>
       )}
       <Text
@@ -128,4 +133,27 @@ function getButtonLabel(
   }
 
   return t`Custom expression`;
+}
+
+function getColumnTableName(
+  query: Lib.Query,
+  stageIndex: number,
+  expression: Lib.ExpressionClause | undefined,
+  isLhsPicker: boolean,
+  tableName: string | undefined,
+) {
+  // The LHS of a join condition can reference a column from the source table
+  // or a previous join, so the join condition table should be the columns
+  // table (#72823).
+  if (
+    isLhsPicker &&
+    expression != null &&
+    Lib.isJoinConditionLHSorRHSColumn(expression)
+  ) {
+    return (
+      Lib.displayInfo(query, stageIndex, expression).table?.displayName ??
+      tableName
+    );
+  }
+  return tableName;
 }

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.tsx
@@ -49,7 +49,8 @@ export const JoinColumnButton = forwardRef(function JoinColumnTarget(
   );
   const columnTableName = useMemo(
     () =>
-      getColumnTableName(query, stageIndex, expression, isLhsPicker, tableName),
+      getLHSColumnTableName(query, stageIndex, expression, isLhsPicker) ??
+      tableName,
     [query, stageIndex, expression, isLhsPicker, tableName],
   );
   const isEmpty = expression == null;
@@ -135,12 +136,11 @@ function getButtonLabel(
   return t`Custom expression`;
 }
 
-function getColumnTableName(
+function getLHSColumnTableName(
   query: Lib.Query,
   stageIndex: number,
   expression: Lib.ExpressionClause | undefined,
   isLhsPicker: boolean,
-  tableName: string | undefined,
 ) {
   // The LHS of a join condition can reference a column from the source table
   // or a previous join, so the join condition table should be the columns
@@ -150,10 +150,6 @@ function getColumnTableName(
     expression != null &&
     Lib.isJoinConditionLHSorRHSColumn(expression)
   ) {
-    return (
-      Lib.displayInfo(query, stageIndex, expression).table?.displayName ??
-      tableName
-    );
+    return Lib.displayInfo(query, stageIndex, expression).table?.displayName;
   }
-  return tableName;
 }

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnButton/JoinColumnButton.unit.spec.tsx
@@ -1,8 +1,12 @@
-import { renderWithProviders } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { isTouchDevice } from "metabase/utils/browser";
 import * as Lib from "metabase-lib";
-import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
-import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+import { SAMPLE_PROVIDER, columnFinder } from "metabase-lib/test-helpers";
+import {
+  ORDERS_ID,
+  PEOPLE_ID,
+  PRODUCTS_ID,
+} from "metabase-types/api/mocks/presets";
 
 import { JoinColumnButton } from "./JoinColumnButton";
 
@@ -13,7 +17,7 @@ jest.mock("metabase/utils/browser", () => ({
 
 const scrollIntoViewMock = jest.fn();
 
-const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
+const ORDERS_QUERY = Lib.createTestQuery(SAMPLE_PROVIDER, {
   stages: [
     {
       source: { type: "table", id: ORDERS_ID },
@@ -22,11 +26,19 @@ const query = Lib.createTestQuery(SAMPLE_PROVIDER, {
 });
 
 function setup({
+  query = ORDERS_QUERY,
+  tableName,
+  lhsExpression,
+  rhsExpression,
   isOpened = false,
   isLhsPicker = true,
   isReadOnly = false,
   touch = false,
 }: {
+  query?: Lib.Query;
+  tableName?: string;
+  lhsExpression?: Lib.ExpressionClause;
+  rhsExpression?: Lib.ExpressionClause;
   isOpened?: boolean;
   isLhsPicker?: boolean;
   isReadOnly?: boolean;
@@ -38,9 +50,9 @@ function setup({
     <JoinColumnButton
       query={query}
       stageIndex={0}
-      tableName={undefined}
-      lhsExpression={undefined}
-      rhsExpression={undefined}
+      tableName={tableName}
+      lhsExpression={lhsExpression}
+      rhsExpression={rhsExpression}
       isLhsPicker={isLhsPicker}
       isOpened={isOpened}
       isReadOnly={isReadOnly}
@@ -76,7 +88,7 @@ describe("JoinColumnButton scroll on auto-open", () => {
 
     rerender(
       <JoinColumnButton
-        query={query}
+        query={ORDERS_QUERY}
         stageIndex={0}
         tableName={undefined}
         lhsExpression={undefined}
@@ -95,5 +107,118 @@ describe("JoinColumnButton scroll on auto-open", () => {
     setup({ isOpened: true, touch: false });
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+});
+
+const QUERY_WITH_JOINS = Lib.createTestQuery(SAMPLE_PROVIDER, {
+  stages: [
+    {
+      source: { type: "table", id: ORDERS_ID },
+      joins: [
+        {
+          source: { type: "table", id: PEOPLE_ID },
+          strategy: "left-join",
+          conditions: [
+            {
+              operator: "=",
+              left: { type: "column", name: "USER_ID" },
+              right: { type: "column", name: "ID" },
+            },
+          ],
+        },
+        {
+          source: { type: "table", id: PRODUCTS_ID },
+          strategy: "left-join",
+          conditions: [
+            {
+              operator: "=",
+              left: { type: "column", name: "PRODUCT_ID" },
+              right: { type: "column", name: "ID" },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const PRODUCTS_JOIN = Lib.joins(QUERY_WITH_JOINS, 0)[1];
+
+function getProductsJoinLhsColumn(tableName: string, columnName: string) {
+  const columns = Lib.joinConditionLHSColumns(
+    QUERY_WITH_JOINS,
+    0,
+    PRODUCTS_JOIN,
+    undefined,
+    undefined,
+  );
+  const findColumn = columnFinder(QUERY_WITH_JOINS, columns);
+  return Lib.expressionClause(findColumn(tableName, columnName));
+}
+
+describe("JoinColumnButton LHS table label (metabase#72823)", () => {
+  // The parent computes a single join-level LHS name and passes it down to
+  // every condition's picker. For the Products join above that name is "Orders"
+  // (derived from the existing FK condition), but the LHS column the user picks
+  // may come from a different table — so the button must label it by the
+  // selected column's own table, not the join-level name.
+  const JOIN_LEVEL_TABLE_NAME = "Orders";
+
+  it("falls back to the provided table name before a column is picked", () => {
+    setup({
+      query: QUERY_WITH_JOINS,
+      tableName: JOIN_LEVEL_TABLE_NAME,
+      lhsExpression: undefined,
+    });
+
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(screen.getByText("Pick a column…")).toBeInTheDocument();
+  });
+
+  it("labels a LHS column from a previous join with that join's table", () => {
+    setup({
+      query: QUERY_WITH_JOINS,
+      tableName: JOIN_LEVEL_TABLE_NAME,
+      lhsExpression: getProductsJoinLhsColumn("PEOPLE", "SOURCE"),
+    });
+
+    expect(screen.getByText("People")).toBeInTheDocument();
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.queryByText("Orders")).not.toBeInTheDocument();
+  });
+
+  it("labels a LHS column from the source table with the source table", () => {
+    setup({
+      query: QUERY_WITH_JOINS,
+      tableName: JOIN_LEVEL_TABLE_NAME,
+      lhsExpression: getProductsJoinLhsColumn("ORDERS", "TAX"),
+    });
+
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(screen.getByText("Tax")).toBeInTheDocument();
+  });
+
+  it("uses the provided table name for the RHS picker", () => {
+    const rhsColumns = Lib.joinConditionRHSColumns(
+      QUERY_WITH_JOINS,
+      0,
+      PRODUCTS_JOIN,
+      undefined,
+      undefined,
+    );
+    const findColumn = columnFinder(QUERY_WITH_JOINS, rhsColumns);
+    const rhsExpression = Lib.expressionClause(
+      findColumn("PRODUCTS", "CATEGORY"),
+    );
+
+    setup({
+      query: QUERY_WITH_JOINS,
+      tableName: "Products",
+      rhsExpression,
+      isLhsPicker: false,
+    });
+
+    expect(screen.getByText("Products")).toBeInTheDocument();
+    expect(screen.getByText("Category")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/72823

### Description

We were always using the source table name after selecting the LHS join column. Fix in this PR is to use the table of the selected column. 

### How to verify

See repro steps in original issue. It should use the selected columns table name now instead. 

### Demo

https://github.com/user-attachments/assets/2a790eb4-9160-4f95-8da5-ec6c00439f9d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
