### PR TITLE
Bundle size stats

### DIFF
--- a/.github/actions/sdk-bundle-size-check/action.yml
+++ b/.github/actions/sdk-bundle-size-check/action.yml
@@ -39,19 +39,17 @@ runs:
     - name: Extract embedding-sdk bundles from current uberjar
       shell: bash
       run: |
-        # Try new layout first (app/embedding-sdk/legacy/), fall back to old layout (app/embedding-sdk.js)
-        unzip -j temp/current-uberjar/metabase.jar \
-          "frontend_client/app/embedding-sdk/legacy/embedding-sdk.js" \
-          -d temp/current-bundle 2>/dev/null || \
-        unzip -j temp/current-uberjar/metabase.jar \
+        # Extract preserving the jar's internal paths under resources/ so the
+        # shared measure script sees the same layout as a source build. Both the
+        # new (embedding-sdk/legacy + chunks) and old (embedding-sdk.js) layouts
+        # are pulled; whichever exists is what gets measured.
+        mkdir -p temp/current/resources
+        unzip -o temp/current-uberjar/metabase.jar \
+          "frontend_client/app/embedding-sdk/*" \
+          -d temp/current/resources 2>/dev/null || true
+        unzip -o temp/current-uberjar/metabase.jar \
           "frontend_client/app/embedding-sdk.js" \
-          -d temp/current-bundle
-
-        # Extract chunks directory if it exists (new layout only)
-        mkdir -p temp/current-chunks
-        unzip -j temp/current-uberjar/metabase.jar \
-          "frontend_client/app/embedding-sdk/chunks/*" \
-          -d temp/current-chunks 2>/dev/null || true
+          -d temp/current/resources 2>/dev/null || true
     - name: Checkout base ref
       uses: actions/checkout@v6
       with:
@@ -63,49 +61,16 @@ runs:
         cd temp/base-ref-src
         bun install
         MB_EDITION=${{ inputs.edition }} bun run build-release
+    - name: Measure current and base bundle sizes
+      shell: bash
+      env:
+        MEASURE_BUNDLES: embedding-sdk-legacy,embedding-sdk-chunked
+      run: |
+        MEASURE_ROOT=temp/current node ./.github/scripts/measure-bundle-sizes.js > temp/current-sizes.json
+        MEASURE_ROOT=temp/base-ref-src node ./.github/scripts/measure-bundle-sizes.js > temp/base-sizes.json
     - name: Compare sizes and set output
       id: compare
       shell: bash
-      run: |
-        # --- Legacy (monolithic) bundle comparison ---
-        current_size=$(wc -c < temp/current-bundle/embedding-sdk.js) || { echo "::error::Failed to read current bundle"; exit 1; }
-
-        # Base ref: try new layout first, fall back to old
-        if [ -f "temp/base-ref-src/resources/frontend_client/app/embedding-sdk/legacy/embedding-sdk.js" ]; then
-          base_ref_size=$(wc -c < "temp/base-ref-src/resources/frontend_client/app/embedding-sdk/legacy/embedding-sdk.js")
-        else
-          base_ref_size=$(wc -c < "temp/base-ref-src/resources/frontend_client/app/embedding-sdk.js")
-        fi
-        [ "$current_size" -gt 0 ] && [ "$base_ref_size" -gt 0 ] || { echo "::error::Bundle file is empty"; exit 1; }
-
-        diff=$((current_size - base_ref_size))
-        percent=$(( diff * 100 / base_ref_size ))
-
-        echo "=== Legacy (monolithic) bundle ==="
-        echo "Current size: $current_size bytes"
-        echo "Base ref size: $base_ref_size bytes"
-        echo "Difference: $diff bytes ($percent%)"
-
-        threshold="${{ inputs.threshold-percent }}"
-        if [ "$percent" -gt "$threshold" ]; then
-          status="increased"
-        elif [ "$percent" -lt "$(( -threshold ))" ]; then
-          status="decreased"
-        else
-          status="stable"
-        fi
-
-        echo "status=$status" >> $GITHUB_OUTPUT
-        echo "size_change_percent=$percent" >> $GITHUB_OUTPUT
-
-        # --- Chunked bundle (informational) ---
-        if ls temp/current-chunks/*.js 1>/dev/null 2>&1; then
-          chunks_size=$(cat temp/current-chunks/*.js | wc -c)
-          echo ""
-          echo "=== Chunked bundle (bootstrap + chunks) ==="
-          echo "Total chunked size: $chunks_size bytes"
-          echo "chunks_size=$chunks_size" >> $GITHUB_OUTPUT
-        else
-          echo ""
-          echo "No chunked bundle found (expected on master)"
-        fi
+      env:
+        THRESHOLD: ${{ inputs.threshold-percent }}
+      run: node ./.github/actions/sdk-bundle-size-check/compare.js temp/current-sizes.json temp/base-sizes.json

--- a/.github/actions/sdk-bundle-size-check/compare.js
+++ b/.github/actions/sdk-bundle-size-check/compare.js
@@ -1,0 +1,54 @@
+/* eslint-disable import/no-commonjs */
+// Diffs the embedding SDK bundle sizes produced by measure-bundle-sizes.js for
+// the current build and the base ref. The gate is driven by the legacy
+// (monolithic) bundle's raw bytes; the chunked delivery is reported for context.
+const fs = require("fs");
+
+const [, , currentPath, basePath] = process.argv;
+const threshold = Number(process.env.THRESHOLD ?? 2);
+
+const current = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+const base = JSON.parse(fs.readFileSync(basePath, "utf8"));
+
+const pick = (rows, bundle, kind) => rows.find(row => row.bundle === bundle && row.kind === kind);
+
+const setOutput = (name, value) => {
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+  }
+};
+
+const mb = bytes => (bytes / 1024 / 1024).toFixed(2);
+
+const legacyCurrent = pick(current, "embedding-sdk-legacy", "total");
+const legacyBase = pick(base, "embedding-sdk-legacy", "total");
+
+if (!legacyCurrent || !legacyBase || !legacyBase.rawBytes) {
+  console.error("::error::Could not find embedding-sdk-legacy size in both builds");
+  process.exit(1);
+}
+
+const diff = legacyCurrent.rawBytes - legacyBase.rawBytes;
+const percent = Math.trunc((diff * 100) / legacyBase.rawBytes);
+
+const status = percent > threshold ? "increased" : percent < -threshold ? "decreased" : "stable";
+
+console.log("=== Embedding SDK legacy (monolithic) bundle ===");
+console.log(`Current:  ${legacyCurrent.rawBytes} bytes raw / ${mb(legacyCurrent.gzipBytes)}MB gzip`);
+console.log(`Base ref: ${legacyBase.rawBytes} bytes raw / ${mb(legacyBase.gzipBytes)}MB gzip`);
+console.log(`Difference: ${diff} bytes (${percent}%), threshold ${threshold}%`);
+console.log(`Status: ${status}`);
+
+const chunkedCurrent = pick(current, "embedding-sdk-chunked", "total");
+const chunkedBase = pick(base, "embedding-sdk-chunked", "total");
+if (chunkedCurrent && chunkedBase) {
+  const chunkedDiff = chunkedCurrent.rawBytes - chunkedBase.rawBytes;
+  console.log("");
+  console.log("=== Embedding SDK chunked (informational) ===");
+  console.log(`Current:  ${chunkedCurrent.rawBytes} bytes raw / ${mb(chunkedCurrent.gzipBytes)}MB gzip`);
+  console.log(`Base ref: ${chunkedBase.rawBytes} bytes raw / ${mb(chunkedBase.gzipBytes)}MB gzip`);
+  console.log(`Difference: ${chunkedDiff} bytes`);
+}
+
+setOutput("status", status);
+setOutput("size_change_percent", percent);

--- a/.github/scripts/measure-bundle-sizes.js
+++ b/.github/scripts/measure-bundle-sizes.js
@@ -3,6 +3,16 @@ const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
 
+// MEASURE_ROOT lets callers point at an extracted tree (e.g. the PR bundle-size
+// check measures a current and a base-ref tree); defaults to cwd for the stats
+// workflow. MEASURE_BUNDLES restricts which bundles are measured (comma-separated).
+const baseDir = process.env.MEASURE_ROOT ? path.resolve(process.env.MEASURE_ROOT) : process.cwd();
+const resolve = (...relativeParts) => path.resolve(baseDir, ...relativeParts);
+const bundleFilter = process.env.MEASURE_BUNDLES
+  ? new Set(process.env.MEASURE_BUNDLES.split(",").map(bundle => bundle.trim()))
+  : null;
+const isBundleWanted = bundle => !bundleFilter || bundleFilter.has(bundle);
+
 const SDK_ROOT = "resources/frontend_client/app/embedding-sdk";
 
 /**
@@ -95,7 +105,7 @@ function collectJsFiles(absolutePath) {
 }
 
 function readStats(statsFile) {
-  const statsPath = path.resolve(process.cwd(), statsFile);
+  const statsPath = resolve(statsFile);
   return fs.existsSync(statsPath) ? JSON.parse(fs.readFileSync(statsPath, "utf8")) : null;
 }
 
@@ -118,13 +128,13 @@ function initialJsFiles({ file: statsFile, entrypoint, root }, joinRoot) {
     console.warn(`Entrypoint "${entrypoint}" missing in ${statsFile}; reporting initial == total.`);
     return null;
   }
-  const base = root ? path.resolve(process.cwd(), root) : joinRoot;
+  const base = root ? resolve(root) : joinRoot;
   return assets.map(name => path.join(base, name));
 }
 
 function measureSimpleTarget({ bundle, dir, file, altFile, stats, optional }) {
   const candidates = [dir, file, altFile].filter(Boolean);
-  const chosen = candidates.find(c => fs.existsSync(path.resolve(process.cwd(), c)));
+  const chosen = candidates.find(c => fs.existsSync(resolve(c)));
   if (!chosen) {
     if (optional) {
       console.warn(`Skipping "${bundle}": output not found (${candidates.join(", ")})`);
@@ -133,7 +143,7 @@ function measureSimpleTarget({ bundle, dir, file, altFile, stats, optional }) {
     throw new Error(`Bundle output not found for "${bundle}": ${candidates.join(", ")}`);
   }
 
-  const root = path.resolve(process.cwd(), chosen);
+  const root = resolve(chosen);
   const total = sizeOf(collectJsFiles(root));
   const initialFiles = stats ? initialJsFiles(stats, root) : null;
   const initial = initialFiles ? sizeOf(initialFiles) : total;
@@ -151,13 +161,13 @@ function measureSimpleTarget({ bundle, dir, file, altFile, stats, optional }) {
  * unless SDK_ASYNC_CHUNKS_LOADABLE is set, at which point "total" includes them.
  */
 function measureChunkedSdk(statsFile) {
-  const chunksDir = path.resolve(process.cwd(), SDK_ROOT, "chunks");
+  const chunksDir = resolve(SDK_ROOT, "chunks");
   if (!fs.existsSync(chunksDir)) {
     // pre-chunked layout (monolith only) — nothing to measure here
     return [];
   }
 
-  const absRoot = path.resolve(process.cwd(), SDK_ROOT);
+  const absRoot = resolve(SDK_ROOT);
   const everything = collectJsFiles(chunksDir).filter(f => !SDK_RUNTIME_RE.test(f));
 
   const stats = readStats(statsFile);
@@ -183,8 +193,10 @@ function measureChunkedSdk(statsFile) {
 
 function measureBundleSizes() {
   return [
-    ...simpleTargets.flatMap(measureSimpleTarget),
-    ...measureChunkedSdk("artifacts/stats-embedding-sdk.json"),
+    ...simpleTargets.filter(target => isBundleWanted(target.bundle)).flatMap(measureSimpleTarget),
+    ...(isBundleWanted("embedding-sdk-chunked")
+      ? measureChunkedSdk("artifacts/stats-embedding-sdk.json")
+      : []),
   ];
 }
 

--- a/.github/scripts/measure-bundle-sizes.js
+++ b/.github/scripts/measure-bundle-sizes.js
@@ -1,0 +1,195 @@
+/* eslint-disable import/no-commonjs */
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+
+const SDK_ROOT = "resources/frontend_client/app/embedding-sdk";
+
+/**
+ * Async SDK chunks are unreachable today: the bootstrap manifest lists only the
+ * chunked entry's INITIAL chunks and output.publicPath is "", so import() chunks
+ * are emitted but never fetched. So they're excluded from "total" (which equals
+ * "initial"). There's no reliable way to detect loadability from the build
+ * artifacts, so this is a manual flag: flip it to true in the same change that
+ * lands the publicPath fix, and "total" will include the lazy chunks while
+ * "initial" stays the eager first-load set.
+ */
+const SDK_ASYNC_CHUNKS_LOADABLE = false;
+
+// The chunk runtime is inlined into the bootstrap, never sent as a standalone file.
+const SDK_RUNTIME_RE = /embedding-sdk-chunk-runtime\./;
+
+/**
+ * Simple targets measured straight from emitted files.
+ * - `dir`/`file`/`altFile`: what to measure (altFile is a fallback single file).
+ * - `stats`: entrypoint whose initial assets are the "initial" download.
+ * - `optional`: skip (don't fail) when the output is absent.
+ * The hosted SDK is split into embedding-sdk-legacy (the self-contained
+ * monolith) and embedding-sdk-chunked (handled separately below).
+ */
+const simpleTargets = [
+  {
+    bundle: "app",
+    dir: "resources/frontend_client/app/dist",
+    stats: { file: "artifacts/stats-main.json", entrypoint: "app-main" },
+  },
+  {
+    bundle: "embedding-sdk-legacy",
+    dir: `${SDK_ROOT}/legacy`,
+    altFile: `${SDK_ROOT}.js`,
+    optional: true,
+  },
+  {
+    bundle: "embedding-sdk-package",
+    dir: "resources/embedding-sdk/dist",
+    optional: true,
+  },
+  {
+    bundle: "embed-js",
+    file: "resources/frontend_client/app/embed.js",
+  },
+];
+
+function sizeOf(files) {
+  let rawBytes = 0;
+  let gzipBytes = 0;
+  let brotliBytes = 0;
+  let anyBrotli = false;
+  for (const file of files) {
+    const contents = fs.readFileSync(file);
+    rawBytes += contents.length;
+    // gzip: recompressed, a proxy for the on-the-fly gzip served on every version
+    gzipBytes += zlib.gzipSync(contents).length;
+    // brotli: as-served — count the precompressed .br the build ships; files
+    // without one (static-viz, sub-threshold chunks) are served compressed on
+    // the fly, so estimate with brotli. Null when no .br shipped at all.
+    const brotliPath = `${file}.br`;
+    if (fs.existsSync(brotliPath)) {
+      anyBrotli = true;
+      brotliBytes += fs.statSync(brotliPath).size;
+    } else {
+      brotliBytes += zlib.brotliCompressSync(contents).length;
+    }
+  }
+  return {
+    fileCount: files.length,
+    rawBytes,
+    gzipBytes,
+    brotliBytes: anyBrotli ? brotliBytes : null,
+  };
+}
+
+function collectJsFiles(absolutePath) {
+  if (fs.statSync(absolutePath).isFile()) {
+    return [absolutePath];
+  }
+  return fs
+    .readdirSync(absolutePath, { withFileTypes: true })
+    .flatMap(entry => {
+      const childPath = path.join(absolutePath, entry.name);
+      if (entry.isDirectory()) {
+        return collectJsFiles(childPath);
+      }
+      return entry.name.endsWith(".js") ? [childPath] : [];
+    });
+}
+
+function readStats(statsFile) {
+  const statsPath = path.resolve(process.cwd(), statsFile);
+  return fs.existsSync(statsPath) ? JSON.parse(fs.readFileSync(statsPath, "utf8")) : null;
+}
+
+function entrypointJsAssets(stats, name) {
+  const entry = stats && stats.entrypoints && stats.entrypoints[name];
+  if (!entry) {
+    return null;
+  }
+  return entry.assets.map(asset => asset.name || asset).filter(name => name.endsWith(".js"));
+}
+
+function initialJsFiles({ file: statsFile, entrypoint, root }, joinRoot) {
+  const stats = readStats(statsFile);
+  if (!stats) {
+    console.warn(`Stats file missing (${statsFile}); reporting initial == total.`);
+    return null;
+  }
+  const assets = entrypointJsAssets(stats, entrypoint);
+  if (!assets) {
+    console.warn(`Entrypoint "${entrypoint}" missing in ${statsFile}; reporting initial == total.`);
+    return null;
+  }
+  const base = root ? path.resolve(process.cwd(), root) : joinRoot;
+  return assets.map(name => path.join(base, name));
+}
+
+function measureSimpleTarget({ bundle, dir, file, altFile, stats, optional }) {
+  const candidates = [dir, file, altFile].filter(Boolean);
+  const chosen = candidates.find(c => fs.existsSync(path.resolve(process.cwd(), c)));
+  if (!chosen) {
+    if (optional) {
+      console.warn(`Skipping "${bundle}": output not found (${candidates.join(", ")})`);
+      return [];
+    }
+    throw new Error(`Bundle output not found for "${bundle}": ${candidates.join(", ")}`);
+  }
+
+  const root = path.resolve(process.cwd(), chosen);
+  const total = sizeOf(collectJsFiles(root));
+  const initialFiles = stats ? initialJsFiles(stats, root) : null;
+  const initial = initialFiles ? sizeOf(initialFiles) : total;
+
+  return [
+    { bundle, kind: "initial", ...initial },
+    { bundle, kind: "total", ...total },
+  ];
+}
+
+/**
+ * Chunked SDK delivery. "Reachable" = what the bootstrap actually sends: the
+ * bootstrap (with its inlined runtime) + the chunked entry's initial chunks,
+ * minus the standalone runtime file. Async chunks are excluded (initial == total)
+ * unless SDK_ASYNC_CHUNKS_LOADABLE is set, at which point "total" includes them.
+ */
+function measureChunkedSdk(statsFile) {
+  const chunksDir = path.resolve(process.cwd(), SDK_ROOT, "chunks");
+  if (!fs.existsSync(chunksDir)) {
+    // pre-chunked layout (monolith only) — nothing to measure here
+    return [];
+  }
+
+  const absRoot = path.resolve(process.cwd(), SDK_ROOT);
+  const everything = collectJsFiles(chunksDir).filter(f => !SDK_RUNTIME_RE.test(f));
+
+  const stats = readStats(statsFile);
+  const chunked = entrypointJsAssets(stats, "embedding-sdk-chunked");
+  let reachableFiles;
+  if (chunked) {
+    const bootstrap = entrypointJsAssets(stats, "embedding-sdk-bootstrap") || [];
+    const names = [...new Set([...bootstrap, ...chunked])].filter(n => !SDK_RUNTIME_RE.test(n));
+    reachableFiles = names.map(n => path.join(absRoot, n));
+  } else {
+    console.warn(`embedding-sdk-chunked: entrypoint missing in ${statsFile}; counting whole chunks/ dir`);
+    reachableFiles = everything;
+  }
+
+  const initial = sizeOf(reachableFiles);
+  const total = SDK_ASYNC_CHUNKS_LOADABLE ? sizeOf(everything) : sizeOf(reachableFiles);
+
+  return [
+    { bundle: "embedding-sdk-chunked", kind: "initial", ...initial },
+    { bundle: "embedding-sdk-chunked", kind: "total", ...total },
+  ];
+}
+
+function measureBundleSizes() {
+  return [
+    ...simpleTargets.flatMap(measureSimpleTarget),
+    ...measureChunkedSdk("artifacts/stats-embedding-sdk.json"),
+  ];
+}
+
+module.exports = { measureBundleSizes };
+
+if (require.main === module) {
+  console.log(JSON.stringify(measureBundleSizes(), null, 2));
+}

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -1,0 +1,129 @@
+name: Bundle Size Stats
+
+# Reuses the uberjar built on every master merge: downloads the jar (for the
+# emitted JS) plus the bundle-stats and embedding-sdk artifacts, measures
+# initial/total bundle sizes, and appends them to stats.metabase.com.
+
+on:
+  workflow_run:
+    workflows: ["Build Uberjar"]
+    types: [completed]
+    branches: [master]
+
+concurrency:
+  group: bundle-size-stats-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-size-stats:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'metabase/metabase' }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 15
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Download EE uberjar
+        uses: ./.github/actions/fetch-artifact
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          edition: ee
+          extract-path: temp/uberjar
+      - name: Extract front-end bundles from uberjar
+        run: |
+          mkdir -p resources artifacts
+          unzip -o "temp/uberjar/metabase.jar" \
+            "frontend_client/app/dist/*" \
+            "frontend_client/app/embed.js" \
+            "frontend_client/app/embedding-sdk/*" \
+            -d resources
+          unzip -o -j "temp/uberjar/metabase.jar" version.properties -d artifacts
+      - name: Download bundle stats and SDK package artifacts
+        uses: actions/github-script@v9
+        with:
+          script: | # js
+            const fs = require("fs");
+
+            async function fetchArtifact(name) {
+              const res = await github.rest.actions.listArtifactsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                per_page: 1,
+              });
+              const artifact = res.data?.artifacts?.[0];
+              if (!artifact) {
+                console.log(`Artifact not found: ${name}`);
+                return "";
+              }
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: "zip",
+              });
+              fs.writeFileSync(`${name}.zip`, Buffer.from(download.data));
+              console.log(`Downloaded ${name}`);
+              return `${name}.zip`;
+            }
+
+            const sha = process.env.HEAD_SHA;
+            core.exportVariable("STATS_ZIP", await fetchArtifact(`metabase-bundle-stats-ee-${sha}`));
+            core.exportVariable("PKG_ZIP", await fetchArtifact(`embedding-sdk-${sha}`));
+      - name: Extract stats and SDK package
+        run: |
+          mkdir -p artifacts resources/embedding-sdk
+          if [ -n "$STATS_ZIP" ]; then unzip -o "$STATS_ZIP" -d artifacts; fi
+          if [ -n "$PKG_ZIP" ]; then unzip -o "$PKG_ZIP" -d resources/embedding-sdk; fi
+      - name: Measure bundle sizes
+        run: node ./.github/scripts/measure-bundle-sizes.js | tee artifacts/bundle-sizes.json
+      - name: Upload sizes to Stats
+        uses: actions/github-script@v9
+        env:
+          API_KEY: ${{ secrets.STATS_API_KEY }}
+        with:
+          script: | # js
+            const fs = require("fs");
+            const { uploadCsvToMb } = require("${{ github.workspace }}/.github/scripts/csv-to-mb.js");
+
+            const measurements = JSON.parse(
+              fs.readFileSync("${{ github.workspace }}/artifacts/bundle-sizes.json", "utf8"),
+            );
+
+            const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+            const commit = process.env.HEAD_SHA.slice(0, 12);
+
+            // version.properties (extracted from the uberjar) carries the build's tag
+            const versionProps = "${{ github.workspace }}/artifacts/version.properties";
+            const version = fs.existsSync(versionProps)
+              ? (fs.readFileSync(versionProps, "utf8").match(/^tag=(.*)$/m)?.[1]?.trim() ?? "")
+              : "";
+
+            const data = measurements.map(measurement => ({
+              "Date": date,
+              "Version": version,
+              "Commit": commit,
+              "Bundle": measurement.bundle,
+              "Kind": measurement.kind, // "initial" or "total"
+              "Raw bytes": measurement.rawBytes,
+              "Gzip bytes": measurement.gzipBytes,
+              "Brotli bytes": measurement.brotliBytes ?? "", // as-served; empty when no .br shipped
+              "File count": measurement.fileCount,
+            }));
+
+            console.table(data);
+
+            uploadCsvToMb({
+              baseUrl: "https://stats.metabase.com",
+              tableId: 40009,
+              jsonData: data,
+              mode: "append",
+            }).then(() => {
+              console.log("Bundle sizes uploaded successfully");
+            }).catch(error => {
+              console.error("Error uploading bundle sizes:", error);
+              process.exit(1);
+            });

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -128,6 +128,8 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
       SKIP_LICENSES: ${{ github.event_name == 'pull_request' }}  # faster builds for dev
+      # Emit bundle stats on trunk/release builds so they can be tracked over time
+      EMIT_BUNDLE_STATS: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'release-')) && 'true' || 'false' }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v6
@@ -143,6 +145,14 @@ jobs:
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
       - name: Build
         run: ./bin/build.sh
+      - name: Upload bundle stats
+        if: ${{ matrix.edition == 'ee' && env.EMIT_BUNDLE_STATS == 'true' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: metabase-bundle-stats-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
+          path: target/bundle-stats
+          if-no-files-found: warn
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
         with:

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -35,7 +35,8 @@
                :env {"PATH"       (env/env :path)
                      "HOME"       (env/env :user-home)
                      "WEBPACK_BUNDLE"   "production"
-                     "MB_EDITION" mb-edition}}
+                     "MB_EDITION" mb-edition
+                     "EMIT_BUNDLE_STATS" (or (env/env :emit-bundle-stats) "false")}}
               "bun" "run" "build-release"))
       (u/step "Build static viz"
         (u/sh {:dir u/project-root-directory

--- a/frontend/build/shared/rspack/bundle-stats.js
+++ b/frontend/build/shared/rspack/bundle-stats.js
@@ -34,7 +34,11 @@ function bundleStatsPlugins(statsFileName) {
           entrypoints: Object.fromEntries(
             Object.entries(stats.entrypoints || {}).map(([name, entry]) => [
               name,
-              { assets: (entry.assets || []).map((asset) => ({ name: asset.name || asset })) },
+              {
+                assets: (entry.assets || []).map((asset) => ({
+                  name: asset.name || asset,
+                })),
+              },
             ]),
           ),
         }),

--- a/frontend/build/shared/rspack/bundle-stats.js
+++ b/frontend/build/shared/rspack/bundle-stats.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* eslint-disable import/no-commonjs */
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 
 const EMIT_BUNDLE_STATS = process.env.EMIT_BUNDLE_STATS === "true";

--- a/frontend/build/shared/rspack/bundle-stats.js
+++ b/frontend/build/shared/rspack/bundle-stats.js
@@ -1,0 +1,45 @@
+/* eslint-env node */
+/* eslint-disable import/no-commonjs */
+const { StatsWriterPlugin } = require("webpack-stats-plugin");
+
+const EMIT_BUNDLE_STATS = process.env.EMIT_BUNDLE_STATS === "true";
+
+// Both bundle outputs (app/dist and app/embedding-sdk) sit four directories
+// below the repo root, so this relative path lands in <repo>/target for both.
+const STATS_OUTPUT_PREFIX = "../../../../target/bundle-stats/";
+
+/**
+ * When EMIT_BUNDLE_STATS is set, writes a minimal stats file (asset names/sizes
+ * plus per-entrypoint asset lists) outside the bundle output dir so it never
+ * ships inside the uberjar. .github/scripts/measure-bundle-sizes.js reads it to
+ * split "initial" (entry + sync chunks) from "total" bundle size.
+ *
+ * Returns an array so it can be spread into a `plugins` list and disappear when
+ * stats are not requested.
+ */
+function bundleStatsPlugins(statsFileName) {
+  if (!EMIT_BUNDLE_STATS) {
+    return [];
+  }
+  return [
+    new StatsWriterPlugin({
+      stats: { all: false, assets: true, entrypoints: true },
+      filename: STATS_OUTPUT_PREFIX + statsFileName,
+      transform: (stats) =>
+        JSON.stringify({
+          assets: (stats.assets || []).map((asset) => ({
+            name: asset.name,
+            size: asset.size,
+          })),
+          entrypoints: Object.fromEntries(
+            Object.entries(stats.entrypoints || {}).map(([name, entry]) => [
+              name,
+              { assets: (entry.assets || []).map((asset) => ({ name: asset.name || asset })) },
+            ]),
+          ),
+        }),
+    }),
+  ];
+}
+
+module.exports = { bundleStatsPlugins };

--- a/rspack.embedding-sdk-bundle.config.js
+++ b/rspack.embedding-sdk-bundle.config.js
@@ -8,6 +8,9 @@ const BundleAnalyzerPlugin =
 const prefixwrap = require("postcss-prefixwrap");
 
 const mainConfig = require("./rspack.main.config");
+const {
+  bundleStatsPlugins,
+} = require("./frontend/build/shared/rspack/bundle-stats");
 const { resolve } = require("path");
 const path = require("path");
 
@@ -234,6 +237,7 @@ const config = {
   },
 
   plugins: [
+    ...bundleStatsPlugins("stats-embedding-sdk.json"),
     new rspack.BannerPlugin(getBannerOptions(LICENSE_TEXT)),
     new NodePolyfillPlugin(), // for crypto, among others
     // https://github.com/remarkjs/remark/discussions/903

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -10,6 +10,9 @@ const WebpackNotifierPlugin = require("webpack-notifier");
 const {
   COMPRESSION_CONFIG,
 } = require("./frontend/build/shared/rspack/compression");
+const {
+  bundleStatsPlugins,
+} = require("./frontend/build/shared/rspack/bundle-stats");
 
 const {
   IS_DEV_MODE,
@@ -261,6 +264,7 @@ const config = {
   },
 
   plugins: [
+    ...bundleStatsPlugins("stats-main.json"),
     // Extracts initial CSS into a standard stylesheet that can be loaded in parallel with JavaScript
     new rspack.CssExtractRspackPlugin({
       filename: isDevMode ? "[name].css" : "[name].[contenthash].css",


### PR DESCRIPTION
This PR adds a CI workflow that pushes the bundle sizes for the commit to stats so we can visualize the progress of getting our bundle sizes under control.

<img width="1296" height="918" alt="image" src="https://github.com/user-attachments/assets/115c2d77-a6ed-4cf1-a415-92171892f210" />
