### PR TITLE
Fix native time grouping ordinal labels

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -697,10 +697,6 @@ const getCategoryXAxisColumn = (
   }
 
   const xValues = dataset.map((datum) => datum[X_AXIS_DATA_KEY]);
-  if (xValues.every((value) => tryGetDate(value) == null)) {
-    return column;
-  }
-
   const dataTimeSeriesInterval = computeTimeseriesDataInterval(xValues, null);
   const formatUnit = dataTimeSeriesInterval
     ? getFormatUnit(column, dataTimeSeriesInterval)

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -680,6 +680,35 @@ const getFormatUnit = (
 
   return dimensionColumn.unit;
 };
+
+const isDateColumn = (column: DatasetColumn) => {
+  return (
+    (column.effective_type ?? column.base_type)?.startsWith("type/Date") ??
+    false
+  );
+};
+
+const getCategoryXAxisColumn = (
+  column: DatasetColumn,
+  dataset: ChartDataset,
+) => {
+  if (!isDateColumn(column) || isAbsoluteDateTimeUnit(column.unit)) {
+    return column;
+  }
+
+  const xValues = dataset.map((datum) => datum[X_AXIS_DATA_KEY]);
+  if (xValues.every((value) => tryGetDate(value) == null)) {
+    return column;
+  }
+
+  const dataTimeSeriesInterval = computeTimeseriesDataInterval(xValues, null);
+  const formatUnit = dataTimeSeriesInterval
+    ? getFormatUnit(column, dataTimeSeriesInterval)
+    : column.unit;
+
+  return formatUnit ? { ...column, unit: formatUnit } : column;
+};
+
 export function getTimeSeriesXAxisModel(
   dimensionModel: DimensionModel,
   rawSeries: RawSeries,
@@ -826,7 +855,7 @@ export function getXAxisModel(
     );
   }
 
-  const column = dimensionModel.column;
+  const column = getCategoryXAxisColumn(dimensionModel.column, dataset);
   const columnSettings =
     column != null ? (settings.column?.(column) ?? {}) : {};
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
@@ -1,9 +1,19 @@
 import dayjs from "dayjs";
 
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { RowValue } from "metabase-types/api";
+import {
+  createMockDatetimeColumn,
+  createMockSingleSeries,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
 
-import { computeSplit, getXAxisDateRangeFromSortedXAxisValues } from "./axis";
-import type { SeriesExtents } from "./types";
+import {
+  computeSplit,
+  getXAxisDateRangeFromSortedXAxisValues,
+  getXAxisModel,
+} from "./axis";
+import type { DimensionModel, SeriesExtents } from "./types";
 
 describe("computeSplit", () => {
   const extents: SeriesExtents = {
@@ -25,6 +35,35 @@ describe("computeSplit", () => {
     expect(computeSplit(extents).flat()).toHaveLength(
       Object.keys(extents).length,
     );
+  });
+});
+
+describe("getXAxisModel", () => {
+  it("should format untagged datetime values using the inferred temporal unit for ordinal scale (#68179)", () => {
+    const dateColumn = createMockDatetimeColumn({ unit: undefined });
+
+    const dimensionModel: DimensionModel = {
+      column: dateColumn,
+      columnIndex: 0,
+      columnByCardId: { 1: dateColumn },
+    };
+
+    const dataset = [
+      { [X_AXIS_DATA_KEY]: "2022-01-01T00:00:00Z", "0": 10 },
+      { [X_AXIS_DATA_KEY]: "2022-02-01T00:00:00Z", "0": 20 },
+      { [X_AXIS_DATA_KEY]: "2022-03-01T00:00:00Z", "0": 30 },
+      { [X_AXIS_DATA_KEY]: "2022-04-01T00:00:00Z", "0": 40 },
+    ];
+
+    const rawSeries = [createMockSingleSeries({ display: "line" })];
+
+    const settings = createMockVisualizationSettings({
+      "graph.x_axis.scale": "ordinal",
+    });
+
+    const model = getXAxisModel(dimensionModel, rawSeries, dataset, settings);
+
+    expect(model.formatter("2022-04-01T00:00:00Z")).toBe("April 2022");
   });
 });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68179
Closes https://linear.app/metabase/issue/UXW-2728/time-grouping-with-native-questions-period-names-are-incorrectly

### Description

Native SQL time grouping result columns can arrive without a temporal unit, so ordinal chart axes formatted period values at day granularity. This infers the unit from date category values before formatting ordinal x-axis labels.

### How to verify

1. Create a native SQL question with a time grouping variable returning monthly periods.
2. Visualize as a line chart.
3. Set the X-axis scale to Ordinal.
4. Confirm monthly periods render as labels like `April 2022`, not `April 1, 2022`.

### Demo
Before:
<img width="1908" height="735" alt="image" src="https://github.com/user-attachments/assets/12d82884-fea4-4721-aba6-ffa793e7c544" />

After:
<img width="1908" height="735" alt="image" src="https://github.com/user-attachments/assets/d5dac0fc-d9c3-40c4-835b-6025d4e1e83c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)