### PR TITLE
Fix find-never-defined-css-variables for multi-line and whitespace var() usages

### DIFF
--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
@@ -28,15 +28,12 @@ const shouldWhiteList = (variable: string) => {
 
 // These are variables that were found by the script but were temporarily allowed to get this script + mantine v7 merged
 const knownIssues = [
-  "--mb-bolor-text-error",
-  "--mb-bolor-text-medium",
-  "--mb-color-accent-3",
-  "--mb-spacing-xs",
-  "--mb-text-text-dark",
-  "--multiselect-pill-font-size",
-  "--select-item-font-size",
-  "--select-item-line-height",
   "--button-bg", // Mantine var defined for buttons and used in Button.module.css
+
+  // Mantine generates `--mantine-color-<name>-<variant>` vars at runtime for every
+  // color registered in the theme (see getMantineThemeColors). They aren't present in
+  // the static @mantine/core/styles.css this script reads, so we allow this known one.
+  "--mantine-color-accent-gray-light-filled",
 ];
 
 interface UsageMap {
@@ -83,10 +80,21 @@ const extractVariableUsages = (filePath: string): Set<string> => {
 export const extractVariableUsagesFromFileContent = (
   content: string,
 ): Set<string> => {
-  const pattern = /var\((--[a-zA-Z0-9-]+)\)/g;
-  const matches = Array.from(content.matchAll(pattern)).map(match => match[1]);
+  const pattern = /var\(\s*(--[a-zA-Z0-9-]+)\s*([,)])/g;
 
-  return new Set(matches);
+  const usages = Array.from(content.matchAll(pattern)).flatMap(match => {
+    const [, variable, terminator] = match;
+    const hasFallback = terminator === ",";
+
+    // A bare `var(--x)` must resolve to a defined variable. A `var(--x, fallback)`
+    // is safe by construction — unless it's one of our `--mb-*` design-system
+    // primitives, which are expected to always be defined
+    const shouldValidate = !hasFallback || variable.startsWith("--mb-");
+
+    return shouldValidate ? [variable] : [];
+  });
+
+  return new Set(usages);
 };
 
 const main = () => {

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
@@ -30,9 +30,10 @@ const shouldWhiteList = (variable: string) => {
 const knownIssues = [
   "--button-bg", // Mantine var defined for buttons and used in Button.module.css
 
-  // Mantine generates `--mantine-color-<name>-<variant>` vars at runtime for every
-  // color registered in the theme (see getMantineThemeColors). They aren't present in
-  // the static @mantine/core/styles.css this script reads, so we allow this known one.
+  // `accent-gray-light` is one of our theme colors (registered via getMantineThemeColors).
+  // Mantine derives variant vars like `--mantine-color-<color>-filled` from each registered
+  // color at runtime, so they aren't in the static @mantine/core/styles.css this script
+  // reads — hence this allow-list entry.
   "--mantine-color-accent-gray-light-filled",
 ];
 

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
@@ -73,4 +73,86 @@ describe("extractVariableUsagesFromFileContent", () => {
     const result = extractVariableUsagesFromFileContent(content);
     expect(result).toEqual(new Set(["--theme-color", "--theme-background"]));
   });
+
+  it("should extract bare usage with inner whitespace", () => {
+    const content = `
+      .button {
+        color: var( --color-brand );
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--color-brand"]));
+  });
+
+  it("should extract bare usage split across multiple lines", () => {
+    const content = `
+      .button {
+        --mb-color-background-secondary: var(
+          --mb-color-background-tertiary-inverse
+        );
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--mb-color-background-tertiary-inverse"]));
+  });
+
+  it("should extract bare usage nested inside a multi-line color-mix", () => {
+    const content = `
+      .label {
+        color: color-mix(
+          in srgb,
+          var(--mb-color-text-primary-inverse) 45%,
+          transparent
+        );
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--mb-color-text-primary-inverse"]));
+  });
+
+  it("should treat a non-mb usage with a fallback as safe and not extract it", () => {
+    // These are intentional override hooks: deliberately undefined, with a
+    // sensible default. The fallback makes them safe by construction.
+    const content = `
+      .schedule {
+        font-weight: var(--schedule-font-weight, normal);
+        flex: var(--native-query-editor-flex, none);
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set());
+  });
+
+  it("should still extract an mb-* usage even when it has a fallback", () => {
+    // `--mb-*` are design-system primitives expected to always be defined; a
+    // fallback would silently mask a typo or a backport that drops the variable.
+    const content = `
+      .preview {
+        border-radius: var(--mb-radius-md, 8px);
+        background: var(--mb-color-brand, red);
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--mb-radius-md", "--mb-color-brand"]));
+  });
+
+  it("should extract a bare var nested in a non-mb fallback but not the safe wrapper", () => {
+    const content = `
+      .button {
+        color: var(--notification-warning-text-color, var(--mb-color-text-secondary));
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--mb-color-text-secondary"]));
+  });
+
+  it("should ignore dynamically constructed var() usages", () => {
+    // We can't statically validate the interpolated name, so these are skipped.
+    const content = `
+      const color = (name) => \`var(--mb-color-\${name})\`;
+      const radius = (size) => \`var(--mb-radius-\${size}, 8px)\`;
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set());
+  });
 });

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
@@ -147,8 +147,6 @@ describe("extractVariableUsagesFromFileContent", () => {
   });
 
   it("should extract an mb-* wrapper with a fallback and the bare var nested in it", () => {
-    // Mirror of the case above: when the mb-* var is the one carrying the fallback it's
-    // still validated (mb-* must always be defined), and the nested bare var is too.
     const content = `
       .button {
         color: var(--mb-color-text-secondary, var(--notification-warning-text-color));

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
@@ -146,6 +146,20 @@ describe("extractVariableUsagesFromFileContent", () => {
     expect(result).toEqual(new Set(["--mb-color-text-secondary"]));
   });
 
+  it("should extract an mb-* wrapper with a fallback and the bare var nested in it", () => {
+    // Mirror of the case above: when the mb-* var is the one carrying the fallback it's
+    // still validated (mb-* must always be defined), and the nested bare var is too.
+    const content = `
+      .button {
+        color: var(--mb-color-text-secondary, var(--notification-warning-text-color));
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(
+      new Set(["--mb-color-text-secondary", "--notification-warning-text-color"]),
+    );
+  });
+
   it("should ignore dynamically constructed var() usages", () => {
     // We can't statically validate the interpolated name, so these are skipped.
     const content = `

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.module.css
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.module.css
@@ -1,6 +1,6 @@
 .PreviewContainer {
   box-shadow: 0 6px 24px 0 rgba(0, 0, 0, 0.1);
-  border-radius: var(--mb-radius-md, 8px);
+  border-radius: var(--mantine-radius-md, 8px);
   overflow: hidden;
 }
 

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -51,9 +51,7 @@ body:where(:global(.mb-wrapper)) {
     var(--mb-color-text-primary-inverse) 45%,
     transparent
   );
-  --mb-color-background-secondary: var(
-    --mb-color-background-tertiary-inverseer
-  );
+  --mb-color-background-secondary: var(--mb-color-background-tertiary-inverse);
 }
 
 [data-metabase-theme="transparent"][data-metabase-theme="transparent"] {

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -26,16 +26,6 @@
   }
 }
 
-.Select {
-  &:has(.SelectLabel),
-  &:has(.SelectDescription),
-  &:has(.SelectError) {
-    .SelectWrapper {
-      margin-top: var(--mb-spacing-xs);
-    }
-  }
-}
-
 .SelectInput {
   color: var(--mb-color-text-primary);
   background-color: var(--mb-color-background-primary);
@@ -92,8 +82,6 @@
   --combobox-option-padding: 0;
 
   color: var(--mb-color-text-primary);
-  font-size: var(--select-item-font-size);
-  line-height: var(--select-item-line-height);
   margin-top: 1px;
 
   &:hover {
@@ -139,8 +127,6 @@
 .SelectItemsNothingFound {
   color: var(--mb-color-text-tertiary);
   padding: var(--mantine-spacing-sm);
-  font-size: var(--select-item-font-size);
-  line-height: var(--select-item-line-height);
 }
 
 .SelectItems_Options {

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.module.css
@@ -18,7 +18,7 @@
   }
 
   &[data-error] .track {
-    border: 1px solid var(--mb-color-accent-3);
+    border: 1px solid var(--mb-color-accent3);
   }
 
   .body {


### PR DESCRIPTION
Closes [GDGT-2642](https://linear.app/metabase/issue/GDGT-2642)

### Description

The previous `var()` matcher missed a couple of cases — whitespace inside `var( … )` and multi-line usages — so some undefined CSS variables slipped past the lint. This PR tightens the matcher to catch them, with unit tests.

The gap turned out to be masking a few real bugs in the code, which are also fixed here (see inline comments), and the `knownIssues` whitelist was pruned accordingly.

### How to verify

CI should be green — these changes are covered by unit tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR