### PR TITLE
test(sdk-bundle): Fix flaky e2e test (data picker)

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1417,43 +1417,37 @@ describe("issue 51934 (EMB-189)", () => {
     // when clicking it causes its own re-render.
     const clickPickerItem = (name) => {
       cy.get('[data-testid="mini-picker-list-loader"]').should("not.exist");
-      cy.findByRole("menuitem", { name }).click({ force: true });
+      cy.findByRole("menuitem", { name }).click();
     };
 
-    // Any click that swaps one popover for another (data-source -> join,
-    // notebook-step click -> data-picker) can leave both briefly — or, on a
-    // slow CI runner, for longer than Cypress's default 4 s retry —
-    // visible: the outgoing one is still in its close transition while the
-    // incoming one is already mounted. Cypress's `H.popover().within()`
-    // selects every visible popover, so on a microtask-scheduled fetch
-    // resolution it can match 2 elements and throw.
+    // The data-source picker and the join picker are both rendered by the same
+    // embedding DataSourceSelector, so a generic popover query could not tell
+    // them apart. When a click swaps one for the other they can briefly overlap
+    // (the outgoing one is still in its close transition while the incoming one
+    // is already mounted), which made matching ambiguous and flaky on slow CI
+    // runners.
     //
-    // `latestPopover()` always returns the most recently mounted visible
-    // popover. Mantine appends portalled popovers to the end of <body>, so
-    // the last DOM match is the newest. Use this in place of
-    // `H.popover()` whenever a click might have just swapped popovers.
-    const latestPopover = () =>
+    // Each picker now carries its trigger's label as the dropdown's accessible
+    // name (`aria-label`), so we can target each popover deterministically by
+    // name regardless of any transition overlap. `.filter(":visible").last()`
+    // guards against a same-named popover that is still animating closed.
+    const pickerPopover = (name) =>
       cy
-        .get(
-          '.popover[data-state~="visible"],[data-element-id=mantine-popover]',
-        )
+        .get(`[data-element-id=mantine-popover][aria-label="${name}"]`)
         .filter(":visible")
         .should("have.length.at.least", 1)
         .last();
+    const dataSourcePopover = () => pickerPopover("Pick your starting data");
+    const joinPopover = () => pickerPopover("Pick data to join");
 
-    // Each click below swaps the picker view (or selects an item), which
-    // remounts the popover. A single `latestPopover().within(...)` would pin
-    // the popover element from its first command, so a later command in the
-    // same block hits the now-detached node. Re-acquire `latestPopover()` for
-    // every remounting action so Cypress re-queries onto the newest popover.
     cy.log("select a table as a data source");
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByText("Raw Data").click();
     });
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByRole("heading", { name: QA_DB_NAME }).click();
     });
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByRole("option", { name: DATA_SOURCE_NAME }).click();
     });
     H.getNotebookStep("data").button("Join data").click();
@@ -1461,7 +1455,7 @@ describe("issue 51934 (EMB-189)", () => {
     cy.log(
       'select the "Join" step when the data source is a table will open a table in the same database',
     );
-    latestPopover().within(() => {
+    joinPopover().within(() => {
       cy.findByText(QA_DB_NAME).should("be.visible");
       cy.findByRole("option", { name: "Orders" }).should("be.visible");
     });
@@ -1472,24 +1466,26 @@ describe("issue 51934 (EMB-189)", () => {
     H.getNotebookStep("data").findByText(DATA_SOURCE_NAME).click();
 
     cy.log('go back to the "Bucket" step');
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.icon("chevronleft").click();
     });
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.icon("chevronleft").click();
     });
 
     cy.log(
       "select a question as a data source should open the saved question step in the same collection as the data source (metabase#58357)",
     );
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByText("Saved Questions").click();
     });
-    latestPopover().within(() => clickPickerItem(COLLECTION_NAME));
-    latestPopover().within(() => clickPickerItem(QUESTION_IN_COLLECTION_NAME));
+    dataSourcePopover().within(() => clickPickerItem(COLLECTION_NAME));
+    dataSourcePopover().within(() =>
+      clickPickerItem(QUESTION_IN_COLLECTION_NAME),
+    );
 
     cy.log("the join popover is automatically opened");
-    latestPopover().within(() => {
+    joinPopover().within(() => {
       cy.log("the collection of the data source should be selected");
       cy.findByRole("menuitem", { name: COLLECTION_NAME }).should(
         "have.css",
@@ -1506,18 +1502,17 @@ describe("issue 51934 (EMB-189)", () => {
     H.getNotebookStep("data").findByText(QUESTION_IN_COLLECTION_NAME).click();
 
     // Go back to the "Bucket" step
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByText("Saved Questions").click();
     });
     // We're now at the "Bucket" step
-    latestPopover().within(() => {
+    dataSourcePopover().within(() => {
       cy.findByText("Models").click();
     });
-    latestPopover().within(() => clickPickerItem(COLLECTION_NAME));
-    latestPopover().within(() => clickPickerItem(MODEL_IN_COLLECTION_NAME));
+    dataSourcePopover().within(() => clickPickerItem(MODEL_IN_COLLECTION_NAME));
 
     cy.log("the join popover is automatically opened");
-    latestPopover().within(() => {
+    joinPopover().within(() => {
       cy.log("the collection of the data source should be selected");
       cy.findByRole("menuitem", { name: COLLECTION_NAME }).should(
         "have.css",
@@ -1532,10 +1527,10 @@ describe("issue 51934 (EMB-189)", () => {
       "select a data source after selecting a join step should refresh the data picker on the join step",
     );
     H.getNotebookStep("data").findByText(MODEL_IN_COLLECTION_NAME).click();
-    latestPopover().within(() => clickPickerItem("Our analytics"));
-    latestPopover().within(() => clickPickerItem(MODEL_IN_ROOT_NAME));
+    dataSourcePopover().within(() => clickPickerItem("Our analytics"));
+    dataSourcePopover().within(() => clickPickerItem(MODEL_IN_ROOT_NAME));
 
-    latestPopover().within(() => {
+    joinPopover().within(() => {
       cy.log("the collection of the new data source should be selected");
       cy.findByRole("menuitem", { name: "Our analytics" }).should(
         "have.css",

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -854,7 +854,9 @@ export class UnconnectedDataSelector extends Component {
             </Box>
           </Popover.Target>
 
-          <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>
+          <Popover.Dropdown aria-label={this.props.popoverAriaLabel}>
+            {this.renderContent()}
+          </Popover.Dropdown>
         </Popover>
       );
     }

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -18,4 +18,10 @@ export interface DataSourceSelectorProps {
   canSelectQuestion: boolean;
   triggerElement: JSX.Element;
   setSourceTableFn: (tableId: TableId) => void;
+  /**
+   * Accessible name applied to the popover dropdown. Lets consumers that
+   * render more than one picker (e.g. the notebook's data and join steps)
+   * give each popover a distinct, queryable name.
+   */
+  popoverAriaLabel?: string;
 }

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -21,6 +21,7 @@ type EmbeddingDataPickerProps = {
   query: Lib.Query;
   stageIndex: number;
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
+  title: string;
   placeholder: string;
   canChangeDatabase: boolean;
   isDisabled: boolean;
@@ -30,6 +31,7 @@ export function EmbeddingDataPicker({
   query,
   stageIndex,
   table,
+  title,
   placeholder,
   canChangeDatabase,
   isDisabled,
@@ -140,6 +142,7 @@ export function EmbeddingDataPicker({
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
       canSelectQuestion={entityTypes.includes("question")}
+      popoverAriaLabel={title}
       triggerElement={
         <DataPickerTarget
           table={table}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
@@ -51,6 +51,7 @@ export function setup({
       canChangeDatabase={true}
       isDisabled={false}
       onChange={jest.fn()}
+      title="Pick your starting data"
       placeholder="Pick your starting data"
       table={undefined}
     />,

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -113,6 +113,7 @@ export function NotebookDataPicker({
           query={query}
           stageIndex={stageIndex}
           table={table}
+          title={title}
           placeholder={placeholder}
           canChangeDatabase={canChangeDatabase}
           isDisabled={isDisabled}


### PR DESCRIPTION
Closes [EMB-1895: \[Flaky Test\] \[e2e-tests\] issue 51934 (EMB-189) issue 51934 (EMB-189) should set the starting join step based on the query source](https://linear.app/metabase/issue/EMB-1895/flaky-test-e2e-tests-issue-51934-emb-189-issue-51934-emb-189-should)

In the embedding notebook, both the **data step** and the **join step** render the same `DataSourceSelector`, whose popover had no way to be told apart. The test had to fall back to "grab the last visible popover" (`latestPopover()`), which is racy: when one click swaps the data-source popover for the join popover, both are briefly mounted during the close/open transition, so on slow CI the test could target the wrong popover.

Each picker now applies its trigger's label as the popover dropdown's accessible name (`aria-label`), so the test can target each popover deterministically by name regardless of transition overlap.

[100 burns stress test](https://github.com/metabase/metabase/actions/runs/27760927724)