### PR TITLE
fix: restore cache-first fetch in addCardToDashboard

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -172,12 +172,20 @@ export type AddCardToDashboardOpts = NewDashCardOpts & {
 
 export const addCardToDashboard =
   ({ dashId, tabId, cardId }: AddCardToDashboardOpts) =>
-  async (dispatch: Dispatch) => {
-    const card = await runRtkEndpoint(
-      { id: cardId },
-      dispatch,
-      cardApi.endpoints.getCard,
-    );
+  async (dispatch: Dispatch, getState: GetState) => {
+    const cached = cardApi.endpoints.getCard.select({ id: cardId })(
+      getState(),
+    ).data;
+    const card =
+      cached ??
+      (await runRtkEndpoint(
+        { id: cardId },
+        dispatch,
+        cardApi.endpoints.getCard,
+        {
+          forceRefetch: false,
+        },
+      ));
 
     const dashcardId = generateTemporaryDashcardId();
     const dashcard = dispatch(

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -173,6 +173,14 @@ export type AddCardToDashboardOpts = NewDashCardOpts & {
 export const addCardToDashboard =
   ({ dashId, tabId, cardId }: AddCardToDashboardOpts) =>
   async (dispatch: Dispatch, getState: GetState) => {
+    dispatch(
+      setDashboardAttributes({
+        id: dashId,
+        attributes: {},
+        isAddingCard: true,
+      }),
+    );
+
     const cached = cardApi.endpoints.getCard.select({ id: cardId })(
       getState(),
     ).data;
@@ -182,10 +190,16 @@ export const addCardToDashboard =
         { id: cardId },
         dispatch,
         cardApi.endpoints.getCard,
-        {
-          forceRefetch: false,
-        },
+        { forceRefetch: false },
       ));
+
+    dispatch(
+      setDashboardAttributes({
+        id: dashId,
+        attributes: {},
+        isAddingCard: false,
+      }),
+    );
 
     const dashcardId = generateTemporaryDashcardId();
     const dashcard = dispatch(

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -356,7 +356,7 @@ async function runAddCardToDashboard({
     dashId,
     tabId,
     cardId,
-  })(store.dispatch);
+  })(store.dispatch, store.getState);
   const nextState = store.getState();
 
   const tempDashCardId =

--- a/frontend/src/metabase/dashboard/actions/core.ts
+++ b/frontend/src/metabase/dashboard/actions/core.ts
@@ -38,6 +38,7 @@ export type SetDashboardAttributesOpts = {
   id: DashboardId;
   attributes: Partial<Dashboard>;
   isDirty?: boolean;
+  isAddingCard?: boolean;
 };
 export const SET_DASHBOARD_ATTRIBUTES =
   "metabase/dashboard/SET_DASHBOARD_ATTRIBUTES";

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -284,6 +284,7 @@ function newDashboard(
   before: StoreDashboard,
   after: Partial<Dashboard>,
   isDirty: boolean,
+  isAddingCard?: boolean,
 ): StoreDashboard {
   return {
     ...before,
@@ -292,6 +293,7 @@ function newDashboard(
     ...omit(after, "dashcards", "tabs"),
     embedding_params: syncParametersAndEmbeddingParams(before, after),
     isDirty,
+    ...(isAddingCard !== undefined && { isAddingCard }),
   };
 }
 
@@ -305,10 +307,18 @@ export const dashboards = createReducer(
       }))
       .addCase(
         setDashboardAttributes,
-        (state, { payload: { id, attributes, isDirty = true } }) => {
+        (
+          state,
+          { payload: { id, attributes, isDirty = true, isAddingCard } },
+        ) => {
           // Cast to avoid infinite type instantiation error.
           const dashboards = state as Record<string, StoreDashboard>;
-          dashboards[id] = newDashboard(dashboards[id], attributes, isDirty);
+          dashboards[id] = newDashboard(
+            dashboards[id],
+            attributes,
+            isDirty,
+            isAddingCard,
+          );
         },
       )
       .addCase(addCardToDash, (state, { payload: dashcard }) => {

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -336,7 +336,7 @@ export const getIsDirty = createSelector(
       return false;
     }
 
-    if (dashboard.isDirty) {
+    if (dashboard.isDirty || dashboard.isAddingCard) {
       return true;
     }
 

--- a/frontend/src/metabase/redux/store/dashboard.ts
+++ b/frontend/src/metabase/redux/store/dashboard.ts
@@ -60,6 +60,7 @@ export type StoreDashboard = Omit<Dashboard, "dashcards" | "tabs"> & {
   dashcards: DashCardId[];
   tabs?: StoreDashboardTab[];
   isDirty?: boolean;
+  isAddingCard?: boolean;
 };
 
 export type StoreDashcard = DashboardCard & {


### PR DESCRIPTION
Fixes EMB-1896

### Description

`addCardToDashboard` regressed in 5325f240e9f ("Remove Question entity", PR #74652). `Questions.actions.fetch` was cache-first — it read from the entity store synchronously on a cache hit. The replacement, `runRtkEndpoint`, defaults to `forceRefetch: true`, always hitting the network. This broke the leave-confirmation modal: on a cache miss, the async fetch meant `dashcard.isAdded` wasn't set before the user navigated away.

Fix: read from `cardApi.endpoints.getCard.select()` synchronously first; fall through to `runRtkEndpoint({ forceRefetch: false })` only on a cache miss — restoring the pre-refactor behavior. Also adds `isAddingCard` flag to `StoreDashboard` that `getIsDirty` checks, set synchronously before the fetch so the modal engages immediately regardless of cache state.

### How to verify

Stress test: `should allow to save unsaved changes before creating a dashboard question` in `e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx`

- `origin/master` — ❌ [27/30](https://github.com/metabase/metabase/actions/runs/27768219438)
- This PR — ❌ [27/30](https://github.com/metabase/metabase/actions/runs/27773347630)