### PR TITLE
BigQuery - `sample-table` with adaptive page size

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -792,8 +792,10 @@
                (recur page it acc' (inc n)))
 
              ;; This page is exhausted - ask `next-page` for another and keep processing.
+             ;; `some->` keeps the old nil-page tolerance (#47339): a nil page yields no next page and falls through
+             ;; to the `acc` branch (empty result) instead of NPEing inside `next-page`.
              :else
-             (if-let [new-page (next-page page)]
+             (if-let [new-page (some-> page next-page)]
                (if-let [new-iter (some-> new-page values-iterator)]
                  (do
                    (log/trace "BigQuery: New page returned")

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -535,52 +535,97 @@
 (declare reducible-bigquery-results)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                          Sizing sample pages by type                                           |
+;;; |                                        Sizing sample pages by measurement                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; `tabledata.list` returns whole rows (it can't project columns in this SDK), and the parsed page is held in memory
 ;;; while we fingerprint it. A wide table, or a narrow one with heavy columns (large text, BYTES, JSON, or nested
-;;; RECORD/REPEATED) can make a page huge and OOM sync. We can't know exact sizes, so we estimate a per-row byte cost
-;;; from column types and request proportionally fewer rows per page for heavier tables.
-
-(def ^:private scalar-field-estimated-bytes
-  "Per-cell estimate for fixed-width scalar columns (numbers, booleans, temporals)."
-  16)
-
-(def ^:private text-field-estimated-bytes
-  "Per-cell estimate for `:type/Text` and unknown (`:type/*`, e.g. BYTES/GEOGRAPHY) columns."
-  2048)
-
-(def ^:private large-field-estimated-bytes
-  "Per-cell estimate for `:type/Large` columns: nested RECORDs (`:type/Dictionary`), arrays/REPEATED (`:type/Array`),
-  and JSON (`:type/JSON`). These dominate the per-row cost, so weighting them high makes their tables sample small
-  pages."
-  262144)
-
-(defn- field-estimated-bytes
-  "Rough per-cell byte estimate for `field`, used only to size sample pages. Weighted by the Metabase base type so
-  variable-length and nested/collection types cost far more than fixed-width scalars."
-  ^long [^Field field]
-  (let [[_ base-type] (field->database+base-type field)]
-    (cond
-      (isa? base-type :type/Large) large-field-estimated-bytes
-      (or (isa? base-type :type/Text)
-          (= base-type :type/*))   text-field-estimated-bytes
-      :else                        scalar-field-estimated-bytes)))
+;;; RECORD/REPEATED) can make a page huge and OOM sync. Rather than guess a per-row cost from column types (which is
+;;; wildly inaccurate -- a TEXT column may hold 5 bytes or 5 MB), we *measure* it: fetch a small probe page, then
+;;; recompute the next page size from the average bytes/row actually seen, so each page targets a fixed byte budget.
 
 (def ^:private ^:dynamic *sample-page-byte-budget*
-  "Target estimated bytes per sample page. Page size = budget / estimated-row-bytes, clamped to [1, max-sample-rows].
-  Kept well under the server's ~10 MB `tabledata.list` page cap to leave headroom for JVM object expansion when the
-  page is parsed."
+  "Target measured bytes per `tabledata.list` sample page. The next page size is `budget / measured-bytes-per-row`,
+  clamped to [1, remaining]. Kept well under the server's ~10 MB page cap to leave headroom for JVM object expansion
+  when the page is parsed."
   (* 4 1024 1024))
 
-(defn- sample-page-size
-  "Rows to request per `tabledata.list` page, derived from `schema`'s column types so heavy tables fetch fewer rows.
-  Clamped to [1, max-sample-rows]."
-  ^long [^Schema schema]
-  (let [row-bytes (transduce (map field-estimated-bytes) + 0 (.getFields schema))]
-    (-> (quot (long *sample-page-byte-budget*) (max 1 (long row-bytes)))
+(def ^:private sample-probe-rows
+  "Rows to request for the first (probe) page, before we've measured the table's real row size. Small enough to stay
+  within the budget even for heavy rows, but not 1 -- a handful averages out per-row size variance."
+  10)
+
+(def ^:private sample-cell-overhead-bytes
+  "Approximate JVM footprint of a single parsed cell beyond its character data (the `FieldValue` wrapper plus boxing).
+  Added per cell so the budget tracks in-memory size, not just the wire bytes."
+  64)
+
+(defn- field-value-bytes
+  "Measured (not type-estimated) in-memory size of one parsed cell. `tabledata.list` returns scalars as Strings, so
+  the character count is a faithful proxy; REPEATED/RECORD values (a `FieldValueList`/`List` of cells) are summed
+  recursively."
+  ^long [^FieldValue cell]
+  (let [v (.getValue cell)]
+    (cond
+      (instance? java.util.List v) (reduce (fn [^long acc c] (+ acc (field-value-bytes c)))
+                                           sample-cell-overhead-bytes
+                                           v)
+      (string? v)                  (+ sample-cell-overhead-bytes (.length ^String v))
+      :else                        sample-cell-overhead-bytes)))
+
+(defn- row-bytes
+  "Measured in-memory size of one fetched row."
+  ^long [^FieldValueList row]
+  (reduce (fn [^long acc cell] (+ acc (field-value-bytes cell))) 0 row))
+
+(defn- next-sample-page-size
+  "Rows to request for the next page given the average measured bytes/row so far, targeting `budget` bytes/page.
+  Clamped to [1, `remaining`]."
+  ^long [^long budget ^long measured-bytes ^long measured-rows ^long remaining]
+  (let [avg-row-bytes (max 1 (quot measured-bytes (max 1 measured-rows)))]
+    (-> (quot budget avg-row-bytes)
         (max 1)
-        (min table-rows-sample/max-sample-rows))))
+        (min remaining))))
+
+(defn- reducible-sample-pages
+  "An `IReduceInit` over up to `max-rows` rows of `bq-table`, fetched via `tabledata.list`. The first page is a small
+  probe (`sample-probe-rows`); after each page the next page size is recomputed from the *measured* average bytes/row
+  to target `*sample-page-byte-budget*` per page -- so heavy tables fetch fewer rows per page without relying on
+  column-type estimates. Pages are walked manually (re-issuing `.list` with the page token) because `.getNextPage`
+  reuses the original request's page size, which would pin us to the tiny probe size forever."
+  [^Table bq-table ^long max-rows]
+  (let [budget (long *sample-page-byte-budget*)]
+    (reify clojure.lang.IReduceInit
+      (reduce [_ rf init]
+        (loop [acc        init
+               token      nil
+               page-size  (long sample-probe-rows)
+               seen       0
+               seen-bytes 0]
+          (let [remaining (- max-rows seen)]
+            (if (or (reduced? acc) (<= remaining 0))
+              (unreduced acc)
+              (let [opts (cond-> [(BigQuery$TableDataListOption/pageSize (min page-size remaining))]
+                           token (conj (BigQuery$TableDataListOption/pageToken token)))
+                    page (.list bq-table (u/varargs BigQuery$TableDataListOption opts))
+                    _    (*page-callback*)
+                    res  (reduce (fn [[acc page-bytes page-n] ^FieldValueList row]
+                                   (let [acc' (rf acc row)]
+                                     (if (reduced? acc')
+                                       (reduced [acc' page-bytes page-n])
+                                       [acc' (+ (long page-bytes) (row-bytes row)) (inc (long page-n))])))
+                                 [acc 0 0]
+                                 (.getValues page))
+                    [acc' page-bytes page-n] (unreduced res)
+                    seen'       (+ seen (long page-n))
+                    seen-bytes' (+ seen-bytes (long page-bytes))
+                    token'      (.getNextPageToken page)]
+                (if (or (reduced? acc') (str/blank? token') (zero? (long page-n)))
+                  (unreduced acc')
+                  (recur acc'
+                         token'
+                         (next-sample-page-size budget seen-bytes' seen' (- max-rows seen'))
+                         seen'
+                         seen-bytes'))))))))))
 
 (defn- sample-table
   "Process a sample of rows of fields corresponding to the Metabase fields
@@ -596,17 +641,14 @@
   (let [^Schema schema (.. bq-table getDefinition getSchema)
         field-idxs     (mapv :database_position fields)
         all-parsers    (get-field-parsers schema)
-        parsers        (mapv all-parsers field-idxs)
-        page           (.list bq-table (u/varargs BigQuery$TableDataListOption
-                                         [(BigQuery$TableDataListOption/pageSize (sample-page-size schema))]))]
+        parsers        (mapv all-parsers field-idxs)]
     (transduce
-     (comp (take table-rows-sample/max-sample-rows)
-           (map (partial extract-fingerprint field-idxs parsers)))
+     (map (partial extract-fingerprint field-idxs parsers))
      ;; Instead of passing on fields, we could recalculate the
      ;; metadata from the schema, but that probably makes no
      ;; difference and currently the metadata is ignored anyway.
      (rff {:cols fields})
-     (reducible-bigquery-results page nil (constantly nil)))))
+     (reducible-sample-pages bq-table table-rows-sample/max-sample-rows))))
 
 (defn- ingestion-time-partitioned-table?
   [table-id]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -586,51 +586,42 @@
         (max 1)
         (min remaining))))
 
-(defn- reducible-sample-pages
-  "An `IReduceInit` over up to `max-rows` rows of `bq-table`, fetched via `tabledata.list`. The first page is a small
-  probe (`sample-probe-rows`); after each page the next page size is recomputed from the *measured* average bytes/row
-  to target `*sample-page-byte-budget*` per page -- so heavy tables fetch fewer rows per page without relying on
-  column-type estimates. Pages are walked manually (re-issuing `.list` with the page token) because `.getNextPage`
-  reuses the original request's page size, which would pin us to the tiny probe size forever."
+(defn- list-sample-page
+  "Issue a `tabledata.list` request for at most `page-size` rows, continuing from `page-token` when given."
+  ^TableResult [^Table bq-table page-size ^String page-token]
+  (let [opts (cond-> [(BigQuery$TableDataListOption/pageSize (long page-size))]
+               (not (str/blank? page-token)) (conj (BigQuery$TableDataListOption/pageToken page-token)))]
+    (.list bq-table (u/varargs BigQuery$TableDataListOption opts))))
+
+(defn- adaptive-sample-next-page
+  "A swappable page-advance for [[reducible-bigquery-results]], used when sampling. It measures the just-consumed
+  page's real bytes/row and re-issues `.list` from the page token with a size targeting `*sample-page-byte-budget*`
+  -- a sliding window that adapts per page to the table's actual data instead of guessing from column types. Returns
+  nil once the `max-rows` budget is spent or there are no more pages."
   [^Table bq-table ^long max-rows]
-  (let [budget (long *sample-page-byte-budget*)]
-    (reify clojure.lang.IReduceInit
-      (reduce [_ rf init]
-        (loop [acc        init
-               token      nil
-               page-size  (long sample-probe-rows)
-               seen       0
-               seen-bytes 0]
-          (let [remaining (- max-rows seen)]
-            (if (or (reduced? acc) (<= remaining 0))
-              (unreduced acc)
-              (let [opts (cond-> [(BigQuery$TableDataListOption/pageSize (min page-size remaining))]
-                           token (conj (BigQuery$TableDataListOption/pageToken token)))
-                    page (.list bq-table (u/varargs BigQuery$TableDataListOption opts))
-                    _    (*page-callback*)
-                    res  (reduce (fn [[acc page-bytes page-n] ^FieldValueList row]
-                                   (let [acc' (rf acc row)]
-                                     (if (reduced? acc')
-                                       (reduced [acc' page-bytes page-n])
-                                       [acc' (+ (long page-bytes) (row-bytes row)) (inc (long page-n))])))
-                                 [acc 0 0]
-                                 (.getValues page))
-                    [acc' page-bytes page-n] (unreduced res)
-                    seen'       (+ seen (long page-n))
-                    seen-bytes' (+ seen-bytes (long page-bytes))
-                    token'      (.getNextPageToken page)]
-                (if (or (reduced? acc') (str/blank? token') (zero? (long page-n)))
-                  (unreduced acc')
-                  (recur acc'
-                         token'
-                         (next-sample-page-size budget seen-bytes' seen' (- max-rows seen'))
-                         seen'
-                         seen-bytes'))))))))))
+  (let [budget (long *sample-page-byte-budget*)
+        seen   (atom {:bytes 0, :rows 0})]
+    (fn [^TableResult page]
+      (let [token (.getNextPageToken page)]
+        (when-not (str/blank? token)
+          (let [[page-bytes page-rows] (reduce (fn [[b n] row] [(+ (long b) (row-bytes row)) (inc (long n))])
+                                               [0 0]
+                                               (.getValues page))
+                {:keys [bytes rows]}   (swap! seen (fn [s] {:bytes (+ (long (:bytes s)) (long page-bytes))
+                                                            :rows  (+ (long (:rows s)) (long page-rows))}))
+                remaining              (- max-rows (long rows))]
+            (when (pos? remaining)
+              (*page-callback*)
+              (list-sample-page bq-table (next-sample-page-size budget bytes rows remaining) token))))))))
 
 (defn- sample-table
   "Process a sample of rows of fields corresponding to the Metabase fields
   `fields` from the BigQuery table `bq-table` using the query result reducing
   function `rff`.
+
+  We fetch a small probe page first and then let [[reducible-bigquery-results]] walk the rest, but with an adaptive
+  page-advance ([[adaptive-sample-next-page]]) that re-sizes each page from the *measured* bytes/row so heavy tables
+  fetch fewer rows -- without column-type guesses, and reusing the existing cancel/dedup/nil-page handling.
 
   `.getSchema` returns nil if called on the result of `.list`, so we have to
   match fields by position. Here it is assumed that :database_position in
@@ -641,14 +632,17 @@
   (let [^Schema schema (.. bq-table getDefinition getSchema)
         field-idxs     (mapv :database_position fields)
         all-parsers    (get-field-parsers schema)
-        parsers        (mapv all-parsers field-idxs)]
+        parsers        (mapv all-parsers field-idxs)
+        probe          (list-sample-page bq-table (min (long sample-probe-rows) table-rows-sample/max-sample-rows) nil)]
     (transduce
-     (map (partial extract-fingerprint field-idxs parsers))
+     (comp (take table-rows-sample/max-sample-rows)
+           (map (partial extract-fingerprint field-idxs parsers)))
      ;; Instead of passing on fields, we could recalculate the
      ;; metadata from the schema, but that probably makes no
      ;; difference and currently the metadata is ignored anyway.
      (rff {:cols fields})
-     (reducible-sample-pages bq-table table-rows-sample/max-sample-rows))))
+     (reducible-bigquery-results probe nil (constantly nil)
+                                 (adaptive-sample-next-page bq-table table-rows-sample/max-sample-rows)))))
 
 (defn- ingestion-time-partitioned-table?
   [table-id]
@@ -749,57 +743,67 @@
      ;; realizing more rows as per the maximum result size
      (.setMaxResults *page-size*))))
 
+(defn- next-page-same-size
+  "Default page-advance for [[reducible-bigquery-results]]: fetch the next page at the original request's page size
+  (BigQuery's `.getNextPage`). Returns nil once the result set is exhausted."
+  ^TableResult [^TableResult page]
+  (when (.hasNextPage page)
+    (log/trace "BigQuery: Fetching new page")
+    (*page-callback*)
+    (or (.getNextPage page)
+        (throw (ex-info "Cannot get next page from BigQuery" {})))))
+
 (defn- reducible-bigquery-results
-  [^TableResult page cancel-chan attempt-job-cancel-fn]
-  (reify
-    clojure.lang.IReduceInit
-    (reduce [_ rf init]
-      ;; TODO: Once we're confident that the memory/thread leaks in BigQuery are resolved, we can remove some of this
-      ;; logging, and certainly remove the `n` counter.
-      ;; NOTE: Page can be nil in various situations, some are understood (early cancel) and some are not. (#47339)
-      (try
-        (loop [^TableResult page page
-               it                (some-> page values-iterator)
-               acc               init
-               n                 0]
-          (cond
-            ;; Early exit. This happens in middleware/limit `(take max)`
-            (reduced? acc)
-            (do (log/tracef "BigQuery: Early exit from reducer after %d rows" n)
-                (attempt-job-cancel-fn)
-                (unreduced acc))
+  "Reducible over the rows of `page` and its successors. `next-page` is the swappable page-advance: given the
+  just-exhausted page it returns the next one (or nil when done). Defaults to [[next-page-same-size]] (fixed page
+  size); the sync sampler passes [[adaptive-sample-next-page]] to resize each page from measured bytes/row."
+  ([^TableResult page cancel-chan attempt-job-cancel-fn]
+   (reducible-bigquery-results page cancel-chan attempt-job-cancel-fn next-page-same-size))
+  ([^TableResult page cancel-chan attempt-job-cancel-fn next-page]
+   (reify
+     clojure.lang.IReduceInit
+     (reduce [_ rf init]
+       ;; TODO: Once we're confident that the memory/thread leaks in BigQuery are resolved, we can remove some of this
+       ;; logging, and certainly remove the `n` counter.
+       ;; NOTE: Page can be nil in various situations, some are understood (early cancel) and some are not. (#47339)
+       (try
+         (loop [^TableResult page page
+                it                (some-> page values-iterator)
+                acc               init
+                n                 0]
+           (cond
+             ;; Early exit. This happens in middleware/limit `(take max)`
+             (reduced? acc)
+             (do (log/tracef "BigQuery: Early exit from reducer after %d rows" n)
+                 (attempt-job-cancel-fn)
+                 (unreduced acc))
 
-            ;; While middleware is processing rows, check for browser initiated cancel.
-            (some-> cancel-chan a/poll!)
-            (throw (ex-info (tru "Query cancelled") {:page n}))
+             ;; While middleware is processing rows, check for browser initiated cancel.
+             (some-> cancel-chan a/poll!)
+             (throw (ex-info (tru "Query cancelled") {:page n}))
 
-            ;; Clear to send: if there's more in `it`, then send it and recur.
-            (some-> it .hasNext)
-            (let [acc' (try
-                         (rf acc (.next it))
-                         (catch Throwable e
-                           (log/errorf e "error in reducible-bigquery-results! %d rows" n)
-                           (throw e)))]
-              (recur page it acc' (inc n)))
+             ;; Clear to send: if there's more in `it`, then send it and recur.
+             (some-> it .hasNext)
+             (let [acc' (try
+                          (rf acc (.next it))
+                          (catch Throwable e
+                            (log/errorf e "error in reducible-bigquery-results! %d rows" n)
+                            (throw e)))]
+               (recur page it acc' (inc n)))
 
-            ;; This page is exhausted - check for another page and keep processing.
-            (some-> page .hasNextPage)
-            (let [_        (log/tracef "BigQuery: Fetching new page after %d rows" n)
-                  _        (*page-callback*)
-                  new-page (.getNextPage page)]
-              (if-let [new-iter (some-> new-page values-iterator)]
-                (do
-                  (log/trace "BigQuery: New page returned")
-                  (recur new-page new-iter acc (inc n)))
-                (throw (ex-info "Cannot get next page from BigQuery" {:page n}))))
-
-            ;; All pages exhausted, so just return.
-            :else
-            (do (log/tracef "BigQuery: All rows consumed (%d)" n)
-                acc)))
-        (catch Throwable t
-          (attempt-job-cancel-fn)
-          (throw t))))))
+             ;; This page is exhausted - ask `next-page` for another and keep processing.
+             :else
+             (if-let [new-page (next-page page)]
+               (if-let [new-iter (some-> new-page values-iterator)]
+                 (do
+                   (log/trace "BigQuery: New page returned")
+                   (recur new-page new-iter acc (inc n)))
+                 (throw (ex-info "Cannot get next page from BigQuery" {:page n})))
+               (do (log/tracef "BigQuery: All rows consumed (%d)" n)
+                   acc))))
+         (catch Throwable t
+           (attempt-job-cancel-fn)
+           (throw t)))))))
 
 (defn- bigquery-execute-response
   "Given the initial query page, respond with metadata and a lazy reducible that will page through the rest of the data."

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -534,6 +534,54 @@
 
 (declare reducible-bigquery-results)
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Sizing sample pages by type                                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; `tabledata.list` returns whole rows (it can't project columns in this SDK), and the parsed page is held in memory
+;;; while we fingerprint it. A wide table, or a narrow one with heavy columns (large text, BYTES, JSON, or nested
+;;; RECORD/REPEATED) can make a page huge and OOM sync. We can't know exact sizes, so we estimate a per-row byte cost
+;;; from column types and request proportionally fewer rows per page for heavier tables.
+
+(def ^:private scalar-field-estimated-bytes
+  "Per-cell estimate for fixed-width scalar columns (numbers, booleans, temporals)."
+  16)
+
+(def ^:private text-field-estimated-bytes
+  "Per-cell estimate for `:type/Text` and unknown (`:type/*`, e.g. BYTES/GEOGRAPHY) columns."
+  2048)
+
+(def ^:private large-field-estimated-bytes
+  "Per-cell estimate for `:type/Large` columns: nested RECORDs (`:type/Dictionary`), arrays/REPEATED (`:type/Array`),
+  and JSON (`:type/JSON`). These dominate the per-row cost, so weighting them high makes their tables sample small
+  pages."
+  262144)
+
+(defn- field-estimated-bytes
+  "Rough per-cell byte estimate for `field`, used only to size sample pages. Weighted by the Metabase base type so
+  variable-length and nested/collection types cost far more than fixed-width scalars."
+  ^long [^Field field]
+  (let [[_ base-type] (field->database+base-type field)]
+    (cond
+      (isa? base-type :type/Large) large-field-estimated-bytes
+      (or (isa? base-type :type/Text)
+          (= base-type :type/*))   text-field-estimated-bytes
+      :else                        scalar-field-estimated-bytes)))
+
+(def ^:private ^:dynamic *sample-page-byte-budget*
+  "Target estimated bytes per sample page. Page size = budget / estimated-row-bytes, clamped to [1, max-sample-rows].
+  Kept well under the server's ~10 MB `tabledata.list` page cap to leave headroom for JVM object expansion when the
+  page is parsed."
+  (* 4 1024 1024))
+
+(defn- sample-page-size
+  "Rows to request per `tabledata.list` page, derived from `schema`'s column types so heavy tables fetch fewer rows.
+  Clamped to [1, max-sample-rows]."
+  ^long [^Schema schema]
+  (let [row-bytes (transduce (map field-estimated-bytes) + 0 (.getFields schema))]
+    (-> (quot (long *sample-page-byte-budget*) (max 1 (long row-bytes)))
+        (max 1)
+        (min table-rows-sample/max-sample-rows))))
+
 (defn- sample-table
   "Process a sample of rows of fields corresponding to the Metabase fields
   `fields` from the BigQuery table `bq-table` using the query result reducing
@@ -545,10 +593,12 @@
   that `.list` returns the fields in that order. The first assumption could be
   lifted by matching the names in `fields` to the names in the table schema."
   [^Table bq-table fields rff]
-  (let [field-idxs  (mapv :database_position fields)
-        all-parsers (get-field-parsers (.. bq-table getDefinition getSchema))
-        parsers     (mapv all-parsers field-idxs)
-        page        (.list bq-table (u/varargs BigQuery$TableDataListOption))]
+  (let [^Schema schema (.. bq-table getDefinition getSchema)
+        field-idxs     (mapv :database_position fields)
+        all-parsers    (get-field-parsers schema)
+        parsers        (mapv all-parsers field-idxs)
+        page           (.list bq-table (u/varargs BigQuery$TableDataListOption
+                                         [(BigQuery$TableDataListOption/pageSize (sample-page-size schema))]))]
     (transduce
      (comp (take table-rows-sample/max-sample-rows)
            (map (partial extract-fingerprint field-idxs parsers)))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -179,6 +179,10 @@
     (getNextPageToken [] token)
     (getValues [] rows)))
 
+(deftest ^:parallel reducible-bigquery-results-nil-page-test
+  (testing "a nil initial page reduces to an empty result instead of NPEing (#47339)"
+    (is (= [] (into [] (#'bigquery/reducible-bigquery-results nil nil (constantly nil)))))))
+
 (deftest ^:synchronized adaptive-sample-next-page-test
   (let [requested (atom [])
         next-size  (fn [budget max-rows rows]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -126,29 +126,35 @@
             ;; TODO Temporarily disabling due to flakiness (#33140)
             #_(is (= 4 @pages-retrieved))))))))
 
+(defn- field-array
+  "A typed `Field[]`. The hint lets the compiler pick the `Field...`/`Schema` overloads of `Field/of`,
+  `Field/newBuilder`, and `Schema/of` without reflection."
+  ^"[Lcom.google.cloud.bigquery.Field;" [fields]
+  (into-array Field fields))
+
 (deftest ^:parallel sample-page-size-type-aware-test
   (let [field-bytes  @#'bigquery/field-estimated-bytes
         page-size    @#'bigquery/sample-page-size
-        no-sub       (into-array Field [])
+        no-sub       (field-array [])
         scalar       (Field/of "n" LegacySQLTypeName/INTEGER no-sub)
         text         (Field/of "s" LegacySQLTypeName/STRING no-sub)
         repeated-str (-> (Field/newBuilder "arr" LegacySQLTypeName/STRING no-sub)
                          (.setMode Field$Mode/REPEATED)
                          (.build))
-        record       (Field/of "rec" LegacySQLTypeName/RECORD (into-array Field [scalar text]))]
+        record       (Field/of "rec" LegacySQLTypeName/RECORD (field-array [scalar text]))]
     (testing "heavier types get larger per-cell estimates"
       (is (< (field-bytes scalar) (field-bytes text)))
       (is (< (field-bytes text) (field-bytes repeated-str)))
       (is (< (field-bytes scalar) (field-bytes record))))
     (testing "narrow scalar tables sample the maximum page"
       (is (= table-rows-sample/max-sample-rows
-             (page-size (Schema/of (into-array Field [scalar scalar scalar]))))))
+             (page-size (Schema/of (field-array [scalar scalar scalar]))))))
     (testing "heavy / nested columns shrink the page well below the max"
-      (is (< (page-size (Schema/of (into-array Field [scalar repeated-str record])))
+      (is (< (page-size (Schema/of (field-array [scalar repeated-str record])))
              table-rows-sample/max-sample-rows)))
     (testing "page size is always at least 1, even for an extremely heavy schema"
       (binding [bigquery/*sample-page-byte-budget* 1]
-        (is (= 1 (page-size (Schema/of (into-array Field [record])))))))))
+        (is (= 1 (page-size (Schema/of (field-array [record])))))))))
 
 ;; These look like the macros from metabase.query-processor.expressions-test
 ;; but conform to bigquery naming rules

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -34,7 +34,7 @@
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2])
   (:import
-   (com.google.cloud.bigquery BigQuery BigQueryException TableResult)
+   (com.google.cloud.bigquery BigQuery BigQueryException Field Field$Mode LegacySQLTypeName Schema TableResult)
    (com.google.cloud.http HttpTransportOptions)))
 
 (set! *warn-on-reflection* true)
@@ -125,6 +125,30 @@
 
             ;; TODO Temporarily disabling due to flakiness (#33140)
             #_(is (= 4 @pages-retrieved))))))))
+
+(deftest ^:parallel sample-page-size-type-aware-test
+  (let [field-bytes  @#'bigquery/field-estimated-bytes
+        page-size    @#'bigquery/sample-page-size
+        no-sub       (into-array Field [])
+        scalar       (Field/of "n" LegacySQLTypeName/INTEGER no-sub)
+        text         (Field/of "s" LegacySQLTypeName/STRING no-sub)
+        repeated-str (-> (Field/newBuilder "arr" LegacySQLTypeName/STRING no-sub)
+                         (.setMode Field$Mode/REPEATED)
+                         (.build))
+        record       (Field/of "rec" LegacySQLTypeName/RECORD (into-array Field [scalar text]))]
+    (testing "heavier types get larger per-cell estimates"
+      (is (< (field-bytes scalar) (field-bytes text)))
+      (is (< (field-bytes text) (field-bytes repeated-str)))
+      (is (< (field-bytes scalar) (field-bytes record))))
+    (testing "narrow scalar tables sample the maximum page"
+      (is (= table-rows-sample/max-sample-rows
+             (page-size (Schema/of (into-array Field [scalar scalar scalar]))))))
+    (testing "heavy / nested columns shrink the page well below the max"
+      (is (< (page-size (Schema/of (into-array Field [scalar repeated-str record])))
+             table-rows-sample/max-sample-rows)))
+    (testing "page size is always at least 1, even for an extremely heavy schema"
+      (binding [bigquery/*sample-page-byte-budget* 1]
+        (is (= 1 (page-size (Schema/of (into-array Field [record])))))))))
 
 ;; These look like the macros from metabase.query-processor.expressions-test
 ;; but conform to bigquery naming rules

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -34,7 +34,7 @@
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2])
   (:import
-   (com.google.cloud.bigquery BigQuery BigQueryException Field Field$Mode LegacySQLTypeName Schema TableResult)
+   (com.google.cloud.bigquery BigQuery BigQueryException Field FieldValue FieldValue$Attribute FieldValueList TableResult)
    (com.google.cloud.http HttpTransportOptions)))
 
 (set! *warn-on-reflection* true)
@@ -126,35 +126,51 @@
             ;; TODO Temporarily disabling due to flakiness (#33140)
             #_(is (= 4 @pages-retrieved))))))))
 
-(defn- field-array
-  "A typed `Field[]`. The hint lets the compiler pick the `Field...`/`Schema` overloads of `Field/of`,
-  `Field/newBuilder`, and `Schema/of` without reflection."
-  ^"[Lcom.google.cloud.bigquery.Field;" [fields]
-  (into-array Field fields))
+(def ^:private ^"[Lcom.google.cloud.bigquery.Field;" no-fields
+  (make-array Field 0))
 
-(deftest ^:parallel sample-page-size-type-aware-test
-  (let [field-bytes  @#'bigquery/field-estimated-bytes
-        page-size    @#'bigquery/sample-page-size
-        no-sub       (field-array [])
-        scalar       (Field/of "n" LegacySQLTypeName/INTEGER no-sub)
-        text         (Field/of "s" LegacySQLTypeName/STRING no-sub)
-        repeated-str (-> (Field/newBuilder "arr" LegacySQLTypeName/STRING no-sub)
-                         (.setMode Field$Mode/REPEATED)
-                         (.build))
-        record       (Field/of "rec" LegacySQLTypeName/RECORD (field-array [scalar text]))]
-    (testing "heavier types get larger per-cell estimates"
-      (is (< (field-bytes scalar) (field-bytes text)))
-      (is (< (field-bytes text) (field-bytes repeated-str)))
-      (is (< (field-bytes scalar) (field-bytes record))))
-    (testing "narrow scalar tables sample the maximum page"
-      (is (= table-rows-sample/max-sample-rows
-             (page-size (Schema/of (field-array [scalar scalar scalar]))))))
-    (testing "heavy / nested columns shrink the page well below the max"
-      (is (< (page-size (Schema/of (field-array [scalar repeated-str record])))
-             table-rows-sample/max-sample-rows)))
-    (testing "page size is always at least 1, even for an extremely heavy schema"
-      (binding [bigquery/*sample-page-byte-budget* 1]
-        (is (= 1 (page-size (Schema/of (field-array [record])))))))))
+(defn- field-value-list
+  "A `FieldValueList` of `cells` with no backing schema (rows from `tabledata.list` are matched by position)."
+  ^FieldValueList [cells]
+  (FieldValueList/of ^java.util.List (vec cells) no-fields))
+
+(defn- prim-cell
+  "A primitive (scalar) `FieldValue`, as `tabledata.list` returns them (everything comes back as a String)."
+  ^FieldValue [v]
+  (FieldValue/of FieldValue$Attribute/PRIMITIVE v))
+
+(defn- repeated-cell
+  "A REPEATED `FieldValue` wrapping `cells` (a `FieldValueList`), as nested/array columns come back."
+  ^FieldValue [cells]
+  (FieldValue/of FieldValue$Attribute/REPEATED (field-value-list cells)))
+
+(deftest ^:parallel field-value-bytes-test
+  (let [field-value-bytes @#'bigquery/field-value-bytes
+        row-bytes         @#'bigquery/row-bytes]
+    (testing "a cell's measured size grows with its actual string length, not its type"
+      (is (< (field-value-bytes (prim-cell "x"))
+             (field-value-bytes (prim-cell (apply str (repeat 1000 "x")))))))
+    (testing "a null cell falls back to the per-cell overhead (no NPE)"
+      (is (pos? (field-value-bytes (prim-cell nil)))))
+    (testing "a REPEATED/RECORD cell sums its children, so it costs more than a scalar"
+      (is (< (field-value-bytes (prim-cell "abc"))
+             (field-value-bytes (repeated-cell [(prim-cell "abc") (prim-cell "abc") (prim-cell "abc")])))))
+    (testing "row-bytes sums its cells"
+      (is (= (+ (field-value-bytes (prim-cell "aa")) (field-value-bytes (prim-cell "bbb")))
+             (row-bytes (field-value-list [(prim-cell "aa") (prim-cell "bbb")])))))))
+
+(deftest ^:parallel next-sample-page-size-test
+  (let [next-size @#'bigquery/next-sample-page-size]
+    (testing "page size = budget / measured-avg-bytes-per-row"
+      ;; 50 rows totalling 500 bytes -> avg 10 -> 1000/10 = 100
+      (is (= 100 (next-size 1000 500 50 1000000))))
+    (testing "heavier rows sample fewer rows per page"
+      (is (< (next-size 1000 1000 10 1000000)    ; avg 100 -> 10 rows
+             (next-size 1000 100 10 1000000))))  ; avg 10  -> 100 rows
+    (testing "page size is at least 1, even when a single row exceeds the whole budget"
+      (is (= 1 (next-size 100 10000 1 1000000))))
+    (testing "page size never exceeds the remaining row budget"
+      (is (= 5 (next-size 1000000000 10 10 5))))))
 
 ;; These look like the macros from metabase.query-processor.expressions-test
 ;; but conform to bigquery naming rules

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -172,6 +172,33 @@
     (testing "page size never exceeds the remaining row budget"
       (is (= 5 (next-size 1000000000 10 10 5))))))
 
+(defn- mock-page
+  "A `TableResult` proxy exposing a page token and a fixed set of rows."
+  ^TableResult [token rows]
+  (proxy [TableResult] []
+    (getNextPageToken [] token)
+    (getValues [] rows)))
+
+(deftest ^:synchronized adaptive-sample-next-page-test
+  (let [requested (atom [])
+        next-size  (fn [budget max-rows rows]
+                     (reset! requested [])
+                     (with-redefs [bigquery/list-sample-page (fn [_bq size _token]
+                                                               (swap! requested conj size)
+                                                               (mock-page nil []))]
+                       (binding [bigquery/*sample-page-byte-budget* budget]
+                         ((#'bigquery/adaptive-sample-next-page :table max-rows) (mock-page "tok" rows))
+                         (first @requested))))
+        light      (vec (repeatedly 5 #(field-value-list [(prim-cell "x")])))
+        heavy      (vec (repeatedly 5 #(field-value-list [(prim-cell (apply str (repeat 5000 "x")))])))]
+    (testing "the next page shrinks when the measured page is heavier (sliding window adapts to real data)"
+      (is (< (next-size 100000 1000000 heavy)
+             (next-size 100000 1000000 light))))
+    (testing "the next page is clamped to the remaining row budget"
+      (is (= 3 (next-size 1000000000 8 light))))
+    (testing "no further page is fetched once the page token is blank"
+      (is (nil? ((#'bigquery/adaptive-sample-next-page :table 100) (mock-page "" light)))))))
+
 ;; These look like the macros from metabase.query-processor.expressions-test
 ;; but conform to bigquery naming rules
 (defn- calculate-bird-scarcity* [formula filter-clause]


### PR DESCRIPTION
Try to avoid OOMs with BigQuery by probing a small page size first (10 rows), and then adapting the next page size based on the bytes seen so far.