### PR TITLE
docs: add embedding telemetry transparency section

### DIFF
--- a/docs/embedding/introduction.md
+++ b/docs/embedding/introduction.md
@@ -100,6 +100,8 @@ If you're using an AI agent to help you embed Metabase in your app, check out [A
 
 [Usage Analytics](../usage-and-performance-tools/usage-analytics.md) tracks embed usage, including embedding context, authentication methods, hostname, and other metadata. Check out the [Embedding usage dashboard](../usage-and-performance-tools/usage-analytics-reference.md#embedding-usage).
 
+For information about the anonymous usage data Metabase collects from embedded components, see [Embedding telemetry](../installation-and-operation/information-collection.md#embedding-telemetry).
+
 ## Further reading
 
 - [Strategies for delivering customer-facing analytics](https://www.metabase.com/learn/metabase-basics/embedding/overview).

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -39,16 +39,12 @@ For static and interactive iframe-based embedding, Metabase records query execut
 
 ### Modular embedding
 
-Both the [modular embedding (iframe)](../embedding/modular-embedding.md) and the [modular embedding SDK](../embedding/sdk/introduction.md) collect a usage event when components are rendered in your app. Each event includes:
+[Modular embedding](../embedding/modular-embedding.md) collects a usage event when components are rendered in your app. Each event includes:
 
-- Which components were used (for example, `metabase-dashboard` or `InteractiveDashboard`)
+- Which components were used (for example, a dashboard or question)
 - The component's configuration options (for example, whether downloads or drill-through are enabled)
 - The authentication method (SSO, API key, or guest)
 - Whether a custom locale is configured
-
-The modular embedding SDK also includes the SDK package version.
-
-**Timing.** The iframe transport fires once per page load after the first component is ready. The SDK transport fires once per component mount per page load.
 
 **No persistent identifiers.** Within a session, an in-memory identifier groups related events. This identifier is regenerated on every page load and is never written to cookies or localStorage — there is no persistent cross-session identifier.
 

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -33,25 +33,28 @@ This anonymous data helps us figure out things like:
 
 When anonymous tracking is enabled, Metabase collects usage data from embedded components in addition to the general product events described above.
 
-### iframe embedding
+### Static and interactive embedding
 
-For iframe-based embedding (static, interactive, and guest), Metabase records query execution counts grouped by embedding type. No query content, result data, or user identifiers are collected.
+For static and interactive iframe-based embedding, Metabase records query execution counts grouped by embedding type. No query content, result data, or user identifiers are collected.
 
-### Modular embedding SDK
+### Modular embedding
 
-When you use the [modular embedding SDK](../embedding/sdk/introduction.md), Metabase collects a component-mount event each time an SDK component is rendered in your app. Each event includes:
+Both the [modular embedding (iframe)](../embedding/modular-embedding.md) and the [modular embedding SDK](../embedding/sdk/introduction.md) collect a usage event when components are rendered in your app. Each event includes:
 
-- Which component was used (for example, `InteractiveDashboard` or `StaticQuestion`)
-- The component's configuration options (for example, whether downloads or subscriptions are enabled)
+- Which components were used (for example, `metabase-dashboard` or `InteractiveDashboard`)
+- The component's configuration options (for example, whether downloads or drill-through are enabled)
 - The authentication method (SSO, API key, or guest)
-- The SDK package version
 - Whether a custom locale is configured
+
+The modular embedding SDK also includes the SDK package version.
+
+**Timing.** The iframe transport fires once per page load after the first component is ready. The SDK transport fires once per component mount per page load.
 
 **No persistent identifiers.** Within a session, an in-memory identifier groups related events. This identifier is regenerated on every page load and is never written to cookies or localStorage — there is no persistent cross-session identifier.
 
-**Routing.** SDK telemetry routes through your Metabase instance, not directly to a third-party analytics host. No additional allowlisting is required in your Content Security Policy.
+**Routing.** Telemetry routes through your Metabase instance, not directly to a third-party analytics host. No additional allowlisting is required in your Content Security Policy.
 
-**Opting out.** Disabling the anonymous tracking toggle (see below) stops all embedding telemetry.
+**Opting out.** Disabling the anonymous tracking toggle (see below) stops all modular embedding telemetry.
 
 ## Opting out of anonymous usage data collection for self-hosted Metabases
 

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -29,6 +29,30 @@ This anonymous data helps us figure out things like:
 - Where people get stuck
 - How performance for key workflows (like querying or loading) changes over time
 
+## Embedding telemetry
+
+When anonymous tracking is enabled, Metabase collects usage data from embedded components in addition to the general product events described above.
+
+### iframe embedding
+
+For iframe-based embedding (static, interactive, and guest), Metabase records query execution counts grouped by embedding type. No query content, result data, or user identifiers are collected.
+
+### Modular embedding SDK
+
+When you use the [modular embedding SDK](../embedding/sdk/introduction.md), Metabase collects a component-mount event each time an SDK component is rendered in your app. Each event includes:
+
+- Which component was used (for example, `InteractiveDashboard` or `StaticQuestion`)
+- The component's configuration options (for example, whether downloads or subscriptions are enabled)
+- The authentication method (SSO, API key, or guest)
+- The SDK package version
+- Whether a custom locale is configured
+
+**No persistent identifiers.** Within a session, an in-memory identifier groups related events. This identifier is regenerated on every page load and is never written to cookies or localStorage — there is no persistent cross-session identifier.
+
+**Routing.** SDK telemetry routes through your Metabase instance, not directly to a third-party analytics host. No additional allowlisting is required in your Content Security Policy.
+
+**Opting out.** Disabling the anonymous tracking toggle (see below) stops all embedding telemetry.
+
 ## Opting out of anonymous usage data collection for self-hosted Metabases
 
 If you're self-hosting Metabase, you can opt out of providing us with your anonymous usage data:
@@ -57,7 +81,7 @@ The token validation request includes:
 - Types of embedding (modular, guest, SDK, full app)
 - Site UUID (just an identifier for your Metabase)
 - Metabase version
-- Query execution timestamp (last UTC day)
+- Query execution counts for the previous UTC day, broken down by embedding type (SDK, interactive, static, public link, simple, and internal)
 - Metabot usage statistics: count of tokens, queries, users, and date (just counts and the date).
 
 ## Further reading

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -31,7 +31,7 @@ This anonymous data helps us figure out things like:
 
 ## Embedding telemetry
 
-When anonymous tracking is enabled, Metabase collects usage data from embedded components in addition to the general product events described above.
+When anonymous tracking is enabled, Metabase collects usage data from embedded iframes and components. This usage data is anonymous, and just concerns embedding feature usage. It doesn't collect query content, result data, or user identifiers.
 
 ### Data collected by modular embeds
 

--- a/docs/installation-and-operation/information-collection.md
+++ b/docs/installation-and-operation/information-collection.md
@@ -33,24 +33,20 @@ This anonymous data helps us figure out things like:
 
 When anonymous tracking is enabled, Metabase collects usage data from embedded components in addition to the general product events described above.
 
-### Static and interactive embedding
+### Data collected by modular embeds
 
-For static and interactive iframe-based embedding, Metabase records query execution counts grouped by embedding type. No query content, result data, or user identifiers are collected.
-
-### Modular embedding
-
-[Modular embedding](../embedding/modular-embedding.md) collects a usage event when components are rendered in your app. Each event includes:
+[Modular embedding components](../embedding/modular-embedding.md) collect usage events when the components are rendered in your app. Each event includes:
 
 - Which components were used (for example, a dashboard or question)
 - The component's configuration options (for example, whether downloads or drill-through are enabled)
-- The authentication method (SSO, API key, or guest)
+- The authentication method (like SSO or guest)
 - Whether a custom locale is configured
 
-**No persistent identifiers.** Within a session, an in-memory identifier groups related events. This identifier is regenerated on every page load and is never written to cookies or localStorage — there is no persistent cross-session identifier.
+Within a session, an in-memory identifier groups related events, but this identifier is regenerated on every page load and is never written to cookies or localStorage, so there's no persistent cross-session identifier.  
 
-**Routing.** Telemetry routes through your Metabase instance, not directly to a third-party analytics host. No additional allowlisting is required in your Content Security Policy.
+### Data collected by iframe embeds
 
-**Opting out.** Disabling the anonymous tracking toggle (see below) stops all modular embedding telemetry.
+For iframe embeds, like public links, or when embedding the full Metabase app, Metabase records query execution counts grouped by embedding type.
 
 ## Opting out of anonymous usage data collection for self-hosted Metabases
 


### PR DESCRIPTION
Fixes EMB-1761

### Description

Documents the telemetry gaps surfaced by the modular embedding SDK insights work.

**`docs/installation-and-operation/information-collection.md`**
- New "Embedding telemetry" section covering both iframe and SDK transports
- Documents what SDK component-mount events include (component name, configuration, auth method, SDK version, locale)
- Clarifies the in-memory session identifier: regenerated on every page load, never written to cookies or localStorage
- Notes that telemetry routes through the Metabase instance proxy, requiring no extra CSP allowlisting
- Fixes misleading "Query execution timestamp (last UTC day)" in the token validation section — it's actually query execution *counts* broken down by embedding type

**`docs/embedding/introduction.md`**
- Adds a pointer from the "Tracking embed usage" section to the new telemetry transparency page

