### PR TITLE
Disable :equals-true linter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -11,7 +11,6 @@
   :def-fn                       {:level :warning}
   :dynamic-var-not-earmuffed    {:level :warning}
   :equals-expected-position     {:level :warning, :only-in-test-assertion true}
-  :equals-true                  {:level :warning}
   :keyword-binding              {:level :warning}
   :main-without-gen-class       {:level :warning}
   :minus-one                    {:level :warning}
@@ -43,7 +42,6 @@
   ;; can understand them.
 
   #_:docstring-leading-trailing-whitespace
-  #_:equals-false
   #_:used-underscored-binding
 
   ;;


### PR DESCRIPTION
### Description

The `:equals-true` linter warns on the following form:

```clojure
(= true x)
```
and recommends this as a replacement:
```clojure
(true? x)
```

This PR disables that linter rule. There's also a `:equals-false` linter rule that we've had in the config but commented out as a future aspiration to turn on. This PR also deletes that commented out rule to indicate that we no longer aspire to turn it on.