### PR TITLE
Fix download permission warning for blocked groups

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -83,6 +83,7 @@ const getPermissionValue = (
   groupId: number,
   entityId: PermissionEntityId,
   permissionSubject: PermissionSubject,
+  permission: DataPermission,
 ) => {
   switch (permissionSubject) {
     case "fields":
@@ -90,23 +91,45 @@ const getPermissionValue = (
         permissions,
         groupId,
         entityId as TableEntityId,
-        DataPermission.DOWNLOAD,
+        permission,
       );
     case "tables":
       return getTablesPermission(
         permissions,
         groupId,
         entityId as SchemaEntityId,
-        DataPermission.DOWNLOAD,
+        permission,
       );
     default:
-      return getSchemasPermission(
-        permissions,
-        groupId,
-        entityId,
-        DataPermission.DOWNLOAD,
-      );
+      return getSchemasPermission(permissions, groupId, entityId, permission);
   }
+};
+
+const getEffectiveDownloadPermissionValue = (
+  permissions: GroupsPermissions,
+  groupId: number,
+  entityId: PermissionEntityId,
+  permissionSubject: PermissionSubject,
+) => {
+  const viewDataPermissionValue = getPermissionValue(
+    permissions,
+    groupId,
+    entityId,
+    permissionSubject,
+    DataPermission.VIEW_DATA,
+  );
+
+  if (viewDataPermissionValue === DataPermissionValue.BLOCKED) {
+    return DOWNLOAD_PERMISSION_OPTIONS.none.value;
+  }
+
+  return getPermissionValue(
+    permissions,
+    groupId,
+    entityId,
+    permissionSubject,
+    DataPermission.DOWNLOAD,
+  );
 };
 
 export const buildDownloadPermission = (
@@ -124,9 +147,15 @@ export const buildDownloadPermission = (
 
   const value = isBlockPermission
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value
-    : getPermissionValue(permissions, groupId, entityId, permissionSubject);
+    : getPermissionValue(
+        permissions,
+        groupId,
+        entityId,
+        permissionSubject,
+        DataPermission.DOWNLOAD,
+      );
 
-  const defaultGroupValue = getPermissionValue(
+  const defaultGroupValue = getEffectiveDownloadPermissionValue(
     permissions,
     defaultGroup.id,
     entityId,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,5 +1,7 @@
 import {
+  DataPermission,
   DataPermissionValue,
+  type DownloadPermission,
   type Group,
   type GroupsPermissions,
 } from "metabase-types/api";
@@ -14,23 +16,45 @@ const groupId = 2;
 
 const databaseId = 1;
 
-const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
-  ({
-    [defaultGroupId]: {
-      [databaseId]: {
-        download: {
-          schemas: "all",
-        },
+const getPermissionGraph = (
+  downloadValue: DownloadPermission = DataPermissionValue.FULL,
+): GroupsPermissions => ({
+  [defaultGroupId]: {
+    [databaseId]: {
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+      [DataPermission.DOWNLOAD]: {
+        schemas: DataPermissionValue.FULL,
       },
     },
-    [groupId]: {
-      [databaseId]: {
-        download: {
-          schemas: downloadValue,
-        },
+  },
+  [groupId]: {
+    [databaseId]: {
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+      [DataPermission.DOWNLOAD]: {
+        schemas: downloadValue,
       },
     },
-  }) as any;
+  },
+});
+
+const getBlockedViewDataPermissionGraph = (): GroupsPermissions => ({
+  [defaultGroupId]: {
+    [databaseId]: {
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+      [DataPermission.DOWNLOAD]: {
+        schemas: DataPermissionValue.LIMITED,
+      },
+    },
+  },
+  [groupId]: {
+    [databaseId]: {
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+      [DataPermission.DOWNLOAD]: {
+        schemas: DataPermissionValue.LIMITED,
+      },
+    },
+  },
+});
 
 const isAdmin = true;
 const isNotAdmin = false;
@@ -39,7 +63,9 @@ const dataAccessPermissionValue = DataPermissionValue.UNRESTRICTED;
 const defaultGroup: Group = {
   id: defaultGroupId,
   name: "All Users",
-} as Group;
+  magic_group_type: "all-internal-users",
+  members: [],
+};
 
 describe("buildDownloadPermission", () => {
   it("sets correct permission and type fields and value", () => {
@@ -53,7 +79,7 @@ describe("buildDownloadPermission", () => {
       "schemas",
     );
 
-    expect(permissionModel.value).toBe("all");
+    expect(permissionModel.value).toBe(DataPermissionValue.FULL);
     expect(permissionModel.type).toBe("download");
     expect(permissionModel.permission).toBe("download");
   });
@@ -169,7 +195,7 @@ describe("buildDownloadPermission", () => {
         { databaseId },
         groupId,
         isNotAdmin,
-        getPermissionGraph("none"),
+        getPermissionGraph(DataPermissionValue.NONE),
         dataAccessPermissionValue,
         defaultGroup,
         "schemas",
@@ -181,6 +207,27 @@ describe("buildDownloadPermission", () => {
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
       );
+      expect(downgradePermissionConfirmation?.message).toBeUndefined();
+    });
+
+    it("does not warn when both groups have blocked view data access (#75750)", () => {
+      const permissionModel = buildDownloadPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getBlockedViewDataPermissionGraph(),
+        DataPermissionValue.BLOCKED,
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] =
+        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
+
+      expect(permissionModel.value).toBe(
+        DOWNLOAD_PERMISSION_OPTIONS.none.value,
+      );
+      expect(permissionModel.warning).toBeNull();
       expect(downgradePermissionConfirmation?.message).toBeUndefined();
     });
   });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75750
Closes https://linear.app/metabase/issue/UXW-4480/permissions-table-shows-warning-icon-when-it-shouldnt

### Description

Fixes the Download results warning comparison to use the effective All Users download permission when View data is Blocked. This keeps the warning icon from appearing when both All Users and another group render Download results as No.

### How to verify

1. Go to Admin -> Permissions -> Data -> Databases -> Sample Database.
2. Set Data Analysts View data to Blocked.
3. Set All Users View data to Blocked.
4. Verify both rows show Download results as No and Data Analysts has no warning icon in the Download results cell.

### Demo
Before:
<img width="1908" height="735" alt="image" src="https://github.com/user-attachments/assets/0cb92a58-760b-4883-99e1-6303a84b556e" />

After:
<img width="1908" height="735" alt="image" src="https://github.com/user-attachments/assets/38e75c9d-97be-43bb-b8f8-87377c976a53" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
