### PR TITLE
Don't drop column order/visibility settings when one column no longer matches

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.streaming
-  (:refer-clojure :exclude [every? some mapv not-empty])
+  (:refer-clojure :exclude [every? mapv not-empty some])
   (:require
    [clojure.string :as str]
    [metabase.analytics-interface.core :as analytics]
@@ -17,11 +17,10 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? mapv some not-empty]])
+   [metabase.util.performance :refer [mapv not-empty some]])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
    (java.io OutputStream)
-   (metabase.server.streaming_response StreamingResponse)
    (org.eclipse.jetty.io EofException)))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.streaming
-  (:refer-clojure :exclude [every? mapv not-empty some])
+  (:refer-clojure :exclude [some mapv not-empty])
   (:require
    [clojure.string :as str]
    [metabase.analytics-interface.core :as analytics]
@@ -17,10 +17,11 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv not-empty some]])
+   [metabase.util.performance :refer [mapv some not-empty]])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
    (java.io OutputStream)
+   (metabase.server.streaming_response StreamingResponse)
    (org.eclipse.jetty.io EofException)))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -58,18 +58,6 @@
                   (assoc :name unique-name)))))
         cols))
 
-(defn- validate-table-columns
-  "Validate that all of the columns in `table-columns` correspond to actual columns in `cols`, correlating them by
-  field ref or name. Returns `nil` if any do not, so that we fall back to using `cols` directly for the export (#19465).
-  Otherwise returns `table-columns`."
-  [table-columns cols]
-  (let [col-field-refs (set (remove nil? (map :field_ref cols)))
-        col-names      (set (remove nil? (map :name cols)))]
-    (when (every? (fn [table-col] (or (col-field-refs (::mb.viz/table-column-field-ref table-col))
-                                      (col-names (::mb.viz/table-column-name table-col))))
-                  table-columns)
-      table-columns)))
-
 (defn- not-explicitly-excluded-columns
   "If a column is not explicitly excluded (it doesn't have a row in `table-columns` that marks it as disabled), we
   should include it. This way, if e.g. the query has changed from `SELECT id FROM ...` to `SELECT id, created_at FROM
@@ -109,9 +97,13 @@
     ;; If the columns contain a pivot-grouping, we're exporting a pivot and the cols order is not used,
     ;; so we can just pass the indices in order.
     (range (count cols))
-    (let [table-columns'     (or (when-let [tcs (seq (validate-table-columns table-columns cols))]
+    (let [;; Entries in `table-columns` that don't match any result column (e.g. a stale column left over from a
+          ;; previous version of the query) are silently dropped per-entry: their `cols-index` lookups below produce
+          ;; `nil`, which is filtered out. This way visibility (`enabled false`) and ordering still apply to the
+          ;; entries that do match, instead of being discarded all-or-nothing (#19465, #75791).
+          table-columns'     (or (when (seq table-columns)
                                    (concat
-                                    (filter ::mb.viz/table-column-enabled tcs)
+                                    (filter ::mb.viz/table-column-enabled table-columns)
                                     (not-explicitly-excluded-columns table-columns cols)))
                                  ;; If table-columns is not provided (e.g. for saved cards), we can construct a fake one
                                  ;; that retains the original column ordering in `cols`

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -703,8 +703,8 @@
             [{::mb.viz/table-column-field-ref ["field" 0 nil], ::mb.viz/table-column-enabled true}])))))
 
 (deftest ^:parallel export-column-order-test-5
-  (testing "if table-columns contains a column without a corresponding entry in cols, table-columns is ignored and
-           cols is used as the source of truth for column order (#19465)"
+  (testing "table-columns entries without a corresponding entry in cols are dropped per-entry; the matching cols are
+           still exported in cols order (#19465, #75791)"
     (is (= [0]
            (@#'qp.streaming/export-column-order
             [{:id 0, :name "Col1" :field_ref [:field 0 nil]}]
@@ -746,6 +746,20 @@
              {:id 2, :name "Col3", :field_ref [:field 2 nil]}]
             [{::mb.viz/table-column-name "Col2" , ::mb.viz/table-column-enabled true}
              {::mb.viz/table-column-name "Col1" , ::mb.viz/table-column-enabled true}])))))
+
+(deftest ^:parallel export-column-order-orphan-entry-test
+  (testing "an unmatchable table-columns entry is ignored per-entry; visibility and ordering of the matching
+           entries are still applied (#75791)"
+    ;; Models the reporter's case: 4-col native query (ID TITLE CATEGORY PRICE), TITLE hidden, custom order, plus
+    ;; one stale orphan entry (EAN) left over from a previous version of the query.
+    (is (= [0 2 3]
+           (@#'qp.streaming/export-column-order
+            [{:name "ID"}, {:name "TITLE"}, {:name "CATEGORY"}, {:name "PRICE"}]
+            [{::mb.viz/table-column-name "ID"       , ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-name "EAN"      , ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-name "TITLE"    , ::mb.viz/table-column-enabled false}
+             {::mb.viz/table-column-name "CATEGORY" , ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-name "PRICE"    , ::mb.viz/table-column-enabled true}])))))
 
 ;; QP Nil Fix Tests
 ;; These tests verify that query cancellation returns proper results instead of nil


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75791
### Description

`metabase.query-processor.streaming/validate-table-columns` used `every?` semantics: if any table.columns entry failed to match a result column, it returned nil. `export-column-order` then fell back to synthesizing a fresh setting from cols directly discarding all visibility and ordering.

This guard was introduced in #19530 to fix #19465, whose actual concern was narrow: avoid an empty export when all stored entries are stale.

Fixed by droping the all-or-nothing validate-table-columns guard and degrade per-entry instead:
- Stale entries are dropped individually because their cols-index lookup already resolves to nil and is filtered out downstream so visibility and ordering survive for the entries that still match.
- #19465's empty-export protection is preserved by not-explicitly-excluded-columns (added later in #61761): any real result column that no surviving entry references is re-included. So when all entries are stale, every column is re-added with the same full fallback as before, never an empty export. Tests from 19465 continue to pass unchanged

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
