### PR TITLE
downgrade apache sshd-core

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -131,7 +131,7 @@
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.poi/poi-ooxml-full             {:mvn/version "5.5.1"}
-  org.apache.sshd/sshd-core                 {:mvn/version "3.0.0-M2"              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.16.0"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.tika/tika-core                 {:mvn/version "3.2.3"}


### PR DESCRIPTION
Why? Because 3.0.0-M2 leaks connections.

 Revert mina-sshd 3.0.0-M2 → 2.16 to stop SSH channel leak OOMs

  3.0.0-M2 leaks one KexListener per SSH port-forward channel, never
  removed on channel close. Each Metabase DB query over an SSH tunnel
  opens and closes a `direct-tcpip` channel, so the listener list grows
  unbounded for the life of the (long-lived) SSH connection.

  Heap dump from a crashed prod instance (highway):
  - 1 SSH connection, but 67,221 closed TcpipClientChannel / Nio2Session / socket-channel objects retained.
  - KexFilter.listeners (a session-scoped CopyOnWriteArrayList) retained 572 MB ≈ 38% of heap — full of AbstractChannel$$Lambda instances, each capturing one closed channel.

  Root cause in mina-sshd 3.x (dev_3.0 branch):
  - AbstractChannel.init() registers an anonymous KexListener on the session for every channel and never removes it on close.
  - AbstractSession.removeKexListener() is also broken: it calls addKexListener() instead of remove (copy-paste bug), so even a correct removal attempt adds a duplicate.

  The 2.x lineage has no KexFilter / addKexListener / per-channel KEX
  listener — the filter-chain mechanism is entirely new in 3.x — so the
  leak cannot occur on 2.16.