### PR TITLE
Clear the stale flag for entities whose database can't be resolved

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/findings.clj
@@ -57,14 +57,20 @@
         instance-id (:id toucan-instance)]
     (if-let [errors (seq (pre-analysis-errors toucan-instance))]
       (deps.analysis-finding/upsert-analysis! entity-type instance-id false errors)
-      (when-let [db-id (instance-db-id toucan-instance)]
+      (if-let [db-id (instance-db-id toucan-instance)]
         (let [mp (lib-be/application-database-metadata-provider db-id)
               results (try (deps.analysis/check-entity mp entity-type instance-id)
                            (catch Exception e
                              (log/error e "Error analyzing entity")
                              [(lib/validation-exception-error (.getMessage e))]))
               success (empty? results)]
-          (deps.analysis-finding/upsert-analysis! entity-type instance-id success results))))))
+          (deps.analysis-finding/upsert-analysis! entity-type instance-id success results))
+        ;; No resolvable database, and no pre-analysis error explaining it: record a terminal error so
+        ;; the entity gets a finding (clearing its stale flag) instead of no-oping forever and being
+        ;; re-selected on every run. It re-checks normally if its database later becomes resolvable.
+        (deps.analysis-finding/upsert-analysis!
+         entity-type instance-id false
+         [(lib/validation-exception-error "Could not resolve a database for this entity.")])))))
 
 (defn analyze-instances!
   "Given a series of toucan entities, upsert analyses for all of them and catch errors."

--- a/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.dependencies.analysis :as deps.analysis]
    [metabase-enterprise.dependencies.findings :as deps.findings]
    [metabase-enterprise.dependencies.models.analysis-finding :as models.analysis-finding]
+   [metabase-enterprise.dependencies.models.analysis-finding-error :as models.analysis-finding-error]
    [metabase-enterprise.dependencies.task.entity-check :as task.entity-check]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -302,3 +303,57 @@
                 (is (= {a-id false, b-id false}
                        (stale-map [a-id b-id]))
                     "both cycle members should be drained (re-analyzed, not stale)")))))))))
+
+(deftest ^:sequential unanalyzable-entity-records-terminal-error-test
+  (testing "A stale entity whose database can't be resolved records a terminal error finding instead of no-oping forever."
+    ;; Without the fix, instance-db-id -> nil makes upsert-analysis! no-op: the stale flag is never
+    ;; cleared, so the entity is re-selected and re-attempted on every run. The fix records a terminal
+    ;; error, clearing the flag.
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-model-cleanup [:model/AnalysisFinding :model/AnalysisFindingError]
+        (mt/with-temp [:model/Card card {:dataset_query (mt/native-query {:query "SELECT 1"})
+                                         :database_id   (mt/id)}]
+          (let [cid (:id card)]
+            ;; seed a clean finding, mark it stale, then make its database unresolvable
+            (models.analysis-finding/upsert-analysis! :card cid true [])
+            (models.analysis-finding/mark-stale! :card [cid])
+            (with-redefs-fn {#'deps.findings/instance-db-id (constantly nil)}
+              (fn []
+                (lib-be/with-metadata-provider-cache
+                  (deps.findings/upsert-analysis! (t2/instance :model/Card card)))))
+            (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
+                                          :analyzed_entity_type :card :analyzed_entity_id cid))
+                "the stale flag is cleared, so the entity stops being re-selected forever")
+            (is (seq (models.analysis-finding-error/errors-for-entity :card cid))
+                "an error finding is recorded explaining why the entity couldn't be analyzed")))))))
+
+(deftest ^:sequential unanalyzable-entity-rechecks-when-database-resolvable-again-test
+  (testing "After a no-DB terminal error, the entity is analyzed normally once its database resolves again."
+    ;; The terminal error finding is not sticky: it clears the stale flag but does not block future
+    ;; analysis. When the entity is next marked stale and its database now resolves, upsert-analysis!
+    ;; takes the normal path and replaces the terminal error with a real analysis result.
+    (mt/with-premium-features #{:dependencies}
+      (mt/with-model-cleanup [:model/AnalysisFinding :model/AnalysisFindingError]
+        (let [mp       (mt/metadata-provider)
+              products (lib.metadata/table mp (mt/id :products))]
+          (mt/with-temp [:model/Card card {:dataset_query (lib/query mp products)}]
+            (let [cid (:id card)]
+              ;; phase 1: database unresolvable -> terminal error recorded, stale cleared
+              (with-redefs-fn {#'deps.findings/instance-db-id (constantly nil)}
+                (fn []
+                  (lib-be/with-metadata-provider-cache
+                    (deps.findings/upsert-analysis! (t2/instance :model/Card card)))))
+              (is (seq (models.analysis-finding-error/errors-for-entity :card cid))
+                  "phase 1: a terminal error is recorded while the database is unresolvable")
+              (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
+                                            :analyzed_entity_type :card :analyzed_entity_id cid))
+                  "phase 1: stale flag cleared")
+              ;; phase 2: database resolvable again; re-trigger analysis (as an event/job would)
+              (models.analysis-finding/mark-stale! :card [cid])
+              (lib-be/with-metadata-provider-cache
+                (deps.findings/upsert-analysis! (t2/instance :model/Card card)))
+              (is (empty? (models.analysis-finding-error/errors-for-entity :card cid))
+                  "phase 2: re-analyzed normally — the terminal db error is replaced by a clean result")
+              (is (false? (t2/select-one-fn :stale :model/AnalysisFinding
+                                            :analyzed_entity_type :card :analyzed_entity_id cid))
+                  "phase 2: re-analysis cleared stale again"))))))))


### PR DESCRIPTION
### Description

The dependency entity-check job analyzes each stale entity and records a finding, which clears its stale flag.

If an entity's database can't be resolved — and there's no prior error that already explains why — analysis silently does nothing. The stale flag is never cleared, so the entity is re-selected and re-analyzed on every run, forever.

### Solution

Record a terminal error finding for that case, which clears the stale flag and explains why the entity couldn't be analyzed. If its database later becomes resolvable, the entity is analyzed normally again.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
