### PR TITLE
Skip sandboxing during metric expansion

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1828,6 +1828,7 @@
            premium-features
            queries
            query-permissions
+           request
            server
            settings
            system

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -293,6 +293,25 @@
                (run-venues-count-query)))
         (fails-without-token (run-venues-count-query))))))
 
+(deftest metric-on-natively-sandboxed-table-test
+  (testing "A :metric reference on a natively-sandboxed table should succeed (#76044)"
+    (met/with-gtaps! {:gtaps {:venues (venues-category-native-sandbox-def)}, :attributes {"cat" 50}}
+      (let [mp           (mt/metadata-provider)
+            metric-query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                             (lib/aggregate (lib/count)))]
+        ;; the sandboxing path needs a real Card in the app DB; a mock MP wouldn't trigger the sandboxing middleware
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (mt/with-temp [:model/Card {metric-id :id} {:name          "Sandboxed Venues Count"
+                                                    :type          :metric
+                                                    :database_id   (mt/id)
+                                                    :table_id      (mt/id :venues)
+                                                    :dataset_query metric-query}]
+          (let [mp         (mt/metadata-provider)
+                user-query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                               (lib/aggregate (lib.metadata/metric mp metric-id)))]
+            (is (= [[10]]
+                   (mt/format-rows-by [int] (mt/rows (qp/process-query user-query)))))))))))
+
 (deftest e2e-test-2
   (mt/test-drivers (e2e-test-drivers)
     (testing "Basic test around querying a table by a user with segmented only permissions and a GTAP question that is MBQL"

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -8,6 +8,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
+   [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
@@ -177,11 +178,16 @@
        (lib.metadata/bulk-metadata-or-throw query :metadata/card)
        (into {}
              (map (fn [card-metadata]
-                    (let [metric-query (->> (:dataset-query card-metadata)
-                                            (lib/query query)
-                                            ((requiring-resolve 'metabase.query-processor.preprocess/preprocess))
-                                            (lib/query query)
-                                            metric-query-filters->aggregation)
+                    ;; Preprocess the metric query as admin so user-context middleware (sandboxing,
+                    ;; impersonation) leaves it untouched. The outer query still goes through those passes
+                    ;; normally, and will sandbox the spliced result. This matches how the sandboxing
+                    ;; middleware preprocesses its own source query (#76044).
+                    (let [metric-query (request/as-admin
+                                         (->> (:dataset-query card-metadata)
+                                              (lib/query query)
+                                              ((requiring-resolve 'metabase.query-processor.preprocess/preprocess))
+                                              (lib/query query)
+                                              metric-query-filters->aggregation))
                           metric-name (:name card-metadata)]
                       (if-let [aggregation (first (lib/aggregations metric-query))]
                         [(:id card-metadata)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76044
Closes QUE2-681

### Description

During metric expansion we don't want to rewrite the query with sandboxing. That's done later.

### How to verify

See the repro test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
