### PR TITLE
Fix conditional formatting range matching

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.ts
+++ b/frontend/src/metabase/visualizations/lib/table_format.ts
@@ -187,6 +187,9 @@ export function compileFormatter(
       return () => null;
     }
 
+    const lowerBound = Math.min(min, max);
+    const upperBound = Math.max(min, max);
+
     const scale = getLinearColorScale(
       [min, max],
       format.colors.map((c) => {
@@ -196,7 +199,7 @@ export function compileFormatter(
       }),
     ).clamp(true);
     return (value) => {
-      if (!isNumber(value)) {
+      if (!isNumber(value) || value < lowerBound || value > upperBound) {
         return null;
       }
       const colorValue = scale(value);

--- a/frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts
@@ -7,7 +7,12 @@ import {
   extent,
   isEmptyString,
   isNonEmptyString,
+  makeCellBackgroundGetter,
 } from "metabase/visualizations/lib/table_format";
+import {
+  createMockColumnRangeFormattingSetting,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
 
 describe("compileFormatter", () => {
   it("should return a function, even for unsupported operators", () => {
@@ -235,5 +240,39 @@ describe("compileFormatter with extreme ranges", () => {
     const colorMax = formatter(1000000);
     expect(colorMax).not.toBeNull();
     expect(colorMax).toBe("rgba(255, 255, 255, 0.75)");
+  });
+});
+
+describe("makeCellBackgroundGetter", () => {
+  it("applies each range rule to values in its own range when ranges do not overlap (#75933)", () => {
+    const getter = makeCellBackgroundGetter(
+      [[-1000], [1000]],
+      [createMockNumericColumn({ name: "score" })],
+      [
+        createMockColumnRangeFormattingSetting({
+          columns: ["score"],
+          colors: ["#ff0000", "#ffffff"],
+          min_type: "custom",
+          min_value: -1800,
+          max_type: "custom",
+          max_value: 0,
+        }),
+        createMockColumnRangeFormattingSetting({
+          columns: ["score"],
+          colors: ["#ffffff", "#00ff00"],
+          min_type: "custom",
+          min_value: 0,
+          max_type: "custom",
+          max_value: 1800,
+        }),
+      ],
+      false,
+    );
+
+    const negativeColor = Color(getter(-1000, 0, "score") ?? "");
+    const positiveColor = Color(getter(1000, 1, "score") ?? "");
+
+    expect(negativeColor.red()).toBeGreaterThan(negativeColor.green());
+    expect(positiveColor.green()).toBeGreaterThan(positiveColor.red());
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75933
Closes https://linear.app/metabase/issue/UXW-4512/non-overlapping-conditional-formatting-color-ranges-on-the-same-column

### Description

Range conditional formatters now return no match for values outside their configured min/max range, allowing later non-overlapping range rules on the same column to apply.

### How to verify

1. Create a native SQL question using the query from UXW-4512.
2. Add one conditional formatting range rule on `score` from `-1800` to `0` with red to white colors.
3. Add another conditional formatting range rule on `score` from `0` to `1800` with white to green colors.
4. Confirm negative values are red-tinted and positive values are green-tinted.

### Demo
Before:
<img width="1299" height="796" alt="image" src="https://github.com/user-attachments/assets/04428028-e577-47f4-9dde-68dc8426e614" />

After:
<img width="1299" height="796" alt="image" src="https://github.com/user-attachments/assets/a944daf2-1534-4c86-b34d-c916f9a275dc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
