### PR TITLE
Move entityType helpers to metabase/utils

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -268,6 +268,15 @@ const rules = [
     message: "Shared modules cannot import from feature modules",
   },
   {
+    // Foundational sink: schema.js may only import lib/* and basic/* modules,
+    // never other shared (or feature/app) modules, so it stays safe to depend
+    // on from anywhere without forming cycles.
+    from: ["shared/schema"],
+    disallow: ["shared/*"],
+    message:
+      "metabase/schema.js is a foundational sink and may only import lib/* and basic/* modules",
+  },
+  {
     from: ["feature/*"],
     allow: ["lib/*", "basic/*", "shared/*"],
     message: "Feature modules cannot import from other feature modules",

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "metabase/api";
 import { useInitialCollectionId } from "metabase/collections/hooks";
 import { CopyModal } from "metabase/common/components/CopyModal";
-import { entityTypeForObject } from "metabase/redux/store/entities";
+import { entityTypeForObject } from "metabase/utils/entity-types";
 
 const getTitle = (entityObject: any, isShallowCopy: boolean) => {
   if (entityObject.model !== "dashboard") {

--- a/frontend/src/metabase/redux/store/entities.ts
+++ b/frontend/src/metabase/redux/store/entities.ts
@@ -12,19 +12,6 @@ import type {
   NormalizedTable,
 } from "metabase-types/api";
 
-// backend returns model = "card" instead of "question"
-export const entityTypeForModel = (model: string): string => {
-  if (model === "card" || model === "dataset" || model === "metric") {
-    return "questions";
-  }
-  return `${model}s`;
-};
-
-export const entityTypeForObject = (
-  object?: { model: string } | null,
-): string | undefined =>
-  object ? entityTypeForModel(object.model) : undefined;
-
 export interface EntitiesState {
   collections: Record<string, NormalizedCollection>;
   dashboards: Record<string, NormalizedDashboard>;

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -2,7 +2,7 @@
 
 import { schema } from "normalizr";
 
-import { entityTypeForObject } from "metabase/redux/store/entities";
+import { entityTypeForObject } from "metabase/utils/entity-types";
 import { getUniqueFieldId } from "metabase-lib/v1/metadata/utils/fields";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";

--- a/frontend/src/metabase/utils/entity-types.ts
+++ b/frontend/src/metabase/utils/entity-types.ts
@@ -1,0 +1,12 @@
+// backend returns model = "card" instead of "question"
+export const entityTypeForModel = (model: string): string => {
+  if (model === "card" || model === "dataset" || model === "metric") {
+    return "questions";
+  }
+  return `${model}s`;
+};
+
+export const entityTypeForObject = (
+  object?: { model: string } | null,
+): string | undefined =>
+  object ? entityTypeForModel(object.model) : undefined;

--- a/frontend/src/metabase/utils/entity-types.unit.spec.ts
+++ b/frontend/src/metabase/utils/entity-types.unit.spec.ts
@@ -1,4 +1,4 @@
-import { entityTypeForModel, entityTypeForObject } from "./entities";
+import { entityTypeForModel, entityTypeForObject } from "./entity-types";
 
 const MODEL_ENTITY_TYPE = [
   { model: "card", entityType: "questions" },


### PR DESCRIPTION
Part of the frontend circular-dependency reduction effort: make foundational `shared/*` modules clean sinks.

`entityTypeForModel` / `entityTypeForObject` are pure functions (they only depend on types) that were sitting in `redux/store/entities.ts`. Moving them to the `metabase/utils` (lib) tier removes `schema.js`'s import of `redux`.

Behavior-preserving: relocation + import-path updates only; the dedicated unit spec moves with them.

**Impact:** `metabase/schema` now imports only `lib`/`basic`.