### PR TITLE
Fix card parameter has_more_values cap

### DIFF
--- a/src/metabase/parameters/field.clj
+++ b/src/metabase/parameters/field.clj
@@ -94,10 +94,14 @@
                        (api/read-check (t2/select-one :model/Field :id field-id)))
         search-field (or (some->> (chain-filter/remapped-field-id field-id)
                                   (t2/select-one :model/Field :id))
-                         field)]
-    {:values          (search-values field search-field query-string)
-     ;; assume there are more if doing a search, otherwise there are no more values
-     :has_more_values (not (str/blank? query-string))
+                         field)
+        limit        default-max-field-search-limit
+        blank-query? (str/blank? query-string)
+        values       (or (search-values field search-field (when-not blank-query? query-string) (inc limit))
+                         [])]
+    {:values          (vec (take limit values))
+     :has_more_values (or (not blank-query?)
+                          (> (count values) limit))
      :field_id        field-id}))
 
 (defn parse-query-param-value-for-field

--- a/test/metabase/parameters/field_test.clj
+++ b/test/metabase/parameters/field_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.parameters.field :as parameters.field]
+   [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.timeseries-test.util :as tqpt]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -67,6 +68,35 @@
                                              (t2/select-one :model/Field :id (mt/id :checkins :venue_name))
                                              "Red"
                                              nil))))))
+
+(deftest search-values-from-field-id-has-more-values-test
+  (binding [qp.perms/*param-values-query* true]
+    (with-redefs [parameters.field/default-max-field-search-limit 2]
+      (let [field-id        (mt/id :venues :id)
+            returned-values (atom [[1] [2] [3]])
+            calls           (atom [])]
+        (mt/with-dynamic-fn-redefs [parameters.field/search-values (fn [_field _search-field query limit]
+                                                                      (swap! calls conj [query limit])
+                                                                      @returned-values)]
+          (testing "unfiltered field value searches report when the default result limit hides more values"
+            (is (= {:values          [[1] [2]]
+                    :has_more_values true
+                    :field_id        field-id}
+                   (parameters.field/search-values-from-field-id field-id nil))))
+          (testing "fields with exactly the default result limit are not marked as having more values"
+            (reset! returned-values [[1] [2]])
+            (is (= {:values          [[1] [2]]
+                    :has_more_values false
+                    :field_id        field-id}
+                   (parameters.field/search-values-from-field-id field-id nil))))
+          (testing "search queries continue to report that more values may exist"
+            (reset! returned-values [[1]])
+            (is (= {:values          [[1]]
+                    :has_more_values true
+                    :field_id        field-id}
+                   (parameters.field/search-values-from-field-id field-id "Red"))))
+          (is (= [[nil 3] [nil 3] ["Red" 3]]
+                 @calls)))))))
 
 (deftest search-values-with-field-and-search-field-is-fk-test
   (testing "searching on a PK field should work (#32985)"


### PR DESCRIPTION
## What changed

This updates card parameter field-value loading to detect when the initial value response is truncated at the default field search limit. The endpoint now fetches one extra value, returns only the configured limit, and sets `has_more_values=true` when additional values exist.

A regression test covers capped unfiltered results, exact-limit results, and searched results.

Fixes #76143.

## Why

The frontend uses `has_more_values` to decide whether to keep filtering locally or switch to server-side search. For high-cardinality field filters, the card parameter values endpoint could return the first 1000 values with `has_more_values=false`, preventing the UI from querying the search endpoint for values outside the initial page.

## Impact

Affected field filters can now discover values beyond the initial capped response by switching to server-side search. The existing behavior for explicit search queries remains unchanged: searched responses continue to report that more values may exist.

## Validation

- `./bin/mage -check-readable src/metabase/parameters/field.clj`
- `./bin/mage -check-readable test/metabase/parameters/field_test.clj`
- `git diff --check -- src/metabase/parameters/field.clj test/metabase/parameters/field_test.clj`
- `clj-kondo` on the changed source and test files
- Focused `metabase.parameters.field-test`: 7 tests, 8 assertions, 0 failures/errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/76144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Disclosure

Assisted by GPT-5.5 with xhigh reasoning effort.
