### PR TITLE
GDGT-2633: Wire up API endpoints

### DIFF
--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -1,0 +1,124 @@
+import type { TransformId } from "./transform";
+import type { UserId } from "./user";
+
+export type TableIndexId = number;
+
+export type IndexColumnDirection = "asc" | "desc";
+
+export type IndexColumn = {
+  name: string;
+  direction?: IndexColumnDirection;
+};
+
+export const CLASSICAL_INDEX_KINDS = [
+  "btree",
+  "hash",
+  "gin",
+  "gist",
+  "brin",
+  "spgist",
+  "fulltext",
+  "spatial",
+  "clustered",
+  "nonclustered",
+  "columnstore",
+] as const;
+export type ClassicalIndexKind = (typeof CLASSICAL_INDEX_KINDS)[number];
+
+export type ClassicalIndex = {
+  kind: ClassicalIndexKind;
+  name: string;
+  columns: IndexColumn[];
+  include?: string[];
+  unique?: boolean;
+};
+
+export type SortKeyStyle = "compound" | "interleaved";
+
+export type SortKeyIndex = {
+  kind: "sortkey";
+  style: SortKeyStyle;
+  columns: IndexColumn[];
+};
+
+export type DistKeyIndex = {
+  kind: "distkey";
+  column: string;
+};
+
+export type ClusteringIndex = {
+  kind: "clustering";
+  name?: string;
+  columns: IndexColumn[];
+};
+
+export type OrderByIndex = {
+  kind: "order-by";
+  columns: IndexColumn[];
+};
+
+export const SKIP_INDEX_TYPES = [
+  "minmax",
+  "set",
+  "bloom_filter",
+  "ngrambf_v1",
+  "tokenbf_v1",
+] as const;
+export type SkipIndexType = (typeof SKIP_INDEX_TYPES)[number];
+
+export type SkipIndex = {
+  kind: "skip-index";
+  name: string;
+  columns: IndexColumn[];
+  type: SkipIndexType;
+  "type-args"?: unknown[];
+  granularity?: number;
+};
+
+export type StructuredIndex =
+  | ClassicalIndex
+  | SortKeyIndex
+  | DistKeyIndex
+  | ClusteringIndex
+  | OrderByIndex
+  | SkipIndex;
+
+export const TABLE_INDEX_STATUSES = [
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "dropped",
+] as const;
+export type TableIndexStatus = (typeof TABLE_INDEX_STATUSES)[number];
+
+export type TableIndex = {
+  id: TableIndexId;
+  transform_id: TransformId;
+  index_name: string;
+  structured: StructuredIndex;
+  status: TableIndexStatus;
+  error_message: string | null;
+  created_by: UserId | null;
+  created_at: string;
+  updated_at: string;
+  last_executed_at: string | null;
+};
+
+export type ListTableIndexesRequest = {
+  "transform-id": TransformId;
+};
+
+export type ListTableIndexesResponse = {
+  data: TableIndex[];
+};
+
+export type CreateTableIndexRequest = {
+  transform_id: TransformId;
+  structured: StructuredIndex;
+};
+
+export type UpdateTableIndexRequest = {
+  id: TableIndexId;
+  structured: StructuredIndex;
+};

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -30,6 +30,7 @@ export * from "./field";
 export * from "./geojson";
 export * from "./group";
 export * from "./icon";
+export * from "./index-manager";
 export * from "./insight";
 export * from "./llm";
 export * from "./logger";

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -1,0 +1,21 @@
+import type { TableIndex } from "metabase-types/api";
+
+export const createMockTableIndex = (
+  opts?: Partial<TableIndex>,
+): TableIndex => ({
+  id: 1,
+  transform_id: 1,
+  index_name: "btree",
+  structured: {
+    kind: "btree",
+    name: "btree",
+    columns: [{ name: "id" }],
+  },
+  status: "pending",
+  error_message: null,
+  created_by: 1,
+  created_at: "2020-01-01T00:00:00.000Z",
+  updated_at: "2020-01-01T00:00:00.000Z",
+  last_executed_at: null,
+  ...opts,
+});

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -14,6 +14,7 @@ export * from "./erd";
 export * from "./field";
 export * from "./geojson";
 export * from "./group";
+export * from "./index-manager";
 export * from "./insight";
 export * from "./logger";
 export * from "./measure";

--- a/frontend/src/metabase/api/index-manager.ts
+++ b/frontend/src/metabase/api/index-manager.ts
@@ -1,0 +1,79 @@
+import type {
+  CreateTableIndexRequest,
+  ListTableIndexesRequest,
+  ListTableIndexesResponse,
+  TableIndex,
+  TableIndexId,
+  UpdateTableIndexRequest,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+import {
+  idTag,
+  invalidateTags,
+  listTag,
+  provideTableIndexListTags,
+  provideTableIndexTags,
+} from "./tags";
+
+export const indexManagerApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    listTableIndexes: builder.query<TableIndex[], ListTableIndexesRequest>({
+      query: (params) => ({
+        method: "GET",
+        url: "/api/indexes",
+        params,
+      }),
+      transformResponse: (response: ListTableIndexesResponse) => response.data,
+      providesTags: (indexes = []) => provideTableIndexListTags(indexes),
+    }),
+    getTableIndex: builder.query<TableIndex, TableIndexId>({
+      query: (id) => ({
+        method: "GET",
+        url: `/api/indexes/${id}`,
+      }),
+      providesTags: (index) => (index ? provideTableIndexTags(index) : []),
+    }),
+    createTableIndex: builder.mutation<TableIndex, CreateTableIndexRequest>({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/indexes",
+        body,
+      }),
+      invalidatesTags: (_index, error) =>
+        invalidateTags(error, [listTag("table-index")]),
+    }),
+    updateTableIndex: builder.mutation<TableIndex, UpdateTableIndexRequest>({
+      query: ({ id, structured }) => ({
+        method: "PUT",
+        url: `/api/indexes/${id}`,
+        body: { structured },
+      }),
+      invalidatesTags: (_index, error, { id }) =>
+        invalidateTags(error, [
+          listTag("table-index"),
+          idTag("table-index", id),
+        ]),
+    }),
+    deleteTableIndex: builder.mutation<void, TableIndexId>({
+      query: (id) => ({
+        method: "DELETE",
+        url: `/api/indexes/${id}`,
+      }),
+      invalidatesTags: (_index, error, id) =>
+        invalidateTags(error, [
+          listTag("table-index"),
+          idTag("table-index", id),
+        ]),
+    }),
+  }),
+});
+
+export const {
+  useListTableIndexesQuery,
+  useGetTableIndexQuery,
+  useLazyGetTableIndexQuery,
+  useCreateTableIndexMutation,
+  useUpdateTableIndexMutation,
+  useDeleteTableIndexMutation,
+} = indexManagerApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -23,6 +23,7 @@ export * from "./field";
 export * from "./glossary";
 export * from "./google";
 export * from "./group-table-access-policy";
+export * from "./index-manager";
 export * from "./ldap";
 export * from "./llm";
 export * from "./login-history";

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -28,6 +28,7 @@ export const TAG_TYPES = [
   "field-values",
   "glossary",
   "indexed-entity",
+  "table-index",
   "llm-models",
   "logger-preset",
   "measure",

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -46,6 +46,7 @@ import type {
   SearchResult,
   Segment,
   Table,
+  TableIndex,
   TableRemapping,
   Task,
   TaskRun,
@@ -668,6 +669,21 @@ export function provideSubscriptionTags(
   subscription: DashboardSubscription,
 ): TagDescription<TagType>[] {
   return [idTag("subscription", subscription.id)];
+}
+
+export function provideTableIndexTags(
+  index: TableIndex,
+): TagDescription<TagType>[] {
+  return [
+    idTag("table-index", index.id),
+    idTag("transform", index.transform_id),
+  ];
+}
+
+export function provideTableIndexListTags(
+  indexes: TableIndex[],
+): TagDescription<TagType>[] {
+  return [listTag("table-index"), ...indexes.flatMap(provideTableIndexTags)];
 }
 
 export function provideTableListTags(

--- a/frontend/test/__support__/server-mocks/index-manager.ts
+++ b/frontend/test/__support__/server-mocks/index-manager.ts
@@ -1,0 +1,34 @@
+import fetchMock from "fetch-mock";
+
+import type { TableIndex, TransformId } from "metabase-types/api";
+import { createMockTableIndex } from "metabase-types/api/mocks";
+
+export function setupTableIndexEndpoints(
+  transformId: TransformId,
+  indexes: TableIndex[] = [],
+) {
+  fetchMock.get({
+    url: `path:/api/indexes`,
+    query: { "transform-id": transformId },
+    response: { data: indexes },
+    name: `listTableIndexes-${transformId}`,
+  });
+
+  indexes.forEach((index) => {
+    fetchMock.get(`path:/api/indexes/${index.id}`, index, {
+      name: `getTableIndex-${index.id}`,
+    });
+    fetchMock.delete(`path:/api/indexes/${index.id}`, 204, {
+      name: `deleteTableIndex-${index.id}`,
+    });
+  });
+
+  fetchMock.post(
+    `path:/api/indexes`,
+    async (call) => {
+      const lastCall = fetchMock.callHistory.lastCall(call.url);
+      return createMockTableIndex(await lastCall?.request?.json());
+    },
+    { name: `createTableIndex` },
+  );
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -28,6 +28,7 @@ export * from "./geojson";
 export * from "./google";
 export * from "./group";
 export * from "./impersonation";
+export * from "./index-manager";
 export * from "./library";
 export * from "./logger";
 export * from "./measure";


### PR DESCRIPTION
Closes [GDGT-2633: Wire up API endpoints.](https://linear.app/metabase/issue/GDGT-2633/wire-up-api-endpoints)

### Description

Simple wiring for the BE API added in https://github.com/metabase/metabase/pull/75894

### How to verify
---

### Demo
---

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
