### PR TITLE
Stabilize flaky datetime cell-edit table-editing e2e test

### DIFF
--- a/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
+++ b/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
@@ -385,9 +385,9 @@ describe("scenarios > table-editing", () => {
             });
           });
 
-        const day = Math.floor(Math.random() * 10) + 10; // 10-20
-        const hour = Math.floor(Math.random() * 12);
-        const minute = Math.floor(Math.random() * 60);
+        const day = 15;
+        const hour = 11;
+        const minute = 35;
 
         H.popover().within(() => {
           cy.findByRole("button", { name: `${day} February 2020` }).click();
@@ -401,9 +401,7 @@ describe("scenarios > table-editing", () => {
         });
 
         cy.wait("@updateTableData").then(({ response, request }) => {
-          const targetDate = dayjs(
-            new Date(2020, 1, day, hour, minute, 0),
-          ).format("YYYY-MM-DDTHH:mm:ss");
+          const targetDate = "2020-02-15T11:35:00";
 
           const requestDate = request.body.params.datetime;
           const responseDate = response?.body.outputs[0].row.datetime;


### PR DESCRIPTION
### Description
~This is a really strange one, but there is a chance that when typing into the mantine time component yourfirst keystrooke might not actually register. Attempted to clear the imput first, and then tried using .realType, but both resulted in 100% failure rates.~

~The only way I could see to have this test pass is to have the test assert on what ended up in the input, rather than what you intended to type. I don't love it though :/~

~Typing the the time in through cypress was proving to be flakey. I tried a few different versions of this (clearing the input first, using realType, etc) but nothing helped. So I landed on eliminating the keystrokes by using paste instead.~

Turns out the date time input doesn't like hours that start with 0. Removed the randomly generated date time value and hardcoded to something without a leading 0.


### How to verify

Green CI and stress test

### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27951842629
