### PR TITLE
Fix flaky remote-sync read-only tenant collection test

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -742,7 +742,9 @@ describe("Remote Sync", () => {
       it("should disable sync toggles in read-only mode", () => {
         H.copySyncedCollectionFixture();
         H.commitToRepo();
-        H.configureGit("read-only");
+        // Wait for the read-only import to finish before creating the tenant collection: racing
+        // their two implicit collection-permission revision bumps triggers a primary-key 500.
+        H.configureGitAndPullChanges("read-only");
 
         // Create a tenant collection
         H.createSharedTenantCollection("Read Only Tenant Collection");


### PR DESCRIPTION
Closes UXW-3485

### Description

Wait for changes to pull when configuring remote sync to read only

### How to verify

Describe the steps to verify that the changes are working as expected.

Green CI and Stress Test

### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27829189947
