### PR TITLE
Fix flaky impersonation caching e2e test

### DIFF
--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -138,6 +138,9 @@ describe("impersonated permission", { tags: "@external" }, () => {
         cy.signOut();
         cy.signInAsImpersonatedUser();
         cy.reload();
+        // wait for the reloaded query to return before asserting the error UI,
+        // since under load the page can outlast the default assertion timeout
+        cy.wait("@query");
 
         cy.log("check that impersonation enforcement occurrs");
         cy.findByTestId("query-builder-main").within(() => {


### PR DESCRIPTION
Closes UXW-4295

### Description

This was a weird one. According to [trunk](https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/5e7349bf-fc72-5854-8ce1-5a048408f0a1), the flake hasn't appeared in over 20 days, and a stress test in master confirmed that these issues were not still happening. However, there is a very [rare chance](https://github.com/metabase/metabase/actions/runs/27835943074/job/82383887344) that the job fail based on the reload taking too long. This fix handles that

### How to verify

Green CI and stress test


### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27837739472