### PR TITLE
Fix flaky document revision-history toast assertion

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -1854,6 +1854,8 @@ describe("documents", () => {
       cy.findByTestId("toast-undo")
         .should("be.visible")
         .and("contain.text", "Document saved");
+      // dismiss after asserting so toasts don't stack into later lookups
+      H.undoToast().icon("close").click({ force: true });
 
       cy.log("Make another change");
       H.documentContent().click();
@@ -1862,6 +1864,7 @@ describe("documents", () => {
       cy.contains('[data-testid="toast-undo"]', "Document saved").should(
         "be.visible",
       );
+      H.undoToast().icon("close").click({ force: true });
 
       cy.log("Open revision history");
       cy.findByLabelText("More options").click();


### PR DESCRIPTION
Closes UXW-4338

### Description

Simple "Too many toasts" flake. Dismiss toasts that we assert on handles it

### How to verify

Green CI and stress test


### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27838917495/job/82393317772
