### PR TITLE
Fix flaky bulk-move dashboard-questions e2e test

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -177,13 +177,18 @@ export function visitMetric(id) {
  * @param {number|string} dashboardIdOrAlias
  * @param {Object} config
  */
-export function visitDashboard(dashboardIdOrAlias, { params = {} } = {}) {
+export function visitDashboard(
+  dashboardIdOrAlias,
+  { params = {}, dashcardTimeout } = {},
+) {
   if (typeof dashboardIdOrAlias === "number") {
-    visitDashboardById(dashboardIdOrAlias, { params });
+    visitDashboardById(dashboardIdOrAlias, { params, dashcardTimeout });
   }
 
   if (typeof dashboardIdOrAlias === "string") {
-    cy.get(dashboardIdOrAlias).then((id) => visitDashboardById(id, { params }));
+    cy.get(dashboardIdOrAlias).then((id) =>
+      visitDashboardById(id, { params, dashcardTimeout }),
+    );
   }
 }
 
@@ -236,7 +241,12 @@ function visitDashboardById(dashboard_id, config) {
         qs: config.params,
       });
 
-      cy.wait(aliases);
+      // dashcardTimeout lets callers widen the per-query wait window for dashboards with
+      // many cards, whose tail queries stagger past cy.wait's 5s default under CPU load
+      cy.wait(
+        aliases,
+        config.dashcardTimeout ? { timeout: config.dashcardTimeout } : {},
+      );
     } else {
       // For a dashboard:
       //  - without questions (can be empty or markdown only) or

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -242,11 +242,13 @@ describe("Dashboard > Dashboard Questions", () => {
       H.entityPickerModal().button("Move").click();
 
       // we shouldn't be making 20 requests here
-      cy.wait(new Array(20).fill("@updateCard"));
+      // their staggered tail can land past cy.wait's default 5s under CPU load, so allow more time
+      cy.wait(new Array(20).fill("@updateCard"), { timeout: 30000 });
 
       H.undoToast().findByText("Moved 20 questions");
 
-      H.visitDashboard(S.ORDERS_DASHBOARD_ID);
+      // 20+ dashcard queries stagger behind the concurrency limit; allow their tail past the 5s default
+      H.visitDashboard(S.ORDERS_DASHBOARD_ID, { dashcardTimeout: 30000 });
 
       new Array(20).fill("slowbro").forEach((_, i) => {
         H.dashboardCards().findByText(`Question ${i + 1}`);
@@ -269,7 +271,7 @@ describe("Dashboard > Dashboard Questions", () => {
 
       cy.wait(["@updateCard", "@updateCard"]);
       cy.findByTestId("error-boundary").should("not.exist");
-      H.visitDashboard(S.ORDERS_DASHBOARD_ID);
+      H.visitDashboard(S.ORDERS_DASHBOARD_ID, { dashcardTimeout: 30000 });
       H.dashboardCards().findByText("Orders");
       H.dashboardCards().findByText("Orders, Count");
     });


### PR DESCRIPTION
Closes UXW-4424

### Description

Adds a dashcardTimeout property to visit dashboard. This is a case where we are intentially loading a very large dashboard on very limited hardware, so it's not too surprising that occasionally things time out. Adding an option to visitDashboard keeps the timeout tucked away and make it reusable if needed

### How to verify

Green CI and stress test


### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27840722252
