### PR TITLE
Fix library tree auto-expand race leaving Data/Metrics collapsed

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
@@ -125,6 +125,8 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
 
       cy.log("select multiple tables");
       TablePicker.getDatabase("Writable Postgres12").click();
+      // wait for the database's tables to load before selecting them
+      cy.wait("@getSchema");
       TablePicker.getTable("Orders").findByRole("checkbox").check();
       TablePicker.getTable("Products").findByRole("checkbox").check();
       TablePicker.getTable("Reviews").findByRole("checkbox").check();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/LibraryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/LibraryPage.tsx
@@ -51,6 +51,7 @@ function LibraryPageContent() {
   const { treeTableInstance, isChildrenLoading, isLoading, emptyMessage } =
     useLibraryTreeTableInstance({
       collections,
+      isLoadingCollections,
       searchQuery,
       onPublishTableClick: openPublishTableModal,
     });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibraryTreeTableInstance.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibraryTreeTableInstance.tsx
@@ -31,12 +31,14 @@ import { useLibrarySearch } from "./useLibrarySearch";
 
 type Params = {
   collections: Collection[];
+  isLoadingCollections: boolean;
   searchQuery: string;
   onPublishTableClick: VoidFunction;
 };
 
 export function useLibraryTreeTableInstance({
   collections,
+  isLoadingCollections,
   searchQuery,
   onPublishTableClick,
 }: Params) {
@@ -99,7 +101,11 @@ export function useLibraryTreeTableInstance({
   );
 
   const isLoading =
-    loadingTables || loadingMetrics || loadingSnippets || isSearchLoading;
+    isLoadingCollections ||
+    loadingTables ||
+    loadingMetrics ||
+    loadingSnippets ||
+    isSearchLoading;
   useErrorHandling(tablesError || metricsError || snippetsError);
 
   const libraryHasContent = useMemo(
@@ -226,18 +232,17 @@ export function useLibraryTreeTableInstance({
     null,
   );
 
-  // Lock browseExpanded only once the collection tree has loaded: `!isLoading` alone fires too
-  // early (section item queries are skipped until `collections` resolves), locking a stale subset.
+  // Lock browseExpanded once loading settles. isLoading now includes the collections fetch, so it
+  // no longer fires early (section item queries are skipped until collections resolve).
   useEffect(() => {
     if (
       browseExpanded === null &&
       !isLoading &&
-      collections.length > 0 &&
       Object.keys(defaultExpanded).length > 0
     ) {
       setBrowseExpanded(defaultExpanded);
     }
-  }, [browseExpanded, defaultExpanded, isLoading, collections.length]);
+  }, [browseExpanded, defaultExpanded, isLoading]);
 
   const expanded = isSearchActive ? true : (browseExpanded ?? defaultExpanded);
   const onExpandedChange = useCallback(

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibraryTreeTableInstance.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibraryTreeTableInstance.tsx
@@ -226,17 +226,18 @@ export function useLibraryTreeTableInstance({
     null,
   );
 
-  // Initialize browseExpanded from defaultExpanded once collections are loaded,
-  // so we stop falling through to a recalculated defaultExpanded on every render.
+  // Lock browseExpanded only once the collection tree has loaded: `!isLoading` alone fires too
+  // early (section item queries are skipped until `collections` resolves), locking a stale subset.
   useEffect(() => {
     if (
       browseExpanded === null &&
       !isLoading &&
+      collections.length > 0 &&
       Object.keys(defaultExpanded).length > 0
     ) {
       setBrowseExpanded(defaultExpanded);
     }
-  }, [browseExpanded, defaultExpanded, isLoading]);
+  }, [browseExpanded, defaultExpanded, isLoading, collections.length]);
 
   const expanded = isSearchActive ? true : (browseExpanded ?? defaultExpanded);
   const onExpandedChange = useCallback(


### PR DESCRIPTION
Closes UXW-4500
Closes UXW-4331

### Description

Wait to set expandedIds until collections are actually present (a better indication of loading being finished).
UXW-4331 actually has a lot of other possible failure conditions too, so we add a wait on getSchema to give the table time to load when publishing multiple tables


### How to verify

Green CI and stress tests

### Checklist

- [x] UXW-4500 https://github.com/metabase/metabase/actions/runs/27866140581
- [x] UXW-4331 https://github.com/metabase/metabase/actions/runs/27866155802
