### PR TITLE
Fix flaky Pro-cloud email settings e2e test

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -521,17 +521,13 @@ describe("scenarios > admin > settings > email settings", () => {
   describe("Pro-cloud instance", () => {
     beforeEach(() => {
       cy.intercept("DELETE", "api/ee/email/override").as("smtpCleared");
-      cy.intercept("GET", "/api/session/properties", (req) => {
-        req.continue((res) => {
-          // in an actual pro-cloud instance this gets configured via env vars
-          res.body["email-configured?"] = true;
-          return res.body;
-        });
-      });
       cy.intercept("PUT", "api/ee/email/override").as("smtpSaved");
       H.restore();
       cy.signInAsAdmin();
       H.activateToken("pro-cloud");
+      // A real pro-cloud instance configures email via env vars; set the SMTP host so
+      // email-configured? is true (avoids a session/properties intercept that flakes on reload).
+      H.updateSetting("email-smtp-host", "smtp.example.test");
       H.resetSnowplow();
       H.enableTracking();
     });


### PR DESCRIPTION
Closes UXW-4501

### Description

Actually sets an email using updateSettings. This causes `email-configured?` to be true on the BE, which is more reliable than the interception

### How to verify

Green CI and Stress Test

### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27842878993
