### PR TITLE
Fix flaky click-behavior fall-back-to-first-tab e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -556,7 +556,19 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
 
       H.editDashboard();
+
+      cy.get("@targetDashboardId").then((targetDashboardId) => {
+        cy.intercept("GET", `/api/dashboard/${targetDashboardId}`).as(
+          "loadTargetDashboard",
+        );
+      });
+
       H.getDashboardCard().realHover().icon("click").click();
+      // Wait for the click-behavior sidebar to finish loading the target dashboard; its load
+      // triggers the tab migration that dirties the dashboard, so Save then issues a request.
+      cy.wait("@loadTargetDashboard");
+      cy.get("aside").findByText(TARGET_DASHBOARD.name).should("be.visible");
+
       cy.get("aside")
         .findByLabelText("Select a dashboard tab")
         .should("not.exist");


### PR DESCRIPTION
Closes UXW-4502

### Description

This is a bit of a strange one, but it boils down to a race condition. The test opens the sidebar, which kicks off a request to load the `@targetDashboard`. Without the wait, it's possible for the test to close the sidebar and save the dashboard before the target loads, and without the target loading, the auto migration never happens.

As an aside, it's a bit strange that the dashboard can"dirty" just from the user navigating around. There's probably an argument to changing how this works

### How to verify

Green CI and Stress test

### Checklist

- [x] https://github.com/metabase/metabase/actions/runs/27865605723