### PR TITLE
manual backport of 🤖 backported "Fix memory leak with notifications a…

### DIFF
--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1150,7 +1150,8 @@
           ;; Batch SELECT #2: all existing table-level permissions for this DB
           ;; (needed for schema-permission-value logic and going-granular expansion)
           table-perms    (t2/select :model/DataPermissions
-                                    {:where [:and
+                                    {:select-distinct [:group_id :perm_type :schema_name :perm_value]
+                                     :where [:and
                                              [:= :db_id db-id]
                                              [:not= :table_id nil]
                                              [:in :group_id group-ids]

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -866,6 +866,47 @@
                                                 :table_id table-id-4 :perm_type :perms/create-queries))
             "should inherit :query-builder from PUBLIC schema, not the :no default")))))
 
+(defn- make-granular-perms-scenario!
+  "Create `db-id` with `n-groups` groups and `n-tables` tables in a single
+  schema, all granted granular table-level view-data perms (kept granular by
+  giving one table a differing value so they don't consolidate to a DB-level
+  row). Returns `[db-id group-ids]`."
+  [n-groups n-tables]
+  (let [db-id     (t2/insert-returning-pk! :model/Database (mt/with-temp-defaults :model/Database))
+        group-ids (vec (for [_ (range n-groups)]
+                         (t2/insert-returning-pk! :model/PermissionsGroup
+                                                  (mt/with-temp-defaults :model/PermissionsGroup))))
+        table-ids (vec (for [_ (range n-tables)]
+                         (t2/insert-returning-pk! :model/Table
+                                                  (merge (mt/with-temp-defaults :model/Table)
+                                                         {:db_id db-id :schema "s1" :active true}))))]
+    (doseq [g group-ids]
+      (doseq [tid (butlast table-ids)]
+        (data-perms/set-table-permission! g tid :perms/view-data :unrestricted))
+      ;; one differing table keeps the schema granular (prevents DB-level consolidation)
+      (data-perms/set-table-permission! g (last table-ids) :perms/view-data :blocked))
+    [db-id group-ids]))
+
+(deftest load-perm-context-distinct-preserves-schema-vals-idx-test
+  (testing "DISTINCT collapse yields the same schema-vals-idx as loading every row (#76077)"
+    (mt/with-model-cleanup [:model/PermissionsGroup :model/Database :model/Table]
+      (let [[db-id group-ids] (make-granular-perms-scenario! 3 12)
+            idx-from (fn [rows]
+                       (reduce (fn [acc {:keys [group_id perm_type schema_name perm_value]}]
+                                 (update-in acc [group_id perm_type schema_name] (fnil conj #{}) perm_value))
+                               {} rows))
+            all      (t2/select :model/DataPermissions
+                                {:where [:and [:= :db_id db-id] [:not= :table_id nil]
+                                         [:in :group_id group-ids]]})
+            distinct (t2/select :model/DataPermissions
+                                {:select-distinct [:group_id :perm_type :schema_name :perm_value]
+                                 :where [:and [:= :db_id db-id] [:not= :table_id nil]
+                                         [:in :group_id group-ids]]})]
+        (is (< (count distinct) (count all))
+            "DISTINCT actually collapses duplicate rows")
+        (is (= (idx-from all) (idx-from distinct))
+            "the resulting schema-vals-idx is byte-identical")))))
+
 (deftest batch-permissions-lock-skips-fine-grained-locks-test
   (testing "Fine-grained cluster locks are skipped inside with-global-permissions-lock"
     (mt/with-temp [:model/Database {db-id :id} {}]


### PR DESCRIPTION
…nd GraalVM" (#76172)

Fixes #76077

When the sync-and-analyze job creates new tables, set-default-table-permissions! calls load-perm-context, which loaded every table-level data_permissions row for the database to figure out, per (group, perm-type, schema), the set of distinct permission values already in use. The result set grew with the table count, so on databases with very many tables it materialized millions of rows (2.5M+ org.postgresql.core.Tuple / toucan2.instance.Instance in the heap dump that prompted this) and OOM'd the JVM on a scheduler thread.

schema-vals-idx only ever needs the distinct (group_id, perm_type, schema_name, perm_value) tuples — it reduces the rows into a set keyed by (group, perm-type, schema), so duplicate rows were already being collapsed in memory. Pushing that DISTINCT into SQL makes the loaded set bounded by groups × perm-types × schemas × values instead of growing with table count.

Rows loaded by the introspection query (measured; one perm-type, one schema):

```
groups  tables   before (groups×tables)   after (DISTINCT)
  5       10              100                    20
  5      100            1,000                    20
  5    1,000           10,000                    20   <- flat across tables
 10      100            2,000                    40
 50      100           10,000                   200   <- linear in groups
```

Before, the result scaled with the table count (the thing that blew up); after, it is flat across table count and grows only linearly with the number of groups. The produced schema-vals-idx is byte-identical because it accumulates into a set — verified in a regression test.

Not scoping the query to the synced tables' schemas (a further reduction): a schema_name IN (...) filter would add NULL/casing correctness risk, and the DISTINCT collapse alone removes the geometric blowup that caused the OOM.