### PR TITLE
UXW-4466 fix Y-axis auto position

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -885,7 +885,9 @@ describe("scenarios > dashboard > dashboard drill", () => {
           H.chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
           assertTooltipValues();
 
-          H.chartPathWithFillColor("#98D9D9").first().trigger("mousemove");
+          H.chartPathWithFillColor("#98D9D9")
+            .first()
+            .trigger("mousemove", { force: true });
           assertTooltipValues();
         });
       });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -252,6 +252,7 @@ describe("issue 51926", () => {
     H.openVizTypeSidebar();
     H.leftSidebar().within(() => {
       cy.findByTestId("Table-button").click();
+      cy.wait(300); // wait for rerender
       cy.findByTestId("Pivot Table-button").click();
     });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -170,23 +170,21 @@ function generateSplits(
 function axisCost(extents: Extent[], favorUnsplit = true) {
   const axisExtent = d3.extent(extents.flatMap((e) => e));
 
-  // TODO: handle cases where members of axisExtent is undefined
-  const axisRange = axisExtent[1]! - axisExtent[0]!;
+  const axisRange =
+    axisExtent[0] != null ? axisExtent[1] - axisExtent[0] : undefined;
 
   if (favorUnsplit && extents.length === 0) {
     return SPLIT_AXIS_UNSPLIT_COST;
-  } else if (axisRange === 0) {
+  } else if (axisRange === 0 || !axisRange) {
     return 0;
   } else {
-    return extents.reduce(
-      (sum, seriesExtent) =>
-        sum +
-        Math.pow(
-          axisRange / (seriesExtent[1] - seriesExtent[0]),
-          SPLIT_AXIS_COST_FACTOR,
-        ),
-      0,
-    );
+    return extents.reduce((sum, seriesExtent) => {
+      const seriesRange = seriesExtent[1] - seriesExtent[0];
+      if (seriesRange === 0) {
+        return sum;
+      }
+      return sum + Math.pow(axisRange / seriesRange, SPLIT_AXIS_COST_FACTOR);
+    }, 0);
   }
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.unit.spec.ts
@@ -26,6 +26,29 @@ describe("computeSplit", () => {
       Object.keys(extents).length,
     );
   });
+
+  it("should not isolate a constant (zero-range) series and force dissimilar series onto the same axis (#36908)", () => {
+    const extentsWithZeroRange: SeriesExtents = {
+      count: [50, 600],
+      zeroes: [0, 0],
+      tax: [3, 7],
+    };
+
+    const [left, right] = computeSplit(extentsWithZeroRange);
+    const onSameAxis = (a: string, b: string) =>
+      (left.includes(a) && left.includes(b)) ||
+      (right.includes(a) && right.includes(b));
+
+    // The dissimilar large/small ranges must be split across axes, otherwise the
+    // small-range series gets squashed flat against the axis.
+    expect(onSameAxis("count", "tax")).toBe(false);
+
+    // The constant series must not be isolated on its own axis — it should share
+    // with another series instead of driving the split.
+    expect(
+      left.includes("zeroes") ? left.length : right.length,
+    ).toBeGreaterThan(1);
+  });
 });
 
 describe("getXAxisDateRangeFromSortedXAxisValues", () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75701
Closes UXW-4466

### Description

fix Y-axis auto position that what caused by "Infinity" `axisCost` value result due to diving by 0

### How to verify

1. Start a question from the orders table
1. Add a custom column of zeros
1. Build a question with 3 metrics: count of orders, sum of the zeroes column, and average of tax, by month
1. Generated question should have 2 non-zero lines have sensible scale.

### Demo

https://www.loom.com/share/35a85e4e739a432ea98d0b384061fce0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
