### PR TITLE
Backport search related commits to 62

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -83,7 +83,11 @@ describe(
       cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("POST", "/api/action").as("createAction");
       cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
-      cy.intercept("GET", "/api/search?archived=true").as("getArchived");
+      cy.intercept({
+        method: "GET",
+        pathname: "/api/search",
+        query: { archived: "true" },
+      }).as("getArchived");
       cy.intercept("GET", "/api/search?*").as("getSearchResults");
       cy.intercept("GET", "/api/database?*").as("getDatabase");
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -230,10 +230,17 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
   });
 
   it("should not include entity-types when model count is 1", () => {
-    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
-      data: [],
-      total: 1,
-    }).as("searchModels");
+    cy.intercept(
+      {
+        method: "GET",
+        pathname: "/api/search",
+        query: { limit: "0", models: "dataset" },
+      },
+      {
+        data: [],
+        total: 1,
+      },
+    ).as("searchModels");
 
     navigateToGetCodeStep({ experience: "exploration" });
 
@@ -252,10 +259,17 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
   });
 
   it("should include entity-types when model count is 3", () => {
-    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
-      data: [],
-      total: 3,
-    }).as("searchModels");
+    cy.intercept(
+      {
+        method: "GET",
+        pathname: "/api/search",
+        query: { limit: "0", models: "dataset" },
+      },
+      {
+        data: [],
+        total: 3,
+      },
+    ).as("searchModels");
 
     navigateToGetCodeStep({ experience: "exploration" });
 

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -68,13 +68,22 @@ describe("scenarios > search > snowplow", () => {
       cy.visit("/");
       H.commandPaletteSearch("Orders", false);
 
-      //Passing a function to ensure that runtime_milliseconds is populated as a number
+      // Match the full event shape (notably a non-null search_term_hash) so this pins the user's "Orders"
+      // search specifically, and stays a count-of-1 even as more search surfaces start emitting events.
+      // Passing a function also asserts runtime_milliseconds is a number.
       H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: NEW_SEARCH_QUERY_EVENT_NAME,
             context: "command-palette",
             runtime_milliseconds: P.number,
+            search_engine: P.string,
+            request_id: P.string,
+            offset: null,
+            search_term_hash: P.string,
+            // The raw term is redacted to null on every instance except Metabase's own stats instance
+            // (shouldReportSearchTerm); the salted search_term_hash above is what identifies the query.
+            search_term: null,
           },
           event,
         ),

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -161,11 +161,23 @@ describe("scenarios > search > snowplow", () => {
           context: "search-app",
         });
 
-        cy.findByRole("heading", { name: "Orders in a dashboard" }).click();
-        H.expectUnstructuredSnowplowEvent({
-          event: SEARCH_CLICK,
-          context: "search-app",
-          position: 0,
+        // The result's rank depends on ranking weights, so derive its position from the DOM order
+        // rather than pinning a specific index.
+        cy.findAllByTestId("search-result-item").then(($items) => {
+          const position = $items
+            .toArray()
+            .findIndex((el) =>
+              el.textContent?.includes("Orders in a dashboard"),
+            );
+          expect(position, "Orders in a dashboard is in the results").to.be.gte(
+            0,
+          );
+          cy.wrap($items.eq(position)).click();
+          H.expectUnstructuredSnowplowEvent({
+            event: SEARCH_CLICK,
+            context: "search-app",
+            position,
+          });
         });
       });
     });

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -13,6 +13,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase.analytics-interface.core :as analytics]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
@@ -43,6 +44,21 @@
   (and
    (some? semantic.db.datasource/db-url)
    (semantic.settings/semantic-search-enabled)))
+
+(defn- with-zero-semantic-distance
+  "Record `:semantic-distance` 0 on `results` that lack it, for a consistent merged-result score breakdown."
+  [search-ctx results]
+  ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance.
+  (let [entry {:name         :semantic-distance
+               :score        0
+               :weight       (search.config/weight search-ctx :semantic-distance)
+               :contribution 0}]
+    (map (fn [result]
+           (cond-> result
+             (and (contains? result :all-scores)
+                  (not-any? (comp #{:semantic-distance} :name) (:all-scores result)))
+             (update :all-scores conj entry)))
+         results)))
 
 (defenterprise results
   "Enterprise implementation of semantic search results with improved fallback logic. Falls back to appdb search only
@@ -85,7 +101,7 @@
                                        []))
                   fallback-results (take total-limit fallback-results)
                   _                (analytics/observe! :metabase-search/semantic-fallback-results-usage (count fallback-results))
-                  combined-results (concat results fallback-results)
+                  combined-results (concat results (with-zero-semantic-distance search-ctx fallback-results))
                   deduped-results  (m/distinct-by (juxt :model :id) combined-results)]
               (take total-limit deduped-results)))))
       (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -621,14 +621,15 @@
 
 (def ^:private ^:const max-cosine-distance "Cut-off used to filter semantic search results" 0.7)
 
-(defn- semantic-search-query
-  "Build a semantic search query using vector similarity with post-filtering to enable HNSW index usage."
-  [index embedding search-context]
-  (let [filters (search-filters search-context)
-        embedding-literal (format-embedding embedding)
-        ;; Inner query: pure vector search to better trigger HNSW index vs. seqscan
-        ;; TODO: only pull in necessary extra columns from configured filters
-        hnsw-query {:select (into common-search-columns
+(defn- hnsw-search-query
+  "Build the semantic vector subquery using the HNSW index, applying `filters` after candidate selection."
+  [index embedding-literal filters]
+  ;; The inner `vector_candidates` CTE is a pure vector search (ORDER BY distance LIMIT) so the planner
+  ;; uses the HNSW index. The filters only run in the outer query, so this is approximate: when the
+  ;; globally-closest rows are dominated by a cluster the filters reject, slightly-further survivors that
+  ;; would have passed the filters never enter the candidate set. `brute-force-search-query` is exact.
+  ;; TODO: only pull in necessary extra columns from configured filters
+  (let [hnsw-query {:select (into common-search-columns
                                   [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
                     :from   [(keyword (:table-name index))]
                     :order-by [[[:raw (str "embedding <=> " embedding-literal)] :asc]]
@@ -644,6 +645,45 @@
       (update base-query :where #(into [:and] [% filters]))
       base-query)))
 
+(defn- brute-force-search-query
+  "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
+  [index embedding-literal filters]
+  ;; The filtered rows and their cosine distance are computed once, inside a MATERIALIZED CTE: that fences
+  ;; the planner off the HNSW index (so the scan is exact) and stores the `distance` column, so the outer
+  ;; query reads it rather than recomputing it. The cutoff and ranking run in the outer query.
+  ;; We deliberately don't push the cutoff into the CTE to avoid materializing rows beyond it: that would
+  ;; either recompute the distance for the qual, or need a subquery optimization fence (Postgres pulls a
+  ;; plain subquery back up and re-inlines the expression) -- not worth it for an exact scan that already
+  ;; touches every filtered row.
+  (let [filtered-query (cond-> {:select (into common-search-columns
+                                              [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
+                                :from   [(keyword (:table-name index))]}
+                         filters (assoc :where filters))]
+    {:with     [[:vector_candidates filtered-query :materialized]]
+     :select   (into common-search-columns
+                     [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                      [:distance :semantic_score]])
+     :from     [:vector_candidates]
+     :where    [:<= :distance max-cosine-distance]
+     :order-by [[:semantic_rank :asc]]
+     :limit    (semantic-settings/semantic-search-results-limit)}))
+
+(defn- vector-search-strategy
+  "Resolve the vector-search strategy for `search-context`, falling back to the configured default setting."
+  [search-context]
+  (or (:vector-search-strategy search-context)
+      (semantic-settings/semantic-search-vector-strategy)))
+
+(defn- semantic-search-query
+  "Build the semantic vector subquery, dispatching on the resolved [[vector-search-strategy]].
+  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
+  [index embedding search-context]
+  (let [filters           (search-filters search-context)
+        embedding-literal (format-embedding embedding)]
+    (case (vector-search-strategy search-context)
+      :brute-force (brute-force-search-query index embedding-literal filters)
+      (hnsw-search-query index embedding-literal filters))))
+
 (defn- flatten-ctes
   "Flatten nested :with clauses into a single top-level :with.
   PostgreSQL doesn't support nested CTEs, so we need to extract all nested :with clauses
@@ -654,9 +694,10 @@
   (if-not (:with query)
     {:ctes [] :query query}
     (let [ctes (reduce
-                (fn [acc [cte-name cte-query]]
+                ;; `opts` carries any trailing CTE options (e.g. `:materialized`) so they survive hoisting.
+                (fn [acc [cte-name cte-query & opts]]
                   (let [{:keys [ctes query]} (flatten-ctes cte-query)]
-                    (into acc (conj ctes [cte-name query]))))
+                    (into acc (conj ctes (into [cte-name query] opts)))))
                 []
                 (:with query))]
       {:ctes ctes

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -637,7 +637,7 @@
         base-query {:with [[:vector_candidates hnsw-query]]
                     :select (into common-search-columns
                                   [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                                   [:distance :semantic_score]])
+                                   [:distance :semantic_distance]])
                     :from [:vector_candidates]
                     :where [:<= :distance max-cosine-distance]
                     :order-by [[:semantic_rank :asc]]}]
@@ -662,7 +662,7 @@
     {:with     [[:vector_candidates filtered-query :materialized]]
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                      [:distance :semantic_score]])
+                      [:distance :semantic_distance]])
      :from     [:vector_candidates]
      :where    [:<= :distance max-cosine-distance]
      :order-by [[:semantic_rank :asc]]
@@ -723,6 +723,7 @@
                     :select (into
                              (mapv hybrid-select common-search-columns)
                              [[:v.semantic_rank :semantic_rank]
+                              [:v.semantic_distance :semantic_distance]
                               [:t.keyword_rank :keyword_rank]])
                     :from [[:vector_results :v]]
                     :full-join [[:text_results :t] [:= :v.id :t.id]]
@@ -743,7 +744,7 @@
         {:keys [ctes query]} (flatten-ctes hybrid-query)
         all-ctes (conj ctes [:hybrid_results query])
         full-query {:with all-ctes
-                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :keyword_rank]
+                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :semantic_distance :keyword_rank]
                     :from [[:hybrid_results :search_index]]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -69,6 +69,19 @@
      [:* [:cast keyword-weight :float]
       [:coalesce [:/ 1.0 [:+ k :keyword_rank]] 0]]]))
 
+(def ^:private cosine-distance-ceiling
+  "Largest possible pgvector cosine distance (`<=>`): `1 - cos(theta)` tops out at 2 for opposed vectors."
+  2.0)
+
+(defn- semantic-distance-score-expr
+  "Map a cosine `distance` (pgvector `<=>`, range [0, 2]) to a [0, 1] score.
+  Linear for now: distance 0 scores 1, the maximum distance of 2 scores 0."
+  [distance]
+  ;; TODO (Chris 2026-06-02) -- consider rescaling against the retrieval cutoff (index/max-cosine-distance) so the
+  ;; [0, cutoff] band spans the full [0, 1], and/or a non-linear curve. For now keep the raw distance as transparent
+  ;; as possible.
+  [:- [:inline 1] [:/ distance [:inline cosine-distance-ceiling]]])
+
 (defn base-scorers
   "The default constituents of the search ranking scores."
   [index-table {:keys [search-string] :as search-ctx}]
@@ -77,6 +90,8 @@
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
     {:rrf        rrf-rank-exp
+     ;; Keyword-only hits have no vector distance, so treat them as maximally distant (score 0).
+     :semantic-distance (semantic-distance-score-expr [:coalesce :semantic_distance [:inline cosine-distance-ceiling]])
      :view-count (view-count-expr index-table search.config/view-count-scaling-percentile)
      :pinned     (search.scoring/truthy :pinned)
      :recency    (search.scoring/inverse-duration
@@ -88,12 +103,14 @@
      :model      (search.scoring/model-rank-expr search-ctx)
      :mine       (search.scoring/equal :creator_id (:current-user-id search-ctx))
      :exact      (if search-string
-                   ;; perform the lower casing within the database, in case it behaves differently to our helper
-                   (search.scoring/equal [:lower :name] [:lower search-string])
+                   ;; normalize both sides in the database, in case it behaves differently to our helper
+                   (search.scoring/equal (search.scoring/normalize-text-expr :postgres :name)
+                                         (search.scoring/normalize-text-expr :postgres search-string))
                    [:inline 0])
      :prefix     (if search-string
                    ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
-                   (search.scoring/prefix [:lower :name] (u/lower-case-en search-string))
+                   (search.scoring/prefix (search.scoring/normalize-text-expr :postgres :name)
+                                          (search.scoring/normalize-text search-string))
                    [:inline 0])
      :library    (search.scoring/library-score-expr)
      :data-layer (search.scoring/data-layer-score-expr search-ctx)}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.llm.settings :as llm-settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.search.config :as search.config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 
@@ -97,6 +98,31 @@
   :export? false
   :visibility :internal
   :doc false)
+
+(def ^:private valid-vector-search-strategies
+  "Valid semantic-search vector-search strategies, mastered in
+  [[metabase.search.config/vector-search-strategies]]."
+  (set search.config/vector-search-strategies))
+
+(defsetting semantic-search-vector-strategy
+  (deferred-tru
+   (str "Default vector-search strategy for semantic search: `hnsw` (approximate, HNSW-index-backed) or "
+        "`brute-force` (exact, applies non-vector filters first then computes cosine distance over the "
+        "survivors). Individual requests may override this via the `vector_search_strategy` API parameter."))
+  :type       :keyword
+  :default    :hnsw
+  :encryption :no
+  :export?    false
+  :visibility :internal
+  :doc        false
+  :setter     (fn [new-value]
+                (let [kw (some-> new-value keyword)]
+                  (when (and kw (not (contains? valid-vector-search-strategies kw)))
+                    (throw (ex-info (str "Invalid vector-search strategy: " (pr-str new-value)
+                                         ". Valid strategies are: " (pr-str valid-vector-search-strategies))
+                                    {:invalid-value new-value
+                                     :valid-values  valid-vector-search-strategies})))
+                  (setting/set-value-of-type! :keyword :semantic-search-vector-strategy kw))))
 
 (defsetting semantic-search-min-results-threshold
   (deferred-tru "Minimum number of semantic search results required before falling back to other engines.")

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -63,13 +63,13 @@
               "custom expression examples"]
              (mapv :name (sort-by #(oss-score search-string %)
                                   (shuffle [a b c d])))))
-      ;; With :official-collection lifted to 80 in :default, the official bump dominates the
-      ;; text scorers — `d` now ranks highest, landing last under the ascending sort, despite
-      ;; having the weakest text match.
-      (is (= ["customer success stories"
+      ;; With :official-collection at 1 in :default, the official bump is only a tie-breaker —
+      ;; it can't overcome the text scorers, so `d` stays ranked by its (weakest) text match
+      ;; and the ordering matches OSS.
+      (is (= ["customer examples of bad sorting"
+              "customer success stories"
               "examples of custom expressions"
-              "custom expression examples"
-              "customer examples of bad sorting"]
+              "custom expression examples"]
              (mapv :name (sort-by #(ee-score search-string %)
                                   (shuffle [a b c (assoc d :collection_authority_level "official")]))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -160,6 +160,27 @@
                     (is (= 1 (:metabase-search/semantic-fallback-triggered @metrics)))
                     (is (= 1 (:metabase-search/semantic-results-before-fallback @metrics)))))))))))))
 
+(deftest fallback-results-zero-semantic-distance-test
+  (testing "fallback results record :semantic-distance as 0 in their score breakdown, leaving other scores intact"
+    (mt/with-premium-features #{:semantic-search}
+      (mt/with-temporary-setting-values [semantic-search-min-results-threshold 3]
+        (let [semantic-result  (assoc (make-card-result 1 "semantic-card" :score 0.9)
+                                      :all-scores [{:name :semantic-distance :score 0.95 :weight 10 :contribution 9.5}])
+              fallback-results [(assoc (make-card-result 2 "fallback-card" :score 0.5)
+                                       :all-scores [{:name :text :score 1 :weight 5 :contribution 5}])]
+              search-ctx       (assoc search-context :weights {:semantic-distance 10})]
+          (with-search-engine-mocks! [semantic-result] fallback-results
+            (fn []
+              (let [results     (vec (semantic.core/results search-ctx))
+                    result-by-id (fn [id] (some #(when (= id (:id %)) %) results))]
+                (testing "fallback result gains a zero semantic-distance entry, keeping its existing scores"
+                  (is (=? [{:name :text :score 1}
+                           {:name :semantic-distance :score 0 :weight 10 :contribution 0}]
+                          (:all-scores (result-by-id 2)))))
+                (testing "genuine semantic result keeps its computed distance"
+                  (is (=? [{:name :semantic-distance :score 0.95}]
+                          (:all-scores (result-by-id 1)))))))))))))
+
 (deftest test-semantic-search-fallback-failure-resilient
   (testing "semantic search is resilient to fallback engine failure"
     (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -3,9 +3,11 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [honey.sql :as sql]
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
@@ -19,6 +21,63 @@
 (set! *warn-on-reflection* true)
 
 (use-fixtures :once #'semantic.tu/once-fixture)
+
+(defn- vector-search-sql
+  "Format the private vector subquery for `strategy` against a stub index, returning the SQL string."
+  [strategy]
+  (let [index   {:table-name "idx_tbl"}
+        ctx     (cond-> {:search-string "pasta" :archived? false}
+                  strategy (assoc :vector-search-strategy strategy))
+        embedding [0.1 0.2 0.3]]
+    (first (sql/format (#'semantic.index/semantic-search-query index embedding ctx) :quoted true))))
+
+(deftest semantic-search-query-strategy-test
+  (testing ":brute-force applies the non-vector filters inside a MATERIALIZED CTE (filter-first, exact)"
+    (let [sql (vector-search-sql :brute-force)]
+      (is (str/includes? sql "AS MATERIALIZED"))
+      ;; filter lives inside the CTE, alongside the distance computation
+      (is (re-find #"AS MATERIALIZED \(SELECT.*\"archived\" = FALSE.*\)" sql))
+      ;; the distance expression appears once -- it is computed and stored in the materialized CTE, and the
+      ;; outer query reads that column rather than recomputing it
+      (is (= 1 (count (re-seq #"embedding <=>" sql))))
+      ;; no pure-vector ORDER BY ... LIMIT that would trigger the HNSW index
+      (is (not (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql)))))
+  (testing ":hnsw does a pure vector search in the inner CTE then post-filters (approximate)"
+    (let [sql (vector-search-sql :hnsw)]
+      (is (not (str/includes? sql "MATERIALIZED")))
+      (is (re-find #"ORDER BY embedding <=>" sql))
+      ;; the filter is applied in the outer query, after the candidate set is chosen
+      (is (str/includes? sql "\"archived\" = FALSE"))))
+  (testing "no explicit strategy falls back to the configured default setting"
+    (is (= (vector-search-sql (semantic.settings/semantic-search-vector-strategy))
+           (vector-search-sql nil)))))
+
+(defn- flattened-vector-candidates-cte
+  "Build the brute-force/hnsw hybrid query, flatten it the way `scored-search-query` does, and return the
+  hoisted `:vector_candidates` CTE binding (e.g. `[:vector_candidates <query> :materialized]`)."
+  [strategy]
+  (let [index  {:table-name "idx_tbl"}
+        ctx    {:search-string "pasta" :archived? false :vector-search-strategy strategy}
+        hybrid (#'semantic.index/hybrid-search-query index [0.1 0.2 0.3] ctx)
+        {:keys [ctes]} (#'semantic.index/flatten-ctes hybrid)]
+    (first (filter #(= :vector_candidates (first %)) ctes))))
+
+(deftest flatten-ctes-preserves-materialized-test
+  (testing "the :materialized opt survives CTE hoisting (the path every real query takes via scored-search-query)"
+    ;; A regression that dropped the opt would change only the query plan, not the results, so the
+    ;; results-based end-to-end tests can't catch it -- assert on the hoisted binding directly.
+    (is (= :materialized (last (flattened-vector-candidates-cte :brute-force)))))
+  (testing ":hnsw hoists a plain CTE binding with no opts"
+    (is (= 2 (count (flattened-vector-candidates-cte :hnsw))))))
+
+(deftest semantic-search-vector-strategy-setting-test
+  (testing "the setting rejects an unknown strategy"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid vector-search strategy"
+                          (semantic.settings/semantic-search-vector-strategy! :nonsense))))
+  (testing "valid strategies round-trip"
+    (doseq [strategy [:hnsw :brute-force]]
+      (mt/with-temporary-setting-values [semantic.settings/semantic-search-vector-strategy strategy]
+        (is (= strategy (semantic.settings/semantic-search-vector-strategy)))))))
 
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -26,6 +26,41 @@
                                 semantic.tu/filter-for-mock-embeddings)]
                 (is (= "Bird Watching Tips" (-> results first :name)))))))))))
 
+(deftest vector-search-strategy-test
+  (testing "Both vector-search strategies find the closest content and honor the same filters"
+    ;; The existing query tests exercise the default :hnsw path; this runs the same kind of filter
+    ;; battery under both strategies, since :brute-force applies the filters in a different SQL position
+    ;; (inside the materialized CTE) than :hnsw (post-candidate-selection).
+    (mt/with-premium-features #{:semantic-search}
+      (mt/as-admin
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
+          (semantic.tu/with-only-semantic-weights
+            (doseq [strategy [:hnsw :brute-force]]
+              (let [q (fn [ctx] (semantic.tu/query-index (assoc ctx :vector-search-strategy strategy)))]
+                (testing (str "strategy = " strategy)
+                  (testing "finds the closest content"
+                    (is (= "Dog Training Guide"
+                           (-> (q {:search-string "puppy"}) semantic.tu/filter-for-mock-embeddings first :name))))
+                  (testing "model filter"
+                    (let [results (q {:search-string "avian" :models ["card"]})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? #(= "card" (:model %)) results))))
+                  (testing "archived filter"
+                    (let [active (q {:search-string "feline" :archived? false})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings active))))
+                      (is (every? #(not (:archived %)) active)))
+                    (let [archived (q {:search-string "feline" :archived? true})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings archived))))
+                      (is (every? :archived archived))))
+                  (testing "verified filter"
+                    (let [results (q {:search-string "puppy" :verified true})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? :verified results))))
+                  (testing "creator filter"
+                    (let [results (q {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})]
+                      (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                      (is (every? #(= (mt/user->id :crowberto) (:creator_id %)) results)))))))))))))
+
 (defn- index-of-name
   "Return the index of the item with :name `name` in `coll`"
   [coll name]
@@ -41,7 +76,8 @@
         (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
             (let [not-top-10? #(or (nil? %) (< 10 %))]
-              (doseq [{:keys [name desc search-string search-native-query? expected-index?]}
+              (doseq [strategy [:hnsw :brute-force]
+                      {:keys [name desc search-string search-native-query? expected-index?]}
                       [{:name "Dog Training Guide"
                         :desc "contains"
                         :search-string "AVG(tricks)"
@@ -97,9 +133,10 @@
                         :search-string "Watching"
                         :search-native-query? true
                         :expected-index? zero?}]]
-                (testing (format "\n%s %s %s %s" name desc search-string search-native-query?)
+                (testing (format "\n[%s] %s %s %s %s" strategy name desc search-string search-native-query?)
                   (is (-> (semantic.tu/query-index {:search-string search-string
-                                                    :search-native-query search-native-query?})
+                                                    :search-native-query search-native-query?
+                                                    :vector-search-strategy strategy})
                           (index-of-name name)
                           expected-index?)))))))))))
 
@@ -178,40 +215,45 @@
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (semantic.tu/with-test-db! {:mode :mock-indexed}
-          (testing "Non-archived cards by specific creator"
-            (let [results (semantic.tu/query-index {:search-string "equine"
-                                                    :models ["card"]
-                                                    :archived? false
-                                                    :created-by [(mt/user->id :rasta)]})
-                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-              (is (pos? (count filtered-results)))
-              (is (every? #(and (= "card" (:model %))
-                                (not (:archived %))
-                                (= (mt/user->id :rasta) (:creator_id %))) results))))
-          (testing "Archived dashboards by multiple creators"
-            (let [results (semantic.tu/query-index {:search-string "Antarctic wildlife"
-                                                    :models ["dashboard"]
-                                                    :archived? true
-                                                    :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
-                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-              (is (pos? (count filtered-results)))
-              (is (every? #(and (= "dashboard" (:model %))
-                                (:archived %)
-                                (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
-          (testing "Verified items with additional filters"
-            (let [results (semantic.tu/query-index {:search-string "marine mammal"
-                                                    :models ["dashboard"]
-                                                    :verified true
-                                                    :archived? false})]
-              (is (every? #(and (= "dashboard" (:model %))
-                                (:verified %)
-                                (not (:archived %))) results)))))))))
+          (doseq [strategy [:hnsw :brute-force]]
+            (let [q (fn [ctx] (semantic.tu/query-index (assoc ctx :vector-search-strategy strategy)))]
+              (testing (str "strategy = " strategy)
+                (testing "Non-archived cards by specific creator"
+                  (let [results (q {:search-string "equine"
+                                    :models ["card"]
+                                    :archived? false
+                                    :created-by [(mt/user->id :rasta)]})
+                        filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+                    (is (pos? (count filtered-results)))
+                    (is (every? #(and (= "card" (:model %))
+                                      (not (:archived %))
+                                      (= (mt/user->id :rasta) (:creator_id %))) results))))
+                (testing "Archived dashboards by multiple creators"
+                  (let [results (q {:search-string "Antarctic wildlife"
+                                    :models ["dashboard"]
+                                    :archived? true
+                                    :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
+                        filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+                    (is (pos? (count filtered-results)))
+                    (is (every? #(and (= "dashboard" (:model %))
+                                      (:archived %)
+                                      (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
+                (testing "Verified items with additional filters"
+                  ;; The fixture's only verified entity is a card ("Dog Training Guide"), so filter on
+                  ;; cards here -- a verified-dashboard query would return nothing and assert vacuously.
+                  (let [results (q {:search-string "puppy"
+                                    :models ["card"]
+                                    :verified true
+                                    :archived? false})]
+                    (is (pos? (count (semantic.tu/filter-for-mock-embeddings results))))
+                    (is (every? #(and (= "card" (:model %))
+                                      (:verified %)
+                                      (not (:archived %))) results))))))))))))
 
 (deftest permissions-test
   (mt/with-premium-features #{:semantic-search}
     (semantic.tu/with-test-db! {:mode :mock-indexed}
       (let [monsters-table (t2/select-one-pk :model/Table :name "Monsters Table")
-            q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]})))
             all-users (perms-group/all-users)
             unrestrict-table (fn [table-id]
                                (data-perms/set-table-permission! all-users table-id :perms/create-queries :query-builder)
@@ -219,26 +261,32 @@
             restrict-table (fn [table-id]
                              (data-perms/set-table-permission! all-users table-id :perms/create-queries :no)
                              (data-perms/set-table-permission! all-users table-id :perms/view-data :blocked))]
-        (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
-        (restrict-table monsters-table)
-        (testing "admin"
-          (mt/with-test-user :crowberto
-            (testing "collection permissions"
-              (is (some #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
-              (is (some #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
-            (testing "data permissions"
-              (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
-        (testing "all-users"
-          (mt/with-test-user :rasta
-            (testing "collection permissions"
-              (is (not-any? #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
-              (is (not-any? #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
-            (testing "data permissions"
-              (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
-            (testing "give data permissions"
-              (unrestrict-table monsters-table)
-              (data-perms/disable-perms-cache
-               (is (some #{"Monsters Table"} (q "table" "monster facts")))))))))))
+        (doseq [strategy [:hnsw :brute-force]]
+          (let [q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]
+                                                                     :vector-search-strategy strategy})))]
+            ;; Re-establish the restricted baseline each iteration: the give-data-permissions block below
+            ;; unrestricts the table, which would otherwise leak into the next strategy's iteration.
+            (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
+            (restrict-table monsters-table)
+            (testing (str "strategy = " strategy)
+              (testing "admin"
+                (mt/with-test-user :crowberto
+                  (testing "collection permissions"
+                    (is (some #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+                    (is (some #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+                  (testing "data permissions"
+                    (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
+              (testing "all-users"
+                (mt/with-test-user :rasta
+                  (testing "collection permissions"
+                    (is (not-any? #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+                    (is (not-any? #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+                  (testing "data permissions"
+                    (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
+                  (testing "give data permissions"
+                    (unrestrict-table monsters-table)
+                    (data-perms/disable-perms-cache
+                     (is (some #{"Monsters Table"} (q "table" "monster facts"))))))))))))))
 
 (deftest basic-batched-query-test
   (testing "Small-batch reindexing"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -94,6 +94,27 @@
                   ["card" 3 "classified"]]
                  (search-results :rrf "order"))))))))
 
+(deftest semantic-distance-test
+  (mt/with-premium-features #{:semantic-search}
+    ;; Bind embeddings around indexing *and* querying: cosine distance scores the stored doc embedding against the
+    ;; query embedding, so the docs must be indexed with these vectors, not the default fallback.
+    ;; Cosine distance ignores magnitude, so these order purely by direction relative to the query: "near" shares the
+    ;; query's direction (distance 0 -> score 1), "mid" diverges a little, "far" the most. All stay under the 0.7
+    ;; cutoff so every doc survives semantic retrieval.
+    (semantic.tu/with-mock-embeddings {"animal"      [1.0 0.0 0.0 0.0]
+                                       "animal near" [1.0 0.0 0.0 0.0]
+                                       "animal mid"  [1.0 0.5 0.0 0.0]
+                                       "animal far"  [1.0 1.0 0.0 0.0]}
+      (with-index-contents!
+        [{:model "card" :id 1 :name "animal near"}
+         {:model "card" :id 2 :name "animal mid"}
+         {:model "card" :id 3 :name "animal far"}]
+        (testing "Closer cosine distance ranks higher"
+          (is (= [["card" 1 "animal near"]
+                  ["card" 2 "animal mid"]
+                  ["card" 3 "animal far"]]
+                 (search-results :semantic-distance "animal"))))))))
+
 (deftest exact-test
   (mt/with-premium-features #{:semantic-search}
     (with-index-contents!
@@ -104,6 +125,16 @@
                 ["card" 2 "stop words"]]
                (search-results :exact "the any most of stop words very")))))))
 
+(deftest exact-normalization-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "Sales,  Revenue"}
+       {:model "card" :id 2 :name "Sales Revenue Report"}]
+      (testing "Exact matching ignores commas and collapses whitespace runs"
+        (is (= [["card" 1 "Sales,  Revenue"]
+                ["card" 2 "Sales Revenue Report"]]
+               (search-results :exact "sales revenue")))))))
+
 (deftest prefix-test
   (mt/with-premium-features #{:semantic-search}
     (with-index-contents!
@@ -113,6 +144,16 @@
         (is (= [["card" 1 "this is a prefix of something longer"]
                 ["card" 2 "a prefix this is not, unfortunately"]]
                (search-results :prefix "this is a prefix")))))))
+
+(deftest prefix-normalization-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "Sales, Revenue Quarterly"}
+       {:model "card" :id 2 :name "Revenue and Sales"}]
+      (testing "Prefix matching ignores commas and collapses whitespace runs"
+        (is (= [["card" 1 "Sales, Revenue Quarterly"]
+                ["card" 2 "Revenue and Sales"]]
+               (search-results :prefix "sales revenue")))))))
 
 (deftest pinned-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -903,6 +903,7 @@ function withAvailableModels(WrappedComponent) {
       calculate_available_models: true,
       limit: 0,
       models: ["dataset"],
+      context: "data-picker",
     });
     const { data: _data, ...metadata } = response ?? {};
     return (

--- a/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/SimpleDataPicker/SimpleDataPicker.tsx
@@ -25,6 +25,7 @@ export function SimpleDataPicker({
   const { data, isLoading, error } = useSearchQuery({
     table_db_id: filterByDatabaseId ? filterByDatabaseId : undefined,
     models: translateEntityTypesToSearchModels(entityTypes),
+    context: "data-picker",
   });
 
   const options = useMemo(() => {

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibrarySearch.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/hooks/useLibrarySearch.ts
@@ -29,6 +29,7 @@ export function useLibrarySearch(
           q: debouncedQuery,
           collection: libraryCollectionId,
           models: ["table", "metric"],
+          context: "library",
         }
       : skipToken,
   );

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/EntrySearchInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/EntrySearchInput.tsx
@@ -54,6 +54,7 @@ export function EntrySearchInput({
     {
       q: searchQuery,
       models: searchModels,
+      context: "dependencies",
     },
     {
       skip: !isSearchEnabled,

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/SearchModelPicker/SearchModelPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/DependencyGraph/GraphEntryInput/EntrySearchInput/SearchModelPicker/SearchModelPicker.tsx
@@ -62,6 +62,7 @@ function SearchModelPopover({
     models: ["card"],
     limit: 0,
     calculate_available_models: true,
+    context: "dependencies",
   });
   const items = data ? getSearchModelItems(data) : [];
 

--- a/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/MigrateModelsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/MigrateModelsPage.tsx
@@ -17,6 +17,7 @@ import { PageHeader } from "./PageHeader";
 export function MigrateModelsPage() {
   const { data, isLoading, error } = useSearchQuery({
     models: ["dataset"],
+    context: "model-migration",
   });
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const [isResizing, { open: startResizing, close: stopResizing }] =

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -131,6 +131,7 @@ export type SearchContext =
   | "entity-picker"
   | "data-picker"
   | "type-filter"
+  | "basic-actions"
   | "browse"
   | "embedding-setup"
   | "document"

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -122,11 +122,21 @@ export interface SearchResult<
   collection_id?: CollectionId;
 }
 
+// The frontend surface that issued a search request; the backend uses it to pick ranking weights and
+// filter defaults. Keep in sync with `metabase.search.config/ui-contexts`.
 export type SearchContext =
   | "search-bar"
   | "search-app"
   | "command-palette"
-  | "entity-picker";
+  | "entity-picker"
+  | "data-picker"
+  | "type-filter"
+  | "browse"
+  | "embedding-setup"
+  | "document"
+  | "library"
+  | "dependencies"
+  | "model-migration";
 
 export type SearchRequest = {
   q?: string;
@@ -135,7 +145,7 @@ export type SearchRequest = {
   models?: SearchModel[];
   ids?: SearchResultId[];
   filter_items_in_personal_collection?: "only" | "exclude";
-  context?: SearchContext;
+  context: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;
   last_edited_at?: string | null;

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -161,7 +161,7 @@ function ActionPickerWithModels(
     data: searchResponse,
     isLoading: isLoadingSearch,
     error: searchError,
-  } = useSearchQuery({ models: ["dataset"] });
+  } = useSearchQuery({ models: ["dataset"], context: "entity-picker" });
   const {
     data: actions = [],
     isLoading: isLoadingActions,

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
@@ -24,7 +24,7 @@ export function useDefaultPreviewResource(): {
   const shouldFallback = !isRecentsLoading && recentResource == null;
 
   const { data: dashboards, isLoading: isDashboardLoading } = useSearchQuery(
-    { models: ["dashboard"], limit: 1 },
+    { models: ["dashboard"], limit: 1, context: "embedding-setup" },
     { skip: !shouldFallback },
   );
 
@@ -32,7 +32,7 @@ export function useDefaultPreviewResource(): {
   const hasDashboard = dashboard != null && typeof dashboard.id === "number";
 
   const { data: questions, isLoading: isQuestionLoading } = useSearchQuery(
-    { models: ["card"], limit: 1 },
+    { models: ["card"], limit: 1, context: "embedding-setup" },
     { skip: !shouldFallback || isDashboardLoading || hasDashboard },
   );
 

--- a/frontend/src/metabase/api/analytics.ts
+++ b/frontend/src/metabase/api/analytics.ts
@@ -1,4 +1,5 @@
 import { trackSchemaEvent } from "metabase/analytics";
+import { isTrackedSearchContext } from "metabase/search/analytics";
 import { openSaveDialog } from "metabase/utils/dom";
 import { hashSearchTerm, shouldReportSearchTerm } from "metabase/utils/search";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
@@ -87,7 +88,9 @@ export const trackSearchRequest = (
       verified_items: !!searchRequest.verified,
       search_native_queries: !!searchRequest.search_native_query,
       search_archived: !!searchRequest.archived,
-      context: searchRequest.context ?? null,
+      context: isTrackedSearchContext(searchRequest.context)
+        ? searchRequest.context
+        : null,
       runtime_milliseconds: duration,
       total_results: searchResponse.total,
       page_results: searchResponse.limit,

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -1,3 +1,4 @@
+import { isTrackedSearchContext } from "metabase/search/analytics";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
 
 import { trackSearchRequest } from "./analytics";
@@ -16,7 +17,7 @@ export const searchApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),
       onQueryStarted: (args, { queryFulfilled, requestId }) => {
-        if (args.context) {
+        if (isTrackedSearchContext(args.context)) {
           const start = Date.now();
           return handleQueryFulfilled(queryFulfilled, (data) => {
             const duration = Date.now() - start;

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -17,7 +17,9 @@ export const searchApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),
       onQueryStarted: (args, { queryFulfilled, requestId }) => {
-        if (isTrackedSearchContext(args.context)) {
+        // Only track searches with an actual text query. Query-less requests are filter/available-model
+        // lookups and internal existence probes, not searches the user performed.
+        if (isTrackedSearchContext(args.context) && args.q?.trim()) {
           const start = Date.now();
           return handleQueryFulfilled(queryFulfilled, (data) => {
             const duration = Date.now() - start;

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -501,6 +501,7 @@ function SearchItemList({ query: externalQuery }: { query: string }) {
       q: query,
       models: models as SearchModel[],
       limit: 50,
+      context: "data-picker",
     };
     const extraParams =
       typeof searchParams === "function" ? searchParams(params) : searchParams;

--- a/frontend/src/metabase/common/hooks/use-fetch-metrics.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-metrics.tsx
@@ -9,6 +9,7 @@ export const useFetchMetrics = (
       ? req
       : {
           models: ["metric"],
+          context: "browse",
           ...req,
         },
   );

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -11,6 +11,7 @@ export const useFetchModels = (
           models: ["dataset"], // 'model' in the sense of 'type of thing'
           filter_items_in_personal_collection: "exclude",
           model_ancestors: false,
+          context: "browse",
           ...req,
         },
   );

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -92,6 +92,7 @@ export function QuestionList({
             : ["card", "dataset", "metric"],
           offset: queryOffset,
           limit: DEFAULT_SEARCH_LIMIT,
+          context: "entity-picker",
         }
       : skipToken,
   );

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
@@ -166,6 +166,7 @@ function LinkVizInner({
                   forceEntitySelect
                   onEntitySelect={handleEntitySelect}
                   models={MODELS_TO_SEARCH}
+                  context="entity-picker"
                 />
               </SearchResultsContainer>
             )

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useSearch.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useSearch.ts
@@ -17,6 +17,7 @@ export function useSearch(query: string) {
       : {
           q: query,
           models: ["table"],
+          context: "data-picker",
         },
   );
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -67,6 +67,7 @@ export const SdkIframeEmbedSetupProvider = ({
   const { data: searchData } = useSearchQuery({
     limit: 0,
     models: ["dataset"],
+    context: "embedding-setup",
   });
 
   const modelCount = searchData?.total ?? 0;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
@@ -20,6 +20,7 @@ export const useRecentlyCreatedDashboards = () => {
       models: ["dashboard"],
       created_by: currentUserId ? [currentUserId] : undefined,
       limit: 5,
+      context: "embedding-setup",
 
       // If the dashboard is created more than 1 hour ago,
       // it is likely stale and latest activity should take priority.

--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useSearch.ts
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/hooks/useSearch.ts
@@ -17,6 +17,7 @@ export function useSearch(query: string) {
       : {
           q: query,
           models: ["table"],
+          context: "data-picker",
         },
   );
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -222,7 +222,7 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
               searchText={searchText}
               onSearchItemSelect={onSearchItemSelect}
               goToSearchApp={goToSearchApp}
-              isSearchBar={true}
+              context="search-bar"
             />
           ) : (
             <RecentsList />

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -14,7 +14,6 @@ import {
 } from "metabase/nav/components/search/SearchResults/SearchResults.styled";
 import { useDispatch } from "metabase/redux";
 import { SearchResult } from "metabase/search/components/SearchResult/SearchResult";
-import { SearchContextTypes } from "metabase/search/constants";
 import type { SearchFilters } from "metabase/search/types";
 import { Loader } from "metabase/ui";
 import { modelToUrl } from "metabase/urls";
@@ -24,6 +23,7 @@ import {
 } from "metabase/utils/constants";
 import type {
   CollectionItem,
+  SearchContext,
   SearchModel,
   SearchResult as SearchResultType,
   SearchResponse as SearchResultsType,
@@ -47,7 +47,7 @@ export type SearchResultsProps = {
   models?: SearchModel[];
   footerComponent?: SearchResultsFooter;
   onFooterSelect?: () => void;
-  isSearchBar?: boolean;
+  context: SearchContext;
 };
 
 export const SearchLoadingSpinner = () => (
@@ -62,7 +62,7 @@ export const SearchResults = ({
   models,
   footerComponent,
   onFooterSelect,
-  isSearchBar = false,
+  context,
 }: SearchResultsProps) => {
   const dispatch = useDispatch();
 
@@ -82,17 +82,14 @@ export const SearchResults = ({
     q?: string;
     limit: number;
     models?: SearchModel[];
-    context?: "search-bar" | "search-app";
+    context: SearchContext;
   } & SearchFilters = {
     q: debouncedSearchText,
     limit: DEFAULT_SEARCH_LIMIT,
+    context,
     ...searchFilters,
     models: models ?? searchFilters.type,
   };
-
-  if (isSearchBar) {
-    query.context = SearchContextTypes.SEARCH_BAR;
-  }
 
   const { data: response, isLoading } = useSearchQuery(
     debouncedSearchText ? query : skipToken,
@@ -170,7 +167,7 @@ export const SearchResults = ({
                 isSelected={cursorIndex === index}
                 onClick={onClick}
                 index={index}
-                context="search-bar"
+                context={context}
                 searchTerm={searchText}
               />
             </li>

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
@@ -65,6 +65,7 @@ const setup = async ({
           forceEntitySelect={forceEntitySelect}
           searchText={searchText}
           footerComponent={footer}
+          context="search-bar"
         />
       )}
     />,

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.tsx
@@ -3,7 +3,7 @@ import { jt, t } from "ttag";
 import type { SearchResultsFooter } from "metabase/nav/components/search/SearchResults";
 import { SearchResults } from "metabase/nav/components/search/SearchResults";
 import { Icon, Text, rem } from "metabase/ui";
-import type { SearchResult } from "metabase-types/api";
+import type { SearchContext, SearchResult } from "metabase-types/api";
 
 import {
   SearchDropdownFooter,
@@ -15,14 +15,14 @@ export type SearchResultsDropdownProps = {
   searchText: string;
   onSearchItemSelect: (item: SearchResult) => void;
   goToSearchApp: () => void;
-  isSearchBar?: boolean;
+  context: SearchContext;
 };
 
 export const SearchResultsDropdown = ({
   searchText,
   onSearchItemSelect,
   goToSearchApp,
-  isSearchBar = false,
+  context,
 }: SearchResultsDropdownProps) => {
   const renderFooter: SearchResultsFooter = ({ metadata, isSelected }) => {
     const resultText =
@@ -58,7 +58,7 @@ export const SearchResultsDropdown = ({
         onEntitySelect={onSearchItemSelect}
         footerComponent={renderFooter}
         onFooterSelect={goToSearchApp}
-        isSearchBar={isSearchBar}
+        context={context}
       />
     </SearchResultsContainer>
   );

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
@@ -70,6 +70,7 @@ const setup = async ({
           searchText={searchText}
           onSearchItemSelect={onSearchItemSelect}
           goToSearchApp={goToSearchApp}
+          context="search-bar"
         />
       )}
     />,

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -65,7 +65,9 @@ export const useCommandPaletteBasicActions = ({
     enabled: isLoggedIn,
   });
   const { data: searchResults } = useSearchQuery(
-    isLoggedIn ? { models: ["dataset"], limit: 1 } : skipToken,
+    isLoggedIn
+      ? { models: ["dataset"], limit: 1, context: "command-palette" }
+      : skipToken,
   );
   const hasModels = (searchResults?.data?.length ?? 0) > 0;
 

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -66,7 +66,7 @@ export const useCommandPaletteBasicActions = ({
   });
   const { data: searchResults } = useSearchQuery(
     isLoggedIn
-      ? { models: ["dataset"], limit: 1, context: "command-palette" }
+      ? { models: ["dataset"], limit: 1, context: "basic-actions" }
       : skipToken,
   );
   const hasModels = (searchResults?.data?.length ?? 0) > 0;

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
@@ -1128,6 +1128,7 @@ function withAvailableModels(WrappedComponent) {
       calculate_available_models: true,
       limit: 0,
       models: ["dataset", "metric"],
+      context: "data-picker",
     });
     let metadata;
     if (response) {

--- a/frontend/src/metabase/querying/components/DataReference/DatabasePane.tsx
+++ b/frontend/src/metabase/querying/components/DataReference/DatabasePane.tsx
@@ -252,6 +252,7 @@ export const DatabasePane = ({
       ? {
           models: ["dataset", "table"],
           table_db_id: databaseId,
+          context: "data-picker",
         }
       : skipToken,
   );

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -39,6 +39,7 @@ export function EmbeddingDataPicker({
     useSearchQuery({
       models: ["dataset", "table"],
       limit: 0,
+      context: "data-picker",
     });
 
   const databaseId = Lib.databaseID(query);

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/useEntitySearch.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/useEntitySearch.ts
@@ -27,7 +27,10 @@ import {
 } from "./suggestionHooks";
 import { buildUserMenuItems, filterRecents } from "./suggestionUtils";
 
-export type EntitySearchOptions = Omit<SearchRequest, "q" | "models" | "limit">;
+export type EntitySearchOptions = Omit<
+  SearchRequest,
+  "q" | "models" | "limit" | "context"
+>;
 
 interface UseEntitySearchOptions {
   query: string;
@@ -81,6 +84,7 @@ export function useEntitySearch({
         (model): model is SearchModel => model !== "user",
       ),
       limit: LINK_SEARCH_LIMIT,
+      context: "document",
       ...searchOptions,
     },
     {

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -1,6 +1,26 @@
 import { trackSchemaEvent } from "metabase/analytics";
 import { hashSearchTerm, shouldReportSearchTerm } from "metabase/utils/search";
-import type { SearchRequest } from "metabase-types/api";
+import type { SearchContext, SearchRequest } from "metabase-types/api";
+
+// The search `context` values we publish Snowplow analytics events for.
+// The other contexts (data pickers, browse, etc.) also issue searches; we don't publish those because it
+// would require a Snowplow schema migration — this list must stay a subset of the `context` enum in the
+// iglu `search` schema (snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/*).
+const ANALYTICS_TRACKED_CONTEXTS = [
+  "search-app",
+  "search-bar",
+  "command-palette",
+  "entity-picker",
+] as const satisfies readonly SearchContext[];
+
+export type AnalyticsSearchContext =
+  (typeof ANALYTICS_TRACKED_CONTEXTS)[number];
+
+export const isTrackedSearchContext = (
+  context: SearchContext | null | undefined,
+): context is AnalyticsSearchContext =>
+  context != null &&
+  (ANALYTICS_TRACKED_CONTEXTS as readonly SearchContext[]).includes(context);
 
 type TrackSearchClickParams = {
   itemType: "item" | "view_more";
@@ -28,7 +48,7 @@ export const trackSearchClick = ({
       event: "search_click",
       position,
       target_type: itemType,
-      context: context ?? null,
+      context: isTrackedSearchContext(context) ? context : null,
       search_engine: searchEngine,
       request_id: requestId,
       entity_model: entityModel,

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
@@ -12,6 +12,7 @@ const EMPTY_SEARCH_QUERY = {
   models: ["dataset" as const],
   limit: 1,
   calculate_available_models: true as const,
+  context: "type-filter" as const,
 };
 
 export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"] =

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
@@ -136,6 +136,7 @@ export function DatasetsList({
         models: ["card", "dataset", "metric"],
         include_dashboard_questions: true,
         include_metadata: true,
+        context: "data-picker",
         ...(visualizationType &&
           isCartesianChart(visualizationType) &&
           search.length === 0 && {

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -101,14 +101,13 @@
   (when (= context :all)
     (throw (ex-info "Cannot set weights for all context"
                     {:status-code 400})))
-  (let [known-ranker?   (set (keys (:default @#'search.config/static-weights)))
-        rankers         (into #{}
+  (let [rankers         (into #{}
                               (map (fn [k]
                                      (if (namespace k)
                                        (keyword (namespace k))
                                        k)))
                               (keys overrides))
-        unknown-rankers (not-empty (remove known-ranker? rankers))]
+        unknown-rankers (not-empty (remove search.config/known-rankers rankers))]
     (when unknown-rankers
       (throw (ex-info (str "Unknown rankers: " (str/join ", " (map name (sort unknown-rankers))))
                       {:status-code 400})))
@@ -127,7 +126,8 @@
   "Return the current weights being used to rank the search results"
   [_route-params
    {:keys [context]} :- [:map [:context {:default :default} :keyword]]]
-  (search.config/weights {:context context}))
+  ;; normalize so the reported weights match what search actually applies for this context
+  (search.config/weights {:context (search.config/normalized-context context)}))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API
@@ -144,7 +144,9 @@
                                         [:context {:default :default} :keyword]
                                         [:search_engine {:optional true} :any]]]
   ;; remove cookie
-  (let [overrides (-> overrides (dissoc :search_engine :context) (update-vals parse-double))]
+  ;; normalize so overrides are stored under the same key search reads them from
+  (let [context   (search.config/normalized-context context)
+        overrides (-> overrides (dissoc :search_engine :context) (update-vals parse-double))]
     (when (seq overrides)
       (set-weights! context overrides))
     (search.config/weights {:context context})))

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -171,6 +171,7 @@
   - `last_edited_at`: search for items last edited at a specific timestamp
   - `last_edited_by`: search for items last edited by a specific user
   - `search_native_query`: set to true to search the content of native queries
+  - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -197,6 +198,7 @@
     last-edited-by                      :last_edited_by
     model-ancestors                     :model_ancestors
     search-engine                       :search_engine
+    vector-search-strategy              :vector_search_strategy
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -217,6 +219,7 @@
        [:last_edited_by                      {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
+       [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -247,6 +250,7 @@
                 :models                              (not-empty (set models))
                 :offset                              (request/offset)
                 :search-engine                       search-engine
+                :vector-search-strategy              vector-search-strategy
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -161,11 +161,14 @@
   "Search for items in Metabase.
   For the list of supported models, check [[metabase.search.config/all-models]].
 
+  `context` identifies the surface issuing the search; it selects the ranking weights and filter defaults.
+  It defaults to `api`, the value for programmatic callers.
+
   Filters:
   - `archived`: set to true to search archived items only, default is false
   - `table_db_id`: search for tables, cards, and models of a certain DB
   - `models`: only search for items of specific models. If not provided, search for all models
-  - `filters_items_in_personal_collection`: only search for items in personal collections
+  - `filter_items_in_personal_collection`: only search for items in personal collections
   - `created_at`: search for items created at a specific timestamp
   - `created_by`: search for items created by a specific user
   - `last_edited_at`: search for items last edited at a specific timestamp
@@ -206,7 +209,9 @@
     has-temporal-dim                    :has_temporal_dim}
    :- [:map
        [:q                                   {:optional true} [:maybe :string]]
-       [:context                             {:optional true} [:maybe :keyword]]
+       ;; no `:optional true`: default-value-transformer skips defaults for absent optional keys, so it's
+       ;; what makes `:default :api` actually apply when the param is omitted
+       [:context                             {:default :api} search.config/Context]
        [:archived                            {:default false} [:maybe :boolean]]
        [:collection                          {:optional true} [:maybe ms/PositiveInt]]
        [:table_db_id                         {:optional true} [:maybe ms/PositiveInt]]

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -56,12 +56,14 @@
      :model        (search.scoring/model-rank-expr search-ctx)
      :mine         (search.scoring/equal :search_index.creator_id (:current-user-id search-ctx))
      :exact        (if search-string
-                     ;; perform the lower casing within the database, in case it behaves differently to our helper
-                     (search.scoring/equal [:lower :search_index.name] [:lower search-string])
+                     ;; normalize both sides in the database, in case it behaves differently to our helper
+                     (search.scoring/equal (search.scoring/normalize-text-expr :search_index.name)
+                                           (search.scoring/normalize-text-expr search-string))
                      [:inline 0])
      :prefix       (if search-string
                      ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
-                     (search.scoring/prefix [:lower :search_index.name] (u/lower-case-en search-string))
+                     (search.scoring/prefix (search.scoring/normalize-text-expr :search_index.name)
+                                            (search.scoring/normalize-text search-string))
                      [:inline 0])
      :library      (search.scoring/library-score-expr)
      :data-layer   (search.scoring/data-layer-score-expr search-ctx)}))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -89,12 +89,13 @@
    :text                5
    :mine                1
    ;; An exact (case-insensitive) name match is the strongest single intent signal: :exact (100) overpowers
-   ;; any one curation tier (:official-collection / :verified, and the :data-picker :library boost, 80 each).
+   ;; any one curation tier (the :data-picker boosts: :library 80, :official-collection / :verified 35 each).
    ;; Base text/recency scorers (0–5) only break ties within a tier.
    :exact               100
    :prefix              0
-   :official-collection 80
-   :verified            80
+   ;; Curation badges act as tie-breakers by default; the :data-picker context boosts them (to 35 each).
+   :official-collection 1
+   :verified            1
    ;; :library is a data-layer curation signal relevant only when picking a data source, so it is off by
    ;; default; the :data-picker context opts in, at a curation-tier level that an exact match can overpower.
    :library             0
@@ -122,9 +123,12 @@
     :model/metric   1
     :model/question 0}
    :data-picker
-   ;; Boost curated library items when picking a data source, but keep it a curation-tier signal (80, like
-   ;; :verified/:official) so an exact name match (:exact 100) can overpower it.
-   {:library 80}
+   ;; Boost curated items when picking a data source, but keep them curation-tier signals that an exact
+   ;; name match (:exact 100) can overpower. :library outweighs :official-collection and :verified even
+   ;; combined (70), so library membership trumps those badges here.
+   {:library             80
+    :official-collection 35
+    :verified            35}
    ;; TODO: lift :data-layer up to :default. It's a structural signal (every visible warehouse
    ;; table gets `data_layer "final"`), so the +33 boost flips orderings across every search
    ;; surface and breaks e2e specs that pin specific top results. To make progress:

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -97,7 +97,9 @@
     :official-collection 80
     :verified            80
     ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
-    :rrf                 500}
+    :rrf                 500
+    ;; Maps the backend's cosine distance to a [0, 1] score: 1 = identical vector, 0 = maximally distant or keyword-only hit.
+    :semantic-distance   10}
    :command-palette
    {:prefix               5
     :model/collection     1

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -231,21 +231,27 @@
 
 (defn- normalize-override-keys
   "Re-key persisted weight overrides ([[search.settings/experimental-search-weight-overrides]]) by
-  [[normalized-context]], so an override saved under a context that has since been collapsed (e.g.
-  `:command-palette` -> `:global`) is still applied.
-  When a raw alias and its normalized context both carry overrides, the normalized one wins -- it's
-  what the weights API writes today."
+  [[normalized-context]], merging overrides whose alias has since collapsed onto the surviving context.
+  Legacy flat `{scorer weight}` overrides fold into the `:default` base, losing to an explicit `:default`."
   [overrides]
-  (reduce-kv (fn [acc context weight-overrides]
-               (let [normalized (normalized-context context)]
-                 (update acc normalized
-                         (if (= context normalized)
-                           #(merge % weight-overrides)
-                           #(merge weight-overrides %)))))
-             {}
-             ;; sorted so the winner is deterministic when several aliases collapse to one normalized
-             ;; context (the normalized key still wins; among aliases the lowest-sorted one does)
-             (into (sorted-map) overrides)))
+  (let [;; legacy overrides (pre-#50338) were a flat {scorer weight} map with no context layer, so they
+        ;; applied to every context; these are the entries whose value is a bare weight, not a per-context map
+        legacy (into {} (remove (comp map? val)) overrides)
+        nested (reduce-kv (fn [acc context weight-overrides]
+                            (let [normalized (normalized-context context)]
+                              (update acc normalized
+                                      ;; when an alias and its normalized context both carry overrides the
+                                      ;; normalized one wins -- it's what the weights API writes today
+                                      (if (= context normalized)
+                                        #(merge % weight-overrides)
+                                        #(merge weight-overrides %)))))
+                          {}
+                          ;; sorted so the winner is deterministic when several aliases collapse to one
+                          ;; normalized context (the normalized key still wins; among aliases the lowest-sorted)
+                          (into (sorted-map) (filter (comp map? val)) overrides))]
+    (cond-> nested
+      ;; :default feeds every context, so folding the flat weights there preserves their global reach
+      (seq legacy) (update :default #(merge legacy %)))))
 
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -310,6 +310,7 @@
    :entity-picker       ; the entity-picker modal (cards, dashboards, collections, …)
    :data-picker         ; picking a data source (table/model/metric) while building a query
    :type-filter         ; the search type-filter dropdown's available-models lookup
+   :basic-actions       ; the command palette's basic-actions "do any models exist?" gate (New action), not a user search
    :browse              ; the Browse models / Browse metrics pages
    :embedding-setup     ; embedding/SDK setup and preview resource selection
    :document            ; entity references embedded in documents
@@ -335,8 +336,7 @@
 (def context->normalized-context
   "Collapses search `context` values that should rank and filter alike onto a shared normalized context.
   Only genuine remappings appear here; an unlisted context normalizes to itself and inherits `:default`.
-  The full-page search app, command palette, and type-filter lookup share `:global`, as opposed to the
-  scoped `:data-picker` / `:entity-picker` contexts."
+  Add an entry to make a surface share another's ranking/filter profile; omit it to keep the surface's own."
   ;; TODO (Chris 2026-06-08) -- the nav search bar is deliberately left off `:global` for now so it keeps
   ;; the default filters/weights; decide whether any of its behaviour should be DRYed up with the other
   ;; broad-search surfaces.

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -260,6 +260,39 @@
   separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
   [:hnsw :brute-force])
 
+(def ^:private ui-contexts
+  "Search `context` values issued by the frontend, one per UI surface.
+  Selects the ranking weights ([[static-weights]]) and filter defaults ([[filter-defaults-by-context]]).
+  Keep in sync with the frontend `SearchContext` type (frontend/src/metabase-types/api/search.ts).
+  Give every value a comment naming the surface that issues it."
+  [:search-bar          ; the global navbar search typeahead
+   :search-app          ; the full-page search results app
+   :command-palette     ; the ⌘K command palette
+   :entity-picker       ; the entity-picker modal (cards, dashboards, collections, …)
+   :data-picker         ; picking a data source (table/model/metric) while building a query
+   :type-filter         ; the search type-filter dropdown's available-models lookup
+   :browse              ; the Browse models / Browse metrics pages
+   :embedding-setup     ; embedding/SDK setup and preview resource selection
+   :document            ; entity references embedded in documents
+   :library             ; the data-studio Library page (EE)
+   :dependencies        ; the dependency-graph entry search (EE)
+   :model-migration])   ; the migrate-models admin page (EE)
+
+(def ^:private non-ui-contexts
+  "Search `context` values for non-frontend callers.
+  Excluded from the frontend `SearchContext` type so the frontend cannot use them."
+  [:api       ; programmatic / third-party API access
+   :metabot]) ; Metabot / agent API searches; accepted over HTTP too, for debugging and reproduction
+
+(def ^:private contexts
+  "All valid search request `context` values: [[ui-contexts]] plus [[non-ui-contexts]]."
+  (into ui-contexts non-ui-contexts))
+
+(def Context
+  "Malli enum for the search request `context` query parameter, over every value in [[contexts]].
+  The `:decode/string keyword` hook coerces the query-string value (e.g. \"search-app\") to a keyword."
+  (into [:enum {:decode/string keyword}] contexts))
+
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   [:map {:closed true}

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -88,15 +88,16 @@
    :view-count          2
    :text                5
    :mine                1
-   :exact               5
+   ;; An exact (case-insensitive) name match is the strongest single intent signal: :exact (100) overpowers
+   ;; any one curation tier (:official-collection / :verified, and the :data-picker :library boost, 80 each).
+   ;; Base text/recency scorers (0–5) only break ties within a tier.
+   :exact               100
    :prefix              0
-   ;; User-curated tiers, from strongest to weakest.
-   ;; :library at 200 exceeds :official-collection + :verified (80 each) combined,
-   ;; so a library item always outranks a non-library one.
-   ;; Base text/recency scorers (0–5 range) only break ties *within* a tier.
-   :library             200
    :official-collection 80
    :verified            80
+   ;; :library is a data-layer curation signal relevant only when picking a data source, so it is off by
+   ;; default; the :data-picker context opts in, at a curation-tier level that an exact match can overpower.
+   :library             0
    ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
    :rrf                 500
    ;; Maps the backend's cosine distance to a [0, 1] score: 1 = identical vector, 0 = maximally distant or keyword-only hit.
@@ -120,6 +121,10 @@
     :model/dataset  1
     :model/metric   1
     :model/question 0}
+   :data-picker
+   ;; Boost curated library items when picking a data source, but keep it a curation-tier signal (80, like
+   ;; :verified/:official) so an exact name match (:exact 100) can overpower it.
+   {:library 80}
    ;; TODO: lift :data-layer up to :default. It's a structural signal (every visible warehouse
    ;; table gets `data_layer "final"`), so the +33 boost flips orderings across every search
    ;; surface and breaks e2e specs that pin specific top results. To make progress:

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -7,6 +7,7 @@
    [metabase.search.settings :as search.settings]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
 (def ^:dynamic *db-max-results*
@@ -75,32 +76,36 @@
 
 (assert (= all-models (set models-search-order)) "The models search order has to include all models")
 
-(def static-weights
-  "Strength of the various scorers."
-  {:default
-   {:pinned              0
-    :bookmarked          1
-    :recency             1
-    :user-recency        5
-    :dashboard           0
-    :model               2
-    :view-count          2
-    :text                5
-    :mine                1
-    :exact               5
-    :prefix              0
-    ;; User-curated tiers, from strongest to weakest.
-    ;; :library at 200 exceeds :official-collection + :verified (80 each) combined,
-    ;; so a library item always outranks a non-library one.
-    ;; Base text/recency scorers (0–5 range) only break ties *within* a tier.
-    :library             200
-    :official-collection 80
-    :verified            80
-    ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
-    :rrf                 500
-    ;; Maps the backend's cosine distance to a [0, 1] score: 1 = identical vector, 0 = maximally distant or keyword-only hit.
-    :semantic-distance   10}
-   :command-palette
+(def static-default-weights
+  "Base scorer weights that every search inherits.
+  Each context layers its overrides on top (see [[static-context-weights]] and [[weights]])."
+  {:pinned              0
+   :bookmarked          1
+   :recency             1
+   :user-recency        5
+   :dashboard           0
+   :model               2
+   :view-count          2
+   :text                5
+   :mine                1
+   :exact               5
+   :prefix              0
+   ;; User-curated tiers, from strongest to weakest.
+   ;; :library at 200 exceeds :official-collection + :verified (80 each) combined,
+   ;; so a library item always outranks a non-library one.
+   ;; Base text/recency scorers (0–5 range) only break ties *within* a tier.
+   :library             200
+   :official-collection 80
+   :verified            80
+   ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
+   :rrf                 500
+   ;; Maps the backend's cosine distance to a [0, 1] score: 1 = identical vector, 0 = maximally distant or keyword-only hit.
+   :semantic-distance   10})
+
+(def static-context-weights
+  "Per-context scorer overrides, keyed by [[normalized-contexts]].
+  Merged onto [[static-default-weights]] for that context (see [[weights]])."
+  {:global
    {:prefix               5
     :model/collection     1
     :model/dashboard      1
@@ -137,6 +142,15 @@
     :data-layer/internal 0.3   ; ≈ 10
     :data-layer/hidden   0.03  ; ≈ 1
     }})
+
+(def known-rankers
+  "Scorer keys the weights API accepts as overrides: the union across [[static-default-weights]] and every
+  [[static-context-weights]] profile.
+  Namespaced scorer params (e.g. `:model/dashboard`) collapse to their namespace (`:model`)."
+  (into #{}
+        (map #(if (namespace %) (keyword (namespace %)) %))
+        (concat (keys static-default-weights)
+                (mapcat keys (vals static-context-weights)))))
 
 (def ^:private FilterDef
   "A relaxed definition, capturing how we can write the filter - with some fields omitted."
@@ -195,18 +209,38 @@
     :display-type            {:type :list, :field "display_type"}}))
 
 (def ^:private filter-defaults-by-context
-  {:default         {:archived               false
-                     ;; keys will typically those in [[filters]], but this is an atypical filter.
-                     ;; we plan to generify it, by precalculating it on the index.
-                     :filter-items-in-personal-collection "all"}
-   :search-app      {:filter-items-in-personal-collection "exclude-others"}
-   :command-palette {:filter-items-in-personal-collection "exclude-others"}})
+  ;; Keyed by [[normalized-contexts]] plus a `:default` base; the broad-search surfaces share `:global`.
+  {:default {:archived                            false
+             ;; keys will typically those in [[filters]], but this is an atypical filter.
+             ;; we plan to generify it, by precalculating it on the index.
+             :filter-items-in-personal-collection "all"}
+   :global  {:filter-items-in-personal-collection "exclude-others"}})
 
 (defn filter-default
   "Get the default value for the given filter in the given context."
   [_engine context filter-key]
   (let [fetch (fn [ctx] (when ctx (-> filter-defaults-by-context (get ctx) (get filter-key))))]
     (or (fetch context) (fetch :default))))
+
+(declare normalized-context)
+
+(defn- normalize-override-keys
+  "Re-key persisted weight overrides ([[search.settings/experimental-search-weight-overrides]]) by
+  [[normalized-context]], so an override saved under a context that has since been collapsed (e.g.
+  `:command-palette` -> `:global`) is still applied.
+  When a raw alias and its normalized context both carry overrides, the normalized one wins -- it's
+  what the weights API writes today."
+  [overrides]
+  (reduce-kv (fn [acc context weight-overrides]
+               (let [normalized (normalized-context context)]
+                 (update acc normalized
+                         (if (= context normalized)
+                           #(merge % weight-overrides)
+                           #(merge weight-overrides %)))))
+             {}
+             ;; sorted so the winner is deterministic when several aliases collapse to one normalized
+             ;; context (the normalized key still wins; among aliases the lowest-sorted one does)
+             (into (sorted-map) overrides)))
 
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights
@@ -215,13 +249,13 @@
    (weights {}))
   ([{request-overrides :weights, :keys [context]}]
    (let [context          (or context :default)
-         system-overrides (search.settings/experimental-search-weight-overrides)]
+         system-overrides (normalize-override-keys (search.settings/experimental-search-weight-overrides))]
      (if (= :all context)
-       (merge-with merge static-weights system-overrides)
-       (merge (get static-weights :default)
+       (merge-with merge (assoc static-context-weights :default static-default-weights) system-overrides)
+       (merge static-default-weights
               ;; Not sure which of the next two should have precedence, arguments for both "¯\_(ツ)_/¯"
               (get system-overrides :default)
-              (get static-weights context)
+              (get static-context-weights context)
               (get system-overrides context)
               request-overrides)))))
 
@@ -262,7 +296,7 @@
 
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
-  Selects the ranking weights ([[static-weights]]) and filter defaults ([[filter-defaults-by-context]]).
+  Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
   Keep in sync with the frontend `SearchContext` type (frontend/src/metabase-types/api/search.ts).
   Give every value a comment naming the surface that issues it."
   [:search-bar          ; the global navbar search typeahead
@@ -292,6 +326,43 @@
   "Malli enum for the search request `context` query parameter, over every value in [[contexts]].
   The `:decode/string keyword` hook coerces the query-string value (e.g. \"search-app\") to a keyword."
   (into [:enum {:decode/string keyword}] contexts))
+
+(def context->normalized-context
+  "Collapses search `context` values that should rank and filter alike onto a shared normalized context.
+  Only genuine remappings appear here; an unlisted context normalizes to itself and inherits `:default`.
+  The full-page search app, command palette, and type-filter lookup share `:global`, as opposed to the
+  scoped `:data-picker` / `:entity-picker` contexts."
+  ;; TODO (Chris 2026-06-08) -- the nav search bar is deliberately left off `:global` for now so it keeps
+  ;; the default filters/weights; decide whether any of its behaviour should be DRYed up with the other
+  ;; broad-search surfaces.
+  {:search-app      :global
+   :command-palette :global
+   :type-filter     :global})
+
+(assert (every? (set contexts) (keys context->normalized-context))
+        "context->normalized-context keys must be valid contexts")
+
+(def normalized-contexts
+  "Context values [[normalized-context]] can return: the remap targets plus every un-remapped context.
+  [[static-context-weights]] and [[filter-defaults-by-context]] are keyed by these (each also has a
+  `:default` base entry)."
+  (into (set (vals context->normalized-context))
+        (remove (set (keys context->normalized-context)))
+        contexts))
+
+(def NormalizedContext
+  "Malli enum schema for a normalized search context (see [[normalized-contexts]])."
+  (into [:enum] (sort normalized-contexts)))
+
+(defn normalized-context
+  "Normalize a search `context` for weight and filter-default lookup.
+  Contexts that should behave alike collapse to a shared value; all others map to themselves.
+  Also used by the `/api/search/weights` endpoints so stored/read override keys agree with search."
+  [context]
+  (get context->normalized-context context context))
+
+(assert (every? (partial mr/validate NormalizedContext) (keys static-context-weights))
+        "static-context-weights must be keyed by normalized contexts")
 
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -251,6 +251,13 @@
   "Schema for searchable models"
   (into [:enum] all-models))
 
+(def vector-search-strategies
+  "Valid semantic-search vector-search strategies, as keywords. Mastered here (rather than in the EE module)
+  so the OSS search API param and the EE semantic-search setting validation share one definition.
+  Note: the per-strategy dispatch in [[metabase-enterprise.semantic-search.index/semantic-search-query]] is a
+  separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
+  [:hnsw :brute-force])
+
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   [:map {:closed true}
@@ -272,6 +279,9 @@
    [:models             [:set SearchableModel]]
    ;; TODO this is optional only for tests, clean those up!
    [:search-engine      {:optional true} keyword?]
+   ;; Semantic-engine vector-search strategy (:hnsw or :brute-force). When absent, the engine uses its
+   ;; configured default setting.
+   [:vector-search-strategy {:optional true} [:maybe keyword?]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -317,7 +317,8 @@
     (premium-features/assert-has-any-features
      [:content-verification :official-collections]
      (deferred-tru "Content Management or Official Collections")))
-  (let [models (if (seq models) models search.config/all-models)
+  (let [context (some-> context search.config/normalized-context)
+        models (if (seq models) models search.config/all-models)
         engine (parse-engine search-engine)
         fvalue (fn [filter-key] (search.config/filter-default engine context filter-key))
         ctx    (cond-> {:archived?                           (boolean (or archived (fvalue :archived)))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -264,6 +264,7 @@
    [:offset                              {:optional true} [:maybe ms/Int]]
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
    [:search-engine                       {:optional true} [:maybe string?]]
+   [:vector-search-strategy              {:optional true} [:maybe string?]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -302,6 +303,7 @@
            models
            offset
            search-engine
+           vector-search-strategy
            search-native-query
            search-string
            table-db-id
@@ -344,6 +346,7 @@
                  (some? table-db-id)                         (assoc :table-db-id table-db-id)
                  (some? limit)                               (assoc :limit-int limit)
                  (some? offset)                              (assoc :offset-int offset)
+                 (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -5,6 +5,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection :as collection]
    [metabase.search.config :as search.config]
+   [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]))
 
 (def ^:private seconds-in-a-day 86400)
@@ -23,6 +24,26 @@
   "Prefer it when the given value is a completion of a specific (non-null) value"
   [column value]
   [:coalesce [:case [:like column (str (str/replace value "%" "%%") "%")] [:inline 1] :else [:inline 0]] [:inline 0]])
+
+(defn normalize-text-expr
+  "Wrap a string column/value SQL expr with the normalization the text scorers compare on:
+  lower-case, replace commas with spaces, collapse whitespace runs to one space, trim.
+  `db-type` picks the regexp_replace dialect -- Postgres needs the 'g' flag; H2 replaces all by default and
+  rejects 'g'."
+  ([expr] (normalize-text-expr (mdb/db-type) expr))
+  ([db-type expr]
+   ;; Replace commas with a space, not nothing, so `a,b` doesn't collapse into `ab`.
+   (let [stripped [:replace [:lower expr] [:inline ","] [:inline " "]]
+         collapsed (case db-type
+                     :postgres [:regexp_replace stripped [:inline "\\s+"] [:inline " "] [:inline "g"]]
+                     :h2       [:regexp_replace stripped [:inline "\\s+"] [:inline " "]])]
+     [:trim collapsed])))
+
+(defn normalize-text
+  "Clojure analogue of `normalize-text-expr`, for callers that must normalize a search string in code (the
+  :prefix scorer builds a LIKE pattern). Keep in lock-step with the SQL version."
+  [s]
+  (-> (u/lower-case-en s) (str/replace "," " ") (str/replace #"\s+" " ") str/trim))
 
 (defn size
   "Prefer items whose value is larger, up to some saturation point. Items beyond that point are equivalent."

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -310,6 +310,23 @@
   [& args]
   (map clean-result (apply search-request-data-with identity args)))
 
+(deftest context-param-test
+  (testing "context is an enum parameter that defaults to :api"
+    (testing "a missing context is accepted and resolves to :api"
+      (let [captured (atom nil)]
+        (mt/with-dynamic-fn-redefs [search/search (fn [search-ctx]
+                                                    (reset! captured search-ctx)
+                                                    {:data [] :total 0 :engine "test"})]
+          (is (=? {:engine string?}
+                  (mt/user-http-request :crowberto :get 200 "search" :q "x"))))
+        (is (= :api (:context @captured)))))
+    (testing "an unknown context value is rejected"
+      (is (=? {:errors {:context #"enum of.*"}}
+              (mt/user-http-request :crowberto :get 400 "search" :q "x" :context "bogus"))))
+    (testing "a known context value is accepted"
+      (is (=? {:engine string?}
+              (mt/user-http-request :crowberto :get 200 "search" :q "x" :context "search-app"))))))
+
 (deftest basic-test
   (testing "Basic search, should find 1 of each entity type, all items in the root collection"
     (with-search-items-in-root-collection "test"

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1831,6 +1831,16 @@
                 (mt/user-http-request :crowberto :put 200 (weights-url context {:model/dataset 5}))))
         (is (= 5.0 (search.config/scorer-param search-ctx :model :dataset)))))))
 
+(deftest ^:synchronized weights-normalize-context-test
+  (mt/with-temporary-setting-values [experimental-search-weight-overrides nil]
+    (testing "the /weights endpoints normalize context, so introspection and overrides match search"
+      (testing "surfaces that share a normalized context report the same weights"
+        (is (= (mt/user-http-request :crowberto :get 200 (weights-url :global {}))
+               (mt/user-http-request :crowberto :get 200 (weights-url :command-palette {})))))
+      (testing "an override set via one normalized surface is read back via another"
+        (mt/user-http-request :crowberto :put 200 (weights-url :command-palette {:recency 9}))
+        (is (= 9.0 (:recency (mt/user-http-request :crowberto :get 200 (weights-url :search-app {})))))))))
+
 (deftest ^:synchronized dashboard-questions
   (testing "Dashboard questions get a dashboard_id when searched"
     (let [search-name (random-uuid)

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -127,6 +127,20 @@
       ;; TODO text ranking (probably in-memory
       nil)))
 
+(deftest ^:parallel exact-normalization-test
+  (with-index-contents
+    [{:model "card" :id 1 :name "Sales,  Revenue"}
+     {:model "card" :id 2 :name "Sales Revenue Report"}]
+    (case (mdb/db-type)
+      :postgres
+      (testing "Exact matching ignores commas and collapses whitespace runs"
+        (is (= [["card" 1 "Sales,  Revenue"]
+                ["card" 2 "Sales Revenue Report"]]
+               (search-results :exact "sales revenue"))))
+      :h2
+      ;; TODO text ranking (probably in-memory)
+      nil)))
+
 (deftest ^:parallel prefix-test
   (with-index-contents
     [{:model "card" :id 1 :name "this is a prefix of something longer"}
@@ -135,6 +149,15 @@
       (is (= [["card" 1 "this is a prefix of something longer"]
               ["card" 2 "a prefix this is not, unfortunately"]]
              (search-results :prefix "this is a prefix"))))))
+
+(deftest ^:parallel prefix-normalization-test
+  (with-index-contents
+    [{:model "card" :id 1 :name "Sales, Revenue Quarterly"}
+     {:model "card" :id 2 :name "Revenue and Sales"}]
+    (testing "Prefix matching ignores commas and collapses whitespace runs"
+      (is (= [["card" 1 "Sales, Revenue Quarterly"]
+              ["card" 2 "Revenue and Sales"]]
+             (search-results :prefix "sales revenue"))))))
 
 (deftest ^:parallel model-test
   (with-index-contents

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -84,4 +84,11 @@
     (is (= 80 (search.config/weight {:context :data-picker} :library))))
   (testing "in the data picker, an exact name match can overpower the library boost"
     (is (> (search.config/weight {:context :data-picker} :exact)
-           (search.config/weight {:context :data-picker} :library)))))
+           (search.config/weight {:context :data-picker} :library))))
+  (testing "curation badges are tie-breakers by default; the data picker boosts them, but the library boost
+            outweighs both badges combined"
+    (is (= 1 (search.config/weight {:context :global} :official-collection)))
+    (is (= 1 (search.config/weight {:context :global} :verified)))
+    (is (> (search.config/weight {:context :data-picker} :library)
+           (+ (search.config/weight {:context :data-picker} :official-collection)
+              (search.config/weight {:context :data-picker} :verified))))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.search.config-test
   (:require
    [clojure.test :refer :all]
-   [metabase.search.config :as search.config]))
+   [metabase.search.config :as search.config]
+   [metabase.util.malli.registry :as mr]))
 
 ;; All that matters is that this is not legacy search.
 (def ^:private search-engine :search.engine/appdb)
@@ -22,3 +23,11 @@
            (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))
     (is (= "exclude-others"
            (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
+
+(deftest context-schema-test
+  (testing "the HTTP `context` enum allows the UI surfaces, :api, and :metabot (accepted for debugging)"
+    (is (mr/validate search.config/Context :search-app))
+    (is (mr/validate search.config/Context :api))
+    (is (mr/validate search.config/Context :metabot)))
+  (testing "values outside the enum are rejected"
+    (is (not (mr/validate search.config/Context :bogus)))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -51,7 +51,12 @@
       (is (= {:global {:text 5 :exact 9}} (normalize {:type-filter {:text 5} :global {:exact 9}}))))
     (testing "the :default base and un-remapped contexts pass through untouched"
       (is (= {:default {:text 7} :entity-picker {:exact 3}}
-             (normalize {:default {:text 7} :entity-picker {:exact 3}})))))
+             (normalize {:default {:text 7} :entity-picker {:exact 3}}))))
+    (testing "legacy flat overrides (bare weights, not per-context maps) fold into the :default base"
+      (is (= {:default {:text 7.0 :exact 3.0}} (normalize {:text 7.0 :exact 3.0})))
+      (is (= {:global {:exact 1} :default {:text 7.0}} (normalize {:command-palette {:exact 1} :text 7.0}))))
+    (testing "an explicit :default context override wins over a legacy flat weight for the same scorer"
+      (is (= {:default {:text 5.0 :exact 9}} (normalize {:text 5.0 :exact 1.0 :default {:exact 9}})))))
   (testing "several aliases collapsing to one normalized context resolve deterministically, regardless of
             input order (the lowest-sorted alias wins among aliases)"
     (let [normalize #'search.config/normalize-override-keys]

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -69,3 +69,14 @@
     ;; :library lives in :default; :data-layer only in :metabot
     (is (contains? search.config/known-rankers :library))
     (is (contains? search.config/known-rankers :data-layer))))
+
+(deftest weight-tuning-test
+  (testing "an exact name match outranks a single curation tier"
+    (is (> (search.config/weight {:context :global} :exact)
+           (search.config/weight {:context :global} :verified))))
+  (testing "the library boost is opt-in: off by default, a curation-tier boost for the data picker"
+    (is (= 0 (search.config/weight {:context :global} :library)))
+    (is (= 80 (search.config/weight {:context :data-picker} :library))))
+  (testing "in the data picker, an exact name match can overpower the library boost"
+    (is (> (search.config/weight {:context :data-picker} :exact)
+           (search.config/weight {:context :data-picker} :library)))))

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -7,22 +7,19 @@
 ;; All that matters is that this is not legacy search.
 (def ^:private search-engine :search.engine/appdb)
 
+;; `filter-default` and `weights` take an already-normalized context (normalization happens once at the top
+;; of the search call tree); these tests pass the normalized values directly.
+
 (deftest filter-default-test
   (testing "Default values"
     (is (= false (search.config/filter-default search-engine nil :archived)))
     (is (= "all" (search.config/filter-default search-engine nil :filter-items-in-personal-collection))))
-  (testing "No overrides"
-    (is (= false (search.config/filter-default search-engine :command-palette :archived))))
-  (testing "Overrides"
+  (testing "the :global profile excludes others' personal collections"
     (is (= "exclude-others"
-           (search.config/filter-default search-engine :command-palette :filter-items-in-personal-collection)))
+           (search.config/filter-default search-engine :global :filter-items-in-personal-collection))))
+  (testing "Legacy search uses the same per-context defaults (#UXW-3238)"
     (is (= "exclude-others"
-           (search.config/filter-default search-engine :search-app :filter-items-in-personal-collection))))
-  (testing "Legacy search should respect context overrides (#UXW-3238)"
-    (is (= "exclude-others"
-           (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))
-    (is (= "exclude-others"
-           (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))
+           (search.config/filter-default :search.engine/in-place :global :filter-items-in-personal-collection)))))
 
 (deftest context-schema-test
   (testing "the HTTP `context` enum allows the UI surfaces, :api, and :metabot (accepted for debugging)"
@@ -31,3 +28,44 @@
     (is (mr/validate search.config/Context :metabot)))
   (testing "values outside the enum are rejected"
     (is (not (mr/validate search.config/Context :bogus)))))
+
+(deftest normalized-context-test
+  (testing "the broad-search surfaces normalize to a single :global context"
+    (is (= [:global :global :global]
+           (map search.config/normalized-context [:search-app :command-palette :type-filter]))))
+  (testing "the nav search bar is intentionally not normalized (keeps default filters/weights for now)"
+    (is (= :search-bar (search.config/normalized-context :search-bar))))
+  (testing "every other context normalizes to itself"
+    (is (= [:entity-picker :data-picker :metabot :api]
+           (map search.config/normalized-context [:entity-picker :data-picker :metabot :api]))))
+  (testing "static-context-weights are keyed only by normalized contexts, never the :default base"
+    (is (not (contains? search.config/static-context-weights :default)))
+    (is (every? (set search.config/normalized-contexts) (keys search.config/static-context-weights)))))
+
+(deftest normalize-override-keys-test
+  (let [normalize #'search.config/normalize-override-keys]
+    (testing "an override persisted under a context that has since collapsed is re-keyed to its normalized context"
+      (is (= {:global {:exact 1}} (normalize {:command-palette {:exact 1}}))))
+    (testing "when a raw alias and its normalized context both have overrides, the normalized one wins"
+      (is (= {:global {:exact 2}} (normalize {:command-palette {:exact 1} :global {:exact 2}})))
+      (is (= {:global {:text 5 :exact 9}} (normalize {:type-filter {:text 5} :global {:exact 9}}))))
+    (testing "the :default base and un-remapped contexts pass through untouched"
+      (is (= {:default {:text 7} :entity-picker {:exact 3}}
+             (normalize {:default {:text 7} :entity-picker {:exact 3}})))))
+  (testing "several aliases collapsing to one normalized context resolve deterministically, regardless of
+            input order (the lowest-sorted alias wins among aliases)"
+    (let [normalize #'search.config/normalize-override-keys]
+      (is (= {:global {:exact 2}}
+             (normalize (array-map :search-app {:exact 1} :command-palette {:exact 2}))
+             (normalize (array-map :command-palette {:exact 2} :search-app {:exact 1})))))))
+
+(deftest weights-by-context-test
+  (testing "the broad-search surfaces share one weight profile that boosts prefix matches"
+    (is (= 5 (search.config/weight {:context :global} :prefix)))
+    (is (= 0 (search.config/weight {:context :default} :prefix)))))
+
+(deftest known-rankers-test
+  (testing "overridable rankers span every profile, not just :default"
+    ;; :library lives in :default; :data-layer only in :metabot
+    (is (contains? search.config/known-rankers :library))
+    (is (contains? search.config/known-rankers :data-layer))))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,0 +1,14 @@
+(ns metabase.search.scoring-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.search.scoring :as scoring]))
+
+(deftest normalize-text-test
+  (testing "normalize-text lower-cases, strips commas, collapses whitespace runs, and trims"
+    (are [in out] (= out (scoring/normalize-text in))
+      "Sales, Revenue"     "sales revenue"
+      "Sales,  Revenue"    "sales revenue"
+      "  Sales   Revenue " "sales revenue"
+      "Sales,Revenue"      "sales revenue"
+      "SALES"              "sales"
+      ""                   "")))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76174
Closes [BOT-1705: Search results sorting degradation after recent changes](https://linear.app/metabase/issue/BOT-1705/search-results-sorting-degradation-after-recent-changes)

Cherry-pick of search related commits to fix regression on 62.

Following shas are from master.

Merge base was d587fb7ffee17692a12ecec355d76c644c1db8cd.

In order of calling `git cherry-pick <sha>` following commits are backported:
53f0305835ba25b56a0403cee85e66dfc23a5215
814398c83511558ec4aa923cf6e463c3daec1eda
fb3416c0c117133b82e030e789583751e1772a15
ad23a6079041c8525e52790cfe4366f051ef34c8
92d89811b30f31b0009302bfffa21c6153a44082
4246d2979a11961530c12e60928f2c200e9b6e5c
75ea90c029461be5e34baf1e63bd26bd9d1be3ff
1bb1a3848acba71558a715a43ee6023991cc21fc

Those commits modify the `src/metabase/search/config.clj`.

I've decided to backport all of them because also last one changes scoring weights. And the weights modification is the key to fixing the linked issue.