### PR TITLE
POC: external MCP servers as Metabot tool sources

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -17,6 +17,7 @@
    [metabase.metabot.self :as self]
    [metabase.metabot.self.core :as self.core]
    [metabase.metabot.tools :as tools]
+   [metabase.metabot.tools.mcp-external :as mcp-external]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -415,7 +416,9 @@
                          (memory/load-todos-from-state seeded)
                          (memory/load-link-registry-from-state seeded))
         memory-atom  (atom memory)
-        tools        (tools/wrap-tools-with-state base-tools memory-atom metabot-id profile-id)]
+        tools        (merge (tools/wrap-tools-with-state base-tools memory-atom metabot-id profile-id)
+                            ;; POC: external MCP server tools (e.g. Notion). No-op if unconfigured.
+                            (mcp-external/external-mcp-tools))]
     (log/info "Starting agent" {:profile  profile-id
                                 :tools    (count tools)
                                 :max-iter (:max-iterations profile)

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -210,7 +210,7 @@
 (defn- tool->claude
   "Convert a tool definition map to Claude API format.
   Accepts a ToolEntry map with :tool-name, :doc, :schema, :fn."
-  [{:keys [tool-name doc schema]}]
+  [{:keys [tool-name doc schema input_schema]}]
   (let [[_:=> [_:cat params] _out] schema
         params                     (schema/filter-schema-by-features params)
         doc                        (if (str/starts-with? (or doc "") "Inputs: ")
@@ -219,7 +219,9 @@
                                      doc)]
     {:name         (or tool-name "unknown")
      :description  doc
-     :input_schema (mjs/transform params {:additionalProperties false})}))
+     ;; External MCP tools carry raw JSON Schema in :input_schema; native tools
+     ;; derive it from their Malli :schema.
+     :input_schema (or input_schema (mjs/transform params {:additionalProperties false}))}))
 
 (defn- add-tools-cache-breakpoint
   "Attach an ephemeral cache_control marker to the last tool in `tools`.

--- a/src/metabase/metabot/tools/mcp_external.clj
+++ b/src/metabase/metabot/tools/mcp_external.clj
@@ -1,0 +1,104 @@
+(ns metabase.metabot.tools.mcp-external
+  "POC: pull tools from an external MCP server (e.g. Notion's hosted MCP) and
+  expose them as Metabot agent tools.
+
+  Implements the minimum slice of MCP's Streamable HTTP transport: JSON-RPC
+  `initialize`, `tools/list`, `tools/call` over a single POST endpoint. The
+  server may answer either as plain JSON or as an SSE stream (text/event-stream);
+  we handle both.
+
+  Config via env vars (POC-grade, no settings UI):
+    MB_MCP_EXTERNAL_URL    - MCP endpoint, e.g. https://mcp.notion.com/mcp
+    MB_MCP_EXTERNAL_TOKEN  - bearer token (Notion OAuth access token / integration secret)
+
+  ponytail: hand-rolled 3-method client, no MCP SDK. add a real client + OAuth
+  flow when this graduates past POC. Notion's hosted MCP expects OAuth; a static
+  token here proves the wiring and swaps for a real token via env, not code."
+  (:require
+   [clj-http.client :as http]
+   [clojure.string :as str]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn- config []
+  {:url   (System/getenv "MB_MCP_EXTERNAL_URL")
+   :token (System/getenv "MB_MCP_EXTERNAL_TOKEN")})
+
+(defn- parse-body
+  "MCP Streamable HTTP may reply as JSON or as SSE. Pull the JSON-RPC payload
+  out of either."
+  [{:keys [body headers]}]
+  (let [ct (get headers "Content-Type" "")]
+    (if (str/includes? ct "text/event-stream")
+      ;; SSE: last `data:` line is the response we want.
+      (->> (str/split-lines body)
+           (keep #(when (str/starts-with? % "data:")
+                    (str/trim (subs % 5))))
+           last
+           json/decode+kw)
+      (json/decode+kw body))))
+
+(defn- rpc!
+  "Fire one JSON-RPC request at the MCP server, return the parsed `:result`.
+  Throws on a JSON-RPC `:error`."
+  [{:keys [url token]} method params]
+  (let [resp   (http/post url
+                          {:headers          (cond-> {"Content-Type" "application/json"
+                                                      ;; both, per spec, so server can pick SSE
+                                                      "Accept"       "application/json, text/event-stream"}
+                                               token (assoc "Authorization" (str "Bearer " token)))
+                           :body             (json/encode {:jsonrpc "2.0"
+                                                           :id      1
+                                                           :method  method
+                                                           :params  params})
+                           :throw-exceptions false
+                           :as               :string})
+        parsed (parse-body resp)]
+    (when-let [err (:error parsed)]
+      (throw (ex-info (str "MCP error: " (:message err)) {:method method :error err})))
+    (:result parsed)))
+
+(defn- mcp-tool->tool-def
+  "Turn one MCP tool descriptor into a Metabot tool-def map.
+
+  Metabot's Claude adapter normally derives the wire schema from a Malli
+  `:schema`; MCP hands us JSON Schema directly, so we stash it under
+  `:input_schema` and teach `tool->claude` to prefer it (see claude.clj)."
+  [cfg {:keys [name description inputSchema]}]
+  {:tool-name    name
+   :doc          description
+   :schema       nil
+   :input_schema (or inputSchema {:type "object" :properties {}})
+   :fn           (fn [args]
+                   (try
+                     (let [result  (rpc! cfg "tools/call" {:name name :arguments (or args {})})
+                           ;; MCP returns {:content [{:type "text" :text "..."} ...]}
+                           text    (->> (:content result)
+                                        (keep :text)
+                                        (str/join "\n"))]
+                       {:output (if (str/blank? text) (json/encode result) text)})
+                     (catch Exception e
+                       (log/error e "External MCP tool call failed" {:tool name})
+                       {:output (str "MCP tool error: " (.getMessage e))})))})
+
+(defn external-mcp-tools
+  "Connect to the configured external MCP server and return a
+  `{tool-name -> tool-def-map}` map ready to merge into the agent's tool
+  registry. Returns `{}` (and logs) if unconfigured or unreachable, so a broken
+  MCP server can never take down the agent loop."
+  []
+  (let [{:keys [url] :as cfg} (config)]
+    (if (str/blank? url)
+      {}
+      (try
+        (rpc! cfg "initialize" {:protocolVersion "2025-06-18"
+                                :capabilities    {}
+                                :clientInfo      {:name "metabase-metabot" :version "poc"}})
+        (let [tools (:tools (rpc! cfg "tools/list" {}))]
+          (log/info "Loaded external MCP tools" {:url url :count (count tools)})
+          (into {} (map (juxt :name #(mcp-tool->tool-def cfg %))) tools))
+        (catch Exception e
+          (log/error e "Failed to load external MCP tools" {:url url})
+          {})))))

--- a/src/metabase/metabot/tools/mcp_external.clj
+++ b/src/metabase/metabot/tools/mcp_external.clj
@@ -1,19 +1,30 @@
 (ns metabase.metabot.tools.mcp-external
-  "POC: pull tools from an external MCP server (e.g. Notion's hosted MCP) and
-  expose them as Metabot agent tools.
+  "POC: expose external MCP servers (Linear, Notion, ...) to the Metabot agent
+  loop — but as ONE meta-tool per server, not one tool per remote tool.
 
-  Implements the minimum slice of MCP's Streamable HTTP transport: JSON-RPC
-  `initialize`, `tools/list`, `tools/call` over a single POST endpoint. The
-  server may answer either as plain JSON or as an SSE stream (text/event-stream);
-  we handle both.
+  Why a meta-tool: dumping every remote tool flat (Linear alone is 46; add
+  Notion + GitHub + Slack and you're at ~250) blows up the request prefix and
+  degrades the LLM's tool selection (it gets confused past ~30 tools). Instead
+  each server is a single tool the LLM sees:
 
-  Config via env vars (POC-grade, no settings UI):
-    MB_MCP_EXTERNAL_URL    - MCP endpoint, e.g. https://mcp.notion.com/mcp
-    MB_MCP_EXTERNAL_TOKEN  - bearer token (Notion OAuth access token / integration secret)
+      linear { op: \"list_tools\" }                       -> the server's catalog
+      linear { op: \"call_tool\", name: \"...\", args: {} } -> dispatch one tool
 
-  ponytail: hand-rolled 3-method client, no MCP SDK. add a real client + OAuth
-  flow when this graduates past POC. Notion's hosted MCP expects OAuth; a static
-  token here proves the wiring and swaps for a real token via env, not code."
+  This is CLI-style progressive disclosure: the LLM discovers a server's tools
+  on demand, then calls them. N servers = N tools, regardless of how many tools
+  each server exposes. Fits Metabot's frozen-at-init tool set (no loop changes).
+
+  Transport is the minimum slice of MCP's Streamable HTTP: JSON-RPC `initialize`,
+  `tools/list`, `tools/call` over one POST endpoint. Server may answer as plain
+  JSON or SSE; we handle both.
+
+  Config via env (POC-grade, no settings UI). One server:
+    MB_MCP_EXTERNAL_URL    - MCP endpoint, e.g. https://mcp.linear.app/mcp
+    MB_MCP_EXTERNAL_TOKEN  - bearer token
+    MB_MCP_EXTERNAL_NAME   - tool name for the server (default \"linear\")
+
+  ponytail: hand-rolled client, single-server-from-env, in-process catalog cache.
+  Add a real client + OAuth + multi-server settings when this graduates."
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
@@ -22,9 +33,23 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- config []
-  {:url   (System/getenv "MB_MCP_EXTERNAL_URL")
-   :token (System/getenv "MB_MCP_EXTERNAL_TOKEN")})
+;; ---------------------------------------------------------------------------
+;; Config
+;; ---------------------------------------------------------------------------
+
+(defn- servers
+  "Configured external MCP servers as [{:name :url :token} ...]. POC reads a
+  single server from env; extend to a registry/settings later."
+  []
+  (let [url (System/getenv "MB_MCP_EXTERNAL_URL")]
+    (when-not (str/blank? url)
+      [{:name  (or (System/getenv "MB_MCP_EXTERNAL_NAME") "linear")
+        :url   url
+        :token (System/getenv "MB_MCP_EXTERNAL_TOKEN")}])))
+
+;; ---------------------------------------------------------------------------
+;; Transport (JSON-RPC over Streamable HTTP)
+;; ---------------------------------------------------------------------------
 
 (defn- parse-body
   "MCP Streamable HTTP may reply as JSON or as SSE. Pull the JSON-RPC payload
@@ -60,45 +85,83 @@
       (throw (ex-info (str "MCP error: " (:message err)) {:method method :error err})))
     (:result parsed)))
 
-(defn- mcp-tool->tool-def
-  "Turn one MCP tool descriptor into a Metabot tool-def map.
+;; ---------------------------------------------------------------------------
+;; Per-server catalog cache (tools/list is stable for a session)
+;; ---------------------------------------------------------------------------
 
-  Metabot's Claude adapter normally derives the wire schema from a Malli
-  `:schema`; MCP hands us JSON Schema directly, so we stash it under
-  `:input_schema` and teach `tool->claude` to prefer it (see claude.clj)."
-  [cfg {:keys [name description inputSchema]}]
-  {:tool-name    name
-   :doc          description
-   :schema       nil
-   :input_schema (or inputSchema {:type "object" :properties {}})
-   :fn           (fn [args]
-                   (try
-                     (let [result  (rpc! cfg "tools/call" {:name name :arguments (or args {})})
-                           ;; MCP returns {:content [{:type "text" :text "..."} ...]}
-                           text    (->> (:content result)
-                                        (keep :text)
-                                        (str/join "\n"))]
-                       {:output (if (str/blank? text) (json/encode result) text)})
-                     (catch Exception e
-                       (log/error e "External MCP tool call failed" {:tool name})
-                       {:output (str "MCP tool error: " (.getMessage e))})))})
+(defonce ^:private catalog-cache (atom {}))
+
+(defn- server-tools
+  "MCP tool descriptors for a server, cached after the first fetch."
+  [{:keys [url] :as cfg}]
+  (or (@catalog-cache url)
+      (let [_     (rpc! cfg "initialize" {:protocolVersion "2025-06-18"
+                                          :capabilities    {}
+                                          :clientInfo      {:name "metabase-metabot" :version "poc"}})
+            tools (:tools (rpc! cfg "tools/list" {}))]
+        (swap! catalog-cache assoc url tools)
+        tools)))
+
+;; ---------------------------------------------------------------------------
+;; Meta-tool: one Metabot tool per MCP server
+;; ---------------------------------------------------------------------------
+
+(def ^:private meta-tool-params
+  "Malli params schema for the per-server meta-tool. `tool->claude` reads the
+  `params` out of [:=> [:cat params] out] and turns it into the wire schema."
+  [:map {:closed true}
+   [:op {:description "\"list_tools\" to see this server's available tools, or \"call_tool\" to invoke one."}
+    [:enum "list_tools" "call_tool"]]
+   [:name {:optional true
+           :description "When op=call_tool: the exact tool name from list_tools."}
+    [:maybe :string]]
+   [:args {:optional true
+           :description "When op=call_tool: a map of arguments for that tool."}
+    [:maybe :map]]])
+
+(defn- list-tools-output
+  "Compact catalog the LLM reads to discover a server's tools."
+  [cfg]
+  (let [tools (server-tools cfg)]
+    {:output (->> tools
+                  (map (fn [{:keys [name description]}]
+                         (str "- " name ": " (some-> description str/trim
+                                                     (#(first (str/split-lines %)))))))
+                  (str/join "\n"))
+     :structured-output {:tools (mapv #(select-keys % [:name :description :inputSchema]) tools)}}))
+
+(defn- call-tool-output
+  "Dispatch one remote tool by name, flatten the MCP result into {:output ...}."
+  [cfg tool-name args]
+  (if (str/blank? tool-name)
+    {:output "call_tool requires :name (call op=list_tools first to see names)."}
+    (let [result (rpc! cfg "tools/call" {:name tool-name :arguments (or args {})})
+          ;; MCP returns {:content [{:type "text" :text "..."} ...]}
+          text   (->> (:content result) (keep :text) (str/join "\n"))]
+      {:output (if (str/blank? text) (json/encode result) text)})))
+
+(defn- server->tool-def
+  "Build the single Metabot tool-def map representing one MCP server."
+  [{:keys [name] :as cfg}]
+  {:tool-name name
+   :doc       (str "External MCP server \"" name "\". Use op=list_tools to discover its tools, "
+                   "then op=call_tool with a tool name + args to invoke one. "
+                   "Tools are discovered on demand — list before you call.")
+   :schema    [:=> [:cat meta-tool-params] :any]
+   :fn        (fn [{:keys [op name args] :as _input}]
+                (try
+                  (case op
+                    "list_tools" (list-tools-output cfg)
+                    "call_tool"  (call-tool-output cfg name args)
+                    {:output (str "Unknown op " (pr-str op) "; use \"list_tools\" or \"call_tool\".")})
+                  (catch Exception e
+                    (log/error e "External MCP meta-tool failed" {:server (:name cfg) :op op})
+                    {:output (str "MCP error: " (.getMessage e))})))})
 
 (defn external-mcp-tools
-  "Connect to the configured external MCP server and return a
-  `{tool-name -> tool-def-map}` map ready to merge into the agent's tool
-  registry. Returns `{}` (and logs) if unconfigured or unreachable, so a broken
-  MCP server can never take down the agent loop."
+  "Return `{tool-name -> tool-def-map}` — one meta-tool per configured MCP
+  server — ready to merge into the agent's registry. Returns `{}` if none
+  configured. Catalogs are fetched lazily (on first list_tools), so an
+  unreachable server costs nothing at agent init and never crashes the loop."
   []
-  (let [{:keys [url] :as cfg} (config)]
-    (if (str/blank? url)
-      {}
-      (try
-        (rpc! cfg "initialize" {:protocolVersion "2025-06-18"
-                                :capabilities    {}
-                                :clientInfo      {:name "metabase-metabot" :version "poc"}})
-        (let [tools (:tools (rpc! cfg "tools/list" {}))]
-          (log/info "Loaded external MCP tools" {:url url :count (count tools)})
-          (into {} (map (juxt :name #(mcp-tool->tool-def cfg %))) tools))
-        (catch Exception e
-          (log/error e "Failed to load external MCP tools" {:url url})
-          {})))))
+  (into {} (map (juxt :name server->tool-def)) (servers)))


### PR DESCRIPTION
## Why

POC to answer one question: how hard is it to add a third-party MCP server (Notion, Linear, ...) as an additional tool source for the Metabot agent loop? Answer: easy.

## Approach

Metabot's tool definition is already a plain map — `{:tool-name :doc :schema :fn}` — and the loop dispatches on that map, not on the var. So an external MCP server's tools can be adapted into the same shape and merged into the registry; the loop needs no changes.

MCP's Streamable HTTP transport is JSON-RPC 2.0 over a single POST endpoint, so a minimal client (`initialize` / `tools/list` / `tools/call`) over the already-present `clj-http` is enough. No MCP SDK is on the classpath and none was added.

## Changes

- **`tools/mcp_external.clj`** (new): the MCP client + adapter. Parses both JSON and SSE responses (the spec lets the server choose). Configured by `MB_MCP_EXTERNAL_URL` / `MB_MCP_EXTERNAL_TOKEN`. Unconfigured or unreachable -> returns no tools, never throws into the loop.
- **`self/claude.clj`** (`tool->claude`, 1 line): prefer a tool's raw JSON Schema (`:input_schema`) when present. Native tools derive their wire schema from Malli; MCP hands us JSON Schema directly.
- **`agent/core.clj`** (`init-agent`, 2 lines): `merge` the external MCP tools into the registry after the native ones.

## Validation

Verified live against Linear's hosted MCP server (`https://mcp.linear.app/mcp`) with a Bearer API key, in the REPL against a running backend:

- `tools/list` -> **46 Linear tools** loaded into Metabot (`list_issues`, `get_issue`, `list_teams`, ...).
- `tools/call` on `list_teams` -> real workspace data returned, flattened into Metabot's `{:output ...}` contract.

Linear accepts a static Bearer token, so no OAuth dance. Swapping to Notion is a two-env-var change, zero code.

## Out of scope (POC)

OAuth flow (only static-token servers work now), per-profile gating (loads into every profile), scope checks on external tools, settings UI, and the prompt-cache cost of the extra tools in the request prefix.
