### PR TITLE
Add fingerprinting batching

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -943,6 +943,10 @@
                               ;; tests expect the converted values.
                               :set-timezone                     true
                               :split-part                       true
+                              ;; `table-rows-sample` uses `tabledata.list`, which returns whole rows and can't project
+                              ;; the requested fields, so fingerprinting samples all of a table's fields in one pass
+                              ;; rather than batching them (re-reading whole rows per batch would buy nothing).
+                              :table-rows-sample/projects-fields false
                               ;; This driver reports inaccurate `:rows-affected` counts; the transforms layer
                               ;; falls back to a native `COUNT(*)` on the CTAS path.
                               ;; TODO: fix `execute-raw-queries!` to return accurate row counts for DDL

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -775,6 +775,12 @@
     ;; Does the driver support fingerprint the fields. Default is true
     :fingerprint
     ;;
+    ;; Can [[metabase.driver.common.table-rows-sample/table-rows-sample]] project (read only) the specific fields it is
+    ;; given, rather than reading whole rows regardless of which fields were requested (e.g. BigQuery's `tabledata.list`
+    ;; returns whole rows)? When false, fingerprinting can't shrink the sample query by batching fields, so it samples
+    ;; all of a table's fields in a single pass. Default is true.
+    :table-rows-sample/projects-fields
+    ;;
     ;; Does a connection to this driver correspond to a single database (false), or to multiple databases (true)?
     ;; Default is false; ie. a single database. This is common for classic relational DBs and some cloud databases.
     ;; Some have access to many databases from one connection; eg. Athena connects to an S3 bucket which might have
@@ -942,6 +948,7 @@
                               :schemas                                true
                               :test/jvm-timezone-setting              true
                               :fingerprint                            true
+                              :table-rows-sample/projects-fields      true
                               :upload-with-auto-pk                    true
                               :saved-question-sandboxing              true
                               :test/create-table-without-data         true

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -232,11 +232,25 @@
         (merge (empty-stats-map 0) stats))
       stats)))
 
+(mu/defn- fingerprint-field-batches :- [:sequential [:sequential i/FieldInstance]]
+  "Split `fields` into the batches to fingerprint separately. On drivers whose `table-rows-sample` projects only the
+  requested fields, batches of [[sync.settings/fingerprint-fields-batch-size]] keep each sample query (and its
+  per-field accumulators) narrow. Drivers that read whole rows regardless (e.g. BigQuery, which lacks
+  `:table-rows-sample/projects-fields`) gain nothing from narrower batches and would just re-read full rows, so they
+  fingerprint all fields in one batch."
+  [table  :- i/TableInstance
+   fields :- [:sequential i/FieldInstance]]
+  (let [database (table/database table)
+        driver   (driver.u/database->driver database)]
+    (if (driver/database-supports? driver :table-rows-sample/projects-fields database)
+      (partition-all (sync.settings/fingerprint-fields-batch-size) fields)
+      [fields])))
+
 (mu/defn- fingerprint-fields-of-table!
-  "Fingerprint the (non-empty) `fields` of `table` in batches of [[sync.settings/fingerprint-fields-batch-size]]. Each
-  batch runs its own warehouse sample query, so peak memory stays bounded by the batch size rather than the table's
-  total field count -- a wide table would otherwise project thousands of columns into a single query and hold one
-  fingerprinter per field at once. Stops at the first failing batch."
+  "Fingerprint the (non-empty) `fields` of `table` in batches (see [[fingerprint-field-batches]]). Each batch runs its
+  own warehouse sample query, so on projecting drivers peak memory stays bounded by the batch size rather than the
+  table's total field count -- a wide table would otherwise project thousands of columns into a single query and hold
+  one fingerprinter per field at once. Stops at the first failing batch."
   [table  :- i/TableInstance
    fields :- [:sequential i/FieldInstance]]
   (log/infof "Fingerprinting %s fields in table %s" (count fields) (sync-util/name-for-logging table))
@@ -245,7 +259,7 @@
                   acc   (merge-with + acc stats)]
               (cond-> acc (:throwable stats) reduced)))
           (empty-stats-map 0)
-          (partition-all (sync.settings/fingerprint-fields-batch-size) fields)))
+          (fingerprint-field-batches table fields)))
 
 (mu/defn fingerprint-table!
   "Generate and save fingerprints for the Fields in `table` that have not been previously analyzed. At most

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -217,12 +217,12 @@
                   "the first %d and skipping the rest. Raise MB_FINGERPRINT_MAX_FIELDS_PER_TABLE to fingerprint more.")
              (sync-util/name-for-logging table) limit limit))
 
-(mu/defn- fingerprint-fields-of-table!
-  "Fingerprint the (non-empty) `fields` of `table`. On a non-transient error, advance their fingerprint version so we
-  don't re-attempt every sync; transient errors are left untouched to retry next sync."
+(mu/defn- fingerprint-field-batch!
+  "Fingerprint a single batch of `fields` of `table` via one warehouse sample query, returning a stats map. On a
+  non-transient error, advance the batch's fingerprint version so we don't re-attempt every sync; transient errors are
+  left untouched to retry next sync. The returned map carries `:throwable` when the batch failed."
   [table  :- i/TableInstance
    fields :- [:sequential i/FieldInstance]]
-  (log/infof "Fingerprinting %s fields in table %s" (count fields) (sync-util/name-for-logging table))
   (let [stats (sync-util/with-returning-throwable (format "Error fingerprinting %s" (sync-util/name-for-logging table))
                 (fingerprint-fields! table fields))]
     (if-let [throwable (:throwable stats)]
@@ -231,6 +231,21 @@
           (mark-fingerprinting-failed! fields))
         (merge (empty-stats-map 0) stats))
       stats)))
+
+(mu/defn- fingerprint-fields-of-table!
+  "Fingerprint the (non-empty) `fields` of `table` in batches of [[sync.settings/fingerprint-fields-batch-size]]. Each
+  batch runs its own warehouse sample query, so peak memory stays bounded by the batch size rather than the table's
+  total field count -- a wide table would otherwise project thousands of columns into a single query and hold one
+  fingerprinter per field at once. Stops at the first failing batch."
+  [table  :- i/TableInstance
+   fields :- [:sequential i/FieldInstance]]
+  (log/infof "Fingerprinting %s fields in table %s" (count fields) (sync-util/name-for-logging table))
+  (reduce (fn [acc batch]
+            (let [stats (fingerprint-field-batch! table batch)
+                  acc   (merge-with + acc stats)]
+              (cond-> acc (:throwable stats) reduced)))
+          (empty-stats-map 0)
+          (partition-all (sync.settings/fingerprint-fields-batch-size) fields)))
 
 (mu/defn fingerprint-table!
   "Generate and save fingerprints for the Fields in `table` that have not been previously analyzed. At most

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -242,7 +242,7 @@
    fields :- [:sequential i/FieldInstance]]
   (let [database (table/database table)
         driver   (driver.u/database->driver database)]
-    (if (driver/database-supports? driver :table-rows-sample/projects-fields database)
+    (if (driver.u/supports? driver :table-rows-sample/projects-fields database)
       (partition-all (sync.settings/fingerprint-fields-batch-size) fields)
       [fields])))
 

--- a/src/metabase/sync/settings.clj
+++ b/src/metabase/sync/settings.clj
@@ -69,3 +69,12 @@
   :export?    true
   :type       :integer
   :default    10000)
+
+(defsetting fingerprint-fields-batch-size
+  "Number of fields to fingerprint per warehouse sample query. Fingerprinting projects every field in the batch into a
+  single query and keeps one accumulator per field, so peak memory scales with the batch size; a table's eligible
+  fields are fingerprinted in batches of this size to keep that bounded (especially for very wide tables)."
+  :visibility :internal
+  :export?    true
+  :type       :integer
+  :default    200)

--- a/src/metabase/sync/settings.clj
+++ b/src/metabase/sync/settings.clj
@@ -77,4 +77,4 @@
   :visibility :internal
   :export?    true
   :type       :integer
-  :default    200)
+  :default    500)

--- a/src/metabase/sync/settings.clj
+++ b/src/metabase/sync/settings.clj
@@ -77,4 +77,4 @@
   :visibility :internal
   :export?    true
   :type       :integer
-  :default    500)
+  :default    200)

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -187,6 +187,33 @@
                 (sync.fingerprint/fingerprint-table! table)
                 (is (= 2 @saved))))))))))
 
+(deftest fingerprint-table!-batches-fields-test
+  (testing "fields are fingerprinted in batches of fingerprint-fields-batch-size (bounds peak memory on wide tables)"
+    (let [sample-calls (atom 0)
+          saved        (atom 0)]
+      (binding [i/*fingerprint-version->types-that-should-be-re-fingerprinted* {2 #{:type/Float}}]
+        (mt/with-dynamic-fn-redefs [qp/process-query                   (fn [_query rff]
+                                                                         (swap! sample-calls inc)
+                                                                         (transduce identity (rff :metadata) [[1 1] [2 2] [3 3] [4 4] [5 5]]))
+                                    sync.fingerprint/save-fingerprint! (fn [& _] (swap! saved inc))]
+          (mt/with-temp [:model/Table table {}
+                         :model/Field _ {:table_id (u/the-id table) :base_type :type/Decimal :fingerprint_version 1 :active true}
+                         :model/Field _ {:table_id (u/the-id table) :base_type :type/Decimal :fingerprint_version 1 :active true}]
+            (testing "batch size 1 -> one warehouse sample query per field, all fields still fingerprinted"
+              (reset! sample-calls 0)
+              (reset! saved 0)
+              (mt/with-temporary-setting-values [fingerprint-fields-batch-size 1]
+                (sync.fingerprint/fingerprint-table! table)
+                (is (= 2 @sample-calls) "two batches -> two sample queries")
+                (is (= 2 @saved) "both fields fingerprinted")))
+            (testing "batch size larger than the field count -> a single sample query"
+              (reset! sample-calls 0)
+              (reset! saved 0)
+              (mt/with-temporary-setting-values [fingerprint-fields-batch-size 10000]
+                (sync.fingerprint/fingerprint-table! table)
+                (is (= 1 @sample-calls) "one batch -> one sample query")
+                (is (= 2 @saved) "both fields fingerprinted")))))))))
+
 (deftest  fingerprint-table!-test
   (testing "field is a substype of newer fingerprint version"
     (is (= [one-updated-map true]


### PR DESCRIPTION
OOM fix for mongo. Confirmed that even with 10k fields, one query causes an immediate OOM. Can only be used if the driver's `table-rows-sample` supports selecting fields (`bigquery` doesn't).