### PR TITLE
Adaptive page sizes for bigquery and mongo to prevent OOMs

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -743,22 +743,36 @@
      ;; realizing more rows as per the maximum result size
      (.setMaxResults *page-size*))))
 
-(defn- next-page-same-size
-  "Default page-advance for [[reducible-bigquery-results]]: fetch the next page at the original request's page size
-  (BigQuery's `.getNextPage`). Returns nil once the result set is exhausted."
-  ^TableResult [^TableResult page]
-  (when (.hasNextPage page)
-    (log/trace "BigQuery: Fetching new page")
-    (*page-callback*)
-    (or (.getNextPage page)
-        (throw (ex-info "Cannot get next page from BigQuery" {})))))
+(defn- adaptive-query-next-page
+  "Adaptive page-advance for query-job results (the regular execution path), mirroring [[adaptive-sample-next-page]]
+  but paging via `getQueryResults` -- the query result's own `.getNextPage` re-uses the original page size and can't
+  be re-sized. Measures the just-consumed page's real bytes/row and re-issues the next page with a `pageSize`
+  targeting [[*sample-page-byte-budget*]], so a wide or heavy result fetches fewer rows per page instead of holding a
+  large parsed page in memory. Returns nil once the result set is exhausted."
+  [^BigQuery client job-id]
+  (let [budget (long *sample-page-byte-budget*)
+        seen   (atom {:bytes 0, :rows 0})]
+    (fn [^TableResult page]
+      (let [token (.getNextPageToken page)]
+        (when-not (str/blank? token)
+          (let [[page-bytes page-rows] (reduce (fn [[b n] row] [(+ (long b) (row-bytes row)) (inc (long n))])
+                                               [0 0]
+                                               (.getValues page))
+                {:keys [bytes rows]}   (swap! seen (fn [s] {:bytes (+ (long (:bytes s)) (long page-bytes))
+                                                            :rows  (+ (long (:rows s)) (long page-rows))}))]
+            (log/trace "BigQuery: Fetching new page")
+            (*page-callback*)
+            (.getQueryResults client job-id
+                              (u/varargs BigQuery$QueryResultsOption
+                                [(BigQuery$QueryResultsOption/pageSize
+                                  (next-sample-page-size budget bytes rows Long/MAX_VALUE))
+                                 (BigQuery$QueryResultsOption/pageToken token)]))))))))
 
 (defn- reducible-bigquery-results
-  "Reducible over the rows of `page` and its successors. `next-page` is the swappable page-advance: given the
-  just-exhausted page it returns the next one (or nil when done). Defaults to [[next-page-same-size]] (fixed page
-  size); the sync sampler passes [[adaptive-sample-next-page]] to resize each page from measured bytes/row."
-  ([^TableResult page cancel-chan attempt-job-cancel-fn]
-   (reducible-bigquery-results page cancel-chan attempt-job-cancel-fn next-page-same-size))
+  "Reducible over the rows of `page` and its successors. `next-page` is the adaptive page-advance: given the
+  just-exhausted page it measures it and returns the next one (re-sized from the measured bytes/row to a byte budget),
+  or nil when done. Adaptive page sizing is the only mode -- callers pass [[adaptive-sample-next-page]] (sampling, via
+  `.list`) or [[adaptive-query-next-page]] (query execution, via `getQueryResults`)."
   ([^TableResult page cancel-chan attempt-job-cancel-fn next-page]
    (reify
      clojure.lang.IReduceInit
@@ -825,7 +839,8 @@
         cols {:cols columns}
         results (eduction (map (fn [^FieldValueList row]
                                  (mapv parse-field-value row parsers)))
-                          (reducible-bigquery-results page cancel-chan attempt-job-cancel-fn))]
+                          (reducible-bigquery-results page cancel-chan attempt-job-cancel-fn
+                                                      (adaptive-query-next-page client job-id)))]
     (respond cols results)))
 
 (defn- execute-bigquery

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -577,9 +577,10 @@
   ^long [^FieldValueList row]
   (reduce (fn [^long acc cell] (+ acc (field-value-bytes cell))) 0 row))
 
-(defn- next-sample-page-size
+(defn- next-page-size
   "Rows to request for the next page given the average measured bytes/row so far, targeting `budget` bytes/page.
-  Clamped to [1, `remaining`]."
+  Clamped to [1, `remaining`]. Shared by the sampler ([[adaptive-sample-next-page]]) and regular query execution
+  ([[adaptive-query-next-page]])."
   ^long [^long budget ^long measured-bytes ^long measured-rows ^long remaining]
   (let [avg-row-bytes (max 1 (quot measured-bytes (max 1 measured-rows)))]
     (-> (quot budget avg-row-bytes)
@@ -612,7 +613,7 @@
                 remaining              (- max-rows (long rows))]
             (when (pos? remaining)
               (*page-callback*)
-              (list-sample-page bq-table (next-sample-page-size budget bytes rows remaining) token))))))))
+              (list-sample-page bq-table (next-page-size budget bytes rows remaining) token))))))))
 
 (defn- sample-table
   "Process a sample of rows of fields corresponding to the Metabase fields
@@ -765,7 +766,7 @@
             (.getQueryResults client job-id
                               (u/varargs BigQuery$QueryResultsOption
                                 [(BigQuery$QueryResultsOption/pageSize
-                                  (next-sample-page-size budget bytes rows Long/MAX_VALUE))
+                                  (next-page-size budget bytes rows Long/MAX_VALUE))
                                  (BigQuery$QueryResultsOption/pageToken token)]))))))))
 
 (defn- reducible-bigquery-results

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -543,10 +543,10 @@
 ;;; wildly inaccurate -- a TEXT column may hold 5 bytes or 5 MB), we *measure* it: fetch a small probe page, then
 ;;; recompute the next page size from the average bytes/row actually seen, so each page targets a fixed byte budget.
 
-(def ^:private ^:dynamic *sample-page-byte-budget*
-  "Target measured bytes per `tabledata.list` sample page. The next page size is `budget / measured-bytes-per-row`,
-  clamped to [1, remaining]. Kept well under the server's ~10 MB page cap to leave headroom for JVM object expansion
-  when the page is parsed."
+(def ^:private ^:dynamic *page-byte-budget*
+  "Target measured bytes per result page, for both `tabledata.list` sampling and regular query execution. The next
+  page size is `budget / measured-bytes-per-row`, clamped to [1, remaining]. Kept well under the server's ~10 MB page
+  cap to leave headroom for JVM object expansion when the page is parsed."
   (* 4 1024 1024))
 
 (def ^:private sample-probe-rows
@@ -596,11 +596,11 @@
 
 (defn- adaptive-sample-next-page
   "A swappable page-advance for [[reducible-bigquery-results]], used when sampling. It measures the just-consumed
-  page's real bytes/row and re-issues `.list` from the page token with a size targeting `*sample-page-byte-budget*`
+  page's real bytes/row and re-issues `.list` from the page token with a size targeting `*page-byte-budget*`
   -- a sliding window that adapts per page to the table's actual data instead of guessing from column types. Returns
   nil once the `max-rows` budget is spent or there are no more pages."
   [^Table bq-table ^long max-rows]
-  (let [budget (long *sample-page-byte-budget*)
+  (let [budget (long *page-byte-budget*)
         seen   (atom {:bytes 0, :rows 0})]
     (fn [^TableResult page]
       (let [token (.getNextPageToken page)]
@@ -748,10 +748,10 @@
   "Adaptive page-advance for query-job results (the regular execution path), mirroring [[adaptive-sample-next-page]]
   but paging via `getQueryResults` -- the query result's own `.getNextPage` re-uses the original page size and can't
   be re-sized. Measures the just-consumed page's real bytes/row and re-issues the next page with a `pageSize`
-  targeting [[*sample-page-byte-budget*]], so a wide or heavy result fetches fewer rows per page instead of holding a
+  targeting [[*page-byte-budget*]], so a wide or heavy result fetches fewer rows per page instead of holding a
   large parsed page in memory. Returns nil once the result set is exhausted."
   [^BigQuery client job-id]
-  (let [budget (long *sample-page-byte-budget*)
+  (let [budget (long *page-byte-budget*)
         seen   (atom {:bytes 0, :rows 0})]
     (fn [^TableResult page]
       (let [token (.getNextPageToken page)]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -159,8 +159,8 @@
       (is (= (+ (field-value-bytes (prim-cell "aa")) (field-value-bytes (prim-cell "bbb")))
              (row-bytes (field-value-list [(prim-cell "aa") (prim-cell "bbb")])))))))
 
-(deftest ^:parallel next-sample-page-size-test
-  (let [next-size @#'bigquery/next-sample-page-size]
+(deftest ^:parallel next-page-size-test
+  (let [next-size @#'bigquery/next-page-size]
     (testing "page size = budget / measured-avg-bytes-per-row"
       ;; 50 rows totalling 500 bytes -> avg 10 -> 1000/10 = 100
       (is (= 100 (next-size 1000 500 50 1000000))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -190,7 +190,7 @@
                      (with-redefs [bigquery/list-sample-page (fn [_bq size _token]
                                                                (swap! requested conj size)
                                                                (mock-page nil []))]
-                       (binding [bigquery/*sample-page-byte-budget* budget]
+                       (binding [bigquery/*page-byte-budget* budget]
                          ((#'bigquery/adaptive-sample-next-page :table max-rows) (mock-page "tok" rows))
                          (first @requested))))
         light      (vec (repeatedly 5 #(field-value-list [(prim-cell "x")])))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -181,7 +181,7 @@
 
 (deftest ^:parallel reducible-bigquery-results-nil-page-test
   (testing "a nil initial page reduces to an empty result instead of NPEing (#47339)"
-    (is (= [] (into [] (#'bigquery/reducible-bigquery-results nil nil (constantly nil)))))))
+    (is (= [] (into [] (#'bigquery/reducible-bigquery-results nil nil (constantly nil) (constantly nil)))))))
 
 (deftest ^:synchronized adaptive-sample-next-page-test
   (let [requested (atom [])

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -156,45 +156,33 @@
   "Cursor batch size used for normal queries (the historical fixed value)."
   100)
 
-(def ^:dynamic *batch-byte-budget*
-  "Target in-memory bytes for one cursor batch of result documents. Every query's batchSize is derived from this and a
-  one-document probe (see [[apply-byte-budgeted-batch-size!]]), so a wide or heavy collection holds a bounded page
-  rather than [[default-batch-size]] full documents -- which, on a schemaless collection like Mongo's, can be
-  hundreds of MB and OOM the instance. Always on (mirrors the BigQuery driver); dynamic only so tests can shrink it."
-  (* 4 1024 1024))
+(def ^:dynamic *max-cells-per-batch*
+  "Upper bound on the cells (rows × result columns) held in a single cursor batch. The cursor's batchSize is reduced
+  below [[default-batch-size]] for wide results so a collection with many fields per document doesn't buffer a huge
+  page and OOM the instance (e.g. fingerprinting a schemaless collection with thousands of keys). Derived purely from
+  the query's projection -- no extra round-trip or re-execution. Dynamic only so tests can shrink it."
+  20000)
 
-(def ^:private probe-batch-size
-  "batchSize used for the one-document size probe, so the probe itself can never buffer a heavy page."
-  1)
+(defn- result-field-count
+  "Number of fields kept by the pipeline's last `$project`, or nil when there is no `$project` (so the result width is
+  unknown and we can't bound it). Suppressed fields (`{... 0}`/`false`) don't count."
+  [query]
+  (when-let [project (->> query
+                          (filter #(and (instance? java.util.Map %) (.containsKey ^java.util.Map % "$project")))
+                          last)]
+    (count (keep (fn [[k v]] (when-not (suppressing-values v) k))
+                 (get project "$project")))))
 
-(def ^:private value-byte-overhead
-  "Approximate JVM footprint of a decoded BSON value beyond its payload (boxing/wrapper), added per value."
-  16)
-
-(defn- value-bytes
-  "Approximate decoded in-memory size of one BSON value, summed recursively through embedded documents and arrays so
-  the estimate tracks heavy nested values, not just field count."
-  ^long [v]
-  (cond
-    (instance? java.util.Map v)         (reduce (fn [^long acc ^java.util.Map$Entry e]
-                                                  (+ acc value-byte-overhead
-                                                     (long (count (str (.getKey e))))
-                                                     (value-bytes (.getValue e))))
-                                                value-byte-overhead
-                                                (.entrySet ^java.util.Map v))
-    (instance? java.util.Collection v)  (reduce (fn [^long acc x] (+ acc (value-bytes x))) value-byte-overhead v)
-    (instance? CharSequence v)          (+ value-byte-overhead (long (count v)))
-    (bytes? v)                          (+ value-byte-overhead (long (alength ^bytes v)))
-    (instance? org.bson.types.Binary v) (+ value-byte-overhead (long (alength (.getData ^org.bson.types.Binary v))))
-    :else                               value-byte-overhead))
-
-(defn- budgeted-batch-size
-  "Cursor batchSize that keeps one fetched batch within `budget` bytes given a measured per-document size, clamped to
-  [1, [[default-batch-size]]]."
-  ^long [^long budget ^long doc-bytes]
-  (-> (quot budget (max 1 doc-bytes))
-      (max 1)
-      (min default-batch-size)))
+(defn- query-batch-size
+  "Cursor batchSize for `query`: [[default-batch-size]], reduced toward 1 for wide projections so that
+  batchSize x columns stays within [[*max-cells-per-batch*]]. Falls back to [[default-batch-size]] when the result
+  width is unknown (no `$project`)."
+  ^long [query]
+  (if-let [fields (result-field-count query)]
+    (-> (quot (long *max-cells-per-batch*) (max 1 (long fields)))
+        (max 1)
+        (min default-batch-size))
+    default-batch-size))
 
 ;; See https://mongodb.github.io/mongo-java-driver/3.12/javadoc/com/mongodb/client/AggregateIterable.html
 (defn- init-aggregate!
@@ -204,32 +192,6 @@
     (.allowDiskUse true)
     (.batchSize (int default-batch-size))
     (.maxTime timeout-ms TimeUnit/MILLISECONDS)))
-
-(defn- has-write-stage?
-  "True if the aggregation pipeline `query` contains a `$out`/`$merge` write stage. The sizing probe executes the
-  pipeline, so we must not probe those -- it would perform the write twice. (Such pipelines also return no result
-  documents, so there is nothing to byte-budget anyway.)"
-  [query]
-  (boolean (some (fn [stage]
-                   (and (instance? java.util.Map stage)
-                        (or (.containsKey ^java.util.Map stage "$out")
-                            (.containsKey ^java.util.Map stage "$merge"))))
-                 query)))
-
-(defn- apply-byte-budgeted-batch-size!
-  "Always size `aggregate`'s cursor batch by bytes (mirroring the BigQuery driver): probe one document, measure it, and
-  set batchSize so each fetched batch stays within [[*batch-byte-budget*]] rather than buffering [[default-batch-size]]
-  whole documents. This is slower -- an extra single-document probe (which re-runs the pipeline) and smaller batches
-  for heavy documents -- but a slower sync beats OOMing the instance on a wide/heavy collection. Skips the probe (and
-  leaves [[default-batch-size]]) only for `$out`/`$merge` pipelines, which must not be re-executed (see
-  [[has-write-stage?]]). Returns `aggregate`."
-  ^AggregateIterable [^AggregateIterable aggregate query]
-  (when-not (has-write-stage? query)
-    (.batchSize aggregate (int probe-batch-size))
-    (.batchSize aggregate (int (if-let [probe (.first aggregate)]
-                                 (budgeted-batch-size (long *batch-byte-budget*) (value-bytes probe))
-                                 default-batch-size))))
-  aggregate)
 
 (defn aggregate-database
   "Used in testing to enable aggregate on pipelines sourced with $documents stage."
@@ -295,7 +257,7 @@
                                                       session
                                                       query
                                                       driver.settings/*query-timeout-ms*)]
-        (apply-byte-budgeted-batch-size! aggregate query)
+        (.batchSize aggregate (int (query-batch-size query)))
         (with-open [^MongoCursor cursor (try (.cursor aggregate)
                                              (catch Throwable e
                                                (throw (ex-info (tru "Error executing query: {0}" (ex-message e))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -150,15 +150,86 @@
   (when row
     (.keySet row)))
 
+;;; ----------------------------------------------- Cursor batch sizing ----------------------------------------------
+
+(def ^:private default-batch-size
+  "Cursor batch size used for normal queries (the historical fixed value)."
+  100)
+
+(def ^:dynamic *batch-byte-budget*
+  "Target in-memory bytes for one cursor batch of result documents. Every query's batchSize is derived from this and a
+  one-document probe (see [[apply-byte-budgeted-batch-size!]]), so a wide or heavy collection holds a bounded page
+  rather than [[default-batch-size]] full documents -- which, on a schemaless collection like Mongo's, can be
+  hundreds of MB and OOM the instance. Always on (mirrors the BigQuery driver); dynamic only so tests can shrink it."
+  (* 4 1024 1024))
+
+(def ^:private probe-batch-size
+  "batchSize used for the one-document size probe, so the probe itself can never buffer a heavy page."
+  1)
+
+(def ^:private value-byte-overhead
+  "Approximate JVM footprint of a decoded BSON value beyond its payload (boxing/wrapper), added per value."
+  16)
+
+(defn- value-bytes
+  "Approximate decoded in-memory size of one BSON value, summed recursively through embedded documents and arrays so
+  the estimate tracks heavy nested values, not just field count."
+  ^long [v]
+  (cond
+    (instance? java.util.Map v)         (reduce (fn [^long acc ^java.util.Map$Entry e]
+                                                  (+ acc value-byte-overhead
+                                                     (long (count (str (.getKey e))))
+                                                     (value-bytes (.getValue e))))
+                                                value-byte-overhead
+                                                (.entrySet ^java.util.Map v))
+    (instance? java.util.Collection v)  (reduce (fn [^long acc x] (+ acc (value-bytes x))) value-byte-overhead v)
+    (instance? CharSequence v)          (+ value-byte-overhead (long (count v)))
+    (bytes? v)                          (+ value-byte-overhead (long (alength ^bytes v)))
+    (instance? org.bson.types.Binary v) (+ value-byte-overhead (long (alength (.getData ^org.bson.types.Binary v))))
+    :else                               value-byte-overhead))
+
+(defn- budgeted-batch-size
+  "Cursor batchSize that keeps one fetched batch within `budget` bytes given a measured per-document size, clamped to
+  [1, [[default-batch-size]]]."
+  ^long [^long budget ^long doc-bytes]
+  (-> (quot budget (max 1 doc-bytes))
+      (max 1)
+      (min default-batch-size)))
+
 ;; See https://mongodb.github.io/mongo-java-driver/3.12/javadoc/com/mongodb/client/AggregateIterable.html
 (defn- init-aggregate!
   [^AggregateIterable aggregate
    ^java.lang.Long timeout-ms]
   (doto aggregate
     (.allowDiskUse true)
-    ;; TODO - consider what the best batch size option is here. Not sure what the default is.
-    (.batchSize 100)
+    (.batchSize (int default-batch-size))
     (.maxTime timeout-ms TimeUnit/MILLISECONDS)))
+
+(defn- has-write-stage?
+  "True if the aggregation pipeline `query` contains a `$out`/`$merge` write stage. The sizing probe executes the
+  pipeline, so we must not probe those -- it would perform the write twice. (Such pipelines also return no result
+  documents, so there is nothing to byte-budget anyway.)"
+  [query]
+  (boolean (some (fn [stage]
+                   (and (instance? java.util.Map stage)
+                        (or (.containsKey ^java.util.Map stage "$out")
+                            (.containsKey ^java.util.Map stage "$merge"))))
+                 query)))
+
+(defn- apply-byte-budgeted-batch-size!
+  "Always size `aggregate`'s cursor batch by bytes (mirroring the BigQuery driver): probe one document, measure it, and
+  set batchSize so each fetched batch stays within [[*batch-byte-budget*]] rather than buffering [[default-batch-size]]
+  whole documents. This is slower -- an extra single-document probe (which re-runs the pipeline) and smaller batches
+  for heavy documents -- but a slower sync beats OOMing the instance on a wide/heavy collection. Skips the probe (and
+  leaves [[default-batch-size]]) only for `$out`/`$merge` pipelines, which must not be re-executed (see
+  [[has-write-stage?]]). Returns `aggregate`."
+  ^AggregateIterable [^AggregateIterable aggregate query]
+  (when-not (has-write-stage? query)
+    (.batchSize aggregate (int probe-batch-size))
+    (.batchSize aggregate (int (if-let [probe (.first aggregate)]
+                                 (budgeted-batch-size (long *batch-byte-budget*) (value-bytes probe))
+                                 default-batch-size))))
+  aggregate)
 
 (defn aggregate-database
   "Used in testing to enable aggregate on pipelines sourced with $documents stage."
@@ -224,6 +295,7 @@
                                                       session
                                                       query
                                                       driver.settings/*query-timeout-ms*)]
+        (apply-byte-budgeted-batch-size! aggregate query)
         (with-open [^MongoCursor cursor (try (.cursor aggregate)
                                              (catch Throwable e
                                                (throw (ex-info (tru "Error executing query: {0}" (ex-message e))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -157,11 +157,11 @@
   100)
 
 (def ^:dynamic *max-cells-per-batch*
-  "Upper bound on the cells (rows × result columns) held in a single cursor batch. The cursor's batchSize is reduced
+  "Upper bound on the cells (rows x result columns) held in a single cursor batch. The cursor's batchSize is reduced
   below [[default-batch-size]] for wide results so a collection with many fields per document doesn't buffer a huge
   page and OOM the instance (e.g. fingerprinting a schemaless collection with thousands of keys). Derived purely from
   the query's projection -- no extra round-trip or re-execution. Dynamic only so tests can shrink it."
-  20000)
+  10000)
 
 (defn- result-field-count
   "Number of fields kept by the pipeline's last `$project`, or nil when there is no `$project` (so the result width is

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -187,10 +187,11 @@
 ;; See https://mongodb.github.io/mongo-java-driver/3.12/javadoc/com/mongodb/client/AggregateIterable.html
 (defn- init-aggregate!
   [^AggregateIterable aggregate
+   stages
    ^java.lang.Long timeout-ms]
   (doto aggregate
     (.allowDiskUse true)
-    (.batchSize (int default-batch-size))
+    (.batchSize (int (query-batch-size stages)))
     (.maxTime timeout-ms TimeUnit/MILLISECONDS)))
 
 (defn aggregate-database
@@ -200,7 +201,7 @@
    stages timeout-ms]
   (let [pipe      (ArrayList. ^Collection (mongo.conversion/to-document stages))
         aggregate (.aggregate db session pipe)]
-    (init-aggregate! aggregate timeout-ms)))
+    (init-aggregate! aggregate stages timeout-ms)))
 
 (defn- ^:dynamic *aggregate*
   [^MongoDatabase db
@@ -210,7 +211,7 @@
   (let [coll      (.getCollection db coll)
         pipe      (ArrayList. ^Collection (mongo.conversion/to-document stages))
         aggregate (.aggregate coll session pipe)]
-    (init-aggregate! aggregate timeout-ms)))
+    (init-aggregate! aggregate stages timeout-ms)))
 
 (defn- reducible-rows [^MongoCursor cursor first-row post-process]
   {:pre [(fn? post-process)]}
@@ -257,7 +258,6 @@
                                                       session
                                                       query
                                                       driver.settings/*query-timeout-ms*)]
-        (.batchSize aggregate (int (query-batch-size query)))
         (with-open [^MongoCursor cursor (try (.cursor aggregate)
                                              (catch Throwable e
                                                (throw (ex-info (tru "Error executing query: {0}" (ex-message e))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -29,7 +29,6 @@
 
 (defn- make-mongo-aggregate-iterable [rows]
   (reify com.mongodb.client.AggregateIterable
-    (batchSize [this _] this)
     (cursor [_] (make-mongo-cursor rows))))
 
 (deftest ^:parallel query-batch-size-test

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -37,9 +37,8 @@
       (testing "narrow projection keeps the default batch size"
         (is (= 100 (qbs [{"$match" {}} {"$project" {"a" 1 "b" 1}}]))))
       (testing "wide projection shrinks the batch so rows × columns stays within the cell budget"
-        (binding [mongo.execute/*max-cells-per-batch* 20000]
-          (is (= 20 (qbs [{"$project" (into {} (for [i (range 1000)] [(str "f" i) 1]))}]))
-              "1000 columns, 20000-cell budget -> 20 rows/batch")))
+        (is (= 10 (qbs [{"$project" (into {} (for [i (range 1000)] [(str "f" i) 1]))}]))
+            "1000 columns, 10000-cell budget -> 10 rows/batch"))
       (testing "suppressed fields ({... 0}) don't count toward the width"
         (is (= 100 (qbs [{"$project" {"a" 1 "_id" 0}}]))))
       (testing "no $project -> default batch size (result width unknown)"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -29,7 +29,6 @@
 
 (defn- make-mongo-aggregate-iterable [rows]
   (reify com.mongodb.client.AggregateIterable
-    ;; batchSize is set from the query's projected field count in execute-reducible-query
     (batchSize [this _] this)
     (cursor [_] (make-mongo-cursor rows))))
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -29,36 +29,23 @@
 
 (defn- make-mongo-aggregate-iterable [rows]
   (reify com.mongodb.client.AggregateIterable
-    ;; batchSize/first are exercised by the always-on byte-budgeting probe in execute-reducible-query
+    ;; batchSize is set from the query's projected field count in execute-reducible-query
     (batchSize [this _] this)
-    (first [_] (when (seq rows) (mongo.conversion/to-document (nth rows 0))))
     (cursor [_] (make-mongo-cursor rows))))
 
-(defn- recording-aggregate-iterable
-  "An AggregateIterable whose `first` returns `probe-doc` and that records each `batchSize` call into `sizes`."
-  [^org.bson.Document probe-doc sizes]
-  (reify com.mongodb.client.AggregateIterable
-    (batchSize [this n] (swap! sizes conj n) this)
-    (first [_] probe-doc)
-    (cursor [_] (make-mongo-cursor []))))
-
-(deftest ^:parallel byte-budgeted-batch-size-test
-  (testing "budgeted-batch-size clamps batchSize to [1, default] from a measured per-document size"
-    (let [bbs @#'mongo.execute/budgeted-batch-size
-          mb  (* 1024 1024)]
-      (is (= 100 (bbs (* 4 mb) 40))      "tiny doc -> default max batch")
-      (is (= 4   (bbs (* 4 mb) mb))      "1MB doc, 4MB budget -> 4 per batch")
-      (is (= 1   (bbs mb (* 50 mb)))     "doc larger than the whole budget -> 1 per batch")))
-  (let [heavy (doto (org.bson.Document.) (.put "blob" (apply str (repeat 2000000 \x))))] ; ~2MB document
-    (testing "every read pipeline is byte-budgeted: probe at batchSize 1, then a small batch for a heavy doc"
-      (let [sizes (atom [])]
-        (binding [mongo.execute/*batch-byte-budget* (* 4 1024 1024)]
-          (#'mongo.execute/apply-byte-budgeted-batch-size! (recording-aggregate-iterable heavy sizes) [{"$match" {}}]))
-        (is (= [1 2] @sizes) "4MB budget / ~2MB doc -> batchSize 2")))
-    (testing "$out/$merge write pipelines are not probed (the probe would execute the write twice)"
-      (let [sizes (atom [])]
-        (#'mongo.execute/apply-byte-budgeted-batch-size! (recording-aggregate-iterable heavy sizes) [{"$out" "dest"}])
-        (is (= [] @sizes))))))
+(deftest ^:parallel query-batch-size-test
+  (testing "cursor batchSize is derived from the projected field count so wide results don't buffer a huge page"
+    (let [qbs @#'mongo.execute/query-batch-size]
+      (testing "narrow projection keeps the default batch size"
+        (is (= 100 (qbs [{"$match" {}} {"$project" {"a" 1 "b" 1}}]))))
+      (testing "wide projection shrinks the batch so rows × columns stays within the cell budget"
+        (binding [mongo.execute/*max-cells-per-batch* 20000]
+          (is (= 20 (qbs [{"$project" (into {} (for [i (range 1000)] [(str "f" i) 1]))}]))
+              "1000 columns, 20000-cell budget -> 20 rows/batch")))
+      (testing "suppressed fields ({... 0}) don't count toward the width"
+        (is (= 100 (qbs [{"$project" {"a" 1 "_id" 0}}]))))
+      (testing "no $project -> default batch size (result width unknown)"
+        (is (= 100 (qbs [{"$match" {}}])))))))
 
 (deftest ^:parallel field-filter-relative-time-native-test
   (mt/test-driver :mongo

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -29,7 +29,36 @@
 
 (defn- make-mongo-aggregate-iterable [rows]
   (reify com.mongodb.client.AggregateIterable
+    ;; batchSize/first are exercised by the always-on byte-budgeting probe in execute-reducible-query
+    (batchSize [this _] this)
+    (first [_] (when (seq rows) (mongo.conversion/to-document (nth rows 0))))
     (cursor [_] (make-mongo-cursor rows))))
+
+(defn- recording-aggregate-iterable
+  "An AggregateIterable whose `first` returns `probe-doc` and that records each `batchSize` call into `sizes`."
+  [^org.bson.Document probe-doc sizes]
+  (reify com.mongodb.client.AggregateIterable
+    (batchSize [this n] (swap! sizes conj n) this)
+    (first [_] probe-doc)
+    (cursor [_] (make-mongo-cursor []))))
+
+(deftest ^:parallel byte-budgeted-batch-size-test
+  (testing "budgeted-batch-size clamps batchSize to [1, default] from a measured per-document size"
+    (let [bbs @#'mongo.execute/budgeted-batch-size
+          mb  (* 1024 1024)]
+      (is (= 100 (bbs (* 4 mb) 40))      "tiny doc -> default max batch")
+      (is (= 4   (bbs (* 4 mb) mb))      "1MB doc, 4MB budget -> 4 per batch")
+      (is (= 1   (bbs mb (* 50 mb)))     "doc larger than the whole budget -> 1 per batch")))
+  (let [heavy (doto (org.bson.Document.) (.put "blob" (apply str (repeat 2000000 \x))))] ; ~2MB document
+    (testing "every read pipeline is byte-budgeted: probe at batchSize 1, then a small batch for a heavy doc"
+      (let [sizes (atom [])]
+        (binding [mongo.execute/*batch-byte-budget* (* 4 1024 1024)]
+          (#'mongo.execute/apply-byte-budgeted-batch-size! (recording-aggregate-iterable heavy sizes) [{"$match" {}}]))
+        (is (= [1 2] @sizes) "4MB budget / ~2MB doc -> batchSize 2")))
+    (testing "$out/$merge write pipelines are not probed (the probe would execute the write twice)"
+      (let [sizes (atom [])]
+        (#'mongo.execute/apply-byte-budgeted-batch-size! (recording-aggregate-iterable heavy sizes) [{"$out" "dest"}])
+        (is (= [] @sizes))))))
 
 (deftest ^:parallel field-filter-relative-time-native-test
   (mt/test-driver :mongo


### PR DESCRIPTION
BigQuery - follow the `sample-table`, real adaptive sliding window-style page size
Mongo - based on the projected fields count; max the current default size `100`