### PR TITLE
Add valkey as cache backend

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -86,6 +86,7 @@
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
+  io.lettuce/lettuce-core                   {:mvn/version "6.7.1.RELEASE"}      ; Redis/Valkey protocol client for QP cache backend
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -2857,7 +2857,35 @@ See [Observability with Prometheus](../installation-and-operation/observability-
 Type: string<br>
 Default: `"db"`
 
-Current cache backend. Dynamically rebindable primarily for test purposes.
+Current query processor cache backend. Supported values are `db` and `valkey`.
+
+### `MB_QP_CACHE_VALKEY_COMMAND_TIMEOUT_MS`
+
+Type: integer<br>
+Default: `5000`
+
+Command timeout, in milliseconds, for the Valkey query processor cache backend.
+
+### `MB_QP_CACHE_VALKEY_CONNECT_TIMEOUT_MS`
+
+Type: integer<br>
+Default: `5000`
+
+Connection timeout, in milliseconds, for the Valkey query processor cache backend.
+
+### `MB_QP_CACHE_VALKEY_KEY_PREFIX`
+
+Type: string<br>
+Default: `"metabase:qp-cache:"`
+
+Key prefix used by the Valkey query processor cache backend. Use a unique prefix when multiple Metabase instances share the same Valkey database.
+
+### `MB_QP_CACHE_VALKEY_URI`
+
+Type: string<br>
+Default: `"redis://localhost:6379"`
+
+Valkey or Redis-compatible URI for the query processor cache backend. Use `rediss://` for TLS; username, password, host, port, and database can be supplied in the URI.
 
 ### `MB_SETUP_TOKEN`
 
@@ -2889,4 +2917,3 @@ Type: string<br>
 Default: `null`
 
 Base-64 encoded public key for this sites SSL certificate. Specify this to enable HTTP Public Key Pinning. Using HPKP is no longer recommended. See http://mzl.la/1EnfqBf for more information.
-

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -492,7 +492,35 @@ See [Observability with Prometheus](../installation-and-operation/observability-
 Type: string<br>
 Default: `"db"`
 
-Current cache backend. Dynamically rebindable primarily for test purposes.
+Current query processor cache backend. Supported values are `db` and `valkey`.
+
+### `MB_QP_CACHE_VALKEY_COMMAND_TIMEOUT_MS`
+
+Type: integer<br>
+Default: `5000`
+
+Command timeout, in milliseconds, for the Valkey query processor cache backend.
+
+### `MB_QP_CACHE_VALKEY_CONNECT_TIMEOUT_MS`
+
+Type: integer<br>
+Default: `5000`
+
+Connection timeout, in milliseconds, for the Valkey query processor cache backend.
+
+### `MB_QP_CACHE_VALKEY_KEY_PREFIX`
+
+Type: string<br>
+Default: `"metabase:qp-cache:"`
+
+Key prefix used by the Valkey query processor cache backend. Use a unique prefix when multiple Metabase instances share the same Valkey database.
+
+### `MB_QP_CACHE_VALKEY_URI`
+
+Type: string<br>
+Default: `"redis://localhost:6379"`
+
+Valkey or Redis-compatible URI for the query processor cache backend. Use `rediss://` for TLS; username, password, host, port, and database can be supplied in the URI.
 
 ### `MB_SETUP_TOKEN`
 

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -63,6 +63,10 @@
    :mb-emoji-in-logs                (str (not is-windows?)) ; disable them by default when running on Windows. Otherwise they're enabled
    :mb-log-team-attribution         "false"
    :mb-qp-cache-backend             "db"
+   :mb-qp-cache-valkey-command-timeout-ms "5000"
+   :mb-qp-cache-valkey-connect-timeout-ms "5000"
+   :mb-qp-cache-valkey-key-prefix   "metabase:qp-cache:"
+   :mb-qp-cache-valkey-uri          "redis://localhost:6379"
    :mb-jetty-async-response-timeout (str (* 10 60 1000)) ; 10m
    :mb-monitor-performance           ""
    :mb-monitor-performance-save-rate ""})

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -18,6 +18,7 @@
    [metabase.lib.core :as lib]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
+   [metabase.query-processor.middleware.cache-backend.valkey :as backend.valkey]
    [metabase.query-processor.middleware.cache.impl :as impl]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
@@ -32,7 +33,8 @@
 
 (set! *warn-on-reflection* true)
 
-(comment backend.db/keep-me)
+(comment backend.db/keep-me
+         backend.valkey/keep-me)
 
 (def ^:private cache-version
   "Current serialization format version. Basically

--- a/src/metabase/query_processor/middleware/cache_backend/valkey.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/valkey.clj
@@ -1,0 +1,183 @@
+(ns metabase.query-processor.middleware.cache-backend.valkey
+  "Valkey/Redis-protocol Query Processor cache backend."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [java-time.api :as t]
+   [metabase.cache.core :as cache]
+   [metabase.config.core :as config]
+   [metabase.query-processor.middleware.cache-backend.interface :as i]
+   [metabase.util.encryption :as encryption]
+   [metabase.util.log :as log])
+  (:import
+   (io.lettuce.core ClientOptions RedisClient RedisURI ScanArgs ScanCursor SetArgs SocketOptions)
+   (io.lettuce.core.api StatefulRedisConnection)
+   (io.lettuce.core.api.sync RedisCommands)
+   (io.lettuce.core.codec ByteArrayCodec)
+   (java.io ByteArrayInputStream Closeable)
+   (java.nio.charset StandardCharsets)
+   (java.time Duration Instant)
+   (java.util HashMap)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private byte-array-class
+  (Class/forName "[B"))
+
+(defn- utf8-bytes
+  ^bytes [^String s]
+  (.getBytes s StandardCharsets/UTF_8))
+
+(defn- utf8-string
+  ^String [^bytes bs]
+  (String. bs StandardCharsets/UTF_8))
+
+(defn- hex-hash
+  [^bytes b]
+  (codecs/bytes->hex b))
+
+(def ^:private ^bytes results-field
+  (utf8-bytes "results"))
+
+(def ^:private ^bytes updated-at-field
+  (utf8-bytes "updated_at"))
+
+(defn- entry-key-prefix
+  ^String [^String key-prefix]
+  (str key-prefix "entry:"))
+
+(defn- lease-key-prefix
+  ^String [^String key-prefix]
+  (str key-prefix "lease:"))
+
+(defn- entry-key
+  ^bytes [^String key-prefix ^bytes query-hash]
+  (utf8-bytes (str (entry-key-prefix key-prefix) (hex-hash query-hash))))
+
+(defn- lease-key
+  ^bytes [^String key-prefix ^bytes query-hash]
+  (utf8-bytes (str (lease-key-prefix key-prefix) (hex-hash query-hash))))
+
+(defn- key-array
+  [keys]
+  (into-array byte-array-class keys))
+
+(defn- long-bytes
+  ^bytes [n]
+  (utf8-bytes (str n)))
+
+(defn- bytes->instant
+  ^Instant [^bytes bs]
+  (Instant/ofEpochMilli (Long/parseLong (utf8-string bs))))
+
+(defn- now-ms []
+  (t/to-millis-from-epoch (t/instant)))
+
+(defn- max-entry-age-seconds []
+  (max 1 (long (Math/ceil (double (cache/query-caching-max-ttl))))))
+
+(defn- make-client
+  ^RedisClient []
+  (let [command-timeout (Duration/ofMillis (config/config-long :mb-qp-cache-valkey-command-timeout-ms))
+        connect-timeout (Duration/ofMillis (config/config-long :mb-qp-cache-valkey-connect-timeout-ms))
+        uri             (doto (RedisURI/create ^String (config/config-str :mb-qp-cache-valkey-uri))
+                          (.setTimeout command-timeout))
+        socket-options  (-> (SocketOptions/builder)
+                            (.connectTimeout connect-timeout)
+                            (.build))
+        client-options  (-> (ClientOptions/builder)
+                            (.socketOptions socket-options)
+                            (.build))
+        client          (RedisClient/create ^RedisURI uri)]
+    (.setOptions client client-options)
+    client))
+
+(defn- commands
+  ^RedisCommands [connection]
+  (.sync ^StatefulRedisConnection @connection))
+
+(defn- save-results!
+  [commands key-prefix ^bytes query-hash ^bytes results]
+  (log/debugf "Caching results for query with hash %s in Valkey." (pr-str (i/short-hex-hash query-hash)))
+  (let [final-results (encryption/maybe-encrypt-for-stream results)
+        cache-key     (entry-key key-prefix query-hash)
+        lease-key     (lease-key key-prefix query-hash)
+        timestamp     (long-bytes (now-ms))
+        fields        (doto (HashMap.)
+                        (.put results-field final-results)
+                        (.put updated-at-field timestamp))]
+    (.hset ^RedisCommands commands cache-key fields)
+    (.expire ^RedisCommands commands cache-key (long (max-entry-age-seconds)))
+    (.del ^RedisCommands commands (key-array [lease-key]))
+    nil))
+
+(defn- scan-args-for-pattern
+  ^ScanArgs [^String pattern]
+  (doto (ScanArgs.)
+    (.match pattern)
+    (.limit 1000)))
+
+(defn- scan-args
+  ^ScanArgs [^String key-prefix]
+  (scan-args-for-pattern (str (entry-key-prefix key-prefix) "*")))
+
+(defn- purge-old-entries!
+  [commands key-prefix max-age-seconds]
+  {:pre [(number? max-age-seconds)]}
+  (let [cutoff (Instant/ofEpochMilli (- (now-ms) (long (* 1000 max-age-seconds))))
+        args   (scan-args key-prefix)]
+    (loop [cursor ScanCursor/INITIAL]
+      (let [scan-cursor (.scan ^RedisCommands commands cursor args)
+            old-keys    (for [cache-key (.getKeys scan-cursor)
+                              :let      [updated-at (.hget ^RedisCommands commands cache-key updated-at-field)]
+                              :when     (and updated-at (.isBefore (bytes->instant updated-at) cutoff))]
+                          cache-key)]
+        (when (seq old-keys)
+          (.del ^RedisCommands commands (key-array old-keys)))
+        (when-not (.isFinished scan-cursor)
+          (recur scan-cursor)))))
+  nil)
+
+(defn- try-acquire-refresh-lease!
+  [commands key-prefix query-hash lease-ms]
+  (let [lease-key (lease-key key-prefix query-hash)]
+    (when-not (pos? lease-ms)
+      (.del ^RedisCommands commands (key-array [lease-key])))
+    (boolean
+     (.set ^RedisCommands commands
+           lease-key
+           (utf8-bytes (str (random-uuid)))
+           (doto (SetArgs.)
+             (.nx)
+             (.px (max 1 (long lease-ms))))))))
+
+(defmethod i/cache-backend :valkey
+  [_]
+  (let [client     (delay (make-client))
+        connection (delay (.connect ^RedisClient @client ByteArrayCodec/INSTANCE))
+        key-prefix (config/config-str :mb-qp-cache-valkey-key-prefix)]
+    (reify i/CacheBackend
+      (cached-results [_ query-hash respond]
+        (let [commands   (commands connection)
+              cache-key  (entry-key key-prefix query-hash)
+              results    (.hget ^RedisCommands commands cache-key results-field)
+              updated-at (.hget ^RedisCommands commands cache-key updated-at-field)]
+          (if (and results updated-at)
+            (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. results))]
+              (respond is (bytes->instant updated-at)))
+            (respond nil nil))))
+
+      (save-results! [_ query-hash results]
+        (save-results! (commands connection) key-prefix query-hash results))
+
+      (purge-old-entries! [_ max-age-seconds]
+        (purge-old-entries! (commands connection) key-prefix max-age-seconds))
+
+      (try-acquire-refresh-lease! [_ query-hash lease-ms]
+        (try-acquire-refresh-lease! (commands connection) key-prefix query-hash lease-ms))
+
+      Closeable
+      (close [_]
+        (when (realized? connection)
+          (.close ^StatefulRedisConnection @connection))
+        (when (realized? client)
+          (.shutdown ^RedisClient @client))))))

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -6,13 +6,21 @@
    [clojure.test :refer :all]
    [metabase.app-db.core :as mdb]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
+   [metabase.query-processor.middleware.cache-backend.test-util :as backend.tu]
    [metabase.test :as mt]
-   [metabase.util.encryption-test :as encryption-test])
+   [metabase.test.initialize :as initialize]
+   [metabase.util.encryption-test :as encryption-test]
+   [toucan2.core :as t2])
   (:import
    (java.sql Connection)
    (java.util.concurrent CountDownLatch TimeUnit)))
 
 (set! *warn-on-reflection* true)
+
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
+(use-fixtures :once (fn [thunk]
+                      (initialize/initialize-if-needed! :db)
+                      (thunk)))
 
 (defn- cache-results
   "Get the stored value from the query_cache"
@@ -80,3 +88,11 @@
               (testing "no \"Error saving query results to cache.\" should be logged"
                 (is (empty? (filter #(some-> % :message (str/includes? "Error saving query results to cache"))
                                     (messages))))))))))))
+
+(deftest query-cache-behavior-test
+  (testing "DB backend supports the shared query-cache middleware behavior"
+    (t2/delete! :model/QueryCache)
+    (try
+      (backend.tu/assert-query-cache-behavior! (i/cache-backend :db))
+      (finally
+        (t2/delete! :model/QueryCache)))))

--- a/test/metabase/query_processor/middleware/cache_backend/test_util.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/test_util.clj
@@ -1,0 +1,170 @@
+(ns metabase.query-processor.middleware.cache-backend.test-util
+  "Shared query-cache behavior tests for concrete cache backends."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.driver.settings :as driver.settings]
+   [metabase.query-processor.middleware.cache :as cache]
+   [metabase.query-processor.middleware.cache-backend.interface :as i]
+   [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.query-processor.reducible :as qp.reducible]
+   [metabase.query-processor.util :as qp.util]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^:dynamic *query-token*
+  nil)
+
+(def ^:private ^:dynamic ^Long *query-execution-delay-ms*
+  10)
+
+(def ^:private ^:dynamic *query-caching-min-ttl*
+  0)
+
+(def ^:private ^:dynamic *rows*
+  [[:toucan      71]
+   [:bald-eagle  92]
+   [:hummingbird 11]
+   [:owl         10]
+   [:chicken     69]
+   [:robin       96]
+   [:osprey      72]
+   [:flamingo    70]])
+
+(defn- ttl-strategy []
+  {:type             :ttl
+   :multiplier       60
+   :avg-execution-ms 1000
+   :min-duration-ms  *query-caching-min-ttl*})
+
+(defn- stage
+  [test-case]
+  {:lib/type                :mbql.stage/mbql
+   :source-table            2
+   :cache-backend-test-token *query-token*
+   :cache-backend-test-case  test-case})
+
+(defn- test-query
+  [test-case query-kvs]
+  (merge {:cache-strategy (ttl-strategy)
+          :lib/type       :mbql/query
+          :database       1
+          :stages         [(stage test-case)]}
+         query-kvs))
+
+(defn- run-query*
+  [test-case & {:as query-kvs}]
+  (let [qp       (cache/maybe-return-cached-results qp.pipeline/*run*)
+        metadata {}
+        rows     *rows*
+        query    (test-query test-case query-kvs)]
+    (binding [driver.settings/*query-timeout-ms* 2000
+              qp.pipeline/*execute*             (fn [_driver _query respond]
+                                                  (Thread/sleep *query-execution-delay-ms*)
+                                                  (respond metadata rows))]
+      (driver/with-driver :h2
+        (-> (qp query qp.reducible/default-rff)
+            (assoc :data {}))))))
+
+(defn- run-query
+  [test-case & args]
+  (let [result (apply run-query* test-case args)]
+    (is (= :completed
+           (:status result)))
+    (if (:cached (:cache/details result))
+      :cached
+      :not-cached)))
+
+(defn- query-hash
+  [test-case & {:as query-kvs}]
+  (qp.util/query-hash (test-query test-case query-kvs)))
+
+(defn assert-query-cache-behavior!
+  "Run the same query-cache middleware behavior checks against `backend`."
+  [backend]
+  (let [token (str (random-uuid))]
+    (binding [cache/*backend* backend
+              *query-token*   token]
+      (mt/with-temporary-setting-values [query-caching-max-ttl     60
+                                         synchronous-batch-updates true]
+        (testing "cache miss then cache hit"
+          (is (= :not-cached
+                 (run-query :hit)))
+          (is (= :cached
+                 (run-query :hit))))
+        (testing "a query that returns no rows is cached"
+          (binding [*rows* []]
+            (is (= :not-cached
+                   (run-query :empty-results)))
+            (is (= :cached
+                   (run-query :empty-results)))))
+        (testing "expired results are recomputed"
+          (let [strategy (assoc (ttl-strategy) :multiplier 0.1)]
+            (is (= :not-cached
+                   (run-query :expired :cache-strategy strategy)))
+            (Thread/sleep 200)
+            (is (= :not-cached
+                   (run-query :expired :cache-strategy strategy)))))
+        (testing "expired results are served stale while another process holds the refresh lease"
+          (let [strategy   (assoc (ttl-strategy) :multiplier 0.1)
+                query-hash (query-hash :stale :cache-strategy strategy)]
+            (is (= :not-cached
+                   (run-query :stale :cache-strategy strategy)))
+            (Thread/sleep 200)
+            (is (true?
+                 (i/try-acquire-refresh-lease! backend query-hash 600000)))
+            (is (= :cached
+                   (run-query :stale :cache-strategy strategy)))))
+        (testing "ignore-cached-results? skips reading a cached entry"
+          (is (= :not-cached
+                 (run-query :ignore-read :middleware {:ignore-cached-results? false})))
+          (is (= :not-cached
+                 (run-query :ignore-read :middleware {:ignore-cached-results? true}))))
+        (testing "ignore-cached-results? still saves results for later"
+          (is (= :not-cached
+                 (run-query :ignore-save :middleware {:ignore-cached-results? true})))
+          (is (= :cached
+                 (run-query :ignore-save))))
+        (testing "min TTL prevents fast queries from being cached"
+          (binding [*query-caching-min-ttl* 1000]
+            (is (= :not-cached
+                   (run-query :min-ttl)))
+            (is (= :not-cached
+                   (run-query :min-ttl)))))
+        (testing "queries longer than min TTL are cached"
+          (binding [*query-caching-min-ttl* 0.1]
+            (is (= :not-cached
+                   (run-query :min-ttl-eligible)))
+            (is (= :cached
+                   (run-query :min-ttl-eligible)))))
+        (testing "invalid cache entries are treated as misses"
+          (let [query-hash (query-hash :invalid)]
+            (is (= :not-cached
+                   (run-query :invalid)))
+            (is (true?
+                 (i/cached-results backend query-hash
+                                   (fn [is _updated-at] (some? is)))))
+            (i/save-results! backend query-hash (byte-array [0 0 0]))
+            (is (= :not-cached
+                   (run-query :invalid)))))
+        (testing "cache hit metadata is returned"
+          (mt/with-clock #t "2020-02-19T02:31:07.798Z[UTC]"
+            (is (= :not-cached
+                   (run-query :metadata)))
+            (let [result (run-query* :metadata)]
+              (is (=? {:data          {}
+                       :cache/details {:cached     true
+                                       :updated_at some?
+                                       :cache-hash some?}
+                       :row_count     8
+                       :status        :completed}
+                      result))
+              (is (bytes? (get-in result [:cache/details :hash]))))))
+        (testing "manual purge of old entries makes the next run miss"
+          (is (= :not-cached
+                 (run-query :purge)))
+          (Thread/sleep 50)
+          (i/purge-old-entries! backend 0)
+          (is (= :not-cached
+                 (run-query :purge))))))))

--- a/test/metabase/query_processor/middleware/cache_backend/valkey_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/valkey_test.clj
@@ -1,0 +1,168 @@
+(ns metabase.query-processor.middleware.cache-backend.valkey-test
+  "Integration tests for the Valkey Query Processor cache backend.
+
+  These tests use the production Valkey configuration path, which defaults to redis://localhost:6379."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [clojure.test :refer :all]
+   [metabase.cache.core :as cache]
+   [metabase.config.core :as config]
+   [metabase.query-processor.middleware.cache-backend.interface :as i]
+   [metabase.query-processor.middleware.cache-backend.test-util :as backend.tu]
+   [metabase.query-processor.middleware.cache-backend.valkey]
+   [metabase.test :as mt]
+   [metabase.test.initialize :as initialize]
+   [metabase.util.encryption-test :as encryption-test])
+  (:import
+   (io.lettuce.core RedisClient RedisURI ScanArgs ScanCursor)
+   (io.lettuce.core.api StatefulRedisConnection)
+   (io.lettuce.core.api.sync RedisCommands)
+   (io.lettuce.core.codec ByteArrayCodec)
+   (java.io Closeable InputStream)
+   (java.nio.charset StandardCharsets)
+   (java.time Instant)))
+
+(set! *warn-on-reflection* true)
+
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
+(use-fixtures :once (fn [thunk]
+                      (initialize/initialize-if-needed! :db)
+                      (thunk)))
+
+(def ^:private byte-array-class
+  (Class/forName "[B"))
+
+(defn- key-array
+  [keys]
+  (into-array byte-array-class keys))
+
+(defn- query-hash
+  ^bytes [^String s]
+  (let [source (.getBytes s StandardCharsets/UTF_8)
+        result (byte-array 32)]
+    (System/arraycopy source 0 result 0 (min (alength source) (alength result)))
+    result))
+
+(defn- cached-result
+  [backend query-hash]
+  (i/with-cached-results backend query-hash [is updated-at]
+                         (when is
+                           {:results    (.readAllBytes ^InputStream is)
+                            :updated-at updated-at})))
+
+(defn- cached-string
+  [backend query-hash]
+  (some-> (cached-result backend query-hash) :results codecs/bytes->str))
+
+(defn- scan-args-for-pattern
+  ^ScanArgs [^String pattern]
+  (doto (ScanArgs.)
+    (.match pattern)
+    (.limit 1000)))
+
+(defn- delete-matching-test-keys!
+  [commands pattern]
+  (let [args (scan-args-for-pattern pattern)]
+    (loop [cursor ScanCursor/INITIAL]
+      (let [scan-cursor (.scan ^RedisCommands commands cursor args)
+            keys        (.getKeys scan-cursor)]
+        (when (seq keys)
+          (.del ^RedisCommands commands (key-array keys)))
+        (when-not (.isFinished scan-cursor)
+          (recur scan-cursor))))))
+
+(defn- clear-test-prefix!
+  [commands prefix]
+  (delete-matching-test-keys! commands (str prefix "entry:*"))
+  (delete-matching-test-keys! commands (str prefix "lease:*")))
+
+(defn- do-with-valkey-backend!
+  [f]
+  (let [prefix              (str "metabase:test:qp-cache:" (random-uuid) ":")
+        original-config-str config/config-str]
+    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+    (with-redefs [config/config-str (fn [k]
+                                      (case (keyword k)
+                                        :mb-qp-cache-valkey-key-prefix prefix
+                                        (original-config-str k)))]
+      (let [client     (RedisClient/create ^RedisURI (RedisURI/create ^String (config/config-str :mb-qp-cache-valkey-uri)))
+            connection (.connect ^RedisClient client ByteArrayCodec/INSTANCE)
+            commands   (.sync ^StatefulRedisConnection connection)
+            backend    (i/cache-backend :valkey)]
+        (try
+          (clear-test-prefix! commands prefix)
+          (f backend)
+          (finally
+            (try
+              (clear-test-prefix! commands prefix)
+              (finally
+                (.close ^Closeable backend)
+                (.close ^StatefulRedisConnection connection)
+                (.shutdown ^RedisClient client)))))))))
+
+(deftest ^:mb/once save-read-overwrite-and-binary-test
+  (do-with-valkey-backend!
+   (fn [backend]
+     (encryption-test/with-secret-key nil
+       (let [hash-1  (query-hash "valkey-contract-1")
+             hash-2  (query-hash "valkey-contract-2")
+             binary  (byte-array (map byte (range -32 32)))]
+         (testing "Cache miss"
+           (is (nil? (cached-result backend hash-1))))
+         (i/save-results! backend hash-1 (codecs/to-bytes "cache-value-A"))
+         (is (= "cache-value-A"
+                (cached-string backend hash-1)))
+         (is (instance? Instant (:updated-at (cached-result backend hash-1))))
+         (i/save-results! backend hash-1 (codecs/to-bytes "cache-value-B"))
+         (is (= "cache-value-B"
+                (cached-string backend hash-1)))
+         (i/save-results! backend hash-2 binary)
+         (is (= (vec binary)
+                (vec (:results (cached-result backend hash-2))))))))))
+
+(deftest ^:mb/once query-cache-behavior-test
+  (testing "Valkey backend supports the same shared query-cache middleware behavior as the DB backend"
+    (do-with-valkey-backend!
+     backend.tu/assert-query-cache-behavior!)))
+
+(deftest ^:mb/once ttl-and-purge-test
+  (do-with-valkey-backend!
+   (fn [backend]
+     (encryption-test/with-secret-key nil
+       (testing "Entries expire using Valkey's native key TTL"
+         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+         (with-redefs [cache/query-caching-max-ttl (constantly 1)]
+           (let [query-hash (query-hash "valkey-ttl")]
+             (i/save-results! backend query-hash (codecs/to-bytes "short-lived"))
+             (is (= "short-lived"
+                    (cached-string backend query-hash)))
+             (Thread/sleep 1500)
+             (is (nil? (cached-result backend query-hash)))))))
+     (encryption-test/with-secret-key nil
+       (testing "Manual purge deletes entries older than the supplied age"
+         (let [query-hash (query-hash "valkey-purge")]
+           (i/save-results! backend query-hash (codecs/to-bytes "old"))
+           (Thread/sleep 50)
+           (i/purge-old-entries! backend 0)
+           (is (nil? (cached-result backend query-hash)))))))))
+
+(deftest ^:mb/once encryption-round-trip-test
+  (do-with-valkey-backend!
+   (fn [backend]
+     (encryption-test/with-secret-key "key1"
+       (let [query-hash (query-hash "valkey-encrypted")]
+         (i/save-results! backend query-hash (codecs/to-bytes "encrypted-cache-value"))
+         (is (= "encrypted-cache-value"
+                (cached-string backend query-hash))))))))
+
+(deftest ^:mb/once refresh-lease-test
+  (do-with-valkey-backend!
+   (fn [backend]
+     (let [query-hash (query-hash "valkey-refresh-lease")]
+       (testing "Only one concurrent caller wins the refresh lease"
+         (let [wins (mt/repeat-concurrently 8 #(i/try-acquire-refresh-lease! backend query-hash 10000))]
+           (is (= 1 (count (filter true? wins))))))
+       (testing "The lease is held until save-results! releases it"
+         (is (false? (i/try-acquire-refresh-lease! backend query-hash 10000)))
+         (i/save-results! backend query-hash (codecs/to-bytes "fresh"))
+         (is (true? (i/try-acquire-refresh-lease! backend query-hash 10000))))))))


### PR DESCRIPTION
See if this passes the tests, but just to start, this will reduce app db pressure on metabase with massive traffic

EDIT: left an agent all night doing performance testing


Metric | DB Backend | Valkey Backend | Δ
-- | -- | -- | --
c3p0 busy app-DB connections — avg | 9.3 | 3.1 | −67%
c3p0 busy app-DB connections — peak | 34 (51¹) | 6 (7¹) | −82% (−86%¹)
c3p0 total app-DB pool | 500 | 500 | 0²
real PG backends (xchk) | ~502 | ~502 | 0²
Metabase CPU — avg cores (/4) | 3.61 | 3.17 | −12%
throughput — Jetty req/s | 368 | 415 | +13%
card-query latency — p95 | 102 ms | 43 ms | −58%
CPU per request (core·ms/req) | 9.8 | 7.6 | −22%
errors | 0% | 0% | —

Results: 40 VUs, 4-minute hold, Metabase capped at 4 cores.

Notes

Instantaneous peak.
The c3p0 pool grows to its cap on ramp-up bursts and doesn't shrink mid-run, so total stays pinned at the configured max for both backends. Busy connections are the meaningful connection-pressure signal. The DB row was confirmed by a repeat run (busy 7.25, peak 24, CPU 3.62).

Fixes https://github.com/metabase/metabase/issues/10129