### PR TITLE
Do not fingerprint MongoDB binary blobs

### DIFF
--- a/src/metabase/types/core.cljc
+++ b/src/metabase/types/core.cljc
@@ -288,6 +288,9 @@
 (derive :type/TextLike :type/*)
 (derive :type/MongoBSONID :type/TextLike)
 (derive :type/MongoBinData :type/TextLike)
+;; binData holds arbitrary binary blobs (files, images, encrypted data) that aren't text-truncated by the sampler, so
+;; fingerprinting them (sampling the full values) can use enormous amounts of memory for no useful result.
+(derive :type/MongoBinData :type/fingerprint-unsupported)
 (derive :type/MySQLEnum :type/Text)
 ;; IP address can be either a data type e.g. Postgres `inet` or a semantic type e.g. a `text` column that has IP
 ;; addresses

--- a/test/metabase/types/core_test.cljc
+++ b/test/metabase/types/core_test.cljc
@@ -14,6 +14,10 @@
     (is (isa? :type/Name :type/Text))
     (is (types/assignable? :type/Name :type/Text))))
 
+(deftest ^:parallel mongo-bindata-fingerprint-unsupported-test
+  (testing "binData holds large binary blobs, which must not be fingerprinted (sampling full values OOMs sync)"
+    (is (isa? :type/MongoBinData :type/fingerprint-unsupported))))
+
 (deftest ^:parallel most-specific-common-ancestor-test
   (are [x y expected] (= expected
                          (types/most-specific-common-ancestor x        y)


### PR DESCRIPTION
3 binData fields 2 MB each -> 2 GB JVM heap -> OOM