### PR TITLE
Bundle sizes stats fix

### DIFF
--- a/.github/scripts/csv-to-mb.js
+++ b/.github/scripts/csv-to-mb.js
@@ -19,23 +19,23 @@ function jsonToCsvFormData(jsonData) {
   return formData;
 }
 
-function uploadCsvToMb({ baseUrl, tableId, jsonData, mode = 'append' }) {
+async function uploadCsvToMb({ baseUrl, tableId, jsonData, mode = 'append' }) {
   const formData = jsonToCsvFormData(jsonData);
   const operation = mode === 'replace' ? 'replace-csv' : 'append-csv';
 
-  return fetch(`${baseUrl}/api/table/${tableId}/${operation}`, {
+  const response = await fetch(`${baseUrl}/api/table/${tableId}/${operation}`, {
     method: 'POST',
     headers: {
       "x-api-key": process.env.API_KEY
     },
     body: formData
-  })
-  .then(response => {
-    if (!response.ok) {
-      throw new Error(`Upload failed`);
-    }
-    return { success: true };
   });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Upload failed: ${response.status} ${response.statusText} ${body}`.trim());
+  }
+  return { success: true };
 }
 
 module.exports = { uploadCsvToMb };

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -96,11 +96,13 @@ jobs:
             const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
             const commit = process.env.HEAD_SHA.slice(0, 12);
 
-            // version.properties (extracted from the uberjar) carries the build's tag
+            // version.properties (extracted from the uberjar) carries the build's tag.
+            // Non-release (master) builds report tag=vUNKNOWN, so leave Version empty there.
             const versionProps = "${{ github.workspace }}/artifacts/version.properties";
-            const version = fs.existsSync(versionProps)
+            const rawVersion = fs.existsSync(versionProps)
               ? (fs.readFileSync(versionProps, "utf8").match(/^tag=(.*)$/m)?.[1]?.trim() ?? "")
               : "";
+            const version = rawVersion === "vUNKNOWN" ? "" : rawVersion;
 
             const data = measurements.map(measurement => ({
               "Date": date,

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -118,7 +118,7 @@ jobs:
 
             uploadCsvToMb({
               baseUrl: "https://stats.metabase.com",
-              tableId: 40009,
+              tableId: 79417,
               jsonData: data,
               mode: "append",
             }).then(() => {


### PR DESCRIPTION
Some small fixes to make the bundle stats workflow actually work.

Mainly, the current workflow is referencing the wrong table to upload to.

Also fixes the version column when the version is `vUNKNOWN`