### PR TITLE
Fix run query button icon being too small on large screens

### DIFF
--- a/frontend/src/metabase/querying/components/QueryVisualization/RunButton.module.css
+++ b/frontend/src/metabase/querying/components/QueryVisualization/RunButton.module.css
@@ -14,10 +14,6 @@
     border-color 200ms linear,
     background-color 200ms linear;
 
-  @media screen and (--breakpoint-min-lg) {
-    padding: 0.75rem 1rem;
-  }
-
   &:hover {
     color: var(--mb-color-text-brand);
     background: var(--mb-color-background-secondary);


### PR DESCRIPTION
Closes [GDGT-2655](https://linear.app/metabase/issue/GDGT-2655)

### Description

Previously, the run/refresh button in the query editor applied an extra `padding: 0.75rem 1rem` override at the large breakpoint (`--breakpoint-min-lg`). Because the icon itself stays a fixed size, the inflated padding made the button balloon around the icon, so the icon looked too small on wider viewports.

Removed the large-breakpoint padding override in `RunButton.module.css` so the button keeps its default, tighter padding across all viewport widths and the icon reads at its intended size.

This is a pure CSS/visual fix with no straightforward regression test, so tests are waived for this PR.

### How to verify

1. Open a question in the query editor (native or notebook) on a wide screen (≥ large breakpoint).
2. Look at the run/refresh button next to the visualization.
3. The icon should look appropriately sized — the button hugs the icon instead of having oversized padding around it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR