### PR TITLE
Use entity id in questionCollections when generating typed schemas

### DIFF
--- a/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/.claude/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -34,7 +34,7 @@ Before generating, make sure the user has explicitly chosen the scopes the app n
   - `includeMetricLibrary=true` for the whole `Library / Metrics` tree
   - `libraryCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data/Metrics library subcollections.
 - Saved question scope:
-  - `questionCollections=<collection-id>[,<collection-id>]` for saved questions from normal collections.
+  - `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` for saved questions from normal collections.
 
 If the user did not already choose a library scope and/or saved question scope, stop and ask what they want:
 
@@ -46,11 +46,12 @@ If the current working tree looks like a Metabase remote-sync repository, inspec
 - `collections/main/library/data.yaml` and `collections/main/library/metrics.yaml` are the top-level Data and Metrics library collections.
 - Child collection YAML under `collections/main/library/data/` or `collections/main/library/metrics/` exposes a stable `entity_id`; use that value in `libraryCollections` when a subcollection name could be ambiguous.
 - Table YAML under `databases/**/tables/**/<table>.yaml` can show `collection_id: librarylibrarydatadat` for tables directly in Data, or another collection `entity_id` for subcollections.
+- Normal collection YAML under `collections/main/**` exposes a stable `entity_id`; use that value in `questionCollections` when targeting saved questions or models from normal collections.
 - Card YAML under `collections/main/**` with `type: question`, `type: model`, or `type: metric` shows normal saved-question/model/metric placement.
 
 Correlate those representation files with the user's request and offer concrete choices.
 
-- Prefer representation `entity_id` values for specific library subcollections.
+- Prefer representation `entity_id` values for specific library subcollections and question collections.
 - Only use `includeDataLibrary=true` / `includeMetricLibrary=true` if the user agrees to include the whole data or metric library.
 - If you cannot tell from representations, say you do not know and ask for collection IDs or entity IDs.
 
@@ -92,7 +93,7 @@ fi
     -o src/metabase.data.ts \
     -H "x-api-key: $VITE_MB_API_KEY" \
     -H "Accept: text/typescript" \
-    "$VITE_MB_URL/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true&questionCollections=10,11"
+    "$VITE_MB_URL/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true&questionCollections=g-jLnamuHKdezZMthJ-z7"
 )
 ```
 
@@ -103,6 +104,7 @@ Other useful filters:
 - `?includeMetricLibrary=true` for every metric in the top-level Metrics library and its subcollections, plus mapped source tables needed by those metrics.
 - `?includeDataLibrary=true&includeMetricLibrary=true` for everything in both top-level semantic libraries.
 - `?includeDataLibrary=true&libraryCollections=g-jLnamuHKdezZMthJ-z7` for the whole Data library plus one specific library subcollection.
+- `?questionCollections=g-jLnamuHKdezZMthJ-z7` for saved questions and models from one normal collection, preferably using the collection `entity_id` from representation YAML.
 - No query parameters only when the user explicitly wants the whole instance.
 
 ## Standard Pattern

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -244,11 +244,6 @@
   (query-comma-separated-values query-params [:question-collections
                                               :questionCollections]))
 
-(defn- parse-collection-id
-  [collection-value]
-  (or (parse-id collection-value)
-      (api/check-400 false (format "Invalid collection id: %s" collection-value))))
-
 (defn- library-collection-for-value
   [library-value]
   (when library-value
@@ -277,17 +272,20 @@
        (filter mi/can-read?)
        first))
 
-(defn- collection-for-id
-  [collection-id]
-  (->> (t2/select :model/Collection :id collection-id)
-       (filter mi/can-read?)
-       first))
+(defn- collection-for-ref
+  [collection-value]
+  (let [collection-id (parse-id collection-value)]
+    (->> (if collection-id
+           (t2/select :model/Collection :id collection-id)
+           (t2/select :model/Collection :entity_id collection-value))
+         (filter mi/can-read?)
+         first)))
 
 (defn- collection-scope
   [collection-values]
   (when (seq collection-values)
     (let [collections (for [collection-value collection-values]
-                        (or (collection-for-id (parse-collection-id collection-value))
+                        (or (collection-for-ref collection-value)
                             (api/check-404 false)))]
       (->> collections
            (mapcat #(cons % (collection/descendants-flat %)))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -448,6 +448,16 @@
               (#'typed-schemas.api/query-question-collection-values
                {:question-collections (str (:id parent))})))))))
 
+(deftest question-collection-scope-accepts-representation-entity-ids-test
+  (mt/with-temp [:model/Collection parent {:name      "Question Parent"
+                                           :entity_id "question-entity-id-1"
+                                           :location  "/"}
+                 :model/Collection child  {:name "Question Child"
+                                           :location (collection/children-location parent)}]
+    (mt/with-test-user :crowberto
+      (is (= #{(:id parent) (:id child)}
+             (#'typed-schemas.api/collection-scope ["question-entity-id-1"]))))))
+
 (deftest library-schema-includes-metric-mapped-tables-test
   (let [selected-table-ids (atom nil)]
     (with-redefs [typed-schemas.api/library-collection-scope

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -458,6 +458,12 @@
       (is (= #{(:id parent) (:id child)}
              (#'typed-schemas.api/collection-scope ["question-entity-id-1"]))))))
 
+(deftest question-collection-scope-rejects-missing-collection-ref-test
+  (mt/with-test-user :crowberto
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (#'typed-schemas.api/collection-scope ["missing-entity-id-1"])))]
+      (is (= 404 (:status-code (ex-data e)))))))
+
 (deftest library-schema-includes-metric-mapped-tables-test
   (let [selected-table-ids (atom nil)]
     (with-redefs [typed-schemas.api/library-collection-scope


### PR DESCRIPTION
Closes EMB-1912

### Description

Typed schema generation now accepts collection entity IDs in `questionCollections`, matching the existing behavior for library collections. Numeric collection IDs still work, while non-numeric refs resolve through `collection.entity_id` before expanding the collection descendant scope.

The data app semantic-layer skill now guides agents to prefer representation `entity_id` values for `questionCollections`, especially when inspecting remote-sync YAML.

### How to verify

1. Find a collection's entity id. Make sure that collection has some questions.
2. Generate typed schemas with `questionCollections` set to a question collection's entity ID. Use the API key. Here's an example:

```bash
curl \
  -H "x-api-key: mb_...=" \
  -H "Accept: text/typescript" \
  -o metabase.data.ts \
  "http://localhost:3000/api/typed-schemas/v1/json?questionCollections=qDTKr-cDslIXIyJwenvZt"
```

3. Confirm questions (and models) from that collection are included in the schema under `metabase.data.ts`
4. Confirm numeric `questionCollections` value still work as a fallback, e.g. `?questionCollections=1,2` if collection ids are 1 and 2
5. Confirm a non-existing `questionCollections` entity ID returns a 404-style not-found error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
