### PR TITLE
Disambiguate singular "Year" granularity label to fix i18n template build

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import DashboardS from "metabase/css/dashboard.module.css";
 import { Box } from "metabase/ui";
@@ -263,7 +263,12 @@ const SmartScalarViz: VisualizationDefinition = {
         getProps: () => ({
           options: [
             { name: t`Full date`, value: "default" },
-            { name: t`Year`, value: "year" },
+            {
+              name: c(
+                "Date granularity option, distinct from the pluralized unit",
+              ).t`Year`,
+              value: "year",
+            },
             { name: t`Quarter and year`, value: "quarter" },
             { name: t`Month and year`, value: "month" },
           ],


### PR DESCRIPTION
The Trend (SmartScalar) viz date-granularity dropdown labels a `year` option with a bare singular `t`Year``. That collides with the pluralized `"Year"/"Years"` msgid emitted by `temporal_bucket.cljc` (`trun`) and `RelativeDateShortcutPicker/utils.ts` (`ngettext`): gettext forbids the same msgid appearing both with and without a plural, so `msgcat` fails the translation-template build with:

```
msgcat: msgid 'Year' is used without plural and with plural.
```

This only surfaces when the `verify-i18n-files` heavy job runs (gated on i18n-relevant file changes), which is why master can stay green on commits that touch no i18n strings.