### PR TITLE
Fix truncated and double-gzipped streaming responses

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -525,3 +525,15 @@
       (is (= "real_dir"
              (.getName ^File (#'api.serialization/find-serialization-dir dst))))
       (run! io/delete-file (reverse (file-seq dst))))))
+
+(deftest export-gzip-encoded-archive-is-complete-test
+  (testing "a gzip-encoded export download is a complete, non-truncated archive"
+    ;; Global (with-redefs) mode so the real Jetty handler threads see the feature, otherwise 402.
+    (mt/test-helpers-set-global-values!
+      (mt/with-premium-features #{:serialization}
+        ;; Needs a real request: the mock client hands the handler a plain ByteArrayOutputStream, so it
+        ;; never builds the GZIPOutputStream whose trailer is missing.
+        (let [resp (mt/user-real-request :crowberto :post 200 "ee/serialization/export"
+                                         {:request-options {:headers {"accept-encoding" "gzip"}
+                                                            :as      :byte-array}})]
+          (is (seq (entry-names resp))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -537,3 +537,18 @@
                                          {:request-options {:headers {"accept-encoding" "gzip"}
                                                             :as      :byte-array}})]
           (is (seq (entry-names resp))))))))
+
+(deftest export-is-not-gzipped-twice-test
+  (testing "the export is already a .tar.gz, so it is not gzip-encoded again at the transport layer"
+    (mt/test-helpers-set-global-values!
+      (mt/with-premium-features #{:serialization}
+        ;; Raw bytes off the wire, i.e. what `curl -H 'Accept-Encoding: gzip' -o export.tar.gz` saves.
+        (let [resp (mt/user-real-request-full-response
+                    :crowberto :post 200 "ee/serialization/export"
+                    {:request-options {:headers         {"accept-encoding" "gzip"}
+                                       :as              :byte-array
+                                       :decompress-body false}})]
+          (testing "no transport-level Content-Encoding is applied"
+            (is (nil? (get-in resp [:headers "content-encoding"]))))
+          (testing "the bytes on the wire are the archive itself, not another gzip layer around it"
+            (is (seq (entry-names (:body resp))))))))))

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -64,6 +64,11 @@
    response object may have been recycled and must not be touched."
   nil)
 
+(def ^:private ^:dynamic *errored?*
+  "An `AtomicBoolean` set to `true` once [[write-error!]] has handled an error. Error paths dispose of
+   the output stream themselves, so the worker thread uses this to decide whether to close it."
+  nil)
+
 (defn- async-context-completed?
   "Returns true if the async context has already been completed (by timeout, error, or worker thread).
    When true, the response object may have been recycled by Jetty and must not be touched."
@@ -181,6 +186,8 @@
   ([os obj export-format]
    (write-error! os obj export-format nil))
   ([^OutputStream os obj export-format status-code]
+   (when *errored?*
+     (.set ^AtomicBoolean *errored?* true))
    (cond
      (async-context-completed?)
      (log-skipped-error! obj)
@@ -239,7 +246,8 @@
   (let [task (^:once fn* []
                (binding [*response*   response
                          *request*    request
-                         *completed?* completed?]
+                         *completed?* completed?
+                         *errored?*   (AtomicBoolean. false)]
                  (try
                    (do-f* f os finished-chan canceled-chan)
                    (catch Throwable e
@@ -247,6 +255,11 @@
                      (a/>!! finished-chan :unexpected-error)
                      (write-error! os e nil))
                    (finally
+                     ;; A gzip trailer is only written on close, so a stream left open truncates the response.
+                     ;; Not on error paths: they close it themselves, and an aborted connection must stay
+                     ;; without a clean terminator.
+                     (when-not (.get ^AtomicBoolean *errored?*)
+                       (try (.close os) (catch Throwable _)))
                      ;; Clear the interrupted flag to prevent the thread from
                      ;; carrying stale interrupted state to the next task.
                      (Thread/interrupted)

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -1,6 +1,7 @@
 (ns metabase.server.streaming-response
   (:require
    [clojure.core.async :as a]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [compojure.response]
    [metabase.api.common.internal]
@@ -280,6 +281,19 @@
   [{{:strs [accept-encoding]} :headers}]
   (some->> accept-encoding (re-find #"gzip|\*")))
 
+(def ^:private already-compressed-content-types
+  #{"application/gzip" "application/x-gzip" "application/zip"})
+
+(defn- already-compressed-content-type?
+  "Is `content-type` already a compressed format? Gzipping it again just makes the client unwrap twice."
+  [content-type]
+  (boolean (some-> content-type
+                   (str/split #";")
+                   first
+                   str/trim
+                   u/lower-case-en
+                   already-compressed-content-types)))
+
 (defn- output-stream-delay [gzip? ^HttpServletResponse response]
   (if gzip?
     (delay
@@ -405,7 +419,8 @@
                     (onStartAsync [_ _event])))
     (try
       (.setStatus response (or status 202))
-      (let [gzip?   (should-gzip-response? request-map)
+      (let [gzip?   (and (should-gzip-response? request-map)
+                         (not (already-compressed-content-type? content-type)))
             headers (cond-> (assoc (merge headers (:headers response-map))
                                    "Content-Type" content-type
                                    ;; Very important: connections which serve streaming responses SHOULD NOT be reused
@@ -466,7 +481,9 @@
     this))
 
 (defn- render [^StreamingResponse streaming-response gzip?]
-  (let [{:keys [headers content-type], :as options} (.options streaming-response)]
+  (let [{:keys [headers content-type], :as options} (.options streaming-response)
+        gzip?                                       (and gzip?
+                                                         (not (already-compressed-content-type? content-type)))]
     (assoc (response/response (if gzip?
                                 (StreamingResponse. (.f streaming-response)
                                                     (assoc options :gzip? true)

--- a/test/metabase/server/streaming_response_test.clj
+++ b/test/metabase/server/streaming_response_test.clj
@@ -20,9 +20,10 @@
   (:import
    (jakarta.servlet AsyncContext ServletOutputStream)
    (jakarta.servlet.http HttpServletResponse)
-   (java.io ByteArrayOutputStream Closeable InputStream)
+   (java.io ByteArrayInputStream ByteArrayOutputStream Closeable InputStream)
    (java.util.concurrent CountDownLatch Executors Future TimeUnit)
    (java.util.concurrent.atomic AtomicBoolean)
+   (java.util.zip GZIPInputStream)
    (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
 
 (set! *warn-on-reflection* true)
@@ -229,6 +230,33 @@
           (is (thrown? Exception (consume))))
         (testing "no JSON error blob is appended to the body"
           (is (not (re-find #"boom" (try (second (consume)) (catch Exception _ ""))))))
+        (finally
+          (.stop server))))))
+
+(deftest gzip-encoded-response-is-not-truncated-test
+  (testing "a gzip-encoded streaming response is terminated so the client can read the whole body"
+    ;; Completing the async context closes the servlet stream but not the GZIPOutputStream wrapping it,
+    ;; and the trailer is only written on close. Needs a real server; the mock client never gzips.
+    (let [payload (apply str (repeat 200 "0123456789abcdefghij"))
+          handler (fn [req respond _raise]
+                    (respond
+                     (compojure.response/render
+                      (streaming-response/streaming-response {:content-type "text/csv"} [os _canceled-chan]
+                        (.write os (.getBytes payload "UTF-8")))
+                      req)))
+          server  (doto (server.instance/create-server handler {:port 0 :join? false})
+                    .start)
+          url     (str "http://localhost:" (.. server getURI getPort))]
+      (try
+        ;; clj-http otherwise decompresses and strips Content-Encoding, hiding whether gzip happened.
+        (let [res (http/request {:method :get, :url url, :as :byte-array
+                                 :decompress-body false
+                                 :headers {"accept-encoding" "gzip"}})]
+          (testing "the response really was gzip-encoded"
+            (is (= "gzip" (get-in res [:headers "content-encoding"]))))
+          (testing "the gzip stream is complete"
+            (is (= payload
+                   (slurp (GZIPInputStream. (ByteArrayInputStream. ^bytes (:body res))))))))
         (finally
           (.stop server))))))
 


### PR DESCRIPTION
Fixes #75165.

There are two independent bugs here, and the repro in the issue needs both fixed before it passes.

### 1. The transport gzip stream is never closed

`do-f-async` in `streaming_response.clj` doesn't close the output stream on the success path. Completing the Jetty async context closes the underlying servlet stream, but not the `GZIPOutputStream` that gets wrapped around it when the client sends `Accept-Encoding: gzip`, and a gzip trailer only gets written on close. So every gzip-encoded streaming response is truncated. The macro's own docstring already promises the stream "will be closed thereafter".

The close is gated to only run on a clean pass. #75586 made a committed mid-stream error abort the connection specifically so the client *doesn't* see a clean terminator; closing unconditionally writes one anyway and hands back a body that looks valid but isn't. `abort-on-committed-error-test` catches that if you get it wrong. `write-error!` now records that it handled an error, since it's the common path for both the outer catch and the query processor's own mid-stream error handling in `query_processor/streaming.clj`.

### 2. Already-compressed responses get gzipped a second time

`should-gzip-response?` only looks at `Accept-Encoding`, so the export, which is already a `.tar.gz`, gets wrapped in a second `GZIPOutputStream` and served as `Content-Encoding: gzip`. Browsers and `curl --compressed` unwrap the outer layer and are fine. The repro in the issue uses plain `curl`, which saves the raw body, so the file on disk is double-wrapped and `tar xzf` only unwraps one layer. Same story for anyone behind a proxy that adds `Accept-Encoding` for them, which is what the traefik report later in the issue thread is.

`application/gzip` is currently only declared by the serialization export, so that's the only endpoint whose framing changes. csv/xlsx/json downloads aren't compressed formats and still gzip as before.

### Where it came from

#69864 (backported in #71235, first released in v0.59.4) converted the export from a plain Ring response to `sr/streaming-response`. That's what exposed both bugs at once, and it lines up with the "began in 59.5" note in the issue.

### Tests

`gzip-encoded-response-is-not-truncated-test` covers the first bug at the streaming-response layer against a real server. Without the close it fails with `EOFException: Unexpected end of ZLIB input stream`.

It deliberately doesn't go through the export endpoint. Once the second bug is fixed the export is no longer transport-gzipped, so an export-based test stops exercising the gzip path at all and passes even with the first fix reverted. The two export tests cover the reported symptom end to end instead.

streaming-response, serialization API and QP streaming suites are green locally.
