### PR TITLE
Make custom viz work in data apps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/DataAppIframeApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/DataAppIframeApp.tsx
@@ -85,7 +85,11 @@ function BundleHost({ name }: { name: string }) {
     );
   }
 
-  return <DataAppProvider theme={data?.theme}>{content}</DataAppProvider>;
+  return (
+    <DataAppProvider providerProps={data?.providerProps}>
+      {content}
+    </DataAppProvider>
+  );
 }
 
 /**

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppProvider.tsx
@@ -5,11 +5,11 @@ import { type ReactNode, useMemo } from "react";
 import { SCOPED_CSS_RESET } from "embedding-sdk-bundle/components/private/PublicComponentStylesWrapper";
 import { PortalContainer } from "embedding-sdk-bundle/components/private/SdkPortalContainer";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { MetabaseReduxProvider } from "metabase/redux";
 import { getCspNonce } from "metabase/utils/csp";
 
 import { useHostSdkStore } from "../lib/use-host-sdk-store";
+import type { DataAppMetabaseProviderProps } from "../sandbox";
 
 // Note: Mantine + SDK CSS is loaded into the iframe via the `data-app-vendors`
 // Rspack entry (`<link rel="stylesheet">` in the iframe srcdoc). Don't side-
@@ -17,7 +17,7 @@ import { useHostSdkStore } from "../lib/use-host-sdk-store";
 // in the host document, not the iframe.
 
 interface DataAppProviderProps {
-  theme?: MetabaseTheme;
+  providerProps?: DataAppMetabaseProviderProps;
   children?: ReactNode;
 }
 
@@ -29,13 +29,13 @@ interface DataAppProviderProps {
  * `#metabase-sdk-portal-root`. Without `PortalContainer` rendered, those
  * overlays mount to `document.body` or silently fail.
  *
- * Takes only `{ theme, children }` — no `authConfig`. The data-app surface
- * inherits the host's session cookie; auth is already established.
+ * Takes the data app `providerProps`. The data-app surface inherits the host's
+ * session cookie; auth is already established.
  */
 export const DataAppProvider = (props: DataAppProviderProps) => {
-  const { children, ...restProps } = props;
-  const { theme } = restProps;
-  const sdkStore = useHostSdkStore(restProps);
+  const { children, providerProps } = props;
+  const { theme } = providerProps ?? {};
+  const sdkStore = useHostSdkStore(providerProps);
 
   // Iframe-side Emotion cache: keyed + CSP-nonced so SDK/Mantine styles inject
   // into this document's head (not the parent's).

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/use-data-app-bundle.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/use-data-app-bundle.ts
@@ -1,19 +1,18 @@
 import { type ComponentType, useEffect, useState } from "react";
 
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
-
 import {
   DataAppBundleError,
   fetchDataAppBundleCode,
   instantiateDataAppBundle,
 } from "../loader";
+import type { DataAppMetabaseProviderProps } from "../sandbox";
 
 import { describeError } from "./describe-error";
 import { reportErrorToParent } from "./report-error-to-parent";
 
 export interface LoadedApp {
   component: ComponentType<Record<string, unknown>>;
-  theme: MetabaseTheme | undefined;
+  providerProps: DataAppMetabaseProviderProps;
 }
 
 /**
@@ -43,9 +42,13 @@ export function useDataAppBundle(name: string): {
         return;
       }
 
-      const { component, theme } = instantiateDataAppBundle(code, name, window);
+      const { component, providerProps } = instantiateDataAppBundle(
+        code,
+        name,
+        window,
+      );
 
-      setData({ component, theme });
+      setData({ component, providerProps });
     };
 
     load().catch((error: unknown) => {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/loader.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/loader.ts
@@ -1,13 +1,17 @@
 import type * as React from "react";
+import { pick } from "underscore";
 
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { getSubpathSafeUrl } from "metabase/urls";
 
-import { createDataAppSandbox } from "./sandbox";
+import {
+  DATA_APP_PROVIDER_PROP_KEYS,
+  type DataAppMetabaseProviderProps,
+  createDataAppSandbox,
+} from "./sandbox";
 
 export interface LoadedDataApp {
   component: React.ComponentType<Record<string, unknown>>;
-  theme?: MetabaseTheme;
+  providerProps: DataAppMetabaseProviderProps;
 }
 
 /**
@@ -73,9 +77,14 @@ export function instantiateDataAppBundle(
 
   if (!def || typeof def.component !== "function") {
     throw new Error(
-      "Factory return value is missing a `component` function (expected { component, theme? })",
+      "Factory return value is missing a `component` function (expected { component, providerProps? })",
     );
   }
 
-  return { component: def.component, theme: def.theme };
+  const providerProps = pick(
+    def.providerProps ?? {},
+    ...DATA_APP_PROVIDER_PROP_KEYS,
+  );
+
+  return { component: def.component, providerProps };
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox.ts
@@ -2,11 +2,22 @@ import createVirtualEnvironment from "@locker/near-membrane-dom";
 import * as React from "react";
 import * as ReactJsxRuntime from "react/jsx-runtime";
 
+import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
 import * as sdkExports from "embedding-sdk-package";
 import * as dataAppExports from "embedding-sdk-package/data-app";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { makeDistortionCallback } from "./sandbox/distortions";
+
+// The MetabaseProvider props a data app may customize.
+export const DATA_APP_PROVIDER_PROP_KEYS = [
+  "theme",
+  "allowedCustomVisualizations",
+] as const;
+
+export type DataAppMetabaseProviderProps = Pick<
+  MetabaseProviderProps,
+  (typeof DATA_APP_PROVIDER_PROP_KEYS)[number]
+>;
 
 /**
  * The bundle's factory returns:
@@ -14,12 +25,12 @@ import { makeDistortionCallback } from "./sandbox/distortions";
  *     `DataAppProvider`. Should be pure content; no `<MetabaseProvider>`
  *     inside — the host owns the provider wrap so the SDK store/theme/
  *     portal context live in host realm.
- *   - `theme` — the theme passed to `<DataAppProvider theme={…}>`. Same
- *     shape as the SDK's public `MetabaseTheme`.
+ *   - `providerProps` — the `MetabaseProvider` props the data app wants to
+ *     customize (theme, allowedCustomVisualizations).
  */
 export type DataAppFactory = () => {
   component: React.ComponentType<Record<string, unknown>>;
-  theme?: MetabaseTheme;
+  providerProps?: DataAppMetabaseProviderProps;
 };
 
 function isLiveTarget(target: object): boolean {

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -237,10 +237,12 @@
                   :font-src     (into (cond-> always-allowed-resource-hosts
                                         config/is-dev? (conj frontend-address))
                                       (application-font-files->hosts))
-                  :img-src      (if (server.settings/csp-img-enabled)
-                                  (cond-> (parse-allowed-resource-hosts (server.settings/csp-img-allowed-hosts))
-                                    config/is-dev? (conj frontend-address))
-                                  (into ["*"] always-allowed-resource-hosts))
+                  :img-src      (cond-> (if (server.settings/csp-img-enabled)
+                                          (cond-> (parse-allowed-resource-hosts (server.settings/csp-img-allowed-hosts))
+                                            config/is-dev? (conj frontend-address))
+                                          (into ["*"] always-allowed-resource-hosts))
+                                  ;; Data apps need blob: to load icons for custom viz
+                                  data-app-iframe? (conj "blob:"))
                   :connect-src  ["'self'"
                                  ;; Google Identity Services
                                  "https://accounts.google.com"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -180,6 +180,19 @@
         ;; sub-routes under the data-app entrypoint are the same SPA shell
         (is (str/includes? (script-src-for "/embed/data-app/boba/sub/route") "'unsafe-eval'"))))))
 
+(deftest data-app-blob-img-csp-test
+  (testing "Only data-app iframe responses allow the blob: scheme in img-src"
+    (with-redefs [config/is-dev? false]
+      (let [wrapped-handler (mw.security/add-security-headers
+                             (fn [_request respond _raise]
+                               (respond {:status 200 :headers {} :body "ok"})))
+            img-src-for     (fn [uri]
+                              (-> (wrapped-handler {:uri uri :headers {}} identity identity)
+                                  (csp-directive-from-response "img-src")))]
+        (is (not (str/includes? (img-src-for "/") "blob:")))
+        (is (str/includes? (img-src-for "/embed/data-app/boba") "blob:"))
+        (is (str/includes? (img-src-for "/embed/data-app/boba/sub/route") "blob:"))))))
+
 (deftest ^:parallel test-parse-url
   (testing "Should parse valid urls"
     (are [url expected] (= expected


### PR DESCRIPTION
Closes EMB-1923
Closes EMB-1880

This PR includes two commits that close EMB-1923 and EMB-1880

- first commit: allows `blob:*` in the data app iframe CSP rules, needed to load icons in custom viz
- second commit: allows passing down some props to the MetabaseProvider, needed to pass down `allowedCustomVisualizations`